### PR TITLE
Jetpack Manage: Disable monitor activation for atomic sites

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity.tsx
@@ -99,18 +99,19 @@ export default function MonitorActivity( { hasMonitor, site, trackEvent, hasErro
 		<ExpandedCard
 			header={ translate( 'Monitor activity' ) }
 			isEnabled={ hasMonitor }
-			emptyContent={ translate(
-				'Activate {{strong}}Monitor{{/strong}} to see your uptime records',
-				{
-					components: {
-						strong: <strong></strong>,
-					},
-				}
-			) }
+			emptyContent={
+				site.is_atomic
+					? translate( 'Monitoring is managed by WordPress.com' )
+					: translate( 'Activate {{strong}}Monitor{{/strong}} to see your uptime records', {
+							components: {
+								strong: <strong></strong>,
+							},
+					  } )
+			}
 			isLoading={ isLoading }
 			hasError={ hasError }
-			// Allow to click on the card only if the monitor is not active
-			onClick={ ! hasMonitor ? handleOnClick : undefined }
+			// Allow to click on the card only if the monitor is not active & the site is not atomic
+			onClick={ ! hasMonitor && ! site.is_atomic ? handleOnClick : undefined }
 		>
 			{ hasMonitor && <MonitorDataContent siteId={ site.blog_id } /> }
 		</ExpandedCard>


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-manage/issues/182

## Proposed Changes

This PR disables monitor activation for atomic sites.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Visit the Dashboard
2. Expand the site content for any atomic site > Verify that the monitor card is disabled and display the text: `Monitoring is managed by WordPress.com` when the monitor is disabled. To disable monitor: https://wordpress.com/settings/security/:site

<img width="344" alt="Screenshot 2023-12-18 at 1 12 15 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8f79caec-0f96-4e40-bbd3-4b51d8d55aa2">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?