### PR TITLE
Purchases: fix situation where MembershipSubscriptionsSite's name is not defined 

### DIFF
--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -231,7 +231,11 @@ export function getSubscriptionsBySite(
 			site.subscriptions = [ ...site.subscriptions, currentValue ];
 			return result;
 		}, [] )
-		.sort( ( a, b ) => ( a.name?.toLowerCase() > b.name?.toLowerCase() ? 1 : -1 ) );
+		.sort( ( a, b ) => {
+			const aName = typeof a.name === 'string' ? a.name.toLowerCase() : '';
+			const bName = typeof b.name === 'string' ? b.name.toLowerCase() : '';
+			return aName > bName ? 1 : -1;
+		} );
 }
 
 export function getName( purchase: Purchase ): string {

--- a/client/lib/purchases/index.ts
+++ b/client/lib/purchases/index.ts
@@ -231,7 +231,7 @@ export function getSubscriptionsBySite(
 			site.subscriptions = [ ...site.subscriptions, currentValue ];
 			return result;
 		}, [] )
-		.sort( ( a, b ) => ( a.name.toLowerCase() > b.name.toLowerCase() ? 1 : -1 ) );
+		.sort( ( a, b ) => ( a.name?.toLowerCase() > b.name?.toLowerCase() ? 1 : -1 ) );
 }
 
 export function getName( purchase: Purchase ): string {


### PR DESCRIPTION
Context: p1702906366081939-slack-C052XEUUBL4 

## Proposed Changes

* Add some additional checks inside `getSubscriptionsBySite`
* This makes the WSOD @millerf is seeing go away. After this we need to look at the root cause.

## Testing Instructions

1. Be @millerf 
2. Apply this PR
3. Visit http://calypso.localhost:3000/me/purchases
4. See if it works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?