### PR TITLE
Unhardcode Business from plugins

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -3,6 +3,8 @@ import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_INSTALL_PLUGINS,
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
+	getPlan,
+	PLAN_BUSINESS,
 } from '@automattic/calypso-products';
 import { Gridicon, Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -374,7 +376,9 @@ const PluginDetailsCTA = ( { plugin, isPlaceholder } ) => {
 							primary
 							onClick={ () => {} }
 						>
-							{ translate( 'Upgrade to Business' ) }
+							{ translate( 'Upgrade to %(planName)s', {
+								args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+							} ) }
 						</Button>
 					</div>
 				) }
@@ -528,7 +532,15 @@ function FreePrice( { shouldUpgrade } ) {
 		<>
 			{ translate( 'Free' ) }
 			{ ( ! isLoggedIn || ! selectedSite || shouldUpgrade ) && (
-				<span className="plugin-details-cta__notice">{ translate( 'on Business plan' ) }</span>
+				<span className="plugin-details-cta__notice">
+					{ translate(
+						// Translators: %(planName)s is the name of a plan (e.g. Creator or Business)
+						'on %(planName)s plan',
+						{
+							args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+						}
+					) }
+				</span>
 			) }
 		</>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fix two instances of Business missed on the /plugins page

## Testing Instructions

* On a Free site, go to plugins
* Search for mailpoet and click it
* On the right side, there should be an upgrade to Creator button instead of upgrade to Business
* Search for Bounce Handler Mailpoet 3
* On the right side, there should be Free on Creator plan

<img width="1020" alt="Screenshot 2023-12-21 at 9 42 47" src="https://github.com/Automattic/wp-calypso/assets/82778/1ddcc260-1ba4-4dbc-af83-335631a9793b">
<img width="434" alt="Screenshot 2023-12-21 at 9 39 36" src="https://github.com/Automattic/wp-calypso/assets/82778/e8139efe-1da1-49c2-a968-00633144a694">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
