### PR TITLE
Remove hasTranslation from marketing

### DIFF
--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -1,6 +1,5 @@
-import config from '@automattic/calypso-config';
 import { PLAN_PREMIUM, WPCOM_FEATURES_NO_ADVERTS, getPlan } from '@automattic/calypso-products';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
@@ -35,11 +34,9 @@ export const Sharing = ( {
 	siteSlug,
 	translate,
 	premiumPlanName,
-	locale,
 } ) => {
 	const pathSuffix = siteSlug ? '/' + siteSlug : '';
 	let filters = [];
-	const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
 
 	filters.push( {
 		id: 'marketing-tools',
@@ -127,9 +124,6 @@ export const Sharing = ( {
 	}
 
 	const selected = find( filters, { route: pathname } );
-	const shouldShowNudge =
-		i18n.hasTranslation( 'No ads with WordPress.com Premium' ) ||
-		config( 'english_locales' ).includes( i18n.getLocaleSlug() );
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 		<Main wideLayout className="sharing">
@@ -156,19 +150,14 @@ export const Sharing = ( {
 					</NavTabs>
 				</SectionNav>
 			) }
-			{ ! isVip && ! isJetpack && shouldShowNudge && (
+			{ ! isVip && ! isJetpack && (
 				<UpsellNudge
 					event="sharing_no_ads"
 					feature={ WPCOM_FEATURES_NO_ADVERTS }
 					description={ translate( 'Prevent ads from showing on your site.' ) }
-					title={
-						isEnglishLocale ||
-						i18n.hasTranslation( 'No ads with WordPress.com %(premiumPlanName)s' )
-							? translate( 'No ads with WordPress.com %(premiumPlanName)s', {
-									args: { premiumPlanName },
-							  } )
-							: translate( 'No ads with WordPress.com Premium' )
-					}
+					title={ translate( 'No ads with WordPress.com %(premiumPlanName)s', {
+						args: { premiumPlanName },
+					} ) }
 					tracksImpressionName="calypso_upgrade_nudge_impression"
 					tracksClickName="calypso_upgrade_nudge_cta_click"
 					showIcon={ true }


### PR DESCRIPTION
## Proposed Changes

* Remove hasTranslation and some old if so that the No Ads ad is visible on Tools > Marketing

## Testing Instructions

* Go to Tools -> Marketing
* Make sure the ad is visible and shows a plan
* 
<img width="1031" alt="Screenshot 2023-12-20 at 17 15 44" src="https://github.com/Automattic/wp-calypso/assets/82778/4d5fb3f5-9129-4c7e-a642-de64a3e570b9">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
