### PR TITLE
Import content flow: Improve UX for progress bar movement

### DIFF
--- a/client/blocks/importer/components/progress-screen/index.tsx
+++ b/client/blocks/importer/components/progress-screen/index.tsx
@@ -2,7 +2,7 @@ import { Progress, SubTitle, Title } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useCallback } from 'react';
 import { ProgressBar } from 'calypso/devdocs/design/playground-scope';
-import { calculateProgress } from 'calypso/my-sites/importer/importing-pane';
+import useProgressValue from './use-progress-value';
 import type { ImportJob } from '../../types';
 
 interface Props {
@@ -12,6 +12,7 @@ const ProgressScreen: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
 	const { job } = props;
 	const { customData } = job || {};
+	const progressValue = useProgressValue( job?.progress );
 
 	const getPlaygroundImportTitle = useCallback( () => {
 		switch ( customData?.current_step ) {
@@ -35,12 +36,11 @@ const ProgressScreen: React.FunctionComponent< Props > = ( props ) => {
 
 	const title =
 		job?.importerFileType !== 'playground' ? __( 'Importing' ) : getPlaygroundImportTitle();
-	const progress = job ? calculateProgress( job.progress ) : NaN;
 
 	return (
 		<Progress>
 			<Title>{ title }...</Title>
-			<ProgressBar compact={ true } value={ Number.isNaN( progress ) ? 0 : progress } />
+			<ProgressBar compact={ true } value={ progressValue } />
 			<SubTitle>
 				{ __( 'Feel free to close this window. We’ll email you when your new site is ready.' ) }
 			</SubTitle>

--- a/client/blocks/importer/components/progress-screen/index.tsx
+++ b/client/blocks/importer/components/progress-screen/index.tsx
@@ -1,7 +1,7 @@
+import { ProgressBar } from '@automattic/components';
 import { Progress, SubTitle, Title } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useCallback } from 'react';
-import { ProgressBar } from 'calypso/devdocs/design/playground-scope';
 import useProgressValue from './use-progress-value';
 import type { ImportJob } from '../../types';
 

--- a/client/blocks/importer/components/progress-screen/index.tsx
+++ b/client/blocks/importer/components/progress-screen/index.tsx
@@ -27,10 +27,12 @@ const ProgressScreen: React.FunctionComponent< Props > = ( props ) => {
 			case 'clean_up':
 				return __( 'Migrating your data' );
 
-			case 'convert_to_atomic':
 			case 'download_archive':
-			default:
 				return __( 'Backing up your data' );
+
+			case 'convert_to_atomic':
+			default:
+				return __( 'Preparing your site for import' );
 		}
 	}, [ customData?.current_step ] );
 

--- a/client/blocks/importer/components/progress-screen/use-progress-value.ts
+++ b/client/blocks/importer/components/progress-screen/use-progress-value.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from 'react';
+import { calculateProgress } from 'calypso/my-sites/importer/importing-pane';
+import type { ImportJobProgress } from 'calypso/blocks/importer/types';
+
+export default function useProgressValue( jobProgress: Partial< ImportJobProgress > = {} ): number {
+	const isBackupImport = Object.keys( jobProgress ).length === 1 && !! jobProgress.steps;
+
+	const [ realProgress, setRealProgress ] = useState( 0 );
+	const [ movableProgress, setMovableProgress ] = useState( 0 );
+
+	// set real progress
+	useEffect( () => {
+		const progress = jobProgress ? calculateProgress( jobProgress ) : NaN;
+		setRealProgress( Number.isNaN( progress ) ? 0 : progress );
+	}, [ jobProgress ] );
+
+	// set movable progress
+	useEffect( () => {
+		if ( ! isBackupImport ) {
+			return;
+		}
+
+		const nextMilestone = calculateProgress(
+			jobProgress.steps
+				? { steps: { completed: jobProgress.steps.completed + 1, total: jobProgress.steps.total } }
+				: {}
+		);
+
+		// calculate movable progress
+		const interval = setInterval( () => {
+			if ( movableProgress >= nextMilestone ) {
+				setMovableProgress( nextMilestone );
+			} else {
+				const progress = realProgress > movableProgress ? realProgress : movableProgress;
+				setMovableProgress( progress + 1 );
+			}
+		}, 500 );
+		return () => clearInterval( interval );
+	}, [ realProgress, movableProgress ] );
+
+	return isBackupImport ? movableProgress : realProgress;
+}

--- a/client/blocks/importer/components/progress-screen/use-progress-value.ts
+++ b/client/blocks/importer/components/progress-screen/use-progress-value.ts
@@ -34,7 +34,7 @@ export default function useProgressValue( jobProgress: Partial< ImportJobProgres
 				const progress = realProgress > movableProgress ? realProgress : movableProgress;
 				setMovableProgress( progress + 1 );
 			}
-		}, 500 );
+		}, 1000 );
 		return () => clearInterval( interval );
 	}, [ realProgress, movableProgress ] );
 

--- a/client/blocks/importer/types.ts
+++ b/client/blocks/importer/types.ts
@@ -54,12 +54,15 @@ export interface ImportJob {
 		description: string;
 		code?: string;
 	};
-	progress: {
-		page: { completed: number; total: number };
-		post: { completed: number; total: number };
-		comment: { completed: number; total: number };
-		attachment: { completed: number; total: number };
-	};
+	progress: ImportJobProgress;
+}
+
+export interface ImportJobProgress {
+	page: { completed: number; total: number };
+	post: { completed: number; total: number };
+	comment: { completed: number; total: number };
+	attachment: { completed: number; total: number };
+	steps: { completed: number; total: number };
 }
 
 export interface ImportJobParams {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/4907

## Proposed Changes

* Created a hook for calculating the progress bar value.
* Introduced movable progress for the backup imports, avoiding a stuck feeling. Every 0.5 seconds, increase by 1% until reaches the next milestone/progress step.
* For the regular WXR import, the logic remains the same

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/import-focused?siteSlug={SLUG}`
* Click on "choose a content platform"
* Select "WordPress"
* Upload the "playground backup" file
* Check if the importing progress bar moves

![Screen Capture on 2023-12-20 at 13-49-25](https://github.com/Automattic/wp-calypso/assets/1241413/4ee6ec67-6614-45c6-93f2-c5e7e17856cd)

<img width="697" alt="Screenshot 2023-12-21 at 00 20 49" src="https://github.com/Automattic/wp-calypso/assets/1241413/5b5cb6f4-bd73-4cc4-ab63-7f4e6567cc36">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?