### PR TITLE
Jetpack Manage Signup - Managed sites: Add default value and unify styling

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -1,16 +1,17 @@
 import { Button, Gridicon } from '@automattic/components';
-import { SelectControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState, useMemo, ChangeEvent, useEffect } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
+import FormSelect from 'calypso/components/forms/form-select';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { PartnerDetailsPayload } from 'calypso/state/partner-portal/types';
 import PartnerProgramOptInFieldSet from '../partner-program-opt-in-fieldset/partner-program-opt-in-fieldset';
 import SearchableDropdown from '../searchable-dropdown';
 import { Option as CountryOption, useCountriesAndStates } from './hooks/use-countries-and-states';
+import type { FormEventHandler } from 'react';
 
 import './style.scss';
 
@@ -153,6 +154,14 @@ export default function CompanyDetailsForm( {
 		[ showCountryFields, isLoading, onSubmit, payload ]
 	);
 
+	// <FormSelect> complains if we "just" pass "setManagedSites" because it expects
+	// React.FormEventHandler, so this wrapper function is made to satisfy everything
+	// in an easily readable way.
+	const handleSetManagedSites: FormEventHandler = ( { target } ) => {
+		const value: string = ( target as HTMLSelectElement ).value;
+		setManagedSites( value );
+	};
+
 	return (
 		<div className="company-details-form">
 			<form onSubmit={ handleSubmit }>
@@ -231,21 +240,26 @@ export default function CompanyDetailsForm( {
 				) }
 				{ showSignupFields && (
 					<FormFieldset>
-						<FormLabel>{ translate( 'How many sites do you manage?' ) }</FormLabel>
-						<SelectControl
-							id="managed_sites"
+						<FormLabel htmlFor="managed_sites">
+							{ translate( 'How many sites do you manage?' ) }
+						</FormLabel>
+						<FormSelect
 							name="managed_sites"
-							value={ managedSites }
-							options={ [
-								{ value: '1-5', label: translate( '1-5' ) },
-								{ value: '6-20', label: translate( '6-20' ) },
-								{ value: '21-50', label: translate( '21-50' ) },
-								{ value: '51-100', label: translate( '51-100' ) },
-								{ value: '101-500', label: translate( '101-500' ) },
-								{ value: '500+', label: translate( '500+' ) },
-							] }
-							onChange={ setManagedSites }
-						/>
+							id="managed_sites"
+							// We check for an empty "managedSites" here (instead of defining it as the fallback
+							// state value) so we do not set "managed sites" to "1-5" for all older partners
+							// when they update their company details which would otherwise happen since we
+							// pass all inputs as the payload no matter what page is being used.
+							value={ managedSites.length === 0 ? '1-5' : managedSites }
+							onChange={ handleSetManagedSites }
+						>
+							<option value="1-5">{ translate( '1-5' ) }</option>
+							<option value="6-20">{ translate( '6-20' ) }</option>
+							<option value="21-50">{ translate( '21-50' ) }</option>
+							<option value="51-100">{ translate( '51-100' ) }</option>
+							<option value="101-500">{ translate( '101-500' ) }</option>
+							<option value="500+">{ translate( '500+' ) }</option>
+						</FormSelect>
 					</FormFieldset>
 				) }
 				<FormFieldset>

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -253,11 +253,11 @@ export default function CompanyDetailsForm( {
 							value={ managedSites.length === 0 ? '1-5' : managedSites }
 							onChange={ handleSetManagedSites }
 						>
-							<option value="1-5">{ translate( '1-5' ) }</option>
-							<option value="6-20">{ translate( '6-20' ) }</option>
-							<option value="21-50">{ translate( '21-50' ) }</option>
-							<option value="51-100">{ translate( '51-100' ) }</option>
-							<option value="101-500">{ translate( '101-500' ) }</option>
+							<option value="1-5">{ translate( '1–5' ) }</option>
+							<option value="6-20">{ translate( '6–20' ) }</option>
+							<option value="21-50">{ translate( '21–50' ) }</option>
+							<option value="51-100">{ translate( '51–100' ) }</option>
+							<option value="101-500">{ translate( '101–500' ) }</option>
 							<option value="500+">{ translate( '500+' ) }</option>
 						</FormSelect>
 					</FormFieldset>

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/index.tsx
@@ -77,7 +77,9 @@ export default function CompanyDetailsForm( {
 	const [ contactPerson, setContactPerson ] = useState( initialValues.contactPerson ?? '' );
 	const [ companyWebsite, setCompanyWebsite ] = useState( initialValues.companyWebsite ?? '' );
 	const [ companyType, setCompanyType ] = useState( initialValues.companyType ?? '' );
-	const [ managedSites, setManagedSites ] = useState( initialValues.managedSites ?? '' );
+	const [ managedSites, setManagedSites ] = useState(
+		initialValues.managedSites ?? ( showSignupFields ? '1-5' : '' )
+	);
 	const [ partnerProgramOptIn, setPartnerProgramOptIn ] = useState( false );
 
 	const [ showPartnerProgramOptIn, setShowPartnerProgramOptIn ] = useState( false );
@@ -246,11 +248,7 @@ export default function CompanyDetailsForm( {
 						<FormSelect
 							name="managed_sites"
 							id="managed_sites"
-							// We check for an empty "managedSites" here (instead of defining it as the fallback
-							// state value) so we do not set "managed sites" to "1-5" for all older partners
-							// when they update their company details which would otherwise happen since we
-							// pass all inputs as the payload no matter what page is being used.
-							value={ managedSites.length === 0 ? '1-5' : managedSites }
+							value={ managedSites }
 							onChange={ handleSetManagedSites }
 						>
 							<option value="1-5">{ translate( '1–5' ) }</option>

--- a/client/jetpack-cloud/sections/partner-portal/company-details-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/company-details-form/style.scss
@@ -21,4 +21,8 @@
 		line-height: 24px;
 		color: var(--studio-black);
 	}
+
+	select {
+		width: 100%;
+	}
 }


### PR DESCRIPTION
We do not provide `1-5` as the default value for "Managed sites" when signing up to Jetpack Manage which means we're just storing an empty value if they do not change the `select` to some other value (e.g.: `6-20`).

Additionally: Before this change the select looked slightly different from the other inputs on the page because it didn't use a components/forms component. 

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-manage/issues/189

## Proposed Changes

* Convert the input to `<FormSelect>` so it looks like the rest of the inputs
* Add `1-5` as the default value when signing up.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up branch
* Create a new WPCOM user
* Go to `/manage/signup`
* Fill out all fields, but do not touch the `Managed Sites` input
* Submit the form
* Go to https://dashboard.stripe.com/customers and verify that your newly created customer has a meta data that represents "1-5 managed sites"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

## Screenshots

### Before

![Screenshot 2023-12-19 at 21 51 47](https://github.com/Automattic/wp-calypso/assets/3846700/e8adcecc-9f6a-416b-bc52-398d972c5b21)

## After

![Screenshot 2023-12-19 at 21 50 32](https://github.com/Automattic/wp-calypso/assets/3846700/6d99391b-a02e-4d96-a5b0-bfa2573285cc)
