### PR TITLE
Reader: update stray follower to subscriber -term

### DIFF
--- a/client/reader/stream/site-feed-sidebar/index.jsx
+++ b/client/reader/stream/site-feed-sidebar/index.jsx
@@ -59,7 +59,7 @@ const FeedStreamSidebar = ( {
 								{ followerCount.toLocaleString( getLocaleSlug() ) }
 							</span>
 							<span className="reader-tag-sidebar-stats__title">
-								{ translate( 'Follower', 'Followers', { count: followerCount } ) }
+								{ translate( 'Subscriber', 'Subscribers', { count: followerCount } ) }
 							</span>
 						</div>
 					) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/76941

Follow up to https://github.com/Automattic/wp-calypso/pull/83714#pullrequestreview-1707125630, which I first thought to cover in https://github.com/Automattic/wp-calypso/pull/83710 but haven't gotten around to finish that yet. So let's just update the term meanwhile.

## Proposed Changes

* Update Follower -> Subscriber in reader. Should be last occurance!

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open an individual feed in the reader, see sidebar count. Example https://wordpress.com/read/feeds/134495982

Before
<img width="305" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/6297d18e-3f56-41e4-8757-5301de48f4ec">

After
<img width="281" alt="image" src="https://github.com/Automattic/wp-calypso/assets/87168/6f8dbb84-a076-4153-95ba-01047075d9e5">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?