### PR TITLE
Checkout e2e: Skip selecting saved card if already selected

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -46,6 +46,8 @@ const selectors = {
 	// Payment method cards
 	existingCreditCard: ( cardHolderName: string ) =>
 		`label[for*="existingCard"]:has-text("${ cardHolderName }")`,
+	alreadySelectedSavedCard: ( cardHolderName: string ) =>
+		`.checkout-payment-methods li:has-text("${ cardHolderName }")`,
 
 	// Payment field
 	cardholderName: `input[id="cardholder-name"]`,
@@ -259,6 +261,13 @@ export class CartCheckoutPage {
 	 * @param {string} cardHolderName Name of the card holder associated with the payment method.
 	 */
 	async selectSavedCard( cardHolderName: string ): Promise< void > {
+		if ( await this.page.isVisible( selectors.alreadySelectedSavedCard( cardHolderName ) ) ) {
+			// If the payment method step is collapsed, which can happen when
+			// there is a saved card already selected, then there's no need to
+			// do anything if the saved card is the one we want.
+			return;
+		}
+
 		// If the account has a saved card, the payment method step may
 		// automatically collapse with the first saved card automatically
 		// selected. So in order to select a different card, we need to click


### PR DESCRIPTION
## Proposed Changes

This attempts to fix the e2e tests again like https://github.com/Automattic/wp-calypso/pull/85586

NOTE: it's hard to know if this is safe because technically the completed step is always rendered, it's just hidden via CSS. It's not clear if `isVisible()` will know it's hidden or not. 

## Testing Instructions

none
