### PR TITLE
BBE Landing: fix header font

### DIFF
--- a/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
+++ b/client/my-sites/marketing/do-it-for-me/difm-landing.tsx
@@ -78,6 +78,7 @@ const ImageSection = styled.div`
 // @ts-expect-error FormattedHeader is not typed and it's causing issues with the styled component
 const Header = styled( FormattedHeader )`
 	.formatted-header__title {
+		font-size: 2.25rem;
 		line-height: 3rem;
 	}
 `;
@@ -402,7 +403,12 @@ export default function DIFMLanding( {
 			<Wrapper>
 				<ContentSection>
 					{ /* @ts-expect-error FormattedHeader is not typed and it's causing issues with the styled component */ }
-					<Header align="left" headerText={ headerText } subHeaderText={ subHeaderText } />
+					<Header
+						brandFont
+						align="left"
+						headerText={ headerText }
+						subHeaderText={ subHeaderText }
+					/>
 					<VerticalStepProgress>
 						<Step
 							index={ translate( '1' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fixes the header on the BBE landing page.

**Before**
<img width="629" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/9feba333-208a-45d6-8e9d-fb25c3732868">

**After**
<img width="584" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/7b2062af-9583-4df7-a986-2631005ef56d">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/site-setup/difmStartingPoint?siteSlug=<site slug>`.
* Confirm that the header matches the screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?