### PR TITLE
Auto-apply coupons in the signup flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -43,8 +43,8 @@ export function generateFlows( {
 				return translate( 'Create an account' );
 			},
 			showRecaptcha: true,
-			providesDependenciesInQuery: [ 'toStepper', 'coupon' ],
-			optionalDependenciesInQuery: [ 'toStepper', 'coupon' ],
+			providesDependenciesInQuery: [ 'toStepper' ],
+			optionalDependenciesInQuery: [ 'toStepper' ],
 			hideProgressIndicator: true,
 		},
 		{
@@ -146,6 +146,8 @@ export function generateFlows( {
 			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pau2Xa-Vs.',
 			lastModified: '2023-10-11',
 			showRecaptcha: true,
+			providesDependenciesInQuery: [ 'coupon' ],
+			optionalDependenciesInQuery: [ 'coupon' ],
 			hideProgressIndicator: true,
 			props: {
 				plans: {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -43,8 +43,8 @@ export function generateFlows( {
 				return translate( 'Create an account' );
 			},
 			showRecaptcha: true,
-			providesDependenciesInQuery: [ 'toStepper' ],
-			optionalDependenciesInQuery: [ 'toStepper' ],
+			providesDependenciesInQuery: [ 'toStepper', 'coupon' ],
+			optionalDependenciesInQuery: [ 'toStepper', 'coupon' ],
 			hideProgressIndicator: true,
 		},
 		{
@@ -54,6 +54,8 @@ export function generateFlows( {
 			description: 'Create an account and a blog and then add the business plan to the users cart.',
 			lastModified: '2023-10-11',
 			showRecaptcha: true,
+			providesDependenciesInQuery: [ 'coupon' ],
+			optionalDependenciesInQuery: [ 'coupon' ],
 			hideProgressIndicator: true,
 		},
 		{
@@ -63,6 +65,8 @@ export function generateFlows( {
 			description: 'Create an account and a blog and then add the premium plan to the users cart.',
 			lastModified: '2023-10-11',
 			showRecaptcha: true,
+			providesDependenciesInQuery: [ 'coupon' ],
+			optionalDependenciesInQuery: [ 'coupon' ],
 			hideProgressIndicator: true,
 		},
 		{
@@ -72,6 +76,8 @@ export function generateFlows( {
 			description: 'Create an account and a blog and then add the personal plan to the users cart.',
 			lastModified: '2023-10-11',
 			showRecaptcha: true,
+			providesDependenciesInQuery: [ 'coupon' ],
+			optionalDependenciesInQuery: [ 'coupon' ],
 			hideProgressIndicator: true,
 		},
 		{

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -26,6 +26,7 @@ function getCheckoutUrl( dependencies, localeSlug, flowName ) {
 		{
 			signup: 1,
 			ref: getQueryArgs()?.ref,
+			...( dependencies.coupon && { coupon: dependencies.coupon } ),
 			...( [ 'domain' ].includes( flowName ) && {
 				isDomainOnly: 1,
 				checkoutBackUrl:


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* This patch auto-applies a coupon to checkout when supplied as a query dependency to the signup flow.
* So something like https://wordpress.com/start/?coupon=MYAWESOMECOUPON will auto-apply this coupon at checkout. 
* This is currently enabled for `/start/`, `/start/personal`, `/start/premium`, and `/start/business`. Since ecommerce flow is on Stepper, I will follow up with a separate PR to enable this on stepper. 


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new account at `/start/?coupon= NEWYEAR2024`, select a paid plan, and verify that the coupon is auto-applied at checkout. Verify this also for `/start/personal/?coupon= NEWYEAR2024`, `/start/premium/?coupon= NEWYEAR2024`, and `/start/business/?coupon= NEWYEAR2024` flows.
* Run through all the above mentioned flows **without** the coupon query param and verify that you're able to create an account and a site, and are able to checkout. That is, `/start/`, `/start/personal` etc should work.
* Add a non-existent coupon (e.g. `/start/?coupon=DINOSAUR`) should still allow you to complete signup and site creation, but an error mesage will be displayed at checkout that the coupon is not valid. 

