### PR TITLE
Plans rename: remove hasTranslation calls from multiple places - part 1

### DIFF
--- a/client/components/domains/domain-search-results/index.jsx
+++ b/client/components/domains/domain-search-results/index.jsx
@@ -1,7 +1,7 @@
 import { PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
 import { CompactCard, ScreenReaderText } from '@automattic/components';
 import classNames from 'classnames';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { get, times } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -72,14 +72,12 @@ class DomainSearchResults extends Component {
 			selectedSite,
 			translate,
 			isDomainOnly,
-			locale,
 		} = this.props;
 		const availabilityElementClasses = classNames( {
 			'domain-search-results__domain-is-available': availableDomain,
 			'domain-search-results__domain-not-available': ! availableDomain,
 		} );
 		const suggestions = this.props.suggestions || [];
-		const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
 		const {
 			MAPPABLE,
 			MAPPED,
@@ -128,22 +126,13 @@ class DomainSearchResults extends Component {
 						{ args: { domain }, components }
 					);
 				} else {
-					offer =
-						isEnglishLocale ||
-						i18n.hasTranslation(
-							'If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} with WordPress.com %(premiumPlanName)s.'
-						)
-							? translate(
-									'If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} with WordPress.com %(premiumPlanName)s.',
-									{
-										args: { domain, premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' },
-										components,
-									}
-							  )
-							: translate(
-									'If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} with WordPress.com Premium.',
-									{ args: { domain }, components }
-							  );
+					offer = translate(
+						'If you purchased %(domain)s elsewhere, you can {{a}}connect it{{/a}} with WordPress.com %(premiumPlanName)s.',
+						{
+							args: { domain, premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' },
+							components,
+						}
+					);
 				}
 			}
 

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-bundled-badge.js
@@ -1,8 +1,7 @@
 import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
 import { BundledBadge, PremiumBadge } from '@automattic/components';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { createInterpolateElement } from '@wordpress/element';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useBundleSettingsByTheme } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
 import { useSelector } from 'calypso/state';
 import { canUseTheme } from 'calypso/state/themes/selectors';
@@ -21,8 +20,6 @@ export default function ThemeTierBundledBadge() {
 		( state ) => siteId && canUseTheme( state, siteId, themeId )
 	);
 
-	const isEnglishLocale = useIsEnglishLocale();
-
 	if ( ! bundleSettings ) {
 		return;
 	}
@@ -35,24 +32,12 @@ export default function ThemeTierBundledBadge() {
 			<ThemeTierTooltipTracker />
 			<div data-testid="upsell-message">
 				{ createInterpolateElement(
-					isEnglishLocale ||
-						i18n.hasTranslation(
-							'This theme is included in the <Link>%(businessPlanName)s plan</Link>.'
-						)
-						? translate( 'This theme is included in the <Link>%(businessPlanName)s plan</Link>.', {
-								args: {
-									businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
-								},
-								textOnly: true,
-						  } )
-						: // Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".
-						  translate(
-								'This %(bundleName)s theme is included in the <Link>Business plan</Link>.',
-								{
-									args: { bundleName },
-									textOnly: true,
-								}
-						  ),
+					translate( 'This theme is included in the <Link>%(businessPlanName)s plan</Link>.', {
+						args: {
+							businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+						},
+						textOnly: true,
+					} ),
 					{
 						Link: <ThemeTierBadgeCheckoutLink plan="business" />,
 					}

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-community-badge.js
@@ -1,8 +1,7 @@
 import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
 import { PremiumBadge } from '@automattic/components';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { createInterpolateElement } from '@wordpress/element';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { canUseTheme } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -15,7 +14,6 @@ export default function ThemeTierCommunityBadge() {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const { themeId } = useThemeTierBadgeContext();
-	const isEnglishLocale = useIsEnglishLocale();
 	const isThemeIncluded = useSelector(
 		( state ) => siteId && canUseTheme( state, siteId, themeId )
 	);
@@ -25,17 +23,10 @@ export default function ThemeTierCommunityBadge() {
 			<ThemeTierTooltipTracker />
 			<div data-testid="upsell-message">
 				{ createInterpolateElement(
-					isEnglishLocale ||
-						i18n.hasTranslation(
-							'This community theme can only be installed if you have the <Link>%(businessPlanName)s plan</Link> or higher on your site.'
-						)
-						? translate(
-								'This community theme can only be installed if you have the <Link>%(businessPlanName)s plan</Link> or higher on your site.',
-								{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
-						  )
-						: translate(
-								'This community theme can only be installed if you have the <Link>Business plan</Link> or higher on your site.'
-						  ),
+					translate(
+						'This community theme can only be installed if you have the <Link>%(businessPlanName)s plan</Link> or higher on your site.',
+						{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
+					),
 					{
 						Link: <ThemeTierBadgeCheckoutLink plan="business" />,
 					}

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
@@ -1,8 +1,7 @@
 import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
 import { PremiumBadge } from '@automattic/components';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { createInterpolateElement } from '@wordpress/element';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import {
 	isMarketplaceThemeSubscribed,
@@ -19,7 +18,6 @@ export default function ThemeTierPartnerBadge() {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const { themeId } = useThemeTierBadgeContext();
-	const isEnglishLocale = useIsEnglishLocale();
 	const isPartnerThemePurchased = useSelector( ( state ) =>
 		siteId ? isMarketplaceThemeSubscribed( state, themeId, siteId ) : false
 	);
@@ -35,17 +33,10 @@ export default function ThemeTierPartnerBadge() {
 	const getTooltipMessage = () => {
 		if ( isPartnerThemePurchased && ! isThemeAllowedOnSite ) {
 			return createInterpolateElement(
-				isEnglishLocale ||
-					i18n.hasTranslation(
-						'You have a subscription for this theme, but it will only be usable if you have the <link>%(businessPlanName)s plan</link> on your site.'
-					)
-					? translate(
-							'You have a subscription for this theme, but it will only be usable if you have the <link>%(businessPlanName)s plan</link> on your site.',
-							{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
-					  )
-					: translate(
-							'You have a subscription for this theme, but it will only be usable if you have the <link>Business plan</link> on your site.'
-					  ),
+				translate(
+					'You have a subscription for this theme, but it will only be usable if you have the <link>%(businessPlanName)s plan</link> on your site.',
+					{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
+				),
 				{
 					Link: <ThemeTierBadgeCheckoutLink plan="business" />,
 				}
@@ -65,30 +56,17 @@ export default function ThemeTierPartnerBadge() {
 		}
 		if ( ! isPartnerThemePurchased && ! isThemeAllowedOnSite ) {
 			return createInterpolateElement(
-				isEnglishLocale ||
-					/* translators: annualPrice and monthlyPrice are prices for the theme, examples: US$50, US$7; */
-					i18n.hasTranslation(
-						'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>%(businessPlanName)s plan</Link> on your site.'
-					)
-					? translate(
-							'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>%(businessPlanName)s plan</Link> on your site.',
-							{
-								args: {
-									annualPrice: subscriptionPrices.year ?? '',
-									monthlyPrice: subscriptionPrices.month ?? '',
-									businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
-								},
-							}
-					  )
-					: translate(
-							'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>%(businessPlanName)s plan</Link> on your site.',
-							{
-								args: {
-									annualPrice: subscriptionPrices.year ?? '',
-									monthlyPrice: subscriptionPrices.month ?? '',
-								},
-							}
-					  ),
+				/* translators: annualPrice and monthlyPrice are prices for the theme, examples: US$50, US$7; */
+				translate(
+					'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>%(businessPlanName)s plan</Link> on your site.',
+					{
+						args: {
+							annualPrice: subscriptionPrices.year ?? '',
+							monthlyPrice: subscriptionPrices.month ?? '',
+							businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+						},
+					}
+				),
 				{
 					Link: <ThemeTierBadgeCheckoutLink plan="business" />,
 				}

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-style-variation-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-style-variation-badge.js
@@ -1,32 +1,23 @@
 import { PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
 import { PremiumBadge } from '@automattic/components';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import ThemeTierBadgeTracker from './theme-tier-badge-tracker';
 import ThemeTierTooltipTracker from './theme-tier-tooltip-tracker';
 
 export default function ThemeTierStyleVariationBadge() {
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
 
 	const tooltipContent = (
 		<>
 			<ThemeTierTooltipTracker />
 			<div data-testid="upsell-header" className="theme-tier-badge-tooltip__header" />
 			<div data-testid="upsell-message">
-				{ isEnglishLocale ||
-				i18n.hasTranslation(
-					'Unlock this style, and tons of other features, by upgrading to a %(premiumPlanName)s plan.'
-				)
-					? translate(
-							'Unlock this style, and tons of other features, by upgrading to a %(premiumPlanName)s plan.',
-							{
-								args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() },
-							}
-					  )
-					: translate(
-							'Unlock this style, and tons of other features, by upgrading to a Premium plan.'
-					  ) }
+				{ translate(
+					'Unlock this style, and tons of other features, by upgrading to a %(premiumPlanName)s plan.',
+					{
+						args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() },
+					}
+				) }
 			</div>
 		</>
 	);

--- a/client/components/theme-type-badge/tooltip.tsx
+++ b/client/components/theme-type-badge/tooltip.tsx
@@ -116,9 +116,10 @@ const ThemeTypeBadgeTooltip = ( {
 		if ( isPurchased ) {
 			message = translate( 'You have purchased this theme.' );
 		} else if ( isIncludedCurrentPlan ) {
-			isEnglishLocale || i18n.hasTranslation( 'This theme is included in your plan.' )
-				? translate( 'This theme is included in your plan.' )
-				: translate( 'This premium theme is included in your plan.' );
+			message =
+				isEnglishLocale || i18n.hasTranslation( 'This theme is included in your plan.' )
+					? translate( 'This theme is included in your plan.' )
+					: translate( 'This premium theme is included in your plan.' );
 		} else {
 			message = createInterpolateElement(
 				translate( 'This theme is included in the <Link>%(premiumPlanName)s plan</Link>.', {

--- a/client/components/theme-type-badge/tooltip.tsx
+++ b/client/components/theme-type-badge/tooltip.tsx
@@ -7,9 +7,10 @@ import {
 	MARKETPLACE_THEME,
 	PREMIUM_THEME,
 } from '@automattic/design-picker';
+import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { Button as LinkButton } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useBundleSettingsByTheme } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
 import { useSelector } from 'calypso/state';
@@ -96,6 +97,8 @@ const ThemeTypeBadgeTooltip = ( {
 		type === MARKETPLACE_THEME ? getMarketplaceThemeSubscriptionPrices( state, themeId ) : {}
 	);
 
+	const isEnglishLocale = useIsEnglishLocale();
+
 	useEffect( () => {
 		recordTracksEvent( 'calypso_upgrade_nudge_impression', {
 			cta_name: 'theme-upsell-popup',
@@ -113,7 +116,9 @@ const ThemeTypeBadgeTooltip = ( {
 		if ( isPurchased ) {
 			message = translate( 'You have purchased this theme.' );
 		} else if ( isIncludedCurrentPlan ) {
-			message = translate( 'This theme is included in your plan.' );
+			isEnglishLocale || i18n.hasTranslation( 'This theme is included in your plan.' )
+				? translate( 'This theme is included in your plan.' )
+				: translate( 'This premium theme is included in your plan.' );
 		} else {
 			message = createInterpolateElement(
 				translate( 'This theme is included in the <Link>%(premiumPlanName)s plan</Link>.', {

--- a/client/components/theme-type-badge/tooltip.tsx
+++ b/client/components/theme-type-badge/tooltip.tsx
@@ -7,10 +7,9 @@ import {
 	MARKETPLACE_THEME,
 	PREMIUM_THEME,
 } from '@automattic/design-picker';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { Button as LinkButton } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useBundleSettingsByTheme } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
 import { useSelector } from 'calypso/state';
@@ -97,8 +96,6 @@ const ThemeTypeBadgeTooltip = ( {
 		type === MARKETPLACE_THEME ? getMarketplaceThemeSubscriptionPrices( state, themeId ) : {}
 	);
 
-	const isEnglishLocale = useIsEnglishLocale();
-
 	useEffect( () => {
 		recordTracksEvent( 'calypso_upgrade_nudge_impression', {
 			cta_name: 'theme-upsell-popup',
@@ -108,36 +105,20 @@ const ThemeTypeBadgeTooltip = ( {
 
 	let message;
 	if ( isLockedStyleVariation ) {
-		message =
-			isEnglishLocale ||
-			i18n.hasTranslation(
-				'Unlock this style, and tons of other features, by upgrading to a %(premiumPlanName)s plan.'
-			)
-				? translate(
-						'Unlock this style, and tons of other features, by upgrading to a %(premiumPlanName)s plan.',
-						{ args: { premiumPlanName: plans?.data?.[ PLAN_PREMIUM ]?.productNameShort ?? '' } }
-				  )
-				: translate(
-						'Unlock this style, and tons of other features, by upgrading to a Premium plan.'
-				  );
+		message = translate(
+			'Unlock this style, and tons of other features, by upgrading to a %(premiumPlanName)s plan.',
+			{ args: { premiumPlanName: plans?.data?.[ PLAN_PREMIUM ]?.productNameShort ?? '' } }
+		);
 	} else if ( type === PREMIUM_THEME ) {
 		if ( isPurchased ) {
 			message = translate( 'You have purchased this theme.' );
 		} else if ( isIncludedCurrentPlan ) {
-			message =
-				isEnglishLocale || i18n.hasTranslation( 'This theme is included in your plan.' )
-					? translate( 'This theme is included in your plan.' )
-					: translate( 'This premium theme is included in your plan.' );
+			message = translate( 'This theme is included in your plan.' );
 		} else {
 			message = createInterpolateElement(
-				isEnglishLocale ||
-					i18n.hasTranslation(
-						'This theme is included in the <Link>%(premiumPlanName)s plan</Link>.'
-					)
-					? ( translate( 'This theme is included in the <Link>%(premiumPlanName)s plan</Link>.', {
-							args: { premiumPlanName: plans?.data?.[ PLAN_PREMIUM ]?.productNameShort ?? '' },
-					  } ) as string )
-					: translate( 'This premium theme is included in the <Link>Premium plan</Link>.' ),
+				translate( 'This theme is included in the <Link>%(premiumPlanName)s plan</Link>.', {
+					args: { premiumPlanName: plans?.data?.[ PLAN_PREMIUM ]?.productNameShort ?? '' },
+				} ) as string,
 				{
 					Link: (
 						<ThemeTypeBadgeTooltipUpgradeLink
@@ -153,21 +134,14 @@ const ThemeTypeBadgeTooltip = ( {
 		message = isIncludedCurrentPlan
 			? translate( 'This community theme is included in your plan.' )
 			: createInterpolateElement(
-					isEnglishLocale ||
-						i18n.hasTranslation(
-							'This community theme can only be installed if you have the <Link>%(businessPlanName)s plan</Link> or higher on your site.'
-						)
-						? ( translate(
-								'This community theme can only be installed if you have the <Link>%(businessPlanName)s plan</Link> or higher on your site.',
-								{
-									args: {
-										businessPlanName: plans?.data?.[ PLAN_BUSINESS ]?.productNameShort ?? '',
-									},
-								}
-						  ) as string )
-						: translate(
-								'This community theme can only be installed if you have the <Link>Business plan</Link> or higher on your site.'
-						  ),
+					translate(
+						'This community theme can only be installed if you have the <Link>%(businessPlanName)s plan</Link> or higher on your site.',
+						{
+							args: {
+								businessPlanName: plans?.data?.[ PLAN_BUSINESS ]?.productNameShort ?? '',
+							},
+						}
+					) as string,
 					{
 						Link: (
 							<ThemeTypeBadgeTooltipUpgradeLink
@@ -189,25 +163,13 @@ const ThemeTypeBadgeTooltip = ( {
 				} );
 			} else {
 				message = createInterpolateElement(
-					isEnglishLocale ||
-						i18n.hasTranslation(
-							'This theme is included in the <Link>%(businessPlanName)s plan</Link>.'
-						)
-						? translate( 'This theme is included in the <Link>%(businessPlanName)s plan</Link>.', {
-								args: {
-									bundleName,
-									businessPlanName: plans?.data?.[ PLAN_BUSINESS ]?.productNameShort ?? '',
-								},
-								textOnly: true,
-						  } )
-						: // Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special".:
-						  translate(
-								'This %(bundleName)s theme is included in the <Link>Business plan</Link>.',
-								{
-									args: { bundleName },
-									textOnly: true,
-								}
-						  ),
+					translate( 'This theme is included in the <Link>%(businessPlanName)s plan</Link>.', {
+						args: {
+							bundleName,
+							businessPlanName: plans?.data?.[ PLAN_BUSINESS ]?.productNameShort ?? '',
+						},
+						textOnly: true,
+					} ),
 					{
 						Link: (
 							<ThemeTypeBadgeTooltipUpgradeLink
@@ -222,31 +184,16 @@ const ThemeTypeBadgeTooltip = ( {
 		}
 	} else if ( type === MARKETPLACE_THEME ) {
 		if ( isPurchased && isIncludedCurrentPlan ) {
-			message =
-				isEnglishLocale ||
-				i18n.hasTranslation(
-					'You have a subscription for this theme, and it will be usable as long as you keep a %(businessPlanName)s plan or higher on your site.'
-				)
-					? translate(
-							'You have a subscription for this theme, and it will be usable as long as you keep a %(businessPlanName)s plan or higher on your site.',
-							{ args: { businessPlanName: plans?.data?.[ PLAN_BUSINESS ]?.productNameShort ?? '' } }
-					  )
-					: translate(
-							'You have a subscription for this theme, and it will be usable as long as you keep a Business plan or higher on your site.'
-					  );
+			message = translate(
+				'You have a subscription for this theme, and it will be usable as long as you keep a %(businessPlanName)s plan or higher on your site.',
+				{ args: { businessPlanName: plans?.data?.[ PLAN_BUSINESS ]?.productNameShort ?? '' } }
+			);
 		} else if ( isPurchased && ! isIncludedCurrentPlan ) {
 			message = createInterpolateElement(
-				isEnglishLocale ||
-					i18n.hasTranslation(
-						'You have a subscription for this theme, but it will only be usable if you have the <link>%(businessPlanName)s plan</link> on your site.'
-					)
-					? ( translate(
-							'You have a subscription for this theme, but it will only be usable if you have the <link>%(businessPlanName)s plan</link> on your site.',
-							{ args: { businessPlanName: plans?.data?.[ PLAN_BUSINESS ]?.productNameShort ?? '' } }
-					  ) as string )
-					: translate(
-							'You have a subscription for this theme, but it will only be usable if you have the <link>Business plan</link> on your site.'
-					  ),
+				translate(
+					'You have a subscription for this theme, but it will only be usable if you have the <link>%(businessPlanName)s plan</link> on your site.',
+					{ args: { businessPlanName: plans?.data?.[ PLAN_BUSINESS ]?.productNameShort ?? '' } }
+				) as string,
 				{
 					link: (
 						<ThemeTypeBadgeTooltipUpgradeLink
@@ -270,30 +217,17 @@ const ThemeTypeBadgeTooltip = ( {
 			);
 		} else if ( ! isPurchased && ! isIncludedCurrentPlan ) {
 			message = createInterpolateElement(
-				isEnglishLocale ||
-					i18n.hasTranslation(
-						'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>%(businessPlanName)s plan</Link> on your site.'
-					)
-					? /* translators: annualPrice and monthlyPrice are prices for the theme, examples: US$50, US$7; */
-					  ( translate(
-							'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>%(businessPlanName)s plan</Link> on your site.',
-							{
-								args: {
-									annualPrice: subscriptionPrices.year ?? '',
-									monthlyPrice: subscriptionPrices.month ?? '',
-									businessPlanName: plans?.data?.[ PLAN_BUSINESS ]?.productNameShort ?? '',
-								},
-							}
-					  ) as string )
-					: ( translate(
-							'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>Business plan</Link> on your site.',
-							{
-								args: {
-									annualPrice: subscriptionPrices.year ?? '',
-									monthlyPrice: subscriptionPrices.month ?? '',
-								},
-							}
-					  ) as string ),
+				/* translators: annualPrice and monthlyPrice are prices for the theme, examples: US$50, US$7; */
+				translate(
+					'This theme costs %(annualPrice)s per year or %(monthlyPrice)s per month, and can only be purchased if you have the <Link>%(businessPlanName)s plan</Link> on your site.',
+					{
+						args: {
+							annualPrice: subscriptionPrices.year ?? '',
+							monthlyPrice: subscriptionPrices.month ?? '',
+							businessPlanName: plans?.data?.[ PLAN_BUSINESS ]?.productNameShort ?? '',
+						},
+					}
+				) as string,
 				{
 					Link: (
 						<ThemeTypeBadgeTooltipUpgradeLink

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-screen.tsx
@@ -79,16 +79,10 @@ const useScreen = ( screenName: ScreenName, options: UseScreenOptions = {} ): Sc
 		upsell: {
 			name: 'upsell',
 			title: translate( 'Premium styles' ),
-			description: hasEnTranslation(
-				"You've chosen premium styles which are exclusive to the %(premiumPlanName)s plan or higher."
-			)
-				? translate(
-						"You've chosen premium styles which are exclusive to the %(premiumPlanName)s plan or higher.",
-						{ args: { premiumPlanName: plans?.data?.[ PLAN_PREMIUM ]?.productNameShort || '' } }
-				  )
-				: translate(
-						"You've chosen premium styles which are exclusive to the Premium plan or higher."
-				  ),
+			description: translate(
+				"You've chosen premium styles which are exclusive to the %(premiumPlanName)s plan or higher.",
+				{ args: { premiumPlanName: plans?.data?.[ PLAN_PREMIUM ]?.productNameShort || '' } }
+			),
 			continueLabel: translate( 'Continue' ),
 			backLabel: hasEnTranslation( 'premium styles' ) ? translate( 'premium styles' ) : undefined,
 			initialPath: NAVIGATOR_PATHS.UPSELL,

--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -5,8 +5,7 @@ import {
 	getPlan,
 	PLAN_PREMIUM,
 } from '@automattic/calypso-products';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import earnImage from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
@@ -31,8 +30,6 @@ const PremiumPlanDetails = ( {
 	const plan = find( sitePlans.data, isPremium );
 	const isPremiumPlan = isPremium( selectedSite.plan );
 	const googleAppsWasPurchased = purchases.some( isGSuiteOrExtraLicenseOrGoogleWorkspace );
-
-	const isEnglishLocale = useIsEnglishLocale();
 
 	return (
 		<div>
@@ -116,22 +113,11 @@ const PremiumPlanDetails = ( {
 					<img alt={ translate( 'Add Media to Your Posts Illustration' ) } src={ mediaPostImage } />
 				}
 				title={ translate( 'Video and audio posts' ) }
-				description={
-					isEnglishLocale ||
-					i18n.hasTranslation(
-						'Enrich your posts with video and audio, uploaded directly on your site. ' +
-							'No ads. The %(premiumPlanName)s plan offers 13GB of file storage.'
-					)
-						? translate(
-								'Enrich your posts with video and audio, uploaded directly on your site. ' +
-									'No ads. The %(premiumPlanName)s plan offers 13GB of file storage.',
-								{ args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() } }
-						  )
-						: translate(
-								'Enrich your posts with video and audio, uploaded directly on your site. ' +
-									'No ads. The Premium plan offers 13GB of file storage.'
-						  )
-				}
+				description={ translate(
+					'Enrich your posts with video and audio, uploaded directly on your site. ' +
+						'No ads. The %(premiumPlanName)s plan offers 13GB of file storage.',
+					{ args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() } }
+				) }
 				buttonText={ translate( 'Start a new post' ) }
 				href={ newPost( selectedSite ) }
 			/>

--- a/client/my-sites/media-library/list-plan-promo.js
+++ b/client/my-sites/media-library/list-plan-promo.js
@@ -1,7 +1,7 @@
 import { PLAN_BUSINESS, PLAN_ECOMMERCE, PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -42,25 +42,16 @@ class MediaLibraryListPlanPromo extends Component {
 	};
 
 	getSummary = () => {
-		const isEnglishLocale = [ 'en', 'en-gb' ].includes( this.props.locale );
-		const contactAdminText =
-			isEnglishLocale ||
-			i18n.hasTranslation(
-				'Contact your site administrator and ask them to upgrade this site to WordPress.com %(premiumPlanName)s, %(businessPlanName)s, or %(commercePlanName)s.'
-			)
-				? this.props.translate(
-						'Contact your site administrator and ask them to upgrade this site to WordPress.com %(premiumPlanName)s, %(businessPlanName)s, or %(commercePlanName)s.',
-						{
-							args: {
-								premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle(),
-								businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle(),
-								commercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle(),
-							},
-						}
-				  )
-				: this.props.translate(
-						'Contact your site administrator and ask them to upgrade this site to WordPress.com Premium, Business, or eCommerce.'
-				  );
+		const contactAdminText = this.props.translate(
+			'Contact your site administrator and ask them to upgrade this site to WordPress.com %(premiumPlanName)s, %(businessPlanName)s, or %(commercePlanName)s.',
+			{
+				args: {
+					premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle(),
+					businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle(),
+					commercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle(),
+				},
+			}
+		);
 		switch ( this.props.filter ) {
 			case 'videos':
 				return preventWidows(

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -1,6 +1,6 @@
 import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { CompactCard, ProductIcon, Gridicon } from '@automattic/components';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -40,12 +40,10 @@ class StepUpgrade extends Component {
 			targetSiteSlug,
 			themes,
 			translate,
-			locale,
 		} = this.props;
 		const sourceSiteDomain = get( sourceSite, 'domain' );
 		const targetSiteDomain = get( targetSite, 'domain' );
 		const backHref = `/migrate/from/${ sourceSiteSlug }/to/${ targetSiteSlug }`;
-		const isEnglishLocale = [ 'en', 'en-bg' ].includes( locale );
 
 		return (
 			<>
@@ -54,12 +52,9 @@ class StepUpgrade extends Component {
 
 				<CompactCard>
 					<CardHeading>
-						{ isEnglishLocale ||
-						i18n.hasTranslation( 'A %(businessPlanName)s Plan is required to import everything.' )
-							? translate( 'A %(businessPlanName)s Plan is required to import everything.', {
-									args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
-							  } )
-							: translate( 'A Business Plan is required to import everything.' ) }
+						{ translate( 'A %(businessPlanName)s Plan is required to import everything.', {
+							args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+						} ) }
 					</CardHeading>
 					<div>
 						{ translate(

--- a/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/business-upgrade-confirmation/index.tsx
@@ -1,8 +1,7 @@
 import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useLayoutEffect } from 'react';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
 import Main from 'calypso/components/main';
@@ -20,7 +19,6 @@ const BusinessUpgradeConfirmation = () => {
 	const selectedSite = useSelector( getSelectedSite );
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
 
 	useLayoutEffect( () => {
 		dispatch( hideMasterbar() );
@@ -49,38 +47,23 @@ const BusinessUpgradeConfirmation = () => {
 						<>
 							<div className="trial-upgrade-confirmation__header">
 								<h1 className="trial-upgrade-confirmation__title">
-									{ isEnglishLocale ||
-									i18n.hasTranslation( 'Welcome to the %(businessPlanName)s plan' )
-										? translate( 'Welcome to the %(businessPlanName)s plan', {
-												args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() || '' },
-										  } )
-										: translate( 'Welcome to the Business plan' ) }
+									{ translate( 'Welcome to the %(businessPlanName)s plan', {
+										args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() || '' },
+									} ) }
 								</h1>
 								<div className="trial-upgrade-confirmation__subtitle">
 									<span className="trial-upgrade-confirmation__subtitle-line">
-										{ isEnglishLocale ||
-										i18n.hasTranslation(
-											"Your purchase is complete, and you're now on the {{strong}}%(businessPlanName)s plan{{/strong}}. It's time to take your website to the next level—here are some options."
-										)
-											? translate(
-													"Your purchase is complete, and you're now on the {{strong}}%(businessPlanName)s plan{{/strong}}. It's time to take your website to the next level—here are some options.",
-													{
-														components: {
-															strong: <strong />,
-														},
-														args: {
-															businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() || '',
-														},
-													}
-											  )
-											: translate(
-													"Your purchase is complete, and you're now on the {{strong}}Business plan{{/strong}}. It's time to take your website to the next level—here are some options.",
-													{
-														components: {
-															strong: <strong />,
-														},
-													}
-											  ) }
+										{ translate(
+											"Your purchase is complete, and you're now on the {{strong}}%(businessPlanName)s plan{{/strong}}. It's time to take your website to the next level—here are some options.",
+											{
+												components: {
+													strong: <strong />,
+												},
+												args: {
+													businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() || '',
+												},
+											}
+										) }
 									</span>
 								</div>
 							</div>

--- a/client/my-sites/post-type-list/index.jsx
+++ b/client/my-sites/post-type-list/index.jsx
@@ -1,7 +1,7 @@
 import { PLAN_PREMIUM, WPCOM_FEATURES_NO_ADVERTS, getPlan } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import classnames from 'classnames';
-import i18n, { localize, getLocaleSlug } from 'i18n-calypso';
+import { localize, getLocaleSlug } from 'i18n-calypso';
 import { isEqual, range, throttle, difference, isEmpty, get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -243,7 +243,7 @@ class PostTypeList extends Component {
 	}
 
 	render() {
-		const { query, siteId, isRequestingPosts, translate, isVip, isJetpack, locale } = this.props;
+		const { query, siteId, isRequestingPosts, translate, isVip, isJetpack } = this.props;
 		const { maxRequestedPage, recentViewIds } = this.state;
 		const posts = this.props.posts || [];
 		const postStatuses = query.status.split( ',' );
@@ -251,8 +251,6 @@ class PostTypeList extends Component {
 		const classes = classnames( 'post-type-list', {
 			'is-empty': isLoadedAndEmpty,
 		} );
-
-		const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
 
 		const isSingleSite = !! siteId;
 
@@ -280,14 +278,9 @@ class PostTypeList extends Component {
 				{ posts.slice( 0, 10 ).map( this.renderPost ) }
 				{ showUpgradeNudge && (
 					<UpsellNudge
-						title={
-							isEnglishLocale ||
-							i18n.hasTranslation( 'No Ads with WordPress.com %(premiumPlanName)s' )
-								? translate( 'No Ads with WordPress.com %(premiumPlanName)s', {
-										args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() },
-								  } )
-								: translate( 'No Ads with WordPress.com Premium' )
-						}
+						title={ translate( 'No Ads with WordPress.com %(premiumPlanName)s', {
+							args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() },
+						} ) }
 						description={ translate( 'Prevent ads from showing on your site.' ) }
 						feature={ WPCOM_FEATURES_NO_ADVERTS }
 						event="published_posts_no_ads"

--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -1,7 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { PLAN_PREMIUM, getPlan, isFreePlan, isPersonalPlan } from '@automattic/calypso-products';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import i18n, { translate } from 'i18n-calypso';
+import { translate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import rocketImage from 'calypso/assets/images/customer-home/illustration--rocket.svg';
@@ -57,8 +56,6 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 	const [ dotPagerIndex, setDotPagerIndex ] = useState( 0 );
 
 	const shouldShowAdvertisingOption = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
-
-	const isEnglishLocale = useIsEnglishLocale();
 
 	// Private site banner.
 	const showPrivateSiteBanner =
@@ -191,21 +188,12 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 				dismissEvent={ EVENT_GOOGLE_ANALYTICS_BANNER_DISMISS }
 				image={ <img src={ GoogleAnalyticsLogo } alt="" width={ 45 } height={ 45 } /> }
 				headerText={ translate( 'Connect your site to Google Analytics' ) }
-				contentText={
-					isEnglishLocale ||
-					i18n.hasTranslation(
-						'Linking Google Analytics to your account is effortless with our %(premiumPlanName)s plan – no coding required. Gain valuable insights in seconds.'
-					)
-						? translate(
-								'Linking Google Analytics to your account is effortless with our %(premiumPlanName)s plan – no coding required. Gain valuable insights in seconds.',
-								{
-									args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() },
-								}
-						  )
-						: translate(
-								'Linking Google Analytics to your account is effortless with our Premium plan – no coding required. Gain valuable insights in seconds.'
-						  )
-				}
+				contentText={ translate(
+					'Linking Google Analytics to your account is effortless with our %(premiumPlanName)s plan – no coding required. Gain valuable insights in seconds.',
+					{
+						args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() },
+					}
+				) }
 				ctaText={ translate( 'Get Premium' ) }
 				href={ `/checkout/premium/${ slug || '' }` }
 				key="google-analytics"

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -1,5 +1,5 @@
 import { FEATURE_GOOGLE_ANALYTICS, PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { merge } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -52,8 +52,7 @@ class StatsSummary extends Component {
 	}
 
 	render() {
-		const { translate, statsQueryOptions, siteId, locale } = this.props;
-		const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
+		const { translate, statsQueryOptions, siteId } = this.props;
 		const summaryViews = [];
 		let title;
 		let summaryView;
@@ -146,17 +145,10 @@ class StatsSummary extends Component {
 						<div className="stats-module__footer-actions--summary-tall">
 							<UpsellNudge
 								title={ translate( 'Add Google Analytics' ) }
-								description={
-									isEnglishLocale ||
-									i18n.hasTranslation(
-										'Upgrade to a %(premiumPlanName)s Plan for Google Analytics integration.'
-									)
-										? translate(
-												'Upgrade to a %(premiumPlanName)s Plan for Google Analytics integration.',
-												{ args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() } }
-										  )
-										: translate( 'Upgrade to a Premium Plan for Google Analytics integration.' )
-								}
+								description={ translate(
+									'Upgrade to a %(premiumPlanName)s Plan for Google Analytics integration.',
+									{ args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() } }
+								) }
 								event="googleAnalytics-stats-countries"
 								feature={ FEATURE_GOOGLE_ANALYTICS }
 								plan={ PLAN_PREMIUM }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/85348

## Proposed Changes

This is part of the plans-rename work. Follow up to https://github.com/Automattic/wp-calypso/pull/85348 to remove the `hasTranslation` calls used initially for the update strings.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow instructions in https://github.com/Automattic/wp-calypso/pull/85348 to confirm the translated strings render correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?