### PR TITLE
ESLint: Change `wpcalypso/no-unsafe-wp-apis` to warning

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -478,7 +478,7 @@ module.exports = {
 		],
 
 		'wpcalypso/no-unsafe-wp-apis': [
-			'error',
+			'warn',
 			{
 				'@wordpress/block-editor': [
 					'__experimentalBlock',

--- a/packages/block-renderer/.eslintrc.js
+++ b/packages/block-renderer/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
 			files: [ '**/*.{js.jsx,ts,tsx}' ],
 			rules: {
 				'wpcalypso/no-unsafe-wp-apis': [
-					'error',
+					'warn',
 					{
 						'@wordpress/block-editor': [ '__unstableIframe', '__unstableEditorStyles' ],
 					},

--- a/packages/design-preview/.eslintrc.js
+++ b/packages/design-preview/.eslintrc.js
@@ -10,7 +10,7 @@ module.exports = {
 			files: [ '**/*.js' ],
 			rules: {
 				'wpcalypso/no-unsafe-wp-apis': [
-					'error',
+					'warn',
 					{
 						'@wordpress/block-editor': [ '__unstableIframe', '__unstableEditorStyles' ],
 						'@wordpress/components': [

--- a/packages/eslint-plugin-wpcalypso/docs/rules/no-unsafe-wp-apis.md
+++ b/packages/eslint-plugin-wpcalypso/docs/rules/no-unsafe-wp-apis.md
@@ -36,7 +36,7 @@ This should be an object where the keys are import package names and the values 
 ```json
 {
 	"wpcalypso/no-unsafe-wp-apis": [
-		"error",
+		"warn",
 		{ "@wordpress/block-editor": [ "__experimentalBlock" ] }
 	]
 }

--- a/packages/eslint-plugin-wpcalypso/lib/configs/recommended.js
+++ b/packages/eslint-plugin-wpcalypso/lib/configs/recommended.js
@@ -154,7 +154,7 @@ module.exports = {
 		'wpcalypso/jsx-gridicon-size': 'error',
 		'wpcalypso/jsx-classname-namespace': 'error',
 		'wpcalypso/redux-no-bound-selectors': 'error',
-		'wpcalypso/no-unsafe-wp-apis': 'error',
+		'wpcalypso/no-unsafe-wp-apis': 'warn',
 
 		yoda: 'off',
 

--- a/packages/eslint-plugin-wpcalypso/lib/rules/no-unsafe-wp-apis.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/no-unsafe-wp-apis.js
@@ -73,7 +73,7 @@ function makeListener( { allowedImports, context } ) {
 			}
 
 			context.report( {
-				message: `Usage of \`${ importedName }\` from \`${ sourceModule }\` is not allowed`,
+				message: `Warning: Using \`${ importedName }\` from \`${ sourceModule }\` could lead to unexpected issues - experimental and unstable features are prone to future breaking changes.`,
 				node: specifierNode,
 			} );
 		} );

--- a/packages/eslint-plugin-wpcalypso/lib/rules/test/no-unsafe-wp-apis.js
+++ b/packages/eslint-plugin-wpcalypso/lib/rules/test/no-unsafe-wp-apis.js
@@ -53,7 +53,8 @@ ruleTester.run( 'no-unsafe-wp-apis', rule, {
 			options,
 			errors: [
 				{
-					message: 'Usage of `__experimentalUnsafe` from `@wordpress/package` is not allowed',
+					message:
+						'Warning: Using `__experimentalUnsafe` from `@wordpress/package` could lead to unexpected issues - experimental and unstable features are prone to future breaking changes.',
 					type: 'ImportSpecifier',
 				},
 			],
@@ -63,7 +64,8 @@ ruleTester.run( 'no-unsafe-wp-apis', rule, {
 			options,
 			errors: [
 				{
-					message: 'Usage of `__experimentalSafe` from `@wordpress/unsafe` is not allowed',
+					message:
+						'Warning: Using `__experimentalSafe` from `@wordpress/unsafe` could lead to unexpected issues - experimental and unstable features are prone to future breaking changes.',
 					type: 'ImportSpecifier',
 				},
 			],
@@ -73,7 +75,8 @@ ruleTester.run( 'no-unsafe-wp-apis', rule, {
 			options,
 			errors: [
 				{
-					message: 'Usage of `__experimentalSafe` from `@wordpress/unsafe` is not allowed',
+					message:
+						'Warning: Using `__experimentalSafe` from `@wordpress/unsafe` could lead to unexpected issues - experimental and unstable features are prone to future breaking changes.',
 					type: 'ImportSpecifier',
 				},
 			],
@@ -83,7 +86,8 @@ ruleTester.run( 'no-unsafe-wp-apis', rule, {
 			options,
 			errors: [
 				{
-					message: 'Usage of `__experimentalUnsafe` from `@wordpress/package` is not allowed',
+					message:
+						'Warning: Using `__experimentalUnsafe` from `@wordpress/package` could lead to unexpected issues - experimental and unstable features are prone to future breaking changes.',
 					type: 'ImportSpecifier',
 				},
 			],
@@ -93,7 +97,8 @@ ruleTester.run( 'no-unsafe-wp-apis', rule, {
 			options,
 			errors: [
 				{
-					message: 'Usage of `__unstableFeature` from `@wordpress/package` is not allowed',
+					message:
+						'Warning: Using `__unstableFeature` from `@wordpress/package` could lead to unexpected issues - experimental and unstable features are prone to future breaking changes.',
 					type: 'ImportSpecifier',
 				},
 			],

--- a/packages/global-styles/.eslintrc.js
+++ b/packages/global-styles/.eslintrc.js
@@ -4,7 +4,7 @@ module.exports = {
 			files: [ '**/*.{js.jsx,ts,tsx}' ],
 			rules: {
 				'wpcalypso/no-unsafe-wp-apis': [
-					'error',
+					'warn',
 					{
 						'@wordpress/block-editor': [ '__unstableIframe', '__unstableEditorStyles' ],
 						'@wordpress/components': [

--- a/packages/page-pattern-modal/src/components/pattern-selector-control.tsx
+++ b/packages/page-pattern-modal/src/components/pattern-selector-control.tsx
@@ -1,5 +1,4 @@
 // @ts-expect-error Missing definition
-// eslint-disable-next-line wpcalypso/no-unsafe-wp-apis
 import { __experimentalBlockPatternsList as BlockPatternsList } from '@wordpress/block-editor';
 import { BaseControl } from '@wordpress/components';
 import { withInstanceId, useAsyncList } from '@wordpress/compose';


### PR DESCRIPTION
## Proposed Changes

This PR updates the `wpcalypso/no-unsafe-wp-apis` to warning, since we shouldn't stop folks from using experimental or unstable Gutenberg features. We keep it as a warning though, so folks are aware that those features might be prone to future breaking changes.

See p1703020301107159-slack-C7YPUHBB2 for a related discussion.

## Testing Instructions

* All Checks should be green. 
* The updated import for the `PatternSelectorControl` component should generate a new ESLint warning after I removed the comment. No errors should be generated.