### PR TITLE
E2E: Update to use new plan names in onboarding

### DIFF
--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -26,7 +26,7 @@ import {
 	PurchasesPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { apiCloseAccount } from '../shared';
+import { apiCloseAccount, getNewPlanName } from '../shared';
 
 declare const browser: Browser;
 
@@ -37,6 +37,7 @@ declare const browser: Browser;
  */
 describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function () {
 	const planName = 'Personal';
+	const newPlanName = getNewPlanName( planName );
 	const testUser = DataHelper.getNewTestUser( {
 		usernamePrefix: 'ftmepersonal',
 	} );
@@ -82,7 +83,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 
 		it( 'See secure payment', async function () {
 			cartCheckoutPage = new CartCheckoutPage( page );
-			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+			await cartCheckoutPage.validateCartItem( `WordPress.com ${ newPlanName }` );
 		} );
 
 		it( 'Prices are shown in GBP', async function () {

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -231,7 +231,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 			purchasesPage = new PurchasesPage( page );
 
 			await purchasesPage.clickOnPurchase(
-				`WordPress.com ${ planName }`,
+				`WordPress.com ${ newPlanName }`,
 				newSiteDetails.blog_details.site_slug
 			);
 			await purchasesPage.purchaseAction( 'Cancel plan' );

--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
@@ -20,7 +20,7 @@ import {
 	PurchasesPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { apiCloseAccount } from '../shared';
+import { apiCloseAccount, getNewPlanName } from '../shared';
 
 declare const browser: Browser;
 
@@ -31,6 +31,7 @@ declare const browser: Browser;
  */
 describe( 'Lifecyle: Logged Out Home Page, signup, onboard, launch and cancel subscription', function () {
 	const planName = 'Premium';
+	const newPlanName = getNewPlanName( planName );
 	let themeSlug: string | null = null;
 
 	const testUser = DataHelper.getNewTestUser( {
@@ -107,7 +108,7 @@ describe( 'Lifecyle: Logged Out Home Page, signup, onboard, launch and cancel su
 
 		it( 'See secure payment', async function () {
 			cartCheckoutPage = new CartCheckoutPage( page );
-			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+			await cartCheckoutPage.validateCartItem( `WordPress.com ${ newPlanName }` );
 		} );
 
 		it( 'Apply coupon', async function () {

--- a/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-LOHP.ts
@@ -164,7 +164,7 @@ describe( 'Lifecyle: Logged Out Home Page, signup, onboard, launch and cancel su
 			purchasesPage = new PurchasesPage( page );
 
 			await purchasesPage.clickOnPurchase(
-				`WordPress.com ${ planName }`,
+				`WordPress.com ${ newPlanName }`,
 				newSiteDetails.blog_details.site_slug
 			);
 			await purchasesPage.purchaseAction( 'Cancel plan' );

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.ts
@@ -159,7 +159,7 @@ describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscripti
 			purchasesPage = new PurchasesPage( page );
 
 			await purchasesPage.clickOnPurchase(
-				`WordPress.com ${ planName }`,
+				`WordPress.com ${ newPlanName }`,
 				newSiteDetails.blog_details.site_slug
 			);
 			await purchasesPage.purchaseAction( 'Cancel plan' );

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.ts
@@ -22,7 +22,7 @@ import {
 	ThemesPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { apiCloseAccount } from '../shared';
+import { apiCloseAccount, getNewPlanName } from '../shared';
 
 declare const browser: Browser;
 
@@ -33,6 +33,7 @@ declare const browser: Browser;
  */
 describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscription', function () {
 	const planName = 'Premium';
+	const newPlanName = getNewPlanName( planName );
 	let themeSlug: string | null = null;
 
 	const testUser = DataHelper.getNewTestUser( {
@@ -98,7 +99,7 @@ describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscripti
 
 		it( 'See secure payment', async function () {
 			cartCheckoutPage = new CartCheckoutPage( page );
-			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+			await cartCheckoutPage.validateCartItem( `WordPress.com ${ newPlanName }` );
 		} );
 
 		it( 'Apply coupon', async function () {

--- a/test/e2e/specs/shared/get-new-plan-name.ts
+++ b/test/e2e/specs/shared/get-new-plan-name.ts
@@ -1,0 +1,14 @@
+import type { Plans } from '@automattic/calypso-e2e';
+
+export function getNewPlanName( planName: Plans ) {
+	if ( planName === 'Personal' ) {
+		return 'Starter';
+	} else if ( planName === 'Premium' ) {
+		return 'Explorer';
+	} else if ( planName === 'Business' ) {
+		return 'Creator';
+	} else if ( planName === 'eCommerce' ) {
+		return 'Entrepreneur';
+	}
+	return planName;
+}

--- a/test/e2e/specs/shared/index.ts
+++ b/test/e2e/specs/shared/index.ts
@@ -1,2 +1,3 @@
 export * from './api-close-account';
 export * from './api-delete-site';
+export * from './get-new-plan-name';


### PR DESCRIPTION
## Proposed Changes

D132501-code aims to rename all plans for 100% of the new users. We also need to update the e2e tests in Calypso.

This is an alternative to #85476 and #85490, but here we're just renaming the plans for some onboarding tests.

## Testing Instructions

Once that diff gets shipped, let's re-run and make sure pre-release checks pass.

cc @dzver and @Automattic/martech 