### PR TITLE
Marketplace Reviews: Create the canPublishPluginReview selector

### DIFF
--- a/client/state/marketplace/selectors.ts
+++ b/client/state/marketplace/selectors.ts
@@ -2,8 +2,11 @@ import {
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 	WPCOM_FEATURES_LIVE_SUPPORT,
 } from '@automattic/calypso-products';
+import { getPluginPurchased } from 'calypso/lib/plugins/utils';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { getBillingInterval } from 'calypso/state/marketplace/billing-interval/selectors';
+import { getUserPurchases } from 'calypso/state/purchases/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { default as isVipSite } from 'calypso/state/selectors/is-vip-site';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -11,6 +14,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { canPublishThemeReview } from 'calypso/state/themes/selectors/can-publish-theme-review';
 import { IAppState } from 'calypso/state/types';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { isMarketplaceProduct } from '../products-list/selectors';
 
 /*
  * shouldUpgradeCheck:
@@ -73,13 +77,29 @@ export const hasOrIntendsToBuyLiveSupport = ( state: IAppState ): boolean => {
 export function canPublishProductReviews(
 	state: IAppState,
 	productType: string,
-	productSlug: string
+	productSlug: string,
+	variations?: []
 ) {
 	if ( productType === 'theme' ) {
 		return canPublishThemeReview( state, productSlug );
 	}
 	if ( productType === 'plugin' ) {
-		throw new Error( `Selector not implemented for plugins` );
+		return canPublishPluginReview( state, productSlug, variations );
 	}
 	throw new Error( `Unknown product type: ${ productType }` );
+}
+
+export function canPublishPluginReview(
+	state: IAppState,
+	pluginSlug: string,
+	variations: [] = []
+) {
+	const isMarketplacePlugin = isMarketplaceProduct( state, pluginSlug );
+	const isLoggedIn = isUserLoggedIn( state );
+
+	const purchases = getUserPurchases( state );
+	const purchasedPlugin = getPluginPurchased( { variations }, purchases || [] );
+	const hasActiveSubscription = !! purchasedPlugin;
+
+	return isLoggedIn && ( ! isMarketplacePlugin || hasActiveSubscription );
 }

--- a/client/state/marketplace/test/selectors.test.js
+++ b/client/state/marketplace/test/selectors.test.js
@@ -1,0 +1,63 @@
+import * as userSelectors from 'calypso/state/current-user/selectors';
+import { canPublishPluginReview } from 'calypso/state/marketplace/selectors';
+import * as productListSelectors from 'calypso/state/products-list/selectors';
+import * as purchasesSelectors from 'calypso/state/purchases/selectors';
+
+jest.mock( 'calypso/state/products-list/selectors' );
+jest.mock( 'calypso/state/current-user/selectors' );
+jest.mock( 'calypso/state/purchases/selectors' );
+
+describe( 'canPublishPluginReview', () => {
+	beforeAll( () => {
+		purchasesSelectors.getUserPurchases.mockReturnValue( [] );
+	} );
+
+	it( 'returns true if the user is logged in and the plugin is not a marketplace product', () => {
+		productListSelectors.isMarketplaceProduct.mockReturnValue( false );
+		userSelectors.isUserLoggedIn.mockReturnValue( true );
+
+		const result = canPublishPluginReview( {}, 'pluginSlug', [] );
+
+		expect( result ).toBe( true );
+	} );
+
+	it( 'returns false if the user is not logged in', () => {
+		userSelectors.isUserLoggedIn.mockReturnValue( false );
+
+		const result = canPublishPluginReview( {}, 'pluginSlug', [] );
+
+		expect( result ).toBe( false );
+	} );
+
+	it( 'returns true if the user is logged in and has an active subscription for a marketplace product', () => {
+		productListSelectors.isMarketplaceProduct.mockReturnValue( true );
+		userSelectors.isUserLoggedIn.mockReturnValue( true );
+		purchasesSelectors.getUserPurchases.mockReturnValue( [
+			{ productId: 'plugin_variation__annual' },
+		] );
+
+		const variations = [
+			{ product_id: 'plugin_variation__annual' },
+			{ product_id: 'plugin_variation__monthly' },
+		];
+		const result = canPublishPluginReview( {}, 'pluginSlug', variations );
+
+		expect( result ).toBe( true );
+	} );
+
+	it( 'returns false if the user is logged in but does not have an active subscription for a marketplace product', () => {
+		productListSelectors.isMarketplaceProduct.mockReturnValue( true );
+		userSelectors.isUserLoggedIn.mockReturnValue( true );
+		purchasesSelectors.getUserPurchases.mockReturnValue( [
+			{ productId: 'plugin_variation__annual' },
+		] );
+
+		const variations = [
+			{ product_id: 'plugin2_variation__annual' },
+			{ product_id: 'plugin2_variation__monthly' },
+		];
+		const result = canPublishPluginReview( {}, 'pluginSlug', variations );
+
+		expect( result ).toBe( false );
+	} );
+} );


### PR DESCRIPTION


## Proposed Changes

* Create the canPublishPluginReview selector
* Add it to canPublishProductReviews implementation
* Add unit tests.

## Testing Instructions

Passes all unit tests

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
