### PR TITLE
Subscription management: fix correct earn link & simplify

### DIFF
--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -1,7 +1,5 @@
 import { SubscriberListArgs } from '../types';
 
-const getEarnPaymentsPageUrl = ( siteSlug: string | null ) => `/earn/payments/${ siteSlug ?? '' }`;
-
 const getSubscribersCacheKey = (
 	siteId: number | undefined | null,
 	currentPage?: number,
@@ -88,7 +86,6 @@ const sanitizeInt = ( intString: string ) => {
 const getSubscriberDetailsType = ( userId: number | undefined ) => ( userId ? 'wpcom' : 'email' );
 
 export {
-	getEarnPaymentsPageUrl,
 	getSubscriberDetailsCacheKey,
 	getSubscriberDetailsUrl,
 	getSubscriberDetailsType,

--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -29,7 +29,7 @@ const useUnsubscribeModal = (
 	const onConfirmModal = ( action: UnsubscribeActionType, subscriber?: Subscriber ) => {
 		if ( action === UnsubscribeActionType.Manage ) {
 			recordRemoveModal( true, 'manage_button_clicked' );
-			navigate( `/earn/supporters/${ selectedSiteSlug }` );
+			navigate( `/earn/supporters/${ selectedSiteSlug ?? '' }` );
 		} else if ( action === UnsubscribeActionType.Unsubscribe && subscriber ) {
 			mutate( subscriber, {
 				onSuccess: () => {

--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
+import { navigate } from 'calypso/lib/navigate';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { UnsubscribeActionType } from '../components/unsubscribe-modal';
-import { getEarnPaymentsPageUrl } from '../helpers';
 import { useSubscriberRemoveMutation } from '../mutations';
 import { useRecordRemoveModal } from '../tracks';
 import { Subscriber, SubscriberListArgs } from '../types';
@@ -29,7 +29,7 @@ const useUnsubscribeModal = (
 	const onConfirmModal = ( action: UnsubscribeActionType, subscriber?: Subscriber ) => {
 		if ( action === UnsubscribeActionType.Manage ) {
 			recordRemoveModal( true, 'manage_button_clicked' );
-			window.open( getEarnPaymentsPageUrl( selectedSiteSlug ), '_blank' );
+			navigate( `/earn/supporters/${ selectedSiteSlug }` );
 		} else if ( action === UnsubscribeActionType.Unsubscribe && subscriber ) {
 			mutate( subscriber, {
 				onSuccess: () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Instead of linking to payment management, links to paid subscriber management instead from the modal.

![image](https://github.com/Automattic/wp-calypso/assets/87168/24e59662-a144-4175-9a2c-3110cf86950a)


## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?