### PR TITLE
Reader Discover stream navigation - use "Bloganary" tab in place of "Daily prompts" during bloganuary.

### DIFF
--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -52,7 +52,7 @@ const DiscoverStream = ( props ) => {
 	} );
 
 	const promptSlug = isBloganuary() ? 'bloganuary' : 'dailyprompt';
-	const promptTitle = isBloganuary() ? 'Bloganuary' : 'Daily prompts';
+	const promptTitle = isBloganuary() ? translate( 'Bloganuary' ) : translate( 'Daily prompts' );
 	// Add dailyprompt to the front of interestTags if not present.
 	const hasPromptTab = interestTags.filter( ( tag ) => tag.slug === promptSlug ).length;
 	if ( ! hasPromptTab ) {

--- a/client/reader/discover/discover-stream.js
+++ b/client/reader/discover/discover-stream.js
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import NavigationHeader from 'calypso/components/navigation-header';
+import isBloganuary from 'calypso/data/blogging-prompt/is-bloganuary';
 import withDimensions from 'calypso/lib/with-dimensions';
 import wpcom from 'calypso/lib/wp';
 import { READER_DISCOVER_POPULAR_SITES } from 'calypso/reader/follow-sources';
@@ -50,10 +51,12 @@ const DiscoverStream = ( props ) => {
 		},
 	} );
 
+	const promptSlug = isBloganuary() ? 'bloganuary' : 'dailyprompt';
+	const promptTitle = isBloganuary() ? 'Bloganuary' : 'Daily prompts';
 	// Add dailyprompt to the front of interestTags if not present.
-	const hasDailyPrompt = interestTags.filter( ( tag ) => tag.slug === 'dailyprompt' ).length;
-	if ( ! hasDailyPrompt ) {
-		interestTags.unshift( { title: translate( 'Daily prompts' ), slug: 'dailyprompt' } );
+	const hasPromptTab = interestTags.filter( ( tag ) => tag.slug === promptSlug ).length;
+	if ( ! hasPromptTab ) {
+		interestTags.unshift( { title: promptTitle, slug: promptSlug } );
 	}
 
 	const isDefaultTab = selectedTab === DEFAULT_TAB;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # idea noted in https://github.com/Automattic/wp-calypso/pull/85084#pullrequestreview-1782370482 

## Proposed Changes

* Updates the "Daily prompts" section of the discover navigation to "Bloganuary" during bloganuary.

<img width="1086" alt="Screenshot 2023-12-18 at 12 08 16 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/b014aa30-cb1d-48b7-94c3-f7647e3b5bef">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run calypso live.
* Smoke test discover stream navigation is the same as it was before.
* Reload with the `?flags=bloganuary` added to the url.
* Verify the "Daily prompts" tab is now a "Bloganuary" tab and that bloganuary feed loads.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
