### PR TITLE
Login: Remove Social first experiment

### DIFF
--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -15,7 +15,6 @@ import LocaleSuggestions from 'calypso/components/locale-suggestions';
 import LoggedOutFormBackLink from 'calypso/components/logged-out-form/back-link';
 import Main from 'calypso/components/main';
 import TranslatorInvite from 'calypso/components/translator-invite';
-import { ProvideExperimentData } from 'calypso/lib/explat';
 import { getSignupUrl, pathWithLeadingSlash } from 'calypso/lib/login';
 import {
 	isJetpackCloudOAuth2Client,
@@ -506,52 +505,33 @@ export class Login extends Component {
 		const { locale, translate, isFromMigrationPlugin, isGravPoweredClient, isWoo, isWhiteLogin } =
 			this.props;
 		const canonicalUrl = localizeUrl( 'https://wordpress.com/log-in', locale );
-		const isSocialFirstEnabled = config.isEnabled( 'login/social-first' );
-		let isSocialFirst = false;
+		const isSocialFirst =
+			config.isEnabled( 'login/social-first' ) && isWhiteLogin && ! isGravPoweredClient && ! isWoo;
 
 		return (
-			<ProvideExperimentData
-				name="wpcom_login_page_emphasise_socials_redesign_202311_v1"
-				options={ {
-					isEligible: isSocialFirstEnabled && isWhiteLogin && ! isGravPoweredClient && ! isWoo,
-				} }
-			>
-				{ ( isLoadingExperiment, experimentAssignment ) => {
-					if ( isLoadingExperiment ) {
-						return null;
-					}
+			<div>
+				{ this.props.isP2Login && this.renderP2Logo() }
+				<Main
+					className={ classNames( 'wp-login__main', {
+						'is-wpcom-migration': isFromMigrationPlugin,
+						'is-social-first': isSocialFirst,
+					} ) }
+				>
+					{ this.renderI18nSuggestions() }
 
-					if ( experimentAssignment?.variationName === 'treatment' ) {
-						isSocialFirst = true;
-					}
+					<DocumentHead
+						title={ translate( 'Log In' ) }
+						link={ [ { rel: 'canonical', href: canonicalUrl } ] }
+						meta={ [ { name: 'description', content: 'Log in to WordPress.com' } ] }
+					/>
 
-					return (
-						<div>
-							{ this.props.isP2Login && this.renderP2Logo() }
-							<Main
-								className={ classNames( 'wp-login__main', {
-									'is-wpcom-migration': isFromMigrationPlugin,
-									'is-social-first': isSocialFirst,
-								} ) }
-							>
-								{ this.renderI18nSuggestions() }
+					{ isSocialFirst && this.renderLoginHeaderNavigation() }
+					<div className="wp-login__container">{ this.renderContent( isSocialFirst ) }</div>
+				</Main>
 
-								<DocumentHead
-									title={ translate( 'Log In' ) }
-									link={ [ { rel: 'canonical', href: canonicalUrl } ] }
-									meta={ [ { name: 'description', content: 'Log in to WordPress.com' } ] }
-								/>
-
-								{ isSocialFirst && this.renderLoginHeaderNavigation() }
-								<div className="wp-login__container">{ this.renderContent( isSocialFirst ) }</div>
-							</Main>
-
-							{ this.renderFooter() }
-							{ this.props.isP2Login && this.renderP2PoweredBy() }
-						</div>
-					);
-				} }
-			</ProvideExperimentData>
+				{ this.renderFooter() }
+				{ this.props.isP2Login && this.renderP2PoweredBy() }
+			</div>
 		);
 	}
 }


### PR DESCRIPTION
With https://github.com/Automattic/wp-calypso/pull/84692 we started the experiment for Login Social First.
With this PR we remove the experiment and keep the login as social first

**Login social first:**
![image](https://github.com/Automattic/wp-calypso/assets/52076348/70020cd2-e644-4ddb-8d8b-c87e3fbf6d0e)


## Testing

1. Live link
2. Visit `/log-in`
3. You should be able to see the new login page