### PR TITLE
Set autoRepositionOnInitialLoad for 7 day highlight component

### DIFF
--- a/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
+++ b/packages/components/src/highlight-cards/weekly-highlight-cards.tsx
@@ -96,6 +96,7 @@ const HighlightCardsSettings = function ( {
 				isVisible={ showTooltip }
 				position="bottom left"
 				context={ settingsActionRef.current }
+				autoRepositionOnInitialLoad={ true }
 			>
 				<div className="highlight-card-tooltip-content">
 					<p>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/4957

> [!WARNING]  
> Dependent on https://github.com/Automattic/wp-calypso/pull/85629, merge that one first!

## Proposed Changes

What happened?
When other components have delayed render, for example, rendering based on API results, causing the target object to "jump positions".

See how the 7-day Highlights target object component gets pushed down, leaving the popover in a wrong place

https://github.com/Automattic/wp-calypso/assets/6586048/83e4a5df-3ccc-4f25-8733-5a069dd5b6d4

After

https://github.com/Automattic/wp-calypso/assets/6586048/dd04e183-3182-461a-8736-e6bb31f3e472



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /stats with a site that haven't dismissed the "Do you love Jetpack Stats?" Notice
* autoRepositionOnInitialLoad should not be triggered for other Popovers, as this is the first PR using it

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?