### PR TITLE
Remove hasTranslation from global styles upsell

### DIFF
--- a/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations.tsx
@@ -1,7 +1,6 @@
 import { PLAN_PREMIUM } from '@automattic/calypso-products';
 import { usePlans } from '@automattic/data-stores/src/plans';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 
 interface Props {
 	numOfSelectedGlobalStyles?: number;
@@ -9,7 +8,6 @@ interface Props {
 
 const useGlobalStylesUpgradeTranslations = ( { numOfSelectedGlobalStyles = 1 }: Props ) => {
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
 	const plans = usePlans();
 	const planTitle = plans?.data?.[ PLAN_PREMIUM ]?.productNameShort ?? '';
 
@@ -24,12 +22,9 @@ const useGlobalStylesUpgradeTranslations = ( { numOfSelectedGlobalStyles = 1 }: 
 
 	return {
 		planTitle,
-		featuresTitle:
-			isEnglishLocale || i18n.hasTranslation( 'Included with your %(planTitle)s plan' )
-				? translate( 'Included with your %(planTitle)s plan', {
-						args: { planTitle },
-				  } )
-				: translate( 'Included with your Premium plan' ),
+		featuresTitle: translate( 'Included with your %(planTitle)s plan', {
+			args: { planTitle },
+		} ),
 		features: features,
 		description: translate(
 			'You’ve selected a premium style that will only be visible to visitors after upgrading to the %(planTitle)s plan or higher.',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Remove hasTranslation from the upsell so that it goes out untranslated rather than showing the old plan name.

## Testing Instructions



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* On a Free site
* Head to the Assembler /setup/with-theme-assembler/patternAssembler?siteSlug=${ SITE_SLUG }
* Select some premium styles and click next to see the upsell

<img width="588" alt="Screenshot 2023-12-20 at 15 20 37" src="https://github.com/Automattic/wp-calypso/assets/82778/9781a062-0ee1-405e-af17-368e9272b91d">

Your Explorer plan should be there

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
