### PR TITLE
Fix selected status for domain move product

### DIFF
--- a/client/lib/cart-values/cart-items.ts
+++ b/client/lib/cart-values/cart-items.ts
@@ -664,7 +664,10 @@ export function getRenewalItemFromCartItem< T extends MinimalRequestCartProduct 
 
 export function hasDomainInCart( cart: ObjectWithProducts, domain: string ): boolean {
 	return getAllCartItems( cart ).some( ( product ) => {
-		return product.is_domain_registration === true && product.meta === domain;
+		return (
+			product.meta === domain &&
+			( isDomainRegistration( product ) || isDomainMoveInternal( product ) )
+		);
 	} );
 }
 


### PR DESCRIPTION
With the new changes introduced in https://github.com/Automattic/wp-calypso/pull/85152/, the domain move product is not showing as selected after adding it to the cart.

### Before

![image](https://github.com/Automattic/wp-calypso/assets/1080253/afa697a0-f84d-427b-a596-bafe527aa3a7)

### After

![image](https://github.com/Automattic/wp-calypso/assets/1080253/4a7c0215-c481-4aae-a393-0cfe50fa7552)

### Testing

* Go to `Switch Site > Add a new site`
* Search for a domain you own that is mapped to one of your old sites
* Add it to your cart
* Check the state of the `Select` button