### PR TITLE
Remove statsCountryViews from paywalled stats list

### DIFF
--- a/client/my-sites/stats/hooks/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/use-should-gate-stats.ts
@@ -7,12 +7,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 // TODO: define shared variables
-const trafficPaidStats = [
-	'statsSearchTerms',
-	'statsClicks',
-	'statsReferrers',
-	'statsCountryViews',
-];
+const trafficPaidStats = [ 'statsSearchTerms', 'statsClicks', 'statsReferrers' ];
 
 const featureFlags = [ 'stats/date-control', 'download-csv' ];
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4954

## Proposed Changes

* Removes country views from the list of paywalled stats

## Testing Instructions

* http://calypso.localhost:3000/stats/day/testingtesterson2546.blog
* Country views should no longer be paywalled when the feature flag is flipped on https://wordpress.com/stats/day/testingtesterson2546.blog?flags=stats/paid-wpcom-v2


Before:
![Screenshot 2023-12-18 at 13-51-58 Jetpack Stats ‹ Site Title — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/04374903-22ff-4349-ba3a-8335175d90db)


After:
![Screenshot 2023-12-18 at 13-49-33 Jetpack Stats ‹ Atomic test site 1 — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/bd1f15b8-50bc-4962-8fc6-2065af1db0b9)

