### PR TITLE
Add closure dates for New Year's holidays

### DIFF
--- a/client/me/concierge/shared/closure-notice.js
+++ b/client/me/concierge/shared/closure-notice.js
@@ -36,7 +36,7 @@ const ClosureNotice = ( { closesAt, displayAt, reopensAt } ) => {
 		);
 	} else {
 		message = translate(
-			'{{strong}}Quick Start Sessions will be closed from %(closesAt)s – %(reopensAt)s for the Christmas holiday.{{/strong}}{{br/}}' +
+			'{{strong}}Quick Start Sessions will be closed from %(closesAt)s – %(reopensAt)s for the New Year’s holiday.{{/strong}}{{br/}}' +
 				'If you need to get in touch with us, please submit a {{link}}support request from this page{{/link}} and we will get to it as fast as we can. ' +
 				'Quick Start Sessions will re-open at %(reopensAt)s. Thank you for your understanding!',
 			{

--- a/client/me/concierge/shared/primary-header.js
+++ b/client/me/concierge/shared/primary-header.js
@@ -13,9 +13,9 @@ class PrimaryHeader extends Component {
 		return (
 			<Fragment>
 				<ClosureNotice
-					displayAt="2023-12-18 00:00Z"
-					closesAt="2023-12-24 00:00Z"
-					reopensAt="2023-12-26 07:00Z"
+					displayAt="2023-12-26 00:00Z"
+					closesAt="2023-12-31 00:00Z"
+					reopensAt="2024-01-02 07:00Z"
 				/>
 				<Card>
 					<img

--- a/packages/components/src/gm-closure-notice/gm-closure-notice.tsx
+++ b/packages/components/src/gm-closure-notice/gm-closure-notice.tsx
@@ -38,7 +38,6 @@ export function GMClosureNotice( { displayAt, closesAt, reopensAt, enabled }: Pr
 				__i18n_text_domain__
 			),
 			{
-				closes_at: format( DATE_FORMAT_LONG, closesAtDate ),
 				reopens_at: format( DATE_FORMAT_LONG, reopensAtDate ),
 			}
 		),
@@ -65,7 +64,7 @@ export function GMClosureNotice( { displayAt, closesAt, reopensAt, enabled }: Pr
 	const heading = sprintf(
 		/* translators: closes and reopens are dates */
 		__(
-			'Live chat will be closed from %(closes)s – %(reopens)s for the Christmas holiday',
+			'Live chat will be closed from %(closes)s – %(reopens)s for the New Year’s holiday',
 			__i18n_text_domain__
 		),
 		{

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -197,9 +197,9 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 				) }
 				{ supportActivity && <HelpCenterActiveTicketNotice tickets={ supportActivity } /> }
 				<GMClosureNotice
-					displayAt="2023-12-18 00:00Z"
-					closesAt="2023-12-24 00:00Z"
-					reopensAt="2023-12-26 07:00Z"
+					displayAt="2023-12-26 00:00Z"
+					closesAt="2023-12-31 00:00Z"
+					reopensAt="2024-01-02 07:00Z"
 					enabled={ renderChat.render }
 				/>
 


### PR DESCRIPTION
_This patch will be deployed on Dec 26_.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Requested on peCdcN-oA-p2

## Proposed Changes

* Adds a notice for Live Chat closure from Dec 30 to January 1.
* Sets the notice to appear since Dec 26.
* Updates the message for the notice to the one proposed on the P2 post.
## Testing Instructions

1. Change the dates in the code to simulate different cases - before, during and after the closure dates.
2. Test http://calypso.localhost:3000/help/contact, the Help Center (? in the main menu bar on top) and http://calypso.localhost:3000/me/quickstart/
3. Check the message at the top when checking the dates for now, during and after the holiday.

Before:

<img width="737" alt="Screenshot 2023-12-17 at 09 33 38" src="https://github.com/Automattic/wp-calypso/assets/3696121/db8d4da0-879d-4938-b621-21b68a809f32">
<img width="404" alt="Screenshot 2023-12-17 at 09 33 08" src="https://github.com/Automattic/wp-calypso/assets/3696121/7a2bff24-e555-4646-b7ef-31f33a990c31">


During:
The start date in these screenshots was edited in browser to serve as an example:

<img width="737" alt="Screenshot 2023-12-17 at 10 22 08" src="https://github.com/Automattic/wp-calypso/assets/3696121/ccd39f61-9b54-48f0-8272-52e37305cdf6">

<img width="410" alt="Screenshot 2023-12-17 at 09 35 04" src="https://github.com/Automattic/wp-calypso/assets/3696121/a9e145af-9428-49a6-8099-df70e8d7bdac">
