### PR TITLE
Plan naming: Fix theme tiers badge

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
@@ -33,28 +33,20 @@ export default function ThemeTierBundledBadge() {
 	const tooltipContent = (
 		<>
 			<ThemeTierTooltipTracker />
-			<div data-testid="upsell-header" className="theme-tier-badge-tooltip__header">
-				{
-					// Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".
-					translate( '%(bundleName)s theme', { textOnly: true, args: { bundleName } } )
-				}
-			</div>
 			<div data-testid="upsell-message">
 				{ createInterpolateElement(
 					isEnglishLocale ||
 						i18n.hasTranslation(
-							'This %(bundleName)s theme is included in the <Link>%(businessPlanName)s plan</Link>.'
+							'This theme is included in the <Link>%(businessPlanName)s plan</Link>.'
 						)
-						? // Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".
-						  translate(
-								'This %(bundleName)s theme is included in the <Link>%(businessPlanName)s plan</Link>.',
-								{
-									args: { bundleName },
-									textOnly: true,
+						? translate( 'This theme is included in the <Link>%(businessPlanName)s plan</Link>.', {
+								args: {
 									businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
-								}
-						  )
-						: translate(
+								},
+								textOnly: true,
+						  } )
+						: // Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".
+						  translate(
 								'This %(bundleName)s theme is included in the <Link>Business plan</Link>.',
 								{
 									args: { bundleName },

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
@@ -23,12 +23,6 @@ export default function ThemeTierCommunityBadge() {
 	const tooltipContent = (
 		<>
 			<ThemeTierTooltipTracker />
-			<div data-testid="upsell-header" className="theme-tier-badge-tooltip__header">
-				{ translate( 'Community theme', {
-					context: 'This theme is developed and supported by a community',
-					textOnly: true,
-				} ) }
-			</div>
 			<div data-testid="upsell-message">
 				{ createInterpolateElement(
 					isEnglishLocale ||

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
@@ -99,12 +99,6 @@ export default function ThemeTierPartnerBadge() {
 	const tooltipContent = (
 		<>
 			<ThemeTierTooltipTracker />
-			<div data-testid="upsell-header" className="theme-tier-badge-tooltip__header">
-				{ translate( 'Partner theme', {
-					context: 'This theme is developed and supported by a theme partner',
-					textOnly: true,
-				} ) }
-			</div>
 			<div data-testid="upsell-message">{ getTooltipMessage() }</div>
 		</>
 	);

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
@@ -29,16 +29,10 @@ export default function ThemeTierUpgradeBadge() {
 	const tooltipContent = (
 		<>
 			<ThemeTierTooltipTracker />
-			<div data-testid="upsell-header" className="theme-tier-badge-tooltip__header">
-				{
-					// Translators: %(planName)s is the name of the plan that includes this theme. Examples: "Personal" or "Premium".
-					translate( '%(planName)s theme', { textOnly: true, args: { planName } } )
-				}
-			</div>
 			<div data-testid="upsell-message">
 				{ createInterpolateElement(
 					// Translators: %(planName)s is the name of the plan that includes this theme. Examples: "Personal" or "Premium".
-					translate( 'This %(planName)s theme is included in the <Link>%(planName)s plan</Link>.', {
+					translate( 'This theme is included in the <Link>%(planName)s plan</Link>.', {
 						args: { planName },
 						textOnly: true,
 					} ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

The changes for the new theme names were flawed, conflating the theme type with plan name. This change undoes that, and also simplifies the badge tooltips, which has been a long-held low priority desire.

Rather than a tooltip saying:
```
** Explorer theme **
This Explorer theme is included in the Explorer plan
```

It will now simply say
```
This theme is included in the Explorer plan
```

The exact wording varies depending upon the tier.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* will be written momentarily

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?