### PR TITLE
Storage Add-Ons: Fix partial string translations for inline pricing

### DIFF
--- a/client/my-sites/plans-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/storage-add-on-dropdown.tsx
@@ -62,6 +62,7 @@ const StorageAddOnOption = ( {
 										priceSpan: <span className="storage-add-on-dropdown-option__price" />,
 										perMonthSpan: <span className="storage-add-on-dropdown-option__per-month" />,
 									},
+									comment: 'The cost of a storage add on per month. Example reads as "+ $50/month"',
 								}
 							) }
 						</span>

--- a/client/my-sites/plans-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/storage-add-on-dropdown.tsx
@@ -164,7 +164,9 @@ export const StorageAddOnDropdown = ( {
 			{ selectedOptionPrice && ( isLargeCurrency || priceOnSeparateLine ) && (
 				<div className="storage-add-on-dropdown__offset-price-container">
 					<span className="storage-add-on-dropdown__offset-price">
-						{ ` + ${ selectedOptionPrice }/${ translate( 'month' ) }` }
+						{ translate( '+ %(selectedOptionPrice)s/month', {
+							args: { selectedOptionPrice },
+						} ) }
 					</span>
 				</div>
 			) }

--- a/client/my-sites/plans-grid/components/storage-add-on-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/storage-add-on-dropdown.tsx
@@ -52,9 +52,18 @@ const StorageAddOnOption = ( {
 				<div>
 					<span className="storage-add-on-dropdown-option__title">{ title }</span>
 					<div className="storage-add-on-dropdown-option__price-container">
-						<span className="storage-add-on-dropdown-option__price">+&nbsp;{ price }</span>
-						<span className="storage-add-on-dropdown-option__per-month">
-							{ `/${ translate( 'month' ) }` }
+						<span>
+							{ translate(
+								'{{priceSpan}}+{{nbsp/}}%(price)s{{/priceSpan}}{{perMonthSpan}}/month{{/perMonthSpan}}',
+								{
+									args: { price },
+									components: {
+										nbsp: <>&nbsp;</>,
+										priceSpan: <span className="storage-add-on-dropdown-option__price" />,
+										perMonthSpan: <span className="storage-add-on-dropdown-option__per-month" />,
+									},
+								}
+							) }
 						</span>
 					</div>
 				</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/82553

## Proposed Changes

Strings should generally be kept in as "complete" a form as possible for the best translation outcomes

* Fix partial pricing strings for the storage add-on dropdowns

## Screenshots

<img width="1481" alt="Screenshot 2023-12-20 at 11 34 21 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/30646925-c2c1-4e14-9b1a-49473838ef32">
<img width="1304" alt="Screenshot 2023-12-20 at 11 34 42 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/39fea86e-1c9f-4cb2-b939-0a81bd9908f7">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch or use calypso live
* Navigate to /start/plans
* Verify that if the add-on prices are small enough, they will render in line with the storage add-on options
* Switch to a currency with larger values, like IDR
* Verify that if the add-on prices are too large, they will render on a new line below the storage add-on options
* Smoke test a few other flows and the /plans page


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?