### PR TITLE
Site Indicator: Fix buggy JavaScript

### DIFF
--- a/client/my-sites/site-indicator/index.jsx
+++ b/client/my-sites/site-indicator/index.jsx
@@ -135,10 +135,10 @@ export class SiteIndicator extends Component {
 		);
 	}
 
-	resetWindowState() {
+	resetWindowState = () => {
 		window.scrollTo( 0, 0 );
 		this.setState( { expand: false } );
-	}
+	};
 
 	handleJetpackConnectionHealthSidebarLinkClick = () => {
 		const { siteIsAutomatedTransfer } = this.props;


### PR DESCRIPTION
Introduced in https://github.com/Automattic/wp-calypso/pull/85148

## Proposed Changes

Fixes `Cannot read properties of undefined (reading 'setState')` error by ensuring the method is bound to `this`.

Silly JavaScript.

## Testing Instructions

1. Create a jurassic.ninja site and install an outdated plugin.
2. Verify the indicator appears in the selector:

![CleanShot 2023-12-20 at 16 33 19@2x](https://github.com/Automattic/wp-calypso/assets/36432/4195d935-91db-4f2c-8ebe-598932d4a854)

3. When you click on the link, verify no JavaScript error occurs:

![CleanShot 2023-12-20 at 16 33 44@2x](https://github.com/Automattic/wp-calypso/assets/36432/6c273bfc-ef72-47b6-ab48-a9dc74b0205a)
