### PR TITLE
Subscription management: make resubscribe a button

### DIFF
--- a/client/blocks/reader-site-subscription/details.tsx
+++ b/client/blocks/reader-site-subscription/details.tsx
@@ -109,6 +109,7 @@ const SiteSubscriptionDetails = ( {
 			<Button
 				onClick={ () => subscribe( { blog_id: blogId, url } ) }
 				disabled={ subscribing || unsubscribing }
+				variant="secondary"
 			>
 				{ translate( 'Resubscribe' ) }
 			</Button>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Update link to resubscribe to be more visible

## Testing Instructions

<img width="1063" alt="Screenshot 2023-12-21 at 12 34 11" src="https://github.com/Automattic/wp-calypso/assets/87168/63c16817-cbe1-4ed3-b5e3-84adce4b0ee3">

Before
<img width="842" alt="Screenshot 2023-12-21 at 12 34 24" src="https://github.com/Automattic/wp-calypso/assets/87168/e160983e-52b9-411f-bb23-a384a404fd99">


After
<img width="801" alt="Screenshot 2023-12-21 at 12 35 20" src="https://github.com/Automattic/wp-calypso/assets/87168/f70637d2-e13d-4a31-b058-d515a50e89b0">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?