### PR TITLE
Update time remaining calculations for trial banners

### DIFF
--- a/client/me/purchases/manage-purchase/notices.tsx
+++ b/client/me/purchases/manage-purchase/notices.tsx
@@ -1097,7 +1097,7 @@ class PurchaseNotice extends Component<
 		const expiry = moment.utc( purchase.expiryDate );
 		const daysToExpiry = isExpired( purchase )
 			? 0
-			: Math.ceil( expiry.diff( moment().utc(), 'days', true ) );
+			: Math.floor( expiry.diff( moment().utc(), 'days', true ) );
 		const productType =
 			productSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY
 				? translate( 'ecommerce' )

--- a/client/my-sites/current-site/notice.jsx
+++ b/client/my-sites/current-site/notice.jsx
@@ -155,7 +155,7 @@ export class SiteNotice extends Component {
 	}
 
 	daysRemaining( { endsAt } ) {
-		return Math.ceil( moment( endsAt ).diff( moment(), 'days', true ) );
+		return Math.floor( moment( endsAt ).diff( moment(), 'days', true ) );
 	}
 
 	render() {

--- a/client/my-sites/plans/trials/trial-banner/index.tsx
+++ b/client/my-sites/plans/trials/trial-banner/index.tsx
@@ -26,7 +26,7 @@ const TrialBanner = ( props: TrialBannerProps ) => {
 		( state ) => ( {
 			currentPlan: getCurrentPlan( state, selectedSiteId ),
 			trialExpired: isTrialExpired( state, selectedSiteId ),
-			trialDaysLeft: Math.ceil( getTrialDaysLeft( state, selectedSiteId ) || 0 ),
+			trialDaysLeft: Math.floor( getTrialDaysLeft( state, selectedSiteId ) || 0 ),
 			trialExpiration: getTrialExpiration( state, selectedSiteId ),
 		} )
 	);

--- a/client/my-sites/plans/trials/trial-banner/use-banner-subtitle.ts
+++ b/client/my-sites/plans/trials/trial-banner/use-banner-subtitle.ts
@@ -4,7 +4,8 @@ import {
 	PlanSlug,
 } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
-import { useLocale } from '@automattic/i18n-utils';
+import { useIsEnglishLocale, useLocale } from '@automattic/i18n-utils';
+import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
 import type { Moment } from 'moment/moment';
@@ -18,6 +19,7 @@ export default function useBannerSubtitle(
 	isEcommerceTrial?: boolean
 ): string {
 	const locale = useLocale();
+	const isEn = useIsEnglishLocale();
 	const translate = useTranslate();
 	const [ bannerSubtitle, setBannerSubtitle ] = useState( '' );
 	// moment.js doesn't have a format option to display the long form in a localized way without the year
@@ -32,8 +34,31 @@ export default function useBannerSubtitle(
 	useEffect( () => {
 		// this may need updating for intro offers with singly counted units e.g. 1 month|year
 		let introOfferSubtitle;
-		if ( isEcommerceTrial && anyWooExpressIntroOffer ) {
-			if ( 'month' === anyWooExpressIntroOffer.intervalUnit ) {
+		if (
+			isEcommerceTrial &&
+			anyWooExpressIntroOffer &&
+			'month' === anyWooExpressIntroOffer.intervalUnit
+		) {
+			if (
+				trialDaysLeftToDisplay < 1 &&
+				( isEn ||
+					hasTranslation(
+						'Your free trial ends today. Upgrade by %(expirationdate)s to start selling and take advantage of our limited time offer ' +
+							'— any Woo Express plan for just %(introOfferFormattedPrice)s a month for your first %(introOfferIntervalCount)d months.'
+					) )
+			) {
+				introOfferSubtitle = translate(
+					'Your free trial ends today. Upgrade by %(expirationdate)s to start selling and take advantage of our limited time offer ' +
+						'— any Woo Express plan for just %(introOfferFormattedPrice)s a month for your first %(introOfferIntervalCount)d months.',
+					{
+						args: {
+							expirationdate: readableExpirationDate as string,
+							introOfferFormattedPrice: anyWooExpressIntroOffer.formattedPrice,
+							introOfferIntervalCount: anyWooExpressIntroOffer.intervalCount,
+						},
+					}
+				);
+			} else {
 				introOfferSubtitle = translate(
 					'Your free trial will end in %(daysLeft)d day. Upgrade by %(expirationdate)s to start selling and take advantage of our limited time offer ' +
 						'— any Woo Express plan for just %(introOfferFormattedPrice)s for your first %(introOfferIntervalCount)d months.',
@@ -61,6 +86,21 @@ export default function useBannerSubtitle(
 					);
 				} else if ( introOfferSubtitle ) {
 					subtitle = introOfferSubtitle;
+				} else if (
+					trialDaysLeftToDisplay < 1 &&
+					( isEn ||
+						hasTranslation(
+							'Your free trial ends today. Upgrade to a plan by %(expirationdate)s to unlock new features and launch your migrated website.'
+						) )
+				) {
+					subtitle = translate(
+						'Your free trial ends today. Upgrade to a plan by %(expirationdate)s to unlock new features and launch your migrated website.',
+						{
+							args: {
+								expirationdate: readableExpirationDate as string,
+							},
+						}
+					);
 				} else {
 					subtitle = translate(
 						'Your free trial will end in %(daysLeft)d day. Upgrade to a plan by %(expirationdate)s to unlock new features and launch your migrated website.',
@@ -79,6 +119,21 @@ export default function useBannerSubtitle(
 				if ( trialExpired ) {
 					subtitle = translate(
 						'Your free trial has expired. Upgrade to a plan to continue using advanced features.'
+					);
+				} else if (
+					trialDaysLeftToDisplay < 1 &&
+					( isEn ||
+						hasTranslation(
+							'Your free trial ends today. Upgrade to a plan by %(expirationdate)s to continue using advanced features.'
+						) )
+				) {
+					subtitle = translate(
+						'Your free trial ends today. Upgrade to a plan by %(expirationdate)s to continue using advanced features.',
+						{
+							args: {
+								expirationdate: readableExpirationDate as string,
+							},
+						}
 					);
 				} else {
 					subtitle = translate(
@@ -101,6 +156,21 @@ export default function useBannerSubtitle(
 					);
 				} else if ( introOfferSubtitle ) {
 					subtitle = introOfferSubtitle;
+				} else if (
+					trialDaysLeftToDisplay < 1 &&
+					( isEn ||
+						hasTranslation(
+							'Your free trial ends today. Upgrade to a plan by %(expirationdate)s to unlock new features and start selling.'
+						) )
+				) {
+					subtitle = translate(
+						'Your free trial ends today. Upgrade to a plan by %(expirationdate)s to unlock new features and start selling.',
+						{
+							args: {
+								expirationdate: readableExpirationDate as string,
+							},
+						}
+					);
 				} else {
 					subtitle = translate(
 						'Your free trial will end in %(daysLeft)d day. Upgrade to a plan by %(expirationdate)s to unlock new features and start selling.',
@@ -126,6 +196,7 @@ export default function useBannerSubtitle(
 		anyWooExpressIntroOffer,
 		isEcommerceTrial,
 		translate,
+		isEn,
 	] );
 
 	return bannerSubtitle;


### PR DESCRIPTION
Trials now give the user one more day than advertised, just to make sure users get the full amount regardless of timezone. This means rounding days remaining down in the UI.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #85272
Fixes https://github.com/Automattic/wc-calypso-bridge/issues/1329

## Proposed Changes

Works in conjunction with D132466-code

* Update banners to round-down
   * sidebar banner for Migration and Hosting trials
   * trial banner that appears on `/plans/:siteSlug`
   * banner that appears on `/me/purchases/:siteSlug/:id`

TODO: deal with the copy for the final day, which currently says "Your free trial will end in 0 days"

![CleanShot 2023-12-19 at 17 38 35@2x](https://github.com/Automattic/wp-calypso/assets/1500769/b88a1305-3720-420f-ad58-758816ca2d21)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?