### PR TITLE
Monetize: Use inline support for customers screen

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -166,6 +166,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/paid-newsletters/',
 		post_id: 168381,
 	},
+	payments_blocks: {
+		link: 'https://wordpress.com/support/wordpress-editor/blocks/payments',
+		post_id: 169123,
+	},
 	payment_button_block: {
 		link: 'https://wordpress.com/support/wordpress-editor/blocks/payments/#payment-button-block',
 		post_id: 169123,

--- a/client/my-sites/earn/customers/index.tsx
+++ b/client/my-sites/earn/customers/index.tsx
@@ -1,6 +1,5 @@
 import { Card, Button, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { saveAs } from 'browser-filesaver';
 import { useTranslate } from 'i18n-calypso';
 import { orderBy } from 'lodash';
@@ -11,6 +10,7 @@ import QueryMembershipsSettings from 'calypso/components/data/query-memberships-
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import Gravatar from 'calypso/components/gravatar';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
+import InlineSupportLink from 'calypso/components/inline-support-link';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
@@ -112,19 +112,16 @@ function CustomerSection() {
 			<div>
 				{ Object.values( subscribers ).length === 0 && (
 					<Card>
-						{ translate( "You haven't added any customers. {{a}}Learn more{{/a}} about payments.", {
-							components: {
-								a: (
-									<a
-										href={ localizeUrl(
-											'https://wordpress.com/support/wordpress-editor/blocks/payments/'
-										) }
-										target="_blank"
-										rel="noreferrer noopener"
-									/>
-								),
-							},
-						} ) }
+						{ translate(
+							"You haven't added any customers. {{learnMoreLink}}Learn more{{/learnMoreLink}} about payments.",
+							{
+								components: {
+									learnMoreLink: (
+										<InlineSupportLink supportContext="payments_blocks" showIcon={ false } />
+									),
+								},
+							}
+						) }
 					</Card>
 				) }
 				{ Object.values( subscribers ).length > 0 && (


### PR DESCRIPTION
## Proposed Changes

Updates support link on Monetize > Supporters screen to be an inline support link.

## Testing Instructions

Go to http://calypso.localhost:3000/earn/supporters/YOURSITESLUG on a simple site that has no current paid subscribers. You will see a Learn More link to learn about payment. Click that and confirm the relevant inline support opens (vs directing out to full wordpress.com link). 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?