### PR TITLE
Show the 'refresh site' box only when the site is old

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/footer/PlanFooter.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/footer/PlanFooter.tsx
@@ -1,25 +1,43 @@
 import { translate } from 'i18n-calypso';
+import moment from 'moment';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
-import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteOptions, getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+function isMonthsOld( rawDate: string, months: number ) {
+	if ( ! rawDate || ! months ) {
+		return false;
+	}
+
+	const parsedDate = moment( rawDate );
+	return moment().diff( parsedDate, 'months' ) > months;
+}
 
 const PlanFooter = () => {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
+	const siteCreatedTimeStamp = useSelector(
+		( state ) => getSiteOptions( state, siteId ?? 0 )?.created_at
+	);
+
+	// If the site has more than 6 months we consider it old for this purpose.
+	const isOldSite = isMonthsOld( siteCreatedTimeStamp ?? '', 6 );
 
 	return (
 		<div>
-			<PurchaseDetail
-				title={ translate( 'A site refresh' ) }
-				description={ translate(
-					'A new look and feel can help you stand out from the crowd. Get a new theme and make an impression.'
-				) }
-				buttonText={ translate( 'Find your new theme' ) }
-				href={ `/themes/${ siteSlug }` }
-				onClick={ () => recordTracksEvent( 'calypso_plan_thank_you_theme_click' ) }
-			/>
+			{ isOldSite && (
+				<PurchaseDetail
+					title={ translate( 'A site refresh' ) }
+					description={ translate(
+						'A new look and feel can help you stand out from the crowd. Get a new theme and make an impression.'
+					) }
+					buttonText={ translate( 'Find your new theme' ) }
+					href={ `/themes/${ siteSlug }` }
+					onClick={ () => recordTracksEvent( 'calypso_plan_thank_you_theme_click' ) }
+				/>
+			) }
 
 			<PurchaseDetail
 				title={ translate( 'Everything you need to know' ) }


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/85195

## Proposed Changes

When a customer buys a new plan, we show this screen:
<img width="783" alt="Screenshot 2023-12-19 at 14 08 02" src="https://github.com/Automattic/wp-calypso/assets/3832570/971b3373-7bfb-4eae-a647-3877f32ed5e2">

We want to show the first box (the one titled "A site refresh") only when the site has been some months since it was created:
<img width="763" alt="Screenshot 2023-12-19 at 14 07 30" src="https://github.com/Automattic/wp-calypso/assets/3832570/dae874e1-0b41-4332-ba39-547c15b3baa7">


## Testing Instructions

- Apply this PR and start the application.
- Go to Calypso on a site for which you have no plan. This site should be at least 6 months old.
- Purchase a new plan. You should see the "A site refresh" box in the "Thank you" screen.
- Create a new site.
- Purchase a new plan for that new site. You should only see the "Everything you need to know" box.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?