### PR TITLE
Monetize: Remove stripe onboarding screen

### DIFF
--- a/client/my-sites/earn/memberships/products-list.tsx
+++ b/client/my-sites/earn/memberships/products-list.tsx
@@ -3,7 +3,7 @@ import {
 	FEATURE_PREMIUM_CONTENT_CONTAINER,
 	FEATURE_RECURRING_PAYMENTS,
 } from '@automattic/calypso-products';
-import { Badge, Button, CompactCard, Gridicon } from '@automattic/components';
+import { Badge, Button, Card, CompactCard, Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
@@ -45,6 +45,7 @@ function ProductsList() {
 	const features = useSelector( ( state ) => getFeaturesBySiteId( state, site?.ID ) );
 	const hasLoadedFeatures = features?.active.length > 0;
 	const products: Product[] = useSelector( ( state ) => getProductsForSiteId( state, site?.ID ) );
+	const hasProducts = products.length > 0;
 
 	const hasDonationsFeature = useSelector( ( state ) =>
 		siteHasFeature( state, site?.ID ?? null, FEATURE_DONATIONS )
@@ -163,6 +164,15 @@ function ProductsList() {
 						{ translate( 'Add a new payment plan' ) }
 					</Button>
 				</SectionHeader>
+			) }
+			{ hasLoadedFeatures && hasStripeFeature && ! hasProducts && (
+				<Card className="memberships__products-card">
+					<div className="memberships__products-card-content">
+						<div className="memberships__products-card-title">
+							{ translate( 'Set up a one-time offer or recurring payments plan.' ) }
+						</div>
+					</div>
+				</Card>
 			) }
 			{ hasLoadedFeatures &&
 				products

--- a/client/my-sites/earn/memberships/products-list.tsx
+++ b/client/my-sites/earn/memberships/products-list.tsx
@@ -17,7 +17,6 @@ import SectionHeader from 'calypso/components/section-header';
 import { useDispatch, useSelector } from 'calypso/state';
 import { bumpStat } from 'calypso/state/analytics/actions';
 import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
-import { getConnectedAccountIdForSiteId } from 'calypso/state/memberships/settings/selectors';
 import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -46,9 +45,7 @@ function ProductsList() {
 	const features = useSelector( ( state ) => getFeaturesBySiteId( state, site?.ID ) );
 	const hasLoadedFeatures = features?.active.length > 0;
 	const products: Product[] = useSelector( ( state ) => getProductsForSiteId( state, site?.ID ) );
-	const connectedAccountId = useSelector( ( state ) =>
-		getConnectedAccountIdForSiteId( state, site?.ID )
-	);
+
 	const hasDonationsFeature = useSelector( ( state ) =>
 		siteHasFeature( state, site?.ID ?? null, FEATURE_DONATIONS )
 	);
@@ -160,7 +157,7 @@ function ProductsList() {
 				/>
 			) }
 
-			{ hasLoadedFeatures && hasStripeFeature && connectedAccountId && (
+			{ hasLoadedFeatures && hasStripeFeature && (
 				<SectionHeader label={ translate( 'Manage plans' ) }>
 					<Button primary compact onClick={ () => openAddEditDialog() }>
 						{ translate( 'Add a new payment plan' ) }
@@ -216,7 +213,7 @@ function ProductsList() {
 							</CompactCard>
 						);
 					} ) }
-			{ hasLoadedFeatures && showAddEditDialog && hasStripeFeature && connectedAccountId && (
+			{ hasLoadedFeatures && showAddEditDialog && hasStripeFeature && (
 				<RecurringPaymentsPlanAddEditModal
 					closeDialog={ closeDialog }
 					product={ Object.assign( product ?? {}, {

--- a/client/my-sites/earn/memberships/section.tsx
+++ b/client/my-sites/earn/memberships/section.tsx
@@ -1,18 +1,14 @@
 import { Card, Button, Dialog, Gridicon } from '@automattic/components';
-import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect, useCallback, ReactNode } from 'react';
-import paymentsImage from 'calypso/assets/images/earn/payments-illustration.svg';
+import { useState, useEffect, useCallback } from 'react';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import SectionHeader from 'calypso/components/section-header';
-import { preventWidows } from 'calypso/lib/formatting';
 import { userCan } from 'calypso/lib/site/utils';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getEarningsWithDefaultsForSiteId } from 'calypso/state/memberships/earnings/selectors';
 import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
 import { requestDisconnectSiteStripeAccount } from 'calypso/state/memberships/settings/actions';
 import {
@@ -21,7 +17,6 @@ import {
 	getConnectUrlForSiteId,
 } from 'calypso/state/memberships/settings/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
-import CommissionFees from '../components/commission-fees';
 import { Query } from '../types';
 import {
 	ADD_TIER_PLAN_HASH,
@@ -54,10 +49,6 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 	);
 	const connectUrl: string = useSelector( ( state ) => getConnectUrlForSiteId( state, site?.ID ) );
 
-	const { commission } = useSelector( ( state ) =>
-		getEarningsWithDefaultsForSiteId( state, site?.ID )
-	);
-
 	const navigateToLaunchpad = useCallback( () => {
 		const shouldGoToLaunchpad = query?.stripe_connect_success === 'launchpad';
 		const siteIntent = site?.options?.site_intent;
@@ -83,31 +74,68 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 	function renderSettings() {
 		return (
 			<div>
-				<SectionHeader label={ translate( 'Settings' ) } />
-				<Card
-					onClick={ () => setDisconnectedConnectedAccountId( connectedAccountId ) }
-					className="memberships__settings-link"
-				>
-					<div className="memberships__module-plans-content">
-						<div className="memberships__module-plans-icon">
-							<Gridicon size={ 24 } icon="link-break" />
-						</div>
-						<div>
-							<div className="memberships__module-settings-title">
-								{ translate( 'Disconnect Stripe Account' ) }
+				<SectionHeader label={ translate( 'Settings' ) }>
+					{ ! connectedAccountId && (
+						<Button
+							primary
+							compact
+							href={ connectUrl }
+							onClick={ () =>
+								dispatch( recordTracksEvent( 'calypso_memberships_stripe_connect_click' ) )
+							}
+						>
+							{ translate( 'Connect Stripe' ) }
+						</Button>
+					) }
+				</SectionHeader>
+				{ connectedAccountId ? (
+					<Card
+						onClick={ () => setDisconnectedConnectedAccountId( connectedAccountId ) }
+						className="memberships__settings-link"
+					>
+						<div className="memberships__module-plans-content">
+							<div className="memberships__module-plans-icon">
+								<Gridicon size={ 24 } icon="link-break" />
 							</div>
-							{ connectedAccountDescription ? (
-								<div className="memberships__module-settings-description">
-									{ translate( 'Connected to %(connectedAccountDescription)s', {
-										args: {
-											connectedAccountDescription: connectedAccountDescription,
-										},
-									} ) }
+							<div>
+								<div className="memberships__module-settings-title">
+									{ translate( 'Disconnect Stripe Account' ) }
 								</div>
-							) : null }
+								{ connectedAccountDescription ? (
+									<div className="memberships__module-settings-description">
+										{ translate( 'Connected to %(connectedAccountDescription)s', {
+											args: {
+												connectedAccountDescription: connectedAccountDescription,
+											},
+										} ) }
+									</div>
+								) : null }
+							</div>
 						</div>
-					</div>
-				</Card>
+					</Card>
+				) : (
+					<Card className="memberships__settings-link">
+						<div className="memberships__module-plans-content">
+							<div>
+								<div className="memberships__module-plans-title">
+									{ translate( 'Connect a Stripe account to start collecting payments.' ) }
+								</div>
+								{ connectedAccountDescription ? (
+									<div className="memberships__module-plans-title">
+										{ translate(
+											'Previously connected to Stripe account %(connectedAccountDescription)s',
+											{
+												args: {
+													connectedAccountDescription: connectedAccountDescription,
+												},
+											}
+										) }
+									</div>
+								) : null }
+							</div>
+						</div>
+					</Card>
+				) }
 				<Dialog
 					isVisible={ !! disconnectedConnectedAccountId }
 					buttons={ [
@@ -136,16 +164,6 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 		);
 	}
 
-	function renderStripeConnected() {
-		return (
-			<div>
-				{ renderNotices() }
-				<ProductList />
-				{ renderSettings() }
-			</div>
-		);
-	}
-
 	function renderNotices() {
 		const stripe_connect_success = query?.stripe_connect_success;
 
@@ -162,13 +180,11 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 			}
 
 			return (
-				! siteHasPlans && (
-					<Notice status="is-success" showDismiss={ false } text={ congratsText }>
-						<NoticeAction href={ `/earn/payments/${ site?.slug }` } icon="create">
-							{ translate( 'Add a payment plan' ) }
-						</NoticeAction>
-					</Notice>
-				)
+				<Notice status="is-success" showDismiss={ false } text={ congratsText }>
+					<NoticeAction href={ `/earn/payments/${ site?.slug }` } icon="create">
+						{ translate( 'Add a payment plan' ) }
+					</NoticeAction>
+				</Notice>
 			);
 		}
 
@@ -192,127 +208,18 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 			);
 		}
 
+		if ( query?.stripe_connect_cancelled ) {
+			return (
+				<Notice
+					showDismiss={ false }
+					text={ translate(
+						'The attempt to connect to Stripe has been cancelled. You can connect again at any time.'
+					) }
+				/>
+			);
+		}
+
 		return null;
-	}
-
-	function renderOnboarding( cta: ReactNode, intro?: ReactNode | null ) {
-		return (
-			<Card>
-				<div className="memberships__onboarding-wrapper">
-					<div className="memberships__onboarding-column-info">
-						<h2 className="memberships__onboarding-header">
-							{ preventWidows( translate( 'Accept payments on your website.' ) ) }
-						</h2>
-						<p className="memberships__onboarding-paragraph">
-							{ preventWidows(
-								translate(
-									'Our payments blocks make it easy to add a buy button for digital goods or services, collect donations via a form, or limit access for specific content to subscribers-only.'
-								)
-							) }
-						</p>
-						<p className="memberships__onboarding-paragraph">
-							{ preventWidows(
-								translate(
-									'The Payment Button, Donations Form, and Premium Content blocks all require you to first connect your bank account details with our secure payment processor, Stripe.',
-									{
-										components: {
-											link: (
-												<a
-													href={ localizeUrl(
-														'https://wordpress.com/support/wordpress-editor/blocks/payments/#setting-up-payments'
-													) }
-												/>
-											),
-										},
-									}
-								)
-							) }
-						</p>
-						{ intro ? <p className="memberships__onboarding-paragraph">{ intro }</p> : null }
-						<p className="memberships__onboarding-paragraph">{ cta }</p>
-						<p className="memberships__onboarding-paragraph memberships__onboarding-paragraph-disclaimer">
-							<em>
-								{ preventWidows(
-									translate(
-										'All credit and debit card payments made through these blocks are securely and seamlessly processed by Stripe.'
-									)
-								) }
-							</em>
-						</p>
-					</div>
-					<div className="memberships__onboarding-column-image">
-						<img src={ paymentsImage } aria-hidden="true" alt="" />
-					</div>
-				</div>
-				<div className="memberships__onboarding-benefits">
-					<div>
-						<h3>{ translate( 'No plugin required' ) }</h3>
-						{ preventWidows(
-							translate(
-								'No additional installs or purchases. Simply connect your banking details with our payment processor, Stripe, and insert a block to get started.'
-							)
-						) }
-					</div>
-					<div>
-						<h3>{ translate( 'One-time and recurring options' ) }</h3>
-						{ preventWidows(
-							translate(
-								'Accept one-time, monthly, and yearly payments from your visitors. This is perfect for a single purchase or tip — or a recurring donation, membership fee, or subscription.'
-							)
-						) }
-					</div>
-					<div>
-						<h3>{ translate( 'Simple fees structure' ) }</h3>
-						<p>
-							<CommissionFees commission={ commission } siteSlug={ site?.slug } />
-						</p>
-						<p>{ preventWidows( translate( 'No fixed monthly or annual fees charged.' ) ) }</p>
-					</div>
-					<div>
-						<h3>{ translate( 'Join thousands of others' ) }</h3>
-						{ preventWidows(
-							translate(
-								'Sites that actively promoted their businesses and causes on social media, email, and other platforms have collected tens of thousands of dollars through these blocks.'
-							)
-						) }
-					</div>
-				</div>
-			</Card>
-		);
-	}
-
-	function renderConnectStripe() {
-		return (
-			<div>
-				{ query?.stripe_connect_cancelled && (
-					<Notice
-						showDismiss={ false }
-						text={ translate(
-							'The attempt to connect to Stripe has been cancelled. You can connect again at any time.'
-						) }
-					/>
-				) }
-				{ renderOnboarding(
-					<Button
-						primary={ true }
-						href={ connectUrl }
-						onClick={ () =>
-							dispatch( recordTracksEvent( 'calypso_memberships_stripe_connect_click' ) )
-						}
-					>
-						{ translate( 'Connect Stripe to Get Started' ) }{ ' ' }
-						<Gridicon size={ 18 } icon="external" />
-					</Button>,
-					connectedAccountDescription
-						? translate( 'Previously connected to Stripe account %(connectedAccountDescription)s', {
-								args: {
-									connectedAccountDescription: connectedAccountDescription,
-								},
-						  } )
-						: null
-				) }
-			</div>
-		);
 	}
 
 	useEffect( () => {
@@ -320,7 +227,7 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 	}, [ navigateToLaunchpad ] );
 
 	if ( ! userCan( 'manage_options', site ) ) {
-		return renderOnboarding(
+		return (
 			<Notice
 				status="is-warning"
 				text={ translate( 'Only site administrators can edit Payments settings.' ) }
@@ -336,14 +243,16 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 	return (
 		<div>
 			<QueryMembershipsSettings siteId={ site.ID } source={ source } />
-			{ connectedAccountId && renderStripeConnected() }
-			{ connectUrl && renderConnectStripe() }
-
 			{ ! connectedAccountId && ! connectUrl && (
 				<div className="earn__payments-loading">
 					<LoadingEllipsis />
 				</div>
 			) }
+			<div>
+				{ renderNotices() }
+				<ProductList />
+				{ renderSettings() }
+			</div>
 		</div>
 	);
 }

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -312,8 +312,10 @@ body.is-section-earn.theme-default.color-scheme {
 	margin-top: 20px;
 }
 
-.memberships__module-plans-title {
+.memberships__module-plans-title,
+.memberships__products-card-title {
 	color: var(--color-neutral-100);
+	font-size: $font-body-small;
 }
 
 .memberships__module-settings-title {


### PR DESCRIPTION
## Proposed Changes

* Remove Stripe onboarding screen that had shows (and blocks plan creation) when Stripe is not connected.
* Instead, we just show the stripe connect button and message in the settings panel on the same screen. 
* Users can also now create paid plans/products before they connect Stripe. 

**Before**
<img width="1091" alt="payments-old" src="https://github.com/Automattic/wp-calypso/assets/21228350/6d4a29fe-ef2c-4643-b488-0216419132e4">

**After** (this screen is nearly the same as what you would have seen after you connected stripe before)
<img width="1082" alt="payments-new" src="https://github.com/Automattic/wp-calypso/assets/21228350/f14360fe-51fa-4383-bd41-90c9b88941b6">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go to http://calypso.localhost:3000/earn/payments/YOURSITESLUG and run through a variety of scenarios and states to confirm everything works well.
   - Confirm you do not see the stripe onboarding screen even when stripe is not connected)
   - Confirm you can create plans without Stripe needing to be connected
   - Connect and disconnect stripe and confirm screen state / notices show as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?