### PR TITLE
Plugins Discovery Page: Release new one click purchase modal to business plan upsell

### DIFF
--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -87,6 +87,10 @@ const PopularPluginsSection = ( props ) => {
 	);
 };
 
+const businessPlanProduct = createRequestCartProduct( {
+	product_slug: PLAN_BUSINESS,
+} );
+
 const PluginsDiscoveryPage = ( props ) => {
 	const {
 		plugins: pluginsByCategoryFeatured = [],
@@ -100,18 +104,14 @@ const PluginsDiscoveryPage = ( props ) => {
 	const [ showPurchaseModal, setShowPurchaseModal ] = useState( false );
 	const { isLoading, result: isEligibleForOneClickCheckout } = useIsEligibleForOneClickCheckout();
 
-	const businessPlanProduct = createRequestCartProduct( {
-		product_slug: PLAN_BUSINESS,
-	} );
-
 	return (
 		<>
-			<CalypsoShoppingCartProvider>
-				<StripeHookProvider
-					fetchStripeConfiguration={ getStripeConfiguration }
-					locale={ translate.localeSlug }
-				>
-					{ showPurchaseModal && (
+			{ showPurchaseModal && (
+				<CalypsoShoppingCartProvider>
+					<StripeHookProvider
+						fetchStripeConfiguration={ getStripeConfiguration }
+						locale={ translate.localeSlug }
+					>
 						<PurchaseModal
 							productToAdd={ businessPlanProduct }
 							onClose={ () => {
@@ -120,9 +120,9 @@ const PluginsDiscoveryPage = ( props ) => {
 							showFeatureList={ true }
 							siteSlug={ props.siteSlug }
 						/>
-					) }
-				</StripeHookProvider>
-			</CalypsoShoppingCartProvider>
+					</StripeHookProvider>
+				</CalypsoShoppingCartProvider>
+			) }
 			<UpgradeNudge
 				{ ...props }
 				isBusy={ isLoading }

--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -87,23 +87,6 @@ const PopularPluginsSection = ( props ) => {
 	);
 };
 
-const OneClickPurchaseModal = ( { setShowPurchaseModal, siteSlug } ) => {
-	const businessPlanProduct = createRequestCartProduct( {
-		product_slug: PLAN_BUSINESS,
-	} );
-
-	return (
-		<PurchaseModal
-			productToAdd={ businessPlanProduct }
-			onClose={ () => {
-				setShowPurchaseModal( false );
-			} }
-			showFeatureList={ true }
-			siteSlug={ siteSlug }
-		/>
-	);
-};
-
 const PluginsDiscoveryPage = ( props ) => {
 	const {
 		plugins: pluginsByCategoryFeatured = [],
@@ -117,6 +100,10 @@ const PluginsDiscoveryPage = ( props ) => {
 	const [ showPurchaseModal, setShowPurchaseModal ] = useState( false );
 	const { isLoading, result: isEligibleForOneClickCheckout } = useIsEligibleForOneClickCheckout();
 
+	const businessPlanProduct = createRequestCartProduct( {
+		product_slug: PLAN_BUSINESS,
+	} );
+
 	return (
 		<>
 			<CalypsoShoppingCartProvider>
@@ -125,11 +112,13 @@ const PluginsDiscoveryPage = ( props ) => {
 					locale={ translate.localeSlug }
 				>
 					{ showPurchaseModal && (
-						<OneClickPurchaseModal
-							localeSlug={ translate.localeSlug }
-							setShowPurchaseModal={ setShowPurchaseModal }
+						<PurchaseModal
+							productToAdd={ businessPlanProduct }
+							onClose={ () => {
+								setShowPurchaseModal( false );
+							} }
+							showFeatureList={ true }
 							siteSlug={ props.siteSlug }
-							isLoading={ isLoading }
 						/>
 					) }
 				</StripeHookProvider>

--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -8,7 +8,6 @@ import { useSelector } from 'react-redux';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import PurchaseModal from 'calypso/my-sites/checkout/upsell-nudge/purchase-modal';
-import PurchaseModalPlaceholder from 'calypso/my-sites/checkout/upsell-nudge/purchase-modal/placeholder';
 import { useIsEligibleForOneClickCheckout } from 'calypso/my-sites/checkout/upsell-nudge/purchase-modal/use-is-eligible-for-one-click-checkout';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -88,28 +87,20 @@ const PopularPluginsSection = ( props ) => {
 	);
 };
 
-const OneClickPurchaseModal = ( { isLoading, localeSlug, setShowPurchaseModal, siteSlug } ) => {
+const OneClickPurchaseModal = ( { setShowPurchaseModal, siteSlug } ) => {
 	const businessPlanProduct = createRequestCartProduct( {
 		product_slug: PLAN_BUSINESS,
 	} );
 
 	return (
-		<CalypsoShoppingCartProvider>
-			<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration } locale={ localeSlug }>
-				{ isLoading ? (
-					<PurchaseModalPlaceholder showFeatureList={ true } />
-				) : (
-					<PurchaseModal
-						productToAdd={ businessPlanProduct }
-						onClose={ () => {
-							setShowPurchaseModal( false );
-						} }
-						showFeatureList={ true }
-						siteSlug={ siteSlug }
-					/>
-				) }
-			</StripeHookProvider>
-		</CalypsoShoppingCartProvider>
+		<PurchaseModal
+			productToAdd={ businessPlanProduct }
+			onClose={ () => {
+				setShowPurchaseModal( false );
+			} }
+			showFeatureList={ true }
+			siteSlug={ siteSlug }
+		/>
 	);
 };
 
@@ -128,14 +119,21 @@ const PluginsDiscoveryPage = ( props ) => {
 
 	return (
 		<>
-			{ showPurchaseModal && (
-				<OneClickPurchaseModal
-					localeSlug={ translate.localeSlug }
-					setShowPurchaseModal={ setShowPurchaseModal }
-					siteSlug={ props.siteSlug }
-					isLoading={ isLoading }
-				/>
-			) }
+			<CalypsoShoppingCartProvider>
+				<StripeHookProvider
+					fetchStripeConfiguration={ getStripeConfiguration }
+					locale={ translate.localeSlug }
+				>
+					{ showPurchaseModal && (
+						<OneClickPurchaseModal
+							localeSlug={ translate.localeSlug }
+							setShowPurchaseModal={ setShowPurchaseModal }
+							siteSlug={ props.siteSlug }
+							isLoading={ isLoading }
+						/>
+					) }
+				</StripeHookProvider>
+			</CalypsoShoppingCartProvider>
 			<UpgradeNudge
 				{ ...props }
 				isBusy={ isLoading }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/84993

## Proposed Changes
* Releases the 1 click upsell modal to a general audience
* Removes experiment code

## Screenshots
<img width="1494" alt="Screenshot 2023-12-18 at 11 20 55 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/ec24c6a4-1e51-4054-8b63-3f95473936f5">

<img width="1722" alt="Screenshot 2023-12-18 at 11 29 55 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/f1caf750-c024-441e-bd21-aad087d6009a">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that test site is _not_ on a business plan or higher
* Ensure that *no* credit card is saved to the account `/me/purchases/payment-methods`
* Go to `/plugins/{SITE_SLUG}`
* Click on the plugins discovery page business plan upsell CTA
* Verify that the user is redirected to a checkout screen with the business plan added to the cart
* Add a saved credit card to user account `/me/purchases/payment-methods`
* Return to `/plugins/{SITE_SLUG}`
* Click on the plugins discovery page business plan upsell CTA
* Verify that there is no page redirect and that, instead, the 1-click checkout modal is shown for users
* Verify that the business plan can be purchased from the modal

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?