### PR TITLE
Stepper: Don't render the header if the flow step content is null

### DIFF
--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -4,6 +4,7 @@ import { DESIGN_FIRST_FLOW } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
+import { translate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
 import { recordSubmitStep } from 'calypso/landing/stepper/declarative-flow/internals/analytics/record-submit-step';
@@ -22,7 +23,15 @@ import { useLoginUrl } from '../utils/path';
 
 const designFirst: Flow = {
 	name: DESIGN_FIRST_FLOW,
-	title: 'Blog',
+	get title() {
+		// Don't assign a title if coming from the logged-out Theme Showcase.
+		// See https://github.com/Automattic/wp-calypso/issues/85396.
+		if ( getQueryArg( window.location.href, 'ref' ) === 'calypshowcase' ) {
+			return '';
+		}
+
+		return translate( 'Blog' );
+	},
 	useSteps() {
 		return [
 			{

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -24,12 +24,6 @@ import { useLoginUrl } from '../utils/path';
 const designFirst: Flow = {
 	name: DESIGN_FIRST_FLOW,
 	get title() {
-		// Don't assign a title if coming from the logged-out Theme Showcase.
-		// See https://github.com/Automattic/wp-calypso/issues/85396.
-		if ( getQueryArg( window.location.href, 'ref' ) === 'calypshowcase' ) {
-			return '';
-		}
-
 		return translate( 'Blog' );
 	},
 	useSteps() {
@@ -291,7 +285,7 @@ const designFirst: Flow = {
 
 		if ( ! isLoggedIn ) {
 			result = {
-				state: AssertConditionState.CHECKING,
+				state: AssertConditionState.FAILURE,
 				message: `${ flowName } requires a logged in user`,
 			};
 		} else if ( isSiteCreationStep && ! userAlreadyHasSites ) {

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -23,6 +23,7 @@ const StepRoute = ( {
 	showWooLogo,
 	renderStep,
 }: StepRouteProps ) => {
+	const stepContent = renderStep( step );
 	const renderProgressBar = () => {
 		// The visual progress bar is removed due to its fragility.
 		// The component will be cleaned up but it'll require more untangling as the component
@@ -56,8 +57,8 @@ const StepRoute = ( {
 		>
 			{ 'videopress' === flow.name && 'intro' === step.slug && <VideoPressIntroBackground /> }
 			{ renderProgressBar() }
-			<SignupHeader pageTitle={ flow.title } showWooLogo={ showWooLogo } />
-			{ renderStep( step ) }
+			{ stepContent && <SignupHeader pageTitle={ flow.title } showWooLogo={ showWooLogo } /> }
+			{ stepContent }
 		</div>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -12,7 +12,7 @@ type StepRouteProps = {
 	progressValue: number;
 	progressBarExtraStyle: React.CSSProperties;
 	showWooLogo: boolean;
-	renderStep: ( step: StepperStep ) => JSX.Element;
+	renderStep: ( step: StepperStep ) => JSX.Element | null;
 };
 
 const StepRoute = ( {

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -197,7 +197,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 				return <StepperLoader />;
 			/* eslint-enable wpcalypso/jsx-classname-namespace */
 			case AssertConditionState.FAILURE:
-				return <></>;
+				return null;
 		}
 
 		const StepComponent = stepComponents[ step.slug ];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85396

## Proposed Changes

This PR updates Stepper so that when the flow assert condition is `FAILURE`, the header is not rendered since the step content will also be `null`.

> [!NOTE]
> This PR also updates the step content to return `null` instead of `<></>` since it's easier to check for `null`. AFAIK there is no signficant impact caused by this change. cc: @andres-blanco in case you have more insights or concerns regarding this change 🙂

![image](https://github.com/Automattic/wp-calypso/assets/797888/e36be613-5f0a-489e-95fe-e02a490b94c2)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the logged-out Theme Showcase `/themes`.
* Select the category Blog.
* Select any free theme via the "Pick this design" button.
* Ensure that the title "Blog" is not shown in the top-left corner of the screen before getting redirected to the account page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?