### PR TITLE
Implement WooCommerce passwordless signup

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button, FormInputValidation } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { Spinner } from '@wordpress/components';
 import classNames from 'classnames';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
@@ -1088,6 +1089,27 @@ class SignupForm extends Component {
 			: formState.getFieldValue( this.state.form, 'email' );
 	};
 
+	getPasswordlessFromProps = () => {
+		const { isGravatar, isWoo } = this.props;
+
+		if ( isGravatar ) {
+			return {
+				inputPlaceholder: this.props.translate( 'Enter your email address' ),
+				submitButtonLabel: this.props.translate( 'Continue' ),
+				submitButtonLoadingLabel: this.props.translate( 'Continue' ),
+			};
+		}
+
+		if ( isWoo ) {
+			return {
+				submitButtonLabel: this.props.translate( 'Get Started' ),
+				submitButtonLoadingLabel: <Spinner />,
+			};
+		}
+
+		return {};
+	};
+
 	render() {
 		if ( this.getUserExistsError( this.props ) && ! this.props.shouldDisplayUserExistsError ) {
 			return null;
@@ -1204,19 +1226,11 @@ class SignupForm extends Component {
 			);
 		}
 
-		const isGravatar = this.props.isGravatar;
+		const { isGravatar, isWoo, isPasswordless, flowName } = this.props;
 		const showSeparator =
 			! config.isEnabled( 'desktop' ) && this.isHorizontal() && ! this.userCreationComplete();
 
-		if ( ( this.props.isPasswordless && 'wpcc' !== this.props.flowName ) || isGravatar ) {
-			const gravatarProps = isGravatar
-				? {
-						inputPlaceholder: this.props.translate( 'Enter your email address' ),
-						submitButtonLabel: this.props.translate( 'Continue' ),
-						submitButtonLoadingLabel: this.props.translate( 'Continue' ),
-				  }
-				: {};
-
+		if ( ( isPasswordless && 'wpcc' !== flowName ) || isGravatar || isWoo ) {
 			return (
 				<div
 					className={ classNames( 'signup-form', this.props.className, {
@@ -1235,7 +1249,7 @@ class SignupForm extends Component {
 						disableSubmitButton={ this.props.disableSubmitButton }
 						queryArgs={ this.props.queryArgs }
 						userEmail={ this.getEmailValue() }
-						{ ...gravatarProps }
+						{ ...this.getPasswordlessFromProps() }
 					/>
 
 					{ ! isGravatar && (
@@ -1243,13 +1257,18 @@ class SignupForm extends Component {
 							{ showSeparator && <FormDivider /> }
 
 							{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
-								<SocialSignupForm
-									handleResponse={ this.props.handleSocialResponse }
-									socialService={ this.props.socialService }
-									socialServiceResponse={ this.props.socialServiceResponse }
-									isReskinned={ this.props.isReskinned }
-									redirectToAfterLoginUrl={ this.props.redirectToAfterLoginUrl }
-								/>
+								<>
+									{ this.props.isWoo && <FormDivider /> }
+									<SocialSignupForm
+										handleResponse={ this.props.handleSocialResponse }
+										socialService={ this.props.socialService }
+										socialServiceResponse={ this.props.socialServiceResponse }
+										isReskinned={ this.props.isReskinned }
+										flowName={ this.props.flowName }
+										compact={ this.props.isWoo }
+										redirectToAfterLoginUrl={ this.props.redirectToAfterLoginUrl }
+									/>
+								</>
 							) }
 							{ this.props.footerLink || this.footerLink() }
 						</>

--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -27,7 +27,7 @@ class PasswordlessSignupForm extends Component {
 		locale: PropTypes.string,
 		inputPlaceholder: PropTypes.string,
 		submitButtonLabel: PropTypes.string,
-		submitButtonLoadingLabel: PropTypes.string,
+		submitButtonLoadingLabel: PropTypes.oneOfType( [ PropTypes.node, PropTypes.string ] ),
 		userEmail: PropTypes.string,
 	};
 

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { Button } from '@wordpress/components';
+import { Button, Spinner } from '@wordpress/components';
 import { useState, createInterpolateElement } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import MailIcon from 'calypso/components/social-icons/mail';
@@ -52,6 +52,24 @@ const SignupFormSocialFirst = ( {
 	const isWoo = isWooOAuth2Client( oauth2Client ) || isWooCoreProfilerFlow;
 	const isGravatar = isGravatarOAuth2Client( oauth2Client );
 
+	const getPasswordlessSignupFormProps = () => {
+		if ( isGravatar ) {
+			return {
+				inputPlaceholder: __( 'Enter your email address' ),
+				submitButtonLoadingLabel: __( 'Continue' ),
+			};
+		}
+
+		if ( isWoo ) {
+			return {
+				submitButtonLabel: __( 'Get Started' ),
+				submitButtonLoadingLabel: <Spinner />,
+			};
+		}
+
+		return {};
+	};
+
 	const renderContent = () => {
 		if ( currentStep === 'initial' ) {
 			return (
@@ -78,13 +96,6 @@ const SignupFormSocialFirst = ( {
 				</>
 			);
 		} else if ( currentStep === 'email' ) {
-			const gravatarProps = isGravatar
-				? {
-						inputPlaceholder: __( 'Enter your email address' ),
-						submitButtonLoadingLabel: __( 'Continue' ),
-				  }
-				: {};
-
 			return (
 				<div className="signup-form-social-first-email">
 					<PasswordlessSignupForm
@@ -97,7 +108,7 @@ const SignupFormSocialFirst = ( {
 						labelText={ __( 'Your email' ) }
 						submitButtonLabel={ __( 'Continue' ) }
 						userEmail={ userEmail }
-						{ ...gravatarProps }
+						{ ...getPasswordlessSignupFormProps() }
 					/>
 					<Button
 						onClick={ () => setCurrentStep( 'initial' ) }

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -508,7 +508,7 @@
 		display: none;
 	}
 
-	.auth-form__social,
+	.auth-form__social.card,
 	.two-factor-authentication__actions {
 		background: initial;
 		border-top: $woo-form-divider-border;
@@ -565,8 +565,7 @@
 
 		.auth-form__separator {
 			width: 100%;
-			margin-left: 0;
-			margin-right: 0;
+			margin: -10px 0;
 
 			&::before,
 			&::after {
@@ -607,6 +606,10 @@
 			color: $gray-50;
 			font-size: inherit;
 		}
+	}
+
+	.step-wrapper__navigation-link.forward {
+		display: none;
 	}
 
 	.login .login__form-forgot-password {
@@ -690,6 +693,47 @@
 
 	.signup-form__woo-wrapper .gridicon {
 		color: var(--color-primary);
+	}
+
+	.signup-form-social-first {
+		.auth-form__social.card {
+			border-top: 0;
+		}
+
+		.auth-form__social {
+			max-width: 400px;
+			align-items: stretch;
+		}
+
+		.auth-form__social-buttons button.social-buttons__button.button {
+			width: 100%;
+
+			svg {
+				border: 0;
+				border-radius: 0;
+			}
+		}
+
+		.back-button {
+			color: #1d2327;
+			text-align: center;
+			font-size: 0.875rem;
+			font-style: normal;
+			font-weight: 500;
+			line-height: 20px;
+			display: block;
+			margin: 0 auto;
+			text-underline-offset: 5px;
+			margin-bottom: 16px;
+		}
+
+		.logged-out-form {
+			margin: 0;
+		}
+	}
+
+	.signup-form-social-first__tos-link {
+		text-align: center;
 	}
 
 	.auth-form__social {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -313,10 +313,11 @@ export function generateFlows( {
 		},
 		{
 			name: 'wpcc',
-			steps: [ 'oauth2-user' ],
+			steps: [ 'oauth2-user', 'oauth2-confirm-email' ],
 			destination: getRedirectDestination,
 			description: 'WordPress.com Connect signup flow',
-			lastModified: '2017-08-24',
+			lastModified: '2023-12-19',
+			providesDependenciesInQuery: [ 'oauth2_client_id', 'oauth2_redirect' ],
 			disallowResume: true, // don't allow resume so we don't clear query params when we go back in the history
 			showRecaptcha: true,
 		},

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -11,6 +11,7 @@ const stepNameToModuleName = {
 	'creds-confirm': 'creds-confirm',
 	'creds-complete': 'creds-complete',
 	'creds-permission': 'creds-permission',
+	'oauth2-confirm-email': 'oauth2-confirm-email',
 	domains: 'domains',
 	'domain-only': 'domains',
 	'domains-launch': 'domains',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -784,6 +784,11 @@ export function generateSteps( {
 			stepName: 'p2-get-started',
 		},
 
+		'oauth2-confirm-email': {
+			stepName: 'oauth2-confirm-email',
+			fulfilledStepCallback: excludeStepIfEmailVerified,
+		},
+
 		'p2-confirm-email': {
 			stepName: 'p2-confirm-email',
 			fulfilledStepCallback: excludeStepIfEmailVerified,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -47,6 +47,7 @@ import P2SignupProcessingScreen from 'calypso/signup/p2-processing-screen';
 import SignupProcessingScreen from 'calypso/signup/processing-screen';
 import ReskinnedProcessingScreen from 'calypso/signup/reskinned-processing-screen';
 import SignupHeader from 'calypso/signup/signup-header';
+import { isWpccFlow } from 'calypso/signup/utils';
 import { loadTrackingTool } from 'calypso/state/analytics/actions';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import {
@@ -711,6 +712,11 @@ class Signup extends Component {
 			this.setState( { previousFlowName: this.props.flowName } );
 		}
 
+		// Call processFulfilledSteps before redirecting to the next step because we don't want to show the email confirmation screen if it's not necessary.
+		if ( isWpccFlow( nextFlowName ) && nextStepName ) {
+			this.processFulfilledSteps( nextStepName, this.props );
+		}
+
 		this.goToStep( nextStepName, nextStepSection, nextFlowName );
 	};
 
@@ -874,6 +880,7 @@ class Signup extends Component {
 			return <QuerySiteDomains siteId={ this.props.siteId } />;
 		}
 	}
+
 	render() {
 		// Prevent rendering a step if in the middle of performing a redirect or resuming progress.
 		if (

--- a/client/signup/steps/oauth2-confirm-email/index.tsx
+++ b/client/signup/steps/oauth2-confirm-email/index.tsx
@@ -1,0 +1,127 @@
+import { Button } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector, useDispatch } from 'react-redux';
+import Gravatar from 'calypso/components/gravatar';
+import wpcom from 'calypso/lib/wp';
+import StepWrapper from 'calypso/signup/step-wrapper';
+import { fetchCurrentUser } from 'calypso/state/current-user/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+
+import './style.scss';
+
+// Current only used in Woo Signup Flow
+function Oauth2ConfirmEmail( {
+	flowName,
+	stepName,
+	positionInFlow,
+}: {
+	flowName: string;
+	stepName: string;
+	positionInFlow: number;
+} ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const currentUser = useSelector( getCurrentUser );
+	const [ emailResendCount, setEmailResendCount ] = useState( 0 );
+	const EMAIL_RESEND_MAX = 3;
+
+	useEffect( () => {
+		dispatch( fetchCurrentUser() as any );
+	}, [ dispatch ] );
+
+	const handleResendEmailClick = ( event: React.MouseEvent< HTMLAnchorElement > ) => {
+		event.preventDefault();
+
+		if ( emailResendCount >= EMAIL_RESEND_MAX ) {
+			return;
+		}
+
+		wpcom.req
+			.post( '/me/send-verification-email', {
+				from: 'woocommerce-signup',
+			} )
+			.then( () => {
+				setEmailResendCount( emailResendCount + 1 );
+				dispatch(
+					successNotice( translate( 'Verification email resent. Please check your inbox.' ) )
+				);
+			} )
+			.catch( () => {
+				dispatch( errorNotice( translate( 'Unable to resend email. Please try again later.' ) ) );
+			} );
+	};
+
+	const getHeaderText = () => {
+		return (
+			<div className={ classNames( 'signup-form__woo-wrapper' ) }>
+				<h3>{ translate( 'One last step!' ) }</h3>
+			</div>
+		);
+	};
+
+	const getSubHeaderText = () => {
+		return translate(
+			"We'll make it quick – promise. Please verify your email address via the{{br}}{{/br}}confirmation email we've sent to you. Don't see an email? It could be hiding in your{{br}}{{/br}}spam folder!",
+			{
+				components: {
+					br: <br />,
+				},
+			}
+		);
+	};
+
+	const renderStepContent = () => {
+		const userName = currentUser?.display_name || currentUser?.username;
+
+		return (
+			<div className="wpcc-confirm-email">
+				<div className="confirm-email__user">
+					<Gravatar
+						user={ currentUser }
+						className="confirm-email-user__gravatar"
+						imgSize={ 400 }
+						size={ 110 }
+					/>
+					<div>
+						<div className="confirm-email-user__username">
+							{ translate( 'Signing in as %(username)s', {
+								args: { username: userName || '' },
+							} ) }
+						</div>
+						<div className="confirm-email-user__email">{ currentUser?.email }</div>
+					</div>
+				</div>
+
+				{ emailResendCount < EMAIL_RESEND_MAX && (
+					<p className="confirm-email__resend-email">
+						{ translate( "Didn't receive an email? {{link}}Resend email{{/link}}", {
+							components: {
+								link: <Button variant="link" href="" onClick={ handleResendEmailClick } />,
+							},
+						} ) }
+					</p>
+				) }
+			</div>
+		);
+	};
+
+	return (
+		<StepWrapper
+			flowName={ flowName }
+			stepName={ stepName }
+			headerText={ getHeaderText() }
+			subHeaderText={ getSubHeaderText() }
+			positionInFlow={ positionInFlow }
+			fallbackHeaderText={ getHeaderText() }
+			fallbackSubHeaderText={ getSubHeaderText() }
+			stepContent={ renderStepContent() }
+			customizedActionButtons={ null }
+			isSticky={ false }
+		/>
+	);
+}
+
+export default Oauth2ConfirmEmail;

--- a/client/signup/steps/oauth2-confirm-email/style.scss
+++ b/client/signup/steps/oauth2-confirm-email/style.scss
@@ -1,0 +1,65 @@
+@import "@wordpress/base-styles/colors";
+
+.wpcc-confirm-email {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+
+	.confirm-email__user {
+		width: 404px;
+		height: 176px;
+		border-radius: 4px;
+		border: 1px solid #c3c4c7;
+		background: #fff;
+		display: flex;
+		padding: 24px;
+		align-items: center;
+		gap: 16px;
+		flex-direction: column;
+		box-sizing: border-box;
+		margin: 48px 0;
+	}
+
+	.confirm-email-user__gravatar {
+		width: 60px;
+		height: 60px;
+	}
+
+	.confirm-email-user__username {
+		color: #101517;
+		text-align: center;
+		font-size: 1rem;
+		font-style: normal;
+		font-weight: 500;
+		line-height: 24px; /* 150% */
+	}
+
+	.confirm-email-user__email {
+		color: $gray-700;
+		text-align: center;
+		font-size: 1rem;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 24px; /* 150% */
+	}
+
+	.confirm-email__resend-email {
+		color: #50575e;
+		text-align: center;
+		font-size: 1rem;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 24px; /* 150% */
+		letter-spacing: -0.1px;
+
+		a {
+			color: #674399;
+			font-size: 1rem;
+			font-style: normal;
+			font-weight: 400;
+			line-height: 24px;
+			letter-spacing: -0.1px;
+			text-decoration: none;
+		}
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdibGW-2Dk-p2

Implement WooCommerce passwordless signup. 

This is a hack project. We haven't confirmed if we will release this yet.

![Screenshot 2023-12-19 at 17 49 14](https://github.com/Automattic/wp-calypso/assets/4344253/b2e98466-e3fa-47f5-8782-082a3f102ede)

![Screenshot 2023-12-19 at 17 48 24](https://github.com/Automattic/wp-calypso/assets/4344253/9c179fda-6afd-4ae1-815d-12bc303f40c2)


## Proposed Changes

- Add oauth2-confrim-email step to wpcc flow and enable it for woocommerce only.
- Update passwordless form styles for woocommerce

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


### Signup with email

* Apply this patch D132489-code on your sandbox
* Use incognito mode or logout your wpcom/wccom account.
* Go to https://woo.com/start/#/installation
* Click on "Try Woo Express for free" button
* Enter your email address
* Click on "Get Started"
* Confirm you're at "Email confirmation" step
* Go to your inbox
* Confirm received WooCommerce activation email
* Copy and paste the `Confirm your email and go to your store` link in the same incognito window.
* Confirm you're redirected to the WooExpress loading screen.

### Signup with Google or Apple

* Set up https://github.com/woocommerce/woocommerce-start-dev-env
* Apply this patch D132489-code on your sandbox
* Use incognito mode or logout your wpcom/wccom account.
* Go to https://woo.com/start/#/installation
* Click on "Try Woo Express for free" button
* Sign up via Google or Apple login
* Confirm you're redirected to the WooExpress loading screen.


### Test other signup flows

- Use the live link.
- P2: [Link](https://wordpress.com/log-in?redirect_to=http%3A%2F%2Fcalypso.localhost%3A3000%2Fstart%2Fp2%2Fp2-confirm-email&from=p2&signup_url=%2Fstart%2Fp2%2Fuser) and live link version. Test desktop and mobile.
- Jetpack: [Link](http://wordpress.com/log-in/jetpack?site=https%3A%2F%2Ffalse-shrike.jurassic.ninja) and live link version. Test desktop and mobile.
- Crowdsignal: [Link](http://wordpress.com/log-in?client_id=978&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D978%26response_type%3Dcode%26blog_id%3D0%26state%3D51d5e1b0d7358dee3de65c45f4b4dc37a3d6e37dab8d6047545f636c2659d104%26redirect_uri%3Dhttps%253A%252F%252Fapp.crowdsignal.com%252Fconnect%253Fsource%253Dlogin%2526action%253Drequest_access_token%26wpcom_connect%3D1) and live link version. Test desktop and mobile.
- Jetpack Cloud: [Link](http://wordpress.com/log-in?client_id=69040&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dtoken%26client_id%3D69040%26redirect_uri%3Dhttps%253A%252F%252Fcloud.jetpack.com%252Fconnect%252Foauth%252Ftoken%253Fnext%253D%25252F%26scope%3Dglobal%26blog_id%3D0)
- MailPoet: [link](https://wordpress.com/log-in?client_id=79002&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fresponse_type%3Dcode%26redirect_uri%3Dhttps%253A%252F%252Faccount.mailpoet.com%252Flogin%252Fwpcom%252Fcallback%26scope%3Dauth%26client_id%3D79002)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?