### PR TITLE
Remove hasTranslation from mailpoet plugin page

### DIFF
--- a/client/my-sites/plugins/mailpoet-upgrade/index.tsx
+++ b/client/my-sites/plugins/mailpoet-upgrade/index.tsx
@@ -1,7 +1,6 @@
 import { PLAN_ECOMMERCE, getPlan } from '@automattic/calypso-products';
 import { Card, Button } from '@automattic/components';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -16,8 +15,6 @@ export const MailPoetUpgradePage = ( { siteId }: { siteId: number } ) => {
 	const dispatch = useDispatch();
 	const [ isBusy, setIsBusy ] = useState( false );
 	const [ isCompleted, setIsCompleted ] = useState( false );
-	const isEnglishLocale = useIsEnglishLocale();
-
 	const getItNowClickHandler = async () => {
 		setIsBusy( true );
 		try {
@@ -52,17 +49,10 @@ export const MailPoetUpgradePage = ( { siteId }: { siteId: number } ) => {
 			/>
 			<Card>
 				<p>
-					{ isEnglishLocale ||
-					i18n.hasTranslation(
-						'Your %(commercePlanName)s plan provides a complimentary MailPoet Business subscription, allowing you to send visually appealing emails that consistently land in inboxes and cultivate a loyal subscriber base.'
-					)
-						? translate(
-								'Your %(commercePlanName)s plan provides a complimentary MailPoet Business subscription, allowing you to send visually appealing emails that consistently land in inboxes and cultivate a loyal subscriber base.',
-								{ args: { commercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() || '' } }
-						  )
-						: translate(
-								'Your Commerce plan provides a complimentary MailPoet Business subscription, allowing you to send visually appealing emails that consistently land in inboxes and cultivate a loyal subscriber base.'
-						  ) }
+					{ translate(
+						'Your %(commercePlanName)s plan provides a complimentary MailPoet Business subscription, allowing you to send visually appealing emails that consistently land in inboxes and cultivate a loyal subscriber base.',
+						{ args: { commercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() || '' } }
+					) }
 				</p>
 				<p>
 					{ translate( 'Know more about {{a/}}', {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Update hardcoded Premium plan

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* e2e tests should pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
