### PR TITLE
Design Picker: Add is_bundled_with_woo to design props

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -114,8 +114,7 @@ export function getDesignEventProps( {
 		design_type: design.design_type,
 		is_premium: design.is_premium,
 		is_externally_managed: design?.is_externally_managed,
-		is_woo:
-			( design.software_sets || [] ).filter( ( set ) => set?.slug === 'woo-on-plans' ).length > 0,
+		is_bundled_with_woo: design?.is_bundled_with_woo,
 		has_style_variations: ( design.style_variations || [] ).length > 0,
 		is_style_variation: is_style_variation,
 		...( colorVariation && {

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -114,6 +114,8 @@ export function getDesignEventProps( {
 		design_type: design.design_type,
 		is_premium: design.is_premium,
 		is_externally_managed: design?.is_externally_managed,
+		is_woo:
+			( design.software_sets || [] ).filter( ( set ) => set?.slug === 'woo-on-plans' ).length > 0,
 		has_style_variations: ( design.style_variations || [] ).length > 0,
 		is_style_variation: is_style_variation,
 		...( colorVariation && {

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -94,6 +94,9 @@ function apiStarterDesignsToDesign( design: StarterDesign ): Design {
 		( design.recipe.stylesheet && design.recipe.stylesheet.startsWith( 'premium/' ) ) || false;
 
 	const is_externally_managed = design.theme_type === 'managed-external';
+	const is_bundled_with_woo = ( design.software_sets || [] ).some(
+		( { slug } ) => slug === 'woo-on-plans'
+	);
 
 	return {
 		slug,
@@ -103,6 +106,7 @@ function apiStarterDesignsToDesign( design: StarterDesign ): Design {
 		categories,
 		is_premium,
 		is_externally_managed,
+		is_bundled_with_woo,
 		price,
 		software_sets,
 		design_type: design_type ?? ( is_premium ? 'premium' : 'standard' ),

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -100,6 +100,7 @@ export interface Design {
 	recipe?: DesignRecipe;
 	is_premium: boolean;
 	is_externally_managed?: boolean;
+	is_bundled_with_woo?: boolean;
 	categories: Category[];
 	features: DesignFeatures[];
 	is_featured_picks?: boolean; // Whether this design will be featured in the sidebar. Example: Blank Canvas


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4978

## Proposed Changes

This PR adds the property `is_bundled_with_woo` to `getDesignEventProps()`, which is called for all events related to the design in the Design Picker.

>[!NOTE]
> The event `calypso_signup_design_type_submit` doesn't inherit the properties from `getDesignEventProps()`. So it doesn't have properties such as `is_premium`. Consider using the event `calypso_signup_select_design` instead, which is triggered together with `calypso_signup_design_type_submit` and has the additional properties. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Onboarding Design Picker.
* Ensure that the property `is_bundled_with_woo` is added for the following events:
  * calypso_signup_design_preview_select
  * calypso_signup_select_design
  
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?