### PR TITLE
WIP: Pass in cart items to Parsely conversion tracker

### DIFF
--- a/client/lib/analytics/ad-tracking/parsely.ts
+++ b/client/lib/analytics/ad-tracking/parsely.ts
@@ -1,5 +1,5 @@
 import { loadScript } from '@automattic/load-script';
-import { mayWeInitTracker } from '../tracker-buckets';
+import { mayWeTrackByTracker } from '../tracker-buckets';
 import { PARSLEY_SCRIPT_URL } from './constants';
 
 /**
@@ -22,7 +22,7 @@ declare global {
  */
 export const loadParselyTracker = async (): Promise< void > => {
 	// Are we allowed to track (user consent, e2e, etc.)?
-	if ( ! mayWeInitTracker( 'parsely' ) ) {
+	if ( ! mayWeTrackByTracker( 'parsely' ) ) {
 		throw new Error( 'Tracking is not allowed' );
 	}
 

--- a/client/lib/analytics/ad-tracking/record-order.ts
+++ b/client/lib/analytics/ad-tracking/record-order.ts
@@ -727,6 +727,10 @@ function recordOrderInParsely( wpcomJetpackCartInfo: WpcomJetpackCartInfo ): voi
 		return;
 	}
 
+	if ( ! wpcomJetpackCartInfo.containsWpcomProducts ) {
+		return;
+	}
+
 	const cartContents = wpcomJetpackCartInfo.wpcomProducts
 		.map( ( product ) => product.product_slug )
 		.join( ', ' );
@@ -734,7 +738,7 @@ function recordOrderInParsely( wpcomJetpackCartInfo: WpcomJetpackCartInfo ): voi
 	loadParselyTracker()
 		.then( () => {
 			debug( `loadParselyTracker: Loaded Parsely tracker ${ TRACKING_IDS.parselyTracker }` );
-			window.PARSELY.conversions.trackPurchase( cartContents );
+			window.PARSELY && window.PARSELY.conversions.trackPurchase( cartContents );
 		} )
 		.then( () => {
 			debug( `recordOrderInParsely: Record Parsely purchase`, cartContents );

--- a/client/lib/analytics/ad-tracking/record-order.ts
+++ b/client/lib/analytics/ad-tracking/record-order.ts
@@ -79,10 +79,10 @@ export async function recordOrder(
 	recordOrderInGAEnhancedEcommerce( cart, orderId, wpcomJetpackCartInfo );
 	recordOrderInJetpackGA( cart, orderId, wpcomJetpackCartInfo );
 	recordOrderInWPcomGA4( cart, orderId, wpcomJetpackCartInfo );
+	recordOrderInParsely( wpcomJetpackCartInfo );
 	recordOrderInAkismetGA( cart, orderId, wpcomJetpackCartInfo );
 	recordOrderInWooGTM( cart, orderId, sitePlanSlug );
 	recordOrderInAkismetGTM( cart, orderId, wpcomJetpackCartInfo );
-	recordOrderInParsely( cart, orderId );
 
 	// Fire a single tracking event without any details about what was purchased
 
@@ -722,20 +722,22 @@ function recordOrderInAkismetGTM(
 /**
  * Sends a purchase conversion event to Prasely.
  */
-function recordOrderInParsely( cart: ResponseCart, orderId: number | null | undefined ): void {
+function recordOrderInParsely( wpcomJetpackCartInfo: WpcomJetpackCartInfo ): void {
+	if ( ! mayWeTrackByTracker( 'parsely' ) ) {
+		return;
+	}
+
+	const cartContents = wpcomJetpackCartInfo.wpcomProducts
+		.map( ( product ) => product.product_slug )
+		.join( ', ' );
+
 	loadParselyTracker()
 		.then( () => {
 			debug( `loadParselyTracker: Loaded Parsely tracker ${ TRACKING_IDS.parselyTracker }` );
-
-			// We ensure that we can track with Parsely
-			if ( ! mayWeTrackByTracker( 'parsely' ) ) {
-				return;
-			}
-
-			// Record Parsely purchase
-			window.PARSELY.conversions.trackPurchase( `Order Id ${ orderId }` );
-
-			debug( `recordOrderInParsely: Record Parsely purchase`, orderId );
+			window.PARSELY.conversions.trackPurchase( cartContents );
+		} )
+		.then( () => {
+			debug( `recordOrderInParsely: Record Parsely purchase`, cartContents );
 		} )
 		.catch( ( error ) => {
 			debug( 'recordOrderInParsely: Error loading Parsely', error );

--- a/client/lib/analytics/tracker-buckets.ts
+++ b/client/lib/analytics/tracker-buckets.ts
@@ -95,7 +95,6 @@ export const AdTrackersInitGuards: Partial< { [ key in AdTracker ]: () => boolea
 	criteo: () => 'criteo_q' in window,
 	quora: () => 'qp' in window,
 	adroll: () => 'adRoll' in window,
-	parsely: () => 'PARSELY' in window,
 	clarity: () => 'clarity' in window,
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This passes in the cart contents as a string (instead of passing in the transaction/order ID) as the conversion label in Parsely. Parsely does not support more complex objects, but this will give us an indication of which products are converting vs. which blog posts.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If in GDPR, allow "analytics" tracking. If you're testing locally, either temporarily change `development.json` to allow `ad-tracking` and `cookie-banner`, or pass these in as `?flags=ad-tracking,cookie-banner` in the URL on the checkout page.
* Make sure that you see calls to parsely.com in the network tab. They should look similar to this:
    * `https://cdn.parsely.com/keys/wordpress.com/p.js?ver=3.3.2` for loading the base tracking code
    * `http://p1.parsely.com/plogger/?rand=1704198873194....` for sending off the tracking call, where the key prop is `data` containing the cart items, e.g. `{"_conversion_type":"purchase","_conversion_label":"personal-bundle, dotblog_domain"}` 
    * You will also see one more `/plogger` call that fires off a pageview event.
* If tracking is disallowed (the user has not consented, or explicitly opted out of analytics, no tracking calls should be made.
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
