### PR TITLE
Checkout e2e: Only try to click edit payment method button if clicking payment method fails

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -265,12 +265,13 @@ export class CartCheckoutPage {
 		// the "Edit" button on the payment method step. There are cases where
 		// the step will not be collapsed, however, so this will only trigger
 		// if the edit button is visible.
-		if ( await this.page.isVisible( selectors.editPaymentStep ) ) {
-			await this.page.click( selectors.editPaymentStep );
-		}
 		const selector = this.page.locator( selectors.existingCreditCard( cardHolderName ) ).first();
-
-		await selector.click();
+		try {
+			await selector.click();
+		} catch ( error ) {
+			await this.page.click( selectors.editPaymentStep );
+			await selector.click();
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Proposed Changes

This attempts to fix the e2e tests again like https://github.com/Automattic/wp-calypso/pull/85586

In this diff we wait to see if we can click on the saved card payment method we want. If we can't, then we try to click the "Edit" button on the payment method step first, and try clicking the payment method again. It's a bit of a hack but I'm not sure how else to say, "wait for the autocomplete to finish, if it runs at all".

## Testing Instructions

none
