### PR TITLE
Remove hasTranslation check from Advertising Removed on my-plan

### DIFF
--- a/client/blocks/product-purchase-features-list/advertising-removed.jsx
+++ b/client/blocks/product-purchase-features-list/advertising-removed.jsx
@@ -1,35 +1,21 @@
 import { getPlan } from '@automattic/calypso-products';
 import { PLAN_BUSINESS } from '@automattic/data-stores/src/plans/constants';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import adsRemovedImage from 'calypso/assets/images/illustrations/removed-ads.svg';
 import PurchaseDetail from 'calypso/components/purchase-detail';
 
 export default localize( ( { isEligiblePlan, selectedSite, translate } ) => {
-	const isEnglishLocale = useIsEnglishLocale();
-	const uneligiblePlanDescription =
-		isEnglishLocale ||
-		i18n.hasTranslation(
-			'All WordPress.com advertising has been removed from your site. Upgrade to %(businessPlanName)s ' +
-				'to remove the WordPress.com footer credit.'
-		)
-			? translate(
-					'All WordPress.com advertising has been removed from your site. Upgrade to %(businessPlanName)s ' +
-						'to remove the WordPress.com footer credit.',
-					{
-						args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
-					}
-			  )
-			: translate(
-					'All WordPress.com advertising has been removed from your site. Upgrade to Business ' +
-						'to remove the WordPress.com footer credit.'
-			  );
-	const buttonText =
-		isEnglishLocale || i18n.hasTranslation( 'Upgrade to %(planName)s' )
-			? translate( 'Upgrade to %(planName)s', {
-					args: { planName: getPlan( PLAN_BUSINESS ).getTitle() },
-			  } )
-			: translate( 'Upgrade to Business' );
+	const businessPlanName = getPlan( PLAN_BUSINESS )?.getTitle() ?? '';
+	const uneligiblePlanDescription = translate(
+		'All WordPress.com advertising has been removed from your site. Upgrade to %(businessPlanName)s ' +
+			'to remove the WordPress.com footer credit.',
+		{
+			args: { businessPlanName },
+		}
+	);
+	const buttonText = translate( 'Upgrade to %(planName)s', {
+		args: { planName: businessPlanName },
+	} );
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Remove hasTranslation check from my-plan

## Testing Instructions

1. Buy Explorer / Premium
2. Go to /plans and click my-plan
3. Make sure the Advertising removed section looks fine


<img width="501" alt="Screenshot 2023-12-20 at 15 00 56" src="https://github.com/Automattic/wp-calypso/assets/82778/2b37d077-33f7-4b3c-b932-4471dfefca1a">


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
