### PR TITLE
Remove hasTranslation check from video-audio-posts

### DIFF
--- a/client/blocks/product-purchase-features-list/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/video-audio-posts.jsx
@@ -9,9 +9,7 @@ import {
 	isWpComPremiumPlan,
 	isWpComProPlan,
 } from '@automattic/calypso-products';
-import { englishLocales } from '@automattic/i18n-utils';
-import { hasTranslation } from '@wordpress/i18n';
-import { localize, getLocaleSlug } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import videoImage from 'calypso/assets/images/illustrations/video-hosting.svg';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 import { newPost } from 'calypso/lib/paths';
@@ -21,32 +19,6 @@ function getDescription( plan, translate ) {
 		return translate(
 			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
 				'directly to your site — the Pro Plan has 50 GB storage.'
-		);
-	}
-
-	if ( isWpComBusinessPlan( plan ) ) {
-		const businessPlan = getPlan( plan );
-		if (
-			englishLocales.includes( String( getLocaleSlug() ) ) ||
-			hasTranslation(
-				'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
-					'directly to your site — the %(planName)s Plan has %(storageLimit)d GB storage.'
-			)
-		) {
-			return translate(
-				'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
-					'directly to your site — the %(planName)s Plan has %(storageLimit)d GB storage.',
-				{
-					args: {
-						planName: businessPlan.getTitle(),
-						storageLimit: 50,
-					},
-				}
-			);
-		}
-		return translate(
-			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
-				'directly to your site — the Business Plan has 200 GB storage.'
 		);
 	}
 
@@ -76,29 +48,19 @@ function getDescription( plan, translate ) {
 			}
 		);
 	}
-	if ( isWpComEcommercePlan( plan ) ) {
-		const eCommercePlan = getPlan( plan );
-		if (
-			englishLocales.includes( String( getLocaleSlug() ) ) ||
-			hasTranslation(
-				'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
-					'directly to your site — the %(planName)s Plan has %(storageLimit)d GB storage.'
-			)
-		) {
-			return translate(
-				'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
-					'directly to your site — the %(planName)s Plan has %(storageLimit)d GB storage.',
-				{
-					args: {
-						planName: eCommercePlan.getTitle(),
-						storageLimit: 50,
-					},
-				}
-			);
-		}
+
+	if ( isWpComBusinessPlan( plan ) || isWpComEcommercePlan( plan ) ) {
+		const newPlan = getPlan( plan );
+		// Translators: %(planName)s is the name of the plan - Creator, Enterpreneur, Business, or eCommerce. %(storageLimit)d is the storage limit in GB.
 		return translate(
 			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
-				'directly to your site — the eCommerce Plan has 200 GB storage.'
+				'directly to your site — the %(planName)s Plan has %(storageLimit)d GB storage.',
+			{
+				args: {
+					planName: newPlan.getTitle(),
+					storageLimit: 50,
+				},
+			}
 		);
 	}
 

--- a/client/blocks/product-purchase-features-list/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/video-audio-posts.jsx
@@ -51,7 +51,7 @@ function getDescription( plan, translate ) {
 
 	if ( isWpComBusinessPlan( plan ) || isWpComEcommercePlan( plan ) ) {
 		const newPlan = getPlan( plan );
-		// Translators: %(planName)s is the name of the plan - Creator, Enterpreneur, Business, or eCommerce. %(storageLimit)d is the storage limit in GB.
+		// Translators: %(planName)s is the name of the plan - Creator, Entrepreneur, Business, or eCommerce. %(storageLimit)d is the storage limit in GB.
 		return translate(
 			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
 				'directly to your site — the %(planName)s Plan has %(storageLimit)d GB storage.',


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Remove unnecessary `hasTranslation` that may result in seeing the old plan names in certain locales after we remove the locale check
* Also deduplicate - the code between Business and eCommerce is identical

## Testing Instructions

* Buy Business / eCommerce / Creator / Entrepreneur
* Go to /plans and click my-plan
* You should see the new string no matter the locale. You can try different locales, and it should be untranslated in the locales with less coverage

<img width="502" alt="Screenshot 2023-12-20 at 10 10 22" src="https://github.com/Automattic/wp-calypso/assets/82778/d3dd2b9e-1e0c-42a4-b5ee-9c186b76086d">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
