### PR TITLE
Revert "Multi-Domain: Added final price at the mobile card"

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -108,7 +108,7 @@ class DomainProductPrice extends Component {
 
 		return (
 			<div className="domain-product-price__price">
-				<strong>{ this.props.salePrice }</strong> <del>{ priceText }</del>
+				<del>{ priceText }</del>
 			</div>
 		);
 	}


### PR DESCRIPTION
Reverts Automattic/wp-calypso#82952 

See p1703136312484799/1703085675.467509-slack-C0BNMNMNG for context.

The domains promo/price text should work like this:
- Show full price crossed out before anything is selected with "Free for first year"
- After adding the first domain, show full price crossed out with promo message and first year pricing