### PR TITLE
Global Styles: Fix logic to show the "Included in your plan" badge

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -827,6 +827,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 						! isPluginBundleEligible &&
 						shouldLimitGlobalStyles
 					}
+					needsUpgrade={ shouldLimitGlobalStyles || isLockedTheme }
 					title={ headerDesignTitle }
 					selectedDesignTitle={ designTitle }
 					shortDescription={ selectedDesign.description }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -779,14 +779,16 @@ class ThemeSheet extends Component {
 	};
 
 	renderStyleVariations = () => {
-		const { styleVariations } = this.props;
+		const { isPremium, isThemePurchased, shouldLimitGlobalStyles, styleVariations } = this.props;
 
 		const splitDefaultVariation =
 			! this.props.isExternallyManagedTheme &&
-			! this.props.isThemePurchased &&
 			! this.props.isBundledSoftwareSet &&
-			! this.props.isPremium &&
-			this.props.shouldLimitGlobalStyles;
+			! isThemePurchased &&
+			! isPremium &&
+			shouldLimitGlobalStyles;
+
+		const needsUpgrade = shouldLimitGlobalStyles || ( isPremium && ! isThemePurchased );
 
 		return (
 			styleVariations.length > 0 && (
@@ -795,6 +797,7 @@ class ThemeSheet extends Component {
 					splitDefaultVariation={ splitDefaultVariation }
 					selectedVariation={ this.getSelectedStyleVariation() }
 					variations={ styleVariations }
+					needsUpgrade={ needsUpgrade }
 					onClick={ this.onStyleVariationClick }
 				/>
 			)

--- a/client/my-sites/theme/theme-style-variations/index.tsx
+++ b/client/my-sites/theme/theme-style-variations/index.tsx
@@ -8,6 +8,7 @@ interface ThemeStyleVariationsProps {
 	selectedVariation: StyleVariation;
 	variations: StyleVariation[];
 	splitDefaultVariation: boolean;
+	needsUpgrade: boolean;
 	onClick: ( variation: StyleVariation ) => void;
 }
 
@@ -16,6 +17,7 @@ const ThemeStyleVariations = ( {
 	selectedVariation,
 	variations,
 	splitDefaultVariation,
+	needsUpgrade,
 	onClick,
 }: ThemeStyleVariationsProps ) => {
 	return (
@@ -31,6 +33,7 @@ const ThemeStyleVariations = ( {
 					splitDefaultVariation={ splitDefaultVariation }
 					displayFreeLabel={ splitDefaultVariation }
 					showOnlyHoverViewDefaultVariation={ false }
+					needsUpgrade={ needsUpgrade }
 					onSelect={ onClick }
 				/>
 			</div>

--- a/packages/design-preview/src/components/index.tsx
+++ b/packages/design-preview/src/components/index.tsx
@@ -22,6 +22,7 @@ interface DesignPreviewProps {
 	selectedDesignTitle: string;
 	onSelectVariation: ( variation: StyleVariation ) => void;
 	splitDefaultVariation: boolean;
+	needsUpgrade?: boolean;
 	onClickCategory?: ( category: Category ) => void;
 	actionButtons: React.ReactNode;
 	recordDeviceClick: ( device: string ) => void;
@@ -56,6 +57,7 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 	selectedVariation,
 	onSelectVariation,
 	splitDefaultVariation,
+	needsUpgrade,
 	onClickCategory,
 	actionButtons,
 	recordDeviceClick,
@@ -96,6 +98,7 @@ const Preview: React.FC< DesignPreviewProps > = ( {
 		limitGlobalStyles,
 		variations,
 		splitDefaultVariation,
+		needsUpgrade,
 		selectedVariation,
 		selectedColorVariation,
 		selectedFontVariation,

--- a/packages/design-preview/src/hooks/use-screens.tsx
+++ b/packages/design-preview/src/hooks/use-screens.tsx
@@ -22,6 +22,7 @@ interface Props {
 	limitGlobalStyles?: boolean;
 	variations?: StyleVariation[];
 	splitDefaultVariation: boolean;
+	needsUpgrade?: boolean;
 	selectedVariation?: StyleVariation;
 	selectedColorVariation: GlobalStylesObject | null;
 	selectedFontVariation: GlobalStylesObject | null;
@@ -42,6 +43,7 @@ const useScreens = ( {
 	limitGlobalStyles,
 	variations,
 	splitDefaultVariation,
+	needsUpgrade,
 	selectedVariation,
 	selectedColorVariation,
 	selectedFontVariation,
@@ -71,6 +73,7 @@ const useScreens = ( {
 									globalStylesVariations={ variations as GlobalStylesObject[] }
 									selectedGlobalStylesVariation={ selectedVariation as GlobalStylesObject }
 									splitDefaultVariation={ splitDefaultVariation }
+									needsUpgrade={ needsUpgrade }
 									showOnlyHoverViewDefaultVariation={ false }
 									onSelect={ ( globalStyleVariation: GlobalStylesObject ) =>
 										onSelectVariation( globalStyleVariation as StyleVariation )

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -28,6 +28,7 @@ interface GlobalStylesVariationsProps {
 	description?: TranslateResult;
 	showOnlyHoverViewDefaultVariation?: boolean;
 	splitDefaultVariation?: boolean;
+	needsUpgrade?: boolean;
 	onSelect: ( globalStylesVariation: GlobalStylesObject ) => void;
 }
 
@@ -96,8 +97,9 @@ const GlobalStylesVariations = ( {
 	selectedGlobalStylesVariation,
 	description,
 	showOnlyHoverViewDefaultVariation,
-	onSelect,
 	splitDefaultVariation = true,
+	needsUpgrade = true,
+	onSelect,
 }: GlobalStylesVariationsProps ) => {
 	const isRegisteredCoreBlocks = useRegisterCoreBlocks();
 	const premiumStylesDescription = translate(
@@ -148,7 +150,7 @@ const GlobalStylesVariations = ( {
 					<div className="global-styles-variations__header">
 						<h2>
 							<span>{ headerText }</span>
-							{ ! splitDefaultVariation && (
+							{ ! splitDefaultVariation && ! needsUpgrade && (
 								<PremiumBadge
 									shouldHideTooltip
 									shouldCompactWithAnimation


### PR DESCRIPTION
## Proposed Changes

This PR fixes an issue where the badge "Included in your plan" is shown for Free plan users viewing Premium themes global styles. See screenshot for reference:
 
![Screenshot 2023-12-18 at 5 15 57 PM](https://github.com/Automattic/wp-calypso/assets/797888/7d05434d-2de7-403c-b5bd-e772fd462f7a)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a Free site.
  * Head to the Theme Showcase.
  * Select a Free theme with style variations.
  * Ensure that the style variations are split, and that the badge next to Premium Styles says "Premium".
  * Go back to the Theme Showcase, and select a Premium theme with style variations (e.g.: Podcasty)
  * Ensure that the style variations are not split, and that there is no badge next to Styles.
  * Ensure that the same happens for WooCommerce themes with style variations, such as Tazza.
  * Test the same steps above for the Onboarding Design Picker.

* Use a Premium site.
  * Head to the Theme Showcase.
  * Select a Free theme with style variations.
  * Ensure that the style variations are not split, and that the badge next to Styles says "Included in your plan".
  * Select a Premium theme, and ensure that the same happens.
  * Go back to the Theme Showcase, and select a WooCommerce theme with style variations.
  * Ensure that the style variations are not split, and that there is no badge next to Styles.
  * Test the same steps above for the Onboarding Design Picker.

* Use a Commerce site.
  * All themes with style variations should show style variations without split, and with badge next to Styles saying "Included in your plan".

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?