### PR TITLE
Self-service resets: address CfT feedback

### DIFF
--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -117,9 +117,10 @@ function SiteResetCard( {
 	const siteId = useSelector( getSelectedSiteId );
 	const dispatch = useDispatch();
 
-	const { data } = useSiteResetContentSummaryQuery( siteId );
+	const { data, refetch: refetchContentSummary } = useSiteResetContentSummaryQuery( siteId );
 	const { data: status, refetch: refetchResetStatus } = useSiteResetStatusQuery( siteId );
 	const [ isDomainConfirmed, setDomainConfirmed ] = useState( false );
+	const [ resetComplete, setResetComplete ] = useState( false );
 
 	const checkStatus = async () => {
 		if ( status?.status !== 'completed' && isAtomic ) {
@@ -128,12 +129,14 @@ function SiteResetCard( {
 			} = await refetchResetStatus();
 
 			if ( latestStatus === 'completed' ) {
+				refetchContentSummary();
 				dispatch(
 					successNotice( translate( 'Your site was successfully reset' ), {
 						id: 'site-reset-success-notice',
 						duration: 4000,
 					} )
 				);
+				setResetComplete( true );
 			}
 		}
 	};
@@ -150,20 +153,16 @@ function SiteResetCard( {
 	const handleResult = ( result ) => {
 		if ( result.success ) {
 			if ( isAtomic ) {
-				dispatch(
-					successNotice( translate( 'Your site will be reset' ), {
-						id: 'site-reset-success-notice',
-						duration: 6000,
-					} )
-				);
 				refetchResetStatus();
 			} else {
+				refetchContentSummary();
 				dispatch(
 					successNotice( translate( 'Your site was successfully reset' ), {
 						id: 'site-reset-success-notice',
 						duration: 4000,
 					} )
 				);
+				setResetComplete( true );
 			}
 		} else {
 			handleError();
@@ -268,6 +267,99 @@ function SiteResetCard( {
 	const ctaText =
 		! isAtomic && isLoading ? translate( 'Resetting site' ) : translate( 'Reset site' );
 
+	const renderBody = () => {
+		if ( resetComplete ) {
+			const message = createInterpolateElement(
+				sprintf(
+					// translators: %s is the site domain
+					translate(
+						'<strong>%s</strong> has been successfully reset and its content removed. Head to <a>My Home</a> to start building your new site.'
+					),
+					siteDomain
+				),
+				{
+					strong: <strong />,
+					a: <a href={ `/home/${ selectedSiteSlug }` } />,
+				}
+			);
+			return (
+				<ActionPanel style={ { margin: 0 } }>
+					<ActionPanelBody>
+						<p>{ message }</p>
+					</ActionPanelBody>
+				</ActionPanel>
+			);
+		} else if ( isResetInProgress ) {
+			return (
+				<ActionPanel style={ { margin: 0 } }>
+					<ActionPanelBody>
+						<LoadingBar progress={ status?.progress } />
+						<p className="reset-site__in-progress-message">
+							{ translate( "We're resetting your site. We'll email you once it's ready." ) }
+						</p>
+					</ActionPanelBody>
+				</ActionPanel>
+			);
+		}
+		return (
+			<ActionPanel style={ { margin: 0 } }>
+				<ActionPanelBody>
+					<p>{ instructions }</p>
+					<p>{ translate( 'The following content will be removed:' ) }</p>
+					<ul>
+						{ contentInfo().map( ( { message, url } ) => {
+							if ( url ) {
+								return (
+									<li key={ message }>
+										<a href={ url }>{ message }</a>
+									</li>
+								);
+							}
+							return <li key={ message }>{ message }</li>;
+						} ) }
+					</ul>
+				</ActionPanelBody>
+				<ActionPanelFooter>
+					<FormLabel htmlFor="confirmResetInput" className="reset-site__confirm-label">
+						{ createInterpolateElement(
+							sprintf(
+								// translators: %s is the site domain
+								translate(
+									"Type <strong>%s</strong> below to confirm you're ready to reset the site:"
+								),
+								siteDomain
+							),
+							{
+								strong: <strong />,
+							}
+						) }
+					</FormLabel>
+					<div className="site-settings__reset-site-controls">
+						<FormTextInput
+							autoCapitalize="off"
+							aria-required="true"
+							id="confirmResetInput"
+							disabled={ isLoading }
+							style={ { flex: 1 } }
+							onChange={ ( event ) =>
+								setDomainConfirmed( event.currentTarget.value.trim() === siteDomain )
+							}
+						/>
+						<Button
+							primary // eslint-disable-line wpcalypso/jsx-classname-namespace
+							onClick={ handleReset }
+							disabled={ isLoading || ! isDomainConfirmed }
+							busy={ isLoading }
+						>
+							{ ctaText }
+						</Button>
+					</div>
+					{ backupHint && <p className="site-settings__reset-site-backup-hint">{ backupHint }</p> }
+				</ActionPanelFooter>
+			</ActionPanel>
+		);
+	};
+
 	return (
 		<Main className="site-settings__reset-site">
 			<Interval onTick={ checkStatus } period={ EVERY_FIVE_SECONDS } />
@@ -287,74 +379,7 @@ function SiteResetCard( {
 			<HeaderCake backHref={ '/settings/general/' + selectedSiteSlug }>
 				<h1>{ translate( 'Site Reset' ) }</h1>
 			</HeaderCake>
-			{ isResetInProgress ? (
-				<ActionPanel style={ { margin: 0 } }>
-					<ActionPanelBody>
-						<LoadingBar progress={ status?.progress } />
-						<p className="reset-site__in-progress-message">
-							{ translate( "We're resetting your site. We'll email you once it's ready." ) }
-						</p>
-					</ActionPanelBody>
-				</ActionPanel>
-			) : (
-				<ActionPanel style={ { margin: 0 } }>
-					<ActionPanelBody>
-						<p>{ instructions }</p>
-						<p>{ translate( 'The following content will be removed:' ) }</p>
-						<ul>
-							{ contentInfo().map( ( { message, url } ) => {
-								if ( url ) {
-									return (
-										<li key={ message }>
-											<a href={ url }>{ message }</a>
-										</li>
-									);
-								}
-								return <li key={ message }>{ message }</li>;
-							} ) }
-						</ul>
-					</ActionPanelBody>
-					<ActionPanelFooter>
-						<FormLabel htmlFor="confirmResetInput" className="reset-site__confirm-label">
-							{ createInterpolateElement(
-								sprintf(
-									// translators: %s is the site domain
-									translate(
-										"Type <strong>%s</strong> below to confirm you're ready to reset the site:"
-									),
-									siteDomain
-								),
-								{
-									strong: <strong />,
-								}
-							) }
-						</FormLabel>
-						<div className="site-settings__reset-site-controls">
-							<FormTextInput
-								autoCapitalize="off"
-								aria-required="true"
-								id="confirmResetInput"
-								disabled={ isLoading }
-								style={ { flex: 1 } }
-								onChange={ ( event ) =>
-									setDomainConfirmed( event.currentTarget.value.trim() === siteDomain )
-								}
-							/>
-							<Button
-								primary // eslint-disable-line wpcalypso/jsx-classname-namespace
-								onClick={ handleReset }
-								disabled={ isLoading || ! isDomainConfirmed }
-								busy={ isLoading }
-							>
-								{ ctaText }
-							</Button>
-						</div>
-						{ backupHint && (
-							<p className="site-settings__reset-site-backup-hint">{ backupHint }</p>
-						) }
-					</ActionPanelFooter>
-				</ActionPanel>
-			) }
+			{ renderBody() }
 			<BuiltByUpsell
 				site={ site }
 				isUnlaunchedSite={ isUnlaunchedSiteProp }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdtkmj-2ag-p2#comment-3917
See also D132472-code

<img width="1002" alt="Screenshot 2566-12-19 at 12 08 41" src="https://github.com/Automattic/wp-calypso/assets/6851384/42d02897-74ed-4b1a-bb1a-00acea1931ad">

## Proposed Changes

* Show a completed UI suggested here https://github.com/Automattic/wp-calypso/issues/85212#issue-2039500559
* Refetch content summary after reset
* Removes a redundant notice

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This update affects Simple and Atomic
* After the reset completes, you should see the UI above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?