### PR TITLE
Plugins: do not redirect after checkout

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -37,7 +37,7 @@ type PurchaseModalProps = {
 	siteSlug: string;
 	productToAdd: MinimalRequestCartProduct;
 	showFeatureList: boolean;
-	disableThankYouPage?: boolean;
+	disabledThankYouPage?: boolean;
 };
 
 export function PurchaseModal( {
@@ -101,7 +101,7 @@ function PurchaseModalWrapper( props: PurchaseModalProps ) {
 	const {
 		onClose,
 		onPurchaseSuccess = null,
-		disableThankYouPage,
+		disabledThankYouPage,
 		productToAdd,
 		siteSlug,
 		showFeatureList,
@@ -111,7 +111,7 @@ function PurchaseModalWrapper( props: PurchaseModalProps ) {
 		isComingFromUpsell: true,
 		siteSlug: siteSlug,
 		isInModal: true,
-		disabledThankYouPage: disableThankYouPage,
+		disabledThankYouPage,
 	} );
 
 	const handlePaymentComplete = ( args: PaymentEventCallbackArguments ) => {

--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -1,6 +1,9 @@
 import { useStripe } from '@automattic/calypso-stripe';
 import { Dialog } from '@automattic/components';
-import { CheckoutProvider } from '@automattic/composite-checkout';
+import {
+	CheckoutProvider,
+	type PaymentEventCallbackArguments,
+} from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import classNames from 'classnames';
 import { useState, useMemo, useEffect, type PropsWithChildren } from 'react';
@@ -30,9 +33,11 @@ import './style.scss';
 
 type PurchaseModalProps = {
 	onClose: () => void;
+	onPurchaseSuccess?: () => void;
 	siteSlug: string;
 	productToAdd: MinimalRequestCartProduct;
 	showFeatureList: boolean;
+	disableThankYouPage?: boolean;
 };
 
 export function PurchaseModal( {
@@ -93,12 +98,27 @@ export function wrapValueInManagedValue( value: string | undefined ): ManagedVal
 }
 
 function PurchaseModalWrapper( props: PurchaseModalProps ) {
-	const { onClose, productToAdd, siteSlug, showFeatureList } = props;
+	const {
+		onClose,
+		onPurchaseSuccess = null,
+		disableThankYouPage,
+		productToAdd,
+		siteSlug,
+		showFeatureList,
+	} = props;
 
-	const onComplete = useCreatePaymentCompleteCallback( {
+	const paymentCompleteCallback = useCreatePaymentCompleteCallback( {
 		isComingFromUpsell: true,
 		siteSlug: siteSlug,
+		isInModal: true,
+		disabledThankYouPage: disableThankYouPage,
 	} );
+
+	const handlePaymentComplete = ( args: PaymentEventCallbackArguments ) => {
+		paymentCompleteCallback( args );
+		onPurchaseSuccess?.();
+	};
+
 	const { stripe, stripeConfiguration } = useStripe();
 	const reduxDispatch = useDispatch();
 	const cartKey = useCartKey();
@@ -199,7 +219,7 @@ function PurchaseModalWrapper( props: PurchaseModalProps ) {
 	return (
 		<CheckoutProvider
 			paymentMethods={ [] }
-			onPaymentComplete={ onComplete }
+			onPaymentComplete={ handlePaymentComplete }
 			paymentProcessors={ {
 				'existing-card': ( transactionData ) =>
 					existingCardProcessor( transactionData, dataForProcessor ),

--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -4,13 +4,14 @@ import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { createRequestCartProduct } from '@automattic/shopping-cart';
 import { useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import PurchaseModal from 'calypso/my-sites/checkout/upsell-nudge/purchase-modal';
 import { useIsEligibleForOneClickCheckout } from 'calypso/my-sites/checkout/upsell-nudge/purchase-modal/use-is-eligible-for-one-click-checkout';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { successNotice } from 'calypso/state/notices/actions';
 import EducationFooter from '../education-footer';
 import CollectionListView from '../plugins-browser/collection-list-view';
 import SingleListView, { SHORT_LIST_LENGTH } from '../plugins-browser/single-list-view';
@@ -101,6 +102,7 @@ const PluginsDiscoveryPage = ( props ) => {
 
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const translate = useTranslate();
+	const dispatch = useDispatch();
 	const [ showPurchaseModal, setShowPurchaseModal ] = useState( false );
 	const { isLoading, result: isEligibleForOneClickCheckout } = useIsEligibleForOneClickCheckout();
 
@@ -117,6 +119,15 @@ const PluginsDiscoveryPage = ( props ) => {
 							onClose={ () => {
 								setShowPurchaseModal( false );
 							} }
+							onPurchaseSuccess={ () => {
+								setShowPurchaseModal( false );
+								dispatch(
+									successNotice( translate( 'Your purchase has been completed!' ), {
+										id: 'plugins-purchase-modal-success',
+									} )
+								);
+							} }
+							disableThankYouPage={ true }
 							showFeatureList={ true }
 							siteSlug={ props.siteSlug }
 						/>

--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -127,7 +127,7 @@ const PluginsDiscoveryPage = ( props ) => {
 									} )
 								);
 							} }
-							disableThankYouPage={ true }
+							disabledThankYouPage={ true }
 							showFeatureList={ true }
 							siteSlug={ props.siteSlug }
 						/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* On the plugins page, after checkout, users are redirected to the "Manage Purchase" page. With the addition of the 1-click checkout modal, it is a better UX to keep the user on the same page so that they can continue what they were doing and go ahead with their plugin install.

https://github.com/Automattic/wp-calypso/assets/5436027/3f8d82af-4336-4e63-92c8-bfbf8bc5115e


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure that you have a saved credit card.
* Go to `/plugins/<site slug>` for a site on a Free/Starter/Explorer plan.
* Click on the "Upgrade to Creator" CTA.
* Confirm that you can see the 1-click checkout modal.
* Once the purchase is complete, confirm that
  * You are not redirected to any other page.
  * The Upgrade CTA is not visible.
  * You see a purchase success notice.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?