### PR TITLE
Use API plans for the premium themes badges in designSetup flow

### DIFF
--- a/client/components/theme-type-badge/test/index.jsx
+++ b/client/components/theme-type-badge/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Provider } from 'react-redux';
@@ -38,7 +39,11 @@ describe( 'ThemeTypeBadge', () => {
 		const mockStore = configureStore();
 		const store = mockStore( initialState );
 
-		return render( <Provider store={ store }>{ content }</Provider> );
+		return render(
+			<QueryClientProvider client={ new QueryClient() }>
+				<Provider store={ store }>{ content }</Provider>
+			</QueryClientProvider>
+		);
 	}
 
 	describe( 'Premium theme popover', () => {

--- a/client/components/theme-type-badge/tooltip.tsx
+++ b/client/components/theme-type-badge/tooltip.tsx
@@ -1,5 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { PLAN_BUSINESS, PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
+import { PLAN_BUSINESS, PLAN_PREMIUM } from '@automattic/calypso-products';
+import { usePlans } from '@automattic/data-stores/src/plans';
 import {
 	BUNDLED_THEME,
 	DOT_ORG_THEME,
@@ -71,6 +72,8 @@ const ThemeTypeBadgeTooltip = ( {
 	themeId,
 }: Props ) => {
 	const translate = useTranslate();
+	// Using API plans because the updated getTitle() method doesn't take the experiment assignment into account.
+	const plans = usePlans();
 	const type = useSelector( ( state ) => getThemeType( state, themeId ) );
 	const bundleSettings = useBundleSettingsByTheme( themeId );
 	const isIncludedCurrentPlan = useSelector(
@@ -148,7 +151,7 @@ const ThemeTypeBadgeTooltip = ( {
 			)
 				? translate(
 						'Unlock this style, and tons of other features, by upgrading to a %(premiumPlanName)s plan.',
-						{ args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' } }
+						{ args: { premiumPlanName: plans?.data?.[ PLAN_PREMIUM ]?.productNameShort ?? '' } }
 				  )
 				: translate(
 						'Unlock this style, and tons of other features, by upgrading to a Premium plan.'
@@ -166,7 +169,7 @@ const ThemeTypeBadgeTooltip = ( {
 					)
 					? ( translate(
 							'This premium theme is included in the <Link>%(premiumPlanName)s plan</Link>.',
-							{ args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' } }
+							{ args: { premiumPlanName: plans?.data?.[ PLAN_PREMIUM ]?.productNameShort ?? '' } }
 					  ) as string )
 					: translate( 'This premium theme is included in the <Link>Premium plan</Link>.' ),
 				{
@@ -190,7 +193,11 @@ const ThemeTypeBadgeTooltip = ( {
 						)
 						? ( translate(
 								'This community theme can only be installed if you have the <Link>%(businessPlanName)s plan</Link> or higher on your site.',
-								{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
+								{
+									args: {
+										businessPlanName: plans?.data?.[ PLAN_BUSINESS ]?.productNameShort ?? '',
+									},
+								}
 						  ) as string )
 						: translate(
 								'This community theme can only be installed if you have the <Link>Business plan</Link> or higher on your site.'
@@ -226,7 +233,7 @@ const ThemeTypeBadgeTooltip = ( {
 								{
 									args: {
 										bundleName,
-										businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+										businessPlanName: plans?.data?.[ PLAN_BUSINESS ]?.productNameShort ?? '',
 									},
 									textOnly: true,
 								}
@@ -259,7 +266,7 @@ const ThemeTypeBadgeTooltip = ( {
 				)
 					? translate(
 							'You have a subscription for this theme, and it will be usable as long as you keep a %(businessPlanName)s plan or higher on your site.',
-							{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
+							{ args: { businessPlanName: plans?.data?.[ PLAN_BUSINESS ]?.productNameShort ?? '' } }
 					  )
 					: translate(
 							'You have a subscription for this theme, and it will be usable as long as you keep a Business plan or higher on your site.'
@@ -272,7 +279,7 @@ const ThemeTypeBadgeTooltip = ( {
 					)
 					? ( translate(
 							'You have a subscription for this theme, but it will only be usable if you have the <link>%(businessPlanName)s plan</link> on your site.',
-							{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
+							{ args: { businessPlanName: plans?.data?.[ PLAN_BUSINESS ]?.productNameShort ?? '' } }
 					  ) as string )
 					: translate(
 							'You have a subscription for this theme, but it will only be usable if you have the <link>Business plan</link> on your site.'
@@ -311,7 +318,7 @@ const ThemeTypeBadgeTooltip = ( {
 								args: {
 									annualPrice: subscriptionPrices.year ?? '',
 									monthlyPrice: subscriptionPrices.month ?? '',
-									businessNamePlan: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									businessNamePlan: plans?.data?.[ PLAN_BUSINESS ]?.productNameShort ?? '',
 								},
 							}
 					  ) as string )

--- a/config/development.json
+++ b/config/development.json
@@ -219,7 +219,7 @@
 		"themes/text-search-lots": true,
 		"themes/theme-switch-persist-template": false,
 		"themes/assembler-first": true,
-		"themes/tiers": true,
+		"themes/tiers": false,
 		"titan/iframe-control-panel": false,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,

--- a/config/development.json
+++ b/config/development.json
@@ -219,7 +219,7 @@
 		"themes/text-search-lots": true,
 		"themes/theme-switch-persist-template": false,
 		"themes/assembler-first": true,
-		"themes/tiers": false,
+		"themes/tiers": true,
 		"titan/iframe-control-panel": false,
 		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85348

## Proposed Changes

This fixes an issue where the assigned variation of the plan names is not followed in the premium theme tooltips from the setup design flow. This is visible only if the `themes/tiers` flag is false.

Although in #85348 the plan names we unhardcoded, the assignment doesn't get used so pointing to the plan names API can be a simple workaround; which is what this PR is attempting.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow instructions from D130166-code to get assigned the experiment
* Set the `themes/tiers` flag to false
* Go to `/setup/site-setup/designSetup?siteSlug=[FREE_SITE_SLUG]`
* Hovering the `Premium` theme badges should show the assigned plan names.
<img width="240" alt="Screenshot 2023-12-18 at 10 30 40" src="https://github.com/Automattic/wp-calypso/assets/2749938/d65350c9-cbe0-4031-b979-fb7f0d9e15ea">
<img width="240" alt="Screenshot 2023-12-18 at 10 28 30" src="https://github.com/Automattic/wp-calypso/assets/2749938/88e21185-8133-4e9c-83c0-4bbc5f1b69da">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
