### PR TITLE
Subscriptions: Add gift label

### DIFF
--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
@@ -269,7 +269,11 @@ const SiteSubscriptionRow = ( {
 							</span>
 						) }
 
-						{ !! is_gift && <span className="gift-label">🎁</span> }
+						{ !! is_gift && (
+							<span className="gift-label">
+								{ translate( 'Gift', { context: 'Label for a gifted subscription' } ) }
+							</span>
+						) }
 
 						{ !! is_rss && <span className="rss-label">RSS</span> }
 					</Link>

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
@@ -88,6 +88,7 @@ const SiteSubscriptionRow = ( {
 	delivery_methods,
 	is_wpforteams_site,
 	is_paid_subscription,
+	is_gift,
 	isDeleted,
 	is_rss,
 	resubscribed,
@@ -267,6 +268,8 @@ const SiteSubscriptionRow = ( {
 								{ translate( 'Paid', { context: 'Label for a paid subscription plan' } ) }
 							</span>
 						) }
+
+						{ !! is_gift && <span className="gift-label">🎁</span> }
 
 						{ !! is_rss && <span className="rss-label">RSS</span> }
 					</Link>

--- a/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
+++ b/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
@@ -63,6 +63,10 @@
 			.rss-label {
 				@extend %rss-label;
 			}
+
+			.gift-label {
+				margin-left: 8px;
+			}
 		}
 
 		.title-url {

--- a/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
+++ b/client/landing/subscriptions/components/site-subscriptions-list/styles/site-subscriptions-list.scss
@@ -65,7 +65,7 @@
 			}
 
 			.gift-label {
-				margin-left: 8px;
+				@extend %gift-label;
 			}
 		}
 

--- a/client/landing/subscriptions/styles/row-title-label.scss
+++ b/client/landing/subscriptions/styles/row-title-label.scss
@@ -22,6 +22,12 @@
 	background: $studio-green-50;
 }
 
+%gift-label {
+	@extend %row-title-label;
+	background: $studio-yellow-40;
+	color: $studio-yellow-0;
+}
+
 %rss-label {
 	@extend %row-title-label;
 	color: $studio-gray-0;

--- a/packages/data-stores/src/reader/types/index.ts
+++ b/packages/data-stores/src/reader/types/index.ts
@@ -70,6 +70,7 @@ export type SiteSubscriptionsResponseItem = {
 	meta: SiteSubscriptionMeta;
 	is_wpforteams_site: boolean;
 	is_paid_subscription: boolean;
+	is_gift: boolean;
 	is_rss: boolean;
 	isDeleted: boolean;
 	resubscribed: boolean;


### PR DESCRIPTION
![CleanShot 2023-12-21 at 09 18 56@2x](https://github.com/Automattic/wp-calypso/assets/528287/638fa864-1ac1-4592-961e-7700d907caaf)


## Proposed Changes

* Adds a gift emoji label when a subscription is a gift

## Testing Instructions

- Depends on D132812-code
- Apply this PR
- Navigate to http://calypso.localhost:3000/read/subscriptions
- Gifted subscriptions should have a 🎁 emoji.

@Automattic/gold @millerf Should the paid / gift label be mutually exclusive? Should we hide the paid label when it's a gift?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?