### PR TITLE
Signup Social First: Move ToS above Continue button

### DIFF
--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -1,7 +1,8 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, isDefaultLocale, useLocale } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useState, createInterpolateElement } from '@wordpress/element';
+import { hasTranslation } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import MailIcon from 'calypso/components/social-icons/mail';
 import { isGravatarOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
@@ -70,6 +71,7 @@ const SignupFormSocialFirst = ( {
 	const isWooCoreProfilerFlow = useSelector( isWooCommerceCoreProfilerFlow );
 	const isWoo = isWooOAuth2Client( oauth2Client ) || isWooCoreProfilerFlow;
 	const isGravatar = isGravatarOAuth2Client( oauth2Client );
+	const locale = useLocale();
 
 	const renderTermsOfService = () => {
 		let tosText;
@@ -118,11 +120,29 @@ const SignupFormSocialFirst = ( {
 
 	const renderEmailStepTermsOfService = () => {
 		if ( currentStep === 'email' ) {
+			if (
+				isDefaultLocale( locale ) ||
+				hasTranslation(
+					'By clicking "Continue," you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+				)
+			) {
+				return (
+					<p className="signup-form-social-first__email-tos-link">
+						{ createInterpolateElement(
+							__(
+								'By clicking "Continue," you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+							),
+							options
+						) }
+					</p>
+				);
+			}
+
 			return (
-				<p className="signup-form-social-first__tos-link">
+				<p className="signup-form-social-first__email-tos-link">
 					{ createInterpolateElement(
 						__(
-							'By clicking "Continue", you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+							'By creating an account you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
 						),
 						options
 					) }

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -29,6 +29,25 @@ interface SignupFormSocialFirst {
 	isSocialFirst: boolean;
 }
 
+const options = {
+	tosLink: (
+		<a
+			href={ localizeUrl( 'https://wordpress.com/tos/' ) }
+			onClick={ () => recordTracksEvent( 'calypso_signup_tos_link_click' ) }
+			target="_blank"
+			rel="noopener noreferrer"
+		/>
+	),
+	privacyLink: (
+		<a
+			href={ localizeUrl( 'https://automattic.com/privacy/' ) }
+			onClick={ () => recordTracksEvent( 'calypso_signup_privacy_link_click' ) }
+			target="_blank"
+			rel="noopener noreferrer"
+		/>
+	),
+};
+
 const SignupFormSocialFirst = ( {
 	goToNextStep,
 	step,
@@ -51,6 +70,66 @@ const SignupFormSocialFirst = ( {
 	const isWooCoreProfilerFlow = useSelector( isWooCommerceCoreProfilerFlow );
 	const isWoo = isWooOAuth2Client( oauth2Client ) || isWooCoreProfilerFlow;
 	const isGravatar = isGravatarOAuth2Client( oauth2Client );
+
+	const renderTermsOfService = () => {
+		let tosText;
+
+		if ( isWoo ) {
+			tosText = createInterpolateElement(
+				__( 'By continuing, you agree to our <tosLink>Terms of Service</tosLink>.' ),
+				options
+			);
+			return (
+				<p className="signup-form-social-first__tos-link">
+					{ createInterpolateElement(
+						__( 'By continuing, you agree to our <tosLink>Terms of Service</tosLink>.' ),
+						options
+					) }
+				</p>
+			);
+		} else if ( isGravatar ) {
+			tosText = createInterpolateElement(
+				__(
+					'By entering your email address, you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+				),
+				options
+			);
+			return (
+				<p className="signup-form-social-first__tos-link">
+					{ createInterpolateElement(
+						__(
+							'By entering your email address, you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+						),
+						options
+					) }
+				</p>
+			);
+		} else if ( currentStep === 'initial' ) {
+			tosText = createInterpolateElement(
+				__(
+					'If you continue with Google or Apple, you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+				),
+				options
+			);
+		}
+
+		return <p className="signup-form-social-first__tos-link">{ tosText }</p>;
+	};
+
+	const renderEmailStepTermsOfService = () => {
+		if ( currentStep === 'email' ) {
+			return (
+				<p className="signup-form-social-first__tos-link">
+					{ createInterpolateElement(
+						__(
+							'By clicking "Continue", you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+						),
+						options
+					) }
+				</p>
+			);
+		}
+	};
 
 	const renderContent = () => {
 		if ( currentStep === 'initial' ) {
@@ -97,6 +176,7 @@ const SignupFormSocialFirst = ( {
 						labelText={ __( 'Your email' ) }
 						submitButtonLabel={ __( 'Continue' ) }
 						userEmail={ userEmail }
+						renderTerms={ renderEmailStepTermsOfService }
 						{ ...gravatarProps }
 					/>
 					<Button
@@ -109,69 +189,6 @@ const SignupFormSocialFirst = ( {
 				</div>
 			);
 		}
-	};
-
-	const renderTermsOfService = () => {
-		const options = {
-			tosLink: (
-				<a
-					href={ localizeUrl( 'https://wordpress.com/tos/' ) }
-					onClick={ () => recordTracksEvent( 'calypso_signup_tos_link_click' ) }
-					target="_blank"
-					rel="noopener noreferrer"
-				/>
-			),
-			privacyLink: (
-				<a
-					href={ localizeUrl( 'https://automattic.com/privacy/' ) }
-					onClick={ () => recordTracksEvent( 'calypso_signup_privacy_link_click' ) }
-					target="_blank"
-					rel="noopener noreferrer"
-				/>
-			),
-		};
-
-		if ( isWoo ) {
-			return (
-				<p className="signup-form-social-first__tos-link">
-					{ createInterpolateElement(
-						__( 'By continuing, you agree to our <tosLink>Terms of Service</tosLink>.' ),
-						options
-					) }
-				</p>
-			);
-		} else if ( isGravatar ) {
-			return (
-				<p className="signup-form-social-first__tos-link">
-					{ createInterpolateElement(
-						__(
-							'By entering your email address, you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
-						),
-						options
-					) }
-				</p>
-			);
-		}
-
-		let tosText;
-
-		if ( currentStep === 'initial' ) {
-			tosText = createInterpolateElement(
-				__(
-					'If you continue with Google or Apple, you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
-				),
-				options
-			);
-		} else if ( currentStep === 'email' ) {
-			tosText = createInterpolateElement(
-				__(
-					'By creating an account you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
-				),
-				options
-			);
-		}
-
-		return <p className="signup-form-social-first__tos-link">{ tosText }</p>;
 	};
 
 	return (

--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -159,20 +159,26 @@ body.is-section-accept-invite {
 				padding: 0 !important;
 			}
 
-			.signup-form-social-first__tos-link {
+			.signup-form-social-first__tos-link,
+			.signup-form-social-first__email-tos-link {
 				color: var(--studio-gray-50, #646970);
-				text-align: center;
 				font-family: "SF Pro Text", sans-serif;
 				font-size: 0.75rem;
 				font-style: normal;
 				font-weight: 400;
 				line-height: 18px;
-				margin-top: 32px;
+				margin-top: 24px;
+				margin-bottom: 12px;
 
 				a {
 					color: var(--studio-gray-50, #646970);
 					text-decoration-line: underline;
 				}
+			}
+
+			.signup-form-social-first__tos-link {
+				margin-top: 32px;
+				text-align: center;
 			}
 		}
 
@@ -213,7 +219,8 @@ body.is-section-accept-invite {
 			}
 
 			.logged-out-form__footer {
-				margin-top: 16px;
+				margin-top: 12px;
+				padding-top: 0;
 			}
 
 			button.back-button {


### PR DESCRIPTION
Context: https://wp.me/p4H3ND-1Cw#comment-3483

## Issue

The ToS is at the bottom of the [page](https://wordpress.com/start/user-social).

<img width="484" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/3dc67643-00f9-4cc8-8b45-97aa33e49d18">

## Solution

Move the ToS.

![image](https://github.com/Automattic/wp-calypso/assets/52076348/7bcccaaa-a740-49fa-bf9e-e4994ad5f6d9)

## Additional

- Fixed the spacing of the ToS
- Added structure to handle the translation

## To Fix

In a following PR, I'll fix the header bottom margin.

## Testing
1. Live link
2. Visit `/start/user-social` and check that the ToS is at the bottom as in production.
3. Click on `Continue with Email` and check that the ToS is above the continue button.