### PR TITLE
Now, removing a subscriber from the list invalidates the query and refresh the data

### DIFF
--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -21,9 +21,9 @@ const useSubscriberRemoveMutation = (
 		siteId,
 		currentPage,
 		perPage,
-		filterOption,
 		searchTerm,
-		sortTerm
+		sortTerm,
+		filterOption
 	);
 
 	return useMutation( {


### PR DESCRIPTION
## Proposed Changes

When the site admin removed a subscriber from the list, the query wasn't invalidated. That caused the page not to refresh the data. The problem was the cache key used to retrieve the data wasn't the same as the one being invalidated in the mutation to delete the subscriber.

## Testing Instructions

- Don't apply this PR and start Calypso.
- Go to http://calypso.localhost:3000/subscribers/[your-domain-here].
- Open the network tab in the developer tools.
- Delete a subscriber. Check that the endpoint `POST https://public-api.wordpress.com/rest/v1.1/sites/[site-id]/email-followers/[subscriber-id]/delete?http_envelope=1` was called.
- Immediately after that, on the query invalidation, the endpoint `GET https://public-api.wordpress.com/wpcom/v2/sites/[site-id]/subscribers?per_page=xx&page=xx&...` should have been called, but check that it wasn't. (**Note:** if you focus on another tab and then focus again on the subscriber page, it will call this endpoint, but it's not because of the invalidation of the query when deleting the subscriber).
- Now, apply the PR and start Calypso again.
- Repeat the process and check that now, right after the delete endpoint returns its value, the endpoint for retrieving subscribers is called.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?