### PR TITLE
Big Sky: Retry button + QOL improvements

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
@@ -43,17 +43,21 @@ const AISitePrompt: Step = function ( props ) {
 		[]
 	);
 
+	const [ searchParams, setSearchParams ] = useSearchParams(); // eslint-disable-line @typescript-eslint/no-unused-vars
 	const [ loading, setLoading ] = useState( false );
-	const [ prompt, setPrompt ] = useState( '' );
+	const [ prompt, setPrompt ] = useState( searchParams.get( 'ai_description' ) || '' );
 
 	const stepProgress = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStepProgress(),
 		[]
 	);
-	const [ searchParams, setSearchParams ] = useSearchParams(); // eslint-disable-line @typescript-eslint/no-unused-vars
 
 	const onSubmit = async ( event: FormEvent ) => {
 		event.preventDefault();
+		setSearchParams( ( currentSearchParams ) => {
+			currentSearchParams.set( 'ai_description', prompt );
+			return currentSearchParams;
+		} );
 		setLoading( true );
 		wpcomRequest( {
 			path: '/pattern-assembler/ai/latest/generate',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
@@ -94,6 +94,10 @@ const AISitePrompt: Step = function ( props ) {
 							currentSearchParams.set( 'font_variation_title', response.font );
 						}
 
+						// So that we close the drawer with patterns when moving to the assembler:
+						currentSearchParams.set( 'screen', 'main' );
+						currentSearchParams.delete( 'screen_parameter' );
+
 						return currentSearchParams;
 					},
 					{ replace: true }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
@@ -71,7 +71,7 @@ const AISitePrompt: Step = function ( props ) {
 						<ActionSection>
 							{ loading && <LoadingEllipsis /> }
 							{ ! loading && (
-								<StyledNextButton type="submit" disabled={ loading }>
+								<StyledNextButton type="submit" disabled={ loading || prompt.length < 16 }>
 									{ __( 'Continue' ) }
 								</StyledNextButton>
 							) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
@@ -3,13 +3,12 @@ import styled from '@emotion/styled';
 import { TextareaControl } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import { FormEvent, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
-import wpcomRequest from 'wpcom-proxy-request';
+import { FormEvent } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import useAIAssembler from '../pattern-assembler/hooks/use-ai-assembler';
 import type { Step } from '../../types';
 import type { OnboardSelect } from '@automattic/data-stores';
 
@@ -43,9 +42,7 @@ const AISitePrompt: Step = function ( props ) {
 		[]
 	);
 
-	const [ searchParams, setSearchParams ] = useSearchParams(); // eslint-disable-line @typescript-eslint/no-unused-vars
-	const [ loading, setLoading ] = useState( false );
-	const [ prompt, setPrompt ] = useState( searchParams.get( 'ai_description' ) || '' );
+	const [ callAIAssembler, setPrompt, prompt, loading ] = useAIAssembler();
 
 	const stepProgress = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStepProgress(),
@@ -54,66 +51,9 @@ const AISitePrompt: Step = function ( props ) {
 
 	const onSubmit = async ( event: FormEvent ) => {
 		event.preventDefault();
-		setSearchParams( ( currentSearchParams ) => {
-			currentSearchParams.set( 'ai_description', prompt );
-			return currentSearchParams;
-		} );
-		setLoading( true );
-		wpcomRequest( {
-			path: '/pattern-assembler/ai/latest/generate',
-			method: 'POST',
-			apiNamespace: 'wpcom/v2',
-			body: {
-				description: prompt,
-			},
-		} )
-			.then( ( response: any ) => {
-				console.log( 'Patterns AI response', response ); /* eslint-disable-line no-console */
-				// This actually passes the patterns to the pattern assembler.
-				setSearchParams(
-					( currentSearchParams ) => {
-						currentSearchParams.set( 'header_pattern_id', response.header_pattern );
-						currentSearchParams.set( 'footer_pattern_id', response.footer_pattern );
-						currentSearchParams.set( 'pattern_ids', response.pages[ 0 ].patterns.join( ',' ) );
-						// These 2 params were introduced in the V5 of the AI endpoint.
-						// TODO: Remove the checks once we settle on the endpoint.
-						if ( response?.site?.site_title ) {
-							currentSearchParams.set( 'site_title', response.site.site_title );
-						}
-						if ( response?.site?.site_tagline ) {
-							currentSearchParams.set( 'site_tagline', response.site.site_tagline );
-						}
-
-						// This was introduced in the V5 of the AI endpoint.
-						const pageSlugs = response.pages.map( ( page: any ) => page?.slug ).filter( Boolean );
-						if ( pageSlugs.length ) {
-							currentSearchParams.set( 'page_slugs', pageSlugs.join( ',' ) );
-						}
-
-						if ( response.style ) {
-							currentSearchParams.set( 'color_variation_title', response.style );
-						}
-
-						if ( response.font ) {
-							currentSearchParams.set( 'font_variation_title', response.font );
-						}
-
-						// So that we close the drawer with patterns when moving to the assembler:
-						currentSearchParams.set( 'screen', 'main' );
-						currentSearchParams.delete( 'screen_parameter' );
-
-						return currentSearchParams;
-					},
-					{ replace: true }
-				);
-				setLoading( false );
-				submit?.();
-			} )
-			.catch( ( error ) => {
-				console.error( 'big sky error', error ); /* eslint-disable-line no-console */
-				setLoading( false );
-				goNext?.();
-			} );
+		callAIAssembler()
+			?.then( () => submit?.() )
+			?.catch( () => goNext?.() );
 	};
 
 	function getContent() {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-ai-assembler.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-ai-assembler.ts
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import wpcomRequest from 'wpcom-proxy-request';
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+export default function useAIAssembler(): [ Function, Function, string, boolean ] {
+	const [ searchParams, setSearchParams ] = useSearchParams();
+	const [ prompt, setPrompt ] = useState( searchParams.get( 'ai_description' ) || '' );
+	const [ loading, setLoading ] = useState( false );
+
+	function callAIAssembler() {
+		setSearchParams( ( currentSearchParams: any ) => {
+			currentSearchParams.set( 'ai_description', prompt );
+			return currentSearchParams;
+		} );
+		setLoading( true );
+		return wpcomRequest( {
+			path: '/pattern-assembler/ai/latest/generate',
+			method: 'POST',
+			apiNamespace: 'wpcom/v2',
+			body: {
+				description: prompt,
+			},
+		} )
+			.catch( ( err ) => {
+				setLoading( false );
+				console.log( 'Patterns AI error', err ); /* eslint-disable-line no-console */
+				return Promise.reject( err );
+			} )
+			.then( ( response: any ) => {
+				setLoading( false );
+				console.log( 'Patterns AI response', response ); /* eslint-disable-line no-console */
+				// This actually passes the patterns to the pattern assembler.
+				setSearchParams(
+					( currentSearchParams: any ) => {
+						currentSearchParams.set( 'header_pattern_id', response.header_pattern );
+						currentSearchParams.set( 'footer_pattern_id', response.footer_pattern );
+						currentSearchParams.set( 'pattern_ids', response.pages[ 0 ].patterns.join( ',' ) );
+						// These 2 params were introduced in the V5 of the AI endpoint.
+						// TODO: Remove the checks once we settle on the endpoint.
+						if ( response?.site?.site_title ) {
+							currentSearchParams.set( 'site_title', response.site.site_title );
+						}
+						if ( response?.site?.site_tagline ) {
+							currentSearchParams.set( 'site_tagline', response.site.site_tagline );
+						}
+
+						// This was introduced in the V5 of the AI endpoint.
+						const pageSlugs = response.pages.map( ( page: any ) => page?.slug ).filter( Boolean );
+						if ( pageSlugs.length ) {
+							currentSearchParams.set( 'page_slugs', pageSlugs.join( ',' ) );
+						}
+
+						if ( response.style ) {
+							currentSearchParams.set( 'color_variation_title', response.style );
+						}
+
+						if ( response.font ) {
+							currentSearchParams.set( 'font_variation_title', response.font );
+						}
+
+						// So that we close the drawer with patterns when moving to the assembler:
+						currentSearchParams.set( 'screen', 'main' );
+						currentSearchParams.delete( 'screen_parameter' );
+
+						return currentSearchParams;
+					},
+					{ replace: true }
+				);
+				return Promise.resolve( response );
+			} );
+	}
+	return [ callAIAssembler, setPrompt, prompt, loading ];
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -99,7 +99,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 	const locale = useLocale();
 	const isNewSite = useIsNewSite( flow );
 	const [ searchParams ] = useSearchParams();
-	const [ callAIAssembler, , , aiAssemblerLoading ] = useAIAssembler();
+	const [ callAIAssembler, , aiAssemblerPrompt, aiAssemblerLoading ] = useAIAssembler();
 
 	// The categories api triggers the ETK plugin before the PTK api request
 	const categories = usePatternCategories( site?.ID );
@@ -493,23 +493,28 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 	};
 
 	const customActionButtons = () => {
-		if ( flow !== AI_ASSEMBLER_FLOW ) {
-			return undefined;
+		if (
+			flow === AI_ASSEMBLER_FLOW &&
+			currentScreen.name === INITIAL_SCREEN &&
+			aiAssemblerPrompt !== ''
+		) {
+			return (
+				<Button
+					variant="secondary"
+					disabled={ aiAssemblerLoading }
+					onClick={ () => callAIAssembler() }
+					style={ {
+						marginRight: 'auto',
+						marginLeft: 14,
+					} }
+					icon={ <Icon icon={ rotateLeft } /> }
+				>
+					{ translate( 'Regenerate AI Suggestions' ) }
+				</Button>
+			);
 		}
-		return (
-			<Button
-				variant="secondary"
-				disabled={ aiAssemblerLoading }
-				onClick={ () => callAIAssembler() }
-				style={ {
-					marginRight: 'auto',
-					marginLeft: 14,
-				} }
-				icon={ <Icon icon={ rotateLeft } /> }
-			>
-				{ translate( 'Regenerate AI Suggestions' ) }
-			</Button>
-		);
+
+		return undefined;
 	};
 
 	const onBack = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -13,11 +13,13 @@ import {
 	NavigatorScreen,
 } from '@automattic/onboarding';
 import {
+	Button,
 	__experimentalNavigatorProvider as NavigatorProvider,
 	__experimentalUseNavigator as useNavigator,
 } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { Icon, rotateLeft } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useRef, useMemo } from 'react';
 import { useSearchParams } from 'react-router-dom';
@@ -44,6 +46,7 @@ import {
 	useSyncNavigatorScreen,
 	useIsNewSite,
 } from './hooks';
+import useAIAssembler from './hooks/use-ai-assembler';
 import withNotices, { NoticesProps } from './notices/notices';
 import PagePreviewList from './pages/page-preview-list';
 import PatternAssemblerContainer from './pattern-assembler-container';
@@ -96,6 +99,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 	const locale = useLocale();
 	const isNewSite = useIsNewSite( flow );
 	const [ searchParams ] = useSearchParams();
+	const [ callAIAssembler, , , aiAssemblerLoading ] = useAIAssembler();
 
 	// The categories api triggers the ETK plugin before the PTK api request
 	const categories = usePatternCategories( site?.ID );
@@ -488,6 +492,26 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 		return isSiteAssemblerFlow( flow );
 	};
 
+	const customActionButtons = () => {
+		if ( flow !== AI_ASSEMBLER_FLOW ) {
+			return undefined;
+		}
+		return (
+			<Button
+				variant="secondary"
+				disabled={ aiAssemblerLoading }
+				onClick={ () => callAIAssembler() }
+				style={ {
+					marginRight: 'auto',
+					marginLeft: 14,
+				} }
+				icon={ <Icon icon={ rotateLeft } /> }
+			>
+				{ translate( 'Regenerate AI Suggestions' ) }
+			</Button>
+		);
+	};
+
 	const onBack = () => {
 		// Go back to the previous screen
 		if ( currentScreen.previousScreen ) {
@@ -720,6 +744,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 
 	return (
 		<StepContainer
+			customizedActionButtons={ customActionButtons() }
 			stepName="pattern-assembler"
 			stepSectionName={ currentScreen.name }
 			backLabelText={ getBackLabel() }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/ai-services/issues/825

## Proposed Changes

* Seperate logic and the API call to a hook, as one does
* Preserve the initial prompt in the URL, which allows
* Prepopulating the field with the previous query when clicking back
* Introduces the "Regenerate" button generating new suggestions from AI
* Close the pattern drawer when opening the assembler with generated patterns
* Block the submit button until the ai prompt is at least 16 chars


![Zrzut ekranu 2023-12-20 o 19 58 10](https://github.com/Automattic/wp-calypso/assets/3775068/089dc51d-a0dc-46bc-a3d0-31c87bbfa219)

I am aware that this regenerate button should probably have different styling / copy, but can we keep this issue separate?

## Testing Instructions

* Go to http://calypso.localhost:3000/setup/ai-assembler
* Fill out your prompt description, observe button being disabled on short ones
* ONce you get to the assembler observe pattern drawer being closed
* Click regenerate button
* See new suggestions
* Click back
* Observe your original prompt being in the textbox

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?