### PR TITLE
Marketplace Reviews: Add the Reviews Modal to Plugin Details page

### DIFF
--- a/client/data/marketplace/types.ts
+++ b/client/data/marketplace/types.ts
@@ -108,10 +108,7 @@ export type ESRelatedPlugin = {
 	slug?: string;
 	name?: string;
 	rating?: number;
-	variations: {
-		monthly: { product_slug?: string; product_id?: number };
-		yearly: { product_slug?: string; product_id?: number };
-	};
+	variations: PluginPeriodVariations;
 };
 
 export type RelatedPlugin = {
@@ -123,12 +120,14 @@ export type RelatedPlugin = {
 	slug?: string;
 	name?: string;
 	rating?: number;
-	variations?: {
-		monthly: { product_slug?: string; product_id?: number };
-		yearly: { product_slug?: string; product_id?: number };
-	};
+	variations?: PluginPeriodVariations;
 };
 
 export type AddPluginUpgrade = {
 	success: true;
+};
+
+export type PluginPeriodVariations = {
+	monthly: { product_slug?: string; product_id?: number };
+	yearly: { product_slug?: string; product_id?: number };
 };

--- a/client/data/marketplace/use-marketplace-reviews.ts
+++ b/client/data/marketplace/use-marketplace-reviews.ts
@@ -20,6 +20,7 @@ export type ProductType = 'plugin' | 'theme';
 export type ProductProps = {
 	productType: ProductType;
 	slug: string;
+	author?: number;
 };
 
 export type PaginationProps = {
@@ -89,7 +90,8 @@ const fetchMarketplaceReviews = (
 	productType: ProductType,
 	productSlug: string,
 	page: number = 1,
-	perPage: number = 10
+	perPage: number = 10,
+	author?: number
 ): Promise< MarketplaceReviewResponse[] > => {
 	return wpcom.req.get(
 		{
@@ -101,6 +103,7 @@ const fetchMarketplaceReviews = (
 			product_slug: productSlug,
 			page,
 			per_page: perPage,
+			...( author ? { author } : {} ),
 		}
 	);
 };
@@ -167,15 +170,15 @@ const fetchMarketplaceReviewsStats = ( {
 };
 
 export const useMarketplaceReviewsQuery = (
-	{ productType, slug, page, perPage }: MarketplaceReviewsQueryProps,
+	{ productType, slug, page, perPage, author }: MarketplaceReviewsQueryProps,
 	{
 		enabled = true,
 		staleTime = BASE_STALE_TIME,
 		refetchOnMount = true,
 	}: MarketplaceReviewsQueryOptions = {}
 ) => {
-	const queryKey: QueryKey = [ queryKeyBase, productType, slug, page, perPage ];
-	const queryFn = () => fetchMarketplaceReviews( productType, slug, page, perPage );
+	const queryKey: QueryKey = [ queryKeyBase, productType, slug, author, page, perPage ];
+	const queryFn = () => fetchMarketplaceReviews( productType, slug, page, perPage, author );
 	return useQuery( { queryKey, queryFn, enabled, staleTime, refetchOnMount } );
 };
 

--- a/client/lib/plugins/utils.js
+++ b/client/lib/plugins/utils.js
@@ -409,7 +409,7 @@ export function getPreinstalledPremiumPluginsVariations( plugin ) {
 
 /**
  * Returns the product slug of periodVariation passed filtering the productsList passed only if required
- * @param {string} periodVariation The variation object with the shape { product_slug: string; product_id: number; }
+ * @param {{ product_slug?: string; product_id?: number } | undefined} periodVariation The variation object with the shape { product_slug: string; product_id: number; }
  * @param {Record<string, Object>} productsList The list of products
  * @returns The product slug if it exists in the periodVariation, if it does not exist in periodVariation
  * it will find the product slug in the productsList filtering by the variation.product_id.

--- a/client/my-sites/marketplace/components/review-modal/index.tsx
+++ b/client/my-sites/marketplace/components/review-modal/index.tsx
@@ -34,11 +34,11 @@ export const ReviewModal = ( { isVisible, onClose, slug, productName, productTyp
 				onClose={ onClose }
 				showCloseIcon
 			>
-				<Card className="marketplace-reviews-modal__card-success">
-					<CardHeading className="marketplace-reviews-modal__card-success-title" tagName="h1">
+				<Card className="marketplace-review-modal__card-success">
+					<CardHeading className="marketplace-review-modal__card-success-title" tagName="h1">
 						{ translate( 'Thank you for your feedback!' ) }
 					</CardHeading>
-					<CardHeading className="marketplace-reviews-modal__card-success-body" tagName="p">
+					<CardHeading className="marketplace-review-modal__card-success-body" tagName="p">
 						{ translate(
 							'Your review it‘s currently under moderation for adherence to our guidelines and will be published soon.'
 						) }

--- a/client/my-sites/marketplace/components/review-modal/index.tsx
+++ b/client/my-sites/marketplace/components/review-modal/index.tsx
@@ -20,7 +20,7 @@ type Props = {
 	productType: ProductType;
 };
 
-export const ReviewsModal = ( { isVisible, onClose, slug, productName, productType }: Props ) => {
+export const ReviewModal = ( { isVisible, onClose, slug, productName, productType }: Props ) => {
 	const [ content, setContent ] = useState< string >( '' );
 	const [ rating, setRating ] = useState< number >( 5 );
 
@@ -29,7 +29,7 @@ export const ReviewsModal = ( { isVisible, onClose, slug, productName, productTy
 	if ( createReview.isSuccess ) {
 		return (
 			<Dialog
-				className="marketplace-reviews-modal"
+				className="marketplace-review-modal"
 				isVisible={ isVisible }
 				onClose={ onClose }
 				showCloseIcon
@@ -50,12 +50,12 @@ export const ReviewsModal = ( { isVisible, onClose, slug, productName, productTy
 
 	return (
 		<Dialog
-			className="marketplace-reviews-modal"
+			className="marketplace-review-modal"
 			isVisible={ isVisible }
 			onClose={ onClose }
 			showCloseIcon
 		>
-			<Card className="marketplace-reviews-modal__card">
+			<Card className="marketplace-review-modal__card">
 				<CardHeading tagName="h1" size={ 21 }>
 					{ translate( 'Add New Review for %(productName)s', { args: { productName } } ) }
 				</CardHeading>
@@ -80,9 +80,9 @@ export const ReviewsModal = ( { isVisible, onClose, slug, productName, productTy
 						onChange={ setContent }
 					/>
 					<ReviewsRatingsStars onSelectRating={ setRating } showSelectedRating rating={ rating } />
-					<div className="marketplace-reviews-modal__buttons-container">
+					<div className="marketplace-review-modal__buttons-container">
 						<Button
-							className="marketplace-reviews-modal__button-submit"
+							className="marketplace-review-modal__button-submit"
 							primary
 							type="submit"
 							disabled={ createReview.isLoading }
@@ -94,7 +94,7 @@ export const ReviewsModal = ( { isVisible, onClose, slug, productName, productTy
 					</div>
 				</form>
 				{ createReview.isError && (
-					<span className="marketplace-reviews-modal__error">
+					<span className="marketplace-review-modal__error">
 						{ ( createReview.error as ErrorResponse ).message }
 					</span>
 				) }

--- a/client/my-sites/marketplace/components/review-modal/styles.scss
+++ b/client/my-sites/marketplace/components/review-modal/styles.scss
@@ -35,10 +35,10 @@
 	color: var(--color-error);
 }
 
-.marketplace-reviews-modal__button-submit {
+.marketplace-review-modal__button-submit {
 	display: flex;
 }
-.marketplace-reviews-modal__buttons-container {
+.marketplace-review-modal__buttons-container {
 	display: flex;
 	gap: 8px;
 	padding-top: 8px;

--- a/client/my-sites/marketplace/components/review-modal/styles.scss
+++ b/client/my-sites/marketplace/components/review-modal/styles.scss
@@ -5,7 +5,7 @@
 	box-shadow: none;
 }
 
-.marketplace-reviews-modal__card-success {
+.marketplace-review-modal__card-successs {
 	box-shadow: none;
 	padding: 26px 40px;
 	display: flex;
@@ -13,7 +13,7 @@
 	align-items: center;
 	margin-bottom: 0;
 
-	& .marketplace-reviews-modal__card-success-title {
+	& .marketplace-review-modal__card-successs-title {
 		font-family: $brand-serif;
 		font-size: $font-title-large;
 		font-weight: 400;
@@ -21,7 +21,7 @@
 		margin: 0;
 	}
 
-	& .marketplace-reviews-modal__card-success-body {
+	& .marketplace-review-modal__card-successs-body {
 		max-width: 400px;
 		font-size: $font-body-small;
 		text-align: center;

--- a/client/my-sites/marketplace/components/reviews-cards/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-cards/index.tsx
@@ -62,7 +62,11 @@ export const MarketplaceReviewsCards = ( props: MarketplaceReviewsCardsProps ) =
 				) ) }
 				{ addEmptyCard && <MarketplaceReviewCard empty={ true } key="empty-card" /> }
 				{ addLeaveAReviewCard && (
-					<MarketplaceReviewCard leaveAReview={ true } key="leave-a-review-card" />
+					<MarketplaceReviewCard
+						leaveAReview={ true }
+						key="leave-a-review-card"
+						showMarketplaceReviews={ props.showMarketplaceReviews }
+					/>
 				) }
 			</div>
 		</div>

--- a/client/my-sites/marketplace/components/reviews-cards/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-cards/index.tsx
@@ -11,7 +11,9 @@ import { IAppState } from 'calypso/state/types';
 import { MarketplaceReviewCard } from './review-card';
 import './style.scss';
 
-export const MarketplaceReviewsCards = ( props: ProductProps ) => {
+type MarketplaceReviewsCardsProps = { showMarketplaceReviews?: () => void } & ProductProps;
+
+export const MarketplaceReviewsCards = ( props: MarketplaceReviewsCardsProps ) => {
 	const translate = useTranslate();
 	const currentUserId = useSelector( ( state: IAppState ) => getCurrentUserId( state ) );
 	const { data: reviews, error } = useMarketplaceReviewsQuery( { ...props, perPage: 2, page: 1 } );
@@ -46,7 +48,7 @@ export const MarketplaceReviewsCards = ( props: ProductProps ) => {
 						className="is-link"
 						borderless
 						primary
-						onClick={ () => alert( 'Not implemented yet!' ) }
+						onClick={ () => props.showMarketplaceReviews && props.showMarketplaceReviews() }
 						href=""
 					>
 						{ translate( 'Read all reviews' ) }

--- a/client/my-sites/marketplace/components/reviews-cards/review-card.tsx
+++ b/client/my-sites/marketplace/components/reviews-cards/review-card.tsx
@@ -7,11 +7,12 @@ type MarketplaceReviewCardProps = {
 	review?: MarketplaceReviewResponse;
 	leaveAReview?: boolean;
 	empty?: boolean;
+	showMarketplaceReviews?: () => void;
 };
 
 export const MarketplaceReviewCard = ( props: MarketplaceReviewCardProps ) => {
 	const translate = useTranslate();
-	const { review, leaveAReview, empty } = props;
+	const { review, leaveAReview, empty, showMarketplaceReviews } = props;
 
 	if ( empty ) {
 		return (
@@ -28,7 +29,13 @@ export const MarketplaceReviewCard = ( props: MarketplaceReviewCardProps ) => {
 
 	if ( leaveAReview || ! review ) {
 		return (
-			<div className="marketplace-reviews-card__leave-a-review">
+			<div
+				className="marketplace-reviews-card__leave-a-review"
+				role="button"
+				onKeyDown={ () => showMarketplaceReviews && showMarketplaceReviews() }
+				tabIndex={ 0 }
+				onClick={ () => showMarketplaceReviews && showMarketplaceReviews() }
+			>
 				<div className="marketplace-reviews-card__leave-a-review-message">
 					{ translate( 'How would you rate your overall experience?' ) }
 				</div>

--- a/client/my-sites/marketplace/components/reviews-list/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-list/index.tsx
@@ -1,7 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
-import { LegacyRef, forwardRef } from 'react';
 import { useSelector } from 'react-redux';
 import Rating from 'calypso/components/rating';
 import {
@@ -15,10 +14,7 @@ import { sanitizeSectionContent } from 'calypso/lib/plugins/sanitize-section-con
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { IAppState } from 'calypso/state/types';
 
-export const MarketplaceReviewsList = forwardRef<
-	HTMLDivElement,
-	MarketplaceReviewsQueryProps & { innerRef: LegacyRef< HTMLDivElement > }
->( ( props, ref ) => {
+export const MarketplaceReviewsList = ( props: MarketplaceReviewsQueryProps ) => {
 	const translate = useTranslate();
 	const { data: reviews, refetch: reviewsRefetch, error } = useMarketplaceReviewsQuery( props );
 
@@ -64,7 +60,7 @@ export const MarketplaceReviewsList = forwardRef<
 	}
 
 	return (
-		<div className="marketplace-reviews-list__container" ref={ ref }>
+		<div className="marketplace-reviews-list__container">
 			<div className="marketplace-reviews-list__customer-reviews">
 				{ Array.isArray( reviews ) &&
 					reviews.map( ( review: MarketplaceReviewResponse ) => (
@@ -129,4 +125,4 @@ export const MarketplaceReviewsList = forwardRef<
 			</div>
 		</div>
 	);
-} );
+};

--- a/client/my-sites/marketplace/components/reviews-list/style.scss
+++ b/client/my-sites/marketplace/components/reviews-list/style.scss
@@ -2,12 +2,6 @@ $profile-picture-size: 36px;
 $border-color: #eee;
 
 .marketplace-reviews-list__container {
-	padding: 0 16px;
-
-	@include breakpoint-deprecated( ">1040px" ) {
-		padding: 0;
-	}
-
 	.marketplace-reviews-list__title {
 		font-family: $brand-serif;
 		font-size: $font-title-large;

--- a/client/my-sites/marketplace/components/reviews-modal/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-modal/index.tsx
@@ -109,20 +109,23 @@ export const ReviewsModal = ( props: Props ) => {
 							</div>
 						) }
 						{ /* TODO: Add theme purchase */ }
-						{ ! askForReview && ! hasActiveSubscription && isMarketplacePlugin && (
-							<div className="marketplace-reviews-modal__summary-button">
-								<Button
-									primary
-									onClick={ () =>
-										page(
-											`/checkout/${ selectedSite?.slug || '' }/${ marketplaceProductSlug }?#step2`
-										)
-									}
-								>
-									{ translate( 'Purchase and activate this plugin' ) }
-								</Button>
-							</div>
-						) }
+						{ ! askForReview &&
+							! hasActiveSubscription &&
+							isMarketplacePlugin &&
+							selectedSite?.slug && (
+								<div className="marketplace-reviews-modal__summary-button">
+									<Button
+										primary
+										onClick={ () =>
+											page(
+												`/checkout/${ selectedSite.slug || '' }/${ marketplaceProductSlug }?#step2`
+											)
+										}
+									>
+										{ translate( 'Purchase and activate this plugin' ) }
+									</Button>
+								</div>
+							) }
 					</div>
 				) }
 

--- a/client/my-sites/marketplace/components/reviews-modal/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-modal/index.tsx
@@ -1,5 +1,5 @@
 import { Dialog } from '@automattic/components';
-import { useTranslate } from 'i18n-calypso';
+import { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import Rating from 'calypso/components/rating';
 import {
 	ProductProps,
@@ -37,18 +37,25 @@ export const ReviewsModal = ( props: Props ) => {
 			</div>
 
 			<div className="marketplace-reviews-modal__content">
-				{ averageRating && numberOfReviews && (
+				{ averageRating !== undefined && numberOfReviews !== undefined && (
 					<div className="marketplace-reviews-modal__stats">
-						<div className="marketplace-reviews-modal__ratings-average"> { averageRating }</div>
+						<div className="marketplace-reviews-modal__ratings-average">
+							{ averageRating.toLocaleString( getLocaleSlug() ?? 'default', {
+								minimumFractionDigits: 1,
+								maximumFractionDigits: 1,
+							} ) }
+						</div>
 						<div className="marketplace-reviews-modal__ratings">
 							<Rating rating={ normalizedRating } />
 							<div className="marketplace-reviews-modal__ratings-count">
-								{ translate( '%(numberOfReviews)d review', '%(numberOfReviews)d reviews', {
-									count: numberOfReviews,
-									args: {
-										numberOfReviews,
-									},
-								} ) }
+								{ numberOfReviews > 0 &&
+									translate( '%(numberOfReviews)d review', '%(numberOfReviews)d reviews', {
+										count: numberOfReviews,
+										args: {
+											numberOfReviews,
+										},
+									} ) }
+								{ numberOfReviews === 0 && translate( 'No reviews' ) }
 							</div>
 						</div>
 					</div>

--- a/client/my-sites/marketplace/components/reviews-modal/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-modal/index.tsx
@@ -1,6 +1,11 @@
 import { Dialog } from '@automattic/components';
-import { ProductProps } from 'calypso/data/marketplace/use-marketplace-reviews';
-
+import { useTranslate } from 'i18n-calypso';
+import Rating from 'calypso/components/rating';
+import {
+	ProductProps,
+	useMarketplaceReviewsStatsQuery,
+} from 'calypso/data/marketplace/use-marketplace-reviews';
+import { MarketplaceReviewsList } from 'calypso/my-sites/marketplace/components/reviews-list';
 import './styles.scss';
 
 type Props = {
@@ -10,7 +15,15 @@ type Props = {
 } & ProductProps;
 
 export const ReviewsModal = ( props: Props ) => {
-	const { isVisible, onClose, productName } = props;
+	const translate = useTranslate();
+	const { isVisible, onClose, productName, productType, slug } = props;
+
+	const { data: reviewsStats } = useMarketplaceReviewsStatsQuery( {
+		productType,
+		slug,
+	} );
+	const { ratings_average: averageRating, ratings_count: numberOfReviews } = reviewsStats || {};
+	const normalizedRating = ( ( averageRating ?? 0 ) * 100 ) / 5; // Normalize to 100
 
 	return (
 		<Dialog
@@ -19,8 +32,31 @@ export const ReviewsModal = ( props: Props ) => {
 			onClose={ onClose }
 			showCloseIcon
 		>
-			<div className="marketplace-reviews-modal-header">
-				<div className="marketplace-reviews-modal-title">{ productName }</div>
+			<div className="marketplace-reviews-modal__header">
+				<div className="marketplace-reviews-modal__title">{ productName }</div>
+			</div>
+
+			<div className="marketplace-reviews-modal__content">
+				{ averageRating && numberOfReviews && (
+					<div className="marketplace-reviews-modal__stats">
+						<div className="marketplace-reviews-modal__ratings-average"> { averageRating }</div>
+						<div className="marketplace-reviews-modal__ratings">
+							<Rating rating={ normalizedRating } />
+							<div className="marketplace-reviews-modal__ratings-count">
+								{ translate( '%(numberOfReviews)d review', '%(numberOfReviews)d reviews', {
+									count: numberOfReviews,
+									args: {
+										numberOfReviews,
+									},
+								} ) }
+							</div>
+						</div>
+					</div>
+				) }
+
+				<div className="marketplace-reviews-modal__reviews-list">
+					<MarketplaceReviewsList productType={ productType } slug={ slug } />
+				</div>
 			</div>
 		</Dialog>
 	);

--- a/client/my-sites/marketplace/components/reviews-modal/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-modal/index.tsx
@@ -1,27 +1,47 @@
-import { Dialog } from '@automattic/components';
+import { Dialog, Button } from '@automattic/components';
 import { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import Rating from 'calypso/components/rating';
 import {
 	ProductProps,
+	useMarketplaceReviewsQuery,
 	useMarketplaceReviewsStatsQuery,
 } from 'calypso/data/marketplace/use-marketplace-reviews';
 import { MarketplaceReviewsList } from 'calypso/my-sites/marketplace/components/reviews-list';
 import './styles.scss';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { canPublishProductReviews } from 'calypso/state/marketplace/selectors';
+import { AppState } from 'calypso/types';
 
 type Props = {
 	isVisible: boolean;
 	onClose: () => void;
 	productName: string;
+	variations?: [];
 } & ProductProps;
 
 export const ReviewsModal = ( props: Props ) => {
 	const translate = useTranslate();
 	const { isVisible, onClose, productName, productType, slug } = props;
+	const currentUser = useSelector( getCurrentUser );
 
+	const { data: userReviews } = useMarketplaceReviewsQuery( {
+		productType,
+		slug,
+		perPage: 1,
+		author: currentUser?.ID ?? undefined,
+	} );
 	const { data: reviewsStats } = useMarketplaceReviewsStatsQuery( {
 		productType,
 		slug,
 	} );
+
+	const userHasReviewed = !! userReviews?.length;
+	const canPublishReview = useSelector( ( state: AppState ) =>
+		canPublishProductReviews( state, productType, slug, props.variations )
+	);
+	const askForReview = canPublishReview && ! userHasReviewed;
+
 	const { ratings_average: averageRating, ratings_count: numberOfReviews } = reviewsStats || {};
 	const normalizedRating = ( ( averageRating ?? 0 ) * 100 ) / 5; // Normalize to 100
 
@@ -38,28 +58,39 @@ export const ReviewsModal = ( props: Props ) => {
 
 			<div className="marketplace-reviews-modal__content">
 				{ averageRating !== undefined && numberOfReviews !== undefined && (
-					<div className="marketplace-reviews-modal__stats">
-						<div className="marketplace-reviews-modal__ratings-average">
-							{ averageRating.toLocaleString( getLocaleSlug() ?? 'default', {
-								minimumFractionDigits: 1,
-								maximumFractionDigits: 1,
-							} ) }
-						</div>
-						<div className="marketplace-reviews-modal__ratings">
-							<Rating rating={ normalizedRating } />
-							<div className="marketplace-reviews-modal__ratings-count">
-								{ numberOfReviews > 0 &&
-									translate( '%(numberOfReviews)d review', '%(numberOfReviews)d reviews', {
-										count: numberOfReviews,
-										args: {
-											numberOfReviews,
-										},
-									} ) }
-								{ numberOfReviews === 0 && translate( 'No reviews' ) }
+					<div className="marketplace-reviews-modal__summary">
+						<div className="marketplace-reviews-modal__stats">
+							<div className="marketplace-reviews-modal__ratings-average">
+								{ averageRating.toLocaleString( getLocaleSlug() ?? 'default', {
+									minimumFractionDigits: 1,
+									maximumFractionDigits: 1,
+								} ) }
+							</div>
+							<div className="marketplace-reviews-modal__ratings">
+								<Rating rating={ normalizedRating } />
+								<div className="marketplace-reviews-modal__ratings-count">
+									{ numberOfReviews > 0 &&
+										translate( '%(numberOfReviews)d review', '%(numberOfReviews)d reviews', {
+											count: numberOfReviews,
+											args: {
+												numberOfReviews,
+											},
+										} ) }
+									{ numberOfReviews === 0 && translate( 'No reviews' ) }
+								</div>
 							</div>
 						</div>
+						{ askForReview && (
+							<div className="marketplace-reviews-modal__leave-review">
+								<Button primary onClick={ () => alert( 'Not implemented yet' ) }>
+									{ translate( 'Leave my review' ) }
+								</Button>
+							</div>
+						) }
 					</div>
 				) }
+
+				{ /* TODO: Add the review creation section */ }
 
 				<div className="marketplace-reviews-modal__reviews-list">
 					<MarketplaceReviewsList productType={ productType } slug={ slug } />

--- a/client/my-sites/marketplace/components/reviews-modal/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-modal/index.tsx
@@ -1,0 +1,27 @@
+import { Dialog } from '@automattic/components';
+import { ProductProps } from 'calypso/data/marketplace/use-marketplace-reviews';
+
+import './styles.scss';
+
+type Props = {
+	isVisible: boolean;
+	onClose: () => void;
+	productName: string;
+} & ProductProps;
+
+export const ReviewsModal = ( props: Props ) => {
+	const { isVisible, onClose, productName } = props;
+
+	return (
+		<Dialog
+			className="marketplace-reviews-modal"
+			isVisible={ isVisible }
+			onClose={ onClose }
+			showCloseIcon
+		>
+			<div className="marketplace-reviews-modal-header">
+				<div className="marketplace-reviews-modal-title">{ productName }</div>
+			</div>
+		</Dialog>
+	);
+};

--- a/client/my-sites/marketplace/components/reviews-modal/styles.scss
+++ b/client/my-sites/marketplace/components/reviews-modal/styles.scss
@@ -1,8 +1,6 @@
 $border-color: #eee;
 
 .marketplace-reviews-modal {
-	width: 850px;
-
 	&.dialog__content {
 		padding: 0;
 	}
@@ -75,4 +73,12 @@ $border-color: #eee;
 .dialog__action-buttons-close {
 	padding: 16px 24px 5px 5px;
 	background-color: #fff;
+}
+
+.dialog.card {
+	max-width: 850px;
+
+	@include breakpoint-deprecated( "<1040px" ) {
+		max-height: 100%;
+	}
 }

--- a/client/my-sites/marketplace/components/reviews-modal/styles.scss
+++ b/client/my-sites/marketplace/components/reviews-modal/styles.scss
@@ -1,7 +1,19 @@
 $border-color: #eee;
 
 .marketplace-reviews-modal {
-	max-width: 850px;
+	width: 850px;
+
+	@include breakpoint-deprecated( "<960px" ) {
+		width: 600px;
+	}
+
+	@include breakpoint-deprecated( "<660px" ) {
+		width: 400px;
+	}
+
+	@include breakpoint-deprecated( "<480px" ) {
+		width: 100%;
+	}
 
 	&.dialog__content {
 		padding: 0;

--- a/client/my-sites/marketplace/components/reviews-modal/styles.scss
+++ b/client/my-sites/marketplace/components/reviews-modal/styles.scss
@@ -1,0 +1,26 @@
+$border-color: #eee;
+
+.marketplace-reviews-modal {
+	width: 850px;
+
+	.marketplace-reviews-modal-header {
+		padding: 16px 24px;
+		border-bottom: 1px solid $border-color;
+
+		.marketplace-reviews-modal-title {
+			font-family: "SF Pro Text", $sans;
+			font-weight: 500;
+			color: var(--studio-gray-100);
+			font-size: $font-body;
+		}
+	}
+
+	&.dialog__content {
+		padding: 0;
+	}
+}
+
+.dialog__action-buttons-close {
+	padding: 16px 24px 5px 5px;
+	color: var(--studio-gray-50);
+}

--- a/client/my-sites/marketplace/components/reviews-modal/styles.scss
+++ b/client/my-sites/marketplace/components/reviews-modal/styles.scss
@@ -67,6 +67,7 @@ $border-color: #eee;
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
+		gap: 20px;
 	}
 
 	.marketplace-reviews-modal__reviews-list {

--- a/client/my-sites/marketplace/components/reviews-modal/styles.scss
+++ b/client/my-sites/marketplace/components/reviews-modal/styles.scss
@@ -51,6 +51,12 @@ $border-color: #eee;
 		}
 	}
 
+	.marketplace-reviews-modal__summary {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
 	.marketplace-reviews-modal__reviews-list {
 		margin-top: 32px;
 	}
@@ -68,4 +74,5 @@ $border-color: #eee;
 
 .dialog__action-buttons-close {
 	padding: 16px 24px 5px 5px;
+	background-color: #fff;
 }

--- a/client/my-sites/marketplace/components/reviews-modal/styles.scss
+++ b/client/my-sites/marketplace/components/reviews-modal/styles.scss
@@ -1,6 +1,8 @@
 $border-color: #eee;
 
 .marketplace-reviews-modal {
+	max-width: 850px;
+
 	&.dialog__content {
 		padding: 0;
 	}
@@ -73,12 +75,4 @@ $border-color: #eee;
 .dialog__action-buttons-close {
 	padding: 16px 24px 5px 5px;
 	background-color: #fff;
-}
-
-.dialog.card {
-	max-width: 850px;
-
-	@include breakpoint-deprecated( "<1040px" ) {
-		max-height: 100%;
-	}
 }

--- a/client/my-sites/marketplace/components/reviews-modal/styles.scss
+++ b/client/my-sites/marketplace/components/reviews-modal/styles.scss
@@ -3,11 +3,15 @@ $border-color: #eee;
 .marketplace-reviews-modal {
 	width: 850px;
 
-	.marketplace-reviews-modal-header {
+	&.dialog__content {
+		padding: 0;
+	}
+
+	.marketplace-reviews-modal__header {
 		padding: 16px 24px;
 		border-bottom: 1px solid $border-color;
 
-		.marketplace-reviews-modal-title {
+		.marketplace-reviews-modal__title {
 			font-family: "SF Pro Text", $sans;
 			font-weight: 500;
 			color: var(--studio-gray-100);
@@ -15,12 +19,53 @@ $border-color: #eee;
 		}
 	}
 
-	&.dialog__content {
-		padding: 0;
+	.marketplace-reviews-modal__content {
+		padding: 32px;
+	}
+
+	.marketplace-reviews-modal__stats {
+		display: flex;
+		gap: 14px;
+		align-items: center;
+
+		.marketplace-reviews-modal__ratings-average {
+			font-family: Recoleta, $sans;
+			font-size: $font-headline-large;
+			color: var(--studio-gray-100);
+			line-height: 110%; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		}
+
+		.marketplace-reviews-modal__ratings-count {
+			font-family: "SF Pro Text", $sans;
+			color: var(--studio-gray-100);
+			font-size: $font-body-small;
+			line-height: 20px;
+		}
+
+		.marketplace-reviews-modal__ratings {
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+			align-items: center;
+			gap: 4px;
+		}
+	}
+
+	.marketplace-reviews-modal__reviews-list {
+		margin-top: 32px;
+	}
+
+	.rating .rating__overlay .is-empty,
+	.rating .rating__star-outline .is-empty {
+		fill: var(--studio-yellow-20);
+	}
+
+	.rating .rating__overlay .gridicon,
+	.rating .rating__star-outline .gridicon {
+		fill: var(--studio-yellow-20);
 	}
 }
 
 .dialog__action-buttons-close {
 	padding: 16px 24px 5px 5px;
-	color: var(--studio-gray-50);
 }

--- a/client/my-sites/marketplace/components/reviews-summary/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-summary/index.tsx
@@ -8,7 +8,7 @@ import {
 	useMarketplaceReviewsStatsQuery,
 	type ProductProps,
 } from 'calypso/data/marketplace/use-marketplace-reviews';
-import { ReviewsModal } from 'calypso/my-sites/marketplace/components/reviews-modal';
+import { ReviewModal } from 'calypso/my-sites/marketplace/components/review-modal';
 import { canPublishProductReviews } from 'calypso/state/marketplace/selectors';
 import './styles.scss';
 import { type IAppState } from 'calypso/state/types';
@@ -46,7 +46,7 @@ export const ReviewsSummary = ( { slug, productName, productType }: Props ) => {
 
 	return (
 		<>
-			<ReviewsModal
+			<ReviewModal
 				isVisible={ isVisible }
 				onClose={ () => setIsVisible( false ) }
 				slug={ slug }

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -4,7 +4,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
@@ -21,6 +21,7 @@ import { useESPlugin } from 'calypso/data/marketplace/use-es-query';
 import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { MarketplaceReviewsCards } from 'calypso/my-sites/marketplace/components/reviews-cards';
+import { ReviewsModal } from 'calypso/my-sites/marketplace/components/reviews-modal';
 import PluginNotices from 'calypso/my-sites/plugins/notices';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import PluginDetailsCTA from 'calypso/my-sites/plugins/plugin-details-CTA';
@@ -115,6 +116,7 @@ function PluginDetails( props ) {
 				? canCurrentUser( state, selectedSite?.ID, 'manage_options' )
 				: canCurrentUserManagePlugins( state ) )
 	);
+	const [ isReviewsModalVisible, setIsReviewsModalVisible ] = useState( false );
 
 	// Site type.
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
@@ -369,6 +371,11 @@ function PluginDetails( props ) {
 					</NoticeAction>
 				</Notice>
 			) }
+			<ReviewsModal
+				isVisible={ isReviewsModalVisible }
+				onClose={ () => setIsReviewsModalVisible( false ) }
+				productName={ fullPlugin.name }
+			/>
 			<PluginDetailsNotices selectedSite={ selectedSite } plugin={ fullPlugin } />
 			<div className="plugin-details__page">
 				<div className={ classnames( 'plugin-details__layout', { 'is-logged-in': isLoggedIn } ) }>
@@ -459,7 +466,11 @@ function PluginDetails( props ) {
 			</div>
 			{ isEnabled( 'marketplace-reviews-show' ) && ! showPlaceholder && (
 				<div className="plugin-details__reviews">
-					<MarketplaceReviewsCards slug={ fullPlugin.slug } productType="plugin" />
+					<MarketplaceReviewsCards
+						slug={ fullPlugin.slug }
+						productType="plugin"
+						showMarketplaceReviews={ () => setIsReviewsModalVisible( true ) }
+					/>
 				</div>
 			) }
 			{ isMarketplaceProduct && ! showPlaceholder && <MarketplaceFooter /> }

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -375,6 +375,8 @@ function PluginDetails( props ) {
 				isVisible={ isReviewsModalVisible }
 				onClose={ () => setIsReviewsModalVisible( false ) }
 				productName={ fullPlugin.name }
+				slug={ fullPlugin.slug }
+				productType="plugin"
 			/>
 			<PluginDetailsNotices selectedSite={ selectedSite } plugin={ fullPlugin } />
 			<div className="plugin-details__page">

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -12,6 +12,7 @@ import QueryPlugins from 'calypso/components/data/query-plugins';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import EmptyContent from 'calypso/components/empty-content';
 import MainComponent from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -346,6 +347,7 @@ function PluginDetails( props ) {
 			<QueryEligibility siteId={ selectedSite?.ID } />
 			<QuerySiteFeatures siteIds={ selectedOrAllSites.map( ( site ) => site.ID ) } />
 			<QueryProductsList persist={ ! wporgPluginNotFound } />
+			<QueryUserPurchases />
 			<QuerySitePurchases siteId={ selectedSite?.ID } />
 			<NavigationHeader compactBreadcrumb={ ! isWide } navigationItems={ breadcrumbs } />
 			<PluginNotices
@@ -376,6 +378,7 @@ function PluginDetails( props ) {
 				onClose={ () => setIsReviewsModalVisible( false ) }
 				productName={ fullPlugin.name }
 				slug={ fullPlugin.slug }
+				variations={ fullPlugin.variations }
 				productType="plugin"
 			/>
 			<PluginDetailsNotices selectedSite={ selectedSite } plugin={ fullPlugin } />

--- a/client/state/marketplace/selectors.ts
+++ b/client/state/marketplace/selectors.ts
@@ -2,6 +2,7 @@ import {
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 	WPCOM_FEATURES_LIVE_SUPPORT,
 } from '@automattic/calypso-products';
+import { PluginPeriodVariations } from 'calypso/data/marketplace/types';
 import { getPluginPurchased } from 'calypso/lib/plugins/utils';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -78,7 +79,7 @@ export function canPublishProductReviews(
 	state: IAppState,
 	productType: string,
 	productSlug: string,
-	variations?: []
+	variations?: PluginPeriodVariations
 ) {
 	if ( productType === 'theme' ) {
 		return canPublishThemeReview( state, productSlug );
@@ -92,14 +93,23 @@ export function canPublishProductReviews(
 export function canPublishPluginReview(
 	state: IAppState,
 	pluginSlug: string,
-	variations: [] = []
+	variations?: PluginPeriodVariations
 ) {
 	const isMarketplacePlugin = isMarketplaceProduct( state, pluginSlug );
 	const isLoggedIn = isUserLoggedIn( state );
 
+	const hasActiveSubscription = hasActivePluginSubscription( state, variations );
+
+	return isLoggedIn && ( ! isMarketplacePlugin || hasActiveSubscription );
+}
+
+export function hasActivePluginSubscription(
+	state: IAppState,
+	variations?: PluginPeriodVariations
+) {
 	const purchases = getUserPurchases( state );
 	const purchasedPlugin = getPluginPurchased( { variations }, purchases || [] );
 	const hasActiveSubscription = !! purchasedPlugin;
 
-	return isLoggedIn && ( ! isMarketplacePlugin || hasActiveSubscription );
+	return hasActiveSubscription;
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4843

## Proposed Changes

* Rename the old component called ReviewsModal to ReviewModal (this component refers to a single review added or updated)
* Create a new component a ReviewsModal to display the reviews of a given product
* Link it to the `Read all reviews` button on the Plugin Details page
* Create different states for this component as below:

| With reviews  | No reviews (with subscription) | No reviews (without subscription)|
| ------------- | ------------- |------------- |
|![CleanShot 2023-12-19 at 12 45 13@2x](https://github.com/Automattic/wp-calypso/assets/5039531/0201d092-972e-4176-8a57-ff42ce968c14)|![CleanShot 2023-12-19 at 12 30 18@2x](https://github.com/Automattic/wp-calypso/assets/5039531/f9cf1767-ee5e-4676-a359-0fce5634619a)|![CleanShot 2023-12-19 at 12 29 21@2x](https://github.com/Automattic/wp-calypso/assets/5039531/c88fdcad-cb77-4524-a67a-10d69d4cc710)|

## Out of scope
* Display the user avatar - #85503
* Always display the user review first - https://github.com/Automattic/wp-calypso/pull/85549
* Warn the user if the review is pending approval - https://github.com/Automattic/dotcom-forge/issues/5029
* Update the button to also support theme purchase - https://github.com/Automattic/dotcom-forge/issues/5024
* Add new review section - https://github.com/Automattic/dotcom-forge/issues/5023
* Update review - https://github.com/Automattic/dotcom-forge/issues/5026





## Testing Instructions

* On this branch
* Go to a plugin details page with reviews. Ex: `/plugins/woocommerce-bookings/`
* On the bottom, click on Read all reviews
* Check if all reviews are displayed 
* Check if plugin without reviews are shown as above
* Check if the button to purchase is displayed if you don't have an active subscription for a given plugin
* Check if the `Leave review` button is displayed only on plugins you have an active subscription

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
