### PR TITLE
Rremove hasTranslation from /themes

### DIFF
--- a/client/my-sites/theme/hooks/use-bundle-settings.tsx
+++ b/client/my-sites/theme/hooks/use-bundle-settings.tsx
@@ -1,7 +1,6 @@
 import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { ExternalLink } from '@wordpress/components';
-import i18n, { useTranslate, TranslateResult } from 'i18n-calypso';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { type FC, useMemo } from 'react';
 import { useSelector } from 'calypso/state';
 import { getThemeSoftwareSet } from 'calypso/state/themes/selectors';
@@ -31,7 +30,6 @@ const WooOnPlansIcon = () => (
 
 export function useBundleSettings( themeSoftware?: string ): BundleSettingsHookReturn {
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
 	const businessPlanName = getPlan( PLAN_BUSINESS )?.getTitle() || '';
 
 	const bundleSettings = useMemo( () => {
@@ -45,18 +43,10 @@ export function useBundleSettings( themeSoftware?: string ): BundleSettingsHookR
 					designPickerBadgeTooltip: translate(
 						'This theme comes bundled with WooCommerce, the best way to sell online.'
 					),
-					bannerUpsellDescription:
-						isEnglishLocale ||
-						i18n.hasTranslation(
-							'This theme comes bundled with the WooCommerce plugin. Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features.'
-						)
-							? ( translate(
-									'This theme comes bundled with the WooCommerce plugin. Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features.',
-									{ args: { businessPlanName } }
-							  ) as string )
-							: translate(
-									'This theme comes bundled with the WooCommerce plugin. Upgrade to a Business plan to select this theme and unlock all its features.'
-							  ),
+					bannerUpsellDescription: translate(
+						'This theme comes bundled with the WooCommerce plugin. Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features.',
+						{ args: { businessPlanName } }
+					) as string,
 					bundledPluginMessage: translate(
 						'This theme comes bundled with {{link}}WooCommerce{{/link}} plugin.',
 						{
@@ -70,7 +60,7 @@ export function useBundleSettings( themeSoftware?: string ): BundleSettingsHookR
 			default:
 				return null;
 		}
-	}, [ themeSoftware, translate, isEnglishLocale, businessPlanName ] );
+	}, [ themeSoftware, translate, businessPlanName ] );
 
 	return bundleSettings;
 }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -17,10 +17,10 @@ import {
 	getDesignPreviewUrl,
 	isDefaultGlobalStylesVariationSlug,
 } from '@automattic/design-picker';
-import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import classNames from 'classnames';
-import i18n, { localize, getLocaleSlug } from 'i18n-calypso';
+import { localize, getLocaleSlug } from 'i18n-calypso';
 import photon from 'photon';
 import PropTypes from 'prop-types';
 import { cloneElement, Component } from 'react';
@@ -129,37 +129,21 @@ const BannerUpsellDescription = ( {
 	isMarketplaceThemeSubscribed,
 } ) => {
 	const bundleSettings = useBundleSettingsByTheme( themeId );
-	const isEnglishLocale = useIsEnglishLocale();
-
 	if ( isBundledSoftwareSet && ! isExternallyManagedTheme ) {
 		if ( ! bundleSettings ) {
-			return isEnglishLocale ||
-				i18n.hasTranslation(
-					'This theme comes bundled with a plugin. Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features.'
-				)
-				? translate(
-						'This theme comes bundled with a plugin. Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features.',
-						{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
-				  )
-				: translate(
-						'This theme comes bundled with a plugin. Upgrade to a Business plan to select this theme and unlock all its features.'
-				  );
+			return translate(
+				'This theme comes bundled with a plugin. Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features.',
+				{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
+			);
 		}
 
 		return bundleSettings.bannerUpsellDescription;
 	} else if ( isExternallyManagedTheme && ! isMarketplaceThemeSubscribed ) {
 		if ( ! isSiteEligibleForManagedExternalThemes ) {
-			return isEnglishLocale ||
-				i18n.hasTranslation(
-					'Unlock this theme by upgrading to a %(businessPlanName)s plan and subscribing to this theme.'
-				)
-				? translate(
-						'Unlock this theme by upgrading to a %(businessPlanName)s plan and subscribing to this theme.',
-						{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
-				  )
-				: translate(
-						'Unlock this theme by upgrading to a Business plan and subscribing to this theme.'
-				  );
+			return translate(
+				'Unlock this theme by upgrading to a %(businessPlanName)s plan and subscribing to this theme.',
+				{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
+			);
 		}
 		return translate( 'Subscribe to this theme and unlock all its features.' );
 	}
@@ -190,55 +174,37 @@ const BannerUpsellTitle = ( {
 	isMarketplaceThemeSubscribed,
 } ) => {
 	const bundleSettings = useBundleSettingsByTheme( themeId );
-	const isEnglishLocale = useIsEnglishLocale();
-
 	if ( isBundledSoftwareSet && ! isExternallyManagedTheme ) {
 		if ( ! bundleSettings ) {
-			return isEnglishLocale ||
-				i18n.hasTranslation( 'Access this theme with a %(businessPlanName)s plan!' )
-				? translate( 'Access this theme with a %(businessPlanName)s plan!', {
-						args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
-				  } )
-				: translate( 'Access this theme with a Business plan!' );
+			return translate( 'Access this theme with a %(businessPlanName)s plan!', {
+				args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+			} );
 		}
 
 		const bundleName = bundleSettings.name;
 
 		/* Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special", %(businessPlanName)s is the short-form of the Business plan name.*/
-		return isEnglishLocale ||
-			i18n.hasTranslation( 'Access this %(bundleName)s theme with a %(businessPlanName)s plan!' )
-			? translate( 'Access this %(bundleName)s theme with a %(businessPlanName)s plan!', {
-					args: { bundleName, businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
-			  } )
-			: translate( 'Access this %(bundleName)s theme with a Business plan!', {
-					args: { bundleName },
-			  } );
+		return translate( 'Access this %(bundleName)s theme with a %(businessPlanName)s plan!', {
+			args: { bundleName, businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+		} );
 	} else if ( isExternallyManagedTheme && ! isMarketplaceThemeSubscribed ) {
 		if ( ! isSiteEligibleForManagedExternalThemes ) {
-			return isEnglishLocale ||
-				i18n.hasTranslation( 'Upgrade to a %(businessPlanName)s plan and subscribe to this theme!' )
-				? translate( 'Upgrade to a %(businessPlanName)s plan and subscribe to this theme!', {
-						args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
-				  } )
-				: translate( 'Upgrade to a Business plan and subscribe to this theme!' );
+			return translate( 'Upgrade to a %(businessPlanName)s plan and subscribe to this theme!', {
+				args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+			} );
 		}
 		return translate( 'Subscribe to this theme!' );
 	}
 
-	return isEnglishLocale ||
-		i18n.hasTranslation(
-			'Access this theme for FREE with a %(premiumPlanName)s or %(businessPlanName)s plan!'
-		)
-		? translate(
-				'Access this theme for FREE with a %(premiumPlanName)s or %(businessPlanName)s plan!',
-				{
-					args: {
-						premiumPlanName: getPlan( PLAN_PREMIUM ).getTitle(),
-						businessPlanName: getPlan( PLAN_BUSINESS ).getTitle(),
-					},
-				}
-		  )
-		: translate( 'Access this theme for FREE with a Premium or Business plan!' );
+	return translate(
+		'Access this theme for FREE with a %(premiumPlanName)s or %(businessPlanName)s plan!',
+		{
+			args: {
+				premiumPlanName: getPlan( PLAN_PREMIUM ).getTitle(),
+				businessPlanName: getPlan( PLAN_BUSINESS ).getTitle(),
+			},
+		}
+	);
 };
 
 class ThemeSheet extends Component {
@@ -1228,17 +1194,8 @@ class ThemeSheet extends Component {
 	};
 
 	getStyleVariationDescription = () => {
-		const {
-			defaultOption,
-			isActive,
-			isWpcomTheme,
-			themeId,
-			shouldLimitGlobalStyles,
-			translate,
-			locale,
-		} = this.props;
-		const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
-
+		const { defaultOption, isActive, isWpcomTheme, themeId, shouldLimitGlobalStyles, translate } =
+			this.props;
 		if ( isActive && defaultOption.getUrl ) {
 			return translate( 'Open the {{a}}site editor{{/a}} to change your site’s style.', {
 				components: {
@@ -1253,12 +1210,9 @@ class ThemeSheet extends Component {
 			return;
 		}
 
-		return isEnglishLocale ||
-			i18n.hasTranslation( 'Additional styles require the %(businessPlanName)s plan or higher.' )
-			? translate( 'Additional styles require the %(businessPlanName)s plan or higher.', {
-					args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
-			  } )
-			: translate( 'Additional styles require the Business plan or higher.' );
+		return translate( 'Additional styles require the %(businessPlanName)s plan or higher.', {
+			args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+		} );
 	};
 
 	handleAddReview = () => {
@@ -1288,8 +1242,6 @@ class ThemeSheet extends Component {
 			isThemeActivationSyncStarted,
 			isWpcomTheme,
 		} = this.props;
-
-		const isEnglishLocale = [ 'en', 'en-gb' ].includes( this.props.locale );
 
 		const analyticsPath = `/theme/${ themeId }${ section ? '/' + section : '' }${
 			siteId ? '/:site' : ''
@@ -1411,28 +1363,14 @@ class ThemeSheet extends Component {
 					plan={ PLAN_BUSINESS }
 					className="theme__page-upsell-banner"
 					onClick={ () => this.props.setProductToBeInstalled( themeId, siteSlug ) }
-					title={
-						isEnglishLocale ||
-						i18n.hasTranslation(
-							'Access this third-party theme with the %(businessPlanName)s plan!'
-						)
-							? translate( 'Access this third-party theme with the %(businessPlanName)s plan!', {
-									args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
-							  } )
-							: translate( 'Access this third-party theme with the Business plan!' )
-					}
+					title={ translate( 'Access this third-party theme with the %(businessPlanName)s plan!', {
+						args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+					} ) }
 					description={ preventWidows(
-						isEnglishLocale ||
-							i18n.hasTranslation(
-								'Instantly unlock thousands of different themes and install your own when you upgrade to the %(businessPlanName)s plan.'
-							)
-							? translate(
-									'Instantly unlock thousands of different themes and install your own when you upgrade to the %(businessPlanName)s plan.',
-									{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
-							  )
-							: translate(
-									'Instantly unlock thousands of different themes and install your own when you upgrade to the Business plan.'
-							  )
+						translate(
+							'Instantly unlock thousands of different themes and install your own when you upgrade to the %(businessPlanName)s plan.',
+							{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
+						)
 					) }
 					forceHref
 					feature={ FEATURE_UPLOAD_THEMES }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Remove several hardcoded Business words from hasTranslation calls on /themes

## Testing Instructions

* Go to /themes with a free plan
* Try to see all upsells - partner themes, premium themes, woo themes

<img width="769" alt="Screenshot 2023-12-21 at 10 41 05" src="https://github.com/Automattic/wp-calypso/assets/82778/f3f155af-6b55-47fa-b3f6-4e94fcbbd051">
<img width="650" alt="Screenshot 2023-12-21 at 11 06 46" src="https://github.com/Automattic/wp-calypso/assets/82778/9dbf68f1-fef9-4f45-9586-cb2063e24df6">
<img width="664" alt="Screenshot 2023-12-21 at 11 07 39" src="https://github.com/Automattic/wp-calypso/assets/82778/5c774d84-f377-49d8-8f63-5c3472218a88">
<img width="663" alt="Screenshot 2023-12-21 at 11 06 33" src="https://github.com/Automattic/wp-calypso/assets/82778/1dc7b2b0-a2c1-4a27-9e3e-4d94988fbba4">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
