### PR TITLE
Domains: Update conditions for showing Manage All Domains CTA.

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -1,6 +1,6 @@
 import page from '@automattic/calypso-router';
 import { useSiteDomainsQuery } from '@automattic/data-stores';
-import { DomainsTable, ResponseDomain } from '@automattic/domains-table';
+import { DomainsTable, ResponseDomain, useDomainsTable } from '@automattic/domains-table';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import SiteAddressChanger from 'calypso/blocks/site-address-changer';
@@ -82,9 +82,11 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 	const [ changeSiteAddressSourceDomain, setChangeSiteAddressSourceDomain ] =
 		useState< ResponseDomain | null >( null );
 
-	// If a site contains more than one domain that is not a subdomain.
+	// If user has more than 1 domain on more than 1 site, show manage all domains CTA.
+	const { domains: allDomains } = useDomainsTable( fetchAllDomains );
 	const showManageAllDomainsCTA =
-		( data?.domains ?? [] ).filter( ( domain ) => ! domain.is_subdomain ).length > 1;
+		( allDomains || [] ).length > 1 &&
+		[ ...new Set( ( allDomains || [] ).map( ( domain ) => domain.blog_id ) ) ].length > 1;
 
 	return (
 		<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/84992 and https://github.com/Automattic/wp-calypso/pull/85157#discussion_r1425551908

## Proposed Changes

* Manage All Domains CTA should show on single site domain management page when user has more than 1 domain on more than 1 sites.

## Testing Instructions

* Go to `domains/manage/your_site_here.wordpress.com` on an account with > 1 site and > 1 domain.
* The "Manage All Domains CTA" should show.
* Go to `domains/manage/your_site_here.wordpress.com` on an account with >1 site but <= 1 domain.
* The "Manage All Domains CTA" should not show.

## Screenshots

<img width="1245" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1287077/bae45e28-9d6b-473e-9eaa-c1355392b749">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?