### PR TITLE
Fix hardcoded Business in the help center homepage

### DIFF
--- a/client/me/help/main.jsx
+++ b/client/me/help/main.jsx
@@ -1,4 +1,9 @@
-import { isWpComBusinessPlan, isWpComEcommercePlan } from '@automattic/calypso-products';
+import {
+	isWpComBusinessPlan,
+	isWpComEcommercePlan,
+	getPlan,
+	PLAN_BUSINESS,
+} from '@automattic/calypso-products';
 import { CompactCard, Gridicon } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import debugModule from 'debug';
@@ -56,7 +61,12 @@ class Help extends PureComponent {
 				link: localizeUrl( 'https://wordpress.com/support/business-plan/' ),
 				title: this.props.translate( 'Uploading custom plugins and themes' ),
 				description: this.props.translate(
-					'Learn more about installing a custom theme or plugin using the Business plan.'
+					'Learn more about installing a custom theme or plugin using the %(businessPlanName)s plan.',
+					{
+						args: {
+							businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+						},
+					}
 				),
 				image: helpPlugins,
 			},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fix hardcoded Business in the help center homepage

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /help
* See Creator instead of Business

<img width="1015" alt="Screenshot 2023-12-21 at 10 07 14" src="https://github.com/Automattic/wp-calypso/assets/82778/fc6106cb-5788-4e3c-bb44-7de0f9c92a8b">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
