### PR TITLE
Post publish modal: remove some copy to simplify

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/index.tsx
@@ -1,8 +1,8 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { START_WRITING_FLOW, DESIGN_FIRST_FLOW } from '@automattic/onboarding';
-import { Modal, Button, ExternalLink } from '@wordpress/components';
+import { Modal, Button } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect, useRef, useState, createInterpolateElement } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { Icon, globe, link as linkIcon } from '@wordpress/icons';
 import { store as noticesStore } from '@wordpress/notices';
 import { useI18n } from '@wordpress/react-i18n';
@@ -174,12 +174,6 @@ const SharingModalInner: React.FC = () => {
 			type: 'snackbar',
 		} );
 	};
-	const trackSubscribersClick = () => {
-		recordTracksEvent( 'calypso_editor_sharing_view_subscribers' );
-	};
-
-	const subscribersUrl = `https://wordpress.com/people/subscribers/${ window.location.hostname }`;
-
 	return (
 		<Modal
 			className="wpcom-block-editor-post-published-sharing-modal"
@@ -190,23 +184,6 @@ const SharingModalInner: React.FC = () => {
 			<div className="wpcom-block-editor-post-published-sharing-modal__inner">
 				<div className="wpcom-block-editor-post-published-sharing-modal__left">
 					<h1> { __( 'Post published!', 'full-site-editing' ) } </h1>
-					<p>
-						{ createInterpolateElement(
-							__(
-								'Your post is now live and was delivered to each of <a>your subscribers</a>.',
-								'full-site-editing'
-							),
-							{
-								a: (
-									<ExternalLink
-										children={ null }
-										href={ subscribersUrl }
-										onClick={ trackSubscribersClick }
-									/>
-								),
-							}
-						) }
-					</p>
 					<div className="wpcom-block-editor-post-published-buttons">
 						<a
 							href={ link }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Removes _"Your post is now live..."_ copy from the post publish modal. The headline already makes it clear: Post published.
* Removes the link to manage subscribers; let's instead focus on sharing & suggested tags (feature not enabled yet). Link got just 100—170 clicks daily which is really little.
* Sometimes the post isn't sent to subscribers, it's possible to not send the email.

<img width="1857" alt="Screenshot 2023-12-19 at 12 44 02" src="https://github.com/Automattic/wp-calypso/assets/87168/3dc92224-db93-4a34-b16c-2db0c1b5a726">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?