### PR TITLE
Only show the Unique Open box in email stats if the email was sent after the release of the feature

### DIFF
--- a/client/my-sites/stats/stats-email-detail/index.jsx
+++ b/client/my-sites/stats/stats-email-detail/index.jsx
@@ -241,7 +241,12 @@ class StatsEmailDetail extends Component {
 							<div class="stats__email-wrapper">
 								<h3 className="highlight-cards-heading">{ this.getTitle( statType ) }</h3>
 
-								<StatsEmailTopRow siteId={ siteId } postId={ postId } statType={ statType } />
+								<StatsEmailTopRow
+									siteId={ siteId }
+									postId={ postId }
+									statType={ statType }
+									postDate={ post.date }
+								/>
 
 								<StatsPeriodHeader>
 									<StatsPeriodNavigation

--- a/client/my-sites/stats/stats-email-top-row/index.jsx
+++ b/client/my-sites/stats/stats-email-top-row/index.jsx
@@ -13,8 +13,14 @@ import {
 import TopCard from './top-card';
 import './style.scss';
 
-export default function StatsEmailTopRow( { siteId, postId, statType, className } ) {
+// The date the Unique Opens box was released.
+// We only show the Unique Opens box if the email was sent after that date.
+const uniqueOpenReleaseDate = new Date( '2023-12-13' );
+
+export default function StatsEmailTopRow( { siteId, postId, statType, postDate, className } ) {
 	const translate = useTranslate();
+	const emailSentDate = useMemo( () => new Date( postDate ) );
+	const shouldShowUniqueOpens = emailSentDate > uniqueOpenReleaseDate;
 
 	const counts = useSelector( ( state ) =>
 		getEmailStatsNormalizedData( state, siteId, postId, PERIOD_ALL_TIME, statType, '', 'rate' )
@@ -34,7 +40,7 @@ export default function StatsEmailTopRow( { siteId, postId, statType, className 
 							isLoading={ isRequesting && ! counts?.hasOwnProperty( 'total_sends' ) }
 							icon={ <Gridicon icon="mail" /> }
 						/>
-						{ counts?.unique_opens ? (
+						{ counts?.unique_opens && shouldShowUniqueOpens ? (
 							<TopCard
 								heading={ translate( 'Unique opens' ) }
 								value={ counts.unique_opens }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/85430

## Proposed Changes

We should only show the unique open stats if the email was sent after implementing that box in the Email Open Stats screen.

## Testing Instructions

- Apply this PR and start the application.
- Go to http://calypso.localhost:3000/stats/day/[your-domain-here]
- Scroll down and click an email in the Emails box.
- Click on the Email Opens tab.
- If the email was sent (the post published) after 2023-12-13, you should see the "Unique Opens" box in the top row:
<img width="1170" alt="Screenshot 2023-12-18 at 18 58 09" src="https://github.com/Automattic/wp-calypso/assets/3832570/f6c395e0-3f0b-45ce-a8fc-3b4bab2ce42e">
- Otherwise, you should only see 3 boxes on top:
<img width="1165" alt="Screenshot 2023-12-18 at 18 58 36" src="https://github.com/Automattic/wp-calypso/assets/3832570/75d0dac8-2f43-46bb-80b6-cf0ed09dced3">

**Note:** you can publish en email today if to test the 4 boxes are there, but if you want to test with your old emails, you can go to `client/my-sites/stats/stats-email-top-row/index.jsx` and change the date in line 17 for anything older, like: `const uniqueOpenReleaseDate = new Date( '2020-12-13' );`

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?