### PR TITLE
Simplify pages data structures. Handle custom pages with Big Sky

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-ai-assembler.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-ai-assembler.ts
@@ -45,10 +45,17 @@ export default function useAIAssembler(): [ Function, Function, string, boolean 
 							currentSearchParams.set( 'site_tagline', response.site.site_tagline );
 						}
 
-						// This was introduced in the V5 of the AI endpoint.
+						// In case we are sending the list of slugs to the assembler
 						const pageSlugs = response.pages.map( ( page: any ) => page?.slug ).filter( Boolean );
 						if ( pageSlugs.length ) {
 							currentSearchParams.set( 'page_slugs', pageSlugs.join( ',' ) );
+						}
+
+						// In case we are sending the list of title / pattern pairs to the assembler
+						// This will also filter out the "home" since it has a different format.
+						const pageTitles = response.pages.filter( ( page: any ) => page?.title && page?.ID );
+						if ( pageTitles.length ) {
+							currentSearchParams.set( 'custom_pages', JSON.stringify( pageTitles ) );
 						}
 
 						if ( response.style ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
@@ -18,6 +18,7 @@ const usePatternPages = (
 	let pageSlugs: string[] = [];
 	let pages: Pattern[] = [];
 	let pagesToShow: any[] = [];
+	let mockedPages: CustomPageTitle[] = [];
 	const page_slugs = searchParams.get( 'page_slugs' );
 	const custom_pages = searchParams.get( 'custom_pages' );
 
@@ -28,10 +29,14 @@ const usePatternPages = (
 	// eslint-disable-next-line prefer-const
 	pageCategoriesInOrder = useCategoriesOrder( categories, ORDERED_PATTERN_PAGES_CATEGORIES );
 
-	// Pairs of page title and pattern id can be passed in the URL from AI flow.
 	if ( custom_pages !== null ) {
-		const mockedPages: CustomPageTitle[] = JSON.parse( custom_pages ) || [];
+		try {
+			mockedPages = JSON.parse( custom_pages );
+		} catch ( e ) {}
+	}
 
+	// Pairs of page title and pattern id can be passed in the URL from AI flow.
+	if ( mockedPages.length > 0 ) {
 		mockedPages.forEach( ( { ID, title, selected }: CustomPageTitle ) => {
 			const patterns = dotcomPatterns.filter( ( pattern: Pattern ) => pattern.ID === ID );
 			if ( patterns.length === 0 ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
@@ -9,12 +9,14 @@ const usePatternPages = (
 ) => {
 	const [ searchParams, setSearchParams ] = useSearchParams();
 	let pageCategoriesInOrder;
+	let pageSlugs: string[] = [];
 	let pages;
 	let pagesToShow;
 	const page_slugs = searchParams.get( 'page_slugs' );
 
-	const pageSlugs = page_slugs !== null ? page_slugs.split( ',' ).filter( Boolean ) : INITIAL_PAGES;
-
+	if ( page_slugs !== null ) {
+		pageSlugs = page_slugs.split( ',' ).filter( Boolean );
+	}
 
 	// eslint-disable-next-line prefer-const
 	pageCategoriesInOrder = useCategoriesOrder( categories, ORDERED_PATTERN_PAGES_CATEGORIES );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
@@ -1,30 +1,76 @@
 import { useSearchParams } from 'react-router-dom';
 import { INITIAL_PAGES, ORDERED_PATTERN_PAGES_CATEGORIES } from '../constants';
 import { useCategoriesOrder } from '../hooks';
-import type { Pattern, Category } from '../types';
+import type { Pattern, Category, Tag } from '../types';
 
 const usePatternPages = (
 	pagesMapByCategory: Record< string, Pattern[] >,
 	categories: Category[]
 ) => {
 	const [ searchParams, setSearchParams ] = useSearchParams();
-	const pageCategoriesInOrder = useCategoriesOrder( categories, ORDERED_PATTERN_PAGES_CATEGORIES );
+	let pageCategoriesInOrder;
+	let pages;
+	let pagesToShow;
 	const page_slugs = searchParams.get( 'page_slugs' );
 
 	const pageSlugs = page_slugs !== null ? page_slugs.split( ',' ).filter( Boolean ) : INITIAL_PAGES;
 
-	const pages = pageSlugs.map( ( slug ) => pagesMapByCategory[ slug ]?.[ 0 ] ).filter( Boolean );
 
-	const pagesToShow = pageCategoriesInOrder.map( ( category: Category ) => {
-		const { name } = category;
-		const hasPages = name && pagesMapByCategory[ name ]?.length;
-		return {
-			name,
-			hasPages,
-			title: hasPages ? pagesMapByCategory[ name ][ 0 ].title : '',
-			isSelected: name ? pageSlugs.includes( name ) : false,
-		};
-	} );
+	// eslint-disable-next-line prefer-const
+	pageCategoriesInOrder = useCategoriesOrder( categories, ORDERED_PATTERN_PAGES_CATEGORIES );
+
+	// This is a way to mock/inject pages that are not in the pattern repository. We may continue with this approach later.:
+	// eslint-disable-next-line no-constant-condition
+	if ( true ) {
+		const mockedPages = [ 'Potato', 'Potato 2', 'Potato 3' ];
+		pages = mockedPages.map(
+			( title ) =>
+				< Pattern >{
+					ID: Math.floor( Math.random() * 1000000 ),
+					// Title with whitespace and special characters replaced with _
+					name: title.replace( /[^a-z0-9]/gi, '_' ).toLowerCase(),
+					title: title,
+					html: '<h1>Test</h1>',
+					tags: {
+						assembler_page: < Tag >{
+							slug: 'assembler_page',
+							title: 'Assembler page',
+							description: '',
+						},
+					},
+					categories: {},
+				}
+		);
+		if ( page_slugs === null ) {
+			pageSlugs = pages.map( ( page ) => page.name );
+		}
+
+		pagesToShow = pages.map( ( page ) => {
+			return {
+				name: page.name,
+				hasPages: true,
+				title: page.title,
+				isSelected: pageSlugs.includes( page.name ),
+			};
+		} );
+	} else {
+		if ( isEnabled( 'pattern-assembler/add-pages' ) && page_slugs === null ) {
+			pageSlugs = INITIAL_PAGES;
+		}
+
+		pages = pageSlugs.map( ( slug ) => pagesMapByCategory[ slug ]?.[ 0 ] ).filter( Boolean );
+
+		pagesToShow = pageCategoriesInOrder.map( ( category: Category ) => {
+			const { name } = category;
+			const hasPages = name && pagesMapByCategory[ name ]?.length;
+			return {
+				name,
+				hasPages,
+				title: hasPages ? pagesMapByCategory[ name ][ 0 ].title : '',
+				isSelected: name ? pageSlugs.includes( name ) : false,
+			};
+		} );
+	}
 
 	const setPageSlugs = ( slugs: string[] ) => {
 		setSearchParams(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
@@ -1,14 +1,30 @@
 import { useSearchParams } from 'react-router-dom';
-import { INITIAL_PAGES } from '../constants';
-import type { Pattern } from '../types';
+import { INITIAL_PAGES, ORDERED_PATTERN_PAGES_CATEGORIES } from '../constants';
+import { useCategoriesOrder } from '../hooks';
+import type { Pattern, Category } from '../types';
 
-const usePatternPages = ( pagesMapByCategory: Record< string, Pattern[] > ) => {
+const usePatternPages = (
+	pagesMapByCategory: Record< string, Pattern[] >,
+	categories: Category[]
+) => {
 	const [ searchParams, setSearchParams ] = useSearchParams();
+	const pageCategoriesInOrder = useCategoriesOrder( categories, ORDERED_PATTERN_PAGES_CATEGORIES );
 	const page_slugs = searchParams.get( 'page_slugs' );
 
 	const pageSlugs = page_slugs !== null ? page_slugs.split( ',' ).filter( Boolean ) : INITIAL_PAGES;
 
 	const pages = pageSlugs.map( ( slug ) => pagesMapByCategory[ slug ]?.[ 0 ] ).filter( Boolean );
+
+	const pagesToShow = pageCategoriesInOrder.map( ( category: Category ) => {
+		const { name } = category;
+		const hasPages = name && pagesMapByCategory[ name ]?.length;
+		return {
+			name,
+			hasPages,
+			title: hasPages ? pagesMapByCategory[ name ][ 0 ].title : '',
+			isSelected: name ? pageSlugs.includes( name ) : false,
+		};
+	} );
 
 	const setPageSlugs = ( slugs: string[] ) => {
 		setSearchParams(
@@ -25,7 +41,7 @@ const usePatternPages = ( pagesMapByCategory: Record< string, Pattern[] > ) => {
 		);
 	};
 
-	return { pages, pageSlugs, setPageSlugs };
+	return { pages, pageSlugs, setPageSlugs, pagesToShow };
 };
 
 export default usePatternPages;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
@@ -7,11 +7,16 @@ const usePatternPages = (
 	pagesMapByCategory: Record< string, Pattern[] >,
 	categories: Category[],
 	dotcomPatterns: Pattern[]
-) => {
+): {
+	pages: Pattern[];
+	pageSlugs: string[];
+	setPageSlugs: ( slugs: string[] ) => void;
+	pagesToShow: any[];
+} => {
 	const [ searchParams, setSearchParams ] = useSearchParams();
 	let pageCategoriesInOrder;
 	let pageSlugs: string[] = [];
-	let pages: ( Pattern | null )[] = [];
+	let pages: Pattern[] = [];
 	let pagesToShow: any[] = [];
 	const page_slugs = searchParams.get( 'page_slugs' );
 	const custom_pages = searchParams.get( 'custom_pages' );
@@ -66,40 +71,40 @@ const usePatternPages = (
 		};
 
 		return { pages, pageSlugs, setPageSlugs, pagesToShow };
-	} else if ( custom_pages === null ) {
-		if ( page_slugs === null ) {
-			pageSlugs = INITIAL_PAGES;
-		}
-
-		pages = pageSlugs.map( ( slug ) => pagesMapByCategory[ slug ]?.[ 0 ] ).filter( Boolean );
-
-		pagesToShow = pageCategoriesInOrder.map( ( category: Category ) => {
-			const { name } = category;
-			const hasPages = name && pagesMapByCategory[ name ]?.length;
-			return {
-				name,
-				hasPages,
-				title: hasPages ? pagesMapByCategory[ name ][ 0 ].title : '',
-				isSelected: name ? pageSlugs.includes( name ) : false,
-			};
-		} );
-		const setPageSlugs = ( slugs: string[] ) => {
-			setSearchParams(
-				( currentSearchParams ) => {
-					if ( slugs.length === 0 ) {
-						currentSearchParams.set( 'page_slugs', '' );
-					} else {
-						currentSearchParams.set( 'page_slugs', slugs.join( ',' ) );
-					}
-
-					return currentSearchParams;
-				},
-				{ replace: true }
-			);
-		};
-
-		return { pages, pageSlugs, setPageSlugs, pagesToShow };
 	}
+
+	if ( page_slugs === null ) {
+		pageSlugs = INITIAL_PAGES;
+	}
+
+	pages = pageSlugs.map( ( slug ) => pagesMapByCategory[ slug ]?.[ 0 ] ).filter( Boolean );
+
+	pagesToShow = pageCategoriesInOrder.map( ( category: Category ) => {
+		const { name } = category;
+		const hasPages = name && pagesMapByCategory[ name ]?.length;
+		return {
+			name,
+			hasPages,
+			title: hasPages ? pagesMapByCategory[ name ][ 0 ].title : '',
+			isSelected: name ? pageSlugs.includes( name ) : false,
+		};
+	} );
+	const setPageSlugs = ( slugs: string[] ) => {
+		setSearchParams(
+			( currentSearchParams ) => {
+				if ( slugs.length === 0 ) {
+					currentSearchParams.set( 'page_slugs', '' );
+				} else {
+					currentSearchParams.set( 'page_slugs', slugs.join( ',' ) );
+				}
+
+				return currentSearchParams;
+			},
+			{ replace: true }
+		);
+	};
+
+	return { pages, pageSlugs, setPageSlugs, pagesToShow };
 };
 
 export default usePatternPages;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
@@ -23,7 +23,7 @@ const usePatternPages = (
 
 	// This is a way to mock/inject pages that are not in the pattern repository. We may continue with this approach later.:
 	// eslint-disable-next-line no-constant-condition
-	if ( true ) {
+	if ( false ) {
 		const mockedPages = [ 'Potato', 'Potato 2', 'Potato 3' ];
 		pages = mockedPages.map(
 			( title ) =>
@@ -56,7 +56,7 @@ const usePatternPages = (
 			};
 		} );
 	} else {
-		if ( isEnabled( 'pattern-assembler/add-pages' ) && page_slugs === null ) {
+		if ( page_slugs === null ) {
 			pageSlugs = INITIAL_PAGES;
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
@@ -1,61 +1,60 @@
 import { useSearchParams } from 'react-router-dom';
 import { INITIAL_PAGES, ORDERED_PATTERN_PAGES_CATEGORIES } from '../constants';
 import { useCategoriesOrder } from '../hooks';
-import type { Pattern, Category, Tag } from '../types';
+import type { Pattern, Category, CustomPageTitle } from '../types';
 
 const usePatternPages = (
 	pagesMapByCategory: Record< string, Pattern[] >,
-	categories: Category[]
+	categories: Category[],
+	dotcomPatterns: Pattern[]
 ) => {
 	const [ searchParams, setSearchParams ] = useSearchParams();
 	let pageCategoriesInOrder;
 	let pageSlugs: string[] = [];
-	let pages;
+	let pages: ( Pattern | null )[] = [];
 	let pagesToShow;
 	const page_slugs = searchParams.get( 'page_slugs' );
+	const custom_pages = searchParams.get( 'custom_pages' );
 
 	if ( page_slugs !== null ) {
 		pageSlugs = page_slugs.split( ',' ).filter( Boolean );
 	}
 
+	pages = [];
+
 	// eslint-disable-next-line prefer-const
 	pageCategoriesInOrder = useCategoriesOrder( categories, ORDERED_PATTERN_PAGES_CATEGORIES );
 
-	// This is a way to mock/inject pages that are not in the pattern repository. We may continue with this approach later.:
-	// eslint-disable-next-line no-constant-condition
-	if ( false ) {
-		const mockedPages = [ 'Potato', 'Potato 2', 'Potato 3' ];
-		pages = mockedPages.map(
-			( title ) =>
-				< Pattern >{
-					ID: Math.floor( Math.random() * 1000000 ),
-					// Title with whitespace and special characters replaced with _
-					name: title.replace( /[^a-z0-9]/gi, '_' ).toLowerCase(),
-					title: title,
-					html: '<h1>Test</h1>',
-					tags: {
-						assembler_page: < Tag >{
-							slug: 'assembler_page',
-							title: 'Assembler page',
-							description: '',
-						},
-					},
-					categories: {},
+	// Pairs of page title and pattern id can be passed in the URL from AI flow.
+	if ( custom_pages !== null ) {
+		const mockedPages: CustomPageTitle[] = JSON.parse( custom_pages ) || [];
+
+		pages = mockedPages
+			.map( ( { ID, title }: CustomPageTitle ) => {
+				const patterns = dotcomPatterns.filter( ( pattern: Pattern ) => pattern.ID === ID );
+				if ( patterns.length < 1 ) {
+					return null;
 				}
-		);
+				const pattern = patterns[ 0 ];
+				pattern.title = title;
+
+				return pattern;
+			} )
+			.filter( Boolean );
+
 		if ( page_slugs === null ) {
-			pageSlugs = pages.map( ( page ) => page.name );
+			pageSlugs = pages.map( ( page ) => page?.name || '' );
 		}
 
 		pagesToShow = pages.map( ( page ) => {
 			return {
-				name: page.name,
+				name: page?.name || '',
 				hasPages: true,
-				title: page.title,
-				isSelected: pageSlugs.includes( page.name ),
+				title: page?.title || '',
+				isSelected: pageSlugs.includes( page?.name || '' ),
 			};
 		} );
-	} else {
+	} else if ( custom_pages === null ) {
 		if ( page_slugs === null ) {
 			pageSlugs = INITIAL_PAGES;
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -105,7 +105,6 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 	const categories = usePatternCategories( site?.ID );
 	// Fetching curated patterns and categories from PTK api
 	const dotcomPatterns = useDotcomPatterns( locale );
-
 	const { allCategoryPatternsMap, layoutCategoryPatternsMap, pageCategoryPatternsMap } =
 		useCategoryPatternsMap( dotcomPatterns );
 	const {
@@ -130,7 +129,8 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 
 	const { pages, pageSlugs, setPageSlugs, pagesToShow } = usePatternPages(
 		pageCategoryPatternsMap,
-		categories
+		categories,
+		dotcomPatterns
 	);
 
 	const currentScreen = useCurrentScreen( { shouldUnlockGlobalStyles } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -236,11 +236,11 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 			} );
 		} );
 
-		pages.forEach( ( { ID, name, categories = {} } ) => {
-			const category_slug = Object.keys( categories )[ 0 ];
+		pages.forEach( ( pattern: Pattern ) => {
+			const category_slug = Object.keys( pattern.categories )[ 0 ];
 			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PAGE_FINAL_SELECT, {
-				pattern_id: ID,
-				pattern_name: name,
+				pattern_id: pattern.ID,
+				pattern_name: pattern.name,
 				...( category_slug && { pattern_category: category_slug } ),
 			} );
 		} );
@@ -391,7 +391,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 						homeHtml: sections.map( ( pattern ) => pattern.html ).join( '' ),
 						headerHtml: header?.html,
 						footerHtml: footer?.html,
-						pages: pages.map( ( page ) => ( {
+						pages: pages.map( ( page: Pattern ) => ( {
 							title: page.title,
 							content: page.html,
 						} ) ),
@@ -628,7 +628,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 
 	const onScreenPagesSelect = ( pageSlug: string ) => {
 		if ( pageSlugs.includes( pageSlug ) ) {
-			setPageSlugs( pageSlugs.filter( ( item ) => item !== pageSlug ) );
+			setPageSlugs( pageSlugs.filter( ( item: string ) => item !== pageSlug ) );
 			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.SCREEN_PAGES_PAGE_REMOVE, { page: pageSlug } );
 		} else {
 			setPageSlugs( [ ...pageSlugs, pageSlug ] );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -105,6 +105,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 	const categories = usePatternCategories( site?.ID );
 	// Fetching curated patterns and categories from PTK api
 	const dotcomPatterns = useDotcomPatterns( locale );
+
 	const { allCategoryPatternsMap, layoutCategoryPatternsMap, pageCategoryPatternsMap } =
 		useCategoryPatternsMap( dotcomPatterns );
 	const {
@@ -127,7 +128,10 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 		hasFont: !! fontVariation,
 	} );
 
-	const { pages, pageSlugs, setPageSlugs } = usePatternPages( pageCategoryPatternsMap );
+	const { pages, pageSlugs, setPageSlugs, pagesToShow } = usePatternPages(
+		pageCategoryPatternsMap,
+		categories
+	);
 
 	const currentScreen = useCurrentScreen( { shouldUnlockGlobalStyles } );
 
@@ -667,9 +671,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 
 				<NavigatorScreen path={ NAVIGATOR_PATHS.PAGES } partialMatch>
 					<ScreenPages
-						categories={ categories }
-						pagesMapByCategory={ pageCategoryPatternsMap }
-						selectedPageSlugs={ pageSlugs }
+						pagesToShow={ pagesToShow }
 						onSelect={ onScreenPagesSelect }
 						onContinueClick={ onContinue }
 						recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-list.tsx
@@ -78,7 +78,6 @@ const PageList = ( { pagesToShow, onSelectPage }: PageListProps ) => {
 							aria-checked={ page.isSelected }
 							onClick={ () => onSelectPage( page.name ) }
 						>
-
 							<PageListItem label={ page.title } isSelected={ page.isSelected } />
 						</CompositeItem>
 					);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-list.tsx
@@ -9,9 +9,6 @@ import {
 } from '@wordpress/components';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { ORDERED_PATTERN_PAGES_CATEGORIES } from '../constants';
-import { useCategoriesOrder } from '../hooks';
-import type { Category, Pattern } from '../types';
 import './page-list.scss';
 
 interface PageListItemProps {
@@ -40,20 +37,13 @@ const PageListItem = ( { label, isSelected, isDisabled }: PageListItemProps ) =>
 };
 
 interface PageListProps {
-	categories: Category[];
-	pagesMapByCategory: Record< string, Pattern[] >;
-	selectedPageSlugs: string[];
+	pagesToShow: any[];
 	onSelectPage: ( selectedPage: string ) => void;
 }
 
-const PageList = ( {
-	categories,
-	pagesMapByCategory,
-	selectedPageSlugs,
-	onSelectPage,
-}: PageListProps ) => {
+const PageList = ( { pagesToShow, onSelectPage }: PageListProps ) => {
 	const translate = useTranslate();
-	const categoriesInOrder = useCategoriesOrder( categories, ORDERED_PATTERN_PAGES_CATEGORIES );
+
 	const composite = useCompositeState( { orientation: 'vertical' } );
 
 	return (
@@ -74,29 +64,22 @@ const PageList = ( {
 				>
 					<PageListItem label={ translate( 'Homepage' ) } isDisabled />
 				</CompositeItem>
-				{ categoriesInOrder.map( ( category: Category ) => {
-					const { name } = category;
-					const isSelected = name ? selectedPageSlugs.includes( name ) : false;
-					const hasPages = name && pagesMapByCategory[ name ]?.length;
-
-					if ( ! hasPages ) {
+				{ pagesToShow.map( ( page ) => {
+					if ( ! page.hasPages ) {
 						return null;
 					}
 
 					return (
 						<CompositeItem
 							{ ...composite }
-							key={ name }
+							key={ page.name }
 							role="checkbox"
 							as="button"
-							aria-checked={ isSelected }
-							onClick={ () => onSelectPage( name ) }
+							aria-checked={ page.isSelected }
+							onClick={ () => onSelectPage( page.name ) }
 						>
-							<PageListItem
-								// Show the latest-updated page per category
-								label={ pagesMapByCategory[ name ][ 0 ].title }
-								isSelected={ isSelected }
-							/>
+
+							<PageListItem label={ page.title } isSelected={ page.isSelected } />
 						</CompositeItem>
 					);
 				} ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-pages.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-pages.tsx
@@ -5,25 +5,15 @@ import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import { useScreen } from './hooks';
 import NavigatorTitle from './navigator-title';
 import PageList from './pages/page-list';
-import type { Category, Pattern } from './types';
 
 interface Props {
-	categories: Category[];
-	pagesMapByCategory: Record< string, Pattern[] >;
-	selectedPageSlugs: string[];
+	pagesToShow: any[];
 	onSelect: ( page: string ) => void;
 	onContinueClick: () => void;
 	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
 }
 
-const ScreenPages = ( {
-	categories,
-	pagesMapByCategory,
-	selectedPageSlugs,
-	onSelect,
-	onContinueClick,
-	recordTracksEvent,
-}: Props ) => {
+const ScreenPages = ( { pagesToShow, onSelect, onContinueClick, recordTracksEvent }: Props ) => {
 	const [ disabled, setDisabled ] = useState( true );
 	const { title, description, continueLabel } = useScreen( 'pages' );
 
@@ -58,12 +48,7 @@ const ScreenPages = ( {
 			/>
 			<div className="screen-container__body">
 				<VStack spacing="4">
-					<PageList
-						categories={ categories }
-						pagesMapByCategory={ pagesMapByCategory }
-						selectedPageSlugs={ selectedPageSlugs }
-						onSelectPage={ onSelect }
-					/>
+					<PageList pagesToShow={ pagesToShow } onSelectPage={ onSelect } />
 				</VStack>
 			</div>
 			<div className="screen-container__footer">

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
@@ -41,3 +41,8 @@ export type Tag = {
 	title: string;
 	description: string;
 };
+
+export type CustomPageTitle = {
+	title: string;
+	ID: number;
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
@@ -45,4 +45,5 @@ export type Tag = {
 export type CustomPageTitle = {
 	title: string;
 	ID: number;
+	selected: boolean;
 };


### PR DESCRIPTION
Related to https://github.com/Automattic/ai-services/issues/607

The core of this diff is to have big sky create custom page titles. With this, it will choose a pattern for each of the secondary pages, as well as create a custom title.

## Proposed Changes

* Move data logic related to displaying pages to the `usePatternPages` hook, so similar logic is together.
* Catch the custom page title/pattern id pairs and pass along to usePatternPages
* Replace pages in the assembler by AI-generated pages from the diff.

Accompanying diff: D133410-code


![Zrzut ekranu 2024-01-2 o 19 19 25](https://github.com/Automattic/wp-calypso/assets/3775068/c3a7566d-ac93-4acc-9556-704bfb83ba7e)

![Zrzut ekranu 2024-01-2 o 19 18 40](https://github.com/Automattic/wp-calypso/assets/3775068/9252ae8a-7c39-4546-9848-05678d11ef53)

![Zrzut ekranu 2024-01-2 o 19 19 18](https://github.com/Automattic/wp-calypso/assets/3775068/c4b97269-e3d7-440e-9167-e42f88d2932c)




## Testing Instructions

* Apply D133410-code , sandbox public-api
* Open http://calypso.localhost:3000/setup/ai-assembler
* Describe your website. Mention some specific page you want.
* See patterns being generated
* Click through to the Pages tab
* Observe custom pages being created

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?