### PR TITLE
Self service site reset: Update progress bar to use progress from backend when page reloads

### DIFF
--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -156,6 +156,7 @@ function SiteResetCard( {
 						duration: 6000,
 					} )
 				);
+				refetchResetStatus();
 			} else {
 				dispatch(
 					successNotice( translate( 'Your site has been reset.' ), {

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -119,25 +119,15 @@ function SiteResetCard( {
 
 	const { data } = useSiteResetContentSummaryQuery( siteId );
 	const { data: status, refetch: refetchResetStatus } = useSiteResetStatusQuery( siteId );
-	let resetStatus = 'ready';
-	if ( status ) {
-		resetStatus = status.status;
-	}
 	const [ isDomainConfirmed, setDomainConfirmed ] = useState( false );
-	const [ resetProgress, setResetProgress ] = useState( 1 );
-
-	if ( resetStatus !== 'ready' && resetProgress === 1 ) {
-		//it's already in progress on load
-		setResetProgress( 0 );
-	}
 
 	const checkStatus = async () => {
-		if ( resetProgress !== 1 ) {
+		if ( status?.status !== 'completed' && isAtomic ) {
 			const {
 				data: { status: latestStatus },
 			} = await refetchResetStatus();
-			if ( latestStatus === 'ready' ) {
-				setResetProgress( 1 );
+
+			if ( latestStatus === 'completed' ) {
 				dispatch(
 					successNotice( translate( 'Your site has been reset.' ), {
 						id: 'site-reset-success-notice',
@@ -158,7 +148,6 @@ function SiteResetCard( {
 	};
 
 	const handleResult = ( result ) => {
-		setResetProgress( 0 );
 		if ( result.success ) {
 			if ( isAtomic ) {
 				dispatch(
@@ -174,7 +163,6 @@ function SiteResetCard( {
 						duration: 4000,
 					} )
 				);
-				setResetProgress( 1 );
 			}
 		} else {
 			handleError();
@@ -274,7 +262,7 @@ function SiteResetCard( {
 				}
 		  );
 
-	const isResetInProgress = resetProgress < 1;
+	const isResetInProgress = status?.status === 'in-progress' && isAtomic;
 
 	const ctaText =
 		! isAtomic && isLoading ? translate( 'Resetting site' ) : translate( 'Reset site' );
@@ -301,7 +289,7 @@ function SiteResetCard( {
 			{ isResetInProgress ? (
 				<ActionPanel style={ { margin: 0 } }>
 					<ActionPanelBody>
-						<LoadingBar progress={ resetProgress / 100 } />
+						<LoadingBar progress={ status?.progress } />
 						<p className="reset-site__in-progress-message">
 							{ translate( "We're resetting your site. We'll email you once it's ready." ) }
 						</p>

--- a/packages/data-stores/src/site-reset/use-site-reset-status-query.ts
+++ b/packages/data-stores/src/site-reset/use-site-reset-status-query.ts
@@ -4,6 +4,7 @@ import { APIError } from './use-site-reset-mutation';
 
 export type SiteResetStatus = {
 	status: 'in-progress' | 'ready';
+	progress: number;
 };
 
 export const useSiteResetStatusQuery = (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/4851

## Proposed Changes

This PR uses backend progress to update the progress bar, this is particular useful if the user navigates away or reloads the page, the progress is fetched from the backend and the bar updated, that way the progress bar doesn't always start from zero.

* Add a progress query param that get's atomic reset progress from the backend

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Setup backend patch D132298-code

* go to `/settings/start-over/atomicSlug`
* Initiate site reset and after the progress bar moves to a certain point (maybe quarter) refresh the page and see the progress bar doesn't start from zero but almost the same place before the page was refreshed. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?