### PR TITLE
Jetpack Manage: Handle missing payment method during Site creation flow.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
@@ -30,12 +30,7 @@ import { addQueryArgs } from 'calypso/lib/url';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
-import {
-	errorNotice,
-	infoNotice,
-	removeNotice,
-	successNotice,
-} from 'calypso/state/notices/actions';
+import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { creditCardStore } from 'calypso/state/partner-portal/credit-card-form';
 import { doesPartnerRequireAPaymentMethod } from 'calypso/state/partner-portal/partner/selectors';
 import { fetchStoredCards } from 'calypso/state/partner-portal/stored-cards/actions';
@@ -185,7 +180,6 @@ function PaymentMethodAdd( { selectedSite }: { selectedSite?: SiteDetails | null
 
 		// If this is a site creation flow, we will need to resume on the creation of site.
 		if ( isSiteCreationFlow ) {
-			dispatch( infoNotice( translate( 'A new WordPress.com site is on the way!' ) ) );
 			issueLicenses( [ { slug: product, quantity: 1 } ] );
 			page( `/dashboard?provisioning=true` );
 			return;

--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
@@ -5,11 +5,14 @@ import { formatCurrency } from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
 import useIssueLicenses from 'calypso/jetpack-cloud/sections/partner-portal/hooks/use-issue-licenses';
+import { partnerPortalBasePath } from 'calypso/lib/jetpack/paths';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
-import { useDispatch } from 'calypso/state';
+import { addQueryArgs } from 'calypso/lib/url';
+import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { infoNotice } from 'calypso/state/notices/actions';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
+import { doesPartnerRequireAPaymentMethod } from 'calypso/state/partner-portal/partner/selectors';
 import FeatureItem from './feature-item';
 import './style.scss';
 
@@ -38,6 +41,7 @@ export default function CardContent( {
 	const tooltipRef = useRef< HTMLDivElement | null >( null );
 	const [ showPopover, setShowPopover ] = useState( false );
 	const { data: agencyProducts } = useProductsQuery();
+	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
 
 	const getLogo = ( planSlug: string ) => {
 		switch ( planSlug ) {
@@ -138,6 +142,19 @@ export default function CardContent( {
 		const productSlug =
 			planSlug === PLAN_BUSINESS ? 'wpcom-hosting-business' : 'wpcom-hosting-ecommerce';
 
+		if ( paymentMethodRequired ) {
+			const nextStep = addQueryArgs(
+				{
+					product: productSlug,
+					source: 'create-site',
+				},
+				partnerPortalBasePath( '/payment-methods/add' )
+			);
+
+			page( nextStep );
+			return;
+		}
+
 		setIsRequesting( true );
 
 		dispatch( infoNotice( translate( 'A new WordPress.com site is on the way!' ) ) );
@@ -147,7 +164,7 @@ export default function CardContent( {
 
 		setIsRequesting( false );
 		page.redirect( `/dashboard?provisioning=true` );
-	}, [ dispatch, planSlug, issueLicenses, translate, setIsRequesting ] );
+	}, [ planSlug, paymentMethodRequired, setIsRequesting, dispatch, translate, issueLicenses ] );
 
 	if ( ! plan ) {
 		return null;


### PR DESCRIPTION
Currently, we do not check if the current user has the payment method when creating a new atomic site. This PR addresses this issue by handling missing payment method flow for site creation.

Closes https://github.com/Automattic/jetpack-manage/issues/172

## Proposed Changes

* Update the Site creation page to check if a payment method is required. If yes, redirect the user to the Add Payment method screen. After the user successfully added the payment method, the site creation flow continues like normal.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Before testing, please remove all Payment Methods you have here (`/partner-portal/payment-methods`)
* After removing all payment methods, Go to the site creation page (`/partner-portal/create-site`)
* Click the Get **Business** or **Commerce** CTA button. 
* Confirm that you are redirected to the Add Payment Method page.
* Click the **Go Back** button and confirm you return to the Site creation page  (`/partner-portal/create-site`)
* Click the Get **Business** or **Commerce** CTA button. 
* This time, input valid CC information and click the **Save payment method** button.
* Confirm that you are redirected to the Dashboard page and that a new site is being provisioned.
* Additionally, do regression testing with other flows that involve payment methods and confirm nothing has been broken with this change.


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?