### PR TITLE
Global Styles: Fix translation check

### DIFF
--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -106,10 +106,7 @@ const GlobalStylesVariations = ( {
 	const hasEnTranslation = useHasEnTranslation();
 	const isRegisteredCoreBlocks = useRegisterCoreBlocks();
 	const premiumStylesDescription = hasEnTranslation(
-		translate(
-			'Unlock style variations and tons of other features with the %(planName)s plan, or try them out now for free.',
-			{ args: { planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' } }
-		) as string
+		'Unlock style variations and tons of other features with the %(planName)s plan, or try them out now for free.'
 	)
 		? translate(
 				'Unlock style variations and tons of other features with the %(planName)s plan, or try them out now for free.',
@@ -196,11 +193,7 @@ const GlobalStylesVariations = ( {
 						<div className="global-styles-variations__header">
 							<h2>
 								<span>
-									{ hasEnTranslation(
-										translate( 'Style Variation', 'Style Variations', {
-											count: nonDefaultStyles.length,
-										} ) as string
-									)
+									{ hasEnTranslation( 'Style Variations' )
 										? translate( 'Style Variation', 'Style Variations', {
 												count: nonDefaultStyles.length,
 										  } )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85513

## Proposed Changes

This PR fixes an issue where the check for whether the translation exists has the wrong argument passed to it. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?