### PR TITLE
Help Center: Allow img tags in AI replies

### DIFF
--- a/packages/help-center/src/components/help-center-gpt.tsx
+++ b/packages/help-center/src/components/help-center-gpt.tsx
@@ -83,7 +83,7 @@ export function HelpCenterGPT( { onResponseReceived }: Props ) {
 		enabled: true,
 	} );
 
-	const allowedTags = [ 'a', 'p', 'ol', 'ul', 'li', 'br', 'b', 'strong', 'i', 'em' ];
+	const allowedTags = [ 'a', 'p', 'ol', 'ul', 'li', 'br', 'b', 'strong', 'i', 'em', 'img' ];
 
 	useEffect( () => {
 		if ( data?.response ) {


### PR DESCRIPTION
The replies sometimes reference and include images from the documentation. This is extremely useful to show to users.

Props to @kriskarkoski for noticing this.

## Proposed Changes

* Add `img` to allowed tags for the HTML returned from the backend.

## Testing Instructions

- Open Help Center.
- Try the contact option - either via Email or Chat.
- Describe your issue like "How to add a domain? Explain with images" (to ensure the AI uses a reply with images).

Before:

<img width="426" alt="Screenshot 2023-12-20 at 18 33 25" src="https://github.com/Automattic/wp-calypso/assets/3392497/b637335f-f4e9-4545-9772-57350aa06fdc">

After:

<img width="427" alt="Screenshot 2023-12-20 at 18 32 59" src="https://github.com/Automattic/wp-calypso/assets/3392497/56a5b61e-db0e-479f-bd58-d04a3f5eed97">

