### PR TITLE
Jetpack Manage: Show the 'Issue New License' option only for non-atomic sites

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
@@ -66,7 +66,7 @@ export default function useSiteActions(
 					: undefined,
 				onClick: () => handleClickMenuItem( 'issue_license' ),
 				isExternalLink: false,
-				isEnabled: partnerCanIssueLicense && ! siteError,
+				isEnabled: partnerCanIssueLicense && ! siteError && ! is_atomic,
 			},
 			{
 				name: translate( 'View activity' ),


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-manage/issues/173

## Proposed Changes

This PR hides the `Issue new license` option for atomic sites.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Verify the `Issue new license` site action is shown only for non-atomic sites.

<img width="1056" alt="Screenshot 2023-12-18 at 8 45 43 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/997be6d1-f966-4562-8bf9-7a396fdaf473">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?