### PR TITLE
Remove hasTranslation from earn

### DIFF
--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -6,8 +6,7 @@ import {
 	getPlan,
 } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
 import wordAdsImage from 'calypso/assets/images/illustrations/dotcom-wordads.svg';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -64,9 +63,6 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 	const adsProgramName = useSelector( ( state ) =>
 		isJetpackSite( state, site?.ID ) ? 'Ads' : 'WordAds'
 	);
-
-	const isEnglishLocale = useIsEnglishLocale();
-
 	const canActivateWordadsInstant =
 		! site?.options?.wordads && canActivateWordAds && hasWordAdsFeature;
 	const canUpgradeToUseWordAds = ! site?.options?.wordads && ! hasWordAdsFeature;
@@ -217,33 +213,18 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 			<UpsellNudge
 				callToAction={ translate( 'Upgrade' ) }
 				plan={ PLAN_PREMIUM }
-				title={
-					isEnglishLocale ||
-					i18n.hasTranslation( 'Upgrade to the %(premiumPlanName)s plan and start earning' )
-						? translate( 'Upgrade to the %(premiumPlanName)s plan and start earning', {
-								args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' },
-						  } )
-						: translate( 'Upgrade to the Premium plan and start earning' )
-				}
-				description={
-					isEnglishLocale ||
-					i18n.hasTranslation(
-						"By upgrading to the %(premiumPlanName)s plan, you'll be able to monetize your site through the <a href='%(url)s'>WordAds program</>."
-					)
-						? translate(
-								"By upgrading to the %(premiumPlanName)s plan, you'll be able to monetize your site through the <a href='%(url)s'>WordAds program</>.",
-								{
-									args: {
-										url: 'https://wordads.co/',
-										premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '',
-									},
-								}
-						  )
-						: translate(
-								"By upgrading to the Premium plan, you'll be able to monetize your site through the <a href='%(url)s'>WordAds program</>.",
-								{ args: { url: 'https://wordads.co/' } }
-						  )
-				}
+				title={ translate( 'Upgrade to the %(premiumPlanName)s plan and start earning', {
+					args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' },
+				} ) }
+				description={ translate(
+					"By upgrading to the %(premiumPlanName)s plan, you'll be able to monetize your site through the <a href='%(url)s'>WordAds program</>.",
+					{
+						args: {
+							url: 'https://wordads.co/',
+							premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '',
+						},
+					}
+				) }
 				feature={ WPCOM_FEATURES_WORDADS }
 				href={ bannerURL }
 				showIcon
@@ -306,14 +287,9 @@ const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 					forceDisplay={ true }
 					callToAction={ translate( 'Upgrade' ) }
 					plan={ PLAN_PREMIUM }
-					title={
-						isEnglishLocale ||
-						i18n.hasTranslation( 'Upgrade to the %(premiumPlanName)s plan to continue earning' )
-							? translate( 'Upgrade to the %(premiumPlanName)s plan to continue earning', {
-									args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' },
-							  } )
-							: translate( 'Upgrade to the Premium plan to continue earning' )
-					}
+					title={ translate( 'Upgrade to the %(premiumPlanName)s plan to continue earning', {
+						args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '' },
+					} ) }
 					description={ translate(
 						'WordAds is disabled for this site because it does not have an eligible plan. You are no longer earning ad revenue, but you can view your earning and payment history. To restore access to WordAds please upgrade to an eligible plan.'
 					) }

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -8,9 +8,9 @@ import {
 	getPlan,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { addQueryArgs } from '@wordpress/url';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { compact } from 'lodash';
 import { useState, useEffect } from 'react';
 import ClipboardButtonInput from 'calypso/components/clipboard-button-input';
@@ -64,9 +64,6 @@ const Home = () => {
 	const isRequestingWordAds = useSelector( ( state ) =>
 		isRequestingWordAdsApprovalForSite( state, site )
 	);
-
-	const isEnglishLocale = useIsEnglishLocale();
-
 	const hasConnectedAccount = Boolean( connectedAccountId );
 	const isNonAtomicJetpack = Boolean( isJetpack && ! isSiteTransfer );
 	const hasSetupAds = Boolean( site?.options?.wordads || isRequestingWordAds );
@@ -133,23 +130,17 @@ const Home = () => {
 	};
 
 	const getPremiumPlanNames = () => {
-		const nonAtomicJetpackText =
-			isEnglishLocale ||
-			i18n.hasTranslation(
-				'Available only with a %(premiumPlanName)s, %(businessPlanName)s, or %(commercePlanName)s plan.'
-			)
-				? translate(
-						'Available only with a %(premiumPlanName)s, %(businessPlanName)s, or %(commercePlanName)s plan.',
-						{
-							args: {
-								premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '',
-								businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() || '',
-								commercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() || '',
-							},
-						}
-				  )
-				: translate( 'Available only with a Premium, Business, or Commerce plan.' );
-
+		const nonAtomicJetpackText = translate(
+			// Translators: %(premiumPlanName)s is Explorer or Premium, %(businessPlanName)s is Creator or Business, %(commercePlanName)s is Entrepreneur or eCommerce.
+			'Available only with a %(premiumPlanName)s, %(businessPlanName)s, or %(commercePlanName)s plan.',
+			{
+				args: {
+					premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() || '',
+					businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() || '',
+					commercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() || '',
+				},
+			}
+		);
 		// Space isn't included in the translatable string to prevent it being easily missed.
 		return isNonAtomicJetpack ? getAnyPlanNames() : ' ' + nonAtomicJetpackText;
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Remove hasTranslation from several strings on earn so that we don't fall back to the old plan names

## Testing Instructions

* On a Free site, go to /earn/siteSlug
* Make sure the Earn ad revenue section shows 3 plan names
* Proceed to click on Ads ( /earn/ads-earnings/siteSlug )
* Make sure the plan name is visible there as well

<img width="322" alt="Screenshot 2023-12-20 at 16 43 34" src="https://github.com/Automattic/wp-calypso/assets/82778/ee54da92-9a81-48af-a685-9b569631a56e">
<img width="1000" alt="Screenshot 2023-12-20 at 16 28 01" src="https://github.com/Automattic/wp-calypso/assets/82778/e6fea4f3-7d03-4842-8ac7-612361a21276">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
