### PR TITLE
Monetize: Ensure three columns for feature cards

### DIFF
--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -71,7 +71,7 @@
 	}
 }
 
-.earn .promo-card {
+.earn .promo-section__promos .promo-card {
 	@include breakpoint-deprecated( ">1280px" ) {
 		width: calc(33% - 1em);
 	}


### PR DESCRIPTION
## Proposed Changes

Very small PR that enforces 3 columns for feature cards on the Monetize screen. The CSS was in place, but selector priority seems different on production vs calypso localhost. This ensures new styles apply by increasing specificity.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to http://calypso.localhost:3000/earn/YOURSITESLUG and confirm feature cards are organized in three columns (on a laptop/desktop device). 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)