### PR TITLE
Zendesk: Ensure useChatWidget works without Help Center

### DIFF
--- a/client/components/chat-button/index.tsx
+++ b/client/components/chat-button/index.tsx
@@ -72,7 +72,7 @@ const ChatButton: FC< Props > = ( {
 	} = useChatStatus( messagingGroup );
 	const { setShowHelpCenter, setInitialRoute } = useDataStoreDispatch( HELP_CENTER_STORE );
 
-	function shouldShowChatButton() {
+	function shouldShowChatButton(): boolean {
 		if ( isEligibleForChat && hasActiveChats ) {
 			return true;
 		}
@@ -96,6 +96,8 @@ const ChatButton: FC< Props > = ( {
 		if ( isEligibleForChat && isChatAvailable ) {
 			return true;
 		}
+
+		return false;
 	}
 
 	const configName = getConfigNameForIntent( chatIntent );

--- a/client/components/chat-button/index.tsx
+++ b/client/components/chat-button/index.tsx
@@ -5,6 +5,7 @@ import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import type { MessagingGroup } from '@automattic/help-center/src/hooks/use-messaging-availability';
+import type { ZendeskConfigName } from '@automattic/help-center/src/hooks/use-zendesk-messaging';
 import type { FC } from 'react';
 
 type ChatIntent = 'SUPPORT' | 'PRESALES' | 'PRECANCELLATION';
@@ -32,6 +33,18 @@ function getMessagingGroupForIntent( chatIntent: ChatIntent ): MessagingGroup {
 		case 'SUPPORT':
 		default:
 			return 'wpcom_messaging';
+	}
+}
+
+function getConfigNameForIntent( chatIntent: ChatIntent ): ZendeskConfigName {
+	switch ( chatIntent ) {
+		case 'PRESALES':
+			return 'zendesk_presales_chat_key';
+
+		case 'PRECANCELLATION':
+		case 'SUPPORT':
+		default:
+			return 'zendesk_support_chat_key';
 	}
 }
 
@@ -85,7 +98,8 @@ const ChatButton: FC< Props > = ( {
 		}
 	}
 
-	const { isOpeningChatWidget, openChatWidget } = useChatWidget();
+	const configName = getConfigNameForIntent( chatIntent );
+	const { isOpeningChatWidget, openChatWidget } = useChatWidget( configName );
 
 	const handleClick = () => {
 		if ( canConnectToZendesk ) {

--- a/client/components/chat-button/index.tsx
+++ b/client/components/chat-button/index.tsx
@@ -99,7 +99,10 @@ const ChatButton: FC< Props > = ( {
 	}
 
 	const configName = getConfigNameForIntent( chatIntent );
-	const { isOpeningChatWidget, openChatWidget } = useChatWidget( configName );
+	const { isOpeningChatWidget, openChatWidget } = useChatWidget(
+		configName,
+		shouldShowChatButton()
+	);
 
 	const handleClick = () => {
 		if ( canConnectToZendesk ) {

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -95,7 +95,6 @@ export const HelpCenterContactForm = () => {
 	const locale = useLocale();
 	const { isLoading: submittingTicket, mutateAsync: submitTicket } = useSubmitTicketMutation();
 	const { isLoading: submittingTopic, mutateAsync: submitTopic } = useSubmitForumsMutation();
-	const { isOpeningChatWidget, openChatWidget } = useChatWidget();
 	const userId = useSelector( getCurrentUserId );
 	const { data: userSites } = useUserSites( userId );
 	const userWithNoSites = userSites?.sites.length === 0;
@@ -124,6 +123,10 @@ export const HelpCenterContactForm = () => {
 		isEligibleForChat,
 		isLoading: isLoadingChatStatus,
 	} = useChatStatus();
+	const { isOpeningChatWidget, openChatWidget } = useChatWidget(
+		'zendesk_support_chat_key',
+		isEligibleForChat || hasActiveChats
+	);
 	useZendeskMessaging(
 		'zendesk_support_chat_key',
 		isEligibleForChat || hasActiveChats,

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -29,7 +29,7 @@ import { useSiteAnalysis } from '../data/use-site-analysis';
 import { useSubmitForumsMutation } from '../data/use-submit-forums-topic';
 import { useSubmitTicketMutation } from '../data/use-submit-support-ticket';
 import { useUserSites } from '../data/use-user-sites';
-import { useChatStatus, useContactFormTitle, useChatWidget, useZendeskMessaging } from '../hooks';
+import { useChatStatus, useContactFormTitle, useChatWidget } from '../hooks';
 import { HELP_CENTER_STORE } from '../stores';
 import { getSupportVariationFromMode } from '../support-variations';
 import { SearchResult } from '../types';
@@ -125,11 +125,6 @@ export const HelpCenterContactForm = () => {
 	} = useChatStatus();
 	const { isOpeningChatWidget, openChatWidget } = useChatWidget(
 		'zendesk_support_chat_key',
-		isEligibleForChat || hasActiveChats
-	);
-	useZendeskMessaging(
-		'zendesk_support_chat_key',
-		isEligibleForChat || hasActiveChats,
 		isEligibleForChat || hasActiveChats
 	);
 

--- a/packages/help-center/src/hooks/use-chat-widget.ts
+++ b/packages/help-center/src/hooks/use-chat-widget.ts
@@ -13,14 +13,15 @@ import { HELP_CENTER_STORE } from '../stores';
 import type { ZendeskConfigName } from '@automattic/help-center/src/hooks/use-zendesk-messaging';
 
 export default function useChatWidget(
-	configName: ZendeskConfigName = 'zendesk_support_chat_key'
+	configName: ZendeskConfigName = 'zendesk_support_chat_key',
+	enabled = true
 ) {
 	const sectionName = useSelector( getSectionName );
 	const { isLoading: isSubmittingZendeskUserFields, mutateAsync: submitZendeskUserFields } =
 		useUpdateZendeskUserFieldsMutation();
 	const { setShowHelpCenter, resetStore } = useDispatch( HELP_CENTER_STORE );
 
-	const { isMessagingScriptLoaded } = useZendeskMessaging( configName, true, true );
+	const { isMessagingScriptLoaded } = useZendeskMessaging( configName, enabled, enabled );
 
 	const openChatWidget = (
 		message: string | undefined,

--- a/packages/help-center/src/hooks/use-chat-widget.ts
+++ b/packages/help-center/src/hooks/use-chat-widget.ts
@@ -1,6 +1,7 @@
 /**
  * External Dependencies
  */
+import { useZendeskMessaging } from '@automattic/help-center/src/hooks';
 import { useDispatch } from '@wordpress/data';
 import { useSelector } from 'react-redux';
 /**
@@ -9,12 +10,17 @@ import { useSelector } from 'react-redux';
 import { getSectionName } from 'calypso/state/ui/selectors'; /* eslint-disable-line no-restricted-imports */
 import { useUpdateZendeskUserFieldsMutation } from '../data/use-update-zendesk-user-fields';
 import { HELP_CENTER_STORE } from '../stores';
+import type { ZendeskConfigName } from '@automattic/help-center/src/hooks/use-zendesk-messaging';
 
-export default function useChatWidget() {
+export default function useChatWidget(
+	configName: ZendeskConfigName = 'zendesk_support_chat_key'
+) {
 	const sectionName = useSelector( getSectionName );
 	const { isLoading: isSubmittingZendeskUserFields, mutateAsync: submitZendeskUserFields } =
 		useUpdateZendeskUserFieldsMutation();
-	const { setShowMessagingChat } = useDispatch( HELP_CENTER_STORE );
+	const { setShowHelpCenter, resetStore } = useDispatch( HELP_CENTER_STORE );
+
+	const { isMessagingScriptLoaded } = useZendeskMessaging( configName, true, true );
 
 	const openChatWidget = (
 		message: string | undefined,
@@ -30,7 +36,12 @@ export default function useChatWidget() {
 		} )
 			.then( () => {
 				onSuccess?.();
-				setShowMessagingChat();
+				setShowHelpCenter( false );
+				resetStore();
+				if ( typeof window.zE === 'function' ) {
+					window.zE( 'messenger', 'open' );
+					window.zE( 'messenger', 'show' );
+				}
 			} )
 			.catch( () => {
 				onError?.();
@@ -38,7 +49,7 @@ export default function useChatWidget() {
 	};
 
 	return {
-		isOpeningChatWidget: isSubmittingZendeskUserFields,
+		isOpeningChatWidget: isSubmittingZendeskUserFields || ! isMessagingScriptLoaded,
 		openChatWidget,
 	};
 }


### PR DESCRIPTION
In #80075, Help Center stopped proactively loading Messaging's scripts. Which is a good idea from a performance/resource usage point of view. However, it broke the cases that use `useChatWidget` (`ChatButton`, precancelation chat, etc.), because that hook worked under the assumption that Help Center already loaded the Messaging scripts.

To fix that and make the code more resilient, I've modified `useChatWidget` to ensure Messaging scripts are loaded. Additionally, I've removed the reliance on Help Center to show the launcher/widget. This will make it future-proof for use cases like the one being implemented in #85381

## Testing Instructions

Verify the pre-cancelation chat is working again:
- Go to `/me/purchases`.
- Try to cancel a paid plan.
- Click on the `Cancel Subscription` button.
This should trigger this modal:

<img width="1271" alt="Screenshot 2023-12-19 at 17 57 49" src="https://github.com/Automattic/wp-calypso/assets/3392497/104b54ea-8895-42e5-9c6c-f33826383320">

Click the "Need help? Chat with us" button. It should close the modal and trigger opening of the Messaging widget:
<img width="666" alt="Screenshot 2023-12-19 at 17 58 47" src="https://github.com/Automattic/wp-calypso/assets/3392497/28c854d0-c31d-4de7-bd84-f69f6d9e49c4">

If you're having troubles seeing the chat with us button, you might need to sandbox `public-api.wordpress.com` and hardcode the availability check there to always return true (or do the same on the frontend).