### PR TITLE
Jetpack Manage: Fix the issue with navigating variants in product cards using arrow keys.

### DIFF
--- a/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-survey.jsx
+++ b/client/components/marketing-survey/gsuite-cancel-purchase-dialog/gsuite-cancellation-survey.jsx
@@ -23,6 +23,7 @@ class GSuiteCancellationSurvey extends Component {
 
 		return (
 			<MultipleChoiceQuestion
+				name="gsuite-cancellation-survey-question"
 				answers={ [
 					{
 						id: 'too-expensive',

--- a/client/components/multiple-choice-question/README.md
+++ b/client/components/multiple-choice-question/README.md
@@ -54,6 +54,7 @@ function MultipleChoiceQuestionExamples( { translate } ) {
 	return (
 		<div>
 			<MultipleChoiceQuestion
+				name="question-1"
 				answers={ answers }
 				question="Please choose one of the following:"
 				onAnswerChange={ ( answer, text ) => {

--- a/client/components/multiple-choice-question/answer.jsx
+++ b/client/components/multiple-choice-question/answer.jsx
@@ -59,7 +59,7 @@ MultipleChoiceAnswer.propTypes = {
 		children: PropTypes.object,
 	} ).isRequired,
 	selectedAnswerText: PropTypes.string,
-	name: PropTypes.string,
+	name: PropTypes.string.isRequired,
 };
 
 MultipleChoiceAnswer.defaultProps = {

--- a/client/components/multiple-choice-question/answer.jsx
+++ b/client/components/multiple-choice-question/answer.jsx
@@ -7,6 +7,7 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 const MultipleChoiceAnswer = ( {
 	disabled,
 	answer: { id, answerText, textInput, textInputPrompt, children },
+	name,
 	isSelected,
 	onAnswerChange,
 	selectedAnswerText,
@@ -20,6 +21,7 @@ const MultipleChoiceAnswer = ( {
 				onChange={ () => {
 					onAnswerChange( id, textResponse );
 				} }
+				name={ name }
 				checked={ isSelected }
 				disabled={ disabled }
 				label={ answerText }
@@ -57,6 +59,7 @@ MultipleChoiceAnswer.propTypes = {
 		children: PropTypes.object,
 	} ).isRequired,
 	selectedAnswerText: PropTypes.string,
+	name: PropTypes.string,
 };
 
 MultipleChoiceAnswer.defaultProps = {

--- a/client/components/multiple-choice-question/docs/example.jsx
+++ b/client/components/multiple-choice-question/docs/example.jsx
@@ -54,6 +54,7 @@ function MultipleChoiceQuestionExamples() {
 		<div>
 			<Card>
 				<MultipleChoiceQuestion
+					name="question-1"
 					answers={ answers }
 					question="Please choose one of the following:"
 					onAnswerChange={ ( answer, text ) => {

--- a/client/components/multiple-choice-question/index.jsx
+++ b/client/components/multiple-choice-question/index.jsx
@@ -21,6 +21,7 @@ const shuffleAnswers = memoize(
 const MultipleChoiceQuestion = ( {
 	disabled,
 	answers,
+	name,
 	onAnswerChange,
 	question,
 	selectedAnswerId,
@@ -40,6 +41,7 @@ const MultipleChoiceQuestion = ( {
 			<div className="multiple-choice-question__answers">
 				{ shuffledAnswers.map( ( answer ) => (
 					<MultipleChoiceAnswer
+						name={ name }
 						key={ answer.id }
 						answer={ answer }
 						disabled={ disabled }
@@ -68,6 +70,7 @@ MultipleChoiceQuestion.propTypes = {
 		} )
 	).isRequired,
 	disabled: PropTypes.bool,
+	name: PropTypes.string,
 	onAnswerChange: PropTypes.func.isRequired,
 	question: PropTypes.string.isRequired,
 	selectedAnswerId: PropTypes.string,

--- a/client/components/multiple-choice-question/index.jsx
+++ b/client/components/multiple-choice-question/index.jsx
@@ -70,7 +70,7 @@ MultipleChoiceQuestion.propTypes = {
 		} )
 	).isRequired,
 	disabled: PropTypes.bool,
-	name: PropTypes.string,
+	name: PropTypes.string.isRequired,
 	onAnswerChange: PropTypes.func.isRequired,
 	question: PropTypes.string.isRequired,
 	selectedAnswerId: PropTypes.string,

--- a/client/components/multiple-choice-question/test/__snapshots__/index.js.snap
+++ b/client/components/multiple-choice-question/test/__snapshots__/index.js.snap
@@ -21,6 +21,7 @@ exports[`MultipleChoiceQuestion should render with the minimum required properti
         checked={false}
         className="form-radio"
         disabled={false}
+        name="test-question"
         onChange={[Function]}
         type="radio"
         value="test-answer-1"
@@ -38,6 +39,7 @@ exports[`MultipleChoiceQuestion should render with the minimum required properti
         checked={false}
         className="form-radio"
         disabled={false}
+        name="test-question"
         onChange={[Function]}
         type="radio"
         value="test-answer-2"
@@ -55,6 +57,7 @@ exports[`MultipleChoiceQuestion should render with the minimum required properti
         checked={false}
         className="form-radio"
         disabled={false}
+        name="test-question"
         onChange={[Function]}
         type="radio"
         value="test-answer-3"
@@ -72,6 +75,7 @@ exports[`MultipleChoiceQuestion should render with the minimum required properti
         checked={false}
         className="form-radio"
         disabled={false}
+        name="test-question"
         onChange={[Function]}
         type="radio"
         value="test-answer-4"

--- a/client/components/multiple-choice-question/test/index.js
+++ b/client/components/multiple-choice-question/test/index.js
@@ -8,6 +8,7 @@ describe( 'MultipleChoiceQuestion', () => {
 		const tree = renderer
 			.create(
 				<MultipleChoiceQuestion
+					name="test-question"
 					question="Test Question One"
 					answers={ [
 						{ id: 'test-answer-1', answerText: 'Test Answer One', doNotShuffle: true },

--- a/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
@@ -166,10 +166,10 @@ export default function LicenseMultiProductCard( props: Props ) {
 								</h3>
 
 								<MultipleChoiceQuestion
-									name={ `${ product?.slug }-variant-options` }
+									name={ `${ product.family_slug }-variant-options` }
 									question={ translate( 'Select variant:' ) }
 									answers={ variantOptions }
-									selectedAnswerId={ product?.slug }
+									selectedAnswerId={ product.slug }
 									onAnswerChange={ onChangeOption }
 									shouldShuffleAnswers={ false }
 								/>

--- a/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
@@ -166,6 +166,7 @@ export default function LicenseMultiProductCard( props: Props ) {
 								</h3>
 
 								<MultipleChoiceQuestion
+									name={ `${ product?.slug }-variant-options` }
 									question={ translate( 'Select variant:' ) }
 									answers={ variantOptions }
 									selectedAnswerId={ product?.slug }

--- a/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/product-lightbox/index.tsx
@@ -133,6 +133,7 @@ const ProductLightbox: React.FC< Props > = ( {
 							<div>
 								<div className="product-lightbox__variants-options">
 									<MultipleChoiceQuestion
+										name="product-variants"
 										question={ PRODUCT_OPTIONS_HEADER[ product?.productSlug ] }
 										answers={ variantOptions }
 										selectedAnswerId={ product?.productSlug }


### PR DESCRIPTION
When using the arrow keys to navigate the product card variant options, the cursor moves to a different product card that also has variant options. The problem arises when the radio elements from different cards lack a unique name. This makes it difficult for the browser to identify and group associated selections. To address this issue, the proposed solution is to add a name property to the radio buttons through this pull request.

**Before**
When hitting the right arrow keys multiple times while selecting a Security variant, the product moves to a different card.

https://github.com/Automattic/wp-calypso/assets/56598660/53acfe6b-5fc2-4aea-8d28-f48e33e51c2b

**After**
When hitting the right arrow keys multiple times while selecting a Security variant, the focus does not move to a different card; instead, the selection remains in the same card.

https://github.com/Automattic/wp-calypso/assets/56598660/693bf816-42ca-4e86-ba6b-787ed22cecd1




Closes https://github.com/Automattic/jetpack-manage/issues/183

## Proposed Changes

* Update the `MultipleChoiceQuestion` component to include a name prop that will allow us to separate unrelated radio buttons.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Use the Jetpack cloud live link below and go to the Issue license page (`/partner-portal/issue-license`)
* Click any product variant options on the card.
* Press the arrow key left or right and confirm that the focus does not move to a different card.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?