### PR TITLE
Plans rename: remove hasTranslation calls from multiple places - part 2

### DIFF
--- a/client/my-sites/plugins/mailpoet-upgrade/index.tsx
+++ b/client/my-sites/plugins/mailpoet-upgrade/index.tsx
@@ -1,7 +1,6 @@
 import { PLAN_ECOMMERCE, getPlan } from '@automattic/calypso-products';
 import { Card, Button } from '@automattic/components';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -16,7 +15,6 @@ export const MailPoetUpgradePage = ( { siteId }: { siteId: number } ) => {
 	const dispatch = useDispatch();
 	const [ isBusy, setIsBusy ] = useState( false );
 	const [ isCompleted, setIsCompleted ] = useState( false );
-	const isEnglishLocale = useIsEnglishLocale();
 
 	const getItNowClickHandler = async () => {
 		setIsBusy( true );
@@ -52,17 +50,10 @@ export const MailPoetUpgradePage = ( { siteId }: { siteId: number } ) => {
 			/>
 			<Card>
 				<p>
-					{ isEnglishLocale ||
-					i18n.hasTranslation(
-						'Your %(commercePlanName)s plan provides a complimentary MailPoet Business subscription, allowing you to send visually appealing emails that consistently land in inboxes and cultivate a loyal subscriber base.'
-					)
-						? translate(
-								'Your %(commercePlanName)s plan provides a complimentary MailPoet Business subscription, allowing you to send visually appealing emails that consistently land in inboxes and cultivate a loyal subscriber base.',
-								{ args: { commercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() || '' } }
-						  )
-						: translate(
-								'Your Commerce plan provides a complimentary MailPoet Business subscription, allowing you to send visually appealing emails that consistently land in inboxes and cultivate a loyal subscriber base.'
-						  ) }
+					{ translate(
+						'Your %(commercePlanName)s plan provides a complimentary MailPoet Business subscription, allowing you to send visually appealing emails that consistently land in inboxes and cultivate a loyal subscriber base.',
+						{ args: { commercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() || '' } }
+					) }
 				</p>
 				<p>
 					{ translate( 'Know more about {{a/}}', {

--- a/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics-simple.jsx
@@ -44,7 +44,6 @@ const GoogleAnalyticsSimpleForm = ( {
 		'Connect your site to Google Analytics in seconds with the %(premiumPlanName)s plan',
 		{ args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() } }
 	);
-
 	useEffect( () => {
 		if ( fields?.wga?.code ) {
 			setDisplayForm( true );

--- a/client/my-sites/theme/hooks/use-bundle-settings.tsx
+++ b/client/my-sites/theme/hooks/use-bundle-settings.tsx
@@ -1,7 +1,6 @@
 import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { ExternalLink } from '@wordpress/components';
-import i18n, { useTranslate, TranslateResult } from 'i18n-calypso';
+import { useTranslate, TranslateResult } from 'i18n-calypso';
 import { type FC, useMemo } from 'react';
 import { useSelector } from 'calypso/state';
 import { getThemeSoftwareSet } from 'calypso/state/themes/selectors';
@@ -31,7 +30,6 @@ const WooOnPlansIcon = () => (
 
 export function useBundleSettings( themeSoftware?: string ): BundleSettingsHookReturn {
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
 	const businessPlanName = getPlan( PLAN_BUSINESS )?.getTitle() || '';
 
 	const bundleSettings = useMemo( () => {
@@ -45,18 +43,10 @@ export function useBundleSettings( themeSoftware?: string ): BundleSettingsHookR
 					designPickerBadgeTooltip: translate(
 						'This theme comes bundled with WooCommerce, the best way to sell online.'
 					),
-					bannerUpsellDescription:
-						isEnglishLocale ||
-						i18n.hasTranslation(
-							'This theme comes bundled with the WooCommerce plugin. Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features.'
-						)
-							? ( translate(
-									'This theme comes bundled with the WooCommerce plugin. Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features.',
-									{ args: { businessPlanName } }
-							  ) as string )
-							: translate(
-									'This theme comes bundled with the WooCommerce plugin. Upgrade to a Business plan to select this theme and unlock all its features.'
-							  ),
+					bannerUpsellDescription: translate(
+						'This theme comes bundled with the WooCommerce plugin. Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features.',
+						{ args: { businessPlanName } }
+					) as string,
 					bundledPluginMessage: translate(
 						'This theme comes bundled with {{link}}WooCommerce{{/link}} plugin.',
 						{
@@ -70,7 +60,7 @@ export function useBundleSettings( themeSoftware?: string ): BundleSettingsHookR
 			default:
 				return null;
 		}
-	}, [ themeSoftware, translate, isEnglishLocale, businessPlanName ] );
+	}, [ themeSoftware, translate, businessPlanName ] );
 
 	return bundleSettings;
 }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -18,10 +18,10 @@ import {
 	getDesignPreviewUrl,
 	isDefaultGlobalStylesVariationSlug,
 } from '@automattic/design-picker';
-import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import classNames from 'classnames';
-import i18n, { localize, getLocaleSlug } from 'i18n-calypso';
+import { localize, getLocaleSlug } from 'i18n-calypso';
 import photon from 'photon';
 import PropTypes from 'prop-types';
 import { cloneElement, Component } from 'react';
@@ -132,37 +132,22 @@ const BannerUpsellDescription = ( {
 	isMarketplaceThemeSubscribed,
 } ) => {
 	const bundleSettings = useBundleSettingsByTheme( themeId );
-	const isEnglishLocale = useIsEnglishLocale();
 
 	if ( isBundledSoftwareSet && ! isExternallyManagedTheme ) {
 		if ( ! bundleSettings ) {
-			return isEnglishLocale ||
-				i18n.hasTranslation(
-					'This theme comes bundled with a plugin. Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features.'
-				)
-				? translate(
-						'This theme comes bundled with a plugin. Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features.',
-						{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
-				  )
-				: translate(
-						'This theme comes bundled with a plugin. Upgrade to a Business plan to select this theme and unlock all its features.'
-				  );
+			return translate(
+				'This theme comes bundled with a plugin. Upgrade to a %(businessPlanName)s plan to select this theme and unlock all its features.',
+				{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
+			);
 		}
 
 		return bundleSettings.bannerUpsellDescription;
 	} else if ( isExternallyManagedTheme && ! isMarketplaceThemeSubscribed ) {
 		if ( ! isSiteEligibleForManagedExternalThemes ) {
-			return isEnglishLocale ||
-				i18n.hasTranslation(
-					'Unlock this theme by upgrading to a %(businessPlanName)s plan and subscribing to this theme.'
-				)
-				? translate(
-						'Unlock this theme by upgrading to a %(businessPlanName)s plan and subscribing to this theme.',
-						{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
-				  )
-				: translate(
-						'Unlock this theme by upgrading to a Business plan and subscribing to this theme.'
-				  );
+			return translate(
+				'Unlock this theme by upgrading to a %(businessPlanName)s plan and subscribing to this theme.',
+				{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
+			);
 		}
 		return translate( 'Subscribe to this theme and unlock all its features.' );
 	}
@@ -197,23 +182,17 @@ const BannerUpsellTitle = ( {
 	themeTier,
 } ) => {
 	const bundleSettings = useBundleSettingsByTheme( themeId );
-	const isEnglishLocale = useIsEnglishLocale();
 
 	const premiumPlanTitle = () =>
-		isEnglishLocale ||
-		i18n.hasTranslation(
-			'Access this theme for FREE with a %(premiumPlanName)s or %(businessPlanName)s plan!'
-		)
-			? translate(
-					'Access this theme for FREE with a %(premiumPlanName)s or %(businessPlanName)s plan!',
-					{
-						args: {
-							premiumPlanName: getPlan( PLAN_PREMIUM ).getTitle(),
-							businessPlanName: getPlan( PLAN_BUSINESS ).getTitle(),
-						},
-					}
-			  )
-			: translate( 'Access this theme for FREE with a Premium or Business plan!' );
+		translate(
+			'Access this theme for FREE with a %(premiumPlanName)s or %(businessPlanName)s plan!',
+			{
+				args: {
+					premiumPlanName: getPlan( PLAN_PREMIUM ).getTitle(),
+					businessPlanName: getPlan( PLAN_BUSINESS ).getTitle(),
+				},
+			}
+		);
 
 	if ( ! isThemeAllowedOnSite ) {
 		switch ( THEME_TIERS[ themeTier.slug ].minimumUpsellPlan ) {
@@ -235,33 +214,22 @@ const BannerUpsellTitle = ( {
 
 	if ( isBundledSoftwareSet && ! isExternallyManagedTheme ) {
 		if ( ! bundleSettings ) {
-			return isEnglishLocale ||
-				i18n.hasTranslation( 'Access this theme with a %(businessPlanName)s plan!' )
-				? translate( 'Access this theme with a %(businessPlanName)s plan!', {
-						args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
-				  } )
-				: translate( 'Access this theme with a Business plan!' );
+			return translate( 'Access this theme with a %(businessPlanName)s plan!', {
+				args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+			} );
 		}
 
 		const bundleName = bundleSettings.name;
 
 		/* Translators: %(bundleName)s is the name of the bundle, sometimes represented as a product name. Examples: "WooCommerce" or "Special", %(businessPlanName)s is the short-form of the Business plan name.*/
-		return isEnglishLocale ||
-			i18n.hasTranslation( 'Access this %(bundleName)s theme with a %(businessPlanName)s plan!' )
-			? translate( 'Access this %(bundleName)s theme with a %(businessPlanName)s plan!', {
-					args: { bundleName, businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
-			  } )
-			: translate( 'Access this %(bundleName)s theme with a Business plan!', {
-					args: { bundleName },
-			  } );
+		return translate( 'Access this %(bundleName)s theme with a %(businessPlanName)s plan!', {
+			args: { bundleName, businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+		} );
 	} else if ( isExternallyManagedTheme && ! isMarketplaceThemeSubscribed ) {
 		if ( ! isSiteEligibleForManagedExternalThemes ) {
-			return isEnglishLocale ||
-				i18n.hasTranslation( 'Upgrade to a %(businessPlanName)s plan and subscribe to this theme!' )
-				? translate( 'Upgrade to a %(businessPlanName)s plan and subscribe to this theme!', {
-						args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
-				  } )
-				: translate( 'Upgrade to a Business plan and subscribe to this theme!' );
+			return translate( 'Upgrade to a %(businessPlanName)s plan and subscribe to this theme!', {
+				args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+			} );
 		}
 		return translate( 'Subscribe to this theme!' );
 	}
@@ -1263,17 +1231,8 @@ class ThemeSheet extends Component {
 	};
 
 	getStyleVariationDescription = () => {
-		const {
-			defaultOption,
-			isActive,
-			isWpcomTheme,
-			themeId,
-			shouldLimitGlobalStyles,
-			translate,
-			locale,
-		} = this.props;
-		const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
-
+		const { defaultOption, isActive, isWpcomTheme, themeId, shouldLimitGlobalStyles, translate } =
+			this.props;
 		if ( isActive && defaultOption.getUrl ) {
 			return translate( 'Open the {{a}}site editor{{/a}} to change your site’s style.', {
 				components: {
@@ -1288,12 +1247,9 @@ class ThemeSheet extends Component {
 			return;
 		}
 
-		return isEnglishLocale ||
-			i18n.hasTranslation( 'Additional styles require the %(businessPlanName)s plan or higher.' )
-			? translate( 'Additional styles require the %(businessPlanName)s plan or higher.', {
-					args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
-			  } )
-			: translate( 'Additional styles require the Business plan or higher.' );
+		return translate( 'Additional styles require the %(businessPlanName)s plan or higher.', {
+			args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+		} );
 	};
 
 	handleAddReview = () => {
@@ -1325,9 +1281,6 @@ class ThemeSheet extends Component {
 			isThemeAllowedOnSite,
 			themeTier,
 		} = this.props;
-
-		const isEnglishLocale = [ 'en', 'en-gb' ].includes( this.props.locale );
-
 		const analyticsPath = `/theme/${ themeId }${ section ? '/' + section : '' }${
 			siteId ? '/:site' : ''
 		}`;
@@ -1460,28 +1413,14 @@ class ThemeSheet extends Component {
 					plan={ PLAN_BUSINESS }
 					className="theme__page-upsell-banner"
 					onClick={ () => this.props.setProductToBeInstalled( themeId, siteSlug ) }
-					title={
-						isEnglishLocale ||
-						i18n.hasTranslation(
-							'Access this third-party theme with the %(businessPlanName)s plan!'
-						)
-							? translate( 'Access this third-party theme with the %(businessPlanName)s plan!', {
-									args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
-							  } )
-							: translate( 'Access this third-party theme with the Business plan!' )
-					}
+					title={ translate( 'Access this third-party theme with the %(businessPlanName)s plan!', {
+						args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
+					} ) }
 					description={ preventWidows(
-						isEnglishLocale ||
-							i18n.hasTranslation(
-								'Instantly unlock thousands of different themes and install your own when you upgrade to the %(businessPlanName)s plan.'
-							)
-							? translate(
-									'Instantly unlock thousands of different themes and install your own when you upgrade to the %(businessPlanName)s plan.',
-									{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
-							  )
-							: translate(
-									'Instantly unlock thousands of different themes and install your own when you upgrade to the Business plan.'
-							  )
+						translate(
+							'Instantly unlock thousands of different themes and install your own when you upgrade to the %(businessPlanName)s plan.',
+							{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
+						)
 					) }
 					forceHref
 					feature={ FEATURE_UPLOAD_THEMES }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/85139

## Proposed Changes

This is part of the plans-rename work. Follow up to https://github.com/Automattic/wp-calypso/pull/85139 to remove the `hasTranslation` calls used initially for the update strings.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow instructions in https://github.com/Automattic/wp-calypso/pull/85139 to confirm the translated strings render correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?