### PR TITLE
Plans 2023 (plans rename): Extend grid size to avoid overflows with the new plan names

### DIFF
--- a/client/my-sites/plans-grid/_media-queries.scss
+++ b/client/my-sites/plans-grid/_media-queries.scss
@@ -5,12 +5,12 @@ $plan-features-header-banner-height: 20px;
 
 // Plan Features Grid Breakpoints
 $plans-2023-small-breakpoint: 780px;
-$plans-2023-medium-breakpoint: 1200px;
+$plans-2023-medium-breakpoint: 1350px;
 
 $minWidthToGridWidthMap: (
 	780px: "668px",
 	1024px: "860px",
-	1200px: "100%",
+	1350px: "100%",
 );
 
 // Plan Comparison Grid Breakpoints

--- a/client/my-sites/plans-grid/media-queries.tsx
+++ b/client/my-sites/plans-grid/media-queries.tsx
@@ -3,10 +3,10 @@ import type { SerializedStyles } from '@emotion/react';
 
 const sidebarWidth = 272; //in px
 const plans2023SmallBreakpoint = '780px';
-const plans2023MediumBreakpoint = '1200px';
+const plans2023MediumBreakpoint = '1350px';
 const plans2023LargeBreakpoint = '1600px';
 const plans2023SmallWithSidebarBreakpoint = `${ 780 + sidebarWidth }px`;
-const plans2023MediumWithSidebarBreakpoint = `${ 1200 + sidebarWidth }px`;
+const plans2023MediumWithSidebarBreakpoint = `${ 1350 + sidebarWidth }px`;
 const plans2023LargeWithSidebarBreakpoint = `${ 1600 + sidebarWidth }px`;
 
 export const plansBreakSmall = ( styles: SerializedStyles ) => css`


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Updates the "medium" breakpoint on the Features Grid by a few pixels (from `1200` to `1350`) to avoid "Enterpreneur" (new plan name) from overflowing. 

## Media

### Before

At 1200 (where the breakpoint hits):

<img width="1191" alt="Screenshot 2023-12-20 at 12 22 24 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/e2f3588c-3b48-49c7-b68f-2fe9c8581ef5">

### After

At 1350 (where the breakpoint hits):

<img width="1341" alt="Screenshot 2023-12-20 at 12 22 42 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/664d668c-86fd-44b2-ac93-0f859676021f">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans` and resize the viewport. Ensure there are no overflows and that plans render fine
* Go to `/plans[site]` and ensure the same with/out the sidebar expanded
* Go to `/setup/newsletter` (or any flow with fewer plans) and ensure things are ok

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?