### PR TITLE
Import content: Update upload error message for WordPress platform

### DIFF
--- a/client/blocks/importer/components/importer-drag/index.tsx
+++ b/client/blocks/importer/components/importer-drag/index.tsx
@@ -57,6 +57,7 @@ const ImporterDrag: React.FunctionComponent< Props > = ( props ) => {
 					description={ errorData.description }
 					siteSlug={ site?.slug }
 					code={ errorData.code }
+					importerEngine={ importerData?.engine }
 				/>
 			) }
 			{ includes( importingStates, importerState ) && (

--- a/client/my-sites/importer/error-pane.jsx
+++ b/client/my-sites/importer/error-pane.jsx
@@ -21,6 +21,7 @@ class ImporterError extends PureComponent {
 		retryImport: PropTypes.func,
 		siteSlug: PropTypes.string,
 		code: PropTypes.string,
+		importerEngine: PropTypes.string,
 	};
 
 	contactSupport = ( event ) => {
@@ -66,7 +67,7 @@ class ImporterError extends PureComponent {
 		);
 		const { description = '' } = this.props;
 
-		if ( isEnabled( 'importer/site-backups' ) ) {
+		if ( isEnabled( 'importer/site-backups' ) && this.props.importerEngine === 'wordpress' ) {
 			return this.props.translate(
 				'The file type you uploaded is not supported. Please upload a WordPress export file in XML or ZIP format, or a Playground ZIP file. {{cs}}Still need help{{/cs}}?',
 				{

--- a/client/my-sites/importer/error-pane.jsx
+++ b/client/my-sites/importer/error-pane.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -64,6 +65,17 @@ class ImporterError extends PureComponent {
 			'Oops! We ran into an unexpected error while uploading your file.'
 		);
 		const { description = '' } = this.props;
+
+		if ( isEnabled( 'importer/site-backups' ) ) {
+			return this.props.translate(
+				'The file type you uploaded is not supported. Please upload a WordPress export file in XML or ZIP format, or a Playground ZIP file. {{cs}}Still need help{{/cs}}?',
+				{
+					components: {
+						cs: <Button className="importer__error-pane is-link" onClick={ this.contactSupport } />,
+					},
+				}
+			);
+		}
 
 		return this.props.translate(
 			'%(errorDescription)s{{br/}}Make sure you are using a valid WordPress export file in XML or ZIP format. {{cs}}Still need help{{/cs}}?',

--- a/client/my-sites/importer/error-pane.jsx
+++ b/client/my-sites/importer/error-pane.jsx
@@ -1,4 +1,3 @@
-import Page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -26,19 +25,22 @@ class ImporterError extends PureComponent {
 	contactSupport = ( event ) => {
 		event.preventDefault();
 		event.stopPropagation();
-		Page( '/help' );
+		window.location.href = '/help';
 	};
 
 	installPlugin = ( event ) => {
 		event.preventDefault();
 		event.stopPropagation();
-		Page( '/plugins/all-in-one-wp-migration' );
+		window.location.href = '/plugins/all-in-one-wp-migration';
 	};
 
 	everythingImport = ( event ) => {
 		event.preventDefault();
 		event.stopPropagation();
-		Page( addQueryArgs( { siteSlug: this.props.siteSlug }, '/setup/site-setup/import' ) );
+		window.location.href = addQueryArgs(
+			{ siteSlug: this.props.siteSlug },
+			'/setup/site-setup/import'
+		);
 	};
 
 	getImportError = () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/4964

## Proposed Changes

* Updated upload error message only for WordPress engine when feature flag is ON
* Fixed issue with opening support links (rely on window.href since the Page class is not configured for the stepper framework)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/import-focused?siteSlug={SLUG}`
* Click on "choose a content platform"
* Select WordPress platform
* Upload unsupported file type, for instance `.svg` file
* Check for a new custom message "The file type you uploaded is not supported. Please upload a WordPress export file in XML or ZIP format, or a Playground ZIP file"

<img width="883" alt="Screenshot 2023-12-18 at 14 42 24" src="https://github.com/Automattic/wp-calypso/assets/1241413/fbb24646-eb8c-46c1-a74c-e6c8e53d292a">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?