### PR TITLE
Rename the Business plan in help center

### DIFF
--- a/client/blocks/product-purchase-features-list/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/video-audio-posts.jsx
@@ -9,9 +9,7 @@ import {
 	isWpComPremiumPlan,
 	isWpComProPlan,
 } from '@automattic/calypso-products';
-import { englishLocales } from '@automattic/i18n-utils';
-import { hasTranslation } from '@wordpress/i18n';
-import { localize, getLocaleSlug } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import videoImage from 'calypso/assets/images/illustrations/video-hosting.svg';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 import { newPost } from 'calypso/lib/paths';
@@ -21,32 +19,6 @@ function getDescription( plan, translate ) {
 		return translate(
 			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
 				'directly to your site — the Pro Plan has 50 GB storage.'
-		);
-	}
-
-	if ( isWpComBusinessPlan( plan ) ) {
-		const businessPlan = getPlan( plan );
-		if (
-			englishLocales.includes( String( getLocaleSlug() ) ) ||
-			hasTranslation(
-				'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
-					'directly to your site — the %(planName)s Plan has %(storageLimit)d GB storage.'
-			)
-		) {
-			return translate(
-				'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
-					'directly to your site — the %(planName)s Plan has %(storageLimit)d GB storage.',
-				{
-					args: {
-						planName: businessPlan.getTitle(),
-						storageLimit: 50,
-					},
-				}
-			);
-		}
-		return translate(
-			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
-				'directly to your site — the Business Plan has 200 GB storage.'
 		);
 	}
 
@@ -76,29 +48,19 @@ function getDescription( plan, translate ) {
 			}
 		);
 	}
-	if ( isWpComEcommercePlan( plan ) ) {
-		const eCommercePlan = getPlan( plan );
-		if (
-			englishLocales.includes( String( getLocaleSlug() ) ) ||
-			hasTranslation(
-				'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
-					'directly to your site — the %(planName)s Plan has %(storageLimit)d GB storage.'
-			)
-		) {
-			return translate(
-				'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
-					'directly to your site — the %(planName)s Plan has %(storageLimit)d GB storage.',
-				{
-					args: {
-						planName: eCommercePlan.getTitle(),
-						storageLimit: 50,
-					},
-				}
-			);
-		}
+
+	if ( isWpComBusinessPlan( plan ) || isWpComEcommercePlan( plan ) ) {
+		const newPlan = getPlan( plan );
+		// Translators: %(planName)s is the name of the plan - Creator, Enterpreneur, Business, or eCommerce. %(storageLimit)d is the storage limit in GB.
 		return translate(
 			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
-				'directly to your site — the eCommerce Plan has 200 GB storage.'
+				'directly to your site — the %(planName)s Plan has %(storageLimit)d GB storage.',
+			{
+				args: {
+					planName: newPlan.getTitle(),
+					storageLimit: 50,
+				},
+			}
 		);
 	}
 

--- a/client/blocks/product-purchase-features-list/video-audio-posts.jsx
+++ b/client/blocks/product-purchase-features-list/video-audio-posts.jsx
@@ -51,7 +51,7 @@ function getDescription( plan, translate ) {
 
 	if ( isWpComBusinessPlan( plan ) || isWpComEcommercePlan( plan ) ) {
 		const newPlan = getPlan( plan );
-		// Translators: %(planName)s is the name of the plan - Creator, Enterpreneur, Business, or eCommerce. %(storageLimit)d is the storage limit in GB.
+		// Translators: %(planName)s is the name of the plan - Creator, Entrepreneur, Business, or eCommerce. %(storageLimit)d is the storage limit in GB.
 		return translate(
 			'Enrich your posts and pages with video or audio. Upload plenty of media, ' +
 				'directly to your site — the %(planName)s Plan has %(storageLimit)d GB storage.',

--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -1,4 +1,9 @@
-import { isWpComBusinessPlan, isWpComEcommercePlan } from '@automattic/calypso-products';
+import {
+	isWpComBusinessPlan,
+	isWpComEcommercePlan,
+	getPlan,
+	PLAN_BUSINESS,
+} from '@automattic/calypso-products';
 import { CompactCard, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import debugModule from 'debug';
@@ -56,7 +61,12 @@ class Help extends PureComponent {
 				link: localizeUrl( 'https://wordpress.com/support/business-plan/' ),
 				title: this.props.translate( 'Uploading custom plugins and themes' ),
 				description: this.props.translate(
-					'Learn more about installing a custom theme or plugin using the Business plan.'
+					'Learn more about installing a custom theme or plugin using the %(businessPlanName)s plan.',
+					{
+						args: {
+							businessPlanName: this.props.businessPlanName,
+						},
+					}
 				),
 				image: helpPlugins,
 			},
@@ -264,11 +274,13 @@ export const mapStateToProps = ( state ) => {
 		purchaseSlugs &&
 		( purchaseSlugs.some( isWpComBusinessPlan ) || purchaseSlugs.some( isWpComEcommercePlan ) )
 	);
+	const businessPlanName = getPlan( PLAN_BUSINESS )?.getTitle() ?? '';
 
 	return {
 		isBusinessOrEcomPlanUser,
 		isLoading,
 		isEmailVerified,
+		businessPlanName,
 	};
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Use getPlan.getTitle to show the plan name in /help

## Testing Instructions

* Go to /help
* Confirm that the plan name appears and is either Business or Creator depending on if your locale is English

<img width="1012" alt="Screenshot 2023-12-20 at 10 49 13" src="https://github.com/Automattic/wp-calypso/assets/82778/4e934e18-0e93-4bf9-ac3a-45eb542df1f6">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
