### PR TITLE
Stats: Limit new tier limit information to commercial plans

### DIFF
--- a/packages/calypso-products/src/is-jetpack-stats-paid-tiered-product-slug.ts
+++ b/packages/calypso-products/src/is-jetpack-stats-paid-tiered-product-slug.ts
@@ -1,0 +1,15 @@
+import {
+	PRODUCT_JETPACK_STATS_YEARLY,
+	PRODUCT_JETPACK_STATS_MONTHLY,
+	PRODUCT_JETPACK_STATS_BI_YEARLY,
+} from './constants';
+
+export function isJetpackStatsPaidTieredProductSlug( productSlug: string ) {
+	return (
+		[
+			PRODUCT_JETPACK_STATS_BI_YEARLY,
+			PRODUCT_JETPACK_STATS_YEARLY,
+			PRODUCT_JETPACK_STATS_MONTHLY,
+		] as ReadonlyArray< string >
+	 ).includes( productSlug );
+}

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -105,6 +105,7 @@ export { isJetpackSocialBasicSlug } from './is-jetpack-social-basic-slug';
 export { isJetpackStatsSlug } from './is-jetpack-stats-slug';
 export { isJetpackStatsPaidProductSlug } from './is-jetpack-stats-paid-product-slug';
 export { isJetpackStatsFreeProductSlug } from './is-jetpack-stats-free-product-slug';
+export { isJetpackStatsPaidTieredProductSlug } from './is-jetpack-stats-paid-tiered-product-slug';
 export { isJetpackVideoPress } from './is-jetpack-videopress';
 export { isJetpackBoostSlug } from './is-jetpack-boost-slug';
 export { isJetpackVideoPressSlug } from './is-jetpack-videopress-slug';

--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -14,7 +14,7 @@ import {
 	isBiennially,
 	isTriennially,
 	isJetpackAISlug,
-	isJetpackStatsPaidProductSlug,
+	isJetpackStatsPaidTieredProductSlug,
 } from '@automattic/calypso-products';
 import { translate, numberFormat } from 'i18n-calypso';
 import { isWpComProductRenewal as isRenewal } from './is-wpcom-product-renewal';
@@ -106,7 +106,7 @@ export function getLabel( product: ResponseCartProduct ): string {
 		} );
 	}
 
-	if ( isJetpackStatsPaidProductSlug( product.product_slug ) && product.quantity ) {
+	if ( isJetpackStatsPaidTieredProductSlug( product.product_slug ) && product.quantity ) {
 		return translate( '%(productName)s - %(quantity)s views per month', {
 			args: {
 				productName: product.product_name,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85326

## Proposed Changes

* Limit new tier information to the commercial plans only and prevent incorrect display of quantity used for PWYW plans

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout the branch
* Go to `/checkout/<blog_slug>/jetpack_stats_pwyw_yearly:-q-<your quantity>` 
* Confirm that the product title does not display any information about view quantity

| Before | After |
| --- | --- |
| <img width="637" alt="SCR-20231220-nltr" src="https://github.com/Automattic/wp-calypso/assets/112354940/2bfd6192-1639-4a78-8e44-31feb9c1b3f4"> | <img width="630" alt="SCR-20231220-nliw" src="https://github.com/Automattic/wp-calypso/assets/112354940/980df0af-1b72-443d-b162-8a3ff290898e"> |





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?