### PR TITLE
Remove hasTranslation for 4 upsells on the settings pages

### DIFF
--- a/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
+++ b/client/my-sites/site-settings/analytics/form-cloudflare-analytics.js
@@ -8,7 +8,6 @@ import {
 } from '@automattic/calypso-products';
 import { CompactCard, FormInputValidation as FormTextValidation } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
-import i18n from 'i18n-calypso';
 import { pick } from 'lodash';
 import { useState, useEffect } from 'react';
 import { connect } from 'react-redux';
@@ -44,7 +43,6 @@ export function CloudflareAnalyticsSettings( {
 	uniqueEventTracker,
 	showUpgradeNudge,
 	site,
-	locale,
 	premiumPlanName,
 } ) {
 	const [ isCodeValid, setIsCodeValid ] = useState( true );
@@ -120,15 +118,9 @@ export function CloudflareAnalyticsSettings( {
 
 	const renderForm = () => {
 		const placeholderText = isRequestingSettings ? translate( 'Loading' ) : '';
-		const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
-
-		const nudgeTitle =
-			isEnglishLocale || i18n.hasTranslation( 'Available with %(premiumPlanName)s plans or higher' )
-				? translate( 'Available with %(premiumPlanName)s plans or higher', {
-						args: { premiumPlanName },
-				  } )
-				: translate( 'Available with Premium plans or higher' );
-
+		const nudgeTitle = translate( 'Available with %(premiumPlanName)s plans or higher', {
+			args: { premiumPlanName },
+		} );
 		const plan = findFirstSimilarPlanKey( site.plan.product_slug, {
 			type: TYPE_PREMIUM,
 		} );

--- a/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
@@ -6,9 +6,8 @@ import {
 	PLAN_PREMIUM,
 } from '@automattic/calypso-products';
 import { CompactCard, FormInputValidation as FormTextValidation } from '@automattic/components';
-import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
-import i18n from 'i18n-calypso';
 import { useEffect } from 'react';
 import googleIllustration from 'calypso/assets/images/illustrations/google-analytics-logo.svg';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -41,17 +40,10 @@ const GoogleAnalyticsSimpleForm = ( {
 	translate,
 } ) => {
 	const analyticsSupportUrl = localizeUrl( 'https://wordpress.com/support/google-analytics/' );
-	const isEnglishLocale = useIsEnglishLocale();
-	const nudgeTitle =
-		isEnglishLocale ||
-		i18n.hasTranslation(
-			'Connect your site to Google Analytics in seconds with the %(premiumPlanName)s plan'
-		)
-			? translate(
-					'Connect your site to Google Analytics in seconds with the %(premiumPlanName)s plan',
-					{ args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() } }
-			  )
-			: translate( 'Connect your site to Google Analytics in seconds with the Premium plan' );
+	const nudgeTitle = translate(
+		'Connect your site to Google Analytics in seconds with the %(premiumPlanName)s plan',
+		{ args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() } }
+	);
 
 	useEffect( () => {
 		if ( fields?.wga?.code ) {

--- a/client/my-sites/site-settings/cloudflare.js
+++ b/client/my-sites/site-settings/cloudflare.js
@@ -7,8 +7,7 @@ import {
 	getPlan,
 } from '@automattic/calypso-products';
 import { CompactCard } from '@automattic/components';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useDispatch, useSelector } from 'react-redux';
 import cloudflareIllustration from 'calypso/assets/images/illustrations/cloudflare-logo-small.svg';
 import jetpackIllustration from 'calypso/assets/images/illustrations/jetpack-logo.svg';
@@ -29,8 +28,6 @@ const Cloudflare = () => {
 	const hasJetpackCDN = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_CDN )
 	);
-	const isEnglishLocale = useIsEnglishLocale();
-
 	const recordClick = () => {
 		dispatch(
 			composeAnalytics( recordTracksEvent( 'calypso_performance_settings_cloudflare_click' ) )
@@ -52,19 +49,12 @@ const Cloudflare = () => {
 									{ translate( 'Jetpack Site Accelerator' ) }
 								</p>
 								<p>
-									{ isEnglishLocale ||
-									i18n.hasTranslation(
-										'The CDN that comes built-in with WordPress.com %(businessPlanName)s plans.'
-									)
-										? translate(
-												'The CDN that comes built-in with WordPress.com %(businessPlanName)s plans.',
-												{
-													args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
-												}
-										  )
-										: translate(
-												'The CDN that comes built-in with WordPress.com Business plans.'
-										  ) }
+									{ translate(
+										'The CDN that comes built-in with WordPress.com %(businessPlanName)s plans.',
+										{
+											args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+										}
+									) }
 								</p>
 								<p>
 									<a
@@ -81,14 +71,9 @@ const Cloudflare = () => {
 					</CompactCard>
 					{ ! hasJetpackCDN && (
 						<UpsellNudge
-							title={
-								isEnglishLocale ||
-								i18n.hasTranslation( 'Available on %(businessPlanName)s plan or higher' )
-									? translate( 'Available on %(businessPlanName)s plan or higher', {
-											args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
-									  } )
-									: translate( 'Available on Business plan or higher' )
-							}
+							title={ translate( 'Available on %(businessPlanName)s plan or higher', {
+								args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+							} ) }
 							feature={ WPCOM_FEATURES_CDN }
 							event="calypso_settings_cloudflare_cdn_upsell_nudge_click"
 							showIcon={ true }
@@ -124,14 +109,9 @@ const Cloudflare = () => {
 					</CompactCard>
 					{ ! hasCloudflareCDN && (
 						<UpsellNudge
-							title={
-								isEnglishLocale ||
-								i18n.hasTranslation( 'Available with %(premiumPlanName)s plans or higher' )
-									? translate( 'Available with %(premiumPlanName)s plans or higher', {
-											args: { premiumPlanName: getPlan( PLAN_PREMIUM ).getTitle() },
-									  } )
-									: translate( 'Available with Premium plans or higher' )
-							}
+							title={ translate( 'Available with %(premiumPlanName)s plans or higher', {
+								args: { premiumPlanName: getPlan( PLAN_PREMIUM ).getTitle() },
+							} ) }
 							description={ translate(
 								'A CDN (Content Delivery Network) optimizes your content to provide users with the fastest experience.'
 							) }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -17,7 +17,6 @@ import { guessTimezone, localizeUrl } from '@automattic/i18n-utils';
 import languages from '@automattic/languages';
 import { ToggleControl } from '@wordpress/components';
 import classNames from 'classnames';
-import i18n from 'i18n-calypso';
 import { flowRight, get } from 'lodash';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -895,9 +894,7 @@ export class SiteSettingsFormGeneral extends Component {
 			isAtomicAndEditingToolkitDeactivated,
 			isWpcomStagingSite,
 			isUnlaunchedSite: propsisUnlaunchedSite,
-			locale,
 		} = this.props;
-		const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
 		const classes = classNames( 'site-settings__general-settings', {
 			'is-loading': isRequestingSettings,
 		} );
@@ -961,18 +958,11 @@ export class SiteSettingsFormGeneral extends Component {
 							<UpsellNudge
 								feature={ WPCOM_FEATURES_NO_WPCOM_BRANDING }
 								plan={ PLAN_BUSINESS }
-								title={
-									isEnglishLocale ||
-									i18n.hasTranslation(
-										'Remove the footer credit entirely with WordPress.com %(businessPlanName)s'
-									)
-										? translate(
-												'Remove the footer credit entirely with WordPress.com %(businessPlanName)s',
+								title={ translate(
+									'Remove the footer credit entirely with WordPress.com %(businessPlanName)s',
 
-												{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
-										  )
-										: translate( 'Remove the footer credit entirely with WordPress.com Business' )
-								}
+									{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
+								) }
 								description={ translate(
 									'Upgrade to remove the footer credit, use advanced SEO tools and more'
 								) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Remove hasTranslation from similar settings upsells

## Testing Instructions

* With a Free site
* Go to settings -> general - confirm the footer upsell is there, offering to remove the footer credit
* Go to settings -> performance and confirm the upsells look fine
* Go to tools -> marketing -> traffic and confirm the Cloudflare upsell

<img width="755" alt="Screenshot 2023-12-21 at 9 24 34" src="https://github.com/Automattic/wp-calypso/assets/82778/f736af3a-1625-44d1-87d4-d0eb1ca1376e">
<img width="767" alt="Screenshot 2023-12-21 at 9 22 12" src="https://github.com/Automattic/wp-calypso/assets/82778/5b9525bb-76a4-45c0-b6c9-07303947c6bb">
<img width="765" alt="Screenshot 2023-12-21 at 9 11 12" src="https://github.com/Automattic/wp-calypso/assets/82778/5405d759-3e41-4720-8770-32752e04630b">
<img width="1004" alt="Screenshot 2023-12-21 at 9 28 58" src="https://github.com/Automattic/wp-calypso/assets/82778/0cdd2edc-85a8-4d80-88ba-727ad794dd51">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
