### PR TITLE
Remove hasTranslation checks from upsell step

### DIFF
--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -3,10 +3,8 @@ import { getPlan, PLAN_PERSONAL, PLAN_BUSINESS } from '@automattic/calypso-produ
 import page from '@automattic/calypso-router';
 import formatCurrency from '@automattic/format-currency';
 import { useChatWidget } from '@automattic/help-center/src/hooks';
-import { englishLocales } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
-import { useI18n } from '@wordpress/react-i18n';
-import { useTranslate, numberFormat, getLocaleSlug } from 'i18n-calypso';
+import { useTranslate, numberFormat } from 'i18n-calypso';
 import { useState } from 'react';
 import imgBuiltBy from 'calypso/assets/images/cancellation/built-by.png';
 import imgBusinessPlan from 'calypso/assets/images/cancellation/business-plan.png';
@@ -110,7 +108,6 @@ type StepProps = {
 
 export default function UpsellStep( { upsell, site, purchase, ...props }: StepProps ) {
 	const translate = useTranslate();
-	const { hasTranslation } = useI18n();
 	const currencyCode = useSelector( getCurrentUserCurrencyCode ) || 'USD';
 	const numberOfPluginsThemes = numberFormat( 50000, 0 );
 	const discountRate = 25;
@@ -119,16 +116,6 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 	const { refundAmount } = props;
 	const { openChatWidget } = useChatWidget();
 	const businessPlanName = getPlan( PLAN_BUSINESS )?.getTitle() ?? '';
-	const hasAtomicCtaTranslation =
-		englishLocales.includes( String( getLocaleSlug() ) ) ||
-		hasTranslation( 'I want the %(businessPlanName)s plan' );
-	const hasAtomicUpsellTranslation =
-		englishLocales.includes( String( getLocaleSlug() ) ) ||
-		hasTranslation(
-			'Did you know that you can now use over %(numberOfPluginsThemes)s third-party plugins and themes on the WordPress.com %(businessPlanName)s plan? ' +
-				'Whatever feature or design you want to add to your site, you’ll find a plugin or theme to get you there. ' +
-				'Claim a %(discountRate)d%% discount when you renew your %(businessPlanName)s plan today – {{b}}just enter the code %(couponCode)s at checkout.{{/b}}'
-		);
 
 	switch ( upsell ) {
 		case 'live-chat:plans':
@@ -192,11 +179,9 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 					title={ translate( 'Go further with %(numberOfPluginsThemes)s plugins and themes', {
 						args: { numberOfPluginsThemes },
 					} ) }
-					acceptButtonText={
-						hasAtomicCtaTranslation
-							? translate( 'I want the %(businessPlanName)s plan', { args: { businessPlanName } } )
-							: translate( 'I want the Business plan' )
-					}
+					acceptButtonText={ translate( 'I want the %(businessPlanName)s plan', {
+						args: { businessPlanName },
+					} ) }
 					acceptButtonUrl={ `/checkout/${ site.slug }/business?coupon=${ couponCode }` }
 					onAccept={ () => {
 						recordTracksEvent( 'calypso_cancellation_upgrade_at_step_upgrade_click' );
@@ -206,30 +191,20 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 				>
 					{
 						/* translators: %(discountRate)d%% is a discount percentage like 20% or 25%, followed by an escaped percentage sign %% */
-						hasAtomicUpsellTranslation
-							? translate(
-									'Did you know that you can now use over %(numberOfPluginsThemes)s third-party plugins and themes on the WordPress.com %(businessPlanName)s plan? ' +
-										'Whatever feature or design you want to add to your site, you’ll find a plugin or theme to get you there. ' +
-										'Claim a %(discountRate)d%% discount when you renew your %(businessPlanName)s plan today – {{b}}just enter the code %(couponCode)s at checkout.{{/b}}',
-									{
-										args: {
-											numberOfPluginsThemes,
-											discountRate,
-											couponCode,
-											businessPlanName,
-										},
-										components: { b: <strong /> },
-									}
-							  )
-							: translate(
-									'Did you know that you can now use over %(numberOfPluginsThemes)s third-party plugins and themes on the WordPress.com Business plan? ' +
-										'Whatever feature or design you want to add to your site, you’ll find a plugin or theme to get you there. ' +
-										'Claim a %(discountRate)d%% discount when you renew your Business plan today – {{b}}just enter the code %(couponCode)s at checkout.{{/b}}',
-									{
-										args: { numberOfPluginsThemes, discountRate, couponCode },
-										components: { b: <strong /> },
-									}
-							  )
+						translate(
+							'Did you know that you can now use over %(numberOfPluginsThemes)s third-party plugins and themes on the WordPress.com %(businessPlanName)s plan? ' +
+								'Whatever feature or design you want to add to your site, you’ll find a plugin or theme to get you there. ' +
+								'Claim a %(discountRate)d%% discount when you renew your %(businessPlanName)s plan today – {{b}}just enter the code %(couponCode)s at checkout.{{/b}}',
+							{
+								args: {
+									numberOfPluginsThemes,
+									discountRate,
+									couponCode,
+									businessPlanName,
+								},
+								components: { b: <strong /> },
+							}
+						)
 					}
 				</Upsell>
 			);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Remove hasTranslation checks from the upsell step in the cancel flow

## Testing Instructions

* Buy Premium / Explorer
* Go to /me/purchases and cancel it, on the cancel form select that you were missing plugins

<img width="1043" alt="Screenshot 2023-12-20 at 10 02 16" src="https://github.com/Automattic/wp-calypso/assets/82778/680945ee-c0c0-49ed-955f-8a8dc5f0d2a4">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
