### PR TITLE
Self-service site reset: launch to prod

### DIFF
--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { compose } from '@wordpress/compose';
 import { addQueryArgs } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
@@ -70,18 +69,10 @@ class SiteTools extends Component {
 
 		const changeSiteAddress = translate( 'Change your site address' );
 
-		const hasSiteReset = isEnabled( 'settings/self-serve-site-reset' );
-		const startOver = hasSiteReset
-			? translate( 'Reset your site' )
-			: translate( 'Delete your content' );
-		const startOverText = hasSiteReset
-			? translate(
-					"Remove all posts, pages, and media to start fresh while keeping your site's address."
-			  )
-			: translate(
-					"Keep your site's address and current theme, but remove all posts, " +
-						'pages, and media so you can start fresh.'
-			  );
+		const startOver = translate( 'Reset your site' );
+		const startOverText = translate(
+			"Remove all posts, pages, and media to start fresh while keeping your site's address."
+		);
 
 		const deleteSite = translate( 'Delete your site permanently' );
 		const deleteSiteText = translate(

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -291,7 +291,7 @@ function SiteResetCard( {
 
 	return (
 		<Main className="site-settings__reset-site">
-			<Interval onTick={ checkStatus } period={ EVERY_FIVE_SECONDS } />
+			{ ! isLoading && <Interval onTick={ checkStatus } period={ EVERY_FIVE_SECONDS } /> }
 			<NavigationHeader
 				navigationItems={ [] }
 				title={ translate( 'Site Reset' ) }

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -1,11 +1,9 @@
-import { isEnabled } from '@automattic/calypso-config';
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
 import {
 	useSiteResetContentSummaryQuery,
 	useSiteResetMutation,
 	useSiteResetStatusQuery,
 } from '@automattic/data-stores';
-import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { useQueryClient } from '@tanstack/react-query';
 import { createInterpolateElement, useState } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -13,9 +11,7 @@ import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import ActionPanel from 'calypso/components/action-panel';
 import ActionPanelBody from 'calypso/components/action-panel/body';
-import ActionPanelFigure from 'calypso/components/action-panel/figure';
 import ActionPanelFooter from 'calypso/components/action-panel/footer';
-import ActionPanelTitle from 'calypso/components/action-panel/title';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import HeaderCake from 'calypso/components/header-cake';
@@ -25,87 +21,12 @@ import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
-import { EMPTY_SITE } from 'calypso/lib/url/support';
 import { useDispatch, useSelector } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { getSite, getSiteDomain, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { BuiltByUpsell } from './built-by-upsell-banner';
-
-const StartOver = ( {
-	translate,
-	selectedSiteSlug,
-	siteDomain,
-	isAtomic,
-	site,
-	isUnlaunchedSite: isUnlaunchedSiteProp,
-} ) => {
-	const localizeUrl = useLocalizeUrl();
-	if ( isEnabled( 'settings/self-serve-site-reset' ) ) {
-		return (
-			<SiteResetCard
-				translate={ translate }
-				selectedSiteSlug={ selectedSiteSlug }
-				siteDomain={ siteDomain }
-				isAtomic={ isAtomic }
-				site={ site }
-				isUnlaunchedSite={ isUnlaunchedSiteProp }
-			/>
-		);
-	}
-	return (
-		<div
-			className="main main-column" // eslint-disable-line wpcalypso/jsx-classname-namespace
-			role="main"
-		>
-			<PageViewTracker path="/settings/start-over/:site" title="Settings > Start Over" />
-			<HeaderCake backHref={ '/settings/general/' + selectedSiteSlug }>
-				<h1>{ translate( 'Start Over' ) }</h1>
-			</HeaderCake>
-			<ActionPanel>
-				<ActionPanelBody>
-					<ActionPanelFigure inlineBodyText={ true }>
-						<img src="/calypso/images/wordpress/logo-stars.svg" alt="" width="170" height="143" />
-					</ActionPanelFigure>
-					<ActionPanelTitle>{ translate( 'Start Over' ) }</ActionPanelTitle>
-					<p>
-						{ translate(
-							"If you want a site but don't want any of the posts and pages you have now, our support " +
-								'team can delete your posts, pages, media, and comments for you.'
-						) }
-					</p>
-					<p>
-						{ translate(
-							'This will keep your site and URL active, but give you a fresh start on your content ' +
-								'creation. Just contact us to have your current content cleared out.'
-						) }
-					</p>
-					<p>
-						{ translate(
-							'Alternatively, you can delete all content from your site by following the steps here.'
-						) }
-					</p>
-				</ActionPanelBody>
-				<ActionPanelFooter>
-					<Button
-						className="action-panel__support-button is-external" // eslint-disable-line wpcalypso/jsx-classname-namespace
-						href={ localizeUrl( EMPTY_SITE ) }
-					>
-						{ translate( 'Follow the steps' ) }
-						<Gridicon icon="external" size={ 48 } />
-					</Button>
-					<Button
-						className="action-panel__support-button" // eslint-disable-line wpcalypso/jsx-classname-namespace
-						href="/help/contact"
-					>
-						{ translate( 'Contact support' ) }
-					</Button>
-				</ActionPanelFooter>
-			</ActionPanel>
-		</div>
-	);
-};
 
 function SiteResetCard( {
 	translate,
@@ -408,4 +329,4 @@ export default connect( ( state ) => {
 		isAtomic: isJetpackSite( state, siteId ),
 		isUnlaunchedSite: isUnlaunchedSite( state, siteId ),
 	};
-} )( localize( StartOver ) );
+} )( localize( SiteResetCard ) );

--- a/config/development.json
+++ b/config/development.json
@@ -181,7 +181,6 @@
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
-		"settings/self-serve-site-reset": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-preview-colors": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -118,7 +118,6 @@
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
-		"settings/self-serve-site-reset": false,
 		"sign-in-with-apple": false,
 		"signup/design-picker-preview-colors": true,
 		"signup/design-picker-preview-fonts": true,

--- a/config/production.json
+++ b/config/production.json
@@ -144,7 +144,6 @@
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
-		"settings/self-serve-site-reset": false,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-preview-colors": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -141,7 +141,6 @@
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
-		"settings/self-serve-site-reset": true,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-preview-colors": true,

--- a/config/test.json
+++ b/config/test.json
@@ -100,7 +100,6 @@
 		"seller-experience": true,
 		"server-side-rendering": true,
 		"settings/security/monitor": true,
-		"settings/self-serve-site-reset": false,
 		"signup/social": true,
 		"signup/social-first": true,
 		"site-indicator": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -150,7 +150,6 @@
 		"server-side-rendering": true,
 		"settings/newsletter-settings-page": true,
 		"settings/security/monitor": true,
-		"settings/self-serve-site-reset": false,
 		"sign-in-with-apple": true,
 		"sign-in-with-apple/redirect": true,
 		"signup/design-picker-preview-colors": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See also D132802-code. 

## Proposed Changes

* Title. 
* Removing the feature flag and the old `StartOver` UI. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure sandbox and proxy is disabled. 
* Try it on Calypso Live and make sure the feature works properly end-to-end, including email:
* `/settings/start-over/:simple`
* `/settings/start-over/:atomic`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?