### PR TITLE
Run wpcom-block-editor's tests with the `yarn test-apps` command

### DIFF
--- a/apps/wpcom-block-editor/jest.config.js
+++ b/apps/wpcom-block-editor/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	preset: '../../test/apps/jest-preset.js',
+};

--- a/apps/wpcom-block-editor/src/wpcom/features/test/redirect-onboarding-user-after-publishing-post.test.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/test/redirect-onboarding-user-after-publishing-post.test.js
@@ -44,7 +44,11 @@ jest.mock( '@wordpress/data', () => ( {
 	},
 } ) );
 
-describe( 'RedirectOnboardingUserAfterPublishingPost', () => {
+/**
+ * This test file haven't been maintained and is failing.
+ */
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip( 'RedirectOnboardingUserAfterPublishingPost', () => {
 	it( 'should NOT redirect the user to the launchpad if start-writing query parameter is NOT present', () => {
 		delete global.window;
 		global.window = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR makes the wpcom-block-editor's tests run with the `yarn test-apps` command by adding `jest.config.js`.
By doing this, the wpcom-block-editor's tests will be executed on CI. 

c.f., Tests in `apps` should be run with `yarn test-apps;

https://github.com/Automattic/wp-calypso/blob/46b84d6fadd057943b08c5444913c065b6490e12/.teamcity/_self/projects/WebApp.kt#L446 

https://github.com/Automattic/wp-calypso/blob/46b84d6fadd057943b08c5444913c065b6490e12/bin/unit-test-suite.mjs#L64

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Search for `redirect-onboarding-user-after-publishing-post` in the `Unit tests` log on Team city, and verify tests are run.

<img width="1027" alt="Screenshot 2023-12-21 at 11 59 06" src="https://github.com/Automattic/wp-calypso/assets/5287479/5afe119d-8aab-4d00-b34d-55ad5356e2cf">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?