### PR TITLE
Monetize: Make warning buttons red

### DIFF
--- a/client/my-sites/earn/customers/cancel-dialog.tsx
+++ b/client/my-sites/earn/customers/cancel-dialog.tsx
@@ -88,6 +88,7 @@ function CancelDialog( { subscriberToCancel, setSubscriberToCancel }: CancelDial
 						{
 							label: getText( subscriberToCancel ).button,
 							isPrimary: true,
+							additionalClassNames: 'is-scary',
 							action: 'cancel',
 						},
 					] }

--- a/client/my-sites/earn/memberships/delete-plan-modal.tsx
+++ b/client/my-sites/earn/memberships/delete-plan-modal.tsx
@@ -46,6 +46,7 @@ const RecurringPaymentsPlanDeleteModal = ( {
 				{
 					label: translate( 'Delete' ),
 					isPrimary: true,
+					additionalClassNames: 'is-scary',
 					action: 'delete',
 				},
 			] }

--- a/client/my-sites/earn/memberships/section.tsx
+++ b/client/my-sites/earn/memberships/section.tsx
@@ -147,6 +147,7 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 						{
 							label: translate( 'Disconnect Payments from Stripe' ),
 							isPrimary: true,
+							additionalClassNames: 'is-scary',
 							action: 'disconnect',
 						},
 					] }


### PR DESCRIPTION
## Proposed Changes

The monetize screen shows confirmation modals for some 'destructive' actions like deleting plans, disconnecting stripe, or canceling payments. This PR makes those red using the 'is-scary' class for the button component. 

(Note: color rendition in screenshots below varies a bit from modal to modal, but they are the same in the UI.). 

**Disconnect Stripe modal**
<img width="643" alt="modal-stripe2" src="https://github.com/Automattic/wp-calypso/assets/21228350/4ce1f0d8-2ddf-4811-999d-80b7a616112f">


**Delete plan modal**
<img width="644" alt="delete-plan" src="https://github.com/Automattic/wp-calypso/assets/21228350/7a404701-5dd3-4bb1-bd1c-96ff3c0156c9">

**Cancel payments modal**
<img width="646" alt="modal-cancel" src="https://github.com/Automattic/wp-calypso/assets/21228350/733ebfc8-4781-47a8-9018-bf9437dbb479">

## Testing Instructions

1. You will need a site with stripe connected, with paid plans, and with paying customers. 
2. Go to http://calypso.localhost:3000/earn/payments/YOURSITESLUG, click the button to disconnect stripe, and confirm modal button is red. 
3. Go to http://calypso.localhost:3000/earn/payments/YOURSITESLUG, click to delete a plan, and confirm the modal button is red. 
2. Go to http://calypso.localhost:3000/earn/supporters/YOURSITESLUG, click the cancel a payment for a subscriber, and confirm modal button is red. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?