### PR TITLE
Fix domain price alignment in domain search results

### DIFF
--- a/client/components/domains/domain-product-price/style.scss
+++ b/client/components/domains/domain-product-price/style.scss
@@ -6,6 +6,7 @@
 	display: flex;
 	flex-direction: column;
 	text-align: right;
+	justify-content: center;
 
 	@include breakpoint-deprecated( ">660px" ) {
 		align-items: flex-end;


### PR DESCRIPTION
## Proposed Changes

This PR fixes the price alignment in domain search results items, when the domain name takes more then one line.

### Before
![price-before](https://github.com/Automattic/wp-calypso/assets/2797601/c9b8b81f-e416-4021-bae6-e73707a303e4)

### After
![price-after](https://github.com/Automattic/wp-calypso/assets/2797601/a7ef65f9-cbb7-428c-a61c-bfffa7033bf2)

## Testing Instructions
Build this PR locally or use the Calypso link below, the visit the onboarding page (`/start/domains`) and use fill the search input field with a long domain name.

Verify the that then price is vertically centered in the result rows.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?