### PR TITLE
Show larger domains by putting the badges on top of them

### DIFF
--- a/client/components/domains/domain-registration-suggestion/index.jsx
+++ b/client/components/domains/domain-registration-suggestion/index.jsx
@@ -272,6 +272,7 @@ class DomainRegistrationSuggestion extends Component {
 		const titleWrapperClassName = classNames( 'domain-registration-suggestion__title-wrapper', {
 			'domain-registration-suggestion__title-domain':
 				this.props.showStrikedOutPrice && ! this.props.isFeatured,
+			'domain-registration-suggestion__larger-domain': name.length > 15 ? true : false,
 		} );
 
 		return (

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -226,7 +226,9 @@ body.is-section-signup.is-white-signup .step-wrapper .featured-domain-suggestion
 		margin-bottom: initial;
 
 		@include break-wide {
-			flex-direction: row;
+			&:not(.domain-registration-suggestion__larger-domain) {
+				flex-direction: row;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Slack thread: p1702906235328909/1702905375.205479-slack-CKZHG0QCR

## Proposed Changes

* Domains bigger than 15 characters will always have badges on top of them

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

| Before | After |
|--------|--------|
|![image](https://github.com/Automattic/wp-calypso/assets/1044309/91782eff-d26d-4552-b0a9-eaa9779a2762)| ![image](https://github.com/Automattic/wp-calypso/assets/1044309/16ce4553-1fed-43bf-8568-b49561b4a8e4) |
| ![image](https://github.com/Automattic/wp-calypso/assets/1044309/8aa7bc69-5802-4efa-a816-4bfd2972c3b5) |![image](https://github.com/Automattic/wp-calypso/assets/1044309/a294b1e3-52f6-4e64-844e-f2b3047ab1d6) | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?