### PR TITLE
Live Preview: Update banner design: Reduce height & change color

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.scss
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.scss
@@ -1,2 +1,15 @@
 @import "./upgrade-modal";
 @import "./upgrade-notice";
+
+.components-editor-notices__pinned .components-notice__content {
+	display: flex;
+	margin-right: 0;
+
+	.components-notice__actions {
+		margin-left: auto;
+
+		.components-notice__action {
+			margin-top: 0;
+		}
+	}
+}

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
@@ -23,12 +23,12 @@ const LivePreviewNotice: FC< {
 	dashboardLink?: string;
 	previewingThemeName?: string;
 } > = ( { dashboardLink, previewingThemeName } ) => {
-	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
+	const { createInfoNotice, removeNotice } = useDispatch( 'core/notices' );
 
 	useHideTemplatePartHint();
 
 	useEffect( () => {
-		createWarningNotice(
+		createInfoNotice(
 			sprintf(
 				// translators: %s: theme name
 				__(
@@ -50,7 +50,7 @@ const LivePreviewNotice: FC< {
 			}
 		);
 		return () => removeNotice( NOTICE_ID );
-	}, [ dashboardLink, createWarningNotice, removeNotice, previewingThemeName ] );
+	}, [ dashboardLink, createInfoNotice, removeNotice, previewingThemeName ] );
 	return null;
 };
 

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.scss
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.scss
@@ -1,8 +1,3 @@
-.components-notice-list .components-notice__action.components-button {
-	display: flex;
-	align-items: center;
-}
-
 .wpcom-live-preview-upgrade-notice-view-container {
 	padding: 24px 24px 0;
 	border-top: 1px solid #2f2f2f;
@@ -26,4 +21,3 @@
 		}
 	}
 }
-

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
@@ -24,7 +24,7 @@ const LivePreviewUpgradeNoticeView: FC< {
 } > = ( { noticeText } ) => {
 	return (
 		<Notice
-			status="warning"
+			status="info"
 			isDismissible={ false }
 			className="wpcom-live-preview-upgrade-notice-view"
 			// TODO: Add the tracking event.
@@ -39,7 +39,7 @@ export const LivePreviewUpgradeNotice: FC< {
 	previewingTheme: ReturnType< typeof usePreviewingTheme >;
 } > = ( { dashboardLink, previewingTheme } ) => {
 	const [ isRendered, setIsRendered ] = useState( false );
-	const { createWarningNotice } = useDispatch( 'core/notices' );
+	const { createInfoNotice } = useDispatch( 'core/notices' );
 	const canvasMode = useSelect(
 		( select ) =>
 			unlock && select( 'core/edit-site' ) && unlock( select( 'core/edit-site' ) ).getCanvasMode(),
@@ -61,7 +61,7 @@ export const LivePreviewUpgradeNotice: FC< {
 	 * Show the notice when the canvas mode is 'edit'.
 	 */
 	useEffect( () => {
-		createWarningNotice( noticeText, {
+		createInfoNotice( noticeText, {
 			id: UPGRADE_NOTICE_ID,
 			isDismissible: false,
 			__unstableHTML: true,
@@ -77,7 +77,7 @@ export const LivePreviewUpgradeNotice: FC< {
 					: [] ),
 			],
 		} );
-	}, [ createWarningNotice, dashboardLink, noticeText ] );
+	}, [ createInfoNotice, dashboardLink, noticeText ] );
 
 	/**
 	 * Show the notice when the canvas mode is 'view'.


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/issues/83984
- https://github.com/Automattic/dotcom-forge/issues/4627

## Proposed Changes

This PR is a first step to update the design of the sticky banners in the live preview experience. This implements @matt-west's design here: https://github.com/Automattic/wp-calypso/issues/83984#issuecomment-1845961481.

### Case 1: Previewing a free theme

Before

<img width="1358" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/bc83d34b-0e3a-484e-8115-9545ce2ada31">

After

<img width="1359" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/076feb42-1197-466e-bd53-c659f1eb1852">

---

### Case 2: Previewing a free theme with custom styles

Before

<img width="1357" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/c3a797ce-a1bc-4abd-bafd-f7687d4e0a7d">


After

<img width="1357" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/3d0e8076-fec2-46c8-af6d-dc899a1dd9ff">

---

### Case 3: Previewing a premium theme

Before

<img width="1359" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/63a5ee03-c63c-4edf-990f-314c745d780a">

After

<img width="1357" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/cc1a62b2-850e-4689-981e-fe60242eaf52">

---

## Note

1. This PR strictly does NOT update any copy. This is so that we can merge this first without waiting for translation, and because there's still ongoing conversation regarding copy in Case 3 (premium theme upgrade) (pekYwv-3xz-p2#comment-2755).
2. This PR does NOT solve the "stacked banners" in Case 2 (free theme with custom styles) because it needs deeper investigation on how to consolidate the banners between Live Preview and GS upgrade. I think we missed this, cc: @okmttdhr.
3. This PR does NOT modify any styles from the Gutenberg's (Core's) defaults. In particular, it retains the same blue color in the left side of the banner, and it keeps the underline below the secondary action ("Back to themes" / "Try another theme"). This will be different from the original Matt's proposal (only slightly). What do you think, @matt-west? I'd prefer not to deviate from Gutenberg's.

## Testing Instructions

1. Sandbox `widgets.wp.com` and your site
4. Run `install-plugins.sh wbe live-preview-sticky-notice-styles`
5. Prepare a site with Free / Personal plan
6. Test CASE 1. Live-review a free theme, verify you see the first screenshot.
7. Test CASE 2. Apply some global styles, verify you see the second screenshot.
8. Test CASE 3. Live-preview a premium theme, verify you see the third screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?