### PR TITLE
Update/self service reset notice copy

### DIFF
--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -129,7 +129,7 @@ function SiteResetCard( {
 
 			if ( latestStatus === 'completed' ) {
 				dispatch(
-					successNotice( translate( 'Your site was successfully reset.' ), {
+					successNotice( translate( 'Your site was successfully reset' ), {
 						id: 'site-reset-success-notice',
 						duration: 4000,
 					} )
@@ -140,7 +140,7 @@ function SiteResetCard( {
 
 	const handleError = () => {
 		dispatch(
-			errorNotice( translate( 'We were unable to reset your site.' ), {
+			errorNotice( translate( 'We were unable to reset your site' ), {
 				id: 'site-reset-failure-notice',
 				duration: 6000,
 			} )
@@ -151,7 +151,7 @@ function SiteResetCard( {
 		if ( result.success ) {
 			if ( isAtomic ) {
 				dispatch(
-					successNotice( translate( 'Your site will be reset. ' ), {
+					successNotice( translate( 'Your site will be reset' ), {
 						id: 'site-reset-success-notice',
 						duration: 6000,
 					} )
@@ -159,7 +159,7 @@ function SiteResetCard( {
 				refetchResetStatus();
 			} else {
 				dispatch(
-					successNotice( translate( 'Your site was successfully reset.' ), {
+					successNotice( translate( 'Your site was successfully reset' ), {
 						id: 'site-reset-success-notice',
 						duration: 4000,
 					} )

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -129,7 +129,7 @@ function SiteResetCard( {
 
 			if ( latestStatus === 'completed' ) {
 				dispatch(
-					successNotice( translate( 'Your site has been reset.' ), {
+					successNotice( translate( 'Your site was successfully reset.' ), {
 						id: 'site-reset-success-notice',
 						duration: 4000,
 					} )
@@ -159,7 +159,7 @@ function SiteResetCard( {
 				refetchResetStatus();
 			} else {
 				dispatch(
-					successNotice( translate( 'Your site has been reset.' ), {
+					successNotice( translate( 'Your site was successfully reset.' ), {
 						id: 'site-reset-success-notice',
 						duration: 4000,
 					} )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the l inked issue.
-->

![image](https://github.com/Automattic/wp-calypso/assets/6851384/ab031aa0-a879-43b6-a808-b25ad80cd199)


Closes https://github.com/Automattic/wp-calypso/issues/85212

## Proposed Changes

* Tweak copy as suggested by @javierarce in https://github.com/Automattic/wp-calypso/issues/85212
* Also removed period from notices

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using this branch, reset a Simple and Atomic site
* Confirm notices match design

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?