### PR TITLE
Assembler v2: Disable pattern cache for a12s testing with "pattern-assembler/v2"

### DIFF
--- a/packages/block-renderer/src/hooks/use-rendered-patterns.ts
+++ b/packages/block-renderer/src/hooks/use-rendered-patterns.ts
@@ -1,6 +1,9 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useQueries } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { RenderedPattern, RenderedPatterns, SiteInfo } from '../types';
+
+const CACHE_TIME = isEnabled( 'pattern-assembler/v2' ) ? 0 : 1000 * 60 * 5; // 5 minutes
 
 const fetchRenderedPatterns = (
 	siteId: number | string,
@@ -41,7 +44,7 @@ const useRenderedPatterns = (
 	const queries = Object.entries( patternIdsByCategory ).map( ( [ category, patternIds ] ) => ( {
 		queryKey: [ 'rendered-patterns', siteId, stylesheet, category, patternIds, siteInfo ],
 		queryFn: () => fetchRenderedPatterns( siteId, stylesheet, category, patternIds, siteInfo ),
-		staleTime: 1000 * 60 * 5, // 5 minutes
+		staleTime: CACHE_TIME,
 		refetchOnWindowFocus: false,
 	} ) );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/85264

## Proposed Changes

* Disable client-side pattern cache for rendered patterns when the flag `pattern-assembler/v2` is enabled

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Using the Calypso Live link below
- Access `/setup/with-theme-assembler/patternAssembler?flags=pattern-assembler/v2&siteSlug={ SITE }`
- Open "Chrome dev tools > Network" and verify that the renderer requests `/wpcom/v2/sites/215354566/block-renderer/patterns/render` are done whenever you refresh the browser.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?