### PR TITLE
Jetpack Manage: Update site action links for atomic sites

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
@@ -70,23 +70,29 @@ export default function useSiteActions(
 			},
 			{
 				name: translate( 'View activity' ),
-				href: `/activity-log/${ siteSlug }`,
+				href: is_atomic
+					? `https://wordpress.com/activity-log/${ siteSlug }`
+					: `/activity-log/${ siteSlug }`,
 				onClick: () => handleClickMenuItem( 'view_activity' ),
-				isExternalLink: false,
+				isExternalLink: is_atomic,
 				isEnabled: ! siteError,
 			},
 			{
 				name: translate( 'Copy this site' ),
-				href: `/backup/${ siteSlug }/clone`,
+				href: is_atomic
+					? `https://wordpress.com/backup/${ siteSlug }/clone`
+					: `/backup/${ siteSlug }/clone`,
 				onClick: () => handleClickMenuItem( 'clone_site' ),
-				isExternalLink: false,
+				isExternalLink: is_atomic,
 				isEnabled: has_backup,
 			},
 			{
 				name: translate( 'Site settings' ),
-				href: `/settings/${ siteSlug }`,
+				href: is_atomic
+					? `https://wordpress.com/settings/general/${ siteSlug }`
+					: `/settings/${ siteSlug }`,
 				onClick: () => handleClickMenuItem( 'site_settings' ),
-				isExternalLink: false,
+				isExternalLink: is_atomic,
 				isEnabled: has_backup,
 			},
 			{
@@ -104,5 +110,5 @@ export default function useSiteActions(
 				isEnabled: true,
 			},
 		];
-	}, [ dispatch, isLargeScreen, siteError, siteValue, translate ] );
+	}, [ dispatch, isLargeScreen, partnerCanIssueLicense, siteError, siteValue, translate ] );
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-manage/issues/179
Resolves https://github.com/Automattic/jetpack-manage/issues/180
Resolves https://github.com/Automattic/jetpack-manage/issues/181

## Proposed Changes

This PR updates:

- Redirect to WP.com for site action: **View activity**
- Redirect to WP.com for site action: **View activity**
- Redirect to WP.com for site action: **Copy site settings**


## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Visit Dashboard
2. Verify the actions: **View activity**, **View activity** & **Copy site settings** for atomic sites redirect to equivalent WP.com links.
3. Verify it works as expected for non-atomic sites.

<img width="274" alt="Screenshot 2023-12-18 at 1 00 52 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/bd1c24ec-c608-4899-9aa2-20859d57bdfe">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?