### PR TITLE
Big Sky: Have AI chose page_slugs

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
@@ -80,6 +80,12 @@ const AISitePrompt: Step = function ( props ) {
 							currentSearchParams.set( 'site_tagline', response.site.site_tagline );
 						}
 
+						// This was introduced in the V5 of the AI endpoint.
+						const pageSlugs = response.pages.map( ( page: any ) => page?.slug ).filter( Boolean );
+						if ( pageSlugs.length ) {
+							currentSearchParams.set( 'page_slugs', pageSlugs.join( ',' ) );
+						}
+
 						return currentSearchParams;
 					},
 					{ replace: true }


### PR DESCRIPTION
Related to #https://github.com/Automattic/ai-services/issues/607

## Proposed Changes

* Handle the endpoint response and pass on the `page_slugs` parameter handled by assembler

Works with. D132381-code

The whole idea is when you mention something like:
![Zrzut ekranu 2023-12-18 o 16 22 50](https://github.com/Automattic/wp-calypso/assets/3775068/06a559a9-f486-46d4-87f3-d32fa2efe6b9)


You will get preselected pages to match that request:


![Zrzut ekranu 2023-12-18 o 16 23 41](https://github.com/Automattic/wp-calypso/assets/3775068/80cb0ced-a264-4cb5-8e41-cd474a607acf)

## Follow-Up issues

1. There is an issue in the assembler, where those page headers are not used in the header in the first screen of the assembler and that should be fixed in a separate PR, as it affects more than only AI flow.
2. Currently we are limiting the flow to choosing the patterns for the home page, and choosing the secondary pages from predefined templates. We _could_ be generating the content and titles of these "secondary" pages but that would require significant rework of how the assembler works as well as experimenting with different AI outputs. Its a good follow-up work but we don't need to tackle it now. I started in https://github.com/Automattic/wp-calypso/pull/85367

## Testing Instructions

* Apply D132381-code
* Sandbox public-api
* Go into the AI assembler flow with http://calypso.localhost:3000/setup/ai-assembler
* Type something into the AI prompt box
* Once requests completes see that your URL has `page_slugs` set
* Click through the assembler and styles tab to the pages tab
* Observe pages selected tha match your needs

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?