### PR TITLE
Make the theme type tooltip less repetitive

### DIFF
--- a/client/components/theme-type-badge/test/index.jsx
+++ b/client/components/theme-type-badge/test/index.jsx
@@ -54,8 +54,6 @@ describe( 'ThemeTypeBadge', () => {
 			const popoverTrigger = container.getElementsByClassName( 'theme-type-badge__content' )[ 0 ];
 			await userEvent.hover( popoverTrigger );
 
-			expect( screen.queryByTestId( 'upsell-header' ) ).toBeDefined();
-			expect( screen.queryByTestId( 'upsell-header' ).innerHTML ).toBe( 'Premium theme' );
 			expect( screen.queryByTestId( 'upsell-message' ).innerHTML ).toContain(
 				'This premium theme is included in the'
 			);
@@ -71,10 +69,8 @@ describe( 'ThemeTypeBadge', () => {
 			const popoverTrigger = container.getElementsByClassName( 'theme-type-badge__content' )[ 0 ];
 			await userEvent.hover( popoverTrigger );
 
-			expect( screen.queryByTestId( 'upsell-header' ) ).toBeDefined();
-			expect( screen.queryByTestId( 'upsell-header' ).innerHTML ).toBe( 'Premium theme' );
 			expect( screen.queryByTestId( 'upsell-message' ).innerHTML ).toContain(
-				'This premium theme is included in your plan.'
+				'This theme is included in your plan.'
 			);
 		} );
 
@@ -88,8 +84,6 @@ describe( 'ThemeTypeBadge', () => {
 			const popoverTrigger = container.getElementsByClassName( 'theme-type-badge__content' )[ 0 ];
 			await userEvent.hover( popoverTrigger );
 
-			expect( screen.queryByTestId( 'upsell-header' ) ).toBeDefined();
-			expect( screen.queryByTestId( 'upsell-header' ).innerHTML ).toBe( 'Premium theme' );
 			expect( screen.queryByTestId( 'upsell-message' ).innerHTML ).toContain(
 				'You have purchased this theme.'
 			);

--- a/client/components/theme-type-badge/test/index.jsx
+++ b/client/components/theme-type-badge/test/index.jsx
@@ -55,7 +55,7 @@ describe( 'ThemeTypeBadge', () => {
 			await userEvent.hover( popoverTrigger );
 
 			expect( screen.queryByTestId( 'upsell-message' ).innerHTML ).toContain(
-				'This premium theme is included in the'
+				'This theme is included in the'
 			);
 		} );
 

--- a/client/components/theme-type-badge/tooltip.tsx
+++ b/client/components/theme-type-badge/tooltip.tsx
@@ -124,7 +124,10 @@ const ThemeTypeBadgeTooltip = ( {
 		if ( isPurchased ) {
 			message = translate( 'You have purchased this theme.' );
 		} else if ( isIncludedCurrentPlan ) {
-			message = translate( 'This premium theme is included in your plan.' );
+			message =
+				isEnglishLocale || i18n.hasTranslation( 'This theme is included in your plan.' )
+					? translate( 'This theme is included in your plan.' )
+					: translate( 'This premium theme is included in your plan.' );
 		} else {
 			message = createInterpolateElement(
 				isEnglishLocale ||

--- a/client/components/theme-type-badge/tooltip.tsx
+++ b/client/components/theme-type-badge/tooltip.tsx
@@ -118,7 +118,7 @@ const ThemeTypeBadgeTooltip = ( {
 						{ args: { premiumPlanName: plans?.data?.[ PLAN_PREMIUM ]?.productNameShort ?? '' } }
 				  )
 				: translate(
-						'Unlock this style, and tons of other features, by upgrading to a Premium plantest.'
+						'Unlock this style, and tons of other features, by upgrading to a Premium plan.'
 				  );
 	} else if ( type === PREMIUM_THEME ) {
 		if ( isPurchased ) {

--- a/client/components/theme-type-badge/tooltip.tsx
+++ b/client/components/theme-type-badge/tooltip.tsx
@@ -21,7 +21,6 @@ import {
 	isMarketplaceThemeSubscribed,
 	getMarketplaceThemeSubscriptionPrices,
 } from 'calypso/state/themes/selectors';
-import type { ReactElement } from 'react';
 
 interface Props {
 	canGoToCheckout?: boolean;
@@ -107,41 +106,6 @@ const ThemeTypeBadgeTooltip = ( {
 		} );
 	}, [ themeId ] );
 
-	const getHeader = (): string | ReactElement | null => {
-		if ( isLockedStyleVariation ) {
-			return null;
-		}
-
-		if ( type === BUNDLED_THEME ) {
-			if ( ! bundleSettings ) {
-				return null;
-			}
-
-			const bundleName = bundleSettings.name;
-
-			// Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".
-			return translate( '%(bundleName)s theme', { textOnly: true, args: { bundleName } } );
-		}
-
-		const headers = {
-			[ PREMIUM_THEME ]: translate( 'Premium theme' ),
-			[ DOT_ORG_THEME ]: translate( 'Community theme', {
-				context: 'This theme is developed and supported by a community',
-				textOnly: true,
-			} ),
-			[ MARKETPLACE_THEME ]: translate( 'Partner theme', {
-				context: 'This theme is developed and supported by a theme partner',
-				textOnly: true,
-			} ),
-		} as { [ key: string ]: string };
-
-		if ( ! ( type in headers ) ) {
-			return null;
-		}
-
-		return headers[ type ];
-	};
-
 	let message;
 	if ( isLockedStyleVariation ) {
 		message =
@@ -154,7 +118,7 @@ const ThemeTypeBadgeTooltip = ( {
 						{ args: { premiumPlanName: plans?.data?.[ PLAN_PREMIUM ]?.productNameShort ?? '' } }
 				  )
 				: translate(
-						'Unlock this style, and tons of other features, by upgrading to a Premium plan.'
+						'Unlock this style, and tons of other features, by upgrading to a Premium plantest.'
 				  );
 	} else if ( type === PREMIUM_THEME ) {
 		if ( isPurchased ) {
@@ -165,12 +129,11 @@ const ThemeTypeBadgeTooltip = ( {
 			message = createInterpolateElement(
 				isEnglishLocale ||
 					i18n.hasTranslation(
-						'This premium theme is included in the <Link>%(premiumPlanName)s plan</Link>.'
+						'This theme is included in the <Link>%(premiumPlanName)s plan</Link>.'
 					)
-					? ( translate(
-							'This premium theme is included in the <Link>%(premiumPlanName)s plan</Link>.',
-							{ args: { premiumPlanName: plans?.data?.[ PLAN_PREMIUM ]?.productNameShort ?? '' } }
-					  ) as string )
+					? ( translate( 'This theme is included in the <Link>%(premiumPlanName)s plan</Link>.', {
+							args: { premiumPlanName: plans?.data?.[ PLAN_PREMIUM ]?.productNameShort ?? '' },
+					  } ) as string )
 					: translate( 'This premium theme is included in the <Link>Premium plan</Link>.' ),
 				{
 					Link: (
@@ -225,20 +188,17 @@ const ThemeTypeBadgeTooltip = ( {
 				message = createInterpolateElement(
 					isEnglishLocale ||
 						i18n.hasTranslation(
-							'This %(bundleName)s theme is included in the <Link>%(businessPlanName)s plan</Link>.'
+							'This theme is included in the <Link>%(businessPlanName)s plan</Link>.'
 						)
-						? // Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".
+						? translate( 'This theme is included in the <Link>%(businessPlanName)s plan</Link>.', {
+								args: {
+									bundleName,
+									businessPlanName: plans?.data?.[ PLAN_BUSINESS ]?.productNameShort ?? '',
+								},
+								textOnly: true,
+						  } )
+						: // Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".:
 						  translate(
-								'This %(bundleName)s theme is included in the <Link>%(businessPlanName)s plan</Link>.',
-								{
-									args: {
-										bundleName,
-										businessPlanName: plans?.data?.[ PLAN_BUSINESS ]?.productNameShort ?? '',
-									},
-									textOnly: true,
-								}
-						  )
-						: translate(
 								'This %(bundleName)s theme is included in the <Link>Business plan</Link>.',
 								{
 									args: { bundleName },
@@ -344,14 +304,7 @@ const ThemeTypeBadgeTooltip = ( {
 		}
 	}
 
-	return (
-		<>
-			<div data-testid="upsell-header" className="theme-type-badge-tooltip__header">
-				{ getHeader() }
-			</div>
-			<div data-testid="upsell-message">{ message }</div>
-		</>
-	);
+	return <div data-testid="upsell-message">{ message }</div>;
 };
 
 export default ThemeTypeBadgeTooltip;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1703008778058039/1703000311.938939-slack-C048CUFRGFQ

## Proposed Changes

The changes for the new theme tiers badge was buggy and so we took the opportunity to reduce the tooltip and make it less repetitive when we fixed those in #85508. This quick change follows in those footsteps for the current badge.

 * Premium and Woo themes should say "This theme is included in the Explorer/Premium plan"
 * Partner themes and Community themes should remain unchanged 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start a new site with a new user
2. Ensure the user is on the "English" locale, no Brits please
3. Use the calypso live link to go through onboarding
4. Hover over the different types of "badges" to read their tooltips - Premium, Woo, Partner, Style variations selected and unselected etc. Ensure that where applicable it uses the new premium plan name.
5. Do the same for the showcase
6. Repeat steps 5&6 for a user that existed before today / or doesn't use the English language and check that it does use the Premium plan name

Before | After
-------|------
<img width="615" alt="Screenshot 2023-12-19 at 21 09 36" src="https://github.com/Automattic/wp-calypso/assets/93301/525c22e1-12f1-4d7b-b533-3870ee337758"> | <img width="615" alt="Screenshot 2023-12-19 at 21 08 15" src="https://github.com/Automattic/wp-calypso/assets/93301/0f72ef68-7642-405d-b60e-b26765865053">
<img width="615" alt="Screenshot 2023-12-19 at 21 11 19" src="https://github.com/Automattic/wp-calypso/assets/93301/ae91847b-9a17-40d1-874c-1b8cf73ee116"> | <img width="615" alt="Screenshot 2023-12-19 at 21 10 50" src="https://github.com/Automattic/wp-calypso/assets/93301/daab7036-bc64-4226-9bc9-559943f676e2">

Note that the "Premium" badge still is the "Premium" badge - I've not changed it to the plan name as that would be confusing.


## Pre-merge Checklist


<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?