### PR TITLE
Import flows: Improve navigation 'Back' logic for import-focused and site-setup flows

### DIFF
--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -286,21 +286,27 @@ const importFlow: Flow = {
 						return navigate( path );
 					}
 
-					return navigate( 'import' );
+					return navigate( `import?siteSlug=${ siteSlugParam }` );
 
+				case 'importerBlogger':
+				case 'importerMedium':
+				case 'importerSquarespace':
+					return navigate( `importList?siteSlug=${ siteSlugParam }` );
+
+				case 'importerWordpress':
+					if ( urlQueryParams.get( 'option' ) === 'content' ) {
+						return navigate( `importList?siteSlug=${ siteSlugParam }` );
+					} else if ( isMigrateFromWp && fromParam ) {
+						return navigate( `sitePicker?from=${ fromParam }` );
+					}
+					return navigate( `import?siteSlug=${ siteSlugParam }` );
+
+				case 'importerWix':
 				case 'importReady':
 				case 'importReadyNot':
 				case 'importReadyWpcom':
 				case 'importReadyPreview':
-				case 'importerWix':
-				case 'importerBlogger':
-				case 'importerMedium':
-				case 'importerSquarespace':
-				case 'importerWordpress':
 				case 'designSetup':
-					if ( isMigrateFromWp && fromParam ) {
-						return navigate( `sitePicker?from=${ fromParam }` );
-					}
 					return navigate( `import?siteSlug=${ siteSlugParam }` );
 
 				case 'verifyEmail':

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -532,20 +532,27 @@ const siteSetupFlow: Flow = {
 					const backToStep = urlQueryParams.get( 'backToStep' );
 
 					if ( backToStep ) {
-						return navigate( `${ backToStep }?siteSlug=${ siteSlug }` );
+						return navigate( `${ backToStep }?siteSlug=${ siteSlugParam }` );
 					}
 
-					return navigate( 'import' );
+					return navigate( `import?siteSlug=${ siteSlugParam }` );
 
+				case 'importerBlogger':
+				case 'importerMedium':
+				case 'importerSquarespace':
+					return navigate( `importList?siteSlug=${ siteSlugParam }` );
+
+				case 'importerWordpress':
+					if ( urlQueryParams.get( 'option' ) === 'content' ) {
+						return navigate( `importList?siteSlug=${ siteSlugParam }` );
+					}
+					return navigate( `import?siteSlug=${ siteSlugParam }` );
+
+				case 'importerWix':
 				case 'importReady':
 				case 'importReadyNot':
 				case 'importReadyWpcom':
 				case 'importReadyPreview':
-				case 'importerWix':
-				case 'importerBlogger':
-				case 'importerMedium':
-				case 'importerSquarespace':
-				case 'importerWordpress':
 					return navigate( `import?siteSlug=${ siteSlugParam }` );
 
 				case 'options':


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/85469

## Proposed Changes

* Improved logic for going back (previous step) when users click on the stepper navigation "Back" button

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/import-focused/import?siteSlug={SLUG}` or `/setup/site-setup/import?siteSlug={SLUG}`
* Click on "choose a content platform"
* Select "WordPress", click Back, and check if it redirects to the `importList` step
* Check if it works in the same way for the "Blogger", "Medium", and "Squarespace" platforms
* Go to the capture screen and enter "make.wordpress.org"
* Click on Back, and check if it redirects to the `import` capture step

it should work on the same way for "import-focused" and "site-setup" flows

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?