### PR TITLE
Plans 2023: Pass selectedSiteId as a prop to pricing meta hook

### DIFF
--- a/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
@@ -1,5 +1,5 @@
 import { PLAN_PREMIUM } from '@automattic/calypso-products';
-import { usePlans } from '@automattic/data-stores/src/plans';
+import { Plans } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 
 interface Props {
@@ -8,7 +8,7 @@ interface Props {
 
 const useGlobalStylesUpgradeTranslations = ( { numOfSelectedGlobalStyles = 1 }: Props ) => {
 	const translate = useTranslate();
-	const plans = usePlans();
+	const plans = Plans.usePlans( { coupon: undefined } );
 	const planTitle = plans?.data?.[ PLAN_PREMIUM ]?.productNameShort ?? '';
 
 	const features = [

--- a/client/components/theme-type-badge/tooltip.tsx
+++ b/client/components/theme-type-badge/tooltip.tsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { PLAN_BUSINESS, PLAN_PREMIUM } from '@automattic/calypso-products';
-import { usePlans } from '@automattic/data-stores/src/plans';
+import { Plans } from '@automattic/data-stores';
 import {
 	BUNDLED_THEME,
 	DOT_ORG_THEME,
@@ -72,7 +72,7 @@ const ThemeTypeBadgeTooltip = ( {
 }: Props ) => {
 	const translate = useTranslate();
 	// Using API plans because the updated getTitle() method doesn't take the experiment assignment into account.
-	const plans = usePlans();
+	const plans = Plans.usePlans( { coupon: undefined } );
 	const type = useSelector( ( state ) => getThemeType( state, themeId ) );
 	const bundleSettings = useBundleSettingsByTheme( themeId );
 	const isIncludedCurrentPlan = useSelector(

--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -23,8 +23,7 @@ import {
 	PLAN_PREMIUM,
 } from '@automattic/calypso-products';
 import { Button, Dialog, ScreenReaderText } from '@automattic/components';
-import { ProductsList } from '@automattic/data-stores';
-import { usePlans } from '@automattic/data-stores/src/plans';
+import { Plans, ProductsList } from '@automattic/data-stores';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { Tooltip } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -103,7 +102,7 @@ export const ThemeUpgradeModal = ( {
 		( select ) => select( ProductsList.store ).getProductBySlug( 'business-bundle-monthly' ),
 		[]
 	);
-	const plans = usePlans();
+	const plans = Plans.usePlans( { coupon: undefined } );
 
 	//Wait until we have theme and product data to show content
 	const isLoading = ! premiumPlanProduct || ! businessPlanProduct || ! theme.data;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
@@ -1,5 +1,5 @@
 import { PLAN_PREMIUM } from '@automattic/calypso-products';
-import { usePlans } from '@automattic/data-stores/src/plans';
+import { Plans } from '@automattic/data-stores';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { NAVIGATOR_PATHS } from '../constants';
@@ -24,7 +24,7 @@ export type Screen = {
 const useScreen = ( screenName: ScreenName, options: UseScreenOptions = {} ): Screen => {
 	const translate = useTranslate();
 	const hasEnTranslation = useHasEnTranslation();
-	const plans = usePlans();
+	const plans = Plans.usePlans( { coupon: undefined } );
 	const screens: Record< ScreenName, Screen > = {
 		main: {
 			name: 'main',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
@@ -30,6 +30,7 @@ const ScreenUpsell = ( { numOfSelectedGlobalStyles = 1, onCheckout, onTryStyle }
 		planSlugs: [ PLAN_PREMIUM ],
 		storageAddOns: null,
 		selectedSiteId,
+		coupon: undefined,
 	} );
 
 	const pricing = pricingMeta?.[ PLAN_PREMIUM ];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
@@ -3,10 +3,12 @@ import { Button, Gridicon, LoadingPlaceholder } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import { NavigatorHeader } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
 import useGlobalStylesUpgradeTranslations from 'calypso/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations';
 import PlanPrice from 'calypso/my-sites/plan-price';
 import usePricingMetaForGridPlans from 'calypso/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useScreen } from './hooks';
 import NavigatorTitle from './navigator-title';
 import './screen-upsell.scss';
@@ -21,9 +23,13 @@ const ScreenUpsell = ( { numOfSelectedGlobalStyles = 1, onCheckout, onTryStyle }
 	const translate = useTranslate();
 	const { title, description } = useScreen( 'upsell' );
 	const translations = useGlobalStylesUpgradeTranslations( { numOfSelectedGlobalStyles } );
+	const selectedSiteId = useSelector( getSelectedSiteId ) ?? undefined;
+
+	// TODO clk pricing
 	const pricingMeta = usePricingMetaForGridPlans( {
 		planSlugs: [ PLAN_PREMIUM ],
 		storageAddOns: null,
+		selectedSiteId,
 	} );
 
 	const pricing = pricingMeta?.[ PLAN_PREMIUM ];

--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -4,45 +4,13 @@ import {
 	getTermFromDuration,
 	calculateMonthlyPrice,
 } from '@automattic/calypso-products';
-import { Plans, WpcomPlansUI, Purchases, type AddOnMeta } from '@automattic/data-stores';
+import { Plans, WpcomPlansUI, Purchases } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
-import { useSelector } from 'react-redux';
-import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import useCheckPlanAvailabilityForPurchase from '../use-check-plan-availability-for-purchase';
-
-export interface PricingMetaForGridPlan {
-	billingPeriod?: Plans.PlanPricing[ 'billPeriod' ];
-	currencyCode?: Plans.PlanPricing[ 'currencyCode' ];
-	originalPrice: Plans.PlanPricing[ 'originalPrice' ];
-	/**
-	 * If discounted prices are provided (not null), they will take precedence over originalPrice.
-	 * UI will show original with a strikethrough or grayed out
-	 */
-	discountedPrice: Plans.PlanPricing[ 'discountedPrice' ];
-	/**
-	 * Intro offers override billing and pricing shown in the UI
-	 * they are currently defined off the site plans (so not defined when siteId is not available)
-	 */
-	introOffer?: Plans.PlanPricing[ 'introOffer' ];
-	expiry?: Plans.SitePlan[ 'expiry' ];
-}
-
-export type UsePricingMetaForGridPlans = ( {
-	planSlugs,
-	withoutProRatedCredits,
-	storageAddOns,
-}: {
-	planSlugs: PlanSlug[];
-	withoutProRatedCredits?: boolean;
-	storageAddOns: ( AddOnMeta | null )[] | null;
-} ) => { [ planSlug: string ]: PricingMetaForGridPlan } | null;
-
-interface Props {
-	planSlugs: PlanSlug[];
-	withoutProRatedCredits?: boolean;
-	storageAddOns?: ( AddOnMeta | null )[] | null;
-	coupon?: string;
-}
+import type {
+	UsePricingMetaForGridPlans,
+	PricingMetaForGridPlan,
+} from 'calypso/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans';
 
 function getTotalPrice( planPrice: number | null | undefined, addOnPrice = 0 ): number | null {
 	return null !== planPrice && undefined !== planPrice ? planPrice + addOnPrice : null;
@@ -56,10 +24,9 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 	planSlugs,
 	withoutProRatedCredits = false,
 	storageAddOns,
+	selectedSiteId,
 	coupon,
-}: Props ) => {
-	// TODO: pass this in as a prop to uncouple the dependency
-	const selectedSiteId = useSelector( getSelectedSiteId ) ?? undefined;
+} ) => {
 	// TODO: pass this in as a prop to uncouple the dependency
 	const planAvailabilityForPurchase = useCheckPlanAvailabilityForPurchase( { planSlugs } );
 

--- a/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -94,6 +94,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 			withoutProRatedCredits: false,
 			storageAddOns: null,
 			selectedSiteId: 100,
+			coupon: undefined,
 		} );
 
 		const expectedPricingMeta = {
@@ -132,6 +133,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 			withoutProRatedCredits: false,
 			storageAddOns: null,
 			selectedSiteId: 100,
+			coupon: undefined,
 		} );
 
 		const expectedPricingMeta = {
@@ -171,6 +173,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 			withoutProRatedCredits: false,
 			storageAddOns: null,
 			selectedSiteId: 100,
+			coupon: undefined,
 		} );
 
 		const expectedPricingMeta = {
@@ -210,6 +213,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 			withoutProRatedCredits: true,
 			storageAddOns: null,
 			selectedSiteId: 100,
+			coupon: undefined,
 		} );
 
 		const expectedPricingMeta = {

--- a/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -26,14 +26,12 @@ jest.mock( '../use-check-plan-availability-for-purchase', () => jest.fn() );
 
 import { PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
 import { Plans, Purchases } from '@automattic/data-stores';
-import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import usePricingMetaForGridPlans from '../data-store/use-pricing-meta-for-grid-plans';
 import useCheckPlanAvailabilityForPurchase from '../use-check-plan-availability-for-purchase';
 
 describe( 'usePricingMetaForGridPlans', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		getSelectedSiteId.mockImplementation( () => 100 );
 		Purchases.useSitePurchaseById.mockImplementation( () => undefined );
 		Plans.useIntroOffers.mockImplementation( () => ( {
 			[ PLAN_PREMIUM ]: null,
@@ -95,6 +93,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 			planSlugs: [ PLAN_PREMIUM ],
 			withoutProRatedCredits: false,
 			storageAddOns: null,
+			selectedSiteId: 100,
 		} );
 
 		const expectedPricingMeta = {
@@ -132,6 +131,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 			planSlugs: [ PLAN_PREMIUM ],
 			withoutProRatedCredits: false,
 			storageAddOns: null,
+			selectedSiteId: 100,
 		} );
 
 		const expectedPricingMeta = {
@@ -170,6 +170,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 			planSlugs: [ PLAN_PREMIUM ],
 			withoutProRatedCredits: false,
 			storageAddOns: null,
+			selectedSiteId: 100,
 		} );
 
 		const expectedPricingMeta = {
@@ -208,6 +209,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 			planSlugs: [ PLAN_PREMIUM ],
 			withoutProRatedCredits: true,
 			storageAddOns: null,
+			selectedSiteId: 100,
 		} );
 
 		const expectedPricingMeta = {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -528,6 +528,7 @@ const PlansFeaturesMain = ( {
 			usePricingMetaForGridPlans,
 			recordTracksEvent,
 			coupon,
+			selectedSiteId: siteId,
 		};
 	}, [
 		_customerType,
@@ -546,6 +547,7 @@ const PlansFeaturesMain = ( {
 		showPlanTypeSelectorDropdown,
 		eligibleForWpcomMonthlyPlans,
 		coupon,
+		siteId,
 	] );
 
 	/**
@@ -812,7 +814,7 @@ const PlansFeaturesMain = ( {
 									isLaunchPage={ isLaunchPage }
 									onUpgradeClick={ handleUpgradeClick }
 									selectedFeature={ selectedFeature }
-									siteId={ siteId }
+									selectedSiteId={ siteId }
 									intervalType={ intervalType }
 									hideUnavailableFeatures={ hideUnavailableFeatures }
 									currentSitePlanSlug={ sitePlanSlug }
@@ -873,7 +875,7 @@ const PlansFeaturesMain = ( {
 												onUpgradeClick={ handleUpgradeClick }
 												selectedFeature={ selectedFeature }
 												selectedPlan={ selectedPlan }
-												siteId={ siteId }
+												selectedSiteId={ siteId }
 												intervalType={ intervalType }
 												hideUnavailableFeatures={ hideUnavailableFeatures }
 												currentSitePlanSlug={ sitePlanSlug }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -425,6 +425,7 @@ const PlansFeaturesMain = ( {
 		isSubdomainNotGenerated: ! resolvedSubdomainName.result,
 		storageAddOns,
 		coupon,
+		selectedSiteId: siteId,
 	} );
 
 	const planFeaturesForFeaturesGrid = usePlanFeaturesForGridPlans( {

--- a/client/my-sites/plans-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plans-grid/components/billing-timeframe.tsx
@@ -19,7 +19,7 @@ import { GridPlan } from '../hooks/npm-ready/data-store/use-grid-plans';
 
 function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 	const translate = useTranslate();
-	const { helpers, gridPlansIndex, coupon } = usePlansGridContext();
+	const { helpers, gridPlansIndex, coupon, selectedSiteId } = usePlansGridContext();
 	const {
 		isMonthlyPlan,
 		pricing: { currencyCode, originalPrice, discountedPrice, billingPeriod, introOffer },
@@ -39,6 +39,7 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 	// (or other) credits should not apply.
 	const yearlyVariantPlanSlug = getPlanSlugForTermVariant( planSlug, TERM_ANNUALLY );
 
+	// TODO clk pricing
 	const yearlyVariantPricing =
 		yearlyVariantPlanSlug &&
 		helpers?.usePricingMetaForGridPlans( {
@@ -46,6 +47,7 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 			withoutProRatedCredits: true,
 			storageAddOns: storageAddOnsForPlan,
 			coupon,
+			selectedSiteId,
 		} )?.[ yearlyVariantPlanSlug ];
 
 	if (

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -331,7 +331,6 @@ type ComparisonGridHeaderProps = {
 	onPlanChange: ( currentPlan: PlanSlug, event: ChangeEvent< HTMLSelectElement > ) => void;
 	currentSitePlanSlug?: string | null;
 	onUpgradeClick: ( planSlug: PlanSlug ) => void;
-	siteId?: number | null;
 	planActionOverrides?: PlanActionOverrides;
 	selectedPlan?: string;
 	showRefundPeriod?: boolean;
@@ -481,7 +480,6 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 			onPlanChange,
 			currentSitePlanSlug,
 			onUpgradeClick,
-			siteId,
 			planActionOverrides,
 			selectedPlan,
 			isHiddenInMobile,
@@ -492,6 +490,7 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 		ref
 	) => {
 		const translate = useTranslate();
+		const { selectedSiteId } = usePlansGridContext();
 		const allVisible = visibleGridPlans.length === displayedGridPlans.length;
 		const { prices, currencyCode } = usePlanPricingInfoFromGridPlans( {
 			gridPlans: visibleGridPlans,
@@ -503,7 +502,7 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 			currencyCode: currencyCode || 'USD',
 		} );
 		const isPlanUpgradeCreditEligible = useIsPlanUpgradeCreditVisible(
-			siteId ?? 0,
+			selectedSiteId ?? 0,
 			displayedGridPlans.map( ( { planSlug } ) => planSlug )
 		);
 
@@ -542,7 +541,6 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 						isLargeCurrency={ isLargeCurrency }
 						planActionOverrides={ planActionOverrides }
 						selectedPlan={ selectedPlan }
-						siteId={ siteId }
 						showRefundPeriod={ showRefundPeriod }
 						isStuck={ isStuck }
 					/>
@@ -957,7 +955,6 @@ const ComparisonGrid = ( {
 	isLaunchPage,
 	currentSitePlanSlug,
 	onUpgradeClick,
-	siteId,
 	planActionOverrides,
 	selectedPlan,
 	selectedFeature,
@@ -1100,7 +1097,6 @@ const ComparisonGrid = ( {
 				>
 					{ ( isStuck: boolean ) => (
 						<ComparisonGridHeader
-							siteId={ siteId }
 							displayedGridPlans={ displayedGridPlans }
 							visibleGridPlans={ visibleGridPlans }
 							isInSignup={ isInSignup }
@@ -1140,7 +1136,6 @@ const ComparisonGrid = ( {
 					onPlanChange={ onPlanChange }
 					currentSitePlanSlug={ currentSitePlanSlug }
 					onUpgradeClick={ onUpgradeClick }
-					siteId={ siteId }
 					planActionOverrides={ planActionOverrides }
 					selectedPlan={ selectedPlan }
 					showRefundPeriod={ showRefundPeriod }

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-toggle.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-toggle.tsx
@@ -21,18 +21,21 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		usePricingMetaForGridPlans,
 		title,
 		coupon,
+		selectedSiteId,
 	} = props;
 	const [ spanRef, setSpanRef ] = useState< HTMLSpanElement >();
 	const segmentClasses = classNames( 'price-toggle', {
 		'is-signup': isInSignup,
 	} );
 	const popupIsVisible = Boolean( intervalType === 'monthly' && isInSignup && props.plans.length );
-	const maxDiscount = useMaxDiscount( props.plans, usePricingMetaForGridPlans );
+	const maxDiscount = useMaxDiscount( props.plans, usePricingMetaForGridPlans, selectedSiteId );
+	// TODO clk pricing
 	const pricingMeta = usePricingMetaForGridPlans( {
 		planSlugs: currentSitePlanSlug ? [ currentSitePlanSlug ] : [],
 		withoutProRatedCredits: true,
 		storageAddOns: null,
 		coupon,
+		selectedSiteId,
 	} );
 	const currentPlanBillingPeriod = currentSitePlanSlug
 		? pricingMeta?.[ currentSitePlanSlug ]?.billingPeriod

--- a/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-interval-options.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-interval-options.tsx
@@ -67,7 +67,8 @@ export default function useIntervalOptions( props: IntervalTypeProps ): Interval
 	const termWiseMaxDiscount = useMaxDiscountsForPlanTerms(
 		props.plans,
 		Object.keys( optionList ) as Array< SupportedUrlFriendlyTermType >,
-		props.usePricingMetaForGridPlans
+		props.usePricingMetaForGridPlans,
+		props.selectedSiteId
 	);
 
 	const additionalPathProps = {

--- a/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-max-discount.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-max-discount.ts
@@ -10,7 +10,8 @@ import { UsePricingMetaForGridPlans } from 'calypso/my-sites/plans-grid/hooks/np
 
 export default function useMaxDiscount(
 	plans: PlanSlug[],
-	usePricingMetaForGridPlans: UsePricingMetaForGridPlans
+	usePricingMetaForGridPlans: UsePricingMetaForGridPlans,
+	selectedSiteId?: number | null
 ): number {
 	const [ maxDiscount, setMaxDiscount ] = useState( 0 );
 	const wpcomMonthlyPlans = ( plans || [] ).filter( isWpComPlan ).filter( isMonthly );
@@ -18,15 +19,19 @@ export default function useMaxDiscount(
 		.map( ( planSlug ) => getPlanSlugForTermVariant( planSlug, TERM_ANNUALLY ) )
 		.filter( Boolean ) as PlanSlug[];
 
+	// TODO clk pricing
 	const monthlyPlansPricing = usePricingMetaForGridPlans( {
 		planSlugs: wpcomMonthlyPlans,
 		withoutProRatedCredits: true,
 		storageAddOns: null,
+		selectedSiteId,
 	} );
+	// TODO clk pricing
 	const yearlyPlansPricing = usePricingMetaForGridPlans( {
 		planSlugs: yearlyVariantPlanSlugs,
 		withoutProRatedCredits: true,
 		storageAddOns: null,
+		selectedSiteId,
 	} );
 
 	const discounts = wpcomMonthlyPlans.map( ( planSlug ) => {

--- a/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-max-discount.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-max-discount.ts
@@ -25,6 +25,7 @@ export default function useMaxDiscount(
 		withoutProRatedCredits: true,
 		storageAddOns: null,
 		selectedSiteId,
+		coupon: undefined,
 	} );
 	// TODO clk pricing
 	const yearlyPlansPricing = usePricingMetaForGridPlans( {
@@ -32,6 +33,7 @@ export default function useMaxDiscount(
 		withoutProRatedCredits: true,
 		storageAddOns: null,
 		selectedSiteId,
+		coupon: undefined,
 	} );
 
 	const discounts = wpcomMonthlyPlans.map( ( planSlug ) => {

--- a/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-max-discounts-for-plan-terms.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-max-discounts-for-plan-terms.ts
@@ -20,7 +20,8 @@ import { UsePricingMetaForGridPlans } from 'calypso/my-sites/plans-grid/hooks/np
 export default function useMaxDiscountsForPlanTerms(
 	plans: PlanSlug[],
 	urlFriendlyTerms: UrlFriendlyTermType[] = [],
-	usePricingMetaForGridPlans: UsePricingMetaForGridPlans
+	usePricingMetaForGridPlans: UsePricingMetaForGridPlans,
+	selectedSiteId?: number | null
 ): Record< UrlFriendlyTermType, number > {
 	const termDefinitionsMapping = urlFriendlyTerms.map( ( urlFriendlyTerm ) => ( {
 		urlFriendlyTerm,
@@ -40,15 +41,19 @@ export default function useMaxDiscountsForPlanTerms(
 		( planSlug ) => ! isMonthly( planSlug )
 	);
 
+	// TODO clk pricing
 	const monthlyPlansPricing = usePricingMetaForGridPlans( {
 		planSlugs: wpcomMonthlyPlanSlugs,
 		withoutProRatedCredits: true,
 		storageAddOns: null,
+		selectedSiteId,
 	} );
+	// TODO clk pricing
 	const nonMonthlyPlansPricing = usePricingMetaForGridPlans( {
 		planSlugs: wpcomNonMonthlyPlans,
 		withoutProRatedCredits: true,
 		storageAddOns: null,
+		selectedSiteId,
 	} );
 
 	const getTermInMonths = ( term: UrlFriendlyTermType ): number => {

--- a/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-max-discounts-for-plan-terms.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-max-discounts-for-plan-terms.ts
@@ -47,6 +47,7 @@ export default function useMaxDiscountsForPlanTerms(
 		withoutProRatedCredits: true,
 		storageAddOns: null,
 		selectedSiteId,
+		coupon: undefined,
 	} );
 	// TODO clk pricing
 	const nonMonthlyPlansPricing = usePricingMetaForGridPlans( {
@@ -54,6 +55,7 @@ export default function useMaxDiscountsForPlanTerms(
 		withoutProRatedCredits: true,
 		storageAddOns: null,
 		selectedSiteId,
+		coupon: undefined,
 	} );
 
 	const getTermInMonths = ( term: UrlFriendlyTermType ): number => {

--- a/client/my-sites/plans-grid/components/plan-type-selector/types.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/types.ts
@@ -4,6 +4,7 @@ import { type UsePricingMetaForGridPlans } from '../../hooks/npm-ready/data-stor
 
 export type PlanTypeSelectorProps = {
 	kind: 'interval';
+	selectedSiteId?: number | null;
 	basePlansPath?: string | null;
 	intervalType: UrlFriendlyTermType;
 	customerType: string;
@@ -38,6 +39,7 @@ export type PlanTypeSelectorProps = {
 export type IntervalTypeProps = Pick<
 	PlanTypeSelectorProps,
 	| 'intervalType'
+	| 'selectedSiteId'
 	| 'plans'
 	| 'isInSignup'
 	| 'eligibleForWpcomMonthlyPlans'

--- a/client/my-sites/plans-grid/grid-context.tsx
+++ b/client/my-sites/plans-grid/grid-context.tsx
@@ -9,6 +9,7 @@ import type { FeatureList } from '@automattic/calypso-products';
 
 interface PlansGridContext {
 	intent?: PlansIntent;
+	selectedSiteId?: number | null;
 	gridPlans: GridPlan[];
 	gridPlansIndex: { [ key: string ]: GridPlan };
 	allFeaturesList: FeatureList;
@@ -23,6 +24,7 @@ const PlansGridContextProvider = ( {
 	gridPlans,
 	usePricingMetaForGridPlans,
 	allFeaturesList,
+	selectedSiteId,
 	children,
 	coupon,
 }: GridContextProps ) => {
@@ -38,6 +40,7 @@ const PlansGridContextProvider = ( {
 		<PlansGridContext.Provider
 			value={ {
 				intent,
+				selectedSiteId,
 				gridPlans,
 				gridPlansIndex,
 				allFeaturesList,

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -73,16 +73,22 @@ export interface PricingMetaForGridPlan {
 // TODO clk: move to plans data store
 export type UsePricingMetaForGridPlans = ( {
 	planSlugs,
-	withoutProRatedCredits,
-	storageAddOns,
-	coupon,
 	selectedSiteId,
+	coupon,
+	storageAddOns,
+	withoutProRatedCredits,
 }: {
 	planSlugs: PlanSlug[];
-	withoutProRatedCredits?: boolean;
+	/**
+	 * `selectedSiteId` required on purpose to mitigate risk with not passing something through when we should
+	 */
+	selectedSiteId: number | null | undefined;
+	/**
+	 * `coupon` required on purpose to mitigate risk with not passing somethiing through when we should
+	 */
+	coupon: string | undefined;
 	storageAddOns: ( AddOnMeta | null )[] | null;
-	coupon?: string;
-	selectedSiteId?: number | null;
+	withoutProRatedCredits?: boolean;
 } ) => { [ planSlug: string ]: PricingMetaForGridPlan } | null;
 
 export type UseFreeTrialPlanSlugs = ( {

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -29,7 +29,7 @@ import { Plans } from '@automattic/data-stores';
 import { isSamePlan } from '../../../lib/is-same-plan';
 import useHighlightLabels from './use-highlight-labels';
 import usePlansFromTypes from './use-plans-from-types';
-import type { AddOnMeta, PlanIntroductoryOffer, PricedAPIPlan } from '@automattic/data-stores';
+import type { AddOnMeta, PricedAPIPlan } from '@automattic/data-stores';
 import type { TranslateResult } from 'i18n-calypso';
 
 // TODO clk: move to plans data store
@@ -48,41 +48,41 @@ export interface PlanFeaturesForGridPlan {
 	conditionalFeatures?: FeatureObject[];
 }
 
-// TODO clk: move to plans data store
-export interface PricingMetaForGridPlan {
-	billingPeriod?: PricedAPIPlan[ 'bill_period' ] | null;
-	currencyCode?: PricedAPIPlan[ 'currency_code' ] | null;
-	originalPrice: {
-		monthly: number | null;
-		full: number | null;
-	};
-	// if discounted prices are provided (not null), they will take precedence over originalPrice.
-	// UI will show original with a strikethrough or grayed out
-	discountedPrice: {
-		monthly: number | null;
-		full: number | null;
-	};
-	// intro offers override billing and pricing shown in the UI
-	// they are currently defined off the site plans (so not defined when siteId is not available)
-	introOffer?: PlanIntroductoryOffer | null;
-	// Expiry date is only available from site plans and is the expiry date of an existing plan.
-	expiry?: string | null;
-}
-
 export type UsePricedAPIPlans = ( { planSlugs }: { planSlugs: PlanSlug[] } ) => {
 	[ planSlug: string ]: PricedAPIPlan | null | undefined;
 } | null;
 
+// TODO clk: move to plans data store
+export interface PricingMetaForGridPlan {
+	billingPeriod?: Plans.PlanPricing[ 'billPeriod' ];
+	currencyCode?: Plans.PlanPricing[ 'currencyCode' ];
+	originalPrice: Plans.PlanPricing[ 'originalPrice' ];
+	/**
+	 * If discounted prices are provided (not null), they will take precedence over originalPrice.
+	 * UI will show original with a strikethrough or grayed out
+	 */
+	discountedPrice: Plans.PlanPricing[ 'discountedPrice' ];
+	/**
+	 * Intro offers override billing and pricing shown in the UI
+	 * they are currently defined off the site plans (so not defined when siteId is not available)
+	 */
+	introOffer?: Plans.PlanPricing[ 'introOffer' ];
+	expiry?: Plans.SitePlan[ 'expiry' ];
+}
+
+// TODO clk: move to plans data store
 export type UsePricingMetaForGridPlans = ( {
 	planSlugs,
 	withoutProRatedCredits,
 	storageAddOns,
 	coupon,
+	selectedSiteId,
 }: {
 	planSlugs: PlanSlug[];
 	withoutProRatedCredits?: boolean;
 	storageAddOns: ( AddOnMeta | null )[] | null;
 	coupon?: string;
+	selectedSiteId?: number | null;
 } ) => { [ planSlug: string ]: PricingMetaForGridPlan } | null;
 
 export type UseFreeTrialPlanSlugs = ( {
@@ -163,6 +163,7 @@ interface Props {
 	isSubdomainNotGenerated?: boolean;
 	storageAddOns: ( AddOnMeta | null )[] | null;
 	coupon?: string;
+	selectedSiteId?: number | null;
 }
 
 const usePlanTypesWithIntent = ( {
@@ -284,6 +285,7 @@ const useGridPlans = ( {
 	isSubdomainNotGenerated,
 	storageAddOns,
 	coupon,
+	selectedSiteId,
 }: Props ): Omit< GridPlan, 'features' >[] | null => {
 	const freeTrialPlanSlugs = useFreeTrialPlanSlugs( {
 		intent: intent ?? 'default',
@@ -330,6 +332,7 @@ const useGridPlans = ( {
 		planSlugs: availablePlanSlugs,
 		storageAddOns,
 		coupon,
+		selectedSiteId,
 	} );
 
 	// Null return would indicate that we are still loading the data. No grid without grid plans.

--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -11,7 +11,7 @@ import './style.scss';
 import type { ComparisonGridExternalProps, FeaturesGridExternalProps } from './types';
 
 const WrappedComparisonGrid = ( {
-	siteId,
+	selectedSiteId,
 	intent,
 	gridPlans,
 	usePricingMetaForGridPlans,
@@ -37,6 +37,7 @@ const WrappedComparisonGrid = ( {
 	return (
 		<PlansGridContextProvider
 			intent={ intent }
+			selectedSiteId={ selectedSiteId }
 			gridPlans={ gridPlans }
 			usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 			allFeaturesList={ allFeaturesList }
@@ -48,7 +49,7 @@ const WrappedComparisonGrid = ( {
 				isLaunchPage={ isLaunchPage }
 				currentSitePlanSlug={ currentSitePlanSlug }
 				onUpgradeClick={ handleUpgradeClick }
-				siteId={ siteId }
+				selectedSiteId={ selectedSiteId }
 				selectedPlan={ selectedPlan }
 				selectedFeature={ selectedFeature }
 				showUpgradeableStorage={ showUpgradeableStorage }
@@ -62,7 +63,7 @@ const WrappedComparisonGrid = ( {
 
 const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 	const {
-		siteId,
+		selectedSiteId,
 		intent,
 		gridPlans,
 		usePricingMetaForGridPlans,
@@ -72,7 +73,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 	} = props;
 	const translate = useTranslate();
 	const isPlanUpgradeCreditEligible = useIsPlanUpgradeCreditVisible(
-		siteId,
+		selectedSiteId,
 		gridPlans.map( ( gridPlan ) => gridPlan.planSlug )
 	);
 	const { prices, currencyCode } = usePlanPricingInfoFromGridPlans( {
@@ -91,6 +92,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 	return (
 		<PlansGridContextProvider
 			intent={ intent }
+			selectedSiteId={ selectedSiteId }
 			gridPlans={ gridPlans }
 			usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 			coupon={ coupon }

--- a/client/my-sites/plans-grid/types.ts
+++ b/client/my-sites/plans-grid/types.ts
@@ -39,7 +39,7 @@ export interface CommonGridProps {
 	/**
 	 * Site id may not be used in ComparisonGrid, but need to be investigated further
 	 */
-	siteId?: number | null;
+	selectedSiteId?: number | null;
 	isInSignup: boolean;
 	isLaunchPage?: boolean | null;
 	isReskinned?: boolean;
@@ -81,6 +81,7 @@ export type GridContextProps = {
 	gridPlans: GridPlan[];
 	allFeaturesList: FeatureList;
 	intent?: PlansIntent;
+	selectedSiteId?: number | null;
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
 	children: React.ReactNode;
 	coupon?: string;

--- a/client/my-sites/plans/hooks/use-onedollar-offer-track.ts
+++ b/client/my-sites/plans/hooks/use-onedollar-offer-track.ts
@@ -10,7 +10,7 @@ type Location = 'plans' | 'trialexpired' | 'homescreen' | 'checkout';
  * @param location Location of the track being fired, i.e. 'plans', 'trialexpired', 'homescreen', 'checkout'
  */
 const useOneDollarOfferTrack = ( siteId: number | null | undefined, location: Location ) => {
-	const wooExpressIntroOffers = Plans.useIntroOffersForWooExpress( { siteId } );
+	const wooExpressIntroOffers = Plans.useIntroOffersForWooExpress( { siteId, coupon: undefined } );
 	const hasWooExpressIntroOffer = Object.values( wooExpressIntroOffers ?? {} ).length > 0;
 
 	useEffect( () => {

--- a/client/my-sites/plans/trials/trial-banner/use-banner-subtitle.ts
+++ b/client/my-sites/plans/trials/trial-banner/use-banner-subtitle.ts
@@ -26,7 +26,10 @@ export default function useBannerSubtitle(
 		month: 'long',
 		day: 'numeric',
 	} );
-	const wooExpressIntroOffers = Plans.useIntroOffersForWooExpress( { siteId: selectedSiteId } );
+	const wooExpressIntroOffers = Plans.useIntroOffersForWooExpress( {
+		siteId: selectedSiteId,
+		coupon: undefined,
+	} );
 	const anyWooExpressIntroOffer = Object.values( wooExpressIntroOffers ?? {} )[ 0 ];
 
 	useEffect( () => {

--- a/packages/data-stores/src/plans/hooks/test/use-intro-offers.ts
+++ b/packages/data-stores/src/plans/hooks/test/use-intro-offers.ts
@@ -28,7 +28,7 @@ describe( 'useIntroOffers selector', () => {
 			},
 		} ) );
 
-		const introOffers = useIntroOffers( { siteId: 1 } );
+		const introOffers = useIntroOffers( { siteId: 1, coupon: undefined } );
 
 		expect( introOffers ).toEqual( {
 			[ MockData.NEXT_STORE_SITE_PLAN_BUSINESS.planSlug ]:
@@ -48,7 +48,7 @@ describe( 'useIntroOffers selector', () => {
 			},
 		} ) );
 
-		const introOffers = useIntroOffers( { siteId: 1 } );
+		const introOffers = useIntroOffers( { siteId: 1, coupon: undefined } );
 
 		expect( introOffers ).toEqual( {
 			[ MockData.NEXT_STORE_SITE_PLAN_PERSONAL.planSlug ]: null,
@@ -65,7 +65,7 @@ describe( 'useIntroOffers selector', () => {
 			},
 		} ) );
 
-		const introOffers = useIntroOffers( { siteId: 1 } );
+		const introOffers = useIntroOffers( { siteId: 1, coupon: undefined } );
 
 		expect( introOffers ).toEqual( {
 			[ MockData.NEXT_STORE_PLAN_BUSINESS.planSlug ]:
@@ -86,7 +86,7 @@ describe( 'useIntroOffers selector', () => {
 			},
 		} ) );
 
-		const introOffers = useIntroOffers( { siteId: 1 } );
+		const introOffers = useIntroOffers( { siteId: 1, coupon: undefined } );
 
 		expect( introOffers ).toEqual( {
 			[ MockData.NEXT_STORE_PLAN_PERSONAL.planSlug ]: null,

--- a/packages/data-stores/src/plans/hooks/use-intro-offers-for-woo-express.ts
+++ b/packages/data-stores/src/plans/hooks/use-intro-offers-for-woo-express.ts
@@ -9,6 +9,7 @@ interface IntroOffersIndex {
 
 interface Props {
 	siteId: string | number | null | undefined;
+	coupon: string | undefined;
 }
 
 /**
@@ -20,8 +21,11 @@ interface Props {
  *     undefined if we haven't observed any metadata yet, or
  *     null if there are no WooExpress intro offers
  */
-const useIntroOffersForWooExpress = ( { siteId }: Props ): IntroOffersIndex | undefined | null => {
-	const introOffers = useIntroOffers( { siteId, coupon: undefined } );
+const useIntroOffersForWooExpress = ( {
+	siteId,
+	coupon,
+}: Props ): IntroOffersIndex | undefined | null => {
+	const introOffers = useIntroOffers( { siteId, coupon } );
 
 	return useMemo( () => {
 		if ( ! introOffers ) {

--- a/packages/data-stores/src/plans/hooks/use-intro-offers-for-woo-express.ts
+++ b/packages/data-stores/src/plans/hooks/use-intro-offers-for-woo-express.ts
@@ -8,21 +8,20 @@ interface IntroOffersIndex {
 }
 
 interface Props {
-	siteId?: string | number | null;
+	siteId: string | number | null | undefined;
 }
 
 /**
  * Get introductory offers for Woo Express plans that have these defined
- *  - Currently retrieved off site-plans: https://public-api.wordpress.com/rest/v1.3/sites/[siteId]/plans
- *  - Can be extended to include /plans endpoint
- *
+ * - Currently retrieved off site-plans: https://public-api.wordpress.com/rest/v1.3/sites/[siteId]/plans
+ * - Can be extended to include /plans endpoint
  * @returns {IntroOffersIndex | undefined | null} -
  *     an object of planSlug->PlanIntroductoryOffer if WooExpress plan offers are found, or
  *     undefined if we haven't observed any metadata yet, or
  *     null if there are no WooExpress intro offers
  */
 const useIntroOffersForWooExpress = ( { siteId }: Props ): IntroOffersIndex | undefined | null => {
-	const introOffers = useIntroOffers( { siteId } );
+	const introOffers = useIntroOffers( { siteId, coupon: undefined } );
 
 	return useMemo( () => {
 		if ( ! introOffers ) {

--- a/packages/data-stores/src/plans/hooks/use-intro-offers.ts
+++ b/packages/data-stores/src/plans/hooks/use-intro-offers.ts
@@ -8,8 +8,8 @@ interface IntroOffersIndex {
 }
 
 interface Props {
-	siteId?: string | number | null;
-	coupon?: string;
+	siteId: string | number | null | undefined;
+	coupon: string | undefined;
 }
 
 /**

--- a/packages/data-stores/src/plans/queries/use-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-plans.ts
@@ -12,7 +12,7 @@ interface PlansIndex {
 /**
  * Plans from `/plans` endpoint, transformed into a map of planSlug => PlanNext
  */
-function usePlans( { coupon }: { coupon?: string } = {} ): UseQueryResult< PlansIndex > {
+function usePlans( { coupon }: { coupon: string | undefined } ): UseQueryResult< PlansIndex > {
 	const queryKeys = useQueryKeysFactory();
 	const params = new URLSearchParams();
 	coupon && params.append( 'coupon_code', coupon );

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -13,7 +13,7 @@ interface PricedAPISitePlansIndex {
 }
 
 interface Props {
-	siteId?: string | number | null;
+	siteId: string | number | null | undefined;
 }
 
 /**

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -105,6 +105,7 @@ export interface SitePlan {
 	currentPlan?: boolean;
 	/**
 	 * This value is only returned for the current plan on the site.
+	 * It is only available from site plans and is the expiry date of an existing plan.
 	 */
 	expiry?: string;
 	/**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/85359 (reverted), https://github.com/Automattic/wp-calypso/pull/85486 (take 2)

## Proposed Changes

- Uncouples the pricing meta hook further from Calypso dependencies by passing in `selectedSiteId`. https://github.com/Automattic/wp-calypso/pull/85486 migrates the pricing, the hook itself remains linked to other imports.
- Given that this hook's use propagated to several places, then the changes have a wider impact, so need thorough testing
- Some obsolete uses of `siteId` in the plans-grid components have been cleaned up too, and all remaining cases are of `selectedSiteId` (it conveys better semantics off the bat)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Typechecks/unit pass
- Check pricing in `/plans` and `/start/plans`
- Confirm savings when clicking "monthly" toggle in `/start/plans` are correct (55%)
- Confirm that a purchased plan is rendered with the price it was purchased with in the Spotlight card (assign an older / 2021 personal USD plan through SA to a site)
- Confirm `/plans/[fresh woo site]` renders intro offers (get a site from `/setup/wooexpress`
- Confirm actions are correct: 
  - can purchase in `/start/plans`
  - cannot downgrade in `/plans/[business]`
  - etc.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?