### PR TITLE
E2E: Update test for changed link in confirmation email

### DIFF
--- a/test/e2e/specs/users/newsletter__subscribe-remove.ts
+++ b/test/e2e/specs/users/newsletter__subscribe-remove.ts
@@ -79,7 +79,9 @@ skipDescribeIf( envVariables.ATOMIC_VARIATION === 'private' )(
 					sentTo: testEmail,
 				} );
 
-				const confirmationURL = emailClient.getLinkFromMessageByKey( message, 'Confirm now' );
+				const confirmationURL =
+					emailClient.getLinkFromMessageByKey( message, 'Confirm email' ) ??
+					emailClient.getLinkFromMessageByKey( message, 'Confirm now' );
 				expect( confirmationURL ).not.toBe( null );
 
 				// Now, when you subscribe from a post, it uses a magic link login and redirects you to the post you subscribed from.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

D131642-code changed the text from "Confirm now" to "Confirm email". Since it's not entirely clear whether it might change back at some point, let's look for either string.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run the test, e.g. `TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/users/newsletter__subscribe-remove.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?