### PR TITLE
Plans rename: remove hasTranslation call in ETK global styles

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
@@ -3,11 +3,10 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { usePlans } from '@automattic/data-stores/src/plans';
 import { PLAN_PREMIUM } from '@automattic/data-stores/src/plans/constants';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { Button, Modal } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
-import { __, sprintf, hasTranslation } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import React from 'react';
 import image from './image.svg';
 import { useCanvas } from './use-canvas';
@@ -17,7 +16,6 @@ import './modal.scss';
 const GlobalStylesModal = () => {
 	const isSiteEditor = useSelect( ( select ) => !! select( 'core/edit-site' ), [] );
 	const { viewCanvasPath } = useCanvas();
-	const isEnglishLocale = useIsEnglishLocale();
 	const plans = usePlans();
 
 	const isVisible = useSelect(
@@ -66,24 +64,14 @@ const GlobalStylesModal = () => {
 		return null;
 	}
 
-	const description =
-		isEnglishLocale ||
-		hasTranslation(
+	const description = sprintf(
+		/* translators: %s is the short-form Premium plan name */
+		__(
 			"Change all of your site's fonts, colors and more. Available on the %s plan.",
 			'full-site-editing'
-		)
-			? sprintf(
-					/* translators: %s is the short-form Premium plan name */
-					__(
-						"Change all of your site's fonts, colors and more. Available on the %s plan.",
-						'full-site-editing'
-					),
-					plans.data?.[ PLAN_PREMIUM ]?.productNameShort || ''
-			  )
-			: __(
-					"Change all of your site's fonts, colors and more. Available on the Premium plan.",
-					'full-site-editing'
-			  );
+		),
+		plans.data?.[ PLAN_PREMIUM ]?.productNameShort || ''
+	);
 
 	return (
 		<Modal

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
@@ -2,7 +2,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { usePlans } from '@automattic/data-stores/src/plans';
 import { PLAN_PREMIUM } from '@automattic/data-stores/src/plans/constants';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ExternalLink, Notice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -13,7 +12,7 @@ import {
 	useEffect,
 	useState,
 } from '@wordpress/element';
-import { __, sprintf, hasTranslation } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { useCanvas } from './use-canvas';
 import { useGlobalStylesConfig } from './use-global-styles-config';
 import { usePreview } from './use-preview';
@@ -28,31 +27,18 @@ const trackEvent = ( eventName, isSiteEditor = true ) =>
 	} );
 
 function GlobalStylesWarningNotice( { plans } ) {
-	const isEnglishLocale = useIsEnglishLocale();
-
 	useEffect( () => {
 		trackEvent( 'calypso_global_styles_gating_notice_view_canvas_show' );
 	}, [] );
 
-	const upgradeTranslation =
-		isEnglishLocale ||
-		hasTranslation(
+	const upgradeTranslation = sprintf(
+		/* translators: %s is the short-form Premium plan name */
+		__(
 			'Your site includes premium styles that are only visible to visitors after <a>upgrading to the %s plan or higher</a>.',
 			'full-site-editing'
-		)
-			? sprintf(
-					/* translators: %s is the short-form Premium plan name */
-					__(
-						'Your site includes premium styles that are only visible to visitors after <a>upgrading to the %s plan or higher</a>.',
-						'full-site-editing'
-					),
-					plans.data?.[ PLAN_PREMIUM ]?.productNameShort || ''
-			  )
-			: __(
-					'Your site includes premium styles that are only visible to visitors after <a>upgrading to the Premium plan or higher</a>.',
-					'full-site-editing'
-			  );
-
+		),
+		plans.data?.[ PLAN_PREMIUM ]?.productNameShort || ''
+	);
 	return (
 		<Notice status="warning" isDismissible={ false } className="wpcom-global-styles-notice">
 			{ createInterpolateElement( upgradeTranslation, {
@@ -127,7 +113,6 @@ function GlobalStylesEditNotice() {
 	);
 	const { previewPostWithoutCustomStyles, canPreviewPost } = usePreview();
 	const plans = usePlans();
-	const isEnglishLocale = useIsEnglishLocale();
 
 	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
 	const { editEntityRecord } = useDispatch( 'core' );
@@ -192,23 +177,14 @@ function GlobalStylesEditNotice() {
 		} );
 
 		createWarningNotice(
-			isEnglishLocale ||
-				hasTranslation(
+			sprintf(
+				/* translators: %s is the short-form Premium plan name */
+				__(
 					'Your site includes premium styles that are only visible to visitors after upgrading to the %s plan or higher.',
 					'full-site-editing'
-				)
-				? sprintf(
-						/* translators: %s is the short-form Premium plan name */
-						__(
-							'Your site includes premium styles that are only visible to visitors after upgrading to the %s plan or higher.',
-							'full-site-editing'
-						),
-						plans.data?.[ PLAN_PREMIUM ]?.productNameShort || ''
-				  )
-				: __(
-						'Your site includes premium styles that are only visible to visitors after upgrading to the Premium plan or higher.',
-						'full-site-editing'
-				  ),
+				),
+				plans.data?.[ PLAN_PREMIUM ]?.productNameShort || ''
+			),
 			{
 				id: NOTICE_ID,
 				actions: actions,
@@ -222,6 +198,7 @@ function GlobalStylesEditNotice() {
 		isPostEditor,
 		isSiteEditor,
 		openResetGlobalStylesSupport,
+		plans.data,
 		previewPost,
 		resetGlobalStyles,
 		upgradePlan,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/85092

## Proposed Changes

This is part of the plans-rename work. Follow up to https://github.com/Automattic/wp-calypso/pull/85092 to remove the `hasTranslation` calls used initially for the update strings.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow instructions in https://github.com/Automattic/wp-calypso/pull/85092 to confirm the translated strings render correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?