### PR TITLE
Monetize: Add commission fee notice for Stripe

### DIFF
--- a/client/my-sites/earn/memberships/section.tsx
+++ b/client/my-sites/earn/memberships/section.tsx
@@ -1,6 +1,7 @@
 import { Card, Button, Dialog, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useCallback } from 'react';
+import QueryMembershipsEarnings from 'calypso/components/data/query-memberships-earnings';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import Notice from 'calypso/components/notice';
@@ -142,11 +143,11 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 								</div>
 							</div>
 						</Card>
-						<p>
-							<CommissionFees commission={ commission } siteSlug={ site?.slug } />
-						</p>
 					</>
 				) }
+				<p className="memberships__commission-notice">
+					<CommissionFees commission={ commission } siteSlug={ site?.slug } />
+				</p>
 				<Dialog
 					className="memberships__stripe-disconnect-modal"
 					isVisible={ !! disconnectedConnectedAccountId }
@@ -254,6 +255,7 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 	return (
 		<div>
 			<QueryMembershipsSettings siteId={ site.ID } source={ source } />
+			<QueryMembershipsEarnings siteId={ site?.ID ?? 0 } />
 			{ ! connectedAccountId && ! connectUrl && (
 				<div className="earn__payments-loading">
 					<LoadingEllipsis />

--- a/client/my-sites/earn/memberships/section.tsx
+++ b/client/my-sites/earn/memberships/section.tsx
@@ -9,6 +9,7 @@ import SectionHeader from 'calypso/components/section-header';
 import { userCan } from 'calypso/lib/site/utils';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getEarningsWithDefaultsForSiteId } from 'calypso/state/memberships/earnings/selectors';
 import { getProductsForSiteId } from 'calypso/state/memberships/product-list/selectors';
 import { requestDisconnectSiteStripeAccount } from 'calypso/state/memberships/settings/actions';
 import {
@@ -17,6 +18,7 @@ import {
 	getConnectUrlForSiteId,
 } from 'calypso/state/memberships/settings/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import CommissionFees from '../components/commission-fees';
 import { Query } from '../types';
 import {
 	ADD_TIER_PLAN_HASH,
@@ -48,6 +50,10 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 		getConnectedAccountDescriptionForSiteId( state, site?.ID )
 	);
 	const connectUrl: string = useSelector( ( state ) => getConnectUrlForSiteId( state, site?.ID ) );
+
+	const { commission } = useSelector( ( state ) =>
+		getEarningsWithDefaultsForSiteId( state, site?.ID )
+	);
 
 	const navigateToLaunchpad = useCallback( () => {
 		const shouldGoToLaunchpad = query?.stripe_connect_success === 'launchpad';
@@ -114,27 +120,32 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 						</div>
 					</Card>
 				) : (
-					<Card className="memberships__settings-link">
-						<div className="memberships__module-plans-content">
-							<div>
-								<div className="memberships__module-plans-title">
-									{ translate( 'Connect a Stripe account to start collecting payments.' ) }
-								</div>
-								{ connectedAccountDescription ? (
+					<>
+						<Card className="memberships__settings-link">
+							<div className="memberships__module-plans-content">
+								<div>
 									<div className="memberships__module-plans-title">
-										{ translate(
-											'Previously connected to Stripe account %(connectedAccountDescription)s',
-											{
-												args: {
-													connectedAccountDescription: connectedAccountDescription,
-												},
-											}
-										) }
+										{ translate( 'Connect a Stripe account to start collecting payments.' ) }
 									</div>
-								) : null }
+									{ connectedAccountDescription ? (
+										<div className="memberships__module-plans-title">
+											{ translate(
+												'Previously connected to Stripe account %(connectedAccountDescription)s',
+												{
+													args: {
+														connectedAccountDescription: connectedAccountDescription,
+													},
+												}
+											) }
+										</div>
+									) : null }
+								</div>
 							</div>
-						</div>
-					</Card>
+						</Card>
+						<p>
+							<CommissionFees commission={ commission } siteSlug={ site?.slug } />
+						</p>
+					</>
 				) }
 				<Dialog
 					className="memberships__stripe-disconnect-modal"

--- a/client/my-sites/earn/memberships/section.tsx
+++ b/client/my-sites/earn/memberships/section.tsx
@@ -121,29 +121,27 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 						</div>
 					</Card>
 				) : (
-					<>
-						<Card className="memberships__settings-link">
-							<div className="memberships__module-plans-content">
-								<div>
-									<div className="memberships__module-plans-title">
-										{ translate( 'Connect a Stripe account to start collecting payments.' ) }
-									</div>
-									{ connectedAccountDescription ? (
-										<div className="memberships__module-plans-title">
-											{ translate(
-												'Previously connected to Stripe account %(connectedAccountDescription)s',
-												{
-													args: {
-														connectedAccountDescription: connectedAccountDescription,
-													},
-												}
-											) }
-										</div>
-									) : null }
+					<Card className="memberships__settings-link">
+						<div className="memberships__module-plans-content">
+							<div>
+								<div className="memberships__module-plans-title">
+									{ translate( 'Connect a Stripe account to start collecting payments.' ) }
 								</div>
+								{ connectedAccountDescription ? (
+									<div className="memberships__module-plans-title">
+										{ translate(
+											'Previously connected to Stripe account %(connectedAccountDescription)s',
+											{
+												args: {
+													connectedAccountDescription: connectedAccountDescription,
+												},
+											}
+										) }
+									</div>
+								) : null }
 							</div>
-						</Card>
-					</>
+						</div>
+					</Card>
 				) }
 				<p className="memberships__commission-notice">
 					<CommissionFees commission={ commission } siteSlug={ site?.slug } />

--- a/client/my-sites/earn/memberships/style.scss
+++ b/client/my-sites/earn/memberships/style.scss
@@ -162,6 +162,11 @@ body.is-section-earn.theme-default.color-scheme {
 	}
 }
 
+.memberships__commission-notice {
+	font-size: $font-body-small;
+	color: var(--studio-gray-70);
+}
+
 .supporters-list {
 	margin: 20px 0 0;
 


### PR DESCRIPTION
## Proposed Changes

Adds a commission fee notice just below the Stripe settings box on Monetize > Payments, to match figma designs here: DqXCQr1dEWpF3P2dIEwiwd-fi-791_91242

**Screenshot**
<img width="1091" alt="commission" src="https://github.com/Automattic/wp-calypso/assets/21228350/5c0b7f5c-d519-4c5e-b605-c198b7e87fd4">

## Testing Instructions

Go to http://calypso.localhost:3000/earn/payments/YOURSITESLUG, and confirm the commission fee notice now shows like the screenshot above. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?