### PR TITLE
Monetize: Update stripe disconnect modal

### DIFF
--- a/client/my-sites/earn/memberships/section.tsx
+++ b/client/my-sites/earn/memberships/section.tsx
@@ -109,6 +109,7 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 					</div>
 				</Card>
 				<Dialog
+					className="memberships__stripe-disconnect-modal"
 					isVisible={ !! disconnectedConnectedAccountId }
 					buttons={ [
 						{
@@ -123,14 +124,12 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 					] }
 					onClose={ onCloseDisconnectStripeAccount }
 				>
-					<h1>{ translate( 'Confirmation' ) }</h1>
-					<p>{ translate( 'Do you want to disconnect Payments from your Stripe account?' ) }</p>
-					<Notice
-						text={ translate(
+					<h1>{ translate( 'Disconnect Stripe?' ) }</h1>
+					<p>
+						{ translate(
 							'Once you disconnect Payments from Stripe, new subscribers won’t be able to sign up and existing subscriptions will stop working.'
 						) }
-						showDismiss={ false }
-					/>
+					</p>
 				</Dialog>
 			</div>
 		);

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -153,7 +153,8 @@ body.is-section-earn.theme-default.color-scheme {
 	}
 }
 
-.memberships__delete-plan-modal {
+.memberships__delete-plan-modal,
+.memberships__stripe-disconnect-modal {
 	width: 580px;
 	max-width: 98%;
 	h1 {


### PR DESCRIPTION
## Proposed Changes

Updates the content and styling of the Stripe disconnect modal to be in line with other Monetize modals as seen in related PRs and figma (https://github.com/Automattic/wp-calypso/pull/85576 and https://github.com/Automattic/wp-calypso/pull/85517 and DqXCQr1dEWpF3P2dIEwiwd-fi-791_91242)

**Before**
<img width="976" alt="stripe-disconnect-before" src="https://github.com/Automattic/wp-calypso/assets/21228350/dd8b9020-ac41-4e87-96ba-26eaabeebf1e">

**After**
<img width="644" alt="stripe-disconnect-after" src="https://github.com/Automattic/wp-calypso/assets/21228350/907935f5-adbe-4f9f-8ad1-16c1622a6ec3">

## Testing Instructions

You will need a site with Stripe connected. Go to http://calypso.localhost:3000/earn/payments/YOURSITESLUG, click to disconnect Stripe, and confirm the modal looks like the new screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?