### PR TITLE
GF Signup: Fix small hit box of term selector dropdown items

### DIFF
--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -31,6 +31,9 @@ const StyledCustomSelectControl = styled( CustomSelectControl )`
 	.components-custom-select-control__menu {
 		margin: 0;
 	}
+	.components-custom-select-control__item {
+		grid-template-columns: auto min-content;
+	}
 `;
 
 export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > = ( props ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/84895#issuecomment-1850860431

## Proposed Changes

* Make hit box of term selector drop down items larger

## Screenshots
### Before
![2023-12-11 10 30 55](https://github.com/Automattic/wp-calypso/assets/5414230/a4d015e4-482a-46c2-a781-987e7b1cc97f)

### After
![2023-12-18 16 34 16](https://github.com/Automattic/wp-calypso/assets/5414230/f4ea871e-22fe-4845-bf17-53a6c02f8824)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start?flags=onboarding%2Finterval-dropdown`
* Make sure the dropdown with term interval appears
* Click on a different interval than yearly and make sure the selected plan stays selected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?