### PR TITLE
Monetize: Add cancel button to supporter screen

### DIFF
--- a/client/my-sites/earn/customers/cancel-dialog.tsx
+++ b/client/my-sites/earn/customers/cancel-dialog.tsx
@@ -1,0 +1,86 @@
+import { Dialog } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { Dispatch, SetStateAction } from 'react';
+import Notice from 'calypso/components/notice';
+import { useDispatch, useSelector } from 'calypso/state';
+import { requestSubscriptionStop } from 'calypso/state/memberships/subscribers/actions';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { Subscriber } from '../types';
+
+type CancelDialogProps = {
+	subscriberToCancel: Subscriber | null;
+	setSubscriberToCancel: Dispatch< SetStateAction< Subscriber | null > >;
+};
+
+function CancelDialog( { subscriberToCancel, setSubscriberToCancel }: CancelDialogProps ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const site = useSelector( ( state ) => getSelectedSite( state ) );
+
+	function onCloseCancelSubscription( reason: string | undefined ) {
+		if ( reason === 'cancel' ) {
+			dispatch(
+				requestSubscriptionStop(
+					site?.ID,
+					subscriberToCancel,
+					getText( subscriberToCancel ).success
+				)
+			);
+		}
+		setSubscriberToCancel( null );
+	}
+
+	function getText( subscriber: Subscriber | null ) {
+		const subscriber_email = subscriber?.user.user_email ?? '';
+		const plan_name = subscriber?.plan.title ?? '';
+
+		if ( subscriber?.plan?.renew_interval === 'one-time' ) {
+			return {
+				button: translate( 'Remove payment' ),
+				confirmation_subheading: translate( 'Do you want to remove this payment?' ),
+				confirmation_info: translate(
+					'Removing this payment means that the user %(subscriber_email)s will no longer have access to any service granted by the %(plan_name)s plan. The payment will not be refunded.',
+					{ args: { subscriber_email, plan_name } }
+				),
+				success: translate( 'Payment removed for %(subscriber_email)s.', {
+					args: { subscriber_email },
+				} ),
+			};
+		}
+		return {
+			button: translate( 'Cancel payment' ),
+			confirmation_subheading: translate( 'Do you want to cancel this payment?' ),
+			confirmation_info: translate(
+				'Cancelling this payment means that the user %(subscriber_email)s will no longer have access to any service granted by the %(plan_name)s plan. Payments already made will not be refunded but any scheduled future payments will not be made.',
+				{ args: { subscriber_email, plan_name } }
+			),
+			success: translate( 'Payment cancelled for %(subscriber_email)s.', {
+				args: { subscriber_email },
+			} ),
+		};
+	}
+
+	return (
+		<Dialog
+			isVisible={ Boolean( subscriberToCancel ) }
+			buttons={ [
+				{
+					label: translate( 'Back' ),
+					action: 'back',
+				},
+				{
+					label: getText( subscriberToCancel ).button,
+					isPrimary: true,
+					action: 'cancel',
+				},
+			] }
+			onClose={ onCloseCancelSubscription }
+		>
+			<h1>{ translate( 'Confirmation' ) }</h1>
+			<p>{ getText( subscriberToCancel ).confirmation_subheading }</p>
+			<Notice text={ getText( subscriberToCancel ).confirmation_info } showDismiss={ false } />
+		</Dialog>
+	);
+}
+
+export default CancelDialog;

--- a/client/my-sites/earn/customers/customer/index.tsx
+++ b/client/my-sites/earn/customers/customer/index.tsx
@@ -1,6 +1,8 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import { Subscriber } from '../../types';
+import CancelDialog from '../cancel-dialog';
 import CustomerDetails from './customer-details';
 import CustomerHeader from './customer-header';
 import CustomerStats from './customer-stats';
@@ -13,6 +15,7 @@ type CustomerProps = {
 
 const Customer = ( { customer }: CustomerProps ) => {
 	const translate = useTranslate();
+	const [ subscriberToCancel, setSubscriberToCancel ] = useState< Subscriber | null >( null );
 
 	function redirectToStripe() {
 		const stripeUrl = `https://dashboard.stripe.com/search?query=metadata%3A${ customer.user.ID }`;
@@ -24,9 +27,21 @@ const Customer = ( { customer }: CustomerProps ) => {
 			<CustomerHeader customer={ customer } />
 			<CustomerStats customer={ customer } />
 			<CustomerDetails customer={ customer } />
-			<Button className="customer__stripe-button" primary onClick={ redirectToStripe }>
-				{ translate( 'Visit Stripe Dashboard' ) }
-			</Button>
+			<div className="customer__action-buttons">
+				<Button className="customer__stripe-button" primary onClick={ redirectToStripe }>
+					{ translate( 'Visit Stripe Dashboard' ) }
+				</Button>
+				<Button
+					className="customer__cancel-button"
+					onClick={ () => setSubscriberToCancel( customer ) }
+				>
+					{ translate( 'Cancel Payment' ) }
+				</Button>
+			</div>
+			<CancelDialog
+				subscriberToCancel={ subscriberToCancel }
+				setSubscriberToCancel={ setSubscriberToCancel }
+			/>
 		</div>
 	);
 };

--- a/client/my-sites/earn/customers/customer/style.scss
+++ b/client/my-sites/earn/customers/customer/style.scss
@@ -88,7 +88,10 @@
 		}
 	}
 
-	.customer__stripe-button {
+	.customer__action-buttons {
+		display: flex;
+		flex-direction: row;
+		gap: 12px;
 		margin-top: 30px;
 	}
 }

--- a/client/my-sites/earn/customers/index.tsx
+++ b/client/my-sites/earn/customers/index.tsx
@@ -1,4 +1,4 @@
-import { Card, Button, Dialog, Gridicon } from '@automattic/components';
+import { Card, Button, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { saveAs } from 'browser-filesaver';
@@ -13,14 +13,10 @@ import Gravatar from 'calypso/components/gravatar';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import Notice from 'calypso/components/notice';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { decodeEntities } from 'calypso/lib/formatting';
 import { useDispatch, useSelector } from 'calypso/state';
-import {
-	requestSubscribers,
-	requestSubscriptionStop,
-} from 'calypso/state/memberships/subscribers/actions';
+import { requestSubscribers } from 'calypso/state/memberships/subscribers/actions';
 import {
 	getTotalSubscribersForSiteId,
 	getOwnershipsForSiteId,
@@ -32,6 +28,7 @@ import {
 	PLAN_ONE_TIME_FREQUENCY,
 } from '../memberships/constants';
 import { Subscriber } from '../types';
+import CancelDialog from './cancel-dialog';
 import Customer from './customer/index';
 
 function CustomerSection() {
@@ -39,9 +36,7 @@ function CustomerSection() {
 	const dispatch = useDispatch();
 	const moment = useLocalizedMoment();
 	const subscriberId = new URLSearchParams( window.location.search ).get( 'subscriber' );
-
-	const [ cancelledSubscriber, setCancelledSubscriber ] = useState< Subscriber | null >( null );
-
+	const [ subscriberToCancel, setSubscriberToCancel ] = useState< Subscriber | null >( null );
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 
 	const subscribers = useSelector(
@@ -62,19 +57,6 @@ function CustomerSection() {
 		},
 		[ dispatch, site, subscribers, totalSubscribers ]
 	);
-
-	function onCloseCancelSubscription( reason: string | undefined ) {
-		if ( reason === 'cancel' ) {
-			dispatch(
-				requestSubscriptionStop(
-					site?.ID,
-					cancelledSubscriber,
-					getIntervalDependantWording( cancelledSubscriber ).success
-				)
-			);
-		}
-		setCancelledSubscriber( null );
-	}
 
 	function downloadSubscriberList( event: MouseEvent< HTMLButtonElement > ) {
 		event.preventDefault();
@@ -126,7 +108,6 @@ function CustomerSection() {
 	}
 
 	function renderSubscriberList() {
-		const wording = getIntervalDependantWording( cancelledSubscriber );
 		return (
 			<div>
 				{ Object.values( subscribers ).length === 0 && (
@@ -169,25 +150,10 @@ function CustomerSection() {
 							) }
 							<InfiniteScroll nextPageMethod={ () => fetchNextSubscriberPage( false ) } />
 						</ul>
-						<Dialog
-							isVisible={ !! cancelledSubscriber }
-							buttons={ [
-								{
-									label: translate( 'Back' ),
-									action: 'back',
-								},
-								{
-									label: wording.button,
-									isPrimary: true,
-									action: 'cancel',
-								},
-							] }
-							onClose={ onCloseCancelSubscription }
-						>
-							<h1>{ translate( 'Confirmation' ) }</h1>
-							<p>{ wording.confirmation_subheading }</p>
-							<Notice text={ wording.confirmation_info } showDismiss={ false } />
-						</Dialog>
+						<CancelDialog
+							subscriberToCancel={ subscriberToCancel }
+							setSubscriberToCancel={ setSubscriberToCancel }
+						/>
 						<div className="memberships__module-footer">
 							<Button onClick={ downloadSubscriberList }>
 								{ translate( 'Download list as CSV' ) }
@@ -199,34 +165,10 @@ function CustomerSection() {
 		);
 	}
 
-	function getIntervalDependantWording( subscriber: Subscriber | null ) {
-		const subscriber_email = subscriber?.user.user_email ?? '';
-		const plan_name = subscriber?.plan.title ?? '';
-
-		if ( subscriber?.plan?.renew_interval === 'one-time' ) {
-			return {
-				button: translate( 'Remove payment' ),
-				confirmation_subheading: translate( 'Do you want to remove this payment?' ),
-				confirmation_info: translate(
-					'Removing this payment means that the user %(subscriber_email)s will no longer have access to any service granted by the %(plan_name)s plan. The payment will not be refunded.',
-					{ args: { subscriber_email, plan_name } }
-				),
-				success: translate( 'Payment removed for %(subscriber_email)s.', {
-					args: { subscriber_email },
-				} ),
-			};
-		}
-		return {
-			button: translate( 'Cancel payment' ),
-			confirmation_subheading: translate( 'Do you want to cancel this payment?' ),
-			confirmation_info: translate(
-				'Cancelling this payment means that the user %(subscriber_email)s will no longer have access to any service granted by the %(plan_name)s plan. Payments already made will not be refunded but any scheduled future payments will not be made.',
-				{ args: { subscriber_email, plan_name } }
-			),
-			success: translate( 'Payment cancelled for %(subscriber_email)s.', {
-				args: { subscriber_email },
-			} ),
-		};
+	function getCancelButtonText( subscriber: Subscriber | null ) {
+		return subscriber?.plan?.renew_interval === 'one-time'
+			? translate( 'Remove payment' )
+			: translate( 'Cancel payment' );
 	}
 
 	function renderSubscriberSubscriptionSummary( subscriber: Subscriber ) {
@@ -258,9 +200,9 @@ function CustomerSection() {
 					<Gridicon size={ 18 } icon="visible" />
 					{ translate( 'View' ) }
 				</PopoverMenuItem>
-				<PopoverMenuItem onClick={ () => setCancelledSubscriber( subscriber ) }>
+				<PopoverMenuItem onClick={ () => setSubscriberToCancel( subscriber ) }>
 					<Gridicon size={ 18 } icon="cross" />
-					{ getIntervalDependantWording( subscriber ).button }
+					{ getCancelButtonText( subscriber ) }
 				</PopoverMenuItem>
 			</EllipsisMenu>
 		);


### PR DESCRIPTION
## Proposed Changes

This PR adds a 'Cancel Payment' button the Single Supporter screen. Because we need to re-use the CancelDialog, the PR also extracts that to its own component so it can be re-used. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) You will need a testing site with paid customers or subscribers. 
2) Go to http://calypso.localhost:3000/earn/supporters/YOURSITESLUG, click on the three action dots for a customer, select Cancel, and confirm the CancelDialog opens as it did before. 
3) Exit the dialog, click on the three action dots again, and click View to go to the Single Supporter screen. From there, click the Cancel button at the bottom of the screen and confirm the CancelDialog opens. 
4) In the dialog, click to cancel, and confirm the paid subscriber is cancelled. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?