### PR TITLE
Fix Gravatar on subscriber list

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list/test/subscriber-row.test.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list/test/subscriber-row.test.tsx
@@ -5,11 +5,16 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { render, fireEvent, screen } from '@testing-library/react';
 import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
 import useSubscriptionPlans from '../../../hooks/use-subscription-plans';
 import { SubscriberRow } from '../subscriber-row';
 
 jest.mock( '@automattic/calypso-config' );
 jest.mock( '../../../hooks/use-subscription-plans' );
+
+const mockStore = configureStore();
+const store = mockStore( {} );
 
 describe( 'SubscriberRow', () => {
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -40,7 +45,13 @@ describe( 'SubscriberRow', () => {
 		( isEnabled as jest.MockedFunction< typeof isEnabled > ).mockReturnValue( true );
 
 		render(
-			<SubscriberRow { ...commonProps } onView={ mockOnView } onUnsubscribe={ mockOnUnsubscribe } />
+			<Provider store={ store }>
+				<SubscriberRow
+					{ ...commonProps }
+					onView={ mockOnView }
+					onUnsubscribe={ mockOnUnsubscribe }
+				/>
+			</Provider>
 		);
 	} );
 
@@ -78,9 +89,9 @@ describe( 'SubscriberRow', () => {
 	it( 'should render the subscriber profile correctly', () => {
 		expect( screen.getByText( commonProps.subscriber.display_name ) ).toBeInTheDocument();
 		expect( screen.getByText( commonProps.subscriber.email_address ) ).toBeInTheDocument();
-		expect( screen.getByAltText( 'Profile pic' ) ).toHaveAttribute(
+		expect( screen.getByRole( 'img' ) ).toHaveAttribute(
 			'src',
-			commonProps.subscriber.avatar
+			'https://i0.wp.com/example.com/avatar.png?resize=96%2C96'
 		);
 	} );
 

--- a/client/my-sites/subscribers/components/subscriber-profile/subscriber-profile.tsx
+++ b/client/my-sites/subscribers/components/subscriber-profile/subscriber-profile.tsx
@@ -1,5 +1,6 @@
 import './style.scss';
 import { ExternalLink } from '@wordpress/components';
+import Gravatar from 'calypso/components/gravatar';
 
 type SubscriberProfileProps = {
 	avatar: string;
@@ -22,7 +23,11 @@ const SubscriberProfile = ( {
 	// recordSubscriberClicked( 'title', { } ); & recordSubscriberClicked( 'icon', { } );
 	return (
 		<div className={ `subscriber-profile ${ compact ? 'subscriber-profile--compact' : '' }` }>
-			<img src={ avatar } className="subscriber-profile__user-image" alt="Profile pic" />
+			<Gravatar
+				className="subscriber-profile__user-image"
+				user={ { avatar_URL: avatar, name: displayName } }
+				size={ 40 }
+			/>
 			<div className="subscriber-profile__user-details">
 				{ url ? (
 					<ExternalLink className="subscriber-profile__name" href={ url }>

--- a/client/my-sites/subscribers/components/subscriber-profile/test/subscriber-profile.test.tsx
+++ b/client/my-sites/subscribers/components/subscriber-profile/test/subscriber-profile.test.tsx
@@ -3,27 +3,35 @@
  */
 import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
 import SubscriberProfile from '../subscriber-profile';
 
 const testName = 'Test Name';
 const testEmail = 'test@test.com';
 const testAvatar = 'testAvatar.jpg';
-const testAvatarAlt = 'Profile pic';
+
+const mockStore = configureStore();
+const store = mockStore( {} );
 
 describe( 'SubscriberProfile', () => {
 	it( 'renders the name and email', () => {
 		render(
-			<SubscriberProfile avatar={ testAvatar } displayName={ testName } email={ testEmail } />
+			<Provider store={ store }>
+				<SubscriberProfile avatar={ testAvatar } displayName={ testName } email={ testEmail } />
+			</Provider>
 		);
 
 		expect( screen.getByText( testName ) ).toBeInTheDocument();
 		expect( screen.getByText( testEmail ) ).toBeInTheDocument();
-		expect( screen.getByAltText( testAvatarAlt ) ).toBeInTheDocument();
+		expect( screen.getByAltText( testName ) ).toBeInTheDocument();
 	} );
 
 	it( 'does not render the email if it is the same as the display name', () => {
 		render(
-			<SubscriberProfile avatar={ testAvatar } displayName={ testEmail } email={ testEmail } />
+			<Provider store={ store }>
+				<SubscriberProfile avatar={ testAvatar } displayName={ testEmail } email={ testEmail } />
+			</Provider>
 		);
 
 		expect( screen.queryByText( testEmail ) ).toBeInTheDocument();
@@ -31,7 +39,11 @@ describe( 'SubscriberProfile', () => {
 	} );
 
 	it( 'does not render the email if it is not provided', () => {
-		render( <SubscriberProfile avatar={ testAvatar } displayName={ testName } email="" /> );
+		render(
+			<Provider store={ store }>
+				<SubscriberProfile avatar={ testAvatar } displayName={ testName } email="" />
+			</Provider>
+		);
 
 		expect( screen.getByText( testName ) ).toBeInTheDocument();
 		expect( screen.queryByTestId( 'subscriber-profile__email' ) ).toBeNull();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Gravatar for unknown users on the subscriber list showed the G logo. Fixed this by using the `<Gravatar />` component

| Before | After |
|-|-|
| ![CleanShot 2023-12-19 at 14 43 40@2x](https://github.com/Automattic/wp-calypso/assets/528287/d9ec0a7f-c810-4cca-af8b-3ec853ea495d) | ![CleanShot 2023-12-19 at 14 44 23@2x](https://github.com/Automattic/wp-calypso/assets/528287/fc909f16-7051-463e-9580-0607dfbe1110) |

## Testing Instructions

1. Apply PR
2. Go to `http://calypso.localhost:3000/subscribers/<yoursite>`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?