### PR TITLE
Jetpack Manage: Accessibility improvement with product cards.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/licenses-form/index.tsx
@@ -231,7 +231,7 @@ export default function LicensesForm( {
 	const isSingleLicenseView = quantity === 1;
 
 	const getProductCards = ( products: APIProductFamilyProduct[] ) => {
-		return products.map( ( productOption, i ) =>
+		return products.map( ( productOption ) =>
 			Array.isArray( productOption ) ? (
 				<LicenseMultiProductCard
 					key={ productOption.map( ( { slug } ) => slug ).join( ',' ) }
@@ -249,7 +249,6 @@ export default function LicensesForm( {
 						( isIncompatibleProduct( productOption, incompatibleProducts ) &&
 							! isSelected( productOption.map( ( { slug } ) => slug ) ) )
 					}
-					tabIndex={ 100 + i }
 					hideDiscount={ isSingleLicenseView }
 					suggestedProduct={ suggestedProduct }
 					quantity={ quantity }
@@ -262,7 +261,6 @@ export default function LicensesForm( {
 					onSelectProduct={ onSelectProduct }
 					isSelected={ isSelected( productOption.slug ) }
 					isDisabled={ ! isReady || isIncompatibleProduct( productOption, incompatibleProducts ) }
-					tabIndex={ 100 + i }
 					hideDiscount={ isSingleLicenseView }
 					suggestedProduct={ suggestedProduct }
 					quantity={ quantity }

--- a/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-multiple-licenses-form/index.tsx
@@ -219,7 +219,7 @@ export default function IssueMultipleLicensesForm( {
 			</div>
 			<div className="issue-multiple-licenses-form__bottom">
 				{ products &&
-					products.map( ( productOption, i ) => (
+					products.map( ( productOption ) => (
 						<LicenseProductCard
 							isMultiSelect
 							key={ productOption.slug }
@@ -227,7 +227,6 @@ export default function IssueMultipleLicensesForm( {
 							onSelectProduct={ onSelectProduct }
 							isSelected={ selectedProductSlugs.includes( productOption.slug ) }
 							isDisabled={ disabledProductSlugs.includes( productOption.slug ) }
-							tabIndex={ 100 + i }
 							suggestedProduct={ suggestedProduct }
 						/>
 					) ) }
@@ -261,7 +260,7 @@ export default function IssueMultipleLicensesForm( {
 						{ translate( 'WooCommerce Extensions:' ) }
 					</p>
 					<div className="issue-multiple-licenses-form__bottom">
-						{ wooExtensions.map( ( productOption, i ) => (
+						{ wooExtensions.map( ( productOption ) => (
 							<LicenseProductCard
 								isMultiSelect
 								key={ productOption.slug }
@@ -269,7 +268,6 @@ export default function IssueMultipleLicensesForm( {
 								onSelectProduct={ onSelectProduct }
 								isSelected={ selectedProductSlugs.includes( productOption.slug ) }
 								isDisabled={ disabledProductSlugs.includes( productOption.slug ) }
-								tabIndex={ 100 + i }
 								suggestedProduct={ suggestedProduct }
 							/>
 						) ) }
@@ -283,7 +281,7 @@ export default function IssueMultipleLicensesForm( {
 						{ translate( 'VaultPress Backup Add-on Storage:' ) }
 					</p>
 					<div className="issue-multiple-licenses-form__bottom">
-						{ backupAddons.map( ( productOption, i ) => (
+						{ backupAddons.map( ( productOption ) => (
 							<LicenseProductCard
 								isMultiSelect
 								key={ productOption.slug }
@@ -291,7 +289,6 @@ export default function IssueMultipleLicensesForm( {
 								onSelectProduct={ onSelectProduct }
 								isSelected={ selectedProductSlugs.includes( productOption.slug ) }
 								isDisabled={ disabledProductSlugs.includes( productOption.slug ) }
-								tabIndex={ 100 + i }
 								suggestedProduct={ suggestedProduct }
 							/>
 						) ) }

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox-link/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox-link/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { FunctionComponent } from 'react';
+import { FunctionComponent, KeyboardEvent, useCallback } from 'react';
 import ModalLinkIcon from 'calypso/assets/images/jetpack/jetpack-icon-modal-link.svg';
 import { preventWidows } from 'calypso/lib/formatting';
 
@@ -14,12 +14,16 @@ type Props = {
 const LicenseLightboxLink: FunctionComponent< Props > = ( { productName, onClick } ) => {
 	const translate = useTranslate();
 
+	const onKeyDown = useCallback( ( e: KeyboardEvent< HTMLButtonElement > ) => {
+		e.stopPropagation();
+	}, [] );
+
 	// In this specific context, not wrapping between words in a product name
 	// gives us a more readable, professional look
 	const noWrapProductName = <>{ preventWidows( productName, Infinity ) }</>;
 
 	return (
-		<Button className="license-lightbox-link" plain onClick={ onClick }>
+		<Button className="license-lightbox-link" plain onClick={ onClick } onKeyDown={ onKeyDown }>
 			<span className="license-lightbox-link__text">
 				{ translate( 'More about {{productName/}}', {
 					components: { productName: noWrapProductName },

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox-link/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox-link/style.scss
@@ -7,6 +7,13 @@
 	text-decoration: underline;
 	text-align: left;
 	cursor: pointer;
+	padding-left: 2px;
+	margin-left: -2px;
+}
+
+.license-lightbox-link:focus-visible {
+	border-radius: 2px;
+	box-shadow: 0 0 0 1px var(--studio-gray-10);
 }
 
 .license-lightbox-link__text {

--- a/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
@@ -17,7 +17,6 @@ import ProductPriceWithDiscount from '../primary/product-price-with-discount-inf
 import '../license-product-card/style.scss';
 
 interface Props {
-	tabIndex: number;
 	products: APIProductFamilyProduct[];
 	isSelected: boolean;
 	isDisabled?: boolean;
@@ -34,7 +33,6 @@ interface Props {
 
 export default function LicenseMultiProductCard( props: Props ) {
 	const {
-		tabIndex,
 		products,
 		isSelected,
 		isDisabled,
@@ -72,8 +70,8 @@ export default function LicenseMultiProductCard( props: Props ) {
 	const onKeyDown = useCallback(
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		( e: any ) => {
-			// Spacebar
-			if ( 32 === e.keyCode ) {
+			// Enter
+			if ( 13 === e.keyCode ) {
 				onSelect();
 			}
 		},
@@ -157,7 +155,7 @@ export default function LicenseMultiProductCard( props: Props ) {
 				role="checkbox"
 				aria-checked={ isSelected }
 				aria-disabled={ isDisabled }
-				tabIndex={ tabIndex }
+				tabIndex={ 0 }
 			>
 				<div className="license-product-card__inner">
 					<div className="license-product-card__details">

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -60,6 +60,7 @@ export default function LicenseProductCard( props: Props ) {
 
 	const onKeyDown = useCallback(
 		( e: any ) => {
+			// Enter
 			if ( 13 === e.keyCode ) {
 				onSelect();
 			}

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/index.tsx
@@ -16,7 +16,6 @@ import ProductPriceWithDiscount from '../primary/product-price-with-discount-inf
 import './style.scss';
 
 interface Props {
-	tabIndex: number;
 	product: APIProductFamilyProduct;
 	isSelected: boolean;
 	isDisabled?: boolean;
@@ -30,7 +29,6 @@ interface Props {
 
 export default function LicenseProductCard( props: Props ) {
 	const {
-		tabIndex,
 		product,
 		isSelected,
 		isDisabled,
@@ -62,8 +60,7 @@ export default function LicenseProductCard( props: Props ) {
 
 	const onKeyDown = useCallback(
 		( e: any ) => {
-			// Spacebar
-			if ( 32 === e.keyCode ) {
+			if ( 13 === e.keyCode ) {
 				onSelect();
 			}
 		},
@@ -115,7 +112,7 @@ export default function LicenseProductCard( props: Props ) {
 				onClick={ onSelect }
 				onKeyDown={ onKeyDown }
 				role={ isMultiSelect ? 'checkbox' : 'radio' }
-				tabIndex={ tabIndex }
+				tabIndex={ 0 }
 				aria-checked={ isSelected }
 				aria-disabled={ isDisabled }
 				className={ classNames( {

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
@@ -32,8 +32,8 @@
 .license-product-card:focus-within,
 .license-product-card.selected {
 	.license-product-card__inner {
-		border: 1px solid #fff;
-		background: #fff;
+		border: 1px solid var(--studio-white);
+		background: var(--studio-white);
 		box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
 	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
@@ -28,10 +28,18 @@
 	}
 }
 
-.license-product-card.selected .license-product-card__inner {
-	border: 1px solid #fff;
-	background: #fff;
-	box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
+.license-product-card:hover,
+.license-product-card:focus-within,
+.license-product-card.selected {
+	.license-product-card__inner {
+		border: 1px solid #fff;
+		background: #fff;
+		box-shadow: 0 0 40px rgba(0, 0, 0, 0.08);
+	}
+}
+
+.license-product-card:focus .license-product-card__select-button {
+	outline: var(--studio-gray-10) solid 2px;
 }
 
 @mixin license-product-card-block__details {
@@ -270,3 +278,4 @@
 		background: var(--studio-green-50);
 	}
 }
+

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
@@ -38,7 +38,7 @@
 	}
 }
 
-.license-product-card:focus .license-product-card__select-button {
+.license-product-card:focus-visible .license-product-card__select-button {
 	outline: var(--studio-gray-10) solid 2px;
 }
 


### PR DESCRIPTION
This pull request aims to enhance the keyboard accessibility of the product cards on our Issue license page. Currently, pressing the tab and enter keys does not work as intended. To fix this, this pull request includes styling rules that indicate when the product cards are in focus, as well as an updated key listener that properly handles the enter key.


https://github.com/Automattic/wp-calypso/assets/56598660/4abc0ec5-1c3f-40cb-8734-d558a6461b97


Closes https://github.com/Automattic/jetpack-genesis/issues/146

## Proposed Changes

* Add styling rules for product cards when elements within it are focused. 
* Update the product card key listener to watch for the **Enter** key instead of the spacebar. **Spacebar** isn't an ideal key for selection as, for some browsers, this causes it to scroll down.
* Remove manual tab index, for best practice, we shouldn't be setting this and allow the browser to decide the tab order.

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Use the Jetpack cloud live link below and go to the Issue license page (`/partner-portal/issue-license`)
* Click the search bar so our tab starts from there.
* Press the **Tab** key and confirm that the product card focuses. Pressing the **Enter** key should select/unselect the product card.
* Press the **Tab** key and confirm the focus moves to the variant option. Use arrow keys to switch options.
* Press the **Tab** key and confirm the focus moves to the 'More info' link. Pressing the **Enter** key will show the product's modal.
* Press the **Tab** key and confirm the focus moves the focus to the next product card.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?