### PR TITLE
Import flows: Fix typo on Upgrade plan screen and update ErrorMessage component

### DIFF
--- a/client/blocks/importer/blogger/index.tsx
+++ b/client/blocks/importer/blogger/index.tsx
@@ -63,7 +63,7 @@ export const BloggerImporter: React.FunctionComponent< ImporterBaseProps > = ( p
 		};
 	}
 
-	function onBackToStartClick() {
+	function onTryAgainClick() {
 		job?.importerId && resetImport( siteId, job.importerId );
 		stepNavigator?.goToImportCapturePage?.();
 	}
@@ -111,12 +111,7 @@ export const BloggerImporter: React.FunctionComponent< ImporterBaseProps > = ( p
 							/>
 						);
 					} else if ( checkIsFailed() ) {
-						return (
-							<ErrorMessage
-								onStartBuilding={ stepNavigator?.goToIntentPage }
-								onBackToStart={ onBackToStartClick }
-							/>
-						);
+						return <ErrorMessage onPrimaryBtnClick={ onTryAgainClick } />;
 					} else if ( checkProgress() ) {
 						return <ProgressScreen job={ job } />;
 					}

--- a/client/blocks/importer/components/error-message/index.tsx
+++ b/client/blocks/importer/components/error-message/index.tsx
@@ -7,21 +7,22 @@ import './style.scss';
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 
 interface Props {
-	onBackToStart?: () => void;
-	onStartBuilding?: () => void;
-	onBackToStartText?: string;
+	primaryBtnText?: string;
+	secondaryBtnText?: string;
+	onPrimaryBtnClick?: () => void;
+	onSecondaryBtnClick?: () => void;
 }
 
 const ErrorMessage: React.FunctionComponent< Props > = ( props ) => {
 	const translate = useTranslate();
-	const { onBackToStart, onStartBuilding, onBackToStartText } = props;
+	const { primaryBtnText, secondaryBtnText, onPrimaryBtnClick, onSecondaryBtnClick } = props;
 
 	useEffect( () => {
 		recordTracksEvent( 'calypso_site_importer_start_import_failure' );
 	}, [] );
 
 	return (
-		<div className="import-layout__center">
+		<div className="import__error-message import-layout__center">
 			<div className="import__header">
 				<div className="import__heading import__heading-center">
 					<Title>{ translate( 'Oops, something went wrong' ) }</Title>
@@ -40,15 +41,15 @@ const ErrorMessage: React.FunctionComponent< Props > = ( props ) => {
 					</SubTitle>
 
 					<div className="import__buttons-group">
-						{ onStartBuilding && (
-							<NextButton type="button" onClick={ onStartBuilding }>
-								{ translate( 'Start building' ) }
+						{ onSecondaryBtnClick && (
+							<NextButton type="button" variant="secondary" onClick={ onSecondaryBtnClick }>
+								{ secondaryBtnText ?? translate( 'Back to goals' ) }
 							</NextButton>
 						) }
-						{ onBackToStart && (
+						{ onPrimaryBtnClick && (
 							<div>
-								<NextButton className="" type="submit" onClick={ onBackToStart }>
-									{ onBackToStartText ?? translate( 'Back to start' ) }
+								<NextButton type="button" onClick={ onPrimaryBtnClick }>
+									{ primaryBtnText ?? translate( 'Try again' ) }
 								</NextButton>
 							</div>
 						) }

--- a/client/blocks/importer/components/error-message/style.scss
+++ b/client/blocks/importer/components/error-message/style.scss
@@ -15,6 +15,7 @@
 		margin: 1.5rem 0;
 
 		button {
+			border-radius: 4px;
 			margin-bottom: 0.5rem;
 		}
 	}

--- a/client/blocks/importer/medium/index.tsx
+++ b/client/blocks/importer/medium/index.tsx
@@ -63,7 +63,7 @@ export const MediumImporter: React.FunctionComponent< ImporterBaseProps > = ( pr
 		};
 	}
 
-	function onBackToStartClick() {
+	function onTryAgainClick() {
 		job?.importerId && resetImport( siteId, job.importerId );
 		stepNavigator?.goToImportCapturePage?.();
 	}
@@ -111,12 +111,7 @@ export const MediumImporter: React.FunctionComponent< ImporterBaseProps > = ( pr
 							/>
 						);
 					} else if ( checkIsFailed() ) {
-						return (
-							<ErrorMessage
-								onStartBuilding={ stepNavigator?.goToIntentPage }
-								onBackToStart={ onBackToStartClick }
-							/>
-						);
+						return <ErrorMessage onPrimaryBtnClick={ onTryAgainClick } />;
 					} else if ( checkProgress() ) {
 						return <ProgressScreen job={ job } />;
 					}

--- a/client/blocks/importer/squarespace/index.tsx
+++ b/client/blocks/importer/squarespace/index.tsx
@@ -63,7 +63,7 @@ export const SquarespaceImporter: React.FunctionComponent< ImporterBaseProps > =
 		};
 	}
 
-	function onBackToStartClick() {
+	function onTryAgainClick() {
 		job?.importerId && resetImport( siteId, job.importerId );
 		stepNavigator?.goToImportCapturePage?.();
 	}
@@ -111,12 +111,7 @@ export const SquarespaceImporter: React.FunctionComponent< ImporterBaseProps > =
 							/>
 						);
 					} else if ( checkIsFailed() ) {
-						return (
-							<ErrorMessage
-								onStartBuilding={ stepNavigator?.goToIntentPage }
-								onBackToStart={ onBackToStartClick }
-							/>
-						);
+						return <ErrorMessage onPrimaryBtnClick={ onTryAgainClick } />;
 					} else if ( checkProgress() ) {
 						return <ProgressScreen job={ job } />;
 					}

--- a/client/blocks/importer/types.ts
+++ b/client/blocks/importer/types.ts
@@ -9,8 +9,10 @@ export type QueryObject = {
 };
 
 export type StepNavigator = {
+	flow: string | null;
 	supportLinkModal?: boolean;
 	goToIntentPage?: () => void;
+	goToGoalsPage?: () => void;
 	goToImportCapturePage?: () => void;
 	goToSiteViewPage?: () => void;
 	goToDashboardPage?: () => void;

--- a/client/blocks/importer/wix/index.tsx
+++ b/client/blocks/importer/wix/index.tsx
@@ -90,7 +90,7 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 		};
 	}
 
-	function onBackToStartClick() {
+	function onTryAgainClick() {
 		job?.importerId && resetImport( siteId, job.importerId );
 		stepNavigator?.goToImportCapturePage?.();
 	}
@@ -133,12 +133,7 @@ export const WixImporter: React.FunctionComponent< Props > = ( props ) => {
 			<div className={ classnames( `importer-${ importer }` ) }>
 				{ ( () => {
 					if ( checkIsFailed() ) {
-						return (
-							<ErrorMessage
-								onStartBuilding={ stepNavigator?.goToIntentPage }
-								onBackToStart={ onBackToStartClick }
-							/>
-						);
+						return <ErrorMessage onPrimaryBtnClick={ onTryAgainClick } />;
 					} else if ( checkProgress() ) {
 						return <ProgressScreen job={ job } />;
 					} else if ( checkIsSuccess() ) {

--- a/client/blocks/importer/wordpress/import-content-only/index.tsx
+++ b/client/blocks/importer/wordpress/import-content-only/index.tsx
@@ -117,10 +117,15 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 		}
 	}, [ job ] );
 
-	const onBackToStartClick = useCallback( () => {
+	const onTryAgainClick = useCallback( () => {
 		dispatch( resetImport( siteItem?.ID, job?.importerId ) );
 		stepNavigator?.goToImportCapturePage?.();
 	}, [ siteItem, job ] );
+
+	const onBackToGoalsClick = useCallback( () => {
+		dispatch( resetImport( siteItem?.ID, job?.importerId ) );
+		stepNavigator?.goToGoalsPage?.();
+	}, [] );
 
 	/**
 	 ↓ Effects
@@ -149,8 +154,10 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 
 			{ renderState === 'error' && (
 				<ErrorMessage
-					onStartBuilding={ stepNavigator?.goToIntentPage }
-					onBackToStart={ onBackToStartClick }
+					onPrimaryBtnClick={ onTryAgainClick }
+					onSecondaryBtnClick={
+						stepNavigator?.flow === 'site-setup' ? onBackToGoalsClick : undefined
+					}
 				/>
 			) }
 

--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -103,7 +103,7 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 							transparent={ ! isAddingTrial }
 							onClick={ onFreeTrialClick }
 						>
-							{ translate( 'Try 7-days for free' ) }
+							{ translate( 'Try 7 days for free' ) }
 						</Button>
 						{ ! isEligibleForTrialPlan && (
 							<small>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/hooks/use-step-navigator.ts
@@ -26,6 +26,10 @@ export function useStepNavigator(
 		navigation.goToStep?.( 'intent' );
 	}
 
+	function goToGoalsPage() {
+		navigation.goToStep?.( 'goals' );
+	}
+
 	function goToImportCapturePage() {
 		navigation.goToStep?.( 'import' );
 	}
@@ -131,8 +135,10 @@ export function useStepNavigator(
 	}
 
 	return {
+		flow,
 		supportLinkModal: false,
 		goToIntentPage,
+		goToGoalsPage,
 		goToImportCapturePage,
 		goToSiteViewPage,
 		goToDashboardPage,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-error/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-error/index.tsx
@@ -1,25 +1,18 @@
 import { StepContainer } from '@automattic/onboarding';
 import classnames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
 import ErrorMessage from 'calypso/blocks/importer/components/error-message';
 import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 
 const MigrationError: Step = function ( props ) {
 	const { submit } = props.navigation;
-	const translate = useTranslate();
 
 	function goToMigrationHandler() {
 		submit?.( { url: 'migrationHandler' } );
 	}
 
 	function renderError() {
-		return (
-			<ErrorMessage
-				onBackToStart={ goToMigrationHandler }
-				onBackToStartText={ translate( 'Try again' ) }
-			/>
-		);
+		return <ErrorMessage onPrimaryBtnClick={ goToMigrationHandler } />;
 	}
 	return (
 		<StepContainer


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/85554

## Proposed Changes

* Fixed typo: `Try 7-days for free` -> `Try 7 days for free`
* Extended ErrorMessage component. Introduced "Go to goals" button instead of the obsolete "Start building"

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Manual testing


<img width="611" alt="Screenshot 2023-12-20 at 15 10 37" src="https://github.com/Automattic/wp-calypso/assets/1241413/45e6b22e-cbe6-4ef3-97a7-ad7921f58fd4">

`site-setup` flow:

<img width="707" alt="Screenshot 2023-12-20 at 23 38 45" src="https://github.com/Automattic/wp-calypso/assets/1241413/925cd39a-7850-4090-8e27-fd7ac31e8398">

other import flows:

<img width="751" alt="Screenshot 2023-12-20 at 23 30 17" src="https://github.com/Automattic/wp-calypso/assets/1241413/36bd136e-0279-443f-b15c-d0d45f548277">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?