### PR TITLE
Assembler AI: Add domain step to the flow

### DIFF
--- a/client/landing/stepper/declarative-flow/ai-assembler.ts
+++ b/client/landing/stepper/declarative-flow/ai-assembler.ts
@@ -76,6 +76,7 @@ const withAIAssemblerFlow: Flow = {
 			STEPS.ERROR,
 			STEPS.LAUNCHPAD,
 			STEPS.PLANS,
+			STEPS.DOMAINS,
 			STEPS.SITE_LAUNCH,
 			STEPS.CELEBRATION,
 		];
@@ -90,7 +91,7 @@ const withAIAssemblerFlow: Flow = {
 
 		const { setPendingAction, setSelectedSite } = useDispatch( ONBOARD_STORE );
 		const { saveSiteSettings, setIntentOnSite } = useDispatch( SITE_STORE );
-		const { siteSlug, siteId } = useSiteData();
+		const { site, siteSlug, siteId } = useSiteData();
 
 		const exitFlow = ( to: string ) => {
 			setPendingAction( () => {
@@ -216,9 +217,22 @@ const withAIAssemblerFlow: Flow = {
 				}
 
 				case 'plans': {
-					await updateLaunchpadSettings( siteSlug, {
+					await updateLaunchpadSettings( siteId, {
 						checklist_statuses: { plan_completed: true },
 					} );
+
+					return navigate( 'launchpad' );
+				}
+
+				case 'domains': {
+					await updateLaunchpadSettings( siteId, {
+						checklist_statuses: { domain_upsell_deferred: true },
+					} );
+
+					if ( providedDependencies?.freeDomain && providedDependencies?.domainName ) {
+						// We have to use the site id since the domain is changed.
+						return navigate( `launchpad?siteId=${ site?.ID }` );
+					}
 
 					return navigate( 'launchpad' );
 				}
@@ -238,7 +252,8 @@ const withAIAssemblerFlow: Flow = {
 					return navigate( 'new-or-existing-site' );
 				}
 
-				case 'freePostSetup': {
+				case 'freePostSetup':
+				case 'domain': {
 					return navigate( 'launchpad' );
 				}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/domains/style.scss
@@ -265,9 +265,11 @@
 
 /**
  * Layout for the following flows
+ * - ai-assembler
  * - assembler-first
  * - domain-upsell
  */
+.ai-assembler.domains,
 .assembler-first.domains,
 .domain-upsell.domains {
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85277

## Proposed Changes

This PR syncs the changes made by @arthur791004 in #85277 to the `ai-assembler` flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/ai-assembler`
* Create a new site
* Finish the Assembler screen
* Exit the Site Editor
* On the Launchpad screen, make sure you won't see the Upgrade plan badge on the “Choose a domain” task
* Pick the “Choose a domain” task, and make sure you can see the *.wordpress.com domain
* Select the domain, and make sure the domain of your site changed successfully

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?