### PR TITLE
E2E Test: Update the name of the textbox we're looking for

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/ai-assistant.ts
@@ -92,7 +92,7 @@ export class AIAssistantFlow implements BlockFlow {
 	 * @param {Locator} block Locator to the block.
 	 */
 	private async enterInput( block: Locator ) {
-		const input = block.getByRole( 'textbox', { name: 'Ask Jetpack AI' } );
+		const input = block.getByRole( 'textbox', { name: 'Write about… Make a table for…' } );
 		await input.waitFor();
 		await input.fill( this.configurationData.query );
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

https://github.com/Automattic/jetpack/pull/34383 updated the placeholder text of the Jetpack AI block which broke the e2e test. This updates it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Run the test:

> TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/blocks/blocks__jetpack-writing.ts


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?