### PR TITLE
Update e2e tests to fix a problem with a hardcoded plan name

### DIFF
--- a/test/e2e/specs/domain-upsell/domain-upsell__sidebar.ts
+++ b/test/e2e/specs/domain-upsell/domain-upsell__sidebar.ts
@@ -14,11 +14,13 @@ import {
 	RestAPIClient,
 } from '@automattic/calypso-e2e';
 import { Page, Browser } from 'playwright';
+import { getNewPlanName } from '../shared';
 
 declare const browser: Browser;
 
 describe( DataHelper.createSuiteTitle( 'Sidebar: Domain upsell' ), function () {
 	const planName = 'Premium';
+	const newPlanName = getNewPlanName( planName );
 	let domainSearchComponent: DomainSearchComponent;
 	let cartCheckoutPage: CartCheckoutPage;
 	let plansPage: PlansPage;
@@ -76,13 +78,13 @@ describe( DataHelper.createSuiteTitle( 'Sidebar: Domain upsell' ), function () {
 		plansPage = new PlansPage( page );
 	} );
 
-	it( `Click button to upgrade to WordPress.com ${ planName }`, async function () {
-		await plansPage.selectPlan( 'Premium' );
+	it( `Click button to upgrade to WordPress.com ${ newPlanName }`, async function () {
+		await plansPage.selectPlan( planName );
 	} );
 
-	it( `WordPress.com ${ planName } is added to cart`, async function () {
+	it( `WordPress.com ${ newPlanName } is added to cart`, async function () {
 		cartCheckoutPage = new CartCheckoutPage( page );
-		await cartCheckoutPage.validateCartItem( `WordPress.com ${ planName }` );
+		await cartCheckoutPage.validateCartItem( `WordPress.com ${ newPlanName }` );
 	} );
 
 	it( 'See secure payment', async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fix e2e test with a hardcoded plan name that got updated

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* e2e tests should pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
