### PR TITLE
Checkout: Update hook to deploy 'Collapse Last Step' treatment

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -42,7 +42,6 @@ import usePrepareProductsForCart from '../hooks/use-prepare-products-for-cart';
 import useRecordCartLoaded from '../hooks/use-record-cart-loaded';
 import useRecordCheckoutLoaded from '../hooks/use-record-checkout-loaded';
 import useRemoveFromCartAndRedirect from '../hooks/use-remove-from-cart-and-redirect';
-import { useShouldCollapseLastStep } from '../hooks/use-should-collapse-last-step';
 import { useStoredPaymentMethods } from '../hooks/use-stored-payment-methods';
 import { logStashLoadErrorEvent, logStashEvent, convertErrorToString } from '../lib/analytics';
 import existingCardProcessor from '../lib/existing-card-processor';
@@ -523,8 +522,6 @@ export default function CheckoutMain( {
 		: {};
 	const theme = { ...checkoutTheme, colors: { ...checkoutTheme.colors, ...jetpackColors } };
 
-	const isCollapseExperimentLoading = useShouldCollapseLastStep() === 'loading';
-
 	// This variable determines if we see the loading page or if checkout can
 	// render its steps.
 	//
@@ -548,7 +545,6 @@ export default function CheckoutMain( {
 			isLoading: responseCart.products.length < 1,
 		},
 		{ name: translate( 'Loading countries list' ), isLoading: countriesList.length < 1 },
-		{ name: translate( 'Loading Site' ), isLoading: isCollapseExperimentLoading },
 	];
 	const isCheckoutPageLoading: boolean = checkoutLoadingConditions.some(
 		( condition ) => condition.isLoading

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -90,7 +90,7 @@ export default function BeforeSubmitCheckoutHeader() {
 	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
-	const shouldCollapseLastStep = useShouldCollapseLastStep() === 'collapse';
+	const shouldCollapseLastStep = useShouldCollapseLastStep();
 	const translate = useTranslate();
 	const subtotalWithoutCoupon = getSubtotalWithoutCoupon( responseCart );
 	const subTotalLineItemWithoutCoupon: LineItemType = {

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -332,7 +332,7 @@ export default function WPCheckout( {
 	const { transactionStatus } = useTransactionStatus();
 	const paymentMethod = usePaymentMethod();
 	const showToSFoldableCard = useToSFoldableCard();
-	const shouldCollapseLastStep = useShouldCollapseLastStep() === 'collapse';
+	const shouldCollapseLastStep = useShouldCollapseLastStep();
 	const excluded3PDAccountProductSlugs = [ 'sensei_pro_monthly', 'sensei_pro_yearly' ];
 
 	const hasMarketplaceProduct = useSelector( ( state ) => {
@@ -848,7 +848,7 @@ function CheckoutTermsAndCheckboxes( {
 	} );
 
 	const translate = useTranslate();
-	const shouldCollapseLastStep = useShouldCollapseLastStep() === 'collapse';
+	const shouldCollapseLastStep = useShouldCollapseLastStep();
 
 	if ( ! shouldCollapseLastStep ) {
 		return null;

--- a/client/my-sites/checkout/src/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/src/hooks/use-cached-domain-contact-details.ts
@@ -79,10 +79,6 @@ function useCachedContactDetailsForCheckoutForm(
 		if ( didFillForm.current ) {
 			return;
 		}
-		if ( collapseLastStepStatus === 'loading' ) {
-			debug( 'prepopulating cached contact details waiting on Explat' );
-			return;
-		}
 		// Do nothing if the contact details are loading, or the countries are loading.
 		if ( ! cachedContactDetails ) {
 			debug( 'cached contact details for form have not loaded' );
@@ -105,7 +101,7 @@ function useCachedContactDetailsForCheckoutForm(
 				if ( cachedContactDetails.countryCode ) {
 					setShouldShowContactDetailsValidationErrors( false );
 					debug( 'Contact details are populated; attempting to skip to payment method step' );
-					if ( collapseLastStepStatus === 'collapse' ) {
+					if ( collapseLastStepStatus ) {
 						debug( 'also attempting to skip payment method step' );
 						return setStepCompleteStatus( 'payment-method-step' );
 					}

--- a/client/my-sites/checkout/src/hooks/use-should-collapse-last-step.tsx
+++ b/client/my-sites/checkout/src/hooks/use-should-collapse-last-step.tsx
@@ -1,12 +1,11 @@
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
-import { useExperiment } from 'calypso/lib/explat';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import { useSelector } from 'calypso/state';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
-export function useShouldCollapseLastStep(): 'loading' | 'collapse' | 'no-collapse' {
+export function useShouldCollapseLastStep(): boolean {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 
 	const isJetpackNotAtomic = useSelector(
@@ -14,17 +13,10 @@ export function useShouldCollapseLastStep(): 'loading' | 'collapse' | 'no-collap
 	);
 
 	const isWPcomCheckout = ! isJetpackCheckout() && ! isAkismetCheckout() && ! isJetpackNotAtomic;
-	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
-		'wp_web_checkout_collapse_payment_method_2',
-		{ isEligible: isWPcomCheckout }
-	);
 
-	if ( isLoadingExperimentAssignment ) {
-		return 'loading';
+	if ( isWPcomCheckout ) {
+		return true;
 	}
 
-	if ( experimentAssignment?.variationName === 'treatment' ) {
-		return 'collapse';
-	}
-	return 'no-collapse';
+	return false;
 }

--- a/client/my-sites/checkout/src/test/use-cached-domain-contact-details.tsx
+++ b/client/my-sites/checkout/src/test/use-cached-domain-contact-details.tsx
@@ -51,6 +51,11 @@ function MyTestWrapper( {
 							activeStepContent={ <MyTestContent countries={ countries } /> }
 						/>
 						<CheckoutStep
+							stepId="payment-method-step"
+							titleContent={ <em>Payment Method Step</em> }
+							isCompleteCallback={ () => false }
+						/>
+						<CheckoutStep
 							stepId="other-step"
 							titleContent={ <em>Other step</em> }
 							isCompleteCallback={ () => false }


### PR DESCRIPTION
The past ten days of data from the Collapse Last Step experiment (21547-explat-experiment) has shown a near identical performance between the old 'default to open' payment step and the treatment. This has provided us with enough confidence that there is no discernible regression in checkout conversions so we are deploying the treatment.

Experiment post pbxNRc-3le-p2

Related to #83985

## Proposed Changes
This PR is simply removing the experiment logic and displays the treatment content for WPCOM checkout only. Jetpack and Akismet checkout will still receive the control content.

Updating the hook in this way will give Jetpack/Akismet, and other teams, time to test the collapsed payment step with their product checkout flows.

| Control | Treatment |
| ----- | ----- |
| <img width="1439" alt="image" src="https://github.com/Automattic/wp-calypso/assets/16580129/1de86a0f-dc01-4663-a022-a7a4ea53ed98" width="400px"> | <img width="1440" alt="image" src="https://github.com/Automattic/wp-calypso/assets/16580129/ab8cb5f4-a16b-4395-912e-e2777184b083" width="400px"> |


## Testing Instructions

* On an account with no payment methods, add a plan to your cart and go to checkout
* Ensure that the last step (payment method) is **not collapsed** and prompts you to enter in your payment details
* Then, add a payment method and go back to checkout, ensure that the last step **is collapsed**
* This collapsed behavior should only show for WordPress.com products in the cart, not Jetpack or Akismet