### PR TITLE
Fix confetti performance issue

### DIFF
--- a/packages/components/src/confetti/index.ts
+++ b/packages/components/src/confetti/index.ts
@@ -10,12 +10,12 @@ type FireOptions = {
 	scalar?: number;
 };
 
-function fireConfetti( colors?: string[] ) {
+function fireConfetti( colors: string[] ) {
 	const count = 60;
 	const scale = 2;
 	const defaults = {
 		origin: { y: 0.4 },
-		colors: colors ?? COLORS,
+		colors,
 		scalar: scale,
 		spread: 180,
 		gravity: 6,
@@ -58,7 +58,7 @@ function fireConfetti( colors?: string[] ) {
 	} );
 }
 
-const ConfettiAnimation = ( { trigger = true, delay = 0, colors = [] } ) => {
+const ConfettiAnimation = ( { trigger = true, delay = 0, colors = COLORS } ) => {
 	useEffect( () => {
 		if ( trigger ) {
 			setTimeout( () => fireConfetti( colors ), delay );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/85218#discussion_r1427833449

## Proposed Changes

* Use `COLORS` const as the default

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add this code after line 106 in `client/my-sites/customer-home/components/celebrate-launch-modal.jsx`
```
<ConfettiAnimation colors={ [ '#DFD1FB', '#CFB9F6', '#AD86E9', '#966CCF', '#966CCF', '#674399', '#533582' ] } />
```
* Open home http://calypso.localhost:3000/home/SITE 
* Confirm that confetti is loaded and it's purple

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
