### PR TITLE
Don't hardcode plan name for global styles in showcase

### DIFF
--- a/packages/global-styles/package.json
+++ b/packages/global-styles/package.json
@@ -32,6 +32,7 @@
 		"@automattic/calypso-sentry": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",
+		"@automattic/i18n-utils": "workspace:^",
 		"@tanstack/react-query": "^4.36.1",
 		"@wordpress/block-editor": "^12.16.0",
 		"@wordpress/block-library": "^8.25.0",

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -109,7 +109,7 @@ const GlobalStylesVariations = ( {
 		translate(
 			'Unlock style variations and tons of other features with the %(planName)s plan, or try them out now for free.',
 			{ args: { planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' } }
-		)
+		) as string
 	)
 		? translate(
 				'Unlock style variations and tons of other features with the %(planName)s plan, or try them out now for free.',
@@ -199,7 +199,7 @@ const GlobalStylesVariations = ( {
 									{ hasEnTranslation(
 										translate( 'Style Variation', 'Style Variations', {
 											count: nonDefaultStyles.length,
-										} )
+										} ) as string
 									)
 										? translate( 'Style Variation', 'Style Variations', {
 												count: nonDefaultStyles.length,

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -1,5 +1,6 @@
 import { PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
 import { PremiumBadge } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useState } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 import classnames from 'classnames';
@@ -102,11 +103,21 @@ const GlobalStylesVariations = ( {
 	needsUpgrade = true,
 	onSelect,
 }: GlobalStylesVariationsProps ) => {
+	const hasEnTranslation = useHasEnTranslation();
 	const isRegisteredCoreBlocks = useRegisterCoreBlocks();
-	const premiumStylesDescription = translate(
-		'Unlock style variations and tons of other features with the %(planName)s plan, or try them out now for free.',
-		{ args: { planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' } }
-	);
+	const premiumStylesDescription = hasEnTranslation(
+		translate(
+			'Unlock style variations and tons of other features with the %(planName)s plan, or try them out now for free.',
+			{ args: { planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' } }
+		)
+	)
+		? translate(
+				'Unlock style variations and tons of other features with the %(planName)s plan, or try them out now for free.',
+				{ args: { planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' } }
+		  )
+		: translate(
+				'Unlock premium styles and tons of other features with the Premium plan, or try them out now for free.'
+		  );
 
 	const baseGlobalStyles = useMemo(
 		() =>
@@ -185,9 +196,17 @@ const GlobalStylesVariations = ( {
 						<div className="global-styles-variations__header">
 							<h2>
 								<span>
-									{ translate( 'Premium Style', 'Premium Styles', {
-										count: nonDefaultStyles.length,
-									} ) }
+									{ hasEnTranslation(
+										translate( 'Style Variation', 'Style Variations', {
+											count: nonDefaultStyles.length,
+										} )
+									)
+										? translate( 'Style Variation', 'Style Variations', {
+												count: nonDefaultStyles.length,
+										  } )
+										: translate( 'Premium Style', 'Premium Styles', {
+												count: nonDefaultStyles.length,
+										  } ) }
 								</span>
 								<PremiumBadge
 									shouldHideTooltip

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -1,3 +1,4 @@
+import { PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
 import { PremiumBadge } from '@automattic/components';
 import { useState } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
@@ -103,7 +104,8 @@ const GlobalStylesVariations = ( {
 }: GlobalStylesVariationsProps ) => {
 	const isRegisteredCoreBlocks = useRegisterCoreBlocks();
 	const premiumStylesDescription = translate(
-		'Unlock premium styles and tons of other features with the Premium plan, or try them out now for free.'
+		'Unlock style variations and tons of other features with the %(planName)s plan, or try them out now for free.',
+		{ args: { planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' } }
 	);
 
 	const baseGlobalStyles = useMemo(

--- a/yarn.lock
+++ b/yarn.lock
@@ -910,6 +910,7 @@ __metadata:
     "@automattic/calypso-typescript-config": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"
+    "@automattic/i18n-utils": "workspace:^"
     "@tanstack/react-query": "npm:^4.36.1"
     "@types/wordpress__block-library": "npm:^2.6.1"
     "@wordpress/block-editor": "npm:^12.16.0"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1703000311938939-slack-C048CUFRGFQ

## Proposed Changes

When describing style variations on the theme details pages the text hardcoded the plan name. Now the proper plan name is retrieved.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Start a new site with a new user
2. Ensure the user is on the "English" locale, no brits please
3. Go to /themes using the calypso live link below
4. Find a free theme with style variations and open the theme details
5. Check that global styles text doesn't mention the premium plan, but rather, the explorers plan.
6. Try on a regular, old whatever language user, you should get the current live text which will always say 'premium plan', or the translation thereof.

Before | After
-------|------
<img width="667" alt="Screenshot 2023-12-19 at 20 55 39" src="https://github.com/Automattic/wp-calypso/assets/93301/dac938b9-ce96-4bd3-8676-61b7098d58c7"> |<img width="667" alt="Screenshot 2023-12-19 at 20 55 12" src="https://github.com/Automattic/wp-calypso/assets/93301/14023e8d-dce6-4d13-882b-18b5477bb86d">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?