### PR TITLE
Stats: Update tier handling to account for disabled free tier

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -105,7 +105,7 @@ function StatsPWYWUpgradeSlider( {
 	const mappedDefaultIndex = disableFreeProduct ? defaultStartingValue - 1 : defaultStartingValue;
 
 	// New slider change handler.
-	const handleSliderChanged2 = ( index: number ) => {
+	const handleSliderChanged = ( index: number ) => {
 		const mappedIndex = steps[ index ].mappedIndex;
 		if ( analyticsEventName ) {
 			recordTracksEvent( analyticsEventName, {
@@ -122,7 +122,7 @@ function StatsPWYWUpgradeSlider( {
 			uiStrings={ uiStrings }
 			steps={ steps }
 			initialValue={ mappedDefaultIndex }
-			onSliderChange={ handleSliderChanged2 }
+			onSliderChange={ handleSliderChanged }
 			marks={ marks }
 		/>
 	);

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -5,29 +5,6 @@ import TierUpgradeSlider from 'calypso/my-sites/stats/stats-purchase/tier-upgrad
 import { StatsPWYWSliderSettings } from 'calypso/my-sites/stats/stats-purchase/types';
 import './styles.scss';
 
-// TODO: Remove test data.
-// Currently used as a fallback if no plan info is provided.
-// Better approach is to require plan info and do some form of validation on it.
-function getPWYWPlanTiers( minPrice: number, stepPrice: number ) {
-	// From $0 to $20, in $1 increments.
-	let tiers: any[] = [];
-	for ( let i = 0; i <= 28; i++ ) {
-		tiers.push( {
-			price: formatCurrency( ( minPrice + i * stepPrice ) / 100, 'USD' ),
-			raw: minPrice + i * stepPrice,
-		} );
-	}
-	tiers = tiers.map( ( tier ) => {
-		const emoji = tier.raw < 500 ? ':|' : ':)';
-		return {
-			...tier,
-			lhValue: tier.price,
-			rhValue: emoji,
-		};
-	} );
-	return tiers;
-}
-
 function useTranslatedStrings( defaultAveragePayment: number, currencyCode: string ) {
 	const translate = useTranslate();
 	const limits = translate( 'Your monthly contribution', {
@@ -64,27 +41,6 @@ function emojiForStep( index: number, uiEmojiHeartTier: number, uiImageCelebrati
 	}
 	// Big spender! Fire emoji.
 	return String.fromCodePoint( 0x1f525 );
-}
-
-// Takes a StatsPWYWSliderSettings object and returns an array of slider steps.
-// The slider wants string values for the left and right labels.
-function stepsFromSettings( settings: StatsPWYWSliderSettings, currencyCode: string ) {
-	// Pull tier strategy from settings.
-	// We ignore the emoji thresholds and use our own.
-	const { sliderStepPrice, minSliderPrice, maxSliderPrice } = settings;
-	// Set up our slider steps based on above strategy.
-	const sliderSteps = [];
-	const maxSliderValue = Math.floor( maxSliderPrice / sliderStepPrice );
-	const minSliderValue = Math.round( minSliderPrice / sliderStepPrice );
-	for ( let i = minSliderValue; i <= maxSliderValue; i++ ) {
-		const rawValue = minSliderPrice + i * sliderStepPrice;
-		sliderSteps.push( {
-			raw: rawValue,
-			lhValue: formatCurrency( rawValue, currencyCode ),
-			rhValue: emojiForStep( i, settings.uiEmojiHeartTier, settings.uiImageCelebrationTier ),
-		} );
-	}
-	return sliderSteps;
 }
 
 // Generate the range of available tiers based on the passed-in slider settings.

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -144,17 +144,6 @@ function StatsPWYWUpgradeSlider( {
 	}
 	const marks = [ 0, steps.length - 1 ];
 
-	const handleSliderChanged = ( index: number ) => {
-		if ( analyticsEventName ) {
-			recordTracksEvent( analyticsEventName, {
-				step: index,
-				default_changed: index !== defaultStartingValue,
-			} );
-		}
-
-		onSliderChange( index );
-	};
-
 	// New steps generation.
 	const tiersX = generatePlanTiers( settings );
 	const stepsX = generateSteps( tiersX, currencyCode, settings );
@@ -167,7 +156,14 @@ function StatsPWYWUpgradeSlider( {
 
 	// New slider change handler.
 	const handleSliderChanged2 = ( index: number ) => {
-		onSliderChange( stepsX[ index ].mappedIndex );
+		const mappedIndex = stepsX[ index ].mappedIndex;
+		if ( analyticsEventName ) {
+			recordTracksEvent( analyticsEventName, {
+				step: mappedIndex,
+				default_changed: mappedIndex !== mappedDefaultIndex,
+			} );
+		}
+		onSliderChange( mappedIndex );
 	};
 
 	return (

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -138,12 +138,6 @@ function StatsPWYWUpgradeSlider( {
 	const defaultAveragePayment = defaultStartingValue * settings.sliderStepPrice;
 	const uiStrings = useTranslatedStrings( defaultAveragePayment, currencyCode );
 
-	let steps = getPWYWPlanTiers( 0, 50 );
-	if ( settings !== undefined ) {
-		steps = stepsFromSettings( settings, currencyCode || '' );
-	}
-	const marks = [ 0, steps.length - 1 ];
-
 	// New steps generation.
 	const tiersX = generatePlanTiers( settings );
 	const stepsX = generateSteps( tiersX, currencyCode, settings );

--- a/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-pwyw-uprade-slider/index.tsx
@@ -95,9 +95,9 @@ function StatsPWYWUpgradeSlider( {
 	const uiStrings = useTranslatedStrings( defaultAveragePayment, currencyCode );
 
 	// New steps generation.
-	const tiersX = generatePlanTiers( settings );
-	const stepsX = generateSteps( tiersX, currencyCode, settings );
-	const marks2 = [ 0, stepsX.length - 1 ];
+	const tiers = generatePlanTiers( settings );
+	const steps = generateSteps( tiers, currencyCode, settings );
+	const marks = [ 0, steps.length - 1 ];
 
 	// New mapped indexing for slider.
 	// Implemented this way so as to not break parent logic.
@@ -106,7 +106,7 @@ function StatsPWYWUpgradeSlider( {
 
 	// New slider change handler.
 	const handleSliderChanged2 = ( index: number ) => {
-		const mappedIndex = stepsX[ index ].mappedIndex;
+		const mappedIndex = steps[ index ].mappedIndex;
 		if ( analyticsEventName ) {
 			recordTracksEvent( analyticsEventName, {
 				step: mappedIndex,
@@ -120,10 +120,10 @@ function StatsPWYWUpgradeSlider( {
 		<TierUpgradeSlider
 			className="stats-pwyw-upgrade-slider"
 			uiStrings={ uiStrings }
-			steps={ stepsX }
+			steps={ steps }
 			initialValue={ mappedDefaultIndex }
 			onSliderChange={ handleSliderChanged2 }
-			marks={ marks2 }
+			marks={ marks }
 		/>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85398.

## Proposed Changes

Update the `StatsPWYWUpgradeSlider` component to handle the case of the free tier being disabled. Does some mapping in the component so as to avoid refactoring in the parent for now.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch the Calypso Live link.
* Navigate to **Stats → Traffic**.
* Click on CTA to purchase Stats plan.
* Purchase a "free" plan.
* Revisit the upgrade page.
* Add `stats/tier-upgrade-slider` to URL flags.
* Confirm the slider defaults to the default tier. (half the max price)
* Confirm the range is correct. Should match the range minus the first free tier.

**Note:** In my testing we do not yet support upgrading from one tier to the next in the PWYW flow. Instead the user is pushed to the commercial plans. Confirmed with the existing flows so the new behaviour matches the previous behaviour.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?