### PR TITLE
Checkout: Disable Apple Pay and Google Pay initially until they load

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -457,9 +457,9 @@ export default function useCreatePaymentMethods( {
 	// The order is the order of Payment Methods in Checkout.
 	return [
 		...existingCardMethods,
+		stripeMethod,
 		applePayMethod,
 		googlePayMethod,
-		stripeMethod,
 		freePaymentMethod,
 		paypalMethod,
 		idealMethod,

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -61,11 +61,7 @@ export function CheckoutProvider( {
 		initiallySelectedPaymentMethodId
 	);
 
-	useDisablePaymentMethodsWhenListChanges(
-		paymentMethods,
-		availablePaymentMethodIds,
-		setDisabledPaymentMethodIds
-	);
+	useDisablePaymentMethodsWhenListChanges( paymentMethods, setDisabledPaymentMethodIds );
 
 	// Reset the selected payment method if the list of payment methods changes.
 	useResetSelectedPaymentMethodWhenListChanges(
@@ -146,29 +142,32 @@ function CheckoutProviderPropValidator( {
 
 function useDisablePaymentMethodsWhenListChanges(
 	paymentMethods: PaymentMethod[],
-	availablePaymentMethodIds: string[],
 	setDisabledPaymentMethodIds: ( setter: ( ids: string[] ) => string[] ) => void
 ) {
+	const previousPaymentMethodIds = useRef< string[] >( [] );
+
 	const initiallyDisabledPaymentMethodIds = paymentMethods
 		.filter( ( method ) => method.isInitiallyDisabled )
 		.map( ( method ) => method.id );
+
 	const newInitiallyDisabledPaymentMethodIds = initiallyDisabledPaymentMethodIds.filter( ( id ) =>
-		availablePaymentMethodIds.includes( id )
+		previousPaymentMethodIds.current.includes( id )
 	);
-	const hashKey = availablePaymentMethodIds.join( '-_-' );
-	const previousKey = useRef< string >();
+
+	const paymentMethodIdsHash = paymentMethods.map( ( method ) => method.id ).join( '-_-' );
+	const previousPaymentMethodIdsHash = useRef< string >();
 
 	useEffect( () => {
-		if ( previousKey.current !== hashKey ) {
+		if ( previousPaymentMethodIdsHash.current !== paymentMethodIdsHash ) {
 			debug( 'paymentMethods changed; disabling any new isInitiallyDisabled payment methods' );
 
 			setDisabledPaymentMethodIds( ( currentlyDisabledIds: string[] ) => [
 				...currentlyDisabledIds,
 				...newInitiallyDisabledPaymentMethodIds,
 			] );
-			previousKey.current = hashKey;
+			previousPaymentMethodIdsHash.current = paymentMethodIdsHash;
 		}
-	}, [ hashKey, setDisabledPaymentMethodIds, newInitiallyDisabledPaymentMethodIds ] );
+	}, [ paymentMethodIdsHash, setDisabledPaymentMethodIds, newInitiallyDisabledPaymentMethodIds ] );
 }
 
 // Reset the selected payment method if the list of payment methods changes.

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -150,8 +150,8 @@ function useDisablePaymentMethodsWhenListChanges(
 		.filter( ( method ) => method.isInitiallyDisabled )
 		.map( ( method ) => method.id );
 
-	const newInitiallyDisabledPaymentMethodIds = initiallyDisabledPaymentMethodIds.filter( ( id ) =>
-		previousPaymentMethodIds.current.includes( id )
+	const newInitiallyDisabledPaymentMethodIds = initiallyDisabledPaymentMethodIds.filter(
+		( id ) => ! previousPaymentMethodIds.current.includes( id )
 	);
 
 	const paymentMethodIdsHash = paymentMethods.map( ( method ) => method.id ).join( '-_-' );

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -166,8 +166,14 @@ function useDisablePaymentMethodsWhenListChanges(
 				...newInitiallyDisabledPaymentMethodIds,
 			] );
 			previousPaymentMethodIdsHash.current = paymentMethodIdsHash;
+			previousPaymentMethodIds.current = paymentMethods.map( ( method ) => method.id );
 		}
-	}, [ paymentMethodIdsHash, setDisabledPaymentMethodIds, newInitiallyDisabledPaymentMethodIds ] );
+	}, [
+		paymentMethodIdsHash,
+		setDisabledPaymentMethodIds,
+		paymentMethods,
+		newInitiallyDisabledPaymentMethodIds,
+	] );
 }
 
 // Reset the selected payment method if the list of payment methods changes.

--- a/packages/composite-checkout/src/components/checkout-provider.tsx
+++ b/packages/composite-checkout/src/components/checkout-provider.tsx
@@ -40,7 +40,9 @@ export function CheckoutProvider( {
 	};
 
 	// Keep track of enabled/disabled payment methods.
-	const [ disabledPaymentMethodIds, setDisabledPaymentMethodIds ] = useState< string[] >( [] );
+	const [ disabledPaymentMethodIds, setDisabledPaymentMethodIds ] = useState< string[] >(
+		paymentMethods.filter( ( method ) => method.isInitiallyDisabled ).map( ( method ) => method.id )
+	);
 	const availablePaymentMethodIds = paymentMethods
 		.filter( ( method ) => ! disabledPaymentMethodIds.includes( method.id ) )
 		.map( ( method ) => method.id );

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -43,6 +43,7 @@ export interface PaymentMethod {
 	submitButton: ReactElement< PaymentMethodSubmitButtonProps >;
 	getAriaLabel: ( localize: ( value: string ) => string ) => string;
 	hasRequiredFields?: boolean;
+	isInitiallyDisabled?: boolean;
 }
 
 export type ExternalPaymentMethod = Partial< PaymentMethod >;

--- a/packages/wpcom-checkout/src/payment-methods/apple-pay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/apple-pay.tsx
@@ -34,6 +34,7 @@ export function createApplePayMethod(
 		),
 		inactiveContent: <ApplePaySummary />,
 		getAriaLabel: ( __ ) => __( 'Apple Pay' ),
+		isInitiallyDisabled: true,
 	};
 }
 

--- a/packages/wpcom-checkout/src/payment-methods/google-pay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/google-pay.tsx
@@ -34,6 +34,7 @@ export function createGooglePayMethod(
 		),
 		inactiveContent: <GooglePaySummary />,
 		getAriaLabel: () => 'Google Pay',
+		isInitiallyDisabled: true,
 	};
 }
 


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/70614 we modified checkout so that Apple Pay and Google Pay would turn themselves off if they were not allowed. This works well to prevent needing to check for these payment methods' availability twice (and risking the two results being different). However, it introduces a new problem (which will be made worse by https://github.com/Automattic/wp-calypso/pull/85516): the list of payment method radio buttons will show Apple Pay and Google Pay near the top of the list when they are loading and then they will disappear if they are not available. In most cases this will happen so fast as to not be an issue, but it can cause a noticeable flicker as the method disappears.

## Proposed Changes

In this PR we modify both payment methods so that they are disabled to begin with and must mark themselves as enabled.

Before (try moving the video slider manually; the flicker is very fast):


https://github.com/Automattic/wp-calypso/assets/2036909/e471fc9c-e1c7-42b1-a067-51a44bea6e06

After:


https://github.com/Automattic/wp-calypso/assets/2036909/b4293f44-cad0-4613-8c80-ffd86d5f6d36


Fixes https://github.com/Automattic/wp-calypso/issues/85569

## Testing Instructions

Testing this is difficult due to the difficulty of testing Apple Pay and Google Pay outside of a production environment. There are two cases we want to verify:

1. That this diff prevents Apple and Google Pay from appearing if they are not enabled.
2. That this diff does not prevent Apple and Google Pay from appearing if they are enabled.

The best way to get Apple Pay and Google Pay to show up is to not sandbox the API so the data being tested is real. If you have Google Pay available, it should show up on this branch. Apple Pay is nearly impossible to get showing in a test environment but testing Google Pay should be sufficient.