### PR TITLE
Add-Ons: Refactor data-layer. Migrate useAddOns hook to data-stores (once dependencies are cleared)

### DIFF
--- a/client/my-sites/add-ons/hooks/use-add-on-display-cost.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-display-cost.ts
@@ -9,6 +9,7 @@ const useAddOnDisplayCost = ( productSlug: string, quantity?: number ) => {
 	const formattedCost = prices?.formattedMonthlyPrice || '';
 
 	return useSelector( ( state ) => {
+		// TODO clk add-ons: add a hook to data-stores/products-list
 		const product = getProductBySlug( state, productSlug );
 
 		if ( product?.product_term === 'month' ) {

--- a/client/my-sites/add-ons/hooks/use-add-on-prices.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-prices.ts
@@ -5,6 +5,7 @@ import { getProductCurrencyCode, getProductBySlug } from 'calypso/state/products
 
 const useAddOnPrices = ( productSlug: string, quantity?: number ) => {
 	const product = useSelector( ( state ) => getProductBySlug( state, productSlug ) );
+	// TODO clk add-ons: add a hook to data-stores/products-list
 	const currencyCode = useSelector( ( state ) => getProductCurrencyCode( state, productSlug ) );
 
 	return useMemo( () => {

--- a/client/my-sites/add-ons/hooks/use-add-on-purchase-status.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-purchase-status.ts
@@ -10,9 +10,12 @@ import type { AddOnMeta } from '@automattic/data-stores';
  */
 const useAddOnPurchaseStatus = ( { productSlug, featureSlugs }: AddOnMeta ) => {
 	const translate = useTranslate();
+	// TODO clk add-ons: pass in as selectedSiteId ( only used as selectedSite?.ID )
 	const selectedSite = useSelector( getSelectedSite );
+	// TODO clk add-ons: move to data-stores/site/queries - useSitePurchases
 	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, selectedSite?.ID ) );
 	const purchased = sitePurchases.find( ( product ) => product.productSlug === productSlug );
+	// TODO clk add-ons: add a hook to data-stores/site/queries - useSiteFeatures
 	const isSiteFeature = useSelector(
 		( state ) =>
 			selectedSite &&

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -33,13 +33,16 @@ const useSpaceUpgradesPurchased = ( {
 	isInSignup: boolean;
 	siteId?: number;
 } ) => {
+	// TODO clk add-ons: move to data-stores/billing/queries
 	const { billingTransactions, isLoading } = usePastBillingTransactions( isInSignup );
+	// TODO clk add-ons: move to data-stores/billing/hooks
 	const filter = useSelector( ( state ) => getBillingTransactionFilters( state, 'past' ) );
 
 	return useMemo( () => {
 		const spaceUpgradesPurchased: number[] = [];
 
 		if ( billingTransactions && ! isInSignup ) {
+			// TODO clk add-ons: move to data-stores/billing/hooks
 			const filteredTransactions = filterTransactions( billingTransactions, filter, siteId );
 			if ( filteredTransactions?.length ) {
 				for ( const transaction of filteredTransactions ) {
@@ -169,23 +172,23 @@ const useAddOns = ( siteId?: number, isInSignup = false ): ( AddOnMeta | null )[
 	// if upgrade is bought - show as manage
 	// if upgrade is not bought - only show it if available storage and if it's larger than previously bought upgrade
 
-	// TODO clk: move to data-stores/queries
+	// TODO clk add-ons: move to data-stores/queries
 	const { data: mediaStorage } = useMediaStorageQuery( siteId );
 
-	// TODO clk: move to data-stores/queries
-	const siteFeatures = useSelector( ( state ) => getFeaturesBySiteId( state, siteId ) );
-
-	// TODO clk: maybe move to data-stores, otherwise pass in as a prop
+	// TODO clk add-ons: maybe move to data-stores, otherwise pass in as a prop
 	const { isLoading, spaceUpgradesPurchased } = useSpaceUpgradesPurchased( { isInSignup, siteId } );
 
-	// TODO clk: same as siteId?
+	// TODO clk add-ons: same as siteId?
 	const selectedSite = useSelector( getSelectedSite ) ?? null;
 
-	// TODO clk: fine
+	// TODO clk add-ons: fine
 	const activeAddOns = useActiveAddOnsDefs( selectedSite );
 
-	// TODO clk: add a query to data-stores/products-list
+	// TODO clk add-ons: add a query to data-stores/products-list
 	const productsList = useSelector( getProductsList );
+
+	// TODO clk add-ons: move to data-stores/queries
+	const siteFeatures = useSelector( ( state ) => getFeaturesBySiteId( state, siteId ) );
 
 	return useMemo(
 		() =>

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -168,12 +168,24 @@ const useActiveAddOnsDefs = ( selectedSite: SiteDetails | null ) => {
 const useAddOns = ( siteId?: number, isInSignup = false ): ( AddOnMeta | null )[] => {
 	// if upgrade is bought - show as manage
 	// if upgrade is not bought - only show it if available storage and if it's larger than previously bought upgrade
+
+	// TODO clk: move to data-stores/queries
 	const { data: mediaStorage } = useMediaStorageQuery( siteId );
-	const { isLoading, spaceUpgradesPurchased } = useSpaceUpgradesPurchased( { isInSignup, siteId } );
-	const selectedSite = useSelector( getSelectedSite ) ?? null;
-	const activeAddOns = useActiveAddOnsDefs( selectedSite );
-	const productsList = useSelector( getProductsList );
+
+	// TODO clk: move to data-stores/queries
 	const siteFeatures = useSelector( ( state ) => getFeaturesBySiteId( state, siteId ) );
+
+	// TODO clk: maybe move to data-stores, otherwise pass in as a prop
+	const { isLoading, spaceUpgradesPurchased } = useSpaceUpgradesPurchased( { isInSignup, siteId } );
+
+	// TODO clk: same as siteId?
+	const selectedSite = useSelector( getSelectedSite ) ?? null;
+
+	// TODO clk: fine
+	const activeAddOns = useActiveAddOnsDefs( selectedSite );
+
+	// TODO clk: add a query to data-stores/products-list
+	const productsList = useSelector( getProductsList );
 
 	return useMemo(
 		() =>

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -187,7 +187,7 @@ const useAddOns = ( siteId?: number, isInSignup = false ): ( AddOnMeta | null )[
 	// TODO clk add-ons: add a query to data-stores/products-list
 	const productsList = useSelector( getProductsList );
 
-	// TODO clk add-ons: move to data-stores/queries
+	// TODO clk add-ons: add a hook to data-stores/site/queries - useSiteFeatures
 	const siteFeatures = useSelector( ( state ) => getFeaturesBySiteId( state, siteId ) );
 
 	return useMemo(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/81374

## Proposed Changes

This is the initial exploratory PR for migrating AddOns (pricing and other metadata) to packages / `data-stores` for encapsulating and enabling use in `plans-grid-next`. This PR will handle the actual migration in the end once all of the dependencies are cleared. Various TODOs (prefixed with `// TODO clk add-ons`) are added in the code for the areas that need to be worked on. 

We can use this as a main thread with more PRs to link from this one, and to only ship (and close https://github.com/Automattic/wp-calypso/issues/81374) once everything's handled (code TODOs removed). The connected issue contains the list of tasks extracted with corresponding GH sub issues.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

TBD. Most likely separate parts will be shipped and tested individually, as there are a few.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?