### PR TITLE
Remove hasTranslation from SEO settings

### DIFF
--- a/client/my-sites/site-settings/seo-settings/form.jsx
+++ b/client/my-sites/site-settings/seo-settings/form.jsx
@@ -7,7 +7,7 @@ import {
 	getPlan,
 } from '@automattic/calypso-products';
 import { Card, Button, FormInputValidation } from '@automattic/components';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { get, isEqual, mapValues, pickBy } from 'lodash';
 import { Component, createRef } from 'react';
 import { connect } from 'react-redux';
@@ -231,11 +231,8 @@ export class SiteSettingsFormSEO extends Component {
 			translate,
 			isFetchingSettings,
 			isSavingSettings,
-			locale,
 		} = this.props;
 		const { slug = '', URL: siteUrl = '' } = selectedSite;
-		const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
-
 		const {
 			frontPageMetaDescription,
 			showPasteError = false,
@@ -259,18 +256,10 @@ export class SiteSettingsFormSEO extends Component {
 						href: `/checkout/${ slug }/${ PRODUCT_UPSELLS_BY_FEATURE[ FEATURE_ADVANCED_SEO ] }`,
 				  }
 				: {
-						title:
-							isEnglishLocale ||
-							i18n.hasTranslation(
-								'Boost your search engine ranking with the powerful SEO tools in the %(businessPlanName)s plan'
-							)
-								? translate(
-										'Boost your search engine ranking with the powerful SEO tools in the %(businessPlanName)s plan',
-										{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
-								  )
-								: translate(
-										'Boost your search engine ranking with the powerful SEO tools in the Business plan'
-								  ),
+						title: translate(
+							'Boost your search engine ranking with the powerful SEO tools in the %(businessPlanName)s plan',
+							{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
+						),
 						feature: FEATURE_ADVANCED_SEO,
 						plan:
 							selectedSite.plan &&


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Remove hasTranslation from SEO settings. This was formerly a tab under Settings, and is now a hanging upsell under Settings Traffic

## Testing Instructions

* With a Free site
* Go to Tools -> Marketing -> Traffic
* Confirm an SEO upsell with the Creator plan

<img width="1030" alt="Screenshot 2023-12-21 at 10 22 32" src="https://github.com/Automattic/wp-calypso/assets/82778/a96e5814-5327-4e68-95dd-93482c40ab9e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
