### PR TITLE
Gravatar: Update the text of the sending email link button & Fix the <a> link color of the error notice

### DIFF
--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -355,11 +355,11 @@ class MagicLogin extends Component {
 			<div className="grav-powered-magic-login__tos">
 				{ isGravatarOAuth2Client( oauth2Client )
 					? translate(
-							`By clicking “Send me login link“, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, have read our {{privacyLink}}Privacy Policy{{/privacyLink}}, and understand that you're creating {{wpAccountLink}}a WordPress.com account{{/wpAccountLink}} if you don't already have one.`,
+							`By clicking “Send me sign in link“, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, have read our {{privacyLink}}Privacy Policy{{/privacyLink}}, and understand that you're creating {{wpAccountLink}}a WordPress.com account{{/wpAccountLink}} if you don't already have one.`,
 							textOptions
 					  )
 					: translate(
-							`By clicking “Send me login link“, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, have read our {{privacyLink}}Privacy Policy{{/privacyLink}}, and understand that you're creating a Gravatar account if you don't already have one.`,
+							`By clicking “Send me sign in link“, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, have read our {{privacyLink}}Privacy Policy{{/privacyLink}}, and understand that you're creating a Gravatar account if you don't already have one.`,
 							textOptions
 					  ) }
 			</div>
@@ -387,7 +387,7 @@ class MagicLogin extends Component {
 						headerText={ translate( 'Sign in with your email' ) }
 						hideSubHeaderText
 						inputPlaceholder={ translate( 'Enter your email address' ) }
-						submitButtonLabel={ translate( 'Send me login link' ) }
+						submitButtonLabel={ translate( 'Send me sign in link' ) }
 						tosComponent={ this.renderGravPoweredMagicLoginTos() }
 						onSendEmailLogin={ ( usernameOrEmail ) => this.setState( { usernameOrEmail } ) }
 						createAccountForNewUser

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -650,7 +650,7 @@ $image-height: 47px;
 		color: #00101c;
 		line-height: 1.5;
 
-		a {
+		a:not(.notice.is-error a) {
 			color: #1d4fc4;
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 106368-gh-Automattic/gravatar

## Proposed Changes

* Update the text of the sending email link button
* Fix the <a> link color of the error notice

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to this [Gravatar login URL](http://calypso.localhost:3000/log-in/link?client_id=1854&redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3Df1e240a76abca382a974309f9b2e866bffb1236ae8d9d93460ca5e6e02e613a3%26redirect_uri%3Dhttps%253A%252F%252Fgravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token%26from-calypso%3D1), and the text of the CTA button has been updated:

| Before | After |
| - | - |
| <img width="569" alt="截圖 2023-12-20 凌晨2 18 45" src="https://github.com/Automattic/wp-calypso/assets/21308003/acb99691-8814-451d-93b4-775439348012"> | <img width="565" alt="截圖 2023-12-20 凌晨2 22 43" src="https://github.com/Automattic/wp-calypso/assets/21308003/91f036cf-f9e5-4be9-96aa-78f34491e9c4"> |

* For the fixed `<a>` link color, it's not able to test locally, so code review should be fine:

| Before | After |
| - | - |
| <img width="558" alt="截圖 2023-12-20 凌晨2 11 27" src="https://github.com/Automattic/wp-calypso/assets/21308003/bd0f8765-2c93-44ac-b401-0ac3dcc10b2a"> | <img width="557" alt="截圖 2023-12-20 凌晨2 10 40" src="https://github.com/Automattic/wp-calypso/assets/21308003/0b337720-2be3-4269-a6ca-45ba2713bfae"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
