### PR TITLE
Domains: hide renew actions in purchase page for domains with pending registration status

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -327,6 +327,16 @@ class ManagePurchase extends Component<
 		return hasSetupAds && purchase && isPlan( purchase );
 	}
 
+	isPendingDomainRegistration( purchase: Purchase ): boolean {
+		if ( isDomainRegistration( purchase ) ) {
+			const domain = this.props.domainsDetails[ purchase.siteId ].find(
+				( domain ) => domain.name === purchase.meta
+			);
+			return domain?.pendingRegistrationAtRegistry ?? false;
+		}
+		return false;
+	}
+
 	renderRenewButton() {
 		const { purchase, translate } = this.props;
 		if ( ! purchase ) {
@@ -339,6 +349,11 @@ class ManagePurchase extends Component<
 			isAkismetFreeProduct( purchase ) ||
 			( is100Year( purchase ) && ! isCloseToExpiration( purchase ) )
 		) {
+			return null;
+		}
+
+		// Hide renew button for pending registration domains
+		if ( this.isPendingDomainRegistration( purchase ) ) {
 			return null;
 		}
 
@@ -1346,7 +1361,9 @@ class ManagePurchase extends Component<
 				) }
 				{ isProductOwner && ! purchase.isLocked && (
 					<>
-						{ preventRenewal && this.renderSelectNewNavItem() }
+						{ preventRenewal &&
+							! this.isPendingDomainRegistration( purchase ) &&
+							this.renderSelectNewNavItem() }
 						{ ! preventRenewal &&
 							! renderMonthlyRenewalOption &&
 							! isActive100YearPurchase &&
@@ -1418,6 +1435,10 @@ class ManagePurchase extends Component<
 		) {
 			showExpiryNotice = isCloseToExpiration( purchase );
 			preventRenewal = ! isRenewable( purchase );
+		}
+
+		if ( this.isPendingDomainRegistration( purchase ) ) {
+			preventRenewal = true;
 		}
 
 		return (

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -328,13 +328,13 @@ class ManagePurchase extends Component<
 	}
 
 	isPendingDomainRegistration( purchase: Purchase ): boolean {
-		if ( isDomainRegistration( purchase ) ) {
-			const domain = this.props.domainsDetails[ purchase.siteId ].find(
-				( domain ) => domain.name === purchase.meta
-			);
-			return domain?.pendingRegistrationAtRegistry ?? false;
+		if ( ! isDomainRegistration( purchase ) ) {
+			return false;
 		}
-		return false;
+		const domain = this.props.domainsDetails[ purchase.siteId ].find(
+			( domain ) => domain.name === purchase.meta
+		);
+		return domain?.pendingRegistrationAtRegistry ?? false;
 	}
 
 	renderRenewButton() {

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -1372,6 +1372,7 @@ class ManagePurchase extends Component<
 						{ ! preventRenewal &&
 							! renderMonthlyRenewalOption &&
 							! isActive100YearPurchase &&
+							! this.isPendingDomainRegistration( purchase ) &&
 							this.renderRenewNowNavItem() }
 						{ ! preventRenewal && renderMonthlyRenewalOption && this.renderRenewAnnuallyNavItem() }
 						{ ! preventRenewal && renderMonthlyRenewalOption && this.renderRenewMonthlyNavItem() }

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -352,7 +352,6 @@ class ManagePurchase extends Component<
 			return null;
 		}
 
-		// Hide renew button for pending registration domains
 		if ( this.isPendingDomainRegistration( purchase ) ) {
 			return null;
 		}
@@ -582,7 +581,11 @@ class ManagePurchase extends Component<
 	}
 
 	renderSelectNewNavItem() {
-		const { translate, siteId } = this.props;
+		const { translate, siteId, purchase } = this.props;
+
+		if ( purchase && this.isPendingDomainRegistration( purchase ) ) {
+			return null;
+		}
 
 		return (
 			<CompactCard tagName="button" displayAsLink href={ `/plans/${ siteId }` }>
@@ -1361,9 +1364,7 @@ class ManagePurchase extends Component<
 				) }
 				{ isProductOwner && ! purchase.isLocked && (
 					<>
-						{ preventRenewal &&
-							! this.isPendingDomainRegistration( purchase ) &&
-							this.renderSelectNewNavItem() }
+						{ preventRenewal && this.renderSelectNewNavItem() }
 						{ ! preventRenewal &&
 							! renderMonthlyRenewalOption &&
 							! isActive100YearPurchase &&
@@ -1435,10 +1436,6 @@ class ManagePurchase extends Component<
 		) {
 			showExpiryNotice = isCloseToExpiration( purchase );
 			preventRenewal = ! isRenewable( purchase );
-		}
-
-		if ( this.isPendingDomainRegistration( purchase ) ) {
-			preventRenewal = true;
 		}
 
 		return (

--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -409,7 +409,11 @@ class ManagePurchase extends Component<
 	}
 
 	renderSelectNewButton() {
-		const { translate, siteId } = this.props;
+		const { translate, siteId, purchase } = this.props;
+
+		if ( purchase && this.isPendingDomainRegistration( purchase ) ) {
+			return null;
+		}
 
 		return (
 			<Button className="manage-purchase__renew-button" href={ `/plans/${ siteId }` } compact>

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -199,7 +199,7 @@ describe( 'Purchase Management Buttons', () => {
 		expect( screen.queryByText( /Cancel/ ) ).not.toBeInTheDocument();
 	} );
 
-	it( "don't renders renew buttons for domain with pending registration at registry", async () => {
+	it( "does't render renew buttons for domain with pending registration at registry", async () => {
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.2/me/payment-methods?expired=include' )
 			.reply( 200 );

--- a/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
+++ b/client/me/purchases/manage-purchase/test/purchase-management-buttons.js
@@ -131,7 +131,7 @@ describe( 'Purchase Management Buttons', () => {
 			.get( '/rest/v1.2/me/payment-methods?expired=include' )
 			.reply( 200 );
 
-		const store = createMockReduxStoreForPurchase( { ...purchase } );
+		const store = createMockReduxStoreForPurchase( { ...purchase, auto_renew: 1 } );
 
 		render(
 			<QueryClientProvider client={ queryClient }>


### PR DESCRIPTION
## Proposed Changes

For some tlds the registration is asynchronous and has to be confirmed by the registry. In case of .com.br tld, this process can take 3 days. We want to disallow domain renewal during this time window.

## Testing Instructions

Register a `.com.br` domain (or hack the `Domain_Management_Domain` class to set `pending_registration_at_registry=true`).

Visite the purchase detail page and verify that all the renew action are not visibile (see screenshot below).

### Before
![domain-renewal-before](https://github.com/Automattic/wp-calypso/assets/2797601/408caf5d-3eee-4840-8578-cffc059b37b9)

### After
![domain-renewal-after](https://github.com/Automattic/wp-calypso/assets/2797601/eeda982f-3a04-46b9-83c9-c68834c68cc7)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?