### PR TITLE
Plan name change: Rollout to all users

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { setPlansListExperiment } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import {
 	getLanguage,
@@ -8,7 +7,6 @@ import {
 } from '@automattic/i18n-utils';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { translate } from 'i18n-calypso';
-import { useEffect } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
 import EmptyContent from 'calypso/components/empty-content';
@@ -16,7 +14,6 @@ import MomentProvider from 'calypso/components/localized-moment/provider';
 import { RouteProvider } from 'calypso/components/route';
 import Layout from 'calypso/layout';
 import LayoutLoggedOut from 'calypso/layout/logged-out';
-import { useExperiment } from 'calypso/lib/explat';
 import { login, createAccountUrl } from 'calypso/lib/paths';
 import { CalypsoReactQueryDevtools } from 'calypso/lib/react-query-devtools-helper';
 import { getSiteFragment } from 'calypso/lib/route';
@@ -47,14 +44,6 @@ export const ProviderWrappedLayout = ( {
 } ) => {
 	const state = store.getState();
 	const userLoggedIn = isUserLoggedIn( state );
-
-	const [ isLoading, experimentAssignment ] = useExperiment( 'wpcom_plan_name_change' );
-
-	useEffect( () => {
-		if ( ! isLoading ) {
-			setPlansListExperiment( 'wpcom_plan_name_change', experimentAssignment?.variationName );
-		}
-	}, [ isLoading ] );
 
 	const layout = userLoggedIn ? (
 		<Layout primary={ primary } secondary={ secondary } />

--- a/client/my-sites/hosting/test/index.js
+++ b/client/my-sites/hosting/test/index.js
@@ -180,9 +180,9 @@ describe( 'Hosting Configuration', () => {
 			renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );
 
 			expect(
-				screen.getByText( 'Upgrade to the Business plan to access all hosting features:' )
+				screen.getByText( 'Upgrade to the Creator plan to access all hosting features:' )
 			).toBeVisible();
-			expect( screen.getByText( 'Upgrade to Business Plan' ) ).toBeVisible();
+			expect( screen.getByText( 'Upgrade to Creator Plan' ) ).toBeVisible();
 
 			const [ mainFeatureExampleElement ] = screen.getAllByTestId( 'feature-example-wrapper' );
 
@@ -199,9 +199,9 @@ describe( 'Hosting Configuration', () => {
 			renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );
 
 			expect(
-				screen.getByText( 'Upgrade to the Business plan to access all hosting features:' )
+				screen.getByText( 'Upgrade to the Creator plan to access all hosting features:' )
 			).toBeVisible();
-			expect( screen.getByText( 'Upgrade to Business Plan' ) ).toBeVisible();
+			expect( screen.getByText( 'Upgrade to Creator Plan' ) ).toBeVisible();
 
 			const [ mainFeatureExampleElement ] = screen.getAllByTestId( 'feature-example-wrapper' );
 
@@ -212,7 +212,7 @@ describe( 'Hosting Configuration', () => {
 		} );
 	} );
 
-	describe( 'Site on Business plan', () => {
+	describe( 'Site on Creator plan', () => {
 		it( 'should show activation notice when the site is not Atomic', () => {
 			const testConfig = getTestConfig( {
 				planSlug: PLAN_BUSINESS_MONTHLY,
@@ -326,9 +326,9 @@ describe( 'Hosting Configuration', () => {
 			renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );
 
 			expect(
-				screen.queryByText( 'Upgrade to the Business plan to access all hosting features:' )
+				screen.queryByText( 'Upgrade to the Creator plan to access all hosting features:' )
 			).toBeNull();
-			expect( screen.queryByText( 'Upgrade to Business Plan' ) ).toBeNull();
+			expect( screen.queryByText( 'Upgrade to Creator Plan' ) ).toBeNull();
 
 			expect( screen.getByTestId( 'staging-site-production-card' ) ).toBeVisible();
 		} );

--- a/packages/calypso-products/src/plans-list.tsx
+++ b/packages/calypso-products/src/plans-list.tsx
@@ -445,7 +445,6 @@ import {
 	PRODUCT_JETPACK_CREATOR_YEARLY,
 	PRODUCT_JETPACK_CREATOR_MONTHLY,
 } from './constants';
-import { getPlansListExperiment } from './experiments';
 import type {
 	BillingTerm,
 	Plan,
@@ -782,10 +781,8 @@ const getPlanPersonalDetails = (): IncompleteWPcomPlan => ( {
 	group: GROUP_WPCOM,
 	type: TYPE_PERSONAL,
 	getTitle: () =>
-		getPlansListExperiment( 'wpcom_plan_name_change' ) === 'treatment'
-			? // translators: Starter is a plan name
-			  i18n.translate( 'Starter' )
-			: i18n.translate( 'Personal' ),
+		// translators: Starter is a plan name
+		i18n.translate( 'Starter' ),
 	getAudience: () => i18n.translate( 'Best for personal use' ),
 	getBlogAudience: () => i18n.translate( 'Best for personal use' ),
 	getPortfolioAudience: () => i18n.translate( 'Best for personal use' ),
@@ -959,10 +956,8 @@ const getPlanEcommerceDetails = (): IncompleteWPcomPlan => ( {
 	group: GROUP_WPCOM,
 	type: TYPE_ECOMMERCE,
 	getTitle: () =>
-		getPlansListExperiment( 'wpcom_plan_name_change' ) === 'treatment'
-			? // translators: Entrepreneur is a plan name
-			  i18n.translate( 'Entrepreneur' )
-			: i18n.translate( 'Commerce' ),
+		// translators: Entrepreneur is a plan name
+		i18n.translate( 'Entrepreneur' ),
 	getAudience: () => i18n.translate( 'Best for online stores' ),
 	getBlogAudience: () => i18n.translate( 'Best for online stores' ),
 	getPortfolioAudience: () => i18n.translate( 'Best for online stores' ),
@@ -1346,10 +1341,8 @@ const getPlanPremiumDetails = (): IncompleteWPcomPlan => ( {
 	group: GROUP_WPCOM,
 	type: TYPE_PREMIUM,
 	getTitle: () =>
-		getPlansListExperiment( 'wpcom_plan_name_change' ) === 'treatment'
-			? // translators: Explorer is a plan name
-			  i18n.translate( 'Explorer' )
-			: i18n.translate( 'Premium' ),
+		// translators: Explorer is a plan name
+		i18n.translate( 'Explorer' ),
 	getAudience: () => i18n.translate( 'Best for freelancers' ),
 	getBlogAudience: () => i18n.translate( 'Best for freelancers' ),
 	getPortfolioAudience: () => i18n.translate( 'Best for freelancers' ),
@@ -1570,10 +1563,8 @@ const getPlanBusinessDetails = (): IncompleteWPcomPlan => ( {
 	group: GROUP_WPCOM,
 	type: TYPE_BUSINESS,
 	getTitle: () =>
-		getPlansListExperiment( 'wpcom_plan_name_change' ) === 'treatment'
-			? // translators: Creator is a plan name
-			  i18n.translate( 'Creator' )
-			: i18n.translate( 'Business' ),
+		// translators: Creator is a plan name
+		i18n.translate( 'Creator' ),
 	getAudience: () => i18n.translate( 'Best for small businesses' ),
 	getBlogAudience: () => i18n.translate( 'Best for small businesses' ),
 	getPortfolioAudience: () => i18n.translate( 'Best for small businesses' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This removes the  `wpcom_plan_name_change` experiment checks so that all users see the new plans.
To avoid inconsistencies, this should be deployed after D132644-code.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/start/plans` or `/plans/{SITE_SLUG}`
* Check that all types of user accounts see the new plan names in the Pricing grid:
  * English and non-English
  * old and new compared to 2024-01-29

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
