### PR TITLE
Big Sky: chose font and style

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
@@ -86,6 +86,14 @@ const AISitePrompt: Step = function ( props ) {
 							currentSearchParams.set( 'page_slugs', pageSlugs.join( ',' ) );
 						}
 
+						if ( response.style ) {
+							currentSearchParams.set( 'color_variation_title', response.style );
+						}
+
+						if ( response.font ) {
+							currentSearchParams.set( 'font_variation_title', response.font );
+						}
+
 						return currentSearchParams;
 					},
 					{ replace: true }


### PR DESCRIPTION
This is related to Big Sky work.
This will chose font and style for the request
Works with D132519-code

## Proposed Changes

* Make AI chose the color variation and the font variation
* Pass it to assembler
* 

## Testing Instructions

* Apply D132519-code
* Sandbox public-api
* Go to http://calypso.localhost:3000/setup/ai-assembler/
* Write something
* See color scheme being chosen
* Observe `color_variation_title` being set

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?