### PR TITLE
Purchase Modal: add Tracks event for view

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -5,6 +5,7 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import classNames from 'classnames';
 import { useState, useMemo, useEffect } from 'react';
 import QueryPaymentCountries from 'calypso/components/data/query-countries/payments';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { isCreditCard, type StoredPaymentMethodCard } from 'calypso/lib/checkout/payment-methods';
 import useCreatePaymentCompleteCallback from 'calypso/my-sites/checkout/src/hooks/use-create-payment-complete-callback';
 import existingCardProcessor from 'calypso/my-sites/checkout/src/lib/existing-card-processor';
@@ -180,6 +181,12 @@ export default function PurchaseModalWrapper( props: PurchaseModalProps ) {
 		// We don't need to wait for the result of the above.
 		onClose();
 	};
+
+	useEffect( () => {
+		recordTracksEvent( 'calypso_oneclick_upsell_modal_view', {
+			product_slug: productToAdd.product_slug,
+		} );
+	}, [ productToAdd.product_slug ] );
 
 	return (
 		<CheckoutProvider


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fire a new Tracks event, `calypso_oneclick_upsell_modal_view`, whenever the 1-click purchase modal is shown.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that you have a saved credit card on file.
* Go to `/checkout/<site slug>/offer-plan-upgrade/business/12345`.
* Open the Network tab of your browser dev tools.
* Click on the "Upgrade Now" CTA.
* Confirm that you see a request to `http://pixel.wp.com/t.gif` with these params:
<img width="317" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/71deadf5-ced7-4d7c-86ee-5a72d66b243b">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?