### PR TITLE
Assembler: Highlight the first plan feature list item

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.scss
@@ -53,8 +53,8 @@
 			margin-top: 8px;
 			gap: 16px;
 
-			/** Highlight the “Premium styles” feature */
-			&:nth-child(2) strong {
+			/** Highlight the “Free domain for one year” feature */
+			&:first-child strong {
 				font-weight: 600;
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85511

## Proposed Changes

This PR updates the CSS so that the first item ("Free domain for a year") of the plan feature list is in bold.

| Before | After |
| --- | --- |
| ![Screenshot 2023-12-20 at 3 02 19 PM](https://github.com/Automattic/wp-calypso/assets/797888/76e1e5f0-ea36-40a2-b54b-d5f68045d07a) | ![Screenshot 2023-12-20 at 3 01 58 PM](https://github.com/Automattic/wp-calypso/assets/797888/67474ed5-86e4-4d56-92aa-abd1f939e130) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler.
* Select any patterns.
* Select any premium style/font.
* Select any pages.
* Ensure that the upsell screen is updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?