### PR TITLE
Theme Tiers: Add personal tier logic to the theme details page.

### DIFF
--- a/client/components/theme-tier/get-theme-tier.js
+++ b/client/components/theme-tier/get-theme-tier.js
@@ -1,0 +1,17 @@
+import config from '@automattic/calypso-config';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { getTheme } from 'calypso/state/themes/selectors';
+
+export default ( state, siteId, themeId ) => {
+	const theme = getTheme( state, 'wpcom', themeId );
+	const themeTier = theme?.theme_tier || {};
+	const isThemeAllowedOnSite =
+		config.isEnabled( 'themes/tiers' ) && themeTier?.feature
+			? siteHasFeature( state, siteId, themeTier.feature )
+			: true;
+
+	return {
+		themeTier,
+		isThemeAllowedOnSite,
+	};
+};

--- a/client/components/theme-tier/use-theme-tier.js
+++ b/client/components/theme-tier/use-theme-tier.js
@@ -1,16 +1,5 @@
+import getThemeTier from 'calypso/components/theme-tier/get-theme-tier';
 import { useSelector } from 'calypso/state';
-import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import { getTheme } from 'calypso/state/themes/selectors/get-theme';
 
-export default function useThemeTier( siteId, themeId ) {
-	const theme = useSelector( ( state ) => getTheme( state, 'wpcom', themeId ) );
-	const themeTier = theme?.theme_tier || {};
-	const isThemeAllowedOnSite = useSelector( ( state ) =>
-		themeTier?.feature ? siteHasFeature( state, siteId, themeTier.feature ) : true
-	);
-
-	return {
-		themeTier,
-		isThemeAllowedOnSite,
-	};
-}
+export default ( siteId, themeId ) =>
+	useSelector( ( state ) => getThemeTier( state, siteId, themeId ) );

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -183,6 +183,7 @@ const BannerUpsellDescription = ( {
  * @param {boolean} props.isSiteEligibleForManagedExternalThemes
  * @param {boolean} props.isMarketplaceThemeSubscribed
  * @param {boolean} props.isThemeAllowedOnSite
+ * @param {Object} props.themeTier
  * @returns {string} The title for the banner upsell.
  */
 const BannerUpsellTitle = ( {
@@ -193,26 +194,48 @@ const BannerUpsellTitle = ( {
 	isSiteEligibleForManagedExternalThemes,
 	isMarketplaceThemeSubscribed,
 	isThemeAllowedOnSite,
+	themeTier,
 } ) => {
 	const bundleSettings = useBundleSettingsByTheme( themeId );
 	const isEnglishLocale = useIsEnglishLocale();
 
-	if ( ! isThemeAllowedOnSite ) {
-		return isEnglishLocale ||
-			i18n.hasTranslation(
-				'Access this theme for FREE with a %(personalPlanName)s, %(premiumPlanName)s, or %(businessPlanName)s plan!'
-			)
+	const premiumPlanTitle = () =>
+		isEnglishLocale ||
+		i18n.hasTranslation(
+			'Access this theme for FREE with a %(premiumPlanName)s or %(businessPlanName)s plan!'
+		)
 			? translate(
-					'Access this theme for FREE with a %(personalPlanName)s, %(premiumPlanName)s, or %(businessPlanName)s plan!',
+					'Access this theme for FREE with a %(premiumPlanName)s or %(businessPlanName)s plan!',
 					{
 						args: {
-							personalPlanName: getPlan( PLAN_PERSONAL ).getTitle(),
 							premiumPlanName: getPlan( PLAN_PREMIUM ).getTitle(),
 							businessPlanName: getPlan( PLAN_BUSINESS ).getTitle(),
 						},
 					}
 			  )
-			: translate( 'Access this theme for FREE with a Personal, Premium, or Business plan!' );
+			: translate( 'Access this theme for FREE with a Premium or Business plan!' );
+
+	if ( ! isThemeAllowedOnSite ) {
+		switch ( THEME_TIERS[ themeTier.slug ].minimumUpsellPlan ) {
+			case PLAN_PERSONAL:
+				return isEnglishLocale ||
+					i18n.hasTranslation(
+						'Access this theme for FREE with a %(personalPlanName)s, %(premiumPlanName)s, or %(businessPlanName)s plan!'
+					)
+					? translate(
+							'Access this theme for FREE with a %(personalPlanName)s, %(premiumPlanName)s, or %(businessPlanName)s plan!',
+							{
+								args: {
+									personalPlanName: getPlan( PLAN_PERSONAL ).getTitle(),
+									premiumPlanName: getPlan( PLAN_PREMIUM ).getTitle(),
+									businessPlanName: getPlan( PLAN_BUSINESS ).getTitle(),
+								},
+							}
+					  )
+					: translate( 'Access this theme for FREE with a Personal, Premium, or Business plan!' );
+			case PLAN_PREMIUM:
+				return premiumPlanTitle();
+		}
 	}
 
 	if ( isBundledSoftwareSet && ! isExternallyManagedTheme ) {
@@ -248,20 +271,7 @@ const BannerUpsellTitle = ( {
 		return translate( 'Subscribe to this theme!' );
 	}
 
-	return isEnglishLocale ||
-		i18n.hasTranslation(
-			'Access this theme for FREE with a %(premiumPlanName)s or %(businessPlanName)s plan!'
-		)
-		? translate(
-				'Access this theme for FREE with a %(premiumPlanName)s or %(businessPlanName)s plan!',
-				{
-					args: {
-						premiumPlanName: getPlan( PLAN_PREMIUM ).getTitle(),
-						businessPlanName: getPlan( PLAN_BUSINESS ).getTitle(),
-					},
-				}
-		  )
-		: translate( 'Access this theme for FREE with a Premium or Business plan!' );
+	return premiumPlanTitle();
 };
 
 class ThemeSheet extends Component {

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -203,7 +203,7 @@ const BannerUpsellTitle = ( {
 				'Access this theme for FREE with a %(personalPlanName)s, %(premiumPlanName)s, or %(businessPlanName)s plan!'
 			)
 			? translate(
-					'Access this theme for FREE with a %(personalPlanName)s or %(businessPlanName)s plan!',
+					'Access this theme for FREE with a %(personalPlanName)s, %(premiumPlanName)s, or %(businessPlanName)s plan!',
 					{
 						args: {
 							personalPlanName: getPlan( PLAN_PERSONAL ).getTitle(),

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -8,6 +8,7 @@ import {
 	PLAN_PREMIUM,
 	WPCOM_FEATURES_PREMIUM_THEMES,
 	getPlan,
+	PLAN_PERSONAL,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Card, Gridicon } from '@automattic/components';
@@ -42,6 +43,8 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
 import SectionHeader from 'calypso/components/section-header';
+import { THEME_TIERS } from 'calypso/components/theme-tier/constants';
+import getThemeTier from 'calypso/components/theme-tier/get-theme-tier';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
@@ -165,7 +168,7 @@ const BannerUpsellDescription = ( {
 	}
 
 	return translate(
-		'Instantly unlock all premium themes, more storage space, advanced customization, video support, and more when you upgrade.'
+		'Instantly unlock more themes and storage space, advanced customization, video support, and more when you upgrade.'
 	);
 };
 
@@ -179,6 +182,7 @@ const BannerUpsellDescription = ( {
  * @param {Function} props.translate
  * @param {boolean} props.isSiteEligibleForManagedExternalThemes
  * @param {boolean} props.isMarketplaceThemeSubscribed
+ * @param {boolean} props.isThemeAllowedOnSite
  * @returns {string} The title for the banner upsell.
  */
 const BannerUpsellTitle = ( {
@@ -188,9 +192,28 @@ const BannerUpsellTitle = ( {
 	translate,
 	isSiteEligibleForManagedExternalThemes,
 	isMarketplaceThemeSubscribed,
+	isThemeAllowedOnSite,
 } ) => {
 	const bundleSettings = useBundleSettingsByTheme( themeId );
 	const isEnglishLocale = useIsEnglishLocale();
+
+	if ( ! isThemeAllowedOnSite ) {
+		return isEnglishLocale ||
+			i18n.hasTranslation(
+				'Access this theme for FREE with a %(personalPlanName)s, %(premiumPlanName)s, or %(businessPlanName)s plan!'
+			)
+			? translate(
+					'Access this theme for FREE with a %(personalPlanName)s or %(businessPlanName)s plan!',
+					{
+						args: {
+							personalPlanName: getPlan( PLAN_PERSONAL ).getTitle(),
+							premiumPlanName: getPlan( PLAN_PREMIUM ).getTitle(),
+							businessPlanName: getPlan( PLAN_BUSINESS ).getTitle(),
+						},
+					}
+			  )
+			: translate( 'Access this theme for FREE with a Personal, Premium, or Business plan!' );
+	}
 
 	if ( isBundledSoftwareSet && ! isExternallyManagedTheme ) {
 		if ( ! bundleSettings ) {
@@ -557,12 +580,14 @@ class ThemeSheet extends Component {
 			isPremium,
 			isVip,
 			retired,
+			isThemeAllowedOnSite,
 		} = this.props;
 
 		// Show theme upsell banner on Simple sites.
 		return (
 			( ! isJetpack && isPremium && ! hasUnlimitedPremiumThemes && ! isVip && ! retired ) ||
 			isBundledSoftwareSet ||
+			! isThemeAllowedOnSite ||
 			isExternallyManagedTheme
 		);
 	}
@@ -1009,6 +1034,7 @@ class ThemeSheet extends Component {
 			isSiteEligibleForManagedExternalThemes,
 			isMarketplaceThemeSubscribed,
 			isThemeActivationSyncStarted,
+			isThemeAllowedOnSite,
 			isThemeInstalled,
 		} = this.props;
 		const { isAtomicTransferCompleted } = this.state;
@@ -1021,7 +1047,11 @@ class ThemeSheet extends Component {
 				</span>
 			);
 		} else if ( isLoggedIn && siteId ) {
-			if ( isPremium && ! isThemePurchased && ! isExternallyManagedTheme ) {
+			if (
+				( ! isThemeAllowedOnSite || isPremium ) &&
+				! isThemePurchased &&
+				! isExternallyManagedTheme
+			) {
 				// upgrade plan
 				return translate( 'Upgrade to activate', {
 					comment:
@@ -1287,6 +1317,8 @@ class ThemeSheet extends Component {
 			isExternallyManagedTheme,
 			isThemeActivationSyncStarted,
 			isWpcomTheme,
+			isThemeAllowedOnSite,
+			themeTier,
 		} = this.props;
 
 		const isEnglishLocale = [ 'en', 'en-gb' ].includes( this.props.locale );
@@ -1303,8 +1335,14 @@ class ThemeSheet extends Component {
 			plansUrl = localizeUrl( 'https://wordpress.com/pricing' );
 		} else if ( siteSlug ) {
 			const redirectTo = `/theme/${ themeId }${ section ? '/' + section : '' }/${ siteSlug }`;
-			const plan = isExternallyManagedTheme || isBundledSoftwareSet ? PLAN_BUSINESS : PLAN_PREMIUM;
+			let plan;
+			if ( ! isThemeAllowedOnSite ) {
+				plan = THEME_TIERS[ themeTier.slug ].minimumUpsellPlan;
+			} else {
+				plan = isExternallyManagedTheme || isBundledSoftwareSet ? PLAN_BUSINESS : PLAN_PREMIUM;
+			}
 
+			// @TODO we should add a new feature for personal plan themes or what we agree on.
 			const feature =
 				PLAN_PREMIUM === plan ? FEATURE_PREMIUM_THEMES_V2 : FEATURE_UPLOAD_THEMES_PLUGINS;
 
@@ -1383,8 +1421,14 @@ class ThemeSheet extends Component {
 					! isThemeInstalled &&
 					( ! isMarketplaceThemeSubscribed || ! isSiteEligibleForManagedExternalThemes ) );
 
-			const upsellNudgePlan =
-				isExternallyManagedTheme || isBundledSoftwareSet ? PLAN_BUSINESS : PLAN_PREMIUM;
+			let upsellNudgePlan;
+			if ( ! isThemeAllowedOnSite ) {
+				upsellNudgePlan = THEME_TIERS[ themeTier.slug ].minimumUpsellPlan;
+			} else {
+				upsellNudgePlan =
+					isExternallyManagedTheme || isBundledSoftwareSet ? PLAN_BUSINESS : PLAN_PREMIUM;
+			}
+
 			pageUpsellBanner = (
 				<UpsellNudge
 					plan={ upsellNudgePlan }
@@ -1641,6 +1685,7 @@ export default connect(
 		const productionSiteSlug = getSiteSlug( state, productionSite?.ID );
 		const isJetpack = isJetpackSite( state, siteId );
 		const isStandaloneJetpack = isJetpack && ! isAtomic;
+		const { themeTier, isThemeAllowedOnSite } = getThemeTier( state, siteId, themeId );
 
 		const isExternallyManagedTheme = getIsExternallyManagedTheme( state, theme?.id );
 		const isLoading =
@@ -1656,6 +1701,8 @@ export default connect(
 
 		return {
 			...theme,
+			themeTier,
+			isThemeAllowedOnSite: isThemeAllowedOnSite,
 			themeId,
 			price: getPremiumThemePrice( state, themeId, siteId ),
 			error,

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -218,21 +218,16 @@ const BannerUpsellTitle = ( {
 	if ( ! isThemeAllowedOnSite ) {
 		switch ( THEME_TIERS[ themeTier.slug ].minimumUpsellPlan ) {
 			case PLAN_PERSONAL:
-				return isEnglishLocale ||
-					i18n.hasTranslation(
-						'Access this theme for FREE with a %(personalPlanName)s, %(premiumPlanName)s, or %(businessPlanName)s plan!'
-					)
-					? translate(
-							'Access this theme for FREE with a %(personalPlanName)s, %(premiumPlanName)s, or %(businessPlanName)s plan!',
-							{
-								args: {
-									personalPlanName: getPlan( PLAN_PERSONAL ).getTitle(),
-									premiumPlanName: getPlan( PLAN_PREMIUM ).getTitle(),
-									businessPlanName: getPlan( PLAN_BUSINESS ).getTitle(),
-								},
-							}
-					  )
-					: translate( 'Access this theme for FREE with a Personal, Premium, or Business plan!' );
+				return translate(
+					'Access this theme for FREE with a %(personalPlanName)s, %(premiumPlanName)s, or %(businessPlanName)s plan!',
+					{
+						args: {
+							personalPlanName: getPlan( PLAN_PERSONAL ).getTitle(),
+							premiumPlanName: getPlan( PLAN_PREMIUM ).getTitle(),
+							businessPlanName: getPlan( PLAN_BUSINESS ).getTitle(),
+						},
+					}
+				);
 			case PLAN_PREMIUM:
 				return premiumPlanTitle();
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/4597

## Proposed Changes

* Updated the themes details page so that it can display the necessary upsell based on the personal plan (behind a feature flag)
* Extracted the getThemeTier hook to a selector so that it can be used outside of functional components.

![Captura de pantalla 2023-12-20 a las 14 23 07](https://github.com/Automattic/wp-calypso/assets/1989914/860fe109-9cc2-45db-983a-6869ffe4095d)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calyspo live link.
* Make sure you have the BE feature enabled in 0-sandbox.
* Go to the Theme Showcase
* Filter or open a Personal Themes details
* You should see the upsell banner and button indicating that a Personal plan is required
* Note: The upgrade button relies on the theme-options.js which is not in the scope of this issue.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?