### PR TITLE
Removing the last subscriber of the last page goes to previous page

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -35,6 +35,7 @@ const SubscriberListContainer = ( {
 		searchTerm,
 		isLoading,
 		subscribers,
+		pages,
 	} = useSubscribersPage();
 	useRecordSearch();
 
@@ -44,8 +45,7 @@ const SubscriberListContainer = ( {
 
 	useEffect( () => {
 		if ( ! isLoading && subscribers.length === 0 && page > 1 ) {
-			const newPageNumber = page - 1;
-			pageChangeCallback( newPageNumber );
+			pageChangeCallback( pages ?? 0 );
 		}
 	}, [ isLoading, subscribers, page, pageChangeCallback ] );
 

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -1,4 +1,5 @@
 import { numberFormat, translate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import Pagination from 'calypso/components/pagination';
 import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
 import { NoSearchResults } from 'calypso/my-sites/subscribers/components/no-search-results';
@@ -12,7 +13,6 @@ import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isSimpleSite } from 'calypso/state/sites/selectors';
 import { useRecordSearch } from '../../tracks';
 import { GrowYourAudience } from '../grow-your-audience';
-
 import './style.scss';
 
 type SubscriberListContainerProps = {
@@ -26,13 +26,28 @@ const SubscriberListContainer = ( {
 	onClickView,
 	onClickUnsubscribe,
 }: SubscriberListContainerProps ) => {
-	const { grandTotal, total, perPage, page, pageChangeCallback, searchTerm, isLoading } =
-		useSubscribersPage();
+	const {
+		grandTotal,
+		total,
+		perPage,
+		page,
+		pageChangeCallback,
+		searchTerm,
+		isLoading,
+		subscribers,
+	} = useSubscribersPage();
 	useRecordSearch();
 
 	const isSimple = useSelector( isSimpleSite );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 	const EmptyComponent = isSimple || isAtomic ? SubscriberLaunchpad : EmptyListView;
+
+	useEffect( () => {
+		if ( ! isLoading && subscribers.length === 0 && page > 1 ) {
+			const newPageNumber = page - 1;
+			pageChangeCallback( newPageNumber );
+		}
+	}, [ isLoading, subscribers, page, pageChangeCallback ] );
 
 	return (
 		<section className="subscriber-list-container">

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -49,6 +49,7 @@ type SubscribersPageContextProps = {
 	closeAllModals: typeof closeAllModals;
 	siteId: number | null;
 	isLoading: boolean;
+	pages?: number;
 };
 
 const SubscribersPageContext = createContext< SubscribersPageContextProps | undefined >(
@@ -112,6 +113,7 @@ export const SubscribersPageProvider = ( {
 		filterOption: subscriberType,
 	} );
 	const grandTotal = subscribersQueryResult.data?.total || 0;
+	const pages = subscribersQueryResult.data?.pages || 0;
 
 	const { pageChangeCallback } = usePagination(
 		pageNumber,
@@ -220,6 +222,7 @@ export const SubscribersPageProvider = ( {
 				migrateSubscribersCallback,
 				siteId,
 				isLoading: subscribersQueryResult.isLoading,
+				pages,
 			} }
 		>
 			{ children }


### PR DESCRIPTION
☢️☢️☢️ Don't merge this one until https://github.com/Automattic/wp-calypso/pull/85572 is merged! ☢️☢️☢️
Fixes https://github.com/Automattic/wp-calypso/issues/85540

## Proposed Changes

This PR fixes this situation: 
- The site's owner is on the last page of their subscribers page. 
- There is only one subscriber there.
- The user removes that subscriber.
- The page has no subscribers, but the user is not redirected to the previous site.

## Testing Instructions

- Apply this PR and start the application.
- You need a site with more than one page of subscribers.
- Remove or add subscribers until the last page has only 1 subscriber.
- Remove that subscriber.
- You should be redirected to the previous page of subscribers (i.e., if you were on page 5 of subscribers, you will end up on page 4).

## Pre-merge Checklist



- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?