### PR TITLE
Add calypso build to components package

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -57,6 +57,7 @@
 		"react-dom": "^18.2.0"
 	},
 	"devDependencies": {
+		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-color-schemes": "workspace:^",
 		"@automattic/calypso-storybook": "workspace:^",
 		"@automattic/calypso-typescript-config": "workspace:^",
@@ -68,9 +69,11 @@
 		"@testing-library/user-event": "^14.5.1",
 		"@types/canvas-confetti": "^1.6.0",
 		"@types/react-slider": "^1.3.4",
+		"postcss": "^8.4.5",
 		"qrcode.react": "^3.1.0",
 		"resize-observer-polyfill": "^1.5.1",
-		"typescript": "^5.3.2"
+		"typescript": "^5.3.2",
+		"webpack": "^5.89.0"
 	},
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -532,6 +532,7 @@ __metadata:
   resolution: "@automattic/components@workspace:packages/components"
   dependencies:
     "@automattic/calypso-analytics": "workspace:^"
+    "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-color-schemes": "workspace:^"
     "@automattic/calypso-storybook": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
@@ -558,6 +559,7 @@ __metadata:
     gridicons: "npm:^3.4.2"
     i18n-calypso: "workspace:^"
     lodash: "npm:^4.17.21"
+    postcss: "npm:^8.4.5"
     prop-types: "npm:^15.7.2"
     qrcode.react: "npm:^3.1.0"
     react-modal: "npm:^3.16.1"
@@ -567,6 +569,7 @@ __metadata:
     typescript: "npm:^5.3.2"
     utility-types: "npm:^3.10.0"
     uuid: "npm:^8.3.2"
+    webpack: "npm:^5.89.0"
     wpcom-proxy-request: "workspace:^"
   peerDependencies:
     "@wordpress/data": ^9.18.0


### PR DESCRIPTION
Adds calypso build as a dependency of the components package, which fixes `yarn prepack` for that package. This happens because yarn cannot lookup the copy-assets bin script provided by calypso build.