### PR TITLE
Revert "Domains onboarding: Only search domain suggestions once on load"

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -333,7 +333,7 @@ class RegisterDomainStep extends Component {
 		const query = this.state.lastQuery || storedQuery || this.getInitialQueryInLaunchFlow();
 
 		if ( query && ! this.state.searchResults && ! this.state.subdomainSearchResults ) {
-			// We used to run the initial search here, it's now triggered on mount in a useEffect inside <Search />
+			this.onSearch( query );
 
 			// Delete the stored query once it is consumed.
 			globalThis?.sessionStorage?.removeItem( SESSION_STORAGE_QUERY_KEY );
@@ -1367,8 +1367,9 @@ class RegisterDomainStep extends Component {
 		} );
 	};
 
-	onSearch = ( searchQuery, { shouldQuerySubdomains = true } = {} ) => {
+	onSearch = async ( searchQuery, { shouldQuerySubdomains = true } = {} ) => {
 		debug( 'onSearch handler was triggered with query', searchQuery );
+
 		const domain = getDomainSuggestionSearch( searchQuery, MIN_QUERY_LENGTH );
 
 		this.setState(


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/85394

Reverts Automattic/wp-calypso#84035