### PR TITLE
Jetpack Manage: Resolves 149 - add intro cards

### DIFF
--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -127,7 +127,7 @@ export const DotPager = ( {
 	isClickEnabled = false,
 	rotateTime = 0,
 	navArrowSize = 18,
-	tracksPrefix,
+	tracksPrefix = '',
 	includePreviousButton = false,
 	includeNextButton = false,
 	includeFinishButton = false,

--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -7,7 +7,13 @@ import Swipeable from '../swipeable';
 
 import './style.scss';
 
-const Controls = ( { showControlLabels = false, currentPage, numberOfPages, setCurrentPage } ) => {
+const Controls = ( {
+	showControlLabels = false,
+	currentPage,
+	numberOfPages,
+	setCurrentPage,
+	navArrowSize,
+} ) => {
 	const translate = useTranslate();
 	const isRtl = useRtl();
 	if ( numberOfPages < 2 ) {
@@ -42,7 +48,7 @@ const Controls = ( { showControlLabels = false, currentPage, numberOfPages, setC
 					{ /* The arrowLeft icon isn't as bold as arrowRight, so using the same icon and flipping to make sure they match */ }
 					<Icon
 						icon={ arrowRight }
-						size={ 18 }
+						size={ navArrowSize }
 						fill="currentColor"
 						style={
 							/* Flip the icon for languages with LTR direction. */
@@ -62,7 +68,7 @@ const Controls = ( { showControlLabels = false, currentPage, numberOfPages, setC
 					{ showControlLabels && translate( 'Next' ) }
 					<Icon
 						icon={ arrowRight }
-						size={ 18 }
+						size={ navArrowSize }
 						fill="currentColor"
 						style={
 							/* Flip the icon for languages with RTL direction. */
@@ -83,6 +89,7 @@ export const DotPager = ( {
 	onPageSelected = null,
 	isClickEnabled = false,
 	rotateTime = 0,
+	navArrowSize = 18,
 	...props
 } ) => {
 	// Filter out the empty children
@@ -120,6 +127,7 @@ export const DotPager = ( {
 				currentPage={ currentPage }
 				numberOfPages={ numPages }
 				setCurrentPage={ handleSelectPage }
+				navArrowSize={ navArrowSize }
 			/>
 			<Swipeable
 				hasDynamicHeight={ hasDynamicHeight }

--- a/client/components/dot-pager/index.jsx
+++ b/client/components/dot-pager/index.jsx
@@ -1,3 +1,4 @@
+import { Button } from '@automattic/components';
 import { Icon, arrowRight } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate, useRtl } from 'i18n-calypso';
@@ -90,8 +91,14 @@ export const DotPager = ( {
 	isClickEnabled = false,
 	rotateTime = 0,
 	navArrowSize = 18,
+	includePreviousButton = false,
+	includeNextButton = false,
+	includeFinishButton = false,
+	onFinish = () => {},
 	...props
 } ) => {
+	const translate = useTranslate();
+
 	// Filter out the empty children
 	const normalizedChildren = Children.toArray( children ).filter( Boolean );
 
@@ -139,6 +146,30 @@ export const DotPager = ( {
 			>
 				{ normalizedChildren }
 			</Swipeable>
+			{ includePreviousButton && currentPage !== 0 && (
+				<Button
+					className="dot-pager__button dot-pager__button_previous"
+					onClick={ () => setCurrentPage( currentPage - 1 ) }
+				>
+					{ translate( 'Previous' ) }
+				</Button>
+			) }
+			{ includeNextButton && currentPage < numPages - 1 && (
+				<Button
+					className="dot-pager__button dot-pager__button_next is-primary"
+					onClick={ () => setCurrentPage( currentPage + 1 ) }
+				>
+					{ translate( 'Next' ) }
+				</Button>
+			) }
+			{ includeFinishButton && currentPage === numPages - 1 && (
+				<Button
+					className="dot-pager__button dot-pager__button_finish is-primary"
+					onClick={ onFinish }
+				>
+					{ translate( 'Done' ) }
+				</Button>
+			) }
 		</div>
 	);
 };

--- a/client/components/dot-pager/style.scss
+++ b/client/components/dot-pager/style.scss
@@ -55,11 +55,6 @@
 .dot-pager__control-prev,
 .dot-pager__control-next {
 	display: inline-flex;
-
-	svg {
-		width: 18px;
-		height: 18px;
-	}
 	background-color: transparent;
 	color: var(--studio-gray-80);
 

--- a/client/components/dot-pager/style.scss
+++ b/client/components/dot-pager/style.scss
@@ -77,3 +77,9 @@
 		background-color: var(--studio-gray-80);
 	}
 }
+
+.dot-pager {
+	&__button {
+		margin-right: 10px;
+	}
+}

--- a/client/jetpack-cloud/sections/overview/primary/intro-cards/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/intro-cards/index.tsx
@@ -1,0 +1,88 @@
+import { useTranslate } from 'i18n-calypso';
+import DotPager from 'calypso/components/dot-pager';
+
+import './style.scss';
+
+const Card1 = () => {
+	const translate = useTranslate();
+	return (
+		<>
+			<h1>{ translate( '👋 Welcome to Jetpack Manage' ) }</h1>
+			<p>
+				{ translate(
+					'Jetpack Manage helps you to monitor security and performance across all of your sites in a single place.'
+				) }
+			</p>
+			<ul>
+				<li>{ translate( 'Insights: traffic and real-time uptime stats.' ) }</li>
+				<li>{ translate( 'Plugin Updates: bulk update plugins in one click.' ) }</li>
+				<li>{ translate( 'Backups & Scans: safeguard your sites and data.' ) }</li>
+				<li>{ translate( 'Boost: manage performance across all of your sites.' ) }</li>
+			</ul>
+		</>
+	);
+};
+
+const Card2 = () => {
+	const translate = useTranslate();
+	return (
+		<>
+			<h1>{ translate( 'Get notified immediately when a site needs attention' ) }</h1>
+			<p>
+				{ translate(
+					"When we detect an issue with one of your sites, you'll get notified immediately. The dashboard will also flag the issue for that site using a traffic light warning system — red for severe or yellow for a warning."
+				) }
+			</p>
+			<p>
+				{ translate(
+					'You can filter the site list in the dashboard by issue type to zero in on the sites that need your attention.'
+				) }
+			</p>
+		</>
+	);
+};
+
+const Card3 = () => {
+	const translate = useTranslate();
+	return (
+		<>
+			<h1>{ translate( 'Flexible billing and a recurring discount' ) }</h1>
+			<p>
+				{ translate(
+					"With Jetpack Manage, you don't need to commit to a year upfront, and you only pay for the number of days that each license you purchase is active, giving you more flexibility and reducing costs. You get a recurring discount, not just for one year."
+				) }
+			</p>
+		</>
+	);
+};
+
+const Card4 = () => {
+	const translate = useTranslate();
+	return (
+		<>
+			<h1>{ translate( 'Use Jetpack Manage from anywhere' ) }</h1>
+			<p>
+				{ translate(
+					'Jetpack Manage is mobile optimized, meaning you can use it on any device that you own, on the go, on your couch, or at your desk — you decide.'
+				) }
+			</p>
+		</>
+	);
+};
+
+export default function IntroCards( { onFinish = () => {} } ) {
+	return (
+		<DotPager
+			className="intro-cards"
+			navArrowSize={ 24 }
+			includeNextButton
+			includeFinishButton
+			onFinish={ onFinish }
+		>
+			<Card1 />
+			<Card2 />
+			<Card3 />
+			<Card4 />
+		</DotPager>
+	);
+}

--- a/client/jetpack-cloud/sections/overview/primary/intro-cards/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/intro-cards/index.tsx
@@ -75,6 +75,7 @@ export default function IntroCards( { onFinish = () => {} } ) {
 		<DotPager
 			className="intro-cards"
 			navArrowSize={ 24 }
+			tracksPrefix="calypso_jetpack_manage_overview_intro_cards"
 			includeNextButton
 			includeFinishButton
 			onFinish={ onFinish }

--- a/client/jetpack-cloud/sections/overview/primary/intro-cards/style.scss
+++ b/client/jetpack-cloud/sections/overview/primary/intro-cards/style.scss
@@ -1,0 +1,36 @@
+.intro-cards {
+	p,
+	li {
+		font-size: rem(16px);
+		font-weight: 400;
+		line-height: 24px;
+		color: var(--studio-gray-80);
+	}
+
+	h1 {
+		font-size: rem(36px);
+		font-weight: 700;
+		line-height: 48px;
+		color: var(--studio-black);
+		margin-top: 24px;
+		margin-bottom: 16px;
+	}
+
+	ul {
+		margin: 0 0 0 1rem;
+		margin-left: 1rem;
+	}
+
+	.dot-pager {
+		&__control-gap {
+			margin-right: 24px;
+		}
+		&__button {
+			padding: 5px 26px;
+		}
+	}
+}
+
+.card:has(.intro-cards) {
+	padding: 32px;
+}

--- a/client/jetpack-cloud/sections/overview/primary/overview/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/overview/index.tsx
@@ -1,16 +1,36 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
+import IntroCards from '../intro-cards';
 
 import './style.scss';
 
 export default function Overview() {
 	const translate = useTranslate();
 
+	const [ hideIntroCards, setHideIntroCards ] = useState( () => {
+		const rawPref = localStorage.getItem( 'jetpack_manage_hide_intro_cards' ) ?? 'false';
+		try {
+			return JSON.parse( rawPref );
+		} catch {
+			return false;
+		}
+	} );
+
+	const finishHandler = () => {
+		setHideIntroCards( true );
+		localStorage.setItem( 'jetpack_manage_hide_intro_cards', JSON.stringify( true ) );
+	};
+
 	return (
 		<div className="overview">
 			<DocumentHead title={ translate( 'Overview' ) } />
-			<Card className="overview__welcome">{ /*<OverviewWelcome />*/ }</Card>
+			{ ! hideIntroCards && (
+				<Card>
+					<IntroCards onFinish={ finishHandler } />
+				</Card>
+			) }
 			{ /*<Card className="overview__steps">*/ }
 			{ /*	/!*<OverviewSteps />*!/*/ }
 			{ /*</Card>*/ }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Jetpack Manage: Resolves Automattic/jetpack-manage#149 - add intro cards

## Proposed Changes
This adds intro cards to the overview page.

* Technical scope: pf36In-mf-p2#intro-cards
* Design: pf36In-fY-p2
* Copy: pf36In-7y-p2

I modified the `DotPager` component to allow for Previous, Next, and Finish buttons, an onFinish function, and a navArrowSize.

The component will be hidden once the "Done" button is clicked, which sets a `jetpack_manage_hide_intro_cards` key in `localStorage` to `true`.

Note that the `DotPager` component has a `hasDynamicHeight` prop, but I opted not to use it, as this would shift future lower components up and down whenever changing a slide.

## Testing Instructions
1. There should be 4 slides, which currently match the copy in the link above.
2. Navigating using the dots, the arrows, or the Next button should work as expected. While the Previous button was implemented, it was not enabled in this component so as to match the given design.
3. Clicking "Done" will hide the component immediately, and persist on refresh.
4. All nav actions should fire a tracks event.

One can reset the localStorage value with the following:

`delete localStorage.jetpack_manage_hide_intro_cards;`

![image](https://github.com/Automattic/wp-calypso/assets/32492176/2793f1b8-b14c-475e-921e-2043f887ceae)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?