### PR TITLE
Domains: Fix styling of domain suggestion select buttons during onboarding

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -251,7 +251,6 @@
 	min-width: 120px;
 	text-align: center;
 	padding: 0.25em 3em;
-	transition: all 0.1s ease-in-out;
 	margin-top: 10px;
 
 	&:focus {
@@ -279,10 +278,20 @@
 	&.is-borderless {
 		color: var(--color-primary);
 		padding: 0;
+		display: flex;
+		align-items: center;
 
 		&:focus {
 			box-shadow: none !important;
 			border-color: transparent !important;
+		}
+
+		/* Checkmark for selected domains */
+		svg {
+			height: 20px;
+			top: 0;
+			left: -2px;
+			margin-right: 4px;
 		}
 	}
 

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -248,7 +248,7 @@
 .button.domain-suggestion__action {
 	width: 100%;
 	height: 40px;
-	min-width: 120px;
+	min-width: 130px;
 	text-align: center;
 	padding: 0.25em 3em;
 	margin-top: 10px;

--- a/client/components/domains/featured-domain-suggestions/style.scss
+++ b/client/components/domains/featured-domain-suggestions/style.scss
@@ -47,7 +47,6 @@
 	.button.domain-suggestion__action {
 		flex-grow: 0;
 		text-align: center;
-		transition: all 0.1s linear;
 
 		.is-placeholder & {
 			animation: loading-fade 1.6s ease-in-out infinite;


### PR DESCRIPTION
## Proposed Changes

This PR fixes the styling of the domain suggestion selection buttons during onboarding based on Design feedback (p9Jlb4-aaJ-p2).

Specifically, this PR fixes 3 points:

When a domain is selected, the "✔️ Selected" button text
- is not 100% vertically aligned with the text that's on its left ("Free", "Free for the first year...", domain price)
- is not horizontally centered with the other buttons for other domain suggestions

There's also a weird bounce animation when the button becomes selected.

### Screenshots

- Before

> <img width="715" alt="Screenshot 2023-12-19 at 16 04 17" src="https://github.com/Automattic/wp-calypso/assets/5324818/82146ae8-00b4-4814-9d55-463d47f1890e">
https://github.com/Automattic/wp-calypso/assets/5324818/da74b2fb-e008-44f7-afd8-daf8e35d17aa

- After

> <img width="709" alt="Screenshot 2023-12-20 at 12 56 36" src="https://github.com/Automattic/wp-calypso/assets/5324818/1f7d4992-ed59-4224-8bd3-c21d4065d256">
https://github.com/Automattic/wp-calypso/assets/5324818/f1db0d45-a396-403a-96e4-a66877fa3f8f

## Testing Instructions

- Open the live Calypso link or build this branch locally
- Go to onboarding (`/start`) and search for any domain
- Select some suggestions and ensure the points mentioned in the description are fixed

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?