### PR TITLE
Update plan names in failing tests

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/plans-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plans-page.ts
@@ -4,7 +4,16 @@ import { clickNavTab } from '../../element-helper';
 import envVariables from '../../env-variables';
 
 // Types to restrict the string arguments passed in. These are fixed sets of strings, so we can be more restrictive.
-export type Plans = 'Free' | 'Personal' | 'Premium' | 'Business' | 'eCommerce';
+export type Plans =
+	| 'Free'
+	| 'Personal'
+	| 'Premium'
+	| 'Business'
+	| 'eCommerce'
+	| 'Starter'
+	| 'Explorer'
+	| 'Creator'
+	| 'Entrepreneur';
 export type PlansPageTab = 'My Plan' | 'Plans';
 export type PlanActionButton = 'Manage plan' | 'Upgrade';
 

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -26,7 +26,7 @@ import {
 	PurchasesPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { apiCloseAccount, getNewPlanName } from '../shared';
+import { apiCloseAccount } from '../shared';
 
 declare const browser: Browser;
 
@@ -36,8 +36,8 @@ declare const browser: Browser;
  * Keywords: Onboarding, Store Checkout, Coupon, Signup, Plan, Subscription, Cancel
  */
 describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function () {
-	const planName = 'Personal';
-	const newPlanName = getNewPlanName( planName );
+	const planName = 'Explorer';
+	const newPlanName = planName;
 	const testUser = DataHelper.getNewTestUser( {
 		usernamePrefix: 'ftmepersonal',
 	} );

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -37,7 +37,6 @@ declare const browser: Browser;
  */
 describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function () {
 	const planName = 'Explorer';
-	const newPlanName = planName;
 	const testUser = DataHelper.getNewTestUser( {
 		usernamePrefix: 'ftmepersonal',
 	} );
@@ -83,7 +82,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 
 		it( 'See secure payment', async function () {
 			cartCheckoutPage = new CartCheckoutPage( page );
-			await cartCheckoutPage.validateCartItem( `WordPress.com ${ newPlanName }` );
+			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
 		} );
 
 		it( 'Prices are shown in GBP', async function () {
@@ -231,7 +230,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 			purchasesPage = new PurchasesPage( page );
 
 			await purchasesPage.clickOnPurchase(
-				`WordPress.com ${ newPlanName }`,
+				`WordPress.com ${ planName }`,
 				newSiteDetails.blog_details.site_slug
 			);
 			await purchasesPage.purchaseAction( 'Cancel plan' );

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -26,7 +26,7 @@ import {
 	PurchasesPage,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { apiCloseAccount } from '../shared';
+import { apiCloseAccount, getNewPlanName } from '../shared';
 
 declare const browser: Browser;
 
@@ -36,7 +36,8 @@ declare const browser: Browser;
  * Keywords: Onboarding, Store Checkout, Coupon, Signup, Plan, Subscription, Cancel
  */
 describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function () {
-	const planName = 'Explorer';
+	const planName = 'Personal';
+	const newPlanName = getNewPlanName( planName );
 	const testUser = DataHelper.getNewTestUser( {
 		usernamePrefix: 'ftmepersonal',
 	} );
@@ -82,7 +83,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 
 		it( 'See secure payment', async function () {
 			cartCheckoutPage = new CartCheckoutPage( page );
-			await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+			await cartCheckoutPage.validateCartItem( `WordPress.com ${ newPlanName }` );
 		} );
 
 		it( 'Prices are shown in GBP', async function () {
@@ -230,7 +231,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 			purchasesPage = new PurchasesPage( page );
 
 			await purchasesPage.clickOnPurchase(
-				`WordPress.com ${ planName }`,
+				`WordPress.com ${ newPlanName }`,
 				newSiteDetails.blog_details.site_slug
 			);
 			await purchasesPage.purchaseAction( 'Cancel plan' );

--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -89,10 +89,10 @@ describe(
 		describe( `Validate WordPress.com ${ planName } functionality`, function () {
 			let sidebarComponent: SidebarComponent;
 
-			it( `Sidebar states user is on WordPress.com ${ planName } plan`, async function () {
+			it( `Sidebar states user is on WordPress.com ${ newPlanName } plan`, async function () {
 				sidebarComponent = new SidebarComponent( page );
 				const currentPlan = await sidebarComponent.getCurrentPlanName();
-				expect( currentPlan ).toBe( planName );
+				expect( currentPlan ).toBe( newPlanName );
 			} );
 		} );
 

--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -20,9 +20,9 @@ import { apiDeleteSite } from '../shared';
 declare const browser: Browser;
 
 describe(
-	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com Business site as exising user' ),
+	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com Creator site as exising user' ),
 	function () {
-		const planName = 'Business';
+		const planName = 'Creator';
 
 		let testAccount: TestAccount;
 		let page: Page;

--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -15,14 +15,17 @@ import {
 	NewSiteResponse,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
-import { apiDeleteSite } from '../shared';
+import { apiDeleteSite, getNewPlanName } from '../shared';
 
 declare const browser: Browser;
 
 describe(
-	DataHelper.createSuiteTitle( 'Plans: Create a WordPress.com Creator site as exising user' ),
+	DataHelper.createSuiteTitle(
+		'Plans: Create a WordPress.com Creator/Business site as exising user'
+	),
 	function () {
-		const planName = 'Creator';
+		const planName = 'Business';
+		const newPlanName = getNewPlanName( planName );
 
 		let testAccount: TestAccount;
 		let page: Page;
@@ -61,7 +64,7 @@ describe(
 
 			it( 'See secure checkout', async function () {
 				cartCheckoutPage = new CartCheckoutPage( page );
-				await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+				await cartCheckoutPage.validateCartItem( `WordPress.com ${ newPlanName }` );
 			} );
 
 			it( 'Enter payment details', async function () {

--- a/test/e2e/specs/plans/plans__upgrade.ts
+++ b/test/e2e/specs/plans/plans__upgrade.ts
@@ -28,11 +28,11 @@ const postTitles = Array.from( { length: 2 }, () => DataHelper.getRandomPhrase()
 
 describe(
 	DataHelper.createSuiteTitle(
-		'Plans: Upgrade exising WordPress.com Free site to WordPress.com Premium'
+		'Plans: Upgrade exising WordPress.com Free site to WordPress.com Explorer'
 	),
 	function () {
 		const blogName = DataHelper.getBlogName();
-		const planName = 'Premium';
+		const planName = 'Explorer';
 		const publishedPosts: PostResponse[] = [];
 		let testMediaFile: TestFile;
 		let siteCreatedFlag: boolean;

--- a/test/e2e/specs/plugins/plugins__purchase.ts
+++ b/test/e2e/specs/plugins/plugins__purchase.ts
@@ -56,7 +56,7 @@ describe( 'Plugins: Add multiple to cart', function () {
 			await pluginsPage.clickInstallPlugin();
 		} );
 
-		it.each( [ 'WordPress.com Business', pluginName ] )(
+		it.each( [ 'WordPress.com Creator', pluginName ] )(
 			`%s is added to cart`,
 			async function ( target ) {
 				cartCheckoutPage = new CartCheckoutPage( page );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This updates the plan names to use WPCOM Starter, Explorer, Creator and Entrepreneur in e2e tests.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure tests pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
