### PR TITLE
Subscribers Page: Fix search empty view

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -53,7 +53,7 @@ const SubscriberListContainer = ( {
 						</span>
 					</div>
 
-					{ total > 3 && <SubscriberListActionsBar /> }
+					{ ( total > 3 || searchTerm ) && <SubscriberListActionsBar /> }
 				</>
 			) }
 			{ isLoading &&


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/85581

## Proposed Changes

* Fix search empty view when no results are returned

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/subscribers/{site-slug}
* Search for something to get an empty result
* The search bar should persist on the page, so you can delete the search term

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?