### PR TITLE
Add post trial dialog to crowdsignal survey for post trial feedback

### DIFF
--- a/client/my-sites/plans/trials/business-trial-expired/index.tsx
+++ b/client/my-sites/plans/trials/business-trial-expired/index.tsx
@@ -19,6 +19,7 @@ import wasMigrationTrialSite from 'calypso/state/selectors/was-migration-trial-s
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import './style.scss';
 import { BusinessTrialPlans } from '../business-trial-plans';
+import { TrialExpiredSurveyDialog } from './trial-expired-survey';
 
 const BusinessTrialExpired = (): JSX.Element => {
 	const translate = useTranslate();
@@ -126,6 +127,7 @@ const BusinessTrialExpired = (): JSX.Element => {
 						<span>{ translate( 'Delete your site permanently' ) }</span>
 					</Button>
 				</div>
+				<TrialExpiredSurveyDialog />
 			</Main>
 		</>
 	);

--- a/client/my-sites/plans/trials/business-trial-expired/trial-expired-survey.tsx
+++ b/client/my-sites/plans/trials/business-trial-expired/trial-expired-survey.tsx
@@ -1,0 +1,59 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Dialog } from '@automattic/components';
+import { getLocaleSlug, useTranslate } from 'i18n-calypso';
+import { useDispatch, useSelector } from 'calypso/state';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getPreference } from 'calypso/state/preferences/selectors';
+
+const CALYPSO_TRIAL_SURVEY_PREFERENCE = 'calypso_business_expired_trial_survey_dismissed';
+
+export const TrialExpiredSurveyDialog = () => {
+	const translate = useTranslate();
+	const buttons = [
+		{ action: 'dismiss', label: translate( 'Dismiss' ) },
+		{ action: 'take-survey', label: translate( 'Take survey' ), isPrimary: true },
+	];
+
+	const dispatch = useDispatch();
+
+	const preferenceName = CALYPSO_TRIAL_SURVEY_PREFERENCE;
+
+	const isDismissed = useSelector( ( state ) => getPreference( state, preferenceName ) ) ?? false;
+
+	const dismissAndRecordEvent = ( dialogAction: string | undefined ) => {
+		dispatch( savePreference( preferenceName, true ) );
+
+		let eventName = 'calypso_business_expired_trial_survey_dismissed';
+
+		if ( dialogAction === 'take-survey' ) {
+			eventName = 'calypso_business_expired_trial_survey_taken';
+			// Open a new window to the survey URL
+			window.open( 'https://automattic.survey.fm/business-trial-survey', '_blank' );
+		}
+
+		//dispatch( recordTracksEvent( eventName ) );
+	};
+
+	// This survey is only available in English only.
+	const isEnglishLocale = getLocaleSlug() === 'en' || getLocaleSlug() === 'en-gb';
+
+	if ( isDismissed || ! isEnglishLocale ) {
+		return null;
+	}
+
+	return (
+		<Dialog
+			isVisible={ ! isDismissed }
+			buttons={ buttons }
+			onClose={ dismissAndRecordEvent }
+			className="delete-site-warning-dialog"
+		>
+			<h1>{ translate( 'Trial Expired' ) }</h1>
+			<p>
+				{ translate(
+					'Take this 2 minute survey to help us better understand your experience during the plaform.'
+				) }
+			</p>
+		</Dialog>
+	);
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR provides a link to crowdsignal survey to ascertain feedback on the trial experience.

* Add dialog to take survey

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `/plans/my-plan/trial-expired/siteSlug`
* Verify there is a dialog to take a survey
* Clicking the CTA should open survey in a new window
* Verify the dialog is not shown again after dismissing 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?