### PR TITLE
Import capture: Update parent class name, avoiding style overrides

### DIFF
--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable wpcalypso/jsx-classname-namespace */
 import { Button } from '@automattic/components';
 import { NextButton } from '@automattic/onboarding';
 import { createElement, createInterpolateElement } from '@wordpress/element';
@@ -65,7 +64,7 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 	}
 
 	return (
-		<form className={ classnames( 'import-light__capture' ) } onSubmit={ onFormSubmit }>
+		<form className="import__capture" onSubmit={ onFormSubmit }>
 			<FormFieldset>
 				<FormLabel>{ translate( 'Enter the URL of the site:' ) }</FormLabel>
 				<FormTextInput

--- a/client/blocks/import/capture/style.scss
+++ b/client/blocks/import/capture/style.scss
@@ -3,7 +3,7 @@
 	margin: 0 auto;
 }
 
-.import-light__capture {
+.import__capture {
 	.form-label {
 		font-size: 0.875rem;
 		font-weight: 500;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/4963

## Proposed Changes

* Update parent class name which was in conflict with the import-light feature fixing style issue on the capture screen

## Testing Instructions

* Go to `/setup/site-setup/import?siteSlug={SLUG}`
* Check if capture screen looks like on design

**Before:**
<img width="589" alt="Screenshot 2023-12-18 at 11 34 53" src="https://github.com/Automattic/wp-calypso/assets/1241413/e44dbd5b-547c-4d17-86e2-fac1477ff470">

**After:**
<img width="596" alt="Screenshot 2023-12-18 at 11 35 02" src="https://github.com/Automattic/wp-calypso/assets/1241413/7d611dcf-aebb-4b69-8464-6ad69b54b030">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?