### PR TITLE
GF Signup: Dropdown Interval: Implement mobile sticky plan type selector behavior

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -20,6 +20,7 @@ import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
 import { isAnyHostingFlow } from '@automattic/onboarding';
+import { isMobile } from '@automattic/viewport';
 import styled from '@emotion/styled';
 import { useDispatch } from '@wordpress/data';
 import {
@@ -701,10 +702,10 @@ const PlansFeaturesMain = ( {
 	const isPlansGridReady = ! isLoadingGridPlans && ! resolvedSubdomainName.isLoading;
 
 	const stickyPlanSelectorHeight = 48;
-
-	const comparisonGridStickyRowOffset = showPlanSelectorDropdown
-		? stickyPlanSelectorHeight + masterbarHeight
-		: masterbarHeight;
+	const comparisonGridStickyRowOffset =
+		showPlanSelectorDropdown && isMobile()
+			? stickyPlanSelectorHeight + masterbarHeight
+			: masterbarHeight;
 
 	return (
 		<>
@@ -783,10 +784,10 @@ const PlansFeaturesMain = ( {
 								stickyClass="is-sticky-plan-type-selector"
 								className="plans-features-main__plan-type-selector-sticky-container"
 							>
-								{ ( isStuck: boolean ) => {
+								{ () => {
 									return (
 										<div className="plans-features-main__plan-type-selector">
-											<PlanTypeSelector { ...planTypeSelectorProps } isStuck={ isStuck } />
+											<PlanTypeSelector { ...planTypeSelectorProps } />
 										</div>
 									);
 								} }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -777,7 +777,10 @@ const PlansFeaturesMain = ( {
 				{ isPlansGridReady && (
 					<>
 						{ ! hidePlanSelector && (
-							<StickyContainer stickyClass="is-sticky-plan-type-selector">
+							<StickyContainer
+								stickyClass="is-sticky-plan-type-selector"
+								className="plans-features-main__plan-type-selector-sticky-container"
+							>
 								{ ( isStuck: boolean ) => {
 									return (
 										<div className="plans-features-main__plan-type-selector">

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -34,7 +34,7 @@ import {
 import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
-import { useInView } from 'react-intersection-observer';
+// import { useInView } from 'react-intersection-observer';
 import { useSelector } from 'react-redux';
 import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
 import QueryPlans from 'calypso/components/data/query-plans';
@@ -700,9 +700,9 @@ const PlansFeaturesMain = ( {
 	);
 
 	const isPlansGridReady = ! isLoadingGridPlans && ! resolvedSubdomainName.isLoading;
-	const [ comparisonGridPlanTypeSelectorRef, isComparisonGridPlanTypeSelectorInView ] = useInView( {
-		rootMargin: '0px 0px -300px 0px',
-	} );
+	// const [ comparisonGridPlanTypeSelectorRef, isComparisonGridPlanTypeSelectorInView ] = useInView( {
+	// 	rootMargin: '0px 0px -300px 0px',
+	// } );
 
 	const stickyPlanTypeSelectorHeight = 48;
 	const comparisonGridStickyRowOffset =
@@ -783,15 +783,12 @@ const PlansFeaturesMain = ( {
 				{ isPlansGridReady && (
 					<>
 						{ ! hidePlanSelector && (
-							// TODO: Migrate plans-features-main__plan-type-selector styles
-							// <div className="plans-features-main__plan-type-selector">
 							<PlanTypeSelector
 								{ ...planTypeSelectorProps }
-								enableStickyBehavior={ true }
-								showPlanTypeSelectorDropdown={ showPlanTypeSelectorDropdown }
-								isComparisonGridPlanTypeSelectorInView={ isComparisonGridPlanTypeSelectorInView }
+								layoutClassName="plans-features-main__plan-type-selector-layout"
+								enableStickyBehavior={ isMobile() && showPlanTypeSelectorDropdown }
+								// isComparisonGridPlanTypeSelectorInView={ isComparisonGridPlanTypeSelectorInView }
 							/>
-							// </div>
 						) }
 						<div
 							className={ classNames(
@@ -862,12 +859,10 @@ const PlansFeaturesMain = ( {
 												{ translate( 'Compare our plans and find yours' ) }
 											</PlanComparisonHeader>
 											{ ! hidePlanSelector && showPlansComparisonGrid && (
-												<div
-													className="plans-features-main__plan-type-selector"
-													ref={ comparisonGridPlanTypeSelectorRef }
-												>
-													<PlanTypeSelector { ...planTypeSelectorProps } />
-												</div>
+												<PlanTypeSelector
+													{ ...planTypeSelectorProps }
+													layoutClassName="plans-features-main__plan-type-selector-layout"
+												/>
 											) }
 											<ComparisonGrid
 												gridPlans={ gridPlansForComparisonGrid }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -64,6 +64,7 @@ import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-f
 import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import { getCurrentPlan, isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
 import { getSitePlanSlug, getSiteSlug, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
+import { StickyContainer } from '../plans-grid/components/sticky-container';
 import ComparisonGridToggle from './components/comparison-grid-toggle';
 import PlanUpsellModal from './components/plan-upsell-modal';
 import { useModalResolutionCallback } from './components/plan-upsell-modal/hooks/use-modal-resolution-callback';
@@ -769,9 +770,15 @@ const PlansFeaturesMain = ( {
 				{ isPlansGridReady && (
 					<>
 						{ ! hidePlanSelector && (
-							<div className="plans-features-main__plan-type-selector">
-								<PlanTypeSelector { ...planTypeSelectorProps } />
-							</div>
+							<StickyContainer stickyClass="is-sticky-plan-type-selector">
+								{ ( isStuck: boolean ) => {
+									return (
+										<div className="plans-features-main__plan-type-selector">
+											<PlanTypeSelector { ...planTypeSelectorProps } isStuck={ isStuck } />
+										</div>
+									);
+								} }
+							</StickyContainer>
 						) }
 						<div
 							className={ classNames(

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -263,7 +263,7 @@ const PlansFeaturesMain = ( {
 	const { setShowDomainUpsellDialog } = useDispatch( WpcomPlansUI.store );
 	const domainFromHomeUpsellFlow = useSelector( getDomainFromHomeUpsellInQuery );
 	const showUpgradeableStorage = config.isEnabled( 'plans/upgradeable-storage' );
-	const showPlanSelectorDropdown = config.isEnabled( 'onboarding/interval-dropdown' );
+	const showPlanTypeSelectorDropdown = config.isEnabled( 'onboarding/interval-dropdown' );
 	const observableForOdieRef = useObservableForOdie();
 	const currentPlanManageHref = useCurrentPlanManageHref();
 	const canUserManageCurrentPlan = useSelector( ( state: IAppState ) =>
@@ -522,7 +522,7 @@ const PlansFeaturesMain = ( {
 			selectedPlan,
 			selectedFeature,
 			showBiennialToggle,
-			showPlanSelectorDropdown,
+			showPlanTypeSelectorDropdown,
 			kind: planTypeSelector,
 			plans: gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug ),
 			currentSitePlanSlug: sitePlanSlug,
@@ -543,7 +543,7 @@ const PlansFeaturesMain = ( {
 		isPlansInsideStepper,
 		isStepperUpgradeFlow,
 		showBiennialToggle,
-		showPlanSelectorDropdown,
+		showPlanTypeSelectorDropdown,
 		eligibleForWpcomMonthlyPlans,
 	] );
 
@@ -707,7 +707,7 @@ const PlansFeaturesMain = ( {
 
 	const stickyPlanTypeSelectorHeight = 48;
 	const comparisonGridStickyRowOffset =
-		showPlanSelectorDropdown && isMobile()
+		showPlanTypeSelectorDropdown && isMobile()
 			? stickyPlanTypeSelectorHeight + masterbarHeight
 			: masterbarHeight;
 

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -520,6 +520,7 @@ const PlansFeaturesMain = ( {
 			selectedPlan,
 			selectedFeature,
 			showBiennialToggle,
+			showPlanSelectorDropdown,
 			kind: planTypeSelector,
 			plans: gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug ),
 			currentSitePlanSlug: sitePlanSlug,
@@ -540,6 +541,7 @@ const PlansFeaturesMain = ( {
 		isPlansInsideStepper,
 		isStepperUpgradeFlow,
 		showBiennialToggle,
+		showPlanSelectorDropdown,
 		eligibleForWpcomMonthlyPlans,
 	] );
 

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -34,7 +34,7 @@ import {
 import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
-import { useInView } from 'react-intersection-observer';
+// import { useInView } from 'react-intersection-observer';
 import { useSelector } from 'react-redux';
 import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
 import QueryPlans from 'calypso/components/data/query-plans';
@@ -66,7 +66,7 @@ import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-f
 import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import { getCurrentPlan, isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
 import { getSitePlanSlug, getSiteSlug, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
-import { StickyContainer } from '../plans-grid/components/sticky-container';
+// import { StickyContainer } from '../plans-grid/components/sticky-container';
 import ComparisonGridToggle from './components/comparison-grid-toggle';
 import PlanUpsellModal from './components/plan-upsell-modal';
 import { useModalResolutionCallback } from './components/plan-upsell-modal/hooks/use-modal-resolution-callback';
@@ -701,9 +701,9 @@ const PlansFeaturesMain = ( {
 	);
 
 	const isPlansGridReady = ! isLoadingGridPlans && ! resolvedSubdomainName.isLoading;
-	const [ comparisonGridPlanTypeSelectorRef, isComparisonGridPlanTypeSelectorInView ] = useInView( {
-		rootMargin: '0px 0px -300px 0px',
-	} );
+	// const [ comparisonGridPlanTypeSelectorRef, isComparisonGridPlanTypeSelectorInView ] = useInView( {
+	// 	rootMargin: '0px 0px -300px 0px',
+	// } );
 
 	const stickyPlanTypeSelectorHeight = 48;
 	const comparisonGridStickyRowOffset =
@@ -784,21 +784,13 @@ const PlansFeaturesMain = ( {
 				{ isPlansGridReady && (
 					<>
 						{ ! hidePlanSelector && (
-							<StickyContainer
-								stickyClass="is-sticky-plan-type-selector"
-								className={ classNames(
-									'plans-features-main__plan-type-selector-sticky-container',
-									{ [ 'is-hidden' ]: isComparisonGridPlanTypeSelectorInView }
-								) }
-							>
-								{ () => {
-									return (
-										<div className="plans-features-main__plan-type-selector">
-											<PlanTypeSelector { ...planTypeSelectorProps } />
-										</div>
-									);
-								} }
-							</StickyContainer>
+							<div className="plans-features-main__plan-type-selector">
+								<PlanTypeSelector
+									{ ...planTypeSelectorProps }
+									// isComparisonGridPlanTypeSelectorInView={ isComparisonGridPlanTypeSelectorInView }
+									showPlanTypeSelectorDropdown={ showPlanTypeSelectorDropdown }
+								/>
+							</div>
 						) }
 						<div
 							className={ classNames(
@@ -871,7 +863,7 @@ const PlansFeaturesMain = ( {
 											{ ! hidePlanSelector && showPlansComparisonGrid && (
 												<div
 													className="plans-features-main__plan-type-selector"
-													ref={ comparisonGridPlanTypeSelectorRef }
+													// ref={ comparisonGridPlanTypeSelectorRef }
 												>
 													<PlanTypeSelector { ...planTypeSelectorProps } />
 												</div>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -20,6 +20,7 @@ import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
 import { isAnyHostingFlow } from '@automattic/onboarding';
+import { isMobile } from '@automattic/viewport';
 import styled from '@emotion/styled';
 import { useDispatch } from '@wordpress/data';
 import {
@@ -704,6 +705,12 @@ const PlansFeaturesMain = ( {
 		rootMargin: '0px 0px -300px 0px',
 	} );
 
+	const stickyPlanTypeSelectorHeight = 48;
+	const comparisonGridStickyRowOffset =
+		showPlanSelectorDropdown && isMobile()
+			? stickyPlanTypeSelectorHeight + masterbarHeight
+			: masterbarHeight;
+
 	return (
 		<>
 			<div
@@ -883,7 +890,7 @@ const PlansFeaturesMain = ( {
 												planActionOverrides={ planActionOverrides }
 												intent={ intent }
 												showUpgradeableStorage={ showUpgradeableStorage }
-												stickyRowOffset={ masterbarHeight }
+												stickyRowOffset={ comparisonGridStickyRowOffset }
 												usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 												allFeaturesList={ FEATURES_LIST }
 												onStorageAddOnClick={ handleStorageAddOnClick }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -783,6 +783,7 @@ const PlansFeaturesMain = ( {
 								{ ...planTypeSelectorProps }
 								layoutClassName="plans-features-main__plan-type-selector-layout"
 								enableStickyBehavior={ enablePlanTypeSelectorStickyBehavior }
+								stickyPlanTypeSelectorOffset={ masterbarHeight }
 							/>
 						) }
 						<div

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -34,7 +34,6 @@ import {
 import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
-// import { useInView } from 'react-intersection-observer';
 import { useSelector } from 'react-redux';
 import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
 import QueryPlans from 'calypso/components/data/query-plans';
@@ -700,15 +699,12 @@ const PlansFeaturesMain = ( {
 	);
 
 	const isPlansGridReady = ! isLoadingGridPlans && ! resolvedSubdomainName.isLoading;
-	// const [ comparisonGridPlanTypeSelectorRef, isComparisonGridPlanTypeSelectorInView ] = useInView( {
-	// 	rootMargin: '0px 0px -300px 0px',
-	// } );
 
+	const enablePlanTypeSelectorStickyBehavior = isMobile() && showPlanTypeSelectorDropdown;
 	const stickyPlanTypeSelectorHeight = 48;
-	const comparisonGridStickyRowOffset =
-		showPlanTypeSelectorDropdown && isMobile()
-			? stickyPlanTypeSelectorHeight + masterbarHeight
-			: masterbarHeight;
+	const comparisonGridStickyRowOffset = enablePlanTypeSelectorStickyBehavior
+		? stickyPlanTypeSelectorHeight + masterbarHeight
+		: masterbarHeight;
 
 	return (
 		<>
@@ -786,8 +782,7 @@ const PlansFeaturesMain = ( {
 							<PlanTypeSelector
 								{ ...planTypeSelectorProps }
 								layoutClassName="plans-features-main__plan-type-selector-layout"
-								enableStickyBehavior={ isMobile() && showPlanTypeSelectorDropdown }
-								// isComparisonGridPlanTypeSelectorInView={ isComparisonGridPlanTypeSelectorInView }
+								enableStickyBehavior={ enablePlanTypeSelectorStickyBehavior }
 							/>
 						) }
 						<div

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -261,6 +261,7 @@ const PlansFeaturesMain = ( {
 	const { setShowDomainUpsellDialog } = useDispatch( WpcomPlansUI.store );
 	const domainFromHomeUpsellFlow = useSelector( getDomainFromHomeUpsellInQuery );
 	const showUpgradeableStorage = config.isEnabled( 'plans/upgradeable-storage' );
+	const showPlanSelectorDropdown = config.isEnabled( 'onboarding/interval-dropdown' );
 	const observableForOdieRef = useObservableForOdie();
 	const currentPlanManageHref = useCurrentPlanManageHref();
 	const canUserManageCurrentPlan = useSelector( ( state: IAppState ) =>
@@ -697,6 +698,12 @@ const PlansFeaturesMain = ( {
 
 	const isPlansGridReady = ! isLoadingGridPlans && ! resolvedSubdomainName.isLoading;
 
+	const stickyPlanSelectorHeight = 48;
+
+	const comparisonGridStickyRowOffset = showPlanSelectorDropdown
+		? stickyPlanSelectorHeight + masterbarHeight
+		: masterbarHeight;
+
 	return (
 		<>
 			<div
@@ -867,7 +874,7 @@ const PlansFeaturesMain = ( {
 												planActionOverrides={ planActionOverrides }
 												intent={ intent }
 												showUpgradeableStorage={ showUpgradeableStorage }
-												stickyRowOffset={ masterbarHeight }
+												stickyRowOffset={ comparisonGridStickyRowOffset }
 												usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 												allFeaturesList={ FEATURES_LIST }
 												onStorageAddOnClick={ handleStorageAddOnClick }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -20,7 +20,6 @@ import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
 import { isAnyHostingFlow } from '@automattic/onboarding';
-// import { isMobile } from '@automattic/viewport';
 import styled from '@emotion/styled';
 import { useDispatch } from '@wordpress/data';
 import {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -20,7 +20,7 @@ import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
 import { isAnyHostingFlow } from '@automattic/onboarding';
-import { isMobile } from '@automattic/viewport';
+// import { isMobile } from '@automattic/viewport';
 import styled from '@emotion/styled';
 import { useDispatch } from '@wordpress/data';
 import {
@@ -34,6 +34,7 @@ import {
 import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
+import { useInView } from 'react-intersection-observer';
 import { useSelector } from 'react-redux';
 import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
 import QueryPlans from 'calypso/components/data/query-plans';
@@ -700,12 +701,9 @@ const PlansFeaturesMain = ( {
 	);
 
 	const isPlansGridReady = ! isLoadingGridPlans && ! resolvedSubdomainName.isLoading;
-
-	const stickyPlanSelectorHeight = 48;
-	const comparisonGridStickyRowOffset =
-		showPlanSelectorDropdown && isMobile()
-			? stickyPlanSelectorHeight + masterbarHeight
-			: masterbarHeight;
+	const [ comparisonGridPlanTypeSelectorRef, isComparisonGridPlanTypeSelectorInView ] = useInView( {
+		rootMargin: '0px 0px -300px 0px',
+	} );
 
 	return (
 		<>
@@ -782,7 +780,10 @@ const PlansFeaturesMain = ( {
 						{ ! hidePlanSelector && (
 							<StickyContainer
 								stickyClass="is-sticky-plan-type-selector"
-								className="plans-features-main__plan-type-selector-sticky-container"
+								className={ classNames(
+									'plans-features-main__plan-type-selector-sticky-container',
+									{ [ 'is-hidden' ]: isComparisonGridPlanTypeSelectorInView }
+								) }
 							>
 								{ () => {
 									return (
@@ -862,7 +863,10 @@ const PlansFeaturesMain = ( {
 												{ translate( 'Compare our plans and find yours' ) }
 											</PlanComparisonHeader>
 											{ ! hidePlanSelector && showPlansComparisonGrid && (
-												<div className="plans-features-main__plan-type-selector">
+												<div
+													className="plans-features-main__plan-type-selector"
+													ref={ comparisonGridPlanTypeSelectorRef }
+												>
 													<PlanTypeSelector { ...planTypeSelectorProps } />
 												</div>
 											) }
@@ -880,7 +884,7 @@ const PlansFeaturesMain = ( {
 												planActionOverrides={ planActionOverrides }
 												intent={ intent }
 												showUpgradeableStorage={ showUpgradeableStorage }
-												stickyRowOffset={ comparisonGridStickyRowOffset }
+												stickyRowOffset={ masterbarHeight }
 												usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 												allFeaturesList={ FEATURES_LIST }
 												onStorageAddOnClick={ handleStorageAddOnClick }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -34,7 +34,7 @@ import {
 import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
-// import { useInView } from 'react-intersection-observer';
+import { useInView } from 'react-intersection-observer';
 import { useSelector } from 'react-redux';
 import QueryActivePromotions from 'calypso/components/data/query-active-promotions';
 import QueryPlans from 'calypso/components/data/query-plans';
@@ -66,7 +66,6 @@ import isEligibleForWpComMonthlyPlan from 'calypso/state/selectors/is-eligible-f
 import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import { getCurrentPlan, isCurrentUserCurrentPlanOwner } from 'calypso/state/sites/plans/selectors';
 import { getSitePlanSlug, getSiteSlug, isCurrentPlanPaid } from 'calypso/state/sites/selectors';
-// import { StickyContainer } from '../plans-grid/components/sticky-container';
 import ComparisonGridToggle from './components/comparison-grid-toggle';
 import PlanUpsellModal from './components/plan-upsell-modal';
 import { useModalResolutionCallback } from './components/plan-upsell-modal/hooks/use-modal-resolution-callback';
@@ -701,9 +700,9 @@ const PlansFeaturesMain = ( {
 	);
 
 	const isPlansGridReady = ! isLoadingGridPlans && ! resolvedSubdomainName.isLoading;
-	// const [ comparisonGridPlanTypeSelectorRef, isComparisonGridPlanTypeSelectorInView ] = useInView( {
-	// 	rootMargin: '0px 0px -300px 0px',
-	// } );
+	const [ comparisonGridPlanTypeSelectorRef, isComparisonGridPlanTypeSelectorInView ] = useInView( {
+		rootMargin: '0px 0px -300px 0px',
+	} );
 
 	const stickyPlanTypeSelectorHeight = 48;
 	const comparisonGridStickyRowOffset =
@@ -784,13 +783,15 @@ const PlansFeaturesMain = ( {
 				{ isPlansGridReady && (
 					<>
 						{ ! hidePlanSelector && (
-							<div className="plans-features-main__plan-type-selector">
-								<PlanTypeSelector
-									{ ...planTypeSelectorProps }
-									// isComparisonGridPlanTypeSelectorInView={ isComparisonGridPlanTypeSelectorInView }
-									showPlanTypeSelectorDropdown={ showPlanTypeSelectorDropdown }
-								/>
-							</div>
+							// TODO: Migrate plans-features-main__plan-type-selector styles
+							// <div className="plans-features-main__plan-type-selector">
+							<PlanTypeSelector
+								{ ...planTypeSelectorProps }
+								enableStickyBehavior={ true }
+								showPlanTypeSelectorDropdown={ showPlanTypeSelectorDropdown }
+								isComparisonGridPlanTypeSelectorInView={ isComparisonGridPlanTypeSelectorInView }
+							/>
+							// </div>
 						) }
 						<div
 							className={ classNames(
@@ -863,7 +864,7 @@ const PlansFeaturesMain = ( {
 											{ ! hidePlanSelector && showPlansComparisonGrid && (
 												<div
 													className="plans-features-main__plan-type-selector"
-													// ref={ comparisonGridPlanTypeSelectorRef }
+													ref={ comparisonGridPlanTypeSelectorRef }
 												>
 													<PlanTypeSelector { ...planTypeSelectorProps } />
 												</div>

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -389,7 +389,7 @@ body.is-section-signup.is-white-signup {
 	}
 }
 
-.plans-features-main__plan-type-selector {
+.plans-features-main__plan-type-selector-layout {
 	display: flex;
 	align-content: space-between;
 	justify-content: center;

--- a/client/my-sites/plans-grid/_media-queries.scss
+++ b/client/my-sites/plans-grid/_media-queries.scss
@@ -228,7 +228,11 @@ $planComparisonMinWidthToGridWidthWithSidebarMap: (
 	}
 }
 
-// TODO: Include inline comment to match custom breakpoint conventions above
+/**
+ * @see client/my-sites/plans-grid/components/plan-type-selector/style.scss
+ * This introduces mobile only sticky behavior for the plan type selector.
+ *
+ */
 @mixin plan-type-selector-custom-mobile-breakpoint() {
 	@media ( max-width: $plans-2023-small-breakpoint ) {
 		@content;

--- a/client/my-sites/plans-grid/_media-queries.scss
+++ b/client/my-sites/plans-grid/_media-queries.scss
@@ -227,3 +227,10 @@ $planComparisonMinWidthToGridWidthWithSidebarMap: (
 		}
 	}
 }
+
+// TODO: Include inline comment to match custom breakpoint conventions above
+@mixin plan-type-selector-custom-mobile-breakpoint() {
+	@media ( max-width: $plans-2023-small-breakpoint ) {
+		@content;
+	}
+}

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -19,56 +19,8 @@ const AddOnOption = styled.a`
 	}
 `;
 
-const StyledCustomSelectControl = styled( CustomSelectControl )`
-	&,
-	&:visited,
-	&:hover span.name {
-		color: var( --color-text );
-	}
-	.components-custom-select-control__button {
-		min-width: 225px;
-	}
-	.components-custom-select-control__menu {
-		margin: 0;
-	}
-	.components-custom-select-control__item {
-		grid-template-columns: auto min-content;
-	}
-`;
-
-const StickyDropdown = styled( CustomSelectControl )`
-	.components-flex {
-		position: fixed;
-		top: 0;
-		left: 0;
-		width: 100%;
-		height: 48px;
-		z-index: 2;
-	}
-
-	.components-custom-select-control__menu {
-		position: fixed;
-		left: 0;
-		top: 47px;
-		width: 100%;
-		margin: 0;
-		z-index: 3;
-
-		border: 1px solid #e0e0e0;
-	}
-
-	.components-custom-select-control__item {
-		grid-template-columns: auto min-content;
-	}
-
-	.components-input-control__backdrop.components-input-control__backdrop.components-input-control__backdrop.components-input-control__backdrop {
-		border: none;
-		border-bottom: 1px solid #e0e0e0;
-	}
-`;
-
 export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
-	const { intervalType, isStuck } = props;
+	const { intervalType } = props;
 	const supportedIntervalType = (
 		[ 'yearly', '2yearly', '3yearly', 'monthly' ].includes( intervalType ) ? intervalType : 'yearly'
 	) as SupportedUrlFriendlyTermType;
@@ -84,20 +36,11 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 	} ) );
 
 	return (
-		<>
-			{ isStuck ? (
-				<StickyDropdown
-					label=""
-					options={ selectOptionsList }
-					value={ selectOptionsList.find( ( { key } ) => key === supportedIntervalType ) }
-				/>
-			) : (
-				<StyledCustomSelectControl
-					label=""
-					options={ selectOptionsList }
-					value={ selectOptionsList.find( ( { key } ) => key === supportedIntervalType ) }
-				/>
-			) }
-		</>
+		<CustomSelectControl
+			className="plan-type-selector__interval-type-dropdown"
+			label=""
+			options={ selectOptionsList }
+			value={ selectOptionsList.find( ( { key } ) => key === supportedIntervalType ) }
+		/>
 	);
 };

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -36,8 +36,39 @@ const StyledCustomSelectControl = styled( CustomSelectControl )`
 	}
 `;
 
+const StickyDropdown = styled( CustomSelectControl )`
+	.components-flex {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 48px;
+		z-index: 2;
+	}
+
+	.components-custom-select-control__menu {
+		position: fixed;
+		left: 0;
+		top: 47px;
+		width: 100%;
+		margin: 0;
+		z-index: 3;
+
+		border: 1px solid #e0e0e0;
+	}
+
+	.components-custom-select-control__item {
+		grid-template-columns: auto min-content;
+	}
+
+	.components-input-control__backdrop.components-input-control__backdrop.components-input-control__backdrop.components-input-control__backdrop {
+		border: none;
+		border-bottom: 1px solid #e0e0e0;
+	}
+`;
+
 export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
-	const { intervalType } = props;
+	const { intervalType, isStuck } = props;
 	const supportedIntervalType = (
 		[ 'yearly', '2yearly', '3yearly', 'monthly' ].includes( intervalType ) ? intervalType : 'yearly'
 	) as SupportedUrlFriendlyTermType;
@@ -51,11 +82,22 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 			</AddOnOption>
 		),
 	} ) );
+
 	return (
-		<StyledCustomSelectControl
-			label=""
-			options={ selectOptionsList }
-			value={ selectOptionsList.find( ( { key } ) => key === supportedIntervalType ) }
-		/>
+		<>
+			{ isStuck ? (
+				<StickyDropdown
+					label=""
+					options={ selectOptionsList }
+					value={ selectOptionsList.find( ( { key } ) => key === supportedIntervalType ) }
+				/>
+			) : (
+				<StyledCustomSelectControl
+					label=""
+					options={ selectOptionsList }
+					value={ selectOptionsList.find( ( { key } ) => key === supportedIntervalType ) }
+				/>
+			) }
+		</>
 	);
 };

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -15,6 +15,7 @@ const AddOnOption = styled.a`
 		font-size: 0.7rem;
 	}
 	.name {
+		font-size: 0.8rem;
 		margin-right: 4px;
 	}
 `;

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-selector.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-selector.tsx
@@ -1,11 +1,29 @@
+import classNames from 'classnames';
+import { StickyContainer } from '../../sticky-container';
 import { IntervalTypeProps } from '../types';
 import { IntervalTypeDropdown } from './interval-type-dropdown';
 import { IntervalTypeToggle } from './interval-type-toggle';
 
 export const IntervalTypeSelector: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
-	return props.showPlanTypeSelectorDropdown ? (
+	const { showPlanTypeSelectorDropdown } = props;
+
+	const Selector = showPlanTypeSelectorDropdown ? (
 		<IntervalTypeDropdown { ...props } />
 	) : (
 		<IntervalTypeToggle { ...props } />
+	);
+
+	return showPlanTypeSelectorDropdown ? (
+		<StickyContainer
+			stickyClass="is-sticky-plan-type-selector"
+			// TODO: Rename sticky container class
+			className={ classNames( 'plans-features-main__plan-type-selector-sticky-container', {
+				// [ 'is-hidden' ]: isComparisonGridPlanTypeSelectorInView,
+			} ) }
+		>
+			{ () => Selector }
+		</StickyContainer>
+	) : (
+		Selector
 	);
 };

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-selector.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-selector.tsx
@@ -1,10 +1,11 @@
-import config from '@automattic/calypso-config';
 import { IntervalTypeProps } from '../types';
 import { IntervalTypeDropdown } from './interval-type-dropdown';
 import { IntervalTypeToggle } from './interval-type-toggle';
 
 export const IntervalTypeSelector: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
-	const isVariant = config.isEnabled( 'onboarding/interval-dropdown' );
-
-	return isVariant ? <IntervalTypeDropdown { ...props } /> : <IntervalTypeToggle { ...props } />;
+	return props.showPlanSelectorDropdown ? (
+		<IntervalTypeDropdown { ...props } />
+	) : (
+		<IntervalTypeToggle { ...props } />
+	);
 };

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-selector.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-selector.tsx
@@ -1,5 +1,3 @@
-import classNames from 'classnames';
-import { StickyContainer } from '../../sticky-container';
 import { IntervalTypeProps } from '../types';
 import { IntervalTypeDropdown } from './interval-type-dropdown';
 import { IntervalTypeToggle } from './interval-type-toggle';
@@ -7,23 +5,9 @@ import { IntervalTypeToggle } from './interval-type-toggle';
 export const IntervalTypeSelector: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
 	const { showPlanTypeSelectorDropdown } = props;
 
-	const Selector = showPlanTypeSelectorDropdown ? (
+	return showPlanTypeSelectorDropdown ? (
 		<IntervalTypeDropdown { ...props } />
 	) : (
 		<IntervalTypeToggle { ...props } />
-	);
-
-	return showPlanTypeSelectorDropdown ? (
-		<StickyContainer
-			stickyClass="is-sticky-plan-type-selector"
-			// TODO: Rename sticky container class
-			className={ classNames( 'plans-features-main__plan-type-selector-sticky-container', {
-				// [ 'is-hidden' ]: isComparisonGridPlanTypeSelectorInView,
-			} ) }
-		>
-			{ () => Selector }
-		</StickyContainer>
-	) : (
-		Selector
 	);
 };

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-selector.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-selector.tsx
@@ -3,7 +3,7 @@ import { IntervalTypeDropdown } from './interval-type-dropdown';
 import { IntervalTypeToggle } from './interval-type-toggle';
 
 export const IntervalTypeSelector: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
-	return props.showPlanSelectorDropdown ? (
+	return props.showPlanTypeSelectorDropdown ? (
 		<IntervalTypeDropdown { ...props } />
 	) : (
 		<IntervalTypeToggle { ...props } />

--- a/client/my-sites/plans-grid/components/plan-type-selector/index.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/index.tsx
@@ -22,7 +22,6 @@ const PlanTypeSelector: React.FunctionComponent< PlanTypeSelectorProps > = ( {
 		return (
 			<StickyContainer
 				stickyClass="is-sticky-plan-type-selector"
-				className="plan-type-selector__sticky-container"
 				disabled={ ! enableStickyBehavior }
 			>
 				{ () => (

--- a/client/my-sites/plans-grid/components/plan-type-selector/index.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/index.tsx
@@ -11,8 +11,6 @@ const PlanTypeSelector: React.FunctionComponent< PlanTypeSelectorProps > = ( {
 	kind,
 	enableStickyBehavior = false,
 	layoutClassName,
-	// TODO: Rename this prop
-	isComparisonGridPlanTypeSelectorInView,
 	...props
 } ) => {
 	useEffect( () => {
@@ -22,31 +20,19 @@ const PlanTypeSelector: React.FunctionComponent< PlanTypeSelectorProps > = ( {
 	}, [] );
 	if ( kind === 'interval' ) {
 		return (
-			<>
-				{ enableStickyBehavior ? (
-					<StickyContainer
-						stickyClass="is-sticky-plan-type-selector"
-						className={ classNames( 'plan-type-selector__sticky-container', {
-							[ 'is-hidden' ]: isComparisonGridPlanTypeSelectorInView,
-						} ) }
-						disabled={ isComparisonGridPlanTypeSelectorInView }
-					>
-						{ () => (
-							<div className={ classNames( layoutClassName ) }>
-								<div className="plan-type-selector">
-									<IntervalTypeSelector { ...props } />
-								</div>
-							</div>
-						) }
-					</StickyContainer>
-				) : (
+			<StickyContainer
+				stickyClass="is-sticky-plan-type-selector"
+				className="plan-type-selector__sticky-container"
+				disabled={ ! enableStickyBehavior }
+			>
+				{ () => (
 					<div className={ classNames( layoutClassName ) }>
 						<div className="plan-type-selector">
 							<IntervalTypeSelector { ...props } />
 						</div>
 					</div>
 				) }
-			</>
+			</StickyContainer>
 		);
 	}
 	/**

--- a/client/my-sites/plans-grid/components/plan-type-selector/index.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/index.tsx
@@ -10,6 +10,7 @@ import './style.scss';
 const PlanTypeSelector: React.FunctionComponent< PlanTypeSelectorProps > = ( {
 	kind,
 	enableStickyBehavior = false,
+	layoutClassName,
 	// TODO: Rename this prop
 	isComparisonGridPlanTypeSelectorInView,
 	...props
@@ -21,19 +22,31 @@ const PlanTypeSelector: React.FunctionComponent< PlanTypeSelectorProps > = ( {
 	}, [] );
 	if ( kind === 'interval' ) {
 		return (
-			<StickyContainer
-				stickyClass="is-sticky-plan-type-selector"
-				className={ classNames( 'plan-type-selector__sticky-container', {
-					[ 'is-hidden' ]: isComparisonGridPlanTypeSelectorInView,
-				} ) }
-				disabled={ ! enableStickyBehavior || isComparisonGridPlanTypeSelectorInView }
-			>
-				{ () => (
-					<div className="plan-type-selector">
-						<IntervalTypeSelector { ...props } />
+			<>
+				{ enableStickyBehavior ? (
+					<StickyContainer
+						stickyClass="is-sticky-plan-type-selector"
+						className={ classNames( 'plan-type-selector__sticky-container', {
+							[ 'is-hidden' ]: isComparisonGridPlanTypeSelectorInView,
+						} ) }
+						disabled={ isComparisonGridPlanTypeSelectorInView }
+					>
+						{ () => (
+							<div className={ classNames( layoutClassName ) }>
+								<div className="plan-type-selector">
+									<IntervalTypeSelector { ...props } />
+								</div>
+							</div>
+						) }
+					</StickyContainer>
+				) : (
+					<div className={ classNames( layoutClassName ) }>
+						<div className="plan-type-selector">
+							<IntervalTypeSelector { ...props } />
+						</div>
 					</div>
 				) }
-			</StickyContainer>
+			</>
 		);
 	}
 	/**

--- a/client/my-sites/plans-grid/components/plan-type-selector/index.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/index.tsx
@@ -11,6 +11,7 @@ const PlanTypeSelector: React.FunctionComponent< PlanTypeSelectorProps > = ( {
 	kind,
 	enableStickyBehavior = false,
 	layoutClassName,
+	stickyPlanTypeSelectorOffset = 0,
 	...props
 } ) => {
 	useEffect( () => {
@@ -23,6 +24,7 @@ const PlanTypeSelector: React.FunctionComponent< PlanTypeSelectorProps > = ( {
 			<StickyContainer
 				stickyClass="is-sticky-plan-type-selector"
 				disabled={ ! enableStickyBehavior }
+				stickyOffset={ stickyPlanTypeSelectorOffset }
 			>
 				{ () => (
 					<div className={ classNames( layoutClassName ) }>

--- a/client/my-sites/plans-grid/components/plan-type-selector/index.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/index.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from '@wordpress/element';
+import classNames from 'classnames';
 import * as React from 'react';
+import { StickyContainer } from '../sticky-container';
 import { IntervalTypeSelector } from './components/interval-type-selector';
 import { PlanTypeSelectorProps } from './types';
 
@@ -7,6 +9,9 @@ import './style.scss';
 
 const PlanTypeSelector: React.FunctionComponent< PlanTypeSelectorProps > = ( {
 	kind,
+	enableStickyBehavior = false,
+	// TODO: Rename this prop
+	isComparisonGridPlanTypeSelectorInView,
 	...props
 } ) => {
 	useEffect( () => {
@@ -14,12 +19,21 @@ const PlanTypeSelector: React.FunctionComponent< PlanTypeSelectorProps > = ( {
 			kind,
 		} );
 	}, [] );
-
 	if ( kind === 'interval' ) {
 		return (
-			<div className="plan-type-selector">
-				<IntervalTypeSelector { ...props } />
-			</div>
+			<StickyContainer
+				stickyClass="is-sticky-plan-type-selector"
+				className={ classNames( 'plan-type-selector__sticky-container', {
+					[ 'is-hidden' ]: isComparisonGridPlanTypeSelectorInView,
+				} ) }
+				disabled={ ! enableStickyBehavior || isComparisonGridPlanTypeSelectorInView }
+			>
+				{ () => (
+					<div className="plan-type-selector">
+						<IntervalTypeSelector { ...props } />
+					</div>
+				) }
+			</StickyContainer>
 		);
 	}
 	/**

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -86,7 +86,8 @@
 
 		@include plan-type-selector-custom-mobile-breakpoint {
 			position: sticky;
-			z-index: 1;
+			// Display above sticky feature and comparison grid plan headers
+			z-index: 3;
 			top: 0;
 		}
 	}
@@ -99,7 +100,6 @@
 				left: 0;
 				width: 100%;
 				height: 48px;
-				z-index: 2;
 			}
 
 			.components-custom-select-control__menu {
@@ -108,7 +108,6 @@
 				top: 47px;
 				width: 100%;
 				margin: 0;
-				z-index: 3;
 
 				border: 1px solid #e0e0e0;
 			}

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -79,24 +79,22 @@
 }
 
 div.is-sticky-plan-type-selector {
+	.components-custom-select-control__label {
+		display: inline;
+	}
+
 	@include plan-type-selector-custom-mobile-breakpoint {
 		// Display above sticky feature and comparison grid plan headers
 		z-index: 3;
 
 		.components-flex {
-			position: fixed;
-			top: 0;
-			left: 0;
-			width: 100%;
+			width: 100vw;
 			height: 48px;
 			padding: 0 16px;
 			border-bottom: 1px solid #e0e0e0;
 		}
 
 		.components-custom-select-control__menu {
-			position: fixed;
-			left: 0;
-			top: 47px;
 			width: 100%;
 			margin: 0;
 

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -89,6 +89,10 @@
 			// Display above sticky feature and comparison grid plan headers
 			z-index: 3;
 			top: 0;
+
+			&.is-hidden {
+				visibility: hidden;
+			}
 		}
 	}
 

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -79,20 +79,10 @@
 	}
 }
 
-.plan-type-selector__sticky-container {
-	position: static;
-	z-index: 1;
-	top: auto;
-
+.plan-type-selector__sticky-container.is-sticky-plan-type-selector {
 	@include plan-type-selector-custom-mobile-breakpoint {
-		position: sticky;
 		// Display above sticky feature and comparison grid plan headers
 		z-index: 3;
-		top: 0;
-
-		&.is-hidden {
-			visibility: hidden;
-		}
 	}
 }
 

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -1,3 +1,4 @@
+// TODO: Check if I need to update this import to avoid referencing calypso alias
 @import "calypso/my-sites/plans-grid/media-queries";
 
 .plan-type-selector {

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -100,7 +100,7 @@
 				left: 0;
 				width: 100%;
 				height: 48px;
-				padding: 0 0.9rem;
+				padding: 0 16px;
 				border-bottom: 1px solid #e0e0e0;
 			}
 
@@ -114,7 +114,11 @@
 				border: 1px solid #e0e0e0;
 			}
 
-			.components-input-control__backdrop.components-input-control__backdrop.components-input-control__backdrop {
+			.components-custom-select-control__item {
+				padding-left: 22px;
+			}
+
+			.components-input-control__backdrop.components-input-control__backdrop {
 				border: none;
 			}
 		}

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -78,53 +78,53 @@
 	}
 }
 
-.plans-features-main {
-	.plans-features-main__plan-type-selector-sticky-container {
-		position: static;
-		z-index: 1;
-		top: auto;
+// .plans-features-main__plan-type-selector-sticky-container {
+// 	position: static;
+// 	z-index: 1;
+// 	top: auto;
 
-		@include plan-type-selector-custom-mobile-breakpoint {
-			position: sticky;
-			// Display above sticky feature and comparison grid plan headers
-			z-index: 3;
-			top: 0;
+// 	@include plan-type-selector-custom-mobile-breakpoint {
+// 		position: sticky;
+// 		// Display above sticky feature and comparison grid plan headers
+// 		z-index: 3;
+// 		top: 0;
 
-			&.is-hidden {
-				visibility: hidden;
-			}
-		}
-	}
+// 		&.is-hidden {
+// 			visibility: hidden;
+// 		}
+// 	}
+// }
 
-	.is-sticky-plan-type-selector {
-		@include plan-type-selector-custom-mobile-breakpoint {
-			.components-flex {
-				position: fixed;
-				top: 0;
-				left: 0;
-				width: 100%;
-				height: 48px;
-				padding: 0 16px;
-				border-bottom: 1px solid #e0e0e0;
-			}
 
-			.components-custom-select-control__menu {
-				position: fixed;
-				left: 0;
-				top: 47px;
-				width: 100%;
-				margin: 0;
+// .is-sticky-plan-type-selector {
+// 	@include plan-type-selector-custom-mobile-breakpoint {
+// 		.components-flex {
+// 			position: fixed;
+// 			top: 0;
+// 			left: 0;
+// 			width: 100%;
+// 			height: 48px;
+// 			padding: 0 16px;
+// 			border-bottom: 1px solid #e0e0e0;
+// 		}
 
-				border: 1px solid #e0e0e0;
-			}
+// 		.components-custom-select-control__menu {
+// 			position: fixed;
+// 			left: 0;
+// 			top: 47px;
+// 			width: 100%;
+// 			margin: 0;
 
-			.components-custom-select-control__item {
-				padding-left: 22px;
-			}
+// 			border: 1px solid #e0e0e0;
+// 		}
 
-			.components-input-control__backdrop.components-input-control__backdrop {
-				border: none;
-			}
-		}
-	}
-}
+// 		.components-custom-select-control__item {
+// 			padding-left: 22px;
+// 		}
+
+// 		.components-input-control__backdrop.components-input-control__backdrop {
+// 			border: none;
+// 		}
+// 	}
+// }
+// }

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -1,4 +1,3 @@
-// TODO: Check if I need to update this import to avoid referencing calypso alias
 @import "calypso/my-sites/plans-grid/media-queries";
 
 .plan-type-selector {

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -100,6 +100,8 @@
 				left: 0;
 				width: 100%;
 				height: 48px;
+				padding: 0 0.9rem;
+				border-bottom: 1px solid #e0e0e0;
 			}
 
 			.components-custom-select-control__menu {
@@ -112,9 +114,8 @@
 				border: 1px solid #e0e0e0;
 			}
 
-			.components-input-control__backdrop.components-input-control__backdrop.components-input-control__backdrop.components-input-control__backdrop {
+			.components-input-control__backdrop.components-input-control__backdrop.components-input-control__backdrop {
 				border: none;
-				border-bottom: 1px solid #e0e0e0;
 			}
 		}
 	}

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -1,4 +1,3 @@
-
 .plan-type-selector {
 	max-width: fit-content;
 }
@@ -56,6 +55,56 @@
 
 		.segmented-control__text {
 			white-space: initial;
+		}
+	}
+}
+
+.plan-type-selector .plan-type-selector__interval-type-dropdown {
+	&,
+	&:visited,
+	&:hover span.name {
+		color: var(--color-text);
+	}
+	.components-custom-select-control__button {
+		min-width: 225px;
+	}
+	.components-custom-select-control__menu {
+		margin: 0;
+	}
+	.components-custom-select-control__item {
+		grid-template-columns: auto min-content;
+	}
+}
+
+.is-sticky-plan-type-selector {
+	.plans-features-main__plan-type-selector {
+		.components-flex {
+			position: fixed;
+			top: 0;
+			left: 0;
+			width: 100%;
+			height: 48px;
+			z-index: 2;
+		}
+
+		.components-custom-select-control__menu {
+			position: fixed;
+			left: 0;
+			top: 47px;
+			width: 100%;
+			margin: 0;
+			z-index: 3;
+
+			border: 1px solid #e0e0e0;
+		}
+
+		.components-custom-select-control__item {
+			grid-template-columns: auto min-content;
+		}
+
+		.components-input-control__backdrop.components-input-control__backdrop.components-input-control__backdrop.components-input-control__backdrop {
+			border: none;
+			border-bottom: 1px solid #e0e0e0;
 		}
 	}
 }

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -1,3 +1,5 @@
+@import "calypso/my-sites/plans-grid/media-queries";
+
 .plan-type-selector {
 	max-width: fit-content;
 }
@@ -76,35 +78,45 @@
 	}
 }
 
-.is-sticky-plan-type-selector {
-	.plans-features-main__plan-type-selector {
-		.components-flex {
-			position: fixed;
+.plans-features-main {
+	.plans-features-main__plan-type-selector-sticky-container {
+		position: static;
+		z-index: 1;
+		top: auto;
+
+		@include plan-type-selector-custom-mobile-breakpoint {
+			position: sticky;
+			z-index: 1;
 			top: 0;
-			left: 0;
-			width: 100%;
-			height: 48px;
-			z-index: 2;
 		}
+	}
 
-		.components-custom-select-control__menu {
-			position: fixed;
-			left: 0;
-			top: 47px;
-			width: 100%;
-			margin: 0;
-			z-index: 3;
+	.is-sticky-plan-type-selector {
+		@include plan-type-selector-custom-mobile-breakpoint {
+			.components-flex {
+				position: fixed;
+				top: 0;
+				left: 0;
+				width: 100%;
+				height: 48px;
+				z-index: 2;
+			}
 
-			border: 1px solid #e0e0e0;
-		}
+			.components-custom-select-control__menu {
+				position: fixed;
+				left: 0;
+				top: 47px;
+				width: 100%;
+				margin: 0;
+				z-index: 3;
 
-		.components-custom-select-control__item {
-			grid-template-columns: auto min-content;
-		}
+				border: 1px solid #e0e0e0;
+			}
 
-		.components-input-control__backdrop.components-input-control__backdrop.components-input-control__backdrop.components-input-control__backdrop {
-			border: none;
-			border-bottom: 1px solid #e0e0e0;
+			.components-input-control__backdrop.components-input-control__backdrop.components-input-control__backdrop.components-input-control__backdrop {
+				border: none;
+				border-bottom: 1px solid #e0e0e0;
+			}
 		}
 	}
 }

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -78,16 +78,11 @@
 	}
 }
 
-.plan-type-selector__sticky-container.is-sticky-plan-type-selector {
+div.is-sticky-plan-type-selector {
 	@include plan-type-selector-custom-mobile-breakpoint {
 		// Display above sticky feature and comparison grid plan headers
 		z-index: 3;
-	}
-}
 
-
-.is-sticky-plan-type-selector {
-	@include plan-type-selector-custom-mobile-breakpoint {
 		.components-flex {
 			position: fixed;
 			top: 0;

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -78,53 +78,52 @@
 	}
 }
 
-// .plans-features-main__plan-type-selector-sticky-container {
-// 	position: static;
-// 	z-index: 1;
-// 	top: auto;
+.plan-type-selector__sticky-container {
+	position: static;
+	z-index: 1;
+	top: auto;
 
-// 	@include plan-type-selector-custom-mobile-breakpoint {
-// 		position: sticky;
-// 		// Display above sticky feature and comparison grid plan headers
-// 		z-index: 3;
-// 		top: 0;
+	@include plan-type-selector-custom-mobile-breakpoint {
+		position: sticky;
+		// Display above sticky feature and comparison grid plan headers
+		z-index: 3;
+		top: 0;
 
-// 		&.is-hidden {
-// 			visibility: hidden;
-// 		}
-// 	}
-// }
+		&.is-hidden {
+			visibility: hidden;
+		}
+	}
+}
 
 
-// .is-sticky-plan-type-selector {
-// 	@include plan-type-selector-custom-mobile-breakpoint {
-// 		.components-flex {
-// 			position: fixed;
-// 			top: 0;
-// 			left: 0;
-// 			width: 100%;
-// 			height: 48px;
-// 			padding: 0 16px;
-// 			border-bottom: 1px solid #e0e0e0;
-// 		}
+.is-sticky-plan-type-selector {
+	@include plan-type-selector-custom-mobile-breakpoint {
+		.components-flex {
+			position: fixed;
+			top: 0;
+			left: 0;
+			width: 100%;
+			height: 48px;
+			padding: 0 16px;
+			border-bottom: 1px solid #e0e0e0;
+		}
 
-// 		.components-custom-select-control__menu {
-// 			position: fixed;
-// 			left: 0;
-// 			top: 47px;
-// 			width: 100%;
-// 			margin: 0;
+		.components-custom-select-control__menu {
+			position: fixed;
+			left: 0;
+			top: 47px;
+			width: 100%;
+			margin: 0;
 
-// 			border: 1px solid #e0e0e0;
-// 		}
+			border: 1px solid #e0e0e0;
+		}
 
-// 		.components-custom-select-control__item {
-// 			padding-left: 22px;
-// 		}
+		.components-custom-select-control__item {
+			padding-left: 22px;
+		}
 
-// 		.components-input-control__backdrop.components-input-control__backdrop {
-// 			border: none;
-// 		}
-// 	}
-// }
-// }
+		.components-input-control__backdrop.components-input-control__backdrop {
+			border: none;
+		}
+	}
+}

--- a/client/my-sites/plans-grid/components/plan-type-selector/types.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/types.ts
@@ -10,6 +10,7 @@ export type PlanTypeSelectorProps = {
 	withDiscount?: string;
 	enableStickyBehavior?: boolean;
 	isComparisonGridPlanTypeSelectorInView?: boolean;
+	layoutClassName?: string;
 	siteSlug?: string | null;
 	selectedPlan?: string;
 	selectedFeature?: string;

--- a/client/my-sites/plans-grid/components/plan-type-selector/types.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/types.ts
@@ -8,6 +8,8 @@ export type PlanTypeSelectorProps = {
 	intervalType: UrlFriendlyTermType;
 	customerType: string;
 	withDiscount?: string;
+	enableStickyBehavior?: boolean;
+	isComparisonGridPlanTypeSelectorInView?: boolean;
 	siteSlug?: string | null;
 	selectedPlan?: string;
 	selectedFeature?: string;

--- a/client/my-sites/plans-grid/components/plan-type-selector/types.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/types.ts
@@ -22,6 +22,7 @@ export type PlanTypeSelectorProps = {
 	currentSitePlanSlug?: PlanSlug | null;
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
 	recordTracksEvent?: ( eventName: string, eventProperties: Record< string, unknown > ) => void;
+	isStuck?: boolean;
 	/**
 	 * Whether to render the selector along with a title if passed.
 	 */
@@ -42,6 +43,7 @@ export type IntervalTypeProps = Pick<
 	| 'currentSitePlanSlug'
 	| 'usePricingMetaForGridPlans'
 	| 'title'
+	| 'isStuck'
 >;
 
 export type SupportedUrlFriendlyTermType = Extract<

--- a/client/my-sites/plans-grid/components/plan-type-selector/types.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/types.ts
@@ -12,6 +12,7 @@ export type PlanTypeSelectorProps = {
 	selectedPlan?: string;
 	selectedFeature?: string;
 	showBiennialToggle?: boolean;
+	showPlanSelectorDropdown?: boolean; // feature flag used for the plan selector dropdown
 	isInSignup: boolean;
 	plans: PlanSlug[];
 	eligibleForWpcomMonthlyPlans?: boolean;
@@ -37,6 +38,7 @@ export type IntervalTypeProps = Pick<
 	| 'hideDiscountLabel'
 	| 'redirectTo'
 	| 'showBiennialToggle'
+	| 'showPlanSelectorDropdown'
 	| 'selectedPlan'
 	| 'selectedFeature'
 	| 'currentSitePlanSlug'

--- a/client/my-sites/plans-grid/components/plan-type-selector/types.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/types.ts
@@ -12,7 +12,7 @@ export type PlanTypeSelectorProps = {
 	selectedPlan?: string;
 	selectedFeature?: string;
 	showBiennialToggle?: boolean;
-	showPlanSelectorDropdown?: boolean; // feature flag used for the plan selector dropdown
+	showPlanTypeSelectorDropdown?: boolean; // feature flag used for the plan selector dropdown
 	isInSignup: boolean;
 	plans: PlanSlug[];
 	eligibleForWpcomMonthlyPlans?: boolean;
@@ -38,7 +38,7 @@ export type IntervalTypeProps = Pick<
 	| 'hideDiscountLabel'
 	| 'redirectTo'
 	| 'showBiennialToggle'
-	| 'showPlanSelectorDropdown'
+	| 'showPlanTypeSelectorDropdown'
 	| 'selectedPlan'
 	| 'selectedFeature'
 	| 'currentSitePlanSlug'

--- a/client/my-sites/plans-grid/components/plan-type-selector/types.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/types.ts
@@ -22,7 +22,6 @@ export type PlanTypeSelectorProps = {
 	currentSitePlanSlug?: PlanSlug | null;
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
 	recordTracksEvent?: ( eventName: string, eventProperties: Record< string, unknown > ) => void;
-	isStuck?: boolean;
 	/**
 	 * Whether to render the selector along with a title if passed.
 	 */
@@ -43,7 +42,6 @@ export type IntervalTypeProps = Pick<
 	| 'currentSitePlanSlug'
 	| 'usePricingMetaForGridPlans'
 	| 'title'
-	| 'isStuck'
 >;
 
 export type SupportedUrlFriendlyTermType = Extract<

--- a/client/my-sites/plans-grid/components/plan-type-selector/types.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/types.ts
@@ -9,7 +9,7 @@ export type PlanTypeSelectorProps = {
 	customerType: string;
 	withDiscount?: string;
 	enableStickyBehavior?: boolean;
-	isComparisonGridPlanTypeSelectorInView?: boolean;
+	stickyPlanTypeSelectorOffset?: number;
 	layoutClassName?: string;
 	siteSlug?: string | null;
 	selectedPlan?: string;

--- a/client/my-sites/plans-grid/components/sticky-container.tsx
+++ b/client/my-sites/plans-grid/components/sticky-container.tsx
@@ -40,6 +40,7 @@ export function StickyContainer( props: Props ) {
 			return;
 		}
 		const observer = new IntersectionObserver(
+			// Each entry describes an intersection change for one observed target element:
 			( [ entry ] ) => {
 				if ( entry.intersectionRatio === 0 ) {
 					// The element is out of view
@@ -53,12 +54,19 @@ export function StickyContainer( props: Props ) {
 				}
 			},
 			{
+				// Root: the specified element that is being intersected
 				rootMargin: `-${ stickyOffset + 1 }px 0px 0px 0px`,
+				// Threshold describes how often the callback is invoked
+				// - A threshold of 1.0 means that when 100% of the target is visible within the element
+				//   specified by the root option, the callback is invoked.
+				// - A threshold of 0.0 means that as soon as even one pixel of the target is visible
+				//   within the root element, the callback will be invoked.
 				threshold: [ 0, 1 ],
 			}
 		);
 
 		if ( stickyRef.current ) {
+			// - Target: the element that is intersecting either the device's viewport or a specified element
 			observer.observe( stickyRef.current );
 		}
 

--- a/client/my-sites/plans-grid/components/sticky-container.tsx
+++ b/client/my-sites/plans-grid/components/sticky-container.tsx
@@ -1,9 +1,11 @@
 import { Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
+import classNames from 'classnames';
 import { useRef, type ElementType, useState, useLayoutEffect, ReactNode } from 'react';
 
 type Props = {
 	children: ( isStuck: boolean ) => ReactNode;
+	className?: string; // class to apply to the sticky container
 	stickyClass?: string; // class to apply when the element is "stuck"
 	element?: ElementType; // which element to render, defaults to div
 	stickyOffset?: number; // offset from the top of the scrolling container to control when the element should start sticking, default 0
@@ -24,7 +26,14 @@ const Container = styled.div`
 `;
 
 export function StickyContainer( props: Props ) {
-	const { stickyOffset = 0, stickyClass = '', element = 'div', disabled = false, children } = props;
+	const {
+		className,
+		stickyOffset = 0,
+		stickyClass = '',
+		element = 'div',
+		disabled = false,
+		children,
+	} = props;
 
 	const stickyRef = useRef( null );
 	const [ isStuck, setIsStuck ] = useState( false );
@@ -94,7 +103,7 @@ export function StickyContainer( props: Props ) {
 				ref={ stickyRef }
 				stickyOffset={ stickyOffset }
 				disabled={ disabled }
-				className={ isStuck ? stickyClass : '' }
+				className={ classNames( { [ stickyClass ]: isStuck }, className ) }
 			>
 				{ children( isStuck ) }
 			</Container>

--- a/client/my-sites/plans-grid/components/sticky-container.tsx
+++ b/client/my-sites/plans-grid/components/sticky-container.tsx
@@ -50,6 +50,9 @@ export function StickyContainer( props: Props ) {
 		}
 		const observer = new IntersectionObserver(
 			( [ entry ] ) => {
+				if ( disabled ) {
+					return;
+				}
 				if ( entry.intersectionRatio === 0 ) {
 					// The element is out of view
 					setIsStuck( false );

--- a/client/my-sites/plans-grid/components/sticky-container.tsx
+++ b/client/my-sites/plans-grid/components/sticky-container.tsx
@@ -49,7 +49,6 @@ export function StickyContainer( props: Props ) {
 			return;
 		}
 		const observer = new IntersectionObserver(
-			// Each entry describes an intersection change for one observed target element:
 			( [ entry ] ) => {
 				if ( entry.intersectionRatio === 0 ) {
 					// The element is out of view
@@ -63,19 +62,12 @@ export function StickyContainer( props: Props ) {
 				}
 			},
 			{
-				// Root: the specified element that is being intersected
 				rootMargin: `-${ stickyOffset + 1 }px 0px 0px 0px`,
-				// Threshold describes how often the callback is invoked
-				// - A threshold of 1.0 means that when 100% of the target is visible within the element
-				//   specified by the root option, the callback is invoked.
-				// - A threshold of 0.0 means that as soon as even one pixel of the target is visible
-				//   within the root element, the callback will be invoked.
 				threshold: [ 0, 1 ],
 			}
 		);
 
 		if ( stickyRef.current ) {
-			// - Target: the element that is intersecting either the device's viewport or a specified element
 			observer.observe( stickyRef.current );
 		}
 

--- a/client/my-sites/plans-grid/components/sticky-container.tsx
+++ b/client/my-sites/plans-grid/components/sticky-container.tsx
@@ -5,7 +5,6 @@ import { useRef, type ElementType, useState, useLayoutEffect, ReactNode } from '
 
 type Props = {
 	children: ( isStuck: boolean ) => ReactNode;
-	className?: string; // class to apply to the sticky container
 	stickyClass?: string; // class to apply when the element is "stuck"
 	element?: ElementType; // which element to render, defaults to div
 	stickyOffset?: number; // offset from the top of the scrolling container to control when the element should start sticking, default 0
@@ -26,14 +25,7 @@ const Container = styled.div`
 `;
 
 export function StickyContainer( props: Props ) {
-	const {
-		className,
-		stickyOffset = 0,
-		stickyClass = '',
-		element = 'div',
-		disabled = false,
-		children,
-	} = props;
+	const { stickyOffset = 0, stickyClass = '', element = 'div', disabled = false, children } = props;
 
 	const stickyRef = useRef( null );
 	const [ isStuck, setIsStuck ] = useState( false );
@@ -98,7 +90,7 @@ export function StickyContainer( props: Props ) {
 				ref={ stickyRef }
 				stickyOffset={ stickyOffset }
 				disabled={ disabled }
-				className={ classNames( { [ stickyClass ]: isStuck }, className ) }
+				className={ classNames( { [ stickyClass ]: isStuck } ) }
 			>
 				{ children( isStuck ) }
 			</Container>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/growth-foundations/issues/296 and Attempt 1 at sticky headers https://github.com/Automattic/wp-calypso/pull/85158

## Proposed Changes

* Introduces the a sticky dropdown for mobile based screens

## Screenshots
![2023-12-21 06 14 59](https://github.com/Automattic/wp-calypso/assets/5414230/49d8eec2-47f2-46d5-925b-a80411099773)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Navigate to /start/plans?flags=onboarding/interval-dropdown ( don't forget the feature flag! )
* Verify that no changes are seen in tablet and desktop views
* Switch to a mobile view and verify that a sticky plan selector dropdown is displayed
* Verify that the dropdown updates mobile plan pricing as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?