### PR TITLE
Remove hasTranslation from theme upgrade modal

### DIFF
--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -25,13 +25,12 @@ import {
 import { Button, Dialog, ScreenReaderText } from '@automattic/components';
 import { ProductsList } from '@automattic/data-stores';
 import { usePlans } from '@automattic/data-stores/src/plans';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { Tooltip } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { Icon as WpIcon, check, close } from '@wordpress/icons';
 import classNames from 'classnames';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import { useBundleSettings } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
@@ -76,7 +75,6 @@ export const ThemeUpgradeModal = ( {
 	checkout,
 }: UpgradeModalProps ) => {
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
 	const theme = useThemeDetails( slug );
 	const isDesktop = useBreakpoint( '>782px' );
 
@@ -119,31 +117,18 @@ export const ThemeUpgradeModal = ( {
 			),
 			text: (
 				<p>
-					{ isEnglishLocale ||
-					i18n.hasTranslation(
-						'Get access to our Premium themes, and a ton of other features, with a subscription to the %(premiumPlanName)s plan. It’s {{strong}}%(planPrice)s{{/strong}} a year, risk-free with a 14-day money-back guarantee.'
-					)
-						? translate(
-								'Get access to our Premium themes, and a ton of other features, with a subscription to the %(premiumPlanName)s plan. It’s {{strong}}%(planPrice)s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
-								{
-									components: {
-										strong: <strong />,
-									},
-									args: {
-										planPrice: planPrice || '',
-										premiumPlanName: plans.data?.[ PLAN_PREMIUM ]?.productNameShort || '',
-									},
-								}
-						  )
-						: translate(
-								'Get access to our Premium themes, and a ton of other features, with a subscription to the Premium plan. It’s {{strong}}%s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
-								{
-									components: {
-										strong: <strong />,
-									},
-									args: planPrice,
-								}
-						  ) }
+					{ translate(
+						'Get access to our Premium themes, and a ton of other features, with a subscription to the %(premiumPlanName)s plan. It’s {{strong}}%(planPrice)s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
+						{
+							components: {
+								strong: <strong />,
+							},
+							args: {
+								planPrice: planPrice || '',
+								premiumPlanName: plans.data?.[ PLAN_PREMIUM ]?.productNameShort || '',
+							},
+						}
+					) }
 				</p>
 			),
 			price: null,
@@ -198,27 +183,16 @@ export const ThemeUpgradeModal = ( {
 			text: (
 				<p>
 					{ bundledPluginMessage }{ ' ' }
-					{ isEnglishLocale ||
-					i18n.hasTranslation(
-						'Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features. It’s %(businessPlanPrice)s per year with a 14-day money-back guarantee.'
-					)
-						? translate(
-								// translators: %s is the business plan price.
-								'Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features. It’s %(businessPlanPrice)s per year with a 14-day money-back guarantee.',
-								{
-									args: {
-										businessPlanPrice: businessPlanPrice || '',
-										businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '',
-									},
-								}
-						  )
-						: translate(
-								// translators: %s is the business plan price.
-								'Upgrade to a Business plan to select this theme and unlock all its features. It’s %s per year with a 14-day money-back guarantee.',
-								{
-									args: businessPlanPrice,
-								}
-						  ) }
+					{ translate(
+						// translators: %s is the business plan price.
+						'Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features. It’s %(businessPlanPrice)s per year with a 14-day money-back guarantee.',
+						{
+							args: {
+								businessPlanPrice: businessPlanPrice || '',
+								businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '',
+							},
+						}
+					) }
 				</p>
 			),
 			price: null,
@@ -264,22 +238,15 @@ export const ThemeUpgradeModal = ( {
 			text: (
 				<>
 					<p>
-						{ isEnglishLocale ||
-						i18n.hasTranslation(
-							'This partner theme is only available to buy on the %(businessPlanName)s or %(commercePlanName)s plans.'
-						)
-							? translate(
-									'This partner theme is only available to buy on the %(businessPlanName)s or %(commercePlanName)s plans.',
-									{
-										args: {
-											businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '',
-											commercePlanName: plans.data?.[ PLAN_ECOMMERCE ]?.productNameShort || '',
-										},
-									}
-							  )
-							: translate(
-									'This partner theme is only available to buy on the Business or eCommerce plans.'
-							  ) }
+						{ translate(
+							'This partner theme is only available to buy on the %(businessPlanName)s or %(commercePlanName)s plans.',
+							{
+								args: {
+									businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '',
+									commercePlanName: plans.data?.[ PLAN_ECOMMERCE ]?.productNameShort || '',
+								},
+							}
+						) }
 					</p>
 					<div>
 						<label>
@@ -298,13 +265,11 @@ export const ThemeUpgradeModal = ( {
 							{ isMarketplacePlanSubscriptionNeeeded && (
 								<div className="theme-upgrade-modal__price-item">
 									<label>
-										{ isEnglishLocale || i18n.hasTranslation( '%(businessPlanName)s plan' )
-											? translate( '%(businessPlanName)s plan', {
-													args: {
-														businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '',
-													},
-											  } )
-											: translate( 'Business plan' ) }
+										{ translate( '%(businessPlanName)s plan', {
+											args: {
+												businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '',
+											},
+										} ) }
 									</label>
 									<label className="theme-upgrade-modal__price-value">
 										<strong>{ businessPlanPriceText }</strong>
@@ -385,30 +350,21 @@ export const ThemeUpgradeModal = ( {
 	if ( showBundleVersion ) {
 		modalData = getBundledFirstPartyPurchaseModalData();
 		featureList = getBundledFirstPartyPurchaseFeatureList();
-		featureListHeader =
-			isEnglishLocale || i18n.hasTranslation( 'Included with your %(businessPlanName)s plan' )
-				? translate( 'Included with your %(businessPlanName)s plan', {
-						args: { businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '' },
-				  } )
-				: translate( 'Included with your Business plan' );
+		featureListHeader = translate( 'Included with your %(businessPlanName)s plan', {
+			args: { businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '' },
+		} );
 	} else if ( isExternallyManaged ) {
 		modalData = getExternallyManagedPurchaseModalData();
 		featureList = getExternallyManagedFeatureList();
-		featureListHeader =
-			isEnglishLocale || i18n.hasTranslation( 'Included with your %(businessPlanName)s plan' )
-				? translate( 'Included with your %(businessPlanName)s plan', {
-						args: { businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '' },
-				  } )
-				: translate( 'Included with your Business plan' );
+		featureListHeader = translate( 'Included with your %(businessPlanName)s plan', {
+			args: { businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '' },
+		} );
 	} else {
 		modalData = getStandardPurchaseModalData();
 		featureList = getStandardPurchaseFeatureList();
-		featureListHeader =
-			isEnglishLocale || i18n.hasTranslation( 'Included with your %(premiumPlanName)s plan' )
-				? translate( 'Included with your %(premiumPlanName)s plan', {
-						args: { premiumPlanName: plans.data?.[ PLAN_PREMIUM ]?.productNameShort || '' },
-				  } )
-				: translate( 'Included with your Premium plan' );
+		featureListHeader = translate( 'Included with your %(premiumPlanName)s plan', {
+			args: { premiumPlanName: plans.data?.[ PLAN_PREMIUM ]?.productNameShort || '' },
+		} );
 	}
 
 	const features =


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Update the theme upgrade modal to use untranslated strings with the new plan names rather than translated with the old plan names

## Testing Instructions

* On an existing free site, go to /setup/site-setup?siteSlug=${site_slug}
* Continue until you land on the Design Picker
* Select a Premium theme, and repeat with a Partner theme, and a Woo theme
* On the upgrade modals make sure you see the plan names. There's no visual change in most locales because the strings are translated

<img width="817" alt="Screenshot 2023-12-20 at 16 03 40" src="https://github.com/Automattic/wp-calypso/assets/82778/9bda3251-a505-45e1-85b4-69455d77336e"> 

<img width="831" alt="Screenshot 2023-12-20 at 15 56 43" src="https://github.com/Automattic/wp-calypso/assets/82778/dee01478-689d-4595-9380-571816b14563">

<img width="812" alt="Screenshot 2023-12-20 at 16 04 05" src="https://github.com/Automattic/wp-calypso/assets/82778/10198a26-7520-4a2c-95a6-1609621e24f3">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
