### PR TITLE
E2E: Update to use new plan names in onboarding

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -4,7 +4,16 @@ import { clickNavTab } from '../../element-helper';
 import envVariables from '../../env-variables';
 
 // Types to restrict the string arguments passed in. These are fixed sets of strings, so we can be more restrictive.
-export type Plans = 'Free' | 'Personal' | 'Premium' | 'Business' | 'eCommerce';
+export type Plans =
+	| 'Free'
+	| 'Personal'
+	| 'Premium'
+	| 'Business'
+	| 'eCommerce'
+	| 'Starter'
+	| 'Explorer'
+	| 'Creator'
+	| 'Entrepreneur';
 export type PlansPageTab = 'My Plan' | 'Plans';
 export type PlanActionButton = 'Manage plan' | 'Upgrade';
 

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -36,7 +36,7 @@ declare const browser: Browser;
  * Keywords: Onboarding, Store Checkout, Coupon, Signup, Plan, Subscription, Cancel
  */
 describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function () {
-	const planName = 'Personal';
+	const planName = 'Starter';
 	const testUser = DataHelper.getNewTestUser( {
 		usernamePrefix: 'ftmepersonal',
 	} );

--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
@@ -30,7 +30,7 @@ declare const browser: Browser;
  * Keywords: Onboarding, Store Checkout, Coupon, Signup, Plan, Subscription, Cancel
  */
 describe( 'Lifecyle: Logged Out Home Page, signup, onboard, launch and cancel subscription', function () {
-	const planName = 'Premium';
+	const planName = 'Explorer';
 	let themeSlug: string | null = null;
 
 	const testUser = DataHelper.getNewTestUser( {

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.ts
@@ -32,7 +32,7 @@ declare const browser: Browser;
  * Keywords: Onboarding, Store Checkout, Coupon, Signup, Plan, Subscription, Cancel
  */
 describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscription', function () {
-	const planName = 'Premium';
+	const planName = 'Explorer';
 	let themeSlug: string | null = null;
 
 	const testUser = DataHelper.getNewTestUser( {


### PR DESCRIPTION
## Proposed Changes

D132501-code aims to rename all plans for 100% of the new users. We also need to update the e2e tests in Calypso.

This is an alternative to #85476, but here we're just renaming the plans for onboarding tests.

## Testing Instructions

Once that diff gets shipped, let's re-run and make sure pre-release checks pass.

cc @dzver and @Automattic/martech 