### PR TITLE
Update AI label on the checkout page

### DIFF
--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -96,11 +96,17 @@ export function getLabel( product: ResponseCartProduct ): string {
 		return product.meta;
 	}
 
-	if ( isJetpackAISlug( product.product_slug ) && product.quantity ) {
+	if (
+		isJetpackAISlug( product.product_slug ) &&
+		( product.quantity !== null || product.current_quantity !== null )
+	) {
+		// In theory, it'll fallback to 0, but just in case.
+		const quantity = product.quantity || product.current_quantity || 0;
+
 		return translate( '%(productName)s (%(quantity)d requests per month)', {
 			args: {
 				productName: product.product_name,
-				quantity: product.quantity,
+				quantity: quantity,
 			},
 			textOnly: true,
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* `quantity` might be null if we don't pass a quantity during the checkout even if the shopping cart has a quantity-based product (for AI, in this case). So this PR adds a fallback to  `current_quantity` which will be used in cases where we don't pass the requested quantity.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If D132730-code hasn't been deployed yet, apply it to your sandbox before testing this change.
* Visit https://wordpress.com/checkout/jetpack_ai_monthly without specifying a quantity, and confirm that it doesn't display the label (100 requests per month)
* Using the Calypso live link, go again to `/checkout/jetpack_ai_monthly` (without the quantity) and make sure it says AI (100)

<img width="658" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5714212/867ac020-00a1-4170-bf3c-19739ed5f8e0">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?