### PR TITLE
Assembler V2: Use the category "page" to identify page patterns

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-list.tsx
@@ -93,7 +93,7 @@ const PageList = ( {
 							onClick={ () => onSelectPage( name ) }
 						>
 							<PageListItem
-								// Show only the first page in that category
+								// Show the latest-updated page per category
 								label={ pagesMapByCategory[ name ][ 0 ].title }
 								isSelected={ isSelected }
 							/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-list.tsx
@@ -93,6 +93,7 @@ const PageList = ( {
 							onClick={ () => onSelectPage( name ) }
 						>
 							<PageListItem
+								// Show only the first page in that category
 								label={ pagesMapByCategory[ name ][ 0 ].title }
 								isSelected={ isSelected }
 							/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -32,4 +32,5 @@ export const injectCategoryToPattern = (
 export const isPriorityPattern = ( { tags: { assembler_priority } }: Pattern ) =>
 	isEnabled( 'pattern-assembler/v2' ) ? true : Boolean( assembler_priority );
 
-export const isPagePattern = ( { tags: { assembler_page } }: Pattern ) => !! assembler_page;
+export const isPagePattern = ( { categories, tags: { assembler_page } }: Pattern ) =>
+	Boolean( isEnabled( 'pattern-assembler/v2' ) ? categories.page : assembler_page );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/85288

## Proposed Changes

* Use the category "page" to identify page patterns when the feature flag `pattern-assembler/v2` is enabled.

The assembler shows only the latest updated page in each of the following subcategories:

- page
  - about
  - services
  - portfolio
  - store
  - posts
  - contact

You can see the pages in the source site https://assemblerv2patterns.wordpress.com/wp-admin/site-editor.php?path=%2Fpatterns&categoryType=pattern&categoryId=page


<img width="1456" alt="Screenshot 2566-12-19 at 20 18 47" src="https://github.com/Automattic/wp-calypso/assets/1881481/2b6f6a78-4d83-4733-bdbe-37714fbc9d3e">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access `/setup/with-theme-assembler/patternAssembler?flags=pattern-assembler/v2&siteSlug={ SITE }`
* Add a pattern, click continue until the pages screen
* Verify you can see and select pages in some of the categories, depending on the pages in the category 
* Continue and verify the pages are created as expected

<img width="1457" alt="Screenshot 2566-12-19 at 20 06 24" src="https://github.com/Automattic/wp-calypso/assets/1881481/7dc85b8f-d130-47ef-9470-4c5612524972">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?