### PR TITLE
[Live Preview in Premium/Woo themes] Add tracking events

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
@@ -8,6 +8,7 @@ import {
 import { getCalypsoUrl } from '@automattic/calypso-url';
 import { useEffect, useState, useCallback } from 'react';
 import wpcom from 'calypso/lib/wp';
+import tracksRecordEvent from '../../tracking/track-record-event';
 import { PREMIUM_THEME, WOOCOMMERCE_THEME } from '../utils';
 import { usePreviewingTheme } from './use-previewing-theme';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -92,6 +93,11 @@ export const useCanPreviewButNeedUpgrade = ( {
 	}, [ previewingTheme.type, setCanPreviewButNeedUpgrade, setSiteSlug ] );
 
 	const upgradePlan = useCallback( () => {
+		tracksRecordEvent( 'calypso_block_theme_live_preview_click_upgrade', {
+			theme: previewingTheme.id,
+			theme_type: previewingTheme.type,
+		} );
+
 		const generateCheckoutUrl = ( plan: string ) => {
 			const locationHref = window.location.href;
 			let url = locationHref;
@@ -125,9 +131,7 @@ export const useCanPreviewButNeedUpgrade = ( {
 				: // For a Premium theme, the users should have the Premium plan or higher.
 				  generateCheckoutUrl( PLAN_PREMIUM );
 		window.location.href = link;
-
-		// TODO: Add the track event.
-	}, [ previewingTheme.type, siteSlug ] );
+	}, [ previewingTheme.id, previewingTheme.type, siteSlug ] );
 
 	return {
 		canPreviewButNeedUpgrade,

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
@@ -93,7 +93,7 @@ export const useCanPreviewButNeedUpgrade = ( {
 	}, [ previewingTheme.type, setCanPreviewButNeedUpgrade, setSiteSlug ] );
 
 	const upgradePlan = useCallback( () => {
-		tracksRecordEvent( 'calypso_block_theme_live_preview_click_upgrade', {
+		tracksRecordEvent( 'calypso_block_theme_live_preview_upgrade_modal_upgrade', {
 			theme: previewingTheme.id,
 			theme_type: previewingTheme.type,
 		} );

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-override-save-button.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-override-save-button.ts
@@ -34,9 +34,10 @@ export const useOverrideSaveButton = ( {
 			e.stopPropagation();
 			setIsThemeUpgradeModalOpen( true );
 			tracksRecordEvent( 'calypso_block_theme_live_preview_upgrade_modal_open', {
+				canvas_mode: canvasMode,
 				opened_by: 'button_click',
-				theme: previewingTheme.id,
 				theme_type: previewingTheme.type,
+				theme: previewingTheme.id,
 			} );
 		};
 		const overrideSaveButtonClick = ( selector: string ) => {
@@ -121,9 +122,10 @@ export const useOverrideSaveButton = ( {
 				e.stopPropagation();
 				setIsThemeUpgradeModalOpen( true );
 				tracksRecordEvent( 'calypso_block_theme_live_preview_upgrade_modal_open', {
+					canvas_mode: canvasMode,
 					opened_by: 'shortcut',
-					theme: previewingTheme.id,
 					theme_type: previewingTheme.type,
+					theme: previewingTheme.id,
 				} );
 			}
 		};

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-override-save-button.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-override-save-button.ts
@@ -133,5 +133,5 @@ export const useOverrideSaveButton = ( {
 		return () => {
 			document.removeEventListener( 'keydown', overrideSaveButtonKeyboardShortcut );
 		};
-	}, [ previewingTheme.id, previewingTheme.type, setIsThemeUpgradeModalOpen ] );
+	}, [ canvasMode, previewingTheme.id, previewingTheme.type, setIsThemeUpgradeModalOpen ] );
 };

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-override-save-button.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-override-save-button.ts
@@ -1,7 +1,9 @@
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useEffect } from 'react';
+import tracksRecordEvent from '../../tracking/track-record-event';
 import { getUnlock } from '../utils';
+import { usePreviewingTheme } from './use-previewing-theme';
 
 const SAVE_HUB_SAVE_BUTTON_SELECTOR = '.edit-site-save-hub__button';
 const HEADER_SAVE_BUTTON_SELECTOR = '.edit-site-save-button__button';
@@ -15,8 +17,10 @@ const unlock = getUnlock();
  */
 export const useOverrideSaveButton = ( {
 	setIsThemeUpgradeModalOpen,
+	previewingTheme,
 }: {
 	setIsThemeUpgradeModalOpen: ( isThemeUpgradeModalOpen: boolean ) => void;
+	previewingTheme: ReturnType< typeof usePreviewingTheme >;
 } ) => {
 	const canvasMode = useSelect(
 		( select ) =>
@@ -29,6 +33,11 @@ export const useOverrideSaveButton = ( {
 			e.preventDefault();
 			e.stopPropagation();
 			setIsThemeUpgradeModalOpen( true );
+			tracksRecordEvent( 'calypso_block_theme_live_preview_upgrade_modal_open', {
+				opened_by: 'button_click',
+				theme: previewingTheme.id,
+				theme_type: previewingTheme.type,
+			} );
 		};
 		const overrideSaveButtonClick = ( selector: string ) => {
 			const button = document.querySelector( selector );
@@ -102,7 +111,7 @@ export const useOverrideSaveButton = ( {
 				.querySelector( HEADER_SAVE_BUTTON_SELECTOR )
 				?.removeEventListener( 'mouseout', stopObserver );
 		};
-	}, [ canvasMode, setIsThemeUpgradeModalOpen ] );
+	}, [ canvasMode, previewingTheme.id, previewingTheme.type, setIsThemeUpgradeModalOpen ] );
 
 	useEffect( () => {
 		// This overrides the keyboard shortcut (⌘S) for saving.
@@ -111,11 +120,16 @@ export const useOverrideSaveButton = ( {
 				e.preventDefault();
 				e.stopPropagation();
 				setIsThemeUpgradeModalOpen( true );
+				tracksRecordEvent( 'calypso_block_theme_live_preview_upgrade_modal_open', {
+					opened_by: 'shortcut',
+					theme: previewingTheme.id,
+					theme_type: previewingTheme.type,
+				} );
 			}
 		};
 		document.addEventListener( 'keydown', overrideSaveButtonKeyboardShortcut );
 		return () => {
 			document.removeEventListener( 'keydown', overrideSaveButtonKeyboardShortcut );
 		};
-	}, [ setIsThemeUpgradeModalOpen ] );
+	}, [ previewingTheme.id, previewingTheme.type, setIsThemeUpgradeModalOpen ] );
 };

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
@@ -80,7 +80,7 @@ const LivePreviewNoticePlugin = () => {
 	if ( canPreviewButNeedUpgrade ) {
 		return (
 			<>
-				<LivePreviewUpgradeModal { ...{ themeId: previewingTheme.id as string, upgradePlan } } />
+				<LivePreviewUpgradeModal { ...{ previewingTheme, upgradePlan } } />
 				<LivePreviewUpgradeNotice { ...{ previewingTheme, dashboardLink } } />
 			</>
 		);

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-modal.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-modal.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { FC, useState } from 'react';
-import { ThemeUpgradeModal } from 'calypso/components/theme-upgrade-modal';
+import { FC, useCallback, useState } from 'react';
+import { ThemeUpgradeModal, UpgradeModalClosedBy } from 'calypso/components/theme-upgrade-modal';
+import tracksRecordEvent from '../tracking/track-record-event';
 import { useOverrideSaveButton } from './hooks/use-override-save-button';
 import { usePreviewingTheme } from './hooks/use-previewing-theme';
 
@@ -14,6 +15,18 @@ export const LivePreviewUpgradeModal: FC< {
 
 	useOverrideSaveButton( { setIsThemeUpgradeModalOpen, previewingTheme } );
 
+	const closeModal = useCallback(
+		( closedBy?: UpgradeModalClosedBy ) => {
+			tracksRecordEvent( 'calypso_block_theme_live_preview_upgrade_modal_close', {
+				closed_by: closedBy,
+				theme: previewingTheme.id,
+				theme_type: previewingTheme.type,
+			} );
+			setIsThemeUpgradeModalOpen( false );
+		},
+		[ previewingTheme.id, previewingTheme.type ]
+	);
+
 	const queryClient = new QueryClient();
 	return (
 		<QueryClientProvider client={ queryClient }>
@@ -23,7 +36,7 @@ export const LivePreviewUpgradeModal: FC< {
 				// We can assume that the theme is present, as this component is rendered in that context.
 				slug={ previewingTheme.id as string }
 				isOpen={ isThemeUpgradeModalOpen }
-				closeModal={ () => setIsThemeUpgradeModalOpen( false ) }
+				closeModal={ closeModal }
 				checkout={ upgradePlan }
 			/>
 		</QueryClientProvider>

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-modal.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-modal.tsx
@@ -2,16 +2,17 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { FC, useState } from 'react';
 import { ThemeUpgradeModal } from 'calypso/components/theme-upgrade-modal';
 import { useOverrideSaveButton } from './hooks/use-override-save-button';
+import { usePreviewingTheme } from './hooks/use-previewing-theme';
 
 import './upgrade-modal.scss';
 
-export const LivePreviewUpgradeModal: FC< { themeId: string; upgradePlan: () => void } > = ( {
-	themeId,
-	upgradePlan,
-} ) => {
+export const LivePreviewUpgradeModal: FC< {
+	previewingTheme: ReturnType< typeof usePreviewingTheme >;
+	upgradePlan: () => void;
+} > = ( { previewingTheme, upgradePlan } ) => {
 	const [ isThemeUpgradeModalOpen, setIsThemeUpgradeModalOpen ] = useState( false );
 
-	useOverrideSaveButton( { setIsThemeUpgradeModalOpen } );
+	useOverrideSaveButton( { setIsThemeUpgradeModalOpen, previewingTheme } );
 
 	const queryClient = new QueryClient();
 	return (
@@ -19,7 +20,8 @@ export const LivePreviewUpgradeModal: FC< { themeId: string; upgradePlan: () => 
 			<ThemeUpgradeModal
 				additionalClassNames="wpcom-live-preview-upgrade-modal"
 				additionalOverlayClassNames="wpcom-live-preview-upgrade-modal__overlay"
-				slug={ themeId }
+				// We can assume that the theme is present, as this component is rendered in that context.
+				slug={ previewingTheme.id as string }
 				isOpen={ isThemeUpgradeModalOpen }
 				closeModal={ () => setIsThemeUpgradeModalOpen( false ) }
 				checkout={ upgradePlan }

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
@@ -27,7 +27,6 @@ const LivePreviewUpgradeNoticeView: FC< {
 			status="info"
 			isDismissible={ false }
 			className="wpcom-live-preview-upgrade-notice-view"
-			// TODO: Add the tracking event.
 		>
 			{ noticeText }
 		</Notice>

--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -39,6 +39,8 @@ import { useThemeDetails } from 'calypso/state/themes/hooks/use-theme-details';
 import { ThemeSoftwareSet } from 'calypso/types';
 import './style.scss';
 
+export type UpgradeModalClosedBy = 'close_icon' | 'cancel_button' | 'dialog_action';
+
 interface UpgradeModalProps {
 	additionalClassNames?: string;
 	additionalOverlayClassNames?: string;
@@ -48,7 +50,7 @@ interface UpgradeModalProps {
 	isMarketplaceThemeSubscriptionNeeded?: boolean;
 	isMarketplacePlanSubscriptionNeeeded?: boolean;
 	marketplaceProduct?: ProductListItem;
-	closeModal: () => void;
+	closeModal: ( closedBy?: UpgradeModalClosedBy ) => void;
 	checkout: () => void;
 }
 
@@ -134,7 +136,10 @@ export const ThemeUpgradeModal = ( {
 			price: null,
 			action: (
 				<div className="theme-upgrade-modal__actions bundle">
-					<Button className="theme-upgrade-modal__cancel" onClick={ () => closeModal() }>
+					<Button
+						className="theme-upgrade-modal__cancel"
+						onClick={ () => closeModal( 'cancel_button' ) }
+					>
 						{ translate( 'Cancel' ) }
 					</Button>
 					<Button
@@ -198,7 +203,10 @@ export const ThemeUpgradeModal = ( {
 			price: null,
 			action: (
 				<div className="theme-upgrade-modal__actions bundle">
-					<Button className="theme-upgrade-modal__cancel" onClick={ () => closeModal() }>
+					<Button
+						className="theme-upgrade-modal__cancel"
+						onClick={ () => closeModal( 'cancel_button' ) }
+					>
 						{ translate( 'Cancel' ) }
 					</Button>
 					<Button
@@ -283,7 +291,10 @@ export const ThemeUpgradeModal = ( {
 			price: null,
 			action: (
 				<div className="theme-upgrade-modal__actions bundle externally-managed">
-					<Button className="theme-upgrade-modal__cancel" onClick={ () => closeModal() }>
+					<Button
+						className="theme-upgrade-modal__cancel"
+						onClick={ () => closeModal( 'cancel_button' ) }
+					>
 						{ translate( 'Cancel' ) }
 					</Button>
 					<Button
@@ -392,7 +403,7 @@ export const ThemeUpgradeModal = ( {
 			additionalOverlayClassNames={ additionalOverlayClassNames }
 			className={ classNames( 'theme-upgrade-modal', { loading: isLoading } ) }
 			isVisible={ isOpen }
-			onClose={ () => closeModal() }
+			onClose={ () => closeModal( 'dialog_action' ) }
 			isFullScreen
 		>
 			{ isLoading && <LoadingEllipsis /> }
@@ -407,7 +418,11 @@ export const ThemeUpgradeModal = ( {
 						{ modalData.action }
 					</div>
 					<div className="theme-upgrade-modal__col">{ features }</div>
-					<Button className="theme-upgrade-modal__close" borderless onClick={ () => closeModal() }>
+					<Button
+						className="theme-upgrade-modal__close"
+						borderless
+						onClick={ () => closeModal( 'close_icon' ) }
+					>
 						<WpIcon className="wpicon" icon={ close } size={ 24 } />
 						<ScreenReaderText>{ translate( 'Close modal' ) }</ScreenReaderText>
 					</Button>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79223

## Proposed Changes

This PR adds tracking events for "Live Preview in Premium/Woo themes". I added the following events;

- calypso_block_theme_live_preview_upgrade_modal_open
	- This event is fired when users open the upgrade modal either by clicking the button or using the shortcut (cmd+S).
		<img width="1437" alt="Screenshot 2023-12-21 at 11 28 53" src="https://github.com/Automattic/wp-calypso/assets/5287479/9b4859f3-e78c-40b7-b684-985c6a2871ef">
		<img width="392" alt="Screenshot 2023-12-21 at 11 29 08" src="https://github.com/Automattic/wp-calypso/assets/5287479/4017d341-a55b-41bb-b912-bb10764e01c6">
- ~~calypso_block_theme_live_preview_click_upgrade~~ -> calypso_block_theme_live_preview_upgrade_modal_upgrade
	- This event is fired when users click the upgrade button on the modal. 
		<img width="1424" alt="Screenshot 2023-12-21 at 11 27 31" src="https://github.com/Automattic/wp-calypso/assets/5287479/3e9db780-0317-4343-82ed-61eb8731322f">
- calypso_block_theme_live_preview_upgrade_modal_close
	- This event is fired when the modal is closed for any reason. 


We can include the `wpcom_product_purchase` event (for checkout completion) and the `wpcom_block_editor_save_click` event (for theme activation) in funnels. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Please Test it on https://horizon.wordpress.com/.

* Sandbox your site and widgets.wp.com.
* Run `install-plugin.sh wpcom-block-editor add/live-preview-track-event` on your sandbox.
* Go to the Theme Showcase page and pick a Premium or Woo theme.
* Click the `Upgrade now` button.
* Verify the event is fired.
	* When you click the button on the header in the edit mode.
		<img width="746" alt="Screenshot 2023-12-21 at 11 19 50" src="https://github.com/Automattic/wp-calypso/assets/5287479/ff1593ec-e2d7-4e9f-ac1c-6961cfa43ab6">
	* When you click the button on the sidebar.
		<img width="746" alt="Screenshot 2023-12-21 at 11 19 34" src="https://github.com/Automattic/wp-calypso/assets/5287479/c1961744-287b-45d6-9f4b-60847952fcb0">
	* When you use the shortcut.
		<img width="750" alt="Screenshot 2023-12-21 at 11 32 13" src="https://github.com/Automattic/wp-calypso/assets/5287479/e37b4cc7-34ce-4d84-8dd7-6213cb7c8765">
* Verify the event is fired when you close the modal by
	* Clicking the close icon
		<img width="750" alt="Screenshot 2023-12-22 at 11 13 56" src="https://github.com/Automattic/wp-calypso/assets/5287479/4af880ca-444a-4806-9eaa-e76f346cdaaa">
	* Clicking the Cancel button
		<img width="745" alt="Screenshot 2023-12-22 at 11 14 06" src="https://github.com/Automattic/wp-calypso/assets/5287479/0825fec3-2799-4431-a5d1-e0bc52bddca1">
	* Clicking the overlay or typing the `escape` key
		<img width="747" alt="Screenshot 2023-12-22 at 11 14 15" src="https://github.com/Automattic/wp-calypso/assets/5287479/46276097-3220-427a-b067-51a368e60dd6">
* Click the `Upgrade plan` button on the modal.
* Verify the event is fired.
	<img width="751" alt="Screenshot 2023-12-22 at 11 15 11" src="https://github.com/Automattic/wp-calypso/assets/5287479/ed279b6c-970e-4a26-816e-493303706404">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?