### PR TITLE
BBE Page Picker: add 1-click checkout

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-complete-callback.tsx
@@ -237,7 +237,12 @@ export default function useCreatePaymentCompleteCallback( {
 
 			// We need to do a hard redirect if we're redirecting to the stepper.
 			// Since stepper is self-contained, it doesn't load properly if we do a normal history state change
-			if ( isURL( url ) || url.includes( '/setup/' ) ) {
+			// The same is true if we are redirecting to the signup flow, we are restricting it to only 1 specific flow here.
+			if (
+				isURL( url ) ||
+				url.includes( '/setup/' ) ||
+				url.includes( '/start/site-content-collection' )
+			) {
 				absoluteRedirectThroughPending( url, {
 					siteSlug,
 					orderId: 'order_id' in transactionResult ? transactionResult.order_id : undefined,

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/content.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/content.tsx
@@ -14,6 +14,7 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useCallback } from 'react';
 import CheckoutTerms from 'calypso/my-sites/checkout/src/components/checkout-terms';
 import { CheckIcon } from '../../src/components/check-icon';
+import CheckoutNextSteps from '../../src/components/checkout-next-steps';
 import { CheckoutSummaryFeaturesList } from '../../src/components/wp-checkout-order-summary';
 import { BEFORE_SUBMIT } from './constants';
 import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
@@ -61,8 +62,7 @@ function LineItemIntroductoryOffer( { product }: { product: ResponseCartProduct 
 	);
 }
 
-function OrderStep( { siteSlug, product }: { siteSlug: string; product: ResponseCartProduct } ) {
-	const translate = useTranslate();
+function OrderStepRow( { product }: { product: ResponseCartProduct } ) {
 	const originalAmountDisplay = formatCurrency(
 		product.item_original_subtotal_integer,
 		product.currency,
@@ -77,29 +77,46 @@ function OrderStep( { siteSlug, product }: { siteSlug: string; product: Response
 	const isDiscounted = Boolean(
 		product.item_subtotal_integer < originalAmountInteger && originalAmountDisplay
 	);
+	return (
+		<div className="purchase-modal__order-step-row">
+			<div className="purchase-modal__step-content-row">
+				<span className="purchase-modal__product-name">{ product.product_name }</span>
+				<span className="purchase-modal__product-cost">
+					{ isDiscounted && originalAmountDisplay ? (
+						<>
+							<s>{ originalAmountDisplay }</s> { actualAmountDisplay }
+						</>
+					) : (
+						actualAmountDisplay
+					) }
+				</span>
+			</div>
+
+			<div className="purchase-modal__step-content-row">
+				<LineItemSublabelAndPrice product={ product } />
+				<LineItemIntroductoryOffer product={ product } />
+			</div>
+		</div>
+	);
+}
+
+function OrderStep( {
+	siteSlug,
+	products,
+}: {
+	siteSlug: string;
+	products: ResponseCartProduct[];
+} ) {
+	const translate = useTranslate();
 
 	return (
-		<PurchaseModalStep id={ product.product_slug }>
+		<PurchaseModalStep id="test">
 			<div className="purchase-modal__step-title">{ translate( 'Your order' ) }</div>
 			<div className="purchase-modal__step-content">
 				<div>{ translate( 'Site: %(siteSlug)s', { args: { siteSlug } } ) }</div>
-				<div className="purchase-modal__step-content-row">
-					<span className="purchase-modal__product-name">{ product.product_name }</span>
-					<span className="purchase-modal__product-cost">
-						{ isDiscounted && originalAmountDisplay ? (
-							<>
-								<s>{ originalAmountDisplay }</s> { actualAmountDisplay }
-							</>
-						) : (
-							actualAmountDisplay
-						) }
-					</span>
-				</div>
-
-				<div className="purchase-modal__step-content-row">
-					<LineItemSublabelAndPrice product={ product } />
-					<LineItemIntroductoryOffer product={ product } />
-				</div>
+				{ products.map( ( product ) => (
+					<OrderStepRow key={ product.product_id } product={ product } />
+				) ) }
 			</div>
 		</PurchaseModalStep>
 	);
@@ -222,7 +239,6 @@ export default function PurchaseModalContent( {
 } ) {
 	const translate = useTranslate();
 	const creditsLineItem = getCreditsLineItemFromCart( cart );
-	const firstProduct = cart.products.length > 0 ? cart.products[ 0 ] : undefined;
 	const firstCard = cards.length > 0 ? cards[ 0 ] : undefined;
 
 	return (
@@ -236,7 +252,7 @@ export default function PurchaseModalContent( {
 				>
 					<Gridicon icon="cross-small" />
 				</Button>
-				{ firstProduct && <OrderStep siteSlug={ siteSlug } product={ firstProduct } /> }
+				{ cart.products?.length && <OrderStep siteSlug={ siteSlug } products={ cart.products } /> }
 				{ firstCard && <PaymentMethodStep siteSlug={ siteSlug } card={ firstCard } /> }
 				<CheckoutTerms cart={ cart } />
 				<OrderReview
@@ -270,6 +286,7 @@ export default function PurchaseModalContent( {
 						siteId={ cart.blog_id }
 						nextDomainIsFree={ cart.next_domain_is_free }
 					/>
+					<CheckoutNextSteps responseCart={ cart } />
 				</div>
 			) }
 		</div>

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/content.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/content.tsx
@@ -110,7 +110,7 @@ function OrderStep( {
 	const translate = useTranslate();
 
 	return (
-		<PurchaseModalStep id="test">
+		<PurchaseModalStep id="purchase-modal-step">
 			<div className="purchase-modal__step-title">{ translate( 'Your order' ) }</div>
 			<div className="purchase-modal__step-content">
 				<div>{ translate( 'Site: %(siteSlug)s', { args: { siteSlug } } ) }</div>
@@ -252,7 +252,9 @@ export default function PurchaseModalContent( {
 				>
 					<Gridicon icon="cross-small" />
 				</Button>
-				{ cart.products?.length && <OrderStep siteSlug={ siteSlug } products={ cart.products } /> }
+				{ cart.products?.length ? (
+					<OrderStep siteSlug={ siteSlug } products={ cart.products } />
+				) : null }
 				{ firstCard && <PaymentMethodStep siteSlug={ siteSlug } card={ firstCard } /> }
 				<CheckoutTerms cart={ cart } />
 				<OrderReview

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -3,8 +3,7 @@ import { Dialog } from '@automattic/components';
 import { CheckoutProvider } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import classNames from 'classnames';
-import { useState, useMemo, useEffect } from 'react';
-import QueryPaymentCountries from 'calypso/components/data/query-countries/payments';
+import { useState, useMemo, useEffect, type PropsWithChildren } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isCreditCard, type StoredPaymentMethodCard } from 'calypso/lib/checkout/payment-methods';
 import useCreatePaymentCompleteCallback from 'calypso/my-sites/checkout/src/hooks/use-create-payment-complete-callback';
@@ -12,10 +11,10 @@ import existingCardProcessor from 'calypso/my-sites/checkout/src/lib/existing-ca
 import getContactDetailsType from 'calypso/my-sites/checkout/src/lib/get-contact-details-type';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useDispatch, useSelector } from 'calypso/state';
-import getCountries from 'calypso/state/selectors/get-countries';
 import { getSiteId } from 'calypso/state/sites/selectors';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import useCountryList from '../../src/hooks/use-country-list';
 import { useStoredPaymentMethods } from '../../src/hooks/use-stored-payment-methods';
 import { updateCartContactDetailsForCheckout } from '../../src/lib/update-cart-contact-details-for-checkout';
 import { BEFORE_SUBMIT } from './constants';
@@ -25,6 +24,7 @@ import { useSubmitTransaction } from './use-submit-transaction';
 import type { MinimalRequestCartProduct, ResponseCart } from '@automattic/shopping-cart';
 import type { ManagedContactDetails, ManagedValue, VatDetails } from '@automattic/wpcom-checkout';
 import type { PaymentProcessorOptions } from 'calypso/my-sites/checkout/src/types/payment-processors';
+import type { SiteSlug } from 'calypso/types';
 
 import './style.scss';
 
@@ -92,7 +92,7 @@ export function wrapValueInManagedValue( value: string | undefined ): ManagedVal
 	};
 }
 
-export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
+function PurchaseModalWrapper( props: PurchaseModalProps ) {
 	const { onClose, productToAdd, siteSlug, showFeatureList } = props;
 
 	const onComplete = useCreatePaymentCompleteCallback( {
@@ -101,27 +101,14 @@ export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
 	} );
 	const { stripe, stripeConfiguration } = useStripe();
 	const reduxDispatch = useDispatch();
-
-	const selectedSite = useSelector( getSelectedSite );
-	const siteId = useSelector( ( state ) => getSiteId( state, siteSlug ) );
-
-	// Set the selected site if it is not set already.
-	// This is necessary for the cart and post-purchase actions to function correctly.
-	const hasSelectedSiteId = selectedSite?.slug && siteSlug === selectedSite.slug;
-	useEffect( () => {
-		if ( ! hasSelectedSiteId && siteId ) {
-			reduxDispatch( setSelectedSiteId( siteId ) );
-		}
-	}, [ hasSelectedSiteId, reduxDispatch, siteId ] );
-
 	const cartKey = useCartKey();
 	const { responseCart, updateLocation, replaceProductsInCart, isPendingUpdate } =
 		useShoppingCart( cartKey );
-
+	const selectedSite = useSelector( getSelectedSite );
 	const paymentMethodsState = useStoredPaymentMethods( {
 		type: 'card',
 	} );
-	const countries = useSelector( ( state ) => getCountries( state, 'payments' ) );
+	const countries = useCountryList();
 
 	const cards = paymentMethodsState.paymentMethods.filter( isCreditCard );
 	const contactDetailsType = getContactDetailsType( responseCart );
@@ -157,16 +144,10 @@ export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
 		]
 	);
 
-	useEffect( () => {
-		let isUpdatingCart = false;
+	const [ requestSent, setRequestSent ] = useState( false );
 
-		if (
-			storedCard &&
-			countries?.length &&
-			hasSelectedSiteId &&
-			responseCart.blog_id &&
-			! isUpdatingCart
-		) {
+	useEffect( () => {
+		if ( storedCard && countries?.length && cartKey && cartKey !== 'no-site' && ! requestSent ) {
 			const vatDetails: VatDetails = {
 				country: storedCard.tax_location?.country_code,
 				id: storedCard.tax_location?.vat_id,
@@ -178,7 +159,7 @@ export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
 				city: wrapValueInManagedValue( storedCard.tax_location?.city ),
 				postalCode: wrapValueInManagedValue( storedCard.tax_location?.postal_code ),
 			};
-
+			setRequestSent( true );
 			updateCartContactDetailsForCheckout(
 				countries ?? [],
 				responseCart,
@@ -188,13 +169,6 @@ export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
 			);
 			replaceProductsInCart( [ productToAdd ] );
 		}
-
-		return () => {
-			isUpdatingCart = true;
-		};
-		// This hook updates cart values which also changes the `responseCart` variable.
-		// We do not want this effect to run when `responseCart` is updated to avoid an infinite loop.
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [
 		replaceProductsInCart,
 		updateLocation,
@@ -202,12 +176,16 @@ export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
 		productToAdd,
 		countries,
 		selectedSite,
-		responseCart.blog_id,
-		hasSelectedSiteId,
+		cartKey,
+		requestSent,
+		setRequestSent,
+		responseCart,
 	] );
 
 	const handleOnClose = () => {
-		Promise.all( [ updateLocation( { countryCode: '' } ), replaceProductsInCart( [] ) ] ).catch();
+		if ( cartKey ) {
+			Promise.all( [ updateLocation( { countryCode: '' } ), replaceProductsInCart( [] ) ] ).catch();
+		}
 		// We don't need to wait for the result of the above.
 		onClose();
 	};
@@ -227,15 +205,39 @@ export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
 					existingCardProcessor( transactionData, dataForProcessor ),
 			} }
 		>
-			{ countries?.length === 0 && <QueryPaymentCountries /> }
 			<PurchaseModal
 				cards={ cards }
-				isLoading={ isPendingUpdate || ! countries?.length || ! responseCart.products.length }
+				isLoading={ isPendingUpdate || ! countries?.length }
 				cart={ responseCart }
 				onClose={ handleOnClose }
 				siteSlug={ siteSlug }
 				showFeatureList={ showFeatureList }
 			/>
 		</CheckoutProvider>
+	);
+}
+
+function EnsureSelectedSite( { siteSlug, children }: PropsWithChildren< { siteSlug: SiteSlug } > ) {
+	const reduxDispatch = useDispatch();
+	const selectedSite = useSelector( getSelectedSite );
+	const siteId = useSelector( ( state ) => getSiteId( state, siteSlug ) );
+
+	// Set the selected site if it is not set already.
+	// This is necessary for the cart and post-purchase actions to function correctly.
+	const hasSelectedSiteId = siteId === selectedSite?.ID;
+	useEffect( () => {
+		if ( ! hasSelectedSiteId && siteId ) {
+			reduxDispatch( setSelectedSiteId( siteId ) );
+		}
+	}, [ hasSelectedSiteId, reduxDispatch, siteId ] );
+
+	return hasSelectedSiteId ? children : null;
+}
+
+export default function ( props: PurchaseModalProps ) {
+	return (
+		<EnsureSelectedSite siteSlug={ props.siteSlug }>
+			<PurchaseModalWrapper { ...props } />
+		</EnsureSelectedSite>
 	);
 }

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/style.scss
@@ -133,6 +133,10 @@ $left-margin: 36px;
 	}
 }
 
+.purchase-modal__order-step-row {
+	margin-bottom: 12px;
+}
+
 .purchase-modal__step-content-row {
 	display: flex;
 	flex-wrap: wrap;

--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -405,7 +405,7 @@ function OneClickPurchaseModal( {
 				<PurchaseModal
 					productToAdd={ product }
 					onClose={ onClose }
-					showFeatureList={ true }
+					showFeatureList={ false }
 					siteSlug={ siteSlug }
 				/>
 			</StripeHookProvider>

--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -587,7 +587,11 @@ function DIFMPagePicker( props: StepProps ) {
 				</StyledButton>
 			}
 			headerContent={
-				<ShoppingCartForDIFM selectedPages={ selectedPages } isStoreFlow={ isStoreFlow } />
+				<ShoppingCartForDIFM
+					selectedPages={ selectedPages }
+					isStoreFlow={ isStoreFlow }
+					isExistingSite={ isExistingSite }
+				/>
 			}
 			{ ...props }
 		/>

--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -432,6 +432,8 @@ function DIFMPagePicker( props: StepProps ) {
 	);
 	const cartKey = useSelector( ( state ) => getSiteId( state, siteSlug ?? siteId ) );
 
+	const isExistingSite = newOrExistingSiteChoice === 'existing-site' || siteSlug;
+
 	const { replaceProductsInCart } = useShoppingCart( cartKey ?? undefined );
 	const {
 		isCartLoading,
@@ -440,7 +442,7 @@ function DIFMPagePicker( props: StepProps ) {
 		isProductsLoading,
 		isFormattedCurrencyLoading,
 		effectiveCurrencyCode,
-	} = useCartForDIFM( selectedPages, isStoreFlow );
+	} = useCartForDIFM( selectedPages, isStoreFlow, isExistingSite );
 
 	const difmLiteProduct = useSelector( ( state ) => getProductBySlug( state, WPCOM_DIFM_LITE ) );
 	let difmTieredPriceDetails = null;
@@ -457,8 +459,6 @@ function DIFMPagePicker( props: StepProps ) {
 		isLoading: isLoadingIsEligibleForOneClickCheckout,
 		result: isEligibleForOneClickCheckout,
 	} = useIsEligibleForOneClickCheckout();
-
-	const isExistingSite = newOrExistingSiteChoice === 'existing-site';
 
 	const submitPickedPages = async () => {
 		if ( ! isCheckoutPressed ) {

--- a/client/signup/steps/page-picker/shopping-cart-for-difm.tsx
+++ b/client/signup/steps/page-picker/shopping-cart-for-difm.tsx
@@ -162,14 +162,17 @@ function DummyLineItem( {
 export default function ShoppingCartForDIFM( {
 	selectedPages,
 	isStoreFlow,
+	isExistingSite,
 }: {
 	selectedPages: string[];
 	isStoreFlow: boolean;
+	isExistingSite: boolean;
 } ) {
 	const translate = useTranslate();
 	const { items, total, effectiveCurrencyCode, isFormattedCurrencyLoading } = useCartForDIFM(
 		selectedPages,
-		isStoreFlow
+		isStoreFlow,
+		isExistingSite
 	);
 	return isFormattedCurrencyLoading || effectiveCurrencyCode === null ? (
 		<LoadingContainer>

--- a/client/signup/steps/page-picker/use-cart-for-difm.tsx
+++ b/client/signup/steps/page-picker/use-cart-for-difm.tsx
@@ -238,7 +238,8 @@ function getSiteCartProducts( {
 
 export function useCartForDIFM(
 	selectedPages: string[],
-	isStoreFlow: boolean
+	isStoreFlow: boolean,
+	isExistingSite: boolean
 ): {
 	items: CartItem[];
 	total: string | null;
@@ -258,8 +259,7 @@ export function useCartForDIFM(
 	const activePlanScheme = useSelector( ( state ) =>
 		getProductBySlug( state, isStoreFlow ? PLAN_BUSINESS : PLAN_PREMIUM )
 	);
-	const { newOrExistingSiteChoice, siteId, siteSlug } = signupDependencies;
-	const isExistingSite = newOrExistingSiteChoice === 'existing-site';
+	const { siteId, siteSlug } = signupDependencies;
 	const isProductsLoading = useSelector( isProductsListFetching );
 	const difmLiteProduct = useSelector( ( state ) => getProductBySlug( state, WPCOM_DIFM_LITE ) );
 	const userCurrencyCode = useSelector( getCurrentUserCurrencyCode );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/2531

## Proposed Changes

* Adds 1-click checkout to the page picker step of the BBE flow. It is enabled only if an existing site is selected.

<img width="1511" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/337901e2-c5aa-4b97-b424-859eab5a3d3f">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Existing free site (BBE flow)

* Ensure that you have a saved credit card to user account `/me/purchases/payment-methods`
* Go to `/start/do-it-for-me`.
* Select "Existing Site" and then select an **existing free site**.
* Go through the flow steps till you reach the page picker step.
* Click on the checkout CTA.
* Confirm that you see the 1-click checkout modal with the **BBE product and the Premium plan** in the cart.
* Confirm that you are able to complete the purchase and are redirected to the content submission form after checkout.

#### Existing site on a Premium or above plan (BBE flow)

* Follow the above steps, but on the site picker step, choose a site which is on a Premium or above plan.
* The 1-click checkout modal should only contain the BBE product.

#### Existing free site (Onboarding flow)

* Ensure that you have a saved credit card to user account `/me/purchases/payment-methods`
* Go to `/setup/site-setup/difmStartingPoint?siteSlug=<site slug>` where `<site slug>` is a free site.
* Go through the flow steps till you reach the page picker step.
* Click on the checkout CTA.
* Confirm that you see the 1-click checkout modal with the **BBE product and the Premium plan** in the cart.
* Confirm that you are able to complete the purchase and are redirected to the content submission form after checkout.

#### Existing site on a Premium or above plan (Onboarding flow)

* Follow the above steps, but on the `<site slug>` should be a site which is on a Premium or above plan.
* The 1-click checkout modal should only contain the BBE product.

#### New Site flow
* Go to `/start/do-it-for-me`.
* Choose "New site" and go through the flow steps.
* The 1-click checkout modal should not be shown.

-----

#### Testing for regressions

* Confirm that the test instructions in the following work:
  * #85434
  * #85129 
  * #84632

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?