### PR TITLE
Purchase Modal - Update styles for ToS foldable card implementation

### DIFF
--- a/client/my-sites/checkout/purchase-modal/style.scss
+++ b/client/my-sites/checkout/purchase-modal/style.scss
@@ -158,16 +158,33 @@ $left-margin: 36px;
 /**
  * Checkout Terms
  */
-.purchase-modal .checkout__terms {
-	margin: 1em 0 4px;
-	padding-left: $left-margin;
-	font-size: $font-body-extra-small;
-}
-.purchase-modal .checkout__terms-item {
-	margin-bottom: 4px;
-	margin-left: 12px;
-	margin-top: 4px;
-}
+
+ .purchase-modal {
+	& .checkout__terms-foldable-card, .foldable-card.card.is-expanded {
+		margin: .5rem 0 .5rem 20px;
+		box-shadow: none;
+
+		& .foldable-card__expand {
+			top: 0;
+		}
+	}
+	& .foldable-card.is-expanded .foldable-card__content {
+		border-top: none;
+
+		& .checkout__terms-item {
+			margin-left: 0;
+		}
+	}
+	& .checkout__terms {
+		margin: 1em 0 4px;
+		padding-left: $left-margin;
+	}
+	& .checkout__terms-item {
+		margin-bottom: .5rem;
+		margin-left: 36px;
+		margin-top: .5rem;
+	}
+ }
 
 /**
  * Taxes and cost

--- a/client/my-sites/checkout/purchase-modal/style.scss
+++ b/client/my-sites/checkout/purchase-modal/style.scss
@@ -159,17 +159,19 @@ $left-margin: 36px;
  * Checkout Terms
  */
 
- .purchase-modal {
+.purchase-modal {
 	& .checkout__terms-foldable-card, .foldable-card.card.is-expanded {
-		margin: .5rem 0 .5rem 20px;
+		margin: 8px 0 8px 20px;
 		box-shadow: none;
-
+		padding: 0;
+		font-size: 14px;
 		& .foldable-card__expand {
 			top: 0;
 		}
 	}
 	& .foldable-card.is-expanded .foldable-card__content {
 		border-top: none;
+		padding-top: 8px;
 
 		& .checkout__terms-item {
 			margin-left: 0;
@@ -180,11 +182,11 @@ $left-margin: 36px;
 		padding-left: $left-margin;
 	}
 	& .checkout__terms-item {
-		margin-bottom: .5rem;
+		margin-bottom: 8px;
 		margin-left: 36px;
-		margin-top: .5rem;
+		margin-top: 8px;
 	}
- }
+}
 
 /**
  * Taxes and cost

--- a/client/my-sites/checkout/purchase-modal/style.scss
+++ b/client/my-sites/checkout/purchase-modal/style.scss
@@ -160,11 +160,12 @@ $left-margin: 36px;
  */
 
 .purchase-modal {
-	& .checkout__terms-foldable-card, .foldable-card.card.is-expanded {
+	& .checkout__terms-foldable-card,
+	.foldable-card.card.is-expanded {
 		margin: 8px 0 8px 20px;
 		box-shadow: none;
 		padding: 0;
-		font-size: 14px;
+		font-size: $font-body-small;
 		& .foldable-card__expand {
 			top: 0;
 		}

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -51,6 +51,7 @@ const CheckoutTermsWrapper = styled.div< {
 
 	& .checkout__terms-foldable-card {
 		box-shadow: none;
+		padding: 0;
 		& .foldable-card__header {
 			font-size: 12px;
 			font-weight: 500;

--- a/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
+++ b/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
@@ -7,15 +7,15 @@ import { getSelectedSiteId, getSectionName } from 'calypso/state/ui/selectors';
 
 export function useToSFoldableCard(): boolean {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const section = useSelector( getSectionName );
 	const isJetpackNotAtomic = useSelector(
 		( state ) => isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId )
 	);
 
+	const section = useSelector( getSectionName );
 	const enabledSections = [ 'business-plan-upgrade-upsell', 'checkout' ];
 
 	const isWPcomCheckout =
-		section != null &&
+		section &&
 		enabledSections.includes( section ) &&
 		! isJetpackCheckout() &&
 		! isAkismetCheckout() &&

--- a/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
+++ b/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
@@ -7,12 +7,16 @@ import { getSelectedSiteId, getSectionName } from 'calypso/state/ui/selectors';
 
 export function useToSFoldableCard(): boolean {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-
+	const section = useSelector( getSectionName );
 	const isJetpackNotAtomic = useSelector(
 		( state ) => isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId )
 	);
+
+	const enabledSections = [ 'business-plan-upgrade-upsell', 'checkout' ];
+
 	const isWPcomCheckout =
-		useSelector( getSectionName ) === 'checkout' &&
+		section != null &&
+		enabledSections.includes( section ) &&
 		! isJetpackCheckout() &&
 		! isAkismetCheckout() &&
 		! isJetpackNotAtomic;


### PR DESCRIPTION
Once the ToS Foldable Card component is merged into production for WPCOM checkout, we can begin implementing the new component into other checkout experiences. This PR handles the 'purchase modal' checkout implementation.

- ~This PR **should not be merged** until after https://github.com/Automattic/wp-calypso/pull/85445 is merged.~
- ~This PR **needs to be rebased** after https://github.com/Automattic/wp-calypso/pull/85445 is merged.~
- There is also a guard that will need to be removed - I'm rather certain this is the only other place `<CheckoutTerms />` is used outside of Checkout: https://github.com/Automattic/wp-calypso/blob/86e4dbd2f9bebeb48c34ba9f56cc71db73f2a396/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx#L16
- 
@aneeshd16 noted an interest in adding the foldable card to the purchase modal so mentioning you here.

Related to #85445

## Proposed Changes

| Before | After |
| ----- | ----- |
| <img src='https://github.com/Automattic/wp-calypso/assets/16580129/91ecc33a-ac6f-433d-a3b7-e127a3758414' width="400px" /> | <img src='https://github.com/Automattic/wp-calypso/assets/16580129/6d771184-2719-4917-bc5f-4d23c77c61a7' width="400px" /> |

* Collapsed legally unrequired terms under a foldable card to minimize wall of text and vertical space usage
* Slight adjustment to 'By checking out' text to match existing 'Read more' font size. This could be reverted to the smaller font size from before, but I suggest we also make the Read More font size match.

## Testing Instructions
- ~Hold off on testing until `https://github.com/Automattic/wp-calypso/pull/85445` is merged and this PR is rebased onto trunk~
- Ensure your account has an active payment/test payment method
- Go to `checkout/your_site_domain_/offer-plan-upgrade/business/12345`
- Click on Upgrade Now to open the purchase modal
- Click on Read More and ensure the styling doesn't have any visible inconsistencies with the overall purchase modal design
- Check on mobile widths as well