### PR TITLE
Monetize: Fix cancel payment modal text

### DIFF
--- a/client/my-sites/earn/customers/cancel-dialog.tsx
+++ b/client/my-sites/earn/customers/cancel-dialog.tsx
@@ -38,7 +38,7 @@ function CancelDialog( { subscriberToCancel, setSubscriberToCancel }: CancelDial
 				button: translate( 'Remove payment' ),
 				confirmation_subheading: translate( 'Do you want to remove this payment?' ),
 				confirmation_info: translate(
-					'A Removing this payment means that the user {{strong}}%(subscriber_email)s{{/strong}} will no longer have access to any service granted by the {{strong}}%(plan_name)s{{/strong}} plan.',
+					'Removing this payment means that the user {{strong}}%(subscriber_email)s{{/strong}} will no longer have access to any service granted by the {{strong}}%(plan_name)s{{/strong}} plan.',
 					{
 						args: { subscriber_email, plan_name },
 						components: {
@@ -57,7 +57,7 @@ function CancelDialog( { subscriberToCancel, setSubscriberToCancel }: CancelDial
 			button: translate( 'Cancel payment' ),
 			confirmation_subheading: translate( 'Do you want to cancel this payment?' ),
 			confirmation_info: translate(
-				'A Cancelling this payment means that the user {{strong}}%(subscriber_email)s{{/strong}} will no longer have access to any service granted by the {{strong}}%(plan_name)s{{/strong}} plan.',
+				'Cancelling this payment means that the user {{strong}}%(subscriber_email)s{{/strong}} will no longer have access to any service granted by the {{strong}}%(plan_name)s{{/strong}} plan.',
 				{
 					args: { subscriber_email, plan_name },
 					components: {


### PR DESCRIPTION
## Proposed Changes

Fixes small typo introduced in new cancel payment dialog.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You will need a testing site with paid customers or subscribers.

Go to http://calypso.localhost:3000/earn/supporters/YOURSITESLUG, click on the three action dots for a customer, select Cancel, and confirm the typo in the modal is fixed. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?