### PR TITLE
Upsell Nudge: integrate 1-click checkout modal

### DIFF
--- a/client/blocks/jitm/test/index.jsx
+++ b/client/blocks/jitm/test/index.jsx
@@ -51,7 +51,7 @@ describe( 'DefaultTemplate JITM', () => {
 		};
 		render(
 			<Provider store={ store }>
-				<QueryClientProvider queryClient={ queryClient }>
+				<QueryClientProvider client={ queryClient }>
 					<DefaultTemplate { ...mockProps } />
 				</QueryClientProvider>
 			</Provider>

--- a/client/blocks/jitm/test/index.jsx
+++ b/client/blocks/jitm/test/index.jsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { Provider } from 'react-redux';
@@ -35,7 +36,7 @@ function createState( siteId = 1 ) {
 
 describe( 'DefaultTemplate JITM', () => {
 	const mockStore = configureStore();
-
+	const queryClient = new QueryClient();
 	const store = mockStore( createState() );
 	test( 'onDismiss should be called when the dismiss button is clicked', () => {
 		const mockOnDismiss = jest.fn();
@@ -50,7 +51,9 @@ describe( 'DefaultTemplate JITM', () => {
 		};
 		render(
 			<Provider store={ store }>
-				<DefaultTemplate { ...mockProps } />
+				<QueryClientProvider queryClient={ queryClient }>
+					<DefaultTemplate { ...mockProps } />
+				</QueryClientProvider>
 			</Provider>
 		);
 

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -34,6 +34,22 @@ import './style.scss';
 
 const debug = debugFactory( 'calypso:upsell-nudge' );
 
+function shouldShowOneClickCheckout( {
+	isOneClickCheckoutEnabled,
+	isEligibleForOneClickCheckout,
+	plan,
+	siteSlug,
+	canUserUpgrade,
+} ) {
+	return (
+		isOneClickCheckoutEnabled &&
+		isEligibleForOneClickCheckout?.result === true &&
+		plan &&
+		siteSlug &&
+		canUserUpgrade
+	);
+}
+
 /**
  * @param {any} props Props declared as `any` to prevent errors in TSX files that use this component.
  */
@@ -141,11 +157,13 @@ export const UpsellNudge = ( {
 
 	const handleClick = ( e ) => {
 		if (
-			isOneClickCheckoutEnabled &&
-			isEligibleForOneClickCheckout?.result === true &&
-			plan &&
-			siteSlug &&
-			canUserUpgrade
+			shouldShowOneClickCheckout( {
+				isOneClickCheckoutEnabled,
+				isEligibleForOneClickCheckout,
+				plan,
+				siteSlug,
+				canUserUpgrade,
+			} )
 		) {
 			e.preventDefault();
 			setShowPurchaseModal( true );
@@ -214,7 +232,7 @@ UpsellNudge.defaultProps = {
 	compactButton: true,
 };
 
-export const ConnectedUpsellNudge = connect( ( state, ownProps ) => {
+const ConnectedUpsellNudge = connect( ( state, ownProps ) => {
 	const siteId = getSelectedSiteId( state );
 
 	return {
@@ -234,7 +252,7 @@ export const ConnectedUpsellNudge = connect( ( state, ownProps ) => {
 } )( UpsellNudge );
 
 export default function Wrapper( props ) {
-	if ( props.isOneClickCheckoutEnabled ) {
+	if ( shouldShowOneClickCheckout( props ) ) {
 		return (
 			<AsyncLoad
 				require="../../my-sites/checkout/purchase-modal/is-eligible-for-one-click-checkout-wrapper"

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -10,20 +10,14 @@ import {
 	WPCOM_FEATURES_NO_ADVERTS,
 	isFreePlanProduct,
 } from '@automattic/calypso-products';
-import { StripeHookProvider } from '@automattic/calypso-stripe';
-import { createRequestCartProduct } from '@automattic/shopping-cart';
 import classnames from 'classnames';
 import debugFactory from 'debug';
-import { useTranslate } from 'i18n-calypso';
-import { useMemo, useState } from 'react';
-import { connect, useDispatch } from 'react-redux';
+import { useState } from 'react';
+import { connect } from 'react-redux';
+import AsyncLoad from 'calypso/components/async-load';
 import Banner from 'calypso/components/banner';
-import { getStripeConfiguration } from 'calypso/lib/store-transactions';
 import { addQueryArgs } from 'calypso/lib/url';
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
-import PurchaseModal from 'calypso/my-sites/checkout/purchase-modal';
 import { withIsEligibleForOneClickCheckout } from 'calypso/my-sites/checkout/purchase-modal/with-is-eligible-for-one-click-checkout';
-import { successNotice } from 'calypso/state/notices/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
@@ -98,12 +92,7 @@ export const UpsellNudge = ( {
 	isOneClickCheckoutEnabled = false,
 } ) => {
 	const [ showPurchaseModal, setShowPurchaseModal ] = useState( false );
-	const translate = useTranslate();
-	const dispatch = useDispatch();
-	const product = useMemo(
-		() => ( plan ? createRequestCartProduct( { product_slug: plan } ) : null ),
-		[ plan ]
-	);
+
 	const shouldNotDisplay =
 		isVip ||
 		! canManageSite ||
@@ -168,30 +157,12 @@ export const UpsellNudge = ( {
 	return (
 		<>
 			{ showPurchaseModal && (
-				<CalypsoShoppingCartProvider>
-					<StripeHookProvider
-						fetchStripeConfiguration={ getStripeConfiguration }
-						locale={ translate.localeSlug }
-					>
-						<PurchaseModal
-							productToAdd={ product }
-							onClose={ () => {
-								setShowPurchaseModal( false );
-							} }
-							onPurchaseSuccess={ () => {
-								setShowPurchaseModal( false );
-								dispatch(
-									successNotice( translate( 'Your purchase has been completed!' ), {
-										id: 'plugins-purchase-modal-success',
-									} )
-								);
-							} }
-							disableThankYouPage={ true }
-							showFeatureList={ true }
-							siteSlug={ siteSlug }
-						/>
-					</StripeHookProvider>
-				</CalypsoShoppingCartProvider>
+				<AsyncLoad
+					require="./purchase-modal-wrapper"
+					plan={ plan }
+					siteSlug={ siteSlug }
+					setShowPurchaseModal={ setShowPurchaseModal }
+				/>
 			) }
 			<Banner
 				callToAction={ callToAction }

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -17,7 +17,6 @@ import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import Banner from 'calypso/components/banner';
 import { addQueryArgs } from 'calypso/lib/url';
-import { withIsEligibleForOneClickCheckout } from 'calypso/my-sites/checkout/purchase-modal/with-is-eligible-for-one-click-checkout';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
@@ -143,7 +142,7 @@ export const UpsellNudge = ( {
 	const handleClick = ( e ) => {
 		if (
 			isOneClickCheckoutEnabled &&
-			isEligibleForOneClickCheckout.result === true &&
+			isEligibleForOneClickCheckout?.result === true &&
 			plan &&
 			siteSlug &&
 			canUserUpgrade
@@ -203,7 +202,7 @@ export const UpsellNudge = ( {
 				tracksImpressionProperties={ tracksImpressionProperties }
 				displayAsLink={ displayAsLink }
 				isBusy={
-					isBusy || ( isOneClickCheckoutEnabled && isEligibleForOneClickCheckout.isLoading )
+					isBusy || ( isOneClickCheckoutEnabled && isEligibleForOneClickCheckout?.isLoading )
 				}
 			/>
 		</>
@@ -215,7 +214,7 @@ UpsellNudge.defaultProps = {
 	compactButton: true,
 };
 
-export default connect( ( state, ownProps ) => {
+export const ConnectedUpsellNudge = connect( ( state, ownProps ) => {
 	const siteId = getSelectedSiteId( state );
 
 	return {
@@ -232,4 +231,17 @@ export default connect( ( state, ownProps ) => {
 		canUserUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 		siteIsWPForTeams: isSiteWPForTeams( state, getSelectedSiteId( state ) ),
 	};
-} )( withIsEligibleForOneClickCheckout( UpsellNudge ) );
+} )( UpsellNudge );
+
+export default function Wrapper( props ) {
+	if ( props.isOneClickCheckoutEnabled ) {
+		return (
+			<AsyncLoad
+				require="../../my-sites/checkout/purchase-modal/is-eligible-for-one-click-checkout-wrapper"
+				component={ ConnectedUpsellNudge }
+				componentProps={ props }
+			/>
+		);
+	}
+	return <ConnectedUpsellNudge { ...props } />;
+}

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -34,22 +34,6 @@ import './style.scss';
 
 const debug = debugFactory( 'calypso:upsell-nudge' );
 
-function shouldShowOneClickCheckout( {
-	isOneClickCheckoutEnabled,
-	isEligibleForOneClickCheckout,
-	plan,
-	siteSlug,
-	canUserUpgrade,
-} ) {
-	return (
-		isOneClickCheckoutEnabled &&
-		isEligibleForOneClickCheckout?.result === true &&
-		plan &&
-		siteSlug &&
-		canUserUpgrade
-	);
-}
-
 /**
  * @param {any} props Props declared as `any` to prevent errors in TSX files that use this component.
  */
@@ -157,13 +141,11 @@ export const UpsellNudge = ( {
 
 	const handleClick = ( e ) => {
 		if (
-			shouldShowOneClickCheckout( {
-				isOneClickCheckoutEnabled,
-				isEligibleForOneClickCheckout,
-				plan,
-				siteSlug,
-				canUserUpgrade,
-			} )
+			isOneClickCheckoutEnabled &&
+			isEligibleForOneClickCheckout?.result === true &&
+			plan &&
+			siteSlug &&
+			canUserUpgrade
 		) {
 			e.preventDefault();
 			setShowPurchaseModal( true );
@@ -252,7 +234,7 @@ const ConnectedUpsellNudge = connect( ( state, ownProps ) => {
 } )( UpsellNudge );
 
 export default function Wrapper( props ) {
-	if ( shouldShowOneClickCheckout( props ) ) {
+	if ( props.isOneClickCheckoutEnabled ) {
 		return (
 			<AsyncLoad
 				require="../../my-sites/checkout/purchase-modal/is-eligible-for-one-click-checkout-wrapper"

--- a/client/blocks/upsell-nudge/purchase-modal-wrapper.tsx
+++ b/client/blocks/upsell-nudge/purchase-modal-wrapper.tsx
@@ -1,0 +1,53 @@
+import { StripeHookProvider } from '@automattic/calypso-stripe';
+import { createRequestCartProduct } from '@automattic/shopping-cart';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import { useDispatch } from 'react-redux';
+import { getStripeConfiguration } from 'calypso/lib/store-transactions';
+import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
+import PurchaseModal from 'calypso/my-sites/checkout/purchase-modal';
+import { successNotice } from 'calypso/state/notices/actions';
+import { SiteSlug } from 'calypso/types';
+
+export default function PurchaseModalWrapper( {
+	plan,
+	siteSlug,
+	setShowPurchaseModal,
+}: {
+	plan?: string;
+	siteSlug: SiteSlug;
+	setShowPurchaseModal: ( arg: boolean ) => void;
+} ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const product = useMemo(
+		() => ( plan ? createRequestCartProduct( { product_slug: plan } ) : null ),
+		[ plan ]
+	);
+	return product ? (
+		<CalypsoShoppingCartProvider>
+			<StripeHookProvider
+				fetchStripeConfiguration={ getStripeConfiguration }
+				locale={ translate.localeSlug }
+			>
+				<PurchaseModal
+					productToAdd={ product }
+					onClose={ () => {
+						setShowPurchaseModal( false );
+					} }
+					onPurchaseSuccess={ () => {
+						setShowPurchaseModal( false );
+						dispatch(
+							successNotice( translate( 'Your purchase has been completed!' ), {
+								id: 'plugins-purchase-modal-success',
+							} )
+						);
+					} }
+					disabledThankYouPage={ true }
+					showFeatureList={ true }
+					siteSlug={ siteSlug }
+				/>
+			</StripeHookProvider>
+		</CalypsoShoppingCartProvider>
+	) : null;
+}

--- a/client/my-sites/checkout/purchase-modal/is-eligible-for-one-click-checkout-wrapper.tsx
+++ b/client/my-sites/checkout/purchase-modal/is-eligible-for-one-click-checkout-wrapper.tsx
@@ -1,0 +1,16 @@
+import { useIsEligibleForOneClickCheckout } from './use-is-eligible-for-one-click-checkout';
+import type { WithIsEligibleForOneClickCheckoutProps } from './with-is-eligible-for-one-click-checkout';
+import type { ComponentType } from 'react';
+
+export default function IsEligibleForOneClickCheckoutWrapper< P >( props: {
+	component: ComponentType< P >;
+	componentProps: Omit< P, keyof WithIsEligibleForOneClickCheckoutProps >;
+} ) {
+	const isEligibleForOneClickCheckout = useIsEligibleForOneClickCheckout();
+	return (
+		<props.component
+			{ ...( props.componentProps as P ) }
+			isEligibleForOneClickCheckout={ isEligibleForOneClickCheckout }
+		/>
+	);
+}

--- a/client/my-sites/checkout/purchase-modal/with-is-eligible-for-one-click-checkout.tsx
+++ b/client/my-sites/checkout/purchase-modal/with-is-eligible-for-one-click-checkout.tsx
@@ -1,7 +1,5 @@
-import {
-	type IsEligibleForOneClickCheckoutReturnValue,
-	useIsEligibleForOneClickCheckout,
-} from './use-is-eligible-for-one-click-checkout';
+import IsEligibleForOneClickCheckoutWrapper from './is-eligible-for-one-click-checkout-wrapper';
+import type { IsEligibleForOneClickCheckoutReturnValue } from './use-is-eligible-for-one-click-checkout';
 import type { ComponentType } from 'react';
 
 export interface WithIsEligibleForOneClickCheckoutProps {
@@ -9,15 +7,9 @@ export interface WithIsEligibleForOneClickCheckoutProps {
 }
 
 export function withIsEligibleForOneClickCheckout< P >( Component: ComponentType< P > ) {
-	return function IsEligibleForOneClickCheckoutWrapper(
-		props: Omit< P, keyof WithIsEligibleForOneClickCheckoutProps >
-	) {
-		const isEligibleForOneClickCheckout = useIsEligibleForOneClickCheckout();
+	return function ( props: Omit< P, keyof WithIsEligibleForOneClickCheckoutProps > ) {
 		return (
-			<Component
-				{ ...( props as P ) }
-				isEligibleForOneClickCheckout={ isEligibleForOneClickCheckout }
-			/>
+			<IsEligibleForOneClickCheckoutWrapper component={ Component } componentProps={ props } />
 		);
 	};
 }

--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -1,17 +1,6 @@
-import { PLAN_BUSINESS, findFirstSimilarPlanKey, getPlan } from '@automattic/calypso-products';
-import page from '@automattic/calypso-router';
-import { StripeHookProvider } from '@automattic/calypso-stripe';
-import { createRequestCartProduct } from '@automattic/shopping-cart';
-import { useState, useMemo } from '@wordpress/element';
-import { useTranslate } from 'i18n-calypso';
-import { useDispatch, useSelector } from 'react-redux';
-import { getStripeConfiguration } from 'calypso/lib/store-transactions';
-import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
-import PurchaseModal from 'calypso/my-sites/checkout/purchase-modal';
-import { useIsEligibleForOneClickCheckout } from 'calypso/my-sites/checkout/purchase-modal/use-is-eligible-for-one-click-checkout';
+import { useSelector } from 'react-redux';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { successNotice } from 'calypso/state/notices/actions';
 import EducationFooter from '../education-footer';
 import CollectionListView from '../plugins-browser/collection-list-view';
 import SingleListView, { SHORT_LIST_LENGTH } from '../plugins-browser/single-list-view';
@@ -97,69 +86,10 @@ const PluginsDiscoveryPage = ( props ) => {
 	} );
 
 	const isLoggedIn = useSelector( isUserLoggedIn );
-	const translate = useTranslate();
-	const dispatch = useDispatch();
-	const [ showPurchaseModal, setShowPurchaseModal ] = useState( false );
-	const { isLoading, result: isEligibleForOneClickCheckout } = useIsEligibleForOneClickCheckout();
-
-	const productToAdd = useMemo( () => {
-		if ( ! props.sitePlan ) {
-			return null;
-		}
-		const currentPlan = getPlan( props.sitePlan.product_slug );
-		const currentPlanTerm = currentPlan.term;
-		const upsellPlan = findFirstSimilarPlanKey( PLAN_BUSINESS, { term: currentPlanTerm } );
-		return createRequestCartProduct( { product_slug: upsellPlan } );
-	}, [ props.sitePlan ] );
 
 	return (
 		<>
-			{ showPurchaseModal && productToAdd && (
-				<CalypsoShoppingCartProvider>
-					<StripeHookProvider
-						fetchStripeConfiguration={ getStripeConfiguration }
-						locale={ translate.localeSlug }
-					>
-						<PurchaseModal
-							productToAdd={ productToAdd }
-							onClose={ () => {
-								setShowPurchaseModal( false );
-							} }
-							onPurchaseSuccess={ () => {
-								setShowPurchaseModal( false );
-								dispatch(
-									successNotice( translate( 'Your purchase has been completed!' ), {
-										id: 'plugins-purchase-modal-success',
-									} )
-								);
-							} }
-							disabledThankYouPage={ true }
-							showFeatureList={ true }
-							siteSlug={ props.siteSlug }
-						/>
-					</StripeHookProvider>
-				</CalypsoShoppingCartProvider>
-			) }
-			<UpgradeNudge
-				{ ...props }
-				isBusy={ isLoading }
-				paidPlugins={ true }
-				handleUpsellNudgeClick={ ( e ) => {
-					e.preventDefault();
-
-					// Prevent multiple clicks
-					if ( isLoading ) {
-						return;
-					}
-
-					if ( isEligibleForOneClickCheckout === true ) {
-						setShowPurchaseModal( true );
-						return;
-					}
-
-					page( `/checkout/${ props.siteSlug }/business` );
-				} }
-			/>
+			<UpgradeNudge { ...props } paidPlugins={ true } />
 			<PaidPluginsSection { ...props } />
 			<CollectionListView category="monetization" { ...props } />
 			<EducationFooter />

--- a/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
@@ -19,7 +19,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSitePlan, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
-const UpgradeNudge = ( { siteSlug, paidPlugins, handleUpsellNudgeClick, isBusy } ) => {
+const UpgradeNudge = ( { siteSlug, paidPlugins, handleUpsellNudgeClick } ) => {
 	const selectedSite = useSelector( getSelectedSite );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
 
@@ -98,6 +98,7 @@ const UpgradeNudge = ( { siteSlug, paidPlugins, handleUpsellNudgeClick, isBusy }
 				feature={ WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS }
 				plan={ requiredPlan.getStoreSlug() }
 				title={ title }
+				isOneClickCheckoutEnabled={ true }
 			/>
 		);
 	}
@@ -141,7 +142,7 @@ const UpgradeNudge = ( { siteSlug, paidPlugins, handleUpsellNudgeClick, isBusy }
 			feature={ FEATURE_INSTALL_PLUGINS }
 			plan={ plan }
 			title={ title }
-			isBusy={ isBusy }
+			isOneClickCheckoutEnabled={ true }
 		/>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Adds 1-click checkout to the `<UpsellNudge>` component. This will enable seamless integration of 1-click checkout in all contextual upsells within Calypso by simply passing a `isOneClickCheckoutEnabled={true}` prop to the component.
* The PR also removes the implementation from the plugins discovery page as it is now inside the `<UpsellNudge/>` component.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure you have a saved credit card.
* Go to `/plugins/<site slug>` for a free site.
* Click on the `Upgrade to Creator` button.
* Confirm that you can see the 1-click checkout modal.
* Go to `/checkout/<site slug>/offer-plan-upgrade/business/12345`.
* Click on the `Upgrade Now` CTA.
* Confirm that you can see the 1-click checkout modal.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?