### PR TITLE
Open "Explore support resources" link on a new tab

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/footer/PlanFooter.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/sections/footer/PlanFooter.tsx
@@ -46,6 +46,7 @@ const PlanFooter = () => {
 				) }
 				buttonText={ translate( 'Explore support resources' ) }
 				href="/support"
+				target="_blank"
 				onClick={ () => recordTracksEvent( 'calypso_plan_thank_you_support_click' ) }
 			/>
 		</div>


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/85196

## Proposed Changes

* Open "Explore support resources" link on a new tab

## Testing Instructions

* Apply this PR to your local
* Open a site with a free plan and go to Upgrades > Plans
* Upgrade to a paid plan, and you should see the thank you screen
* Click on the "Explore support resources" link
* The link should open on a new tab

<img width="748" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/981db297-5ac2-4668-a9cb-7188bc8445e4">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?