### PR TITLE
E2E: Update to use new plan names

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/donations-form.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/donations-form.ts
@@ -91,7 +91,7 @@ export class DonationsFormFlow implements BlockFlow {
 			.click();
 
 		// Verify the donation popup.
-		// For sites with plans Premium or lower, the block cannot be used and so the popup modal
+		// For sites with plans Explorer or lower, the block cannot be used and so the popup modal
 		// states as such.
 		// For sites where sales are allowed, ther are two variants in how this flow can behave:
 		// 	1. on normal, user-controlled browsers, a Stripe-powered overlay appears.

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -20,7 +20,7 @@ const selectors = {
 		}
 		return `button.is-${ name.toLowerCase() }-plan:visible`;
 	},
-	selectModalUpsellPlanButton: ( name: 'Free' | 'Personal' ) => {
+	selectModalUpsellPlanButton: ( name: 'Free' | 'Starter' ) => {
 		if ( name === 'Free' ) {
 			return `button.is-upsell-modal-free-plan:visible`;
 		}
@@ -101,7 +101,7 @@ export class PlansPage {
 	 * @param {Plans} plan Plan to select.
 	 */
 	async selectModalUpsellPlan( plan: Plans ): Promise< void > {
-		if ( plan !== 'Free' && plan !== 'Personal' ) {
+		if ( plan !== 'Free' && plan !== 'Starter' ) {
 			throw Error( `Unsupported plan to be selected in modal upsell: ${ plan }` );
 		}
 
@@ -177,7 +177,7 @@ export class PlansPage {
 	 * Click a plan action button (on the plan cards on the "Plans" tab) based on expected plan name and button text.
 	 *
 	 * @param {Object} param0 Object containing plan name and button text
-	 * @param {Plans} param0.plan Name of the plan (e.g. "Premium")
+	 * @param {Plans} param0.plan Name of the plan (e.g. "Explorer")
 	 * @param {PlanActionButton} param0.buttonText Expected action button text (e.g. "Upgrade")
 	 */
 	async clickPlanActionButton( {

--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -4,7 +4,7 @@ import { clickNavTab } from '../../element-helper';
 import envVariables from '../../env-variables';
 
 // Types to restrict the string arguments passed in. These are fixed sets of strings, so we can be more restrictive.
-export type Plans = 'Free' | 'Personal' | 'Premium' | 'Business' | 'eCommerce';
+export type Plans = 'Free' | 'Starter' | 'Explorer' | 'Creator' | 'Entrepreneur';
 export type PlansPageTab = 'My Plan' | 'Plans';
 export type PlanActionButton = 'Manage plan' | 'Upgrade';
 

--- a/test/e2e/specs/blocks/blocks__media.ts
+++ b/test/e2e/specs/blocks/blocks__media.ts
@@ -31,7 +31,7 @@ declare const browser: Browser;
 describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 	const features = envToFeatureKey( envVariables );
 
-	// Default to `defaultUser` as it has WordPress.com Premium enabled, which is required
+	// Default to `defaultUser` as it has WordPress.com Explorer enabled, which is required
 	// for VideoPress block testing.
 	const accountName = getTestAccountByFeature( features, [
 		{
@@ -120,7 +120,7 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 			await fileBlock.upload( testFiles.audio.fullpath );
 		} );
 
-		// If this starts failing, check whether Premium or higher plan is enabled.
+		// If this starts failing, check whether Explorer or higher plan is enabled.
 		it( `${ VideoPressBlock.blockName } block: upload video file`, async function () {
 			await editorPage.addBlockFromSidebar(
 				VideoPressBlock.blockName,

--- a/test/e2e/specs/domain-upsell/domain-upsell__sidebar.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__sidebar.ts
@@ -18,7 +18,7 @@ import { Page, Browser } from 'playwright';
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Sidebar: Domain upsell' ), function () {
-	const planName = 'Premium';
+	const planName = 'Explorer';
 	let domainSearchComponent: DomainSearchComponent;
 	let cartCheckoutPage: CartCheckoutPage;
 	let plansPage: PlansPage;
@@ -77,7 +77,7 @@ describe( DataHelper.createSuiteTitle( 'Sidebar: Domain upsell' ), function () {
 	} );
 
 	it( `Click button to upgrade to WordPress.com ${ planName }`, async function () {
-		await plansPage.selectPlan( 'Premium' );
+		await plansPage.selectPlan( 'Explorer' );
 	} );
 
 	it( `WordPress.com ${ planName } is added to cart`, async function () {

--- a/test/e2e/specs/fse/fse__temp-smoke-test.ts
+++ b/test/e2e/specs/fse/fse__temp-smoke-test.ts
@@ -71,7 +71,7 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 
 		testAccount = new TestAccount( accountName );
 		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
-			// eCommerce plan sites attempt to load Calypso, but with
+			// Entrepreneur plan sites attempt to load Calypso, but with
 			// third-party cookies disabled the fallback route to WP-Admin
 			// kicks in after some time.
 			await testAccount.authenticate( page, { url: /wp-admin/ } );
@@ -83,7 +83,7 @@ describe( DataHelper.createSuiteTitle( 'Site Editor Smoke Test' ), function () {
 	it( 'Navigate to Full Site Editor', async function () {
 		fullSiteEditorPage = new FullSiteEditorPage( page );
 
-		// eCommerce plan loads WP-Admin for home dashboard,
+		// Entrepreneur plan loads WP-Admin for home dashboard,
 		// so instead navigate straight to the FSE page.
 		if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
 			await fullSiteEditorPage.visit( testAccount.getSiteURL( { protocol: true } ) );

--- a/test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts
+++ b/test/e2e/specs/jetpack/jetpack__dashboard-smoke.ts
@@ -38,7 +38,7 @@ skipDescribeIf( envVariables.TEST_ON_ATOMIC !== true )(
 			page = await browser.newPage();
 
 			if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
-				// eCommerce plan sites attempt to load Calypso, but with
+				// Entrepreneur plan sites attempt to load Calypso, but with
 				// third-party cookies disabled the fallback route to WP-Admin
 				// kicks in after some time.
 				await testAccount.authenticate( page, { url: /wp-admin/ } );

--- a/test/e2e/specs/jetpack/settings__hosting-config-phpmyadmin.ts
+++ b/test/e2e/specs/jetpack/settings__hosting-config-phpmyadmin.ts
@@ -38,7 +38,7 @@ skipDescribeIf( ! envVariables.TEST_ON_ATOMIC )(
 			testAccount = new TestAccount( accountName );
 
 			if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
-				// Switching to or logging into eCommerce plan sites inevitably
+				// Switching to or logging into Entrepreneur plan sites inevitably
 				// loads WP-Admin instead of Calypso, but the rediret occurs
 				// only after Calypso attempts to load.
 				await testAccount.authenticate( page, { url: /wp-admin/ } );

--- a/test/e2e/specs/martech/tos-screenshots__checkout.ts
+++ b/test/e2e/specs/martech/tos-screenshots__checkout.ts
@@ -43,9 +43,9 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 		await sidebarComponent.navigate( 'Upgrades', 'Plans' );
 	} );
 
-	it( 'Add WordPress.com Business plan to cart', async function () {
+	it( 'Add WordPress.com Creator plan to cart', async function () {
 		const plansPage = new PlansPage( page );
-		await Promise.all( [ page.waitForURL( /.*checkout.*/ ), plansPage.selectPlan( 'Business' ) ] );
+		await Promise.all( [ page.waitForURL( /.*checkout.*/ ), plansPage.selectPlan( 'Creator' ) ] );
 	} );
 
 	describe.each( DataHelper.getMag16Locales() )(

--- a/test/e2e/specs/media/media__edit.ts
+++ b/test/e2e/specs/media/media__edit.ts
@@ -40,7 +40,7 @@ describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
 
 		testAccount = new TestAccount( accountName );
 		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
-			// Switching to or logging into eCommerce plan sites inevitably
+			// Switching to or logging into Entrepreneur plan sites inevitably
 			// loads WP-Admin instead of Calypso, but the rediret occurs
 			// only after Calypso attempts to load.
 			await testAccount.authenticate( page, { url: /wp-admin/ } );
@@ -52,7 +52,7 @@ describe( DataHelper.createSuiteTitle( 'Media: Edit Media' ), function () {
 	} );
 
 	it( 'Navigate to Media', async function () {
-		// eCommerce plan loads WP-Admin for home dashboard,
+		// Entrepreneur plan loads WP-Admin for home dashboard,
 		// so instead navigate straight to the Media page.
 		if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
 			await mediaPage.visit( testAccount.credentials.testSites?.primary.url as string );

--- a/test/e2e/specs/media/media__upload.ts
+++ b/test/e2e/specs/media/media__upload.ts
@@ -49,7 +49,7 @@ describe( DataHelper.createSuiteTitle( 'Media: Upload' ), () => {
 
 		testAccount = new TestAccount( accountName );
 		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
-			// Switching to or logging into eCommerce plan sites inevitably
+			// Switching to or logging into Entrepreneur plan sites inevitably
 			// loads WP-Admin instead of Calypso, but the rediret occurs
 			// only after Calypso attempts to load.
 			await testAccount.authenticate( page, { url: /wp-admin/ } );
@@ -61,7 +61,7 @@ describe( DataHelper.createSuiteTitle( 'Media: Upload' ), () => {
 	} );
 
 	it( 'Navigate to Media', async function () {
-		// eCommerce plan loads WP-Admin for home dashboard,
+		// Entrepreneur plan loads WP-Admin for home dashboard,
 		// so instead navigate straight to the Media page.
 		if ( envVariables.ATOMIC_VARIATION === 'ecomm-plan' ) {
 			await mediaPage.visit( testAccount.credentials.testSites?.primary.url as string );

--- a/test/e2e/specs/media/settings__media.ts
+++ b/test/e2e/specs/media/settings__media.ts
@@ -38,7 +38,7 @@ describe( DataHelper.createSuiteTitle( 'Jetpack Settings: Media' ), function () 
 		testAccount = new TestAccount( accountName );
 
 		if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
-			// Switching to or logging into eCommerce plan sites inevitably
+			// Switching to or logging into Entrepreneur plan sites inevitably
 			// loads WP-Admin instead of Calypso, but the rediret occurs
 			// only after Calypso attempts to load.
 			await testAccount.authenticate( page, { url: /wp-admin/ } );
@@ -82,7 +82,7 @@ describe( DataHelper.createSuiteTitle( 'Jetpack Settings: Media' ), function () 
 		let wpAdminMediaSettingsPage: WpAdminMediaSettingsPage;
 
 		it( 'Navigate to Settings > Media', async function () {
-			// eCommerce plan loads WP-Admin for home dashboard,
+			// Entrepreneur plan loads WP-Admin for home dashboard,
 			// so instead navigate straight to the Media page.
 			if ( testAccount.accountName === 'jetpackAtomicEcommPlanUser' ) {
 				await page.goto( `${ testAccount.getSiteURL() }wp-admin/options-media.php` );

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -36,7 +36,7 @@ declare const browser: Browser;
  * Keywords: Onboarding, Store Checkout, Coupon, Signup, Plan, Subscription, Cancel
  */
 describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function () {
-	const planName = 'Personal';
+	const planName = 'Starter';
 	const testUser = DataHelper.getNewTestUser( {
 		usernamePrefix: 'ftmepersonal',
 	} );

--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
@@ -30,7 +30,7 @@ declare const browser: Browser;
  * Keywords: Onboarding, Store Checkout, Coupon, Signup, Plan, Subscription, Cancel
  */
 describe( 'Lifecyle: Logged Out Home Page, signup, onboard, launch and cancel subscription', function () {
-	const planName = 'Premium';
+	const planName = 'Explorer';
 	let themeSlug: string | null = null;
 
 	const testUser = DataHelper.getNewTestUser( {

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.ts
@@ -32,7 +32,7 @@ declare const browser: Browser;
  * Keywords: Onboarding, Store Checkout, Coupon, Signup, Plan, Subscription, Cancel
  */
 describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscription', function () {
-	const planName = 'Premium';
+	const planName = 'Explorer';
 	let themeSlug: string | null = null;
 
 	const testUser = DataHelper.getNewTestUser( {

--- a/test/e2e/specs/plans/plans__signup-creator.ts
+++ b/test/e2e/specs/plans/plans__signup-creator.ts
@@ -20,9 +20,9 @@ import { apiDeleteSite } from '../shared';
 declare const browser: Browser;
 
 describe(
-	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com Business site as exising user' ),
+	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com Creator site as exising user' ),
 	function () {
-		const planName = 'Business';
+		const planName = 'Creator';
 
 		let testAccount: TestAccount;
 		let page: Page;

--- a/test/e2e/specs/plans/plans__upgrade.ts
+++ b/test/e2e/specs/plans/plans__upgrade.ts
@@ -28,7 +28,7 @@ const postTitles = Array.from( { length: 2 }, () => DataHelper.getRandomPhrase()
 
 describe(
 	DataHelper.createSuiteTitle(
-		'Plans: Upgrade exising WordPress.com Free site to WordPress.com Premium'
+		'Plans: Upgrade exising WordPress.com Free site to WordPress.com Explorer'
 	),
 	function () {
 		const blogName = DataHelper.getBlogName();

--- a/test/e2e/specs/plans/plans__upgrade.ts
+++ b/test/e2e/specs/plans/plans__upgrade.ts
@@ -32,7 +32,7 @@ describe(
 	),
 	function () {
 		const blogName = DataHelper.getBlogName();
-		const planName = 'Premium';
+		const planName = 'Explorer';
 		const publishedPosts: PostResponse[] = [];
 		let testMediaFile: TestFile;
 		let siteCreatedFlag: boolean;
@@ -96,7 +96,7 @@ describe(
 			} );
 
 			it( `Click button to upgrade to WordPress.com ${ planName }`, async function () {
-				await plansPage.selectPlan( 'Premium' );
+				await plansPage.selectPlan( planName );
 			} );
 
 			it( `WordPress.com ${ planName } is added to cart`, async function () {
@@ -136,7 +136,7 @@ describe(
 
 			it( `Plans page states user is on WordPress.com ${ planName } plan`, async function () {
 				const plansPage = new PlansPage( page );
-				await plansPage.validateActivePlan( 'Premium' );
+				await plansPage.validateActivePlan( planName );
 			} );
 		} );
 

--- a/test/e2e/specs/plugins/plugins__purchase.ts
+++ b/test/e2e/specs/plugins/plugins__purchase.ts
@@ -56,7 +56,7 @@ describe( 'Plugins: Add multiple to cart', function () {
 			await pluginsPage.clickInstallPlugin();
 		} );
 
-		it.each( [ 'WordPress.com Business', pluginName ] )(
+		it.each( [ 'WordPress.com Creator', pluginName ] )(
 			`%s is added to cart`,
 			async function ( target ) {
 				cartCheckoutPage = new CartCheckoutPage( page );

--- a/test/e2e/specs/published-content/forms__submissions.ts
+++ b/test/e2e/specs/published-content/forms__submissions.ts
@@ -108,7 +108,7 @@ describe( DataHelper.createSuiteTitle( 'Feedback: Form Submission' ), function (
 
 		beforeAll( async function () {
 			if ( accountName === 'jetpackAtomicEcommPlanUser' ) {
-				// eCommerce plan sites attempt to load Calypso, but with
+				// Entrepreneur plan sites attempt to load Calypso, but with
 				// third-party cookies disabled the fallback route to WP-Admin
 				// kicks in after some time.
 				await testAccount.authenticate( page, { url: /wp-admin/ } );

--- a/test/e2e/specs/stats/stats.ts
+++ b/test/e2e/specs/stats/stats.ts
@@ -36,7 +36,7 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 
 		testAccount = new TestAccount( accountName );
 		if ( testAccount.accountName === 'jetpackAtomicEcommPlanUser' ) {
-			// eCommerce plan sites attempt to load Calypso, but with
+			// Entrepreneur plan sites attempt to load Calypso, but with
 			// third-party cookies disabled the fallback route to WP-Admin
 			// kicks in after some time.
 			await testAccount.authenticate( page, { url: /wp-admin/ } );
@@ -103,7 +103,7 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 		} );
 	} );
 
-	// The Store tab is not present unless Business or higher plan is on the site and the
+	// The Store tab is not present unless Creator or higher plan is on the site and the
 	// site has gone AT.
 	skipDescribeIf( accountName !== 'jetpackAtomicEcommPlanUser' )( 'Store', function () {
 		it( 'Click on the Store tab', async function () {

--- a/test/e2e/specs/tools/marketing__seo.ts
+++ b/test/e2e/specs/tools/marketing__seo.ts
@@ -20,7 +20,7 @@ declare const browser: Browser;
 /**
  * Quick test to verify various SEO text fields and previews render.
  *
- * This is a feature exclusive to Business plans and higher.
+ * This is a feature exclusive to Creator plans and higher.
  *
  * Keywords: Jetpack, SEO, Traffic, Marketing.
  */


### PR DESCRIPTION
## Proposed Changes

D132501-code aims to rename all plans for 100% of the new users. We also need to update the e2e tests in Calypso.

## Testing Instructions

Once that diff gets shipped, let's re-run and make sure pre-release checks pass.

cc @dzver and @Automattic/martech 