### PR TITLE
Disable pre release failure messages in Slack

### DIFF
--- a/.teamcity/_self/projects/WebApp.kt
+++ b/.teamcity/_self/projects/WebApp.kt
@@ -859,22 +859,6 @@ object PreReleaseE2ETests : BuildType({
 			dockerImage = "%docker_image_e2e%"
 		}
 
-		bashNodeScript {
-				name = "Send TeamCity Message"
-				executionMode = BuildStep.ExecutionMode.RUN_ON_FAILURE
-				scriptContent = """
-					set -x
-
-					export slack_oauth_token="%TEAMCITY_SLACK_RICH_NOTIFICATION_APP_OAUTH_TOKEN%"
-					export tc_build_conf_name="%system.teamcity.buildConfName%"
-					export tc_project_name="%system.teamcity.projectName%"
-					export tc_build_number=%build.number%
-					export tc_build_branch=%teamcity.build.branch%
-
-					node ./bin/teamcity-e2e-slack-notify.mjs --file test/e2e/pre-release-test-results.json
-				"""
-				dockerImage = "%docker_image_e2e%"
-			}
 
 		bashNodeScript {
 			name = "Collect results"

--- a/bin/teamcity-e2e-slack-notify.mjs
+++ b/bin/teamcity-e2e-slack-notify.mjs
@@ -1,3 +1,6 @@
+// NOTE: if we decide to use this again in the future, see https://github.com/Automattic/wp-calypso/pull/85597
+// for more context on why this was disabled. It needs to be updated to avoid
+// adding so much noise to the channel.
 import fs from 'fs';
 import { exit } from 'process';
 import fetch from 'node-fetch';

--- a/bin/teamcity-e2e-slack-notify.mjs
+++ b/bin/teamcity-e2e-slack-notify.mjs
@@ -72,47 +72,20 @@ function buildSlackMessage( failures ) {
 				type: 'section',
 				text: {
 					type: 'mrkdwn',
-					text: `:x: E2E Build Failed on branch *${ process.env.tc_build_branch }*: ${ process.env.tc_project_name }: ${ process.env.tc_build_conf_name }, #${ process.env.tc_build_number }`,
-				},
-			},
-			{
-				type: 'section',
-				text: {
-					type: 'mrkdwn',
-					text: `:teamcity: <${ process.env.BUILD_URL }|*Build*>`,
+					text: `:x: E2E Build Failed on branch *${ process.env.tc_build_branch }*: ${ process.env.tc_project_name }: ${ process.env.tc_build_conf_name }, :teamcity: <${ process.env.BUILD_URL }|Build #${ process.env.tc_build_number }>`,
 				},
 			},
 			{
 				type: 'divider',
 			},
-			{
-				type: 'header',
-				text: {
-					type: 'plain_text',
-					text: 'Stacktraces',
-				},
-			},
 		],
 	};
-	for ( const failure of failures ) {
-		body.blocks.push(
-			{
-				type: 'section',
-				text: {
-					type: 'mrkdwn',
-					text:
-						'*' + failure.step.join( ': ' ) + '*' + '\n' + '```' + failure.error.pop() + '\n```',
-				},
-			},
-			{ type: 'divider' }
-		);
-	}
+	const failedTestNames = failures.map( ( failure ) => failure.step.join( ': ' ) );
 	body.blocks.push( {
 		type: 'section',
 		text: {
 			type: 'mrkdwn',
-			// text: 'placeholder text so that I do not waste a8c GPT bandwidth',
-			text: '@gpt, can you tell me more about the error(s) above, provide link(s) to the E2E test file in GitHub, and a snippet of the relevant code section?',
+			text: `*Failed Tests:*\n - ${ failedTestNames.join( '\n - ' ) }`,
 		},
 	} );
 	return body;

--- a/bin/teamcity-e2e-slack-notify.mjs
+++ b/bin/teamcity-e2e-slack-notify.mjs
@@ -75,20 +75,47 @@ function buildSlackMessage( failures ) {
 				type: 'section',
 				text: {
 					type: 'mrkdwn',
-					text: `:x: E2E Build Failed on branch *${ process.env.tc_build_branch }*: ${ process.env.tc_project_name }: ${ process.env.tc_build_conf_name }, :teamcity: <${ process.env.BUILD_URL }|Build #${ process.env.tc_build_number }>`,
+					text: `:x: E2E Build Failed on branch *${ process.env.tc_build_branch }*: ${ process.env.tc_project_name }: ${ process.env.tc_build_conf_name }, #${ process.env.tc_build_number }`,
+				},
+			},
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text: `:teamcity: <${ process.env.BUILD_URL }|*Build*>`,
 				},
 			},
 			{
 				type: 'divider',
 			},
+			{
+				type: 'header',
+				text: {
+					type: 'plain_text',
+					text: 'Stacktraces',
+				},
+			},
 		],
 	};
-	const failedTestNames = failures.map( ( failure ) => failure.step.join( ': ' ) );
+	for ( const failure of failures ) {
+		body.blocks.push(
+			{
+				type: 'section',
+				text: {
+					type: 'mrkdwn',
+					text:
+						'*' + failure.step.join( ': ' ) + '*' + '\n' + '```' + failure.error.pop() + '\n```',
+				},
+			},
+			{ type: 'divider' }
+		);
+	}
 	body.blocks.push( {
 		type: 'section',
 		text: {
 			type: 'mrkdwn',
-			text: `*Failed Tests:*\n - ${ failedTestNames.join( '\n - ' ) }`,
+			// text: 'placeholder text so that I do not waste a8c GPT bandwidth',
+			text: '@gpt, can you tell me more about the error(s) above, provide link(s) to the E2E test file in GitHub, and a snippet of the relevant code section?',
 		},
 	} );
 	return body;


### PR DESCRIPTION
Unfortunately, these are incredibly noisy, and haven't proven to be super useful yet. Ideally, we would enhance the existing glorybot "pre-release tests failed" message with a small amount of extra info like what test failed.

One big problem with the current message is that it sends even for muted tests, which is a TeamCity feature, so this script doesn't know about what tests are muted, and just sends the message anyways.

The messages also become so long with the stack trace that the channel becomes impossible to scroll through.

If this gets re-enabled, we should do a few things:
1. Do not duplicate the existing pre-release failure message, and instead enhance it somehow.
2. Include a small amount of extra info in the existing message, like what failed, but don't include very long stack traces in the main channel text, because it takes up too much space. Maybe just a list of the first few tests which failed in the suite.
3. Make sure the failure messages are not sent for tests muted in TeamCity.