### PR TITLE
Paid Stats: Add gating to new date control picker

### DIFF
--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -1,8 +1,6 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
-import { useTranslate } from 'i18n-calypso';
 import qs from 'qs';
-import React from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import DateControlPicker from './stats-date-control-picker';
@@ -11,45 +9,19 @@ import './style.scss';
 
 const COMPONENT_CLASS_NAME = 'stats-date-control';
 
-const StatsDateControl = ( { slug, queryParams, dateRange }: StatsDateControlProps ) => {
+const StatsDateControl = ( {
+	slug,
+	queryParams,
+	dateRange,
+	shortcutList,
+	overlay,
+}: StatsDateControlProps ) => {
 	// ToDo: Consider removing period from shortcuts.
 	// We could use the bestPeriodForDays() helper and keep the shortcuts
 	// consistent with the custom ranges.
 
-	const translate = useTranslate();
 	const moment = useLocalizedMoment();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
-
-	const shortcutList = [
-		{
-			id: 'last-7-days',
-			label: translate( 'Last 7 Days' ),
-			offset: 0,
-			range: 6,
-			period: 'day',
-		},
-		{
-			id: 'last-30-days',
-			label: translate( 'Last 30 Days' ),
-			offset: 0,
-			range: 29,
-			period: 'day',
-		},
-		{
-			id: 'last-3-months',
-			label: translate( 'Last 90 Days' ),
-			offset: 0,
-			range: 89,
-			period: 'week',
-		},
-		{
-			id: 'last-year',
-			label: translate( 'Last Year' ),
-			offset: 0,
-			range: 364, // ranges are zero based!
-			period: 'month',
-		},
-	];
 
 	// Shared link generation helper.
 	const generateNewLink = ( period: string, startDate: string, endDate: string ) => {
@@ -95,12 +67,15 @@ const StatsDateControl = ( { slug, queryParams, dateRange }: StatsDateControlPro
 
 	// Handler for shortcut selection.
 	const onShortcutHandler = ( shortcut: DateControlPickerShortcut ) => {
+		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
+		if ( shortcut.isGated ) {
+			return shortcut.onGatedClick( shortcut, event_from );
+		}
 		// Generate new dates.
 		const anchor = moment().subtract( shortcut.offset, 'days' );
 		const endDate = anchor.format( 'YYYY-MM-DD' );
 		const startDate = anchor.subtract( shortcut.range, 'days' ).format( 'YYYY-MM-DD' );
 
-		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 		recordTracksEvent( `${ event_from }_stats_date_picker_shortcut_${ shortcut.id }_clicked` );
 
 		// Update chart via routing.
@@ -149,6 +124,7 @@ const StatsDateControl = ( { slug, queryParams, dateRange }: StatsDateControlPro
 				selectedShortcut={ getShortcutForRange()?.id }
 				onShortcut={ onShortcutHandler }
 				onApply={ onApplyButtonHandler }
+				overlay={ overlay }
 			/>
 		</div>
 	);

--- a/client/components/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/components/stats-date-control/stats-date-control-picker-date.tsx
@@ -1,7 +1,10 @@
 import { Button } from '@wordpress/components';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import DateInput from './stats-date-control-date-input';
 import { DateControlPickerDateProps } from './types';
+
+const BASE_CLASS_NAME = 'stats-date-control-picker-date';
 
 const DateControlPickerDate = ( {
 	startDate = '',
@@ -10,32 +13,38 @@ const DateControlPickerDate = ( {
 	onEndChange,
 	onApply,
 	onCancel,
+	overlay,
 }: DateControlPickerDateProps ) => {
 	const translate = useTranslate();
 
 	return (
-		<div className="date-control-picker-date">
-			<h2 className="date-control-picker-date__heading">
+		<div
+			className={ classNames( BASE_CLASS_NAME, {
+				[ `${ BASE_CLASS_NAME }__hasoverlay` ]: !! overlay,
+			} ) }
+		>
+			<h2 className={ `${ BASE_CLASS_NAME }__heading` }>
 				{ translate( 'Date Range' ) }
 				<span> &#8212;</span>
 				<input id="date-example" type="date" disabled />
 			</h2>
-			<div className="stats-date-control-picker-dates__inputs">
-				<div className="stats-date-control-picker-dates__inputs-input-group">
+			<div className={ `${ BASE_CLASS_NAME }s__inputs` }>
+				<div className={ `${ BASE_CLASS_NAME }s__inputs-input-group` }>
 					<label htmlFor="startDate">From</label>
 					<DateInput id="startDate" value={ startDate } onChange={ onStartChange } />
 				</div>
-				<div className="stats-date-control-picker-dates__inputs-input-group">
+				<div className={ `${ BASE_CLASS_NAME }s__inputs-input-group` }>
 					<label htmlFor="endDate">To</label>
 					<DateInput id="endDate" value={ endDate } onChange={ onEndChange } />
 				</div>
 			</div>
-			<div className="stats-date-control-picker-dates__buttons">
+			<div className={ `${ BASE_CLASS_NAME }s__buttons` }>
 				<Button onClick={ onCancel }>{ translate( 'Cancel' ) }</Button>
 				<Button variant="primary" onClick={ onApply }>
 					{ translate( 'Apply' ) }
 				</Button>
 			</div>
+			{ overlay && <div className={ `${ BASE_CLASS_NAME }__overlay` }>{ overlay }</div> }
 		</div>
 	);
 };

--- a/client/components/stats-date-control/stats-date-control-picker-shortcuts.tsx
+++ b/client/components/stats-date-control/stats-date-control-picker-shortcuts.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@wordpress/components';
-import { Icon, check } from '@wordpress/icons';
+import { Icon, check, lock } from '@wordpress/icons';
 import classNames from 'classnames';
 import React from 'react';
 import { DateControlPickerShortcutsProps } from './types';
@@ -31,6 +31,7 @@ const DateControlPickerShortcuts = ( {
 							>
 								<span>{ shortcut.label }</span>
 								{ isSelected && <Icon icon={ check } /> }
+								{ shortcut.isGated && <Icon icon={ lock } /> }
 							</Button>
 						</li>
 					);

--- a/client/components/stats-date-control/stats-date-control-picker.tsx
+++ b/client/components/stats-date-control/stats-date-control-picker.tsx
@@ -17,6 +17,7 @@ const DateControlPicker = ( {
 	selectedShortcut,
 	onShortcut,
 	onApply,
+	overlay,
 }: DateControlPickerProps ) => {
 	const moment = useLocalizedMoment();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
@@ -108,6 +109,7 @@ const DateControlPicker = ( {
 						onEndChange={ changeEndDate }
 						onApply={ handleOnApply }
 						onCancel={ handleOnCancel }
+						overlay={ overlay }
 					/>
 				</div>
 			</Popover>

--- a/client/components/stats-date-control/style.scss
+++ b/client/components/stats-date-control/style.scss
@@ -3,13 +3,36 @@
 
 $date-control-shortcut-min-width: 140px;
 
-.date-control-picker-date {
+.stats-date-control-picker-date {
 	margin: 16px;
 
 	// Internal layout
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
+
+	&.stats-date-control-picker-date__hasoverlay {
+		display: grid;
+		position: relative;
+
+		.stats-date-control-picker-date__content,
+		.stats-date-control-picker-date__overlay {
+			grid-column: 1;
+			grid-row: 1;
+		}
+
+		.stats-date-control-picker-dates__inputs,
+		.stats-date-control-picker-dates__buttons {
+			filter: blur(5px);
+			z-index: 0;
+		}
+
+		.stats-date-control-picker-date__overlay {
+			position: absolute;
+			z-index: 1;
+			background: rgba(255, 255, 255, 0.5);
+		}
+	}
 }
 
 .date-control-picker-shortcuts {
@@ -123,7 +146,7 @@ $date-control-shortcut-min-width: 140px;
 	}
 }
 
-.stats-date-control-picker__popover-content .date-control-picker-date .date-control-picker-date__heading {
+.stats-date-control-picker__popover-content .stats-date-control-picker-date .stats-date-control-picker-date__heading {
 	color: var(--gray-gray-80, #2c3338);
 	font-family: $font-sf-pro-text;
 	font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */

--- a/client/components/stats-date-control/types.d.ts
+++ b/client/components/stats-date-control/types.d.ts
@@ -32,7 +32,7 @@ interface DateControlPickerShortcut {
 	statType: string;
 	isGated: boolean;
 	onGatedClick: (
-		shorcut: DateControlPickerShortcut,
+		shortcut: DateControlPickerShortcut,
 		event_from: 'jetpack_odyssey' | 'calypso'
 	) => void;
 }

--- a/client/components/stats-date-control/types.d.ts
+++ b/client/components/stats-date-control/types.d.ts
@@ -3,6 +3,8 @@ interface StatsDateControlProps {
 	queryParams: string;
 	period: 'day' | 'week' | 'month' | 'year';
 	dateRange: any;
+	shortcutList: DateControlPickerShortcut[];
+	overlay?: JSX.Element;
 }
 
 interface DateControlPickerProps {
@@ -12,6 +14,7 @@ interface DateControlPickerProps {
 	selectedShortcut: string | undefined;
 	onShortcut: ( shortcut: DateControlPickerShortcut ) => void;
 	onApply: ( startDate: string, endDate: string ) => void;
+	overlay?: JSX.Element;
 }
 
 interface DateControlPickerShortcutsProps {
@@ -26,6 +29,12 @@ interface DateControlPickerShortcut {
 	offset: number;
 	range: number;
 	period: string;
+	statType: string;
+	isGated: boolean;
+	onGatedClick: (
+		shorcut: DateControlPickerShortcut,
+		event_from: 'jetpack_odyssey' | 'calypso'
+	) => void;
 }
 
 interface DateControlPickerDateProps {
@@ -35,6 +44,7 @@ interface DateControlPickerDateProps {
 	onEndChange: ( value: string ) => void;
 	onApply: () => void;
 	onCancel: () => void;
+	overlay?: JSX.Element;
 }
 
 export {

--- a/client/my-sites/stats/constants.ts
+++ b/client/my-sites/stats/constants.ts
@@ -36,4 +36,8 @@ export const STAT_TYPE_WPCOM_PLUGINS_LIST = 'wpcomPluginsList';
 
 // stats feature are for more granular control, string value is based on component name
 export const STATS_FEATURE_DATE_CONTROL = 'StatsDateControl';
+export const STATS_FEATURE_DATE_CONTROL_LAST_7_DAYS = 'StatsDateControl/last_7_days';
+export const STATS_FEATURE_DATE_CONTROL_LAST_30_DAYS = 'StatsDateControl/last_30_days';
+export const STATS_FEATURE_DATE_CONTROL_LAST_90_DAYS = 'StatsDateControl/last_3_months';
+export const STATS_FEATURE_DATE_CONTROL_LAST_YEAR = 'StatsDateControl/last_year';
 export const STATS_FEATURE_DOWNLOAD_CSV = 'StatsDownloadCsv';

--- a/client/my-sites/stats/hooks/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/use-should-gate-stats.ts
@@ -6,16 +6,23 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import {
-	STATS_FEATURE_DATE_CONTROL,
 	STATS_FEATURE_DOWNLOAD_CSV,
 	STAT_TYPE_SEARCH_TERMS,
 	STAT_TYPE_CLICKS,
 	STAT_TYPE_REFERRERS,
+	STATS_FEATURE_DATE_CONTROL_LAST_90_DAYS,
+	STATS_FEATURE_DATE_CONTROL_LAST_YEAR,
+	STATS_FEATURE_DATE_CONTROL,
 } from '../constants';
 
 const paidStats = [ STAT_TYPE_SEARCH_TERMS, STAT_TYPE_CLICKS, STAT_TYPE_REFERRERS ];
 
-const granularControlForPaidStats = [ STATS_FEATURE_DATE_CONTROL, STATS_FEATURE_DOWNLOAD_CSV ];
+const granularControlForPaidStats = [
+	STATS_FEATURE_DATE_CONTROL,
+	STATS_FEATURE_DATE_CONTROL_LAST_90_DAYS,
+	STATS_FEATURE_DATE_CONTROL_LAST_YEAR,
+	STATS_FEATURE_DOWNLOAD_CSV,
+];
 
 /*
  * Check if a site has access to a paid stats feature in wpcom.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/4895

## Proposed Changes

* Added gating to new date picker in stats
* When clicked, should redirect to PWYW screen

![paid stats](https://github.com/Automattic/wp-calypso/assets/6586048/0aaf7745-b225-459a-a1d3-355eae716f34)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Enabled by default in development, in calypso live enable with the query param: `?flags=stats/paid-wpcom-v2`
Disable paid stats in development with the query param: `?flags=-stats/paid-wpcom-v2`

* View stats in calypso.live and jetpack, ensure the feature locking in the screenshots below isn't triggered.
* Go to /stats
* TODO: Check stats in `/store` to make sure to not break anything (they share the `StatsPeriodNavigation` component) 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?