### PR TITLE
Monetize: Update delete plan modal

### DIFF
--- a/client/my-sites/earn/memberships/delete-plan-modal.tsx
+++ b/client/my-sites/earn/memberships/delete-plan-modal.tsx
@@ -54,7 +54,7 @@ const RecurringPaymentsPlanDeleteModal = ( {
 			<h1>{ translate( 'Delete offering?' ) }</h1>
 			<p>
 				{ translate(
-					'Deleting this offering ({{strong}}%s{{/strong}}) will not affect existing subscribers, who will continue to be charged. You can cancel existing subscriptions on the Supporters screen.',
+					'Deleting this offering ({{strong}}%s{{/strong}}) will not affect existing subscribers, which means they will continue to be charged. You can cancel existing subscriptions on the Supporters screen.',
 					{
 						args: product?.title,
 						components: {

--- a/client/my-sites/earn/memberships/delete-plan-modal.tsx
+++ b/client/my-sites/earn/memberships/delete-plan-modal.tsx
@@ -1,6 +1,5 @@
 import { Dialog } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import Notice from 'calypso/components/notice';
 import { useDispatch, useSelector } from 'calypso/state';
 import { requestDeleteProduct } from 'calypso/state/memberships/product-list/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -38,6 +37,7 @@ const RecurringPaymentsPlanDeleteModal = ( {
 	return (
 		<Dialog
 			isVisible={ true }
+			className="memberships__delete-plan-modal"
 			buttons={ [
 				{
 					label: translate( 'Cancel' ),
@@ -51,19 +51,18 @@ const RecurringPaymentsPlanDeleteModal = ( {
 			] }
 			onClose={ onClose }
 		>
-			<h1>{ translate( 'Confirmation' ) }</h1>
+			<h1>{ translate( 'Delete offering?' ) }</h1>
 			<p>
-				{ translate( 'Do you want to delete "%s"?', {
-					args: product?.title,
-				} ) }
-			</p>
-			<Notice
-				text={ translate(
-					'Deleting a product does not cancel the subscription for existing subscribers.{{br/}}They will continue to be charged even after you delete it.',
-					{ components: { br: <br /> } }
+				{ translate(
+					'Deleting this offering ({{strong}}%s{{/strong}}) will not affect existing subscribers, who will continue to be charged. You can cancel existing subscriptions on the Supporters screen.',
+					{
+						args: product?.title,
+						components: {
+							strong: <strong />,
+						},
+					}
 				) }
-				showDismiss={ false }
-			/>
+			</p>
 		</Dialog>
 	);
 };

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -153,6 +153,13 @@ body.is-section-earn.theme-default.color-scheme {
 	}
 }
 
+.memberships__delete-plan-modal {
+	width: 580px;
+	max-width: 98%;
+	h1 {
+		margin-bottom: 1em;
+	}
+}
 
 .supporters-list {
 	margin: 20px 0 0;


### PR DESCRIPTION
Resolves https://github.com/Automattic/gold/issues/262

## Proposed Changes

- Updates markup and styles of delete plan modal to match figma designs here: DqXCQr1dEWpF3P2dIEwiwd-fi-791_89983
- We are not yet adopting the toggle to delete all associated subscriptions as the code is not in place to do that. It'll be a follow up. Since we can't do that, I've also tweaked the copy a bit.

**Delete plan modal after changes:**
<img width="651" alt="delete-plan2" src="https://github.com/Automattic/wp-calypso/assets/21228350/09429fa4-7d88-4288-9f1c-5ca863d19f90">

## Testing Instructions

1) You will need a testing site with paid customers. 
2) Go to http://calypso.localhost:3000/earn/payments/YOURSITESLUG, click on the three action dots for an offering, select Delete. 
3) Confirm the modal appears like screenshot above. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?