### PR TITLE
Checkout: Launch treatment version of ToS Foldable Card

### DIFF
--- a/client/my-sites/checkout/src/components/accept-terms-of-service-checkbox.tsx
+++ b/client/my-sites/checkout/src/components/accept-terms-of-service-checkbox.tsx
@@ -73,7 +73,7 @@ function AcceptTermsOfServiceCheckbox( {
 		onChange( event.target.checked );
 	};
 
-	const showToSFoldableCard = useToSFoldableCard() === 'treatment';
+	const showToSFoldableCard = useToSFoldableCard();
 
 	return (
 		<FormLabel>

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -44,7 +44,6 @@ import useRecordCheckoutLoaded from '../hooks/use-record-checkout-loaded';
 import useRemoveFromCartAndRedirect from '../hooks/use-remove-from-cart-and-redirect';
 import { useShouldCollapseLastStep } from '../hooks/use-should-collapse-last-step';
 import { useStoredPaymentMethods } from '../hooks/use-stored-payment-methods';
-import { useToSFoldableCard } from '../hooks/use-tos-foldable-card';
 import { logStashLoadErrorEvent, logStashEvent, convertErrorToString } from '../lib/analytics';
 import existingCardProcessor from '../lib/existing-card-processor';
 import filterAppropriatePaymentMethods from '../lib/filter-appropriate-payment-methods';
@@ -524,7 +523,6 @@ export default function CheckoutMain( {
 		: {};
 	const theme = { ...checkoutTheme, colors: { ...checkoutTheme.colors, ...jetpackColors } };
 
-	const isToSExperimentLoading = useToSFoldableCard() === 'loading';
 	const isCollapseExperimentLoading = useShouldCollapseLastStep() === 'loading';
 
 	// This variable determines if we see the loading page or if checkout can
@@ -550,7 +548,6 @@ export default function CheckoutMain( {
 			isLoading: responseCart.products.length < 1,
 		},
 		{ name: translate( 'Loading countries list' ), isLoading: countriesList.length < 1 },
-		{ name: translate( 'Loading Site' ), isLoading: isToSExperimentLoading },
 		{ name: translate( 'Loading Site' ), isLoading: isCollapseExperimentLoading },
 	];
 	const isCheckoutPageLoading: boolean = checkoutLoadingConditions.some(

--- a/client/my-sites/checkout/src/components/checkout-terms-item.tsx
+++ b/client/my-sites/checkout/src/components/checkout-terms-item.tsx
@@ -40,7 +40,7 @@ const CheckoutTermsItem = ( {
 	onClick?: MouseEventHandler< HTMLDivElement >;
 	isPrewrappedChildren?: boolean;
 } > ) => {
-	const showToSFoldableCard = useToSFoldableCard() === 'treatment';
+	const showToSFoldableCard = useToSFoldableCard();
 
 	return (
 		<Wrapper

--- a/client/my-sites/checkout/src/components/checkout-terms.tsx
+++ b/client/my-sites/checkout/src/components/checkout-terms.tsx
@@ -60,7 +60,7 @@ export default function CheckoutTerms( { cart }: { cart: ResponseCart } ) {
 		}
 	`;
 
-	const showToSFoldableCard = useToSFoldableCard() === 'treatment';
+	const showToSFoldableCard = useToSFoldableCard();
 
 	const shouldShowBundledDomainNotice = showBundledDomainNotice( cart );
 	const shouldShowRefundPolicy = isNotJetpackOrAkismetCheckout;

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -103,7 +103,7 @@ export default function BeforeSubmitCheckoutHeader() {
 		} ),
 	};
 
-	const showToSFoldableCard = useToSFoldableCard() === 'treatment';
+	const showToSFoldableCard = useToSFoldableCard();
 
 	return (
 		<>

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -331,7 +331,7 @@ export default function WPCheckout( {
 
 	const { transactionStatus } = useTransactionStatus();
 	const paymentMethod = usePaymentMethod();
-	const showToSFoldableCard = useToSFoldableCard() === 'treatment';
+	const showToSFoldableCard = useToSFoldableCard();
 	const shouldCollapseLastStep = useShouldCollapseLastStep() === 'collapse';
 	const excluded3PDAccountProductSlugs = [ 'sensei_pro_monthly', 'sensei_pro_yearly' ];
 

--- a/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
+++ b/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
@@ -1,12 +1,11 @@
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
-import { useExperiment } from 'calypso/lib/explat';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import { useSelector } from 'calypso/state';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSectionName } from 'calypso/state/ui/selectors';
 
-export function useToSFoldableCard(): 'loading' | 'treatment' | 'control' {
+export function useToSFoldableCard(): boolean {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 
 	const isJetpackNotAtomic = useSelector(
@@ -18,19 +17,13 @@ export function useToSFoldableCard(): 'loading' | 'treatment' | 'control' {
 		! isAkismetCheckout() &&
 		! isJetpackNotAtomic;
 
-	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
-		'wp_web_checkout_tos_foldable_card_v1_attempt_2',
-		{ isEligible: isWPcomCheckout }
-	);
+	/* Only show the foldable card on the checkout page for WPCOM,
+	 * further testing for Jetpack and Akismet is required before removing this hook
+	 * and showing the foldable ToS for all checkout pages.
+	 */
+	if ( isWPcomCheckout ) {
+		return true;
+	}
 
-	// Is loading experiment assignment
-	if ( isLoadingExperimentAssignment ) {
-		return 'loading';
-	}
-	// Done loading experiment assignment, and treatment assignment found
-	if ( experimentAssignment?.variationName === 'treatment' ) {
-		return 'treatment';
-	}
-	// Done loading experiment assignment, and control or null assignment found
-	return 'control';
+	return false;
 }


### PR DESCRIPTION
The past ten days of data from the ToS Foldable Card experiment (21551-explat-experiment) has shown a near identical performance between the old static ToS design and the new foldable card treatment. This has provided us with enough confidence that there is no discernible regression in checkout conversions so we are deploying the treatment.

Experiment post pbxNRc-3r0-p2

Related to #84031 

## Proposed Changes

This PR is simply removing the experiment logic and displays the treatment content for WPCOM checkout _**only**_. Jetpack and Akismet checkout will still receive the control content.

Updating the hook in this way will give Jetpack/Akismet, and other teams, time to implement the new foldable card layout into their variants of checkout before we clean up the experiment code in January.

## Testing Instructions

**Test WPCOM checkout**
- Add a WPCOM plan to your cart and head to checkout
- Ensure the ToS foldable card is displayed and that it opens/closes correctly
- Check that it also works on mobile devices
![image](https://github.com/Automattic/wp-calypso/assets/16580129/404fa10a-75dc-4384-84fc-681e585c7488)

**Test Jetpack or Akismet checkout**
- Add a Jetpack or Akismet product to your cart, you can use a link like `http://calypso.localhost:3000/checkout/jetpack/jetpack_backup_t1_yearly`
- Ensure that the ToS foldable card **does not show**
![image](https://github.com/Automattic/wp-calypso/assets/16580129/8310c6e7-243c-43e9-80af-d35834e71058)

**Test the purchase modal**
- On a test account with a valid payment option go to `checkout/[your-site-name.com]/offer-plan-upgrade/business/12345`
- Click on `Upgrade Now` to launch the purchase modal
- Ensure the ToS foldable card **does not show**
![image](https://github.com/Automattic/wp-calypso/assets/16580129/862aaacf-04df-48f9-a82c-77600743bc4f)