### PR TITLE
Jetpack Manage: Hide the Bundle navigation when there is not license bundle to list.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/index.tsx
@@ -3,7 +3,7 @@ import { useBreakpoint } from '@automattic/viewport-react';
 import { getQueryArg } from '@wordpress/url';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import Layout from 'calypso/jetpack-cloud/components/layout';
 import LayoutBody from 'calypso/jetpack-cloud/components/layout/body';
 import LayoutHeader, {
@@ -122,7 +122,7 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 		...( selectedCount && { selectedCount } ),
 	};
 
-	const showBundle = ! selectedSite;
+	const showBundle = ! selectedSite && availableSizes.length > 1;
 
 	useEffect( () => {
 		if ( ! fetchingAvailableSizes ) {
@@ -133,6 +133,22 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 			);
 		}
 	}, [ dispatch, fetchingAvailableSizes, selectedSize ] );
+
+	const subtitle = useMemo( () => {
+		if ( selectedSite?.domain ) {
+			return translate(
+				'Select the Jetpack products you would like to add to {{strong}}%(selectedSiteDomain)s{{/strong}}:',
+				{
+					args: { selectedSiteDomain: selectedSite.domain },
+					components: { strong: <strong /> },
+				}
+			);
+		}
+
+		return showBundle
+			? translate( 'Select single product licenses or save when you issue in bulk' )
+			: translate( 'Select the Jetpack products you would like to issue a new license for:' );
+	}, [ selectedSite?.domain, showBundle, translate ] );
 
 	return (
 		<>
@@ -148,17 +164,7 @@ export default function IssueLicenseV2( { selectedSite, suggestedProduct }: Assi
 
 					<LayoutHeader showStickyContent={ showStickyContent }>
 						<Title>{ translate( 'Issue product licenses' ) } </Title>
-						<Subtitle>
-							{ selectedSite?.domain
-								? translate(
-										'Select the Jetpack products you would like to add to {{strong}}%(selectedSiteDomain)s{{/strong}}:',
-										{
-											args: { selectedSiteDomain: selectedSite.domain },
-											components: { strong: <strong /> },
-										}
-								  )
-								: translate( 'Select single product licenses or save when you issue in bulk' ) }
-						</Subtitle>
+						<Subtitle>{ subtitle }</Subtitle>
 						{ selectedLicenses.length > 0 && (
 							<Actions>
 								<div className="issue-license-v2__controls">


### PR DESCRIPTION
 The current Issue license page for agency users without access to the license bundles causes confusion by mentioning bulk purchases and showing bundle navigation. This PR solves the issue by hiding the bundle navigation and showing an appropriate subtitle. 

**Before**
<img width="892" alt="Screen Shot 2023-12-21 at 2 54 29 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/d8ae2805-43bd-47d9-9968-bee507f7776d">

**After**
<img width="869" alt="Screen Shot 2023-12-21 at 2 53 16 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/2458bdf8-ddf7-4580-91b4-95f9ec31f133">



Closes https://github.com/Automattic/jetpack-manage/issues/191

## Proposed Changes

* Only show bundle navigation and subtitles mentioning the bulk purchases when we have bundle licenses to be listed.

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Please change your billing scheme to a different one that does not have bundle licenses (anything other than 784).
* Use the Jetpack cloud live link below and go to the Issue license page (`/partner-portal/issue-license`)
* Confirm that the Header do not show the bundle navigation and has different subtitle.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?