### PR TITLE
Assembler: Remove flag pattern-assembler/add-pages

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useSearchParams } from 'react-router-dom';
 import { INITIAL_PAGES } from '../constants';
 import type { Pattern } from '../types';
@@ -7,10 +6,7 @@ const usePatternPages = ( pagesMapByCategory: Record< string, Pattern[] > ) => {
 	const [ searchParams, setSearchParams ] = useSearchParams();
 	const page_slugs = searchParams.get( 'page_slugs' );
 
-	const pageSlugs =
-		page_slugs !== null
-			? page_slugs.split( ',' ).filter( Boolean )
-			: [ ...( isEnabled( 'pattern-assembler/add-pages' ) ? INITIAL_PAGES : [] ) ];
+	const pageSlugs = page_slugs !== null ? page_slugs.split( ',' ).filter( Boolean ) : INITIAL_PAGES;
 
 	const pages = pageSlugs.map( ( slug ) => pagesMapByCategory[ slug ]?.[ 0 ] ).filter( Boolean );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { NAVIGATOR_PATHS } from '../constants';
@@ -22,7 +21,6 @@ export type Screen = {
 };
 
 const useScreen = ( screenName: ScreenName, options: UseScreenOptions = {} ): Screen => {
-	const isAddPagesEnabled = isEnabled( 'pattern-assembler/add-pages' );
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
 	const screens: Record< ScreenName, Screen > = {
@@ -56,9 +54,7 @@ const useScreen = ( screenName: ScreenName, options: UseScreenOptions = {} ): Sc
 				: translate(
 						'Create your homepage by first adding patterns and then choosing a color palette and font style.'
 				  ),
-			continueLabel: isAddPagesEnabled
-				? translate( 'Select pages' )
-				: translate( 'Save and continue' ),
+			continueLabel: translate( 'Select pages' ),
 			backLabel: hasEnTranslation( 'styles' ) ? translate( 'styles' ) : undefined,
 			initialPath: NAVIGATOR_PATHS.STYLES_COLORS,
 		},
@@ -107,36 +103,14 @@ const useScreen = ( screenName: ScreenName, options: UseScreenOptions = {} ): Sc
 		main: null,
 		styles: screens.main,
 		pages: screens.styles,
-		upsell: isAddPagesEnabled ? screens.pages : screens.styles,
-		activation: ( () => {
-			if ( options.shouldUnlockGlobalStyles ) {
-				return screens.upsell;
-			}
-
-			return isAddPagesEnabled ? screens.pages : screens.styles;
-		} )(),
-		confirmation: ( () => {
-			if ( options.shouldUnlockGlobalStyles ) {
-				return screens.upsell;
-			}
-
-			return isAddPagesEnabled ? screens.pages : screens.styles;
-		} )(),
+		upsell: screens.pages,
+		activation: options.shouldUnlockGlobalStyles ? screens.upsell : screens.pages,
+		confirmation: options.shouldUnlockGlobalStyles ? screens.upsell : screens.pages,
 	};
 
 	const nextScreens = {
 		main: screens.styles,
-		styles: ( () => {
-			if ( isAddPagesEnabled ) {
-				return screens.pages;
-			}
-
-			if ( options.shouldUnlockGlobalStyles ) {
-				return screens.upsell;
-			}
-
-			return options.isNewSite ? screens.confirmation : screens.activation;
-		} )(),
+		styles: screens.pages,
 		pages: ( () => {
 			if ( options.shouldUnlockGlobalStyles ) {
 				return screens.upsell;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { getThemeIdFromStylesheet } from '@automattic/data-stores';
 import {
 	useSyncGlobalStylesUserConfig,
@@ -681,8 +680,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 					activePosition={ activePosition }
 					pages={
 						// Consider the selected pages in the final screen.
-						isEnabled( 'pattern-assembler/add-pages' ) &&
-						( currentScreen.name === 'confirmation' || currentScreen.name === 'activation' )
+						currentScreen.name === 'confirmation' || currentScreen.name === 'activation'
 							? pages
 							: undefined
 					}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -1,5 +1,4 @@
 import { PatternRenderer } from '@automattic/block-renderer';
-import { isEnabled } from '@automattic/calypso-config';
 import { DeviceSwitcher } from '@automattic/components';
 import { useGlobalStyle } from '@automattic/global-styles';
 import { Popover } from '@wordpress/components';
@@ -308,11 +307,9 @@ const PatternLargePreview = ( {
 					<h2>{ translate( 'Welcome to your homepage.' ) }</h2>
 					<ul>
 						<li>{ translate( 'Select patterns for your homepage.' ) }</li>
-						<li>{ translate( 'Choose your colors and fonts.' ) } </li>
-						{ isEnabled( 'pattern-assembler/add-pages' ) && (
-							<li>{ translate( 'Pick additional site pages.' ) } </li>
-						) }
-						<li>{ translate( 'Add your own content in the Editor.' ) } </li>
+						<li>{ translate( 'Choose your colors and fonts.' ) }</li>
+						<li>{ translate( 'Pick additional site pages.' ) }</li>
+						<li>{ translate( 'Add your own content in the Editor.' ) }</li>
 					</ul>
 				</div>
 			) }

--- a/config/development.json
+++ b/config/development.json
@@ -147,7 +147,6 @@
 		"p2/p2-plus": true,
 		"page/export": true,
 		"pattern-assembler/v2": false,
-		"pattern-assembler/add-pages": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -90,7 +90,6 @@
 		"network-connection": true,
 		"p2/p2-plus": true,
 		"pattern-assembler/v2": false,
-		"pattern-assembler/add-pages": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/production.json
+++ b/config/production.json
@@ -113,7 +113,6 @@
 		"onboarding/interval-dropdown": false,
 		"p2/p2-plus": true,
 		"pattern-assembler/v2": false,
-		"pattern-assembler/add-pages": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -110,7 +110,6 @@
 		"p2/p2-plus": true,
 		"page/export": true,
 		"pattern-assembler/v2": false,
-		"pattern-assembler/add-pages": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -119,7 +119,6 @@
 		"onboarding/interval-dropdown": false,
 		"p2/p2-plus": true,
 		"pattern-assembler/v2": false,
-		"pattern-assembler/add-pages": true,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,
 		"plans/personal-plan": true,

--- a/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
+++ b/packages/design-picker/src/components/pattern-assembler-cta/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useTranslate } from 'i18n-calypso';
@@ -30,9 +29,7 @@ export function usePatternAssemblerCtaData(): PatternAssemblerCtaData {
 			<ul>
 				<li>{ translate( 'Select patterns to create your homepage layout.' ) }</li>
 				<li>{ translate( 'Style it up with premium colors and font pairings.' ) }</li>
-				{ isEnabled( 'pattern-assembler/add-pages' ) && (
-					<li>{ translate( 'Add powerful pages to fill out your site.' ) } </li>
-				) }
+				<li>{ translate( 'Add powerful pages to fill out your site.' ) }</li>
 				<li>{ translate( 'Bring your site to life with your own content.' ) }</li>
 			</ul>
 		) : (


### PR DESCRIPTION
## Proposed Changes

This PR removes the flag `pattern-assembler/add-pages` as a clean-up task since the feature has been in production for a couple of weeks now without critical issues.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler.
* Ensure that the following works as before:
  * The button in the Styles screen should say Select pages.
  * The screen after the Styles screen should be the Pages screen.
  * The screen before the Upsell/Confirmation/Activation screen should be the Pages screen.
  * The back button label in the Upsell/Confirmation/Activation screen should be "back to pages".
  * The About page should be pre-selected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?