### PR TITLE
Remove hasTranslation from security SSH key

### DIFF
--- a/client/me/security-ssh-key/security-ssh-key.tsx
+++ b/client/me/security-ssh-key/security-ssh-key.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable no-nested-ternary */
 import { PLAN_BUSINESS, PLAN_ECOMMERCE, getPlan } from '@automattic/calypso-products';
 import { Button, CompactCard, Dialog, LoadingPlaceholder } from '@automattic/components';
-import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
+import { localizeUrl } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -79,9 +79,7 @@ export const SecuritySSHKey = ( { queryParams }: SecuritySSHKeyProps ) => {
 	const [ sshKeyNameToUpdate, setSSHKeyNameToUpdate ] = useState( '' );
 	const [ oldSSHFingerprint, setOldSSHFingerprint ] = useState( '' );
 	const [ showDialog, setShowDialog ] = useState( false );
-	const isEnglishLocale = useIsEnglishLocale();
-
-	const { __, hasTranslation } = useI18n();
+	const { __ } = useI18n();
 
 	const { addSSHKey, isLoading: isAdding } = useAddSSHKeyMutation( {
 		onMutate: () => {
@@ -193,21 +191,14 @@ export const SecuritySSHKey = ( { queryParams }: SecuritySSHKeyProps ) => {
 						) }
 					</p>
 					<p>
-						{ isEnglishLocale ||
-						hasTranslation(
-							'Once added, attach the SSH key to a site with a %1$s or %2$s plan to enable SSH key authentication for that site.'
-						)
-							? sprintf(
-									// translators: %1$s is the short-form name of the Business plan, %2$s is the short-form name of the eCommerce plan.
-									__(
-										'Once added, attach the SSH key to a site with a %1$s or %2$s plan to enable SSH key authentication for that site.'
-									),
-									getPlan( PLAN_BUSINESS )?.getTitle() || '',
-									getPlan( PLAN_ECOMMERCE )?.getTitle() || ''
-							  )
-							: __(
-									'Once added, attach the SSH key to a site with a Business or eCommerce plan to enable SSH key authentication for that site.'
-							  ) }
+						{ sprintf(
+							// translators: %1$s is the short-form name of the Business plan, %2$s is the short-form name of the eCommerce plan.
+							__(
+								'Once added, attach the SSH key to a site with a %1$s or %2$s plan to enable SSH key authentication for that site.'
+							),
+							getPlan( PLAN_BUSINESS )?.getTitle() || '',
+							getPlan( PLAN_ECOMMERCE )?.getTitle() || ''
+						) }
 					</p>
 					<p style={ isLoading || hasKeys ? { marginBlockEnd: 0 } : undefined }>
 						{ createInterpolateElement(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Remove hasTranslation so that the plan names are correct rather than the localization to be fine

## Testing Instructions

* Go to /me/security/ssh-key
* Make sure the plan names appear correctly as follows

<img width="995" alt="Screenshot 2023-12-20 at 16 15 43" src="https://github.com/Automattic/wp-calypso/assets/82778/894b3f42-2d49-4b34-a0d6-9557809c9d8a">

I used Romanian for the screenshot but English is also fine to test and confirm it works

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
