### PR TITLE
getTask: fix interpolation

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
+++ b/client/my-sites/customer-home/cards/tasks/site-setup-list/get-task.js
@@ -200,10 +200,10 @@ export const getTask = (
 						"Your site is private and only visible to you. When you're ready, launch your site to make it public."
 				  );
 			const descriptionOnCompleted = translate(
-				'Your site is already live. You can change your site visibility in <Link>privacy options</Link> at any time.',
+				'Your site is already live. You can change your site visibility in {{link}}privacy options{{/link}} at any time.',
 				{
 					components: {
-						Link: <a href={ `/settings/general/${ siteSlug }#site-privacy-settings` } />,
+						link: <a href={ `/settings/general/${ siteSlug }#site-privacy-settings` } />,
 					},
 					comment:
 						'pressing <Link> will redirect the user to Settings -> Privacy where they can change the site visibility',


### PR DESCRIPTION
Followup to #85068, fixing bug reported in https://github.com/Automattic/wp-calypso/pull/85068#issuecomment-1861801713. Use the right format for tags. `i18n-calypso` doesn't use `<Link>`, but `{{Link}}`. Screenshot of the fixed version:

<img width="717" alt="Screenshot 2023-12-19 at 10 43 41" src="https://github.com/Automattic/wp-calypso/assets/664258/54e9e054-dc56-4275-b751-2336c96f4545">
