### PR TITLE
Add domain transfers refund policy in checkout page

### DIFF
--- a/client/my-sites/checkout/src/components/refund-policies.tsx
+++ b/client/my-sites/checkout/src/components/refund-policies.tsx
@@ -193,7 +193,6 @@ export function getRefundWindows( refundPolicies: RefundPolicy[] ): RefundWindow
 			case RefundPolicy.DomainNameRegistration:
 			case RefundPolicy.DomainNameRegistrationBundled:
 			case RefundPolicy.DomainNameRenewal:
-			case RefundPolicy.DomainNameTransfer:
 				return 4;
 
 			case RefundPolicy.GenericMonthly:

--- a/client/my-sites/checkout/src/components/refund-policies.tsx
+++ b/client/my-sites/checkout/src/components/refund-policies.tsx
@@ -190,6 +190,9 @@ type RefundWindow = 4 | 7 | 14 | 120;
 export function getRefundWindows( refundPolicies: RefundPolicy[] ): RefundWindow[] {
 	const refundWindows = refundPolicies.map( ( refundPolicy ) => {
 		switch ( refundPolicy ) {
+			case RefundPolicy.DomainNameTransfer:
+				return 0;
+
 			case RefundPolicy.DomainNameRegistration:
 			case RefundPolicy.DomainNameRegistrationBundled:
 			case RefundPolicy.DomainNameRenewal:

--- a/client/my-sites/checkout/src/components/refund-policies.tsx
+++ b/client/my-sites/checkout/src/components/refund-policies.tsx
@@ -8,6 +8,7 @@ import {
 	isTriennially,
 	isCentennially,
 	isYearly,
+	isDomainTransfer,
 } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -43,6 +44,7 @@ export enum RefundPolicy {
 	PlanYearlyBundle,
 	PlanYearlyRenewal,
 	PremiumTheme,
+	DomainNameTransfer,
 }
 
 export function getRefundPolicies( cart: ResponseCart ): RefundPolicy[] {
@@ -80,6 +82,10 @@ export function getRefundPolicies( cart: ResponseCart ): RefundPolicy[] {
 				return RefundPolicy.DomainNameRenewal;
 			}
 			return RefundPolicy.DomainNameRegistration;
+		}
+
+		if ( isDomainTransfer( product ) ) {
+			return RefundPolicy.DomainNameTransfer;
 		}
 
 		if ( product.product_slug === 'premium_theme' ) {
@@ -187,6 +193,7 @@ export function getRefundWindows( refundPolicies: RefundPolicy[] ): RefundWindow
 			case RefundPolicy.DomainNameRegistration:
 			case RefundPolicy.DomainNameRegistrationBundled:
 			case RefundPolicy.DomainNameRenewal:
+			case RefundPolicy.DomainNameTransfer:
 				return 4;
 
 			case RefundPolicy.GenericMonthly:
@@ -248,6 +255,13 @@ function RefundPolicyItem( {
 		case RefundPolicy.DomainNameRegistration:
 			text = translate(
 				'You understand that {{refundsSupportPage}}domain name refunds{{/refundsSupportPage}} are limited to 96 hours after registration.',
+				{ components: { refundsSupportPage } }
+			);
+			break;
+
+		case RefundPolicy.DomainNameTransfer:
+			text = translate(
+				'You understand that {{refundsSupportPage}}domain name transfers are non-refundable{{/refundsSupportPage}} unless the process is canceled before the transfer is completed.',
 				{ components: { refundsSupportPage } }
 			);
 			break;

--- a/client/my-sites/checkout/src/components/test/refund-policies.ts
+++ b/client/my-sites/checkout/src/components/test/refund-policies.ts
@@ -132,6 +132,21 @@ describe( 'getRefundPolicies', () => {
 		expect( refundPolicies ).toEqual( [ RefundPolicy.DomainNameRegistration ] );
 	} );
 
+	test( 'transfer domain', () => {
+		const cart = getEmptyResponseCart();
+		cart.products.push( {
+			...getEmptyResponseCartProduct(),
+			item_subtotal_integer: 10,
+			is_domain_registration: false,
+			meta: 'test.live',
+			product_slug: 'domain_transfer',
+		} );
+
+		const refundPolicies = getRefundPolicies( cart );
+
+		expect( refundPolicies ).toEqual( [ RefundPolicy.DomainNameTransfer ] );
+	} );
+
 	test( 'free domain', () => {
 		const cart = getEmptyResponseCart();
 		cart.products.push( {


### PR DESCRIPTION
## Proposed Changes

We want to include a refund policy note for domain transfers in the checkout.

Context: pcYYhz-1mJ-p2#comment-1325

## Testing Instructions

Apply this patch locally or use the Calypso link below.

Start a domain transfer and verify that the new clause is added in the checkout.

### BEFORE
<img width="773" alt="Screenshot 2023-12-19 alle 11 34 25" src="https://github.com/Automattic/wp-calypso/assets/2797601/3fe17614-94c1-4c8e-bb56-1589d991ef68">

### AFTER
![refund-transfer-after](https://github.com/Automattic/wp-calypso/assets/2797601/be7f7fbc-c566-4228-9427-c7f34c324bdc)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?