### PR TITLE
Updated copy for upsell in plan selection screen

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
@@ -48,7 +48,7 @@ export default function PaidPlanIsRequiredDialog( {
 			</Heading>
 			<SubHeading id="plan-upsell-modal-description">
 				{ translate(
-					'Custom domains are only available with a paid plan. And they are free for the first year with an annual paid plan.'
+					"Custom domains are only available with a paid plan. Choose annual billing and receive the domain's first year free."
 				) }
 			</SubHeading>
 			<ButtonContainer>

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
@@ -1,5 +1,5 @@
 import { LoadingPlaceholder } from '@automattic/components';
-import { useLocale } from '@automattic/i18n-utils';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useEffect, useState } from '@wordpress/element';
 import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
@@ -43,8 +43,7 @@ export default function PaidPlanIsRequiredDialog( {
 		onFreePlanSelected();
 	}
 
-	const localeSlug = useLocale();
-	const isEnglish = localeSlug && localeSlug.startsWith( 'en' );
+	const isEnglish = useIsEnglishLocale();
 	const upsellDescription =
 		isEnglish ||
 		hasTranslation(

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
@@ -1,5 +1,7 @@
 import { LoadingPlaceholder } from '@automattic/components';
+import { useLocale } from '@automattic/i18n-utils';
 import { useEffect, useState } from '@wordpress/element';
+import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
@@ -41,16 +43,26 @@ export default function PaidPlanIsRequiredDialog( {
 		onFreePlanSelected();
 	}
 
+	const localeSlug = useLocale();
+	const isEnglish = localeSlug && localeSlug.startsWith( 'en' );
+	const upsellDescription =
+		isEnglish ||
+		hasTranslation(
+			"Custom domains are only available with a paid plan. Choose annual billing and receive the domain's first year free."
+		)
+			? translate(
+					"Custom domains are only available with a paid plan. Choose annual billing and receive the domain's first year free."
+			  )
+			: translate(
+					'Custom domains are only available with a paid plan. And they are free for the first year with an annual paid plan.'
+			  );
+
 	return (
 		<DialogContainer>
 			<Heading id="plan-upsell-modal-title" shrinkMobileFont>
 				{ translate( 'A paid plan is required for your domain.' ) }
 			</Heading>
-			<SubHeading id="plan-upsell-modal-description">
-				{ translate(
-					"Custom domains are only available with a paid plan. Choose annual billing and receive the domain's first year free."
-				) }
-			</SubHeading>
+			<SubHeading id="plan-upsell-modal-description">{ upsellDescription }</SubHeading>
 			<ButtonContainer>
 				<RowWithBorder>
 					<SuggestedPlanSection


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/85194

## Proposed Changes

This PR changes the copy of the upsell popup in the plan selection screen.

## Testing Instructions

- Apply this PR and start the application. 
- In an incognito window, go to http://calypso.localhost:3000/start
- Create an account using an email.
- Select a paid domain (.com, for example).
- In the plan selection screen, select the Free plan.
- You will see the upsell popup with the new phrase.
<img width="701" alt="Screenshot 2023-12-18 at 11 39 07" src="https://github.com/Automattic/wp-calypso/assets/3832570/fc2de955-717a-4fa4-be74-19c3bf9cb6aa">


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?