### PR TITLE
Fix interpolated translation strings

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
@@ -33,10 +33,10 @@ export default function ThemeTierCommunityBadge() {
 				{ createInterpolateElement(
 					isEnglishLocale ||
 						i18n.hasTranslation(
-							'This community theme can only be installed if you have the <Link>%(businessNamePlan)s plan</Link> or higher on your site.'
+							'This community theme can only be installed if you have the <Link>%(businessPlanName)s plan</Link> or higher on your site.'
 						)
 						? translate(
-								'This community theme can only be installed if you have the <Link>%(businessNamePlan)s plan</Link> or higher on your site.',
+								'This community theme can only be installed if you have the <Link>%(businessPlanName)s plan</Link> or higher on your site.',
 								{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
 						  )
 						: translate(

--- a/client/components/theme-type-badge/tooltip.tsx
+++ b/client/components/theme-type-badge/tooltip.tsx
@@ -309,16 +309,16 @@ const ThemeTypeBadgeTooltip = ( {
 			message = createInterpolateElement(
 				isEnglishLocale ||
 					i18n.hasTranslation(
-						'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>%(businessNamePlan)s plan</Link> on your site.'
+						'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>%(businessPlanName)s plan</Link> on your site.'
 					)
 					? /* translators: annualPrice and monthlyPrice are prices for the theme, examples: US$50, US$7; */
 					  ( translate(
-							'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>%(businessNamePlan)s plan</Link> on your site.',
+							'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>%(businessPlanName)s plan</Link> on your site.',
 							{
 								args: {
 									annualPrice: subscriptionPrices.year ?? '',
 									monthlyPrice: subscriptionPrices.month ?? '',
-									businessNamePlan: plans?.data?.[ PLAN_BUSINESS ]?.productNameShort ?? '',
+									businessPlanName: plans?.data?.[ PLAN_BUSINESS ]?.productNameShort ?? '',
 								},
 							}
 					  ) as string )

--- a/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
@@ -50,8 +50,8 @@ const BusinessUpgradeConfirmation = () => {
 							<div className="trial-upgrade-confirmation__header">
 								<h1 className="trial-upgrade-confirmation__title">
 									{ isEnglishLocale ||
-									i18n.hasTranslation( 'Welcome to the %(businessPlanName) plan' )
-										? translate( 'Welcome to the %(businessPlanName) plan', {
+									i18n.hasTranslation( 'Welcome to the %(businessPlanName)s plan' )
+										? translate( 'Welcome to the %(businessPlanName)s plan', {
 												args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() || '' },
 										  } )
 										: translate( 'Welcome to the Business plan' ) }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -204,7 +204,7 @@ const BannerUpsellTitle = ( {
 
 		const bundleName = bundleSettings.name;
 
-		/* Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special", %(businessPlanName) is the short-form of the Business plan name.*/
+		/* Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special", %(businessPlanName)s is the short-form of the Business plan name.*/
 		return isEnglishLocale ||
 			i18n.hasTranslation( 'Access this %(bundleName)s theme with a %(businessPlanName)s plan!' )
 			? translate( 'Access this %(bundleName)s theme with a %(businessPlanName)s plan!', {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85348

## Proposed Changes

This fixes the missing `s` from a few unhardcoded plan name strings.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure strings look good.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
