### PR TITLE
Plan naming: Fix the global styles launchbar dialog

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -488,12 +488,13 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 				<div class="launch-bar-global-styles-message">
 					<?php
 					$message = sprintf(
-						/* translators: %s - documentation URL. */
+						/* translators: %1$s - documentation URL, %2$s - the name of the required plan */
 						__(
-							'Your site includes <a href="%s" target="_blank">premium styles</a> that are only visible to visitors after upgrading to the Premium plan or higher.',
+							'Your site includes <a href="%1$s" target="_blank">premium styles</a> that are only visible to visitors after upgrading to the %2$s plan or higher.',
 							'full-site-editing'
 						),
-						'https://wordpress.com/support/using-styles/'
+						'https://wordpress.com/support/using-styles/',
+						get_store_product( WPCOM_VALUE_BUNDLE )->product_name
 					);
 					echo sprintf(
 						wp_kses(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

The GS launchbar dialog hardcoded "Premium" as the plan name, with this change it now gets the product's name from the product itself. When the name of the plan changes, this changes automatically.


## Testing Instructions

 1. Create a new user account
 2. Go through the new site process, making a free site
 3. Select a theme with a style variation and choose a style variation then continue
 4. Whenever prompted opt to upgrade later
 5. Make doubly sure that the users account is in "English", i.e. American English
 6. Sandbox the site
 7. Apply this change to your sandbox
 8. Visit the front-end of the site
 9. You should see a launch bar it should say "WordPress.com Explorer plan"
 10. Non en-us accounts should say "WordPress.com Premium plan".

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


<img width="372" alt="Screenshot 2023-12-19 at 17 28 48" src="https://github.com/Automattic/wp-calypso/assets/93301/5b3bf164-8d0c-4a59-8ed4-c54c30a47caf">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?