### PR TITLE
Plans rename: remove hasTranslation calls from multiple places - part 3

### DIFF
--- a/client/blocks/eligibility-warnings/hold-list.tsx
+++ b/client/blocks/eligibility-warnings/hold-list.tsx
@@ -1,9 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { PLAN_BUSINESS, PLAN_PERSONAL, getPlan } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
-import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
+import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
-import i18n, { localize, LocalizeProps } from 'i18n-calypso';
+import { localize, LocalizeProps } from 'i18n-calypso';
 import { map } from 'lodash';
 import ExcessiveDiskSpace from 'calypso/blocks/eligibility-warnings/excessive-disk-space';
 import CardHeading from 'calypso/components/card-heading';
@@ -19,25 +19,20 @@ function getHoldMessages(
 	context: string | null,
 	translate: LocalizeProps[ 'translate' ],
 	billingPeriod?: string,
-	isMarketplace?: boolean,
-	isEnglishLocale?: boolean
+	isMarketplace?: boolean
 ) {
 	return {
 		NO_BUSINESS_PLAN: {
 			title: ( function () {
 				if ( isMarketplace && isEnabled( 'marketplace-personal-premium' ) ) {
-					return isEnglishLocale || i18n.hasTranslation( 'Upgrade to a %(personalPlanName)s plan' )
-						? translate( 'Upgrade to a %(personalPlanName)s plan', {
-								args: { personalPlanName: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
-						  } )
-						: translate( 'Upgrade to a Personal plan' );
+					return translate( 'Upgrade to a %(personalPlanName)s plan', {
+						args: { personalPlanName: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
+					} );
 				}
 
-				return isEnglishLocale || i18n.hasTranslation( 'Upgrade to a %(businessPlanName)s plan' )
-					? translate( 'Upgrade to a %(businessPlanName)s plan', {
-							args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-					  } )
-					: translate( 'Upgrade to a Business plan' );
+				return translate( 'Upgrade to a %(businessPlanName)s plan', {
+					args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+				} );
 			} )(),
 			description: ( function () {
 				if ( context === 'themes' ) {
@@ -224,14 +219,7 @@ export const HardBlockingNotice = ( {
 
 export const HoldList = ( { context, holds, isMarketplace, isPlaceholder, translate }: Props ) => {
 	const billingPeriod = useSelector( getBillingInterval );
-	const isEnglishLocale = useIsEnglishLocale();
-	const holdMessages = getHoldMessages(
-		context,
-		translate,
-		billingPeriod,
-		isMarketplace,
-		isEnglishLocale
-	);
+	const holdMessages = getHoldMessages( context, translate, billingPeriod, isMarketplace );
 	const blockingMessages = getBlockingMessages( translate );
 
 	const blockingHold = holds.find( ( h ) => isHardBlockingHoldType( h, blockingMessages ) );

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -5,9 +5,8 @@ import {
 	usePatternAssemblerCtaData,
 	isAssemblerSupported,
 } from '@automattic/design-picker';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { Icon, addTemplate, brush, cloudUpload } from '@wordpress/icons';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { isEmpty, times } from 'lodash';
 import PropTypes from 'prop-types';
 import React, { useCallback, useEffect, useRef, useState } from 'react';
@@ -247,8 +246,6 @@ function Options( { isFSEActive, recordTracksEvent, searchTerm, translate, upsel
 		getSiteThemeInstallUrl( state, selectedSite?.ID )
 	);
 	const assemblerCtaData = usePatternAssemblerCtaData();
-	const isEnglishLocale = useIsEnglishLocale();
-
 	const options = [];
 
 	useEffect( () => {
@@ -310,18 +307,10 @@ function Options( { isFSEActive, recordTracksEvent, searchTerm, translate, upsel
 		options.push( {
 			title: translate( 'Upload a theme' ),
 			icon: cloudUpload,
-			description:
-				isEnglishLocale ||
-				i18n.hasTranslation(
-					'With a %(businessPlanName)s plan, you can upload and install third-party themes, including your own themes.'
-				)
-					? translate(
-							'With a %(businessPlanName)s plan, you can upload and install third-party themes, including your own themes.',
-							{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() } }
-					  )
-					: translate(
-							'With a Business plan, you can upload and install third-party themes, including your own themes.'
-					  ),
+			description: translate(
+				'With a %(businessPlanName)s plan, you can upload and install third-party themes, including your own themes.',
+				{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() } }
+			),
 			onClick: () =>
 				recordTracksEvent( 'calypso_themeshowcase_more_options_upload_theme_click', {
 					site_plan: sitePlan,
@@ -351,18 +340,10 @@ function Options( { isFSEActive, recordTracksEvent, searchTerm, translate, upsel
 		options.push( {
 			title: translate( 'Upload a theme' ),
 			icon: cloudUpload,
-			description:
-				isEnglishLocale ||
-				i18n.hasTranslation(
-					'With a %(businessPlanName)s plan, you can upload and install third-party themes, including your own themes.'
-				)
-					? translate(
-							'With a %(businessPlanName)s plan, you can upload and install third-party themes, including your own themes.',
-							{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() } }
-					  )
-					: translate(
-							'With a Business plan, you can upload and install third-party themes, including your own themes.'
-					  ),
+			description: translate(
+				'With a %(businessPlanName)s plan, you can upload and install third-party themes, including your own themes.',
+				{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() } }
+			),
 			onClick: () =>
 				recordTracksEvent( 'calypso_themeshowcase_more_options_upload_theme_click', {
 					site_plan: sitePlan,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/migration-trial-acknowledge.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/migration-trial-acknowledge.tsx
@@ -1,6 +1,6 @@
 import { getPlan, PLAN_BUSINESS, PLAN_MIGRATION_TRIAL_MONTHLY } from '@automattic/calypso-products';
 import { SiteDetails } from '@automattic/data-stores';
-import { useHasEnTranslation, useIsEnglishLocale } from '@automattic/i18n-utils';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { Title, SubTitle, NextButton } from '@automattic/onboarding';
 import { createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -38,13 +38,10 @@ const MigrationTrialAcknowledgeInternal = function ( props: Props ) {
 	const hasEnTranslation = useHasEnTranslation();
 	const urlQueryParams = useQuery();
 	const { user, site, siteSlug, flowName, stepName, submit } = props;
-	const isEnglishLocale = useIsEnglishLocale();
-
 	const { data: migrationTrialEligibility, isLoading: isCheckingEligibility } =
 		useCheckEligibilityMigrationTrialPlan( site?.ID );
 	const isEligibleForTrialPlan = migrationTrialEligibility?.eligible;
 	const eligibilityErrorCode = migrationTrialEligibility?.error_code;
-
 	const plan = getPlan( PLAN_BUSINESS );
 	const { addHostingTrial, isLoading: isAddingTrial } = useAddHostingTrialMutation( {
 		onSuccess: () => {
@@ -95,20 +92,13 @@ const MigrationTrialAcknowledgeInternal = function ( props: Props ) {
 				<Title>{ __( 'You already have an active free trial' ) }</Title>
 				<SubTitle>
 					{ createInterpolateElement(
-						isEnglishLocale ||
-							hasEnTranslation(
+						sprintf(
+							/* translators: the planName is the short-from of the Business plan */
+							__(
 								"You're currently enrolled in a free trial. Please wait until it expires to start a new one.<br />To migrate your site now, upgrade to the %(planName)s plan."
-							)
-							? sprintf(
-									/* translators: the planName is the short-from of the Business plan */
-									__(
-										"You're currently enrolled in a free trial. Please wait until it expires to start a new one.<br />To migrate your site now, upgrade to the %(planName)s plan."
-									),
-									{ planName: plan?.getTitle() }
-							  )
-							: __(
-									"You're currently enrolled in a free trial. Please wait until it expires to start a new one.<br />To migrate your site now, upgrade to the Business plan."
-							  ),
+							),
+							{ planName: plan?.getTitle() }
+						),
 						{ br: <br /> }
 					) }
 				</SubTitle>

--- a/client/my-sites/backup/wpcom-backup-upsell.tsx
+++ b/client/my-sites/backup/wpcom-backup-upsell.tsx
@@ -4,9 +4,8 @@ import {
 	getPlan,
 } from '@automattic/calypso-products';
 import { Button, Gridicon } from '@automattic/components';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { addQueryArgs } from '@wordpress/url';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import JetpackBackupSVG from 'calypso/assets/images/illustrations/jetpack-backup.svg';
 import VaultPressLogo from 'calypso/assets/images/jetpack/vaultpress-logo.svg';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -84,7 +83,6 @@ const BackupUpsellBody = () => {
 	const postCheckoutUrl = window.location.pathname + window.location.search;
 	const isJetpack = useSelector( ( state ) => siteId && isJetpackSite( state, siteId ) );
 	const isAtomic = useSelector( ( state ) => siteId && isSiteWpcomAtomic( state, siteId ) );
-	const isEnglishLocale = useIsEnglishLocale();
 	const isWPcomSite = ! isJetpack || isAtomic;
 	const onUpgradeClick = useTrackCallback(
 		undefined,
@@ -134,12 +132,9 @@ const BackupUpsellBody = () => {
 				{ isAdmin && isWPcomSite && (
 					<PromoCardCTA
 						cta={ {
-							text:
-								isEnglishLocale || i18n.hasTranslation( 'Upgrade to %(planName)s Plan' )
-									? translate( 'Upgrade to %(planName)s Plan', {
-											args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-									  } )
-									: translate( 'Upgrade to Business Plan' ),
+							text: translate( 'Upgrade to %(planName)s Plan', {
+								args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+							} ),
 							action: {
 								url: `/checkout/${ siteSlug }/business`,
 								onClick: onUpgradeClick,
@@ -167,11 +162,9 @@ const BackupUpsellBody = () => {
 			{ isWPcomSite && ! hasFullActivityLogFeature && (
 				<>
 					<h2 className="backup__subheader">
-						{ isEnglishLocale || i18n.hasTranslation( 'Also included in the %(planName)s Plan' )
-							? translate( 'Also included in the %(planName)s Plan', {
-									args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-							  } )
-							: translate( 'Also included in the Business Plan' ) }
+						{ translate( 'Also included in the %(planName)s Plan', {
+							args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+						} ) }
 					</h2>
 
 					<PromoSection { ...promos } />

--- a/client/my-sites/backup/wpcom-upsell.tsx
+++ b/client/my-sites/backup/wpcom-upsell.tsx
@@ -4,8 +4,7 @@ import {
 	getPlan,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import JetpackBackupSVG from 'calypso/assets/images/illustrations/jetpack-backup.svg';
 import DocumentHead from 'calypso/components/data/document-head';
 import WhatIsJetpack from 'calypso/components/jetpack/what-is-jetpack';
@@ -33,7 +32,6 @@ export default function WPCOMUpsellPage() {
 	const isAdmin = useSelector( ( state ) =>
 		canCurrentUser( state, siteId ?? 0, 'manage_options' )
 	);
-	const isEnglishLocale = useIsEnglishLocale();
 	const hasFullActivityLogFeature = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_FULL_ACTIVITY_LOG )
 	);
@@ -74,29 +72,19 @@ export default function WPCOMUpsellPage() {
 				{ ! isAdmin && (
 					<Notice
 						status="is-warning"
-						text={
-							isEnglishLocale ||
-							i18n.hasTranslation(
-								'Only site administrators can upgrade to the %(businessPlanName)s plan.'
-							)
-								? translate(
-										'Only site administrators can upgrade to the %(businessPlanName)s plan.',
-										{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
-								  )
-								: translate( 'Only site administrators can upgrade to the Business plan.' )
-						}
+						text={ translate(
+							'Only site administrators can upgrade to the %(businessPlanName)s plan.',
+							{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
+						) }
 						showDismiss={ false }
 					/>
 				) }
 				{ isAdmin && (
 					<PromoCardCTA
 						cta={ {
-							text:
-								isEnglishLocale || i18n.hasTranslation( 'Upgrade to %(planName)s Plan' )
-									? translate( 'Upgrade to %(planName)s Plan', {
-											args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-									  } )
-									: translate( 'Upgrade to Business Plan' ),
+							text: translate( 'Upgrade to %(planName)s Plan', {
+								args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+							} ),
 							action: {
 								url: `/checkout/${ siteSlug }/business`,
 								onClick: onUpgradeClick,
@@ -110,11 +98,9 @@ export default function WPCOMUpsellPage() {
 			{ ! hasFullActivityLogFeature && (
 				<>
 					<h2 className="backup__subheader">
-						{ isEnglishLocale || i18n.hasTranslation( 'Also included in the %(planName)s Plan' )
-							? translate( 'Also included in the %(planName)s Plan', {
-									args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-							  } )
-							: translate( 'Also included in the Business Plan' ) }
+						{ translate( 'Also included in the %(planName)s Plan', {
+							args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+						} ) }
 					</h2>
 
 					<PromoSection { ...promos } />

--- a/client/my-sites/checkout/checkout-thank-you/personal-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/personal-plan-details.jsx
@@ -4,7 +4,7 @@ import {
 	getPlan,
 	PLAN_BUSINESS,
 } from '@automattic/calypso-products';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { find } from 'lodash';
 import PropTypes from 'prop-types';
 import earnImage from 'calypso/assets/images/customer-home/illustration--task-earn.svg';
@@ -13,9 +13,8 @@ import PurchaseDetail from 'calypso/components/purchase-detail';
 import CustomDomainPurchaseDetail from './custom-domain-purchase-detail';
 import GoogleAppsDetails from './google-apps-details';
 
-const PersonalPlanDetails = ( { translate, selectedSite, sitePlans, purchases, locale } ) => {
+const PersonalPlanDetails = ( { translate, selectedSite, sitePlans, purchases } ) => {
 	const plan = find( sitePlans.data, isPersonal );
-	const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
 	const googleAppsWasPurchased = purchases.some( isGSuiteOrExtraLicenseOrGoogleWorkspace );
 
 	return (
@@ -41,22 +40,11 @@ const PersonalPlanDetails = ( { translate, selectedSite, sitePlans, purchases, l
 			<PurchaseDetail
 				icon={ <img alt="" src={ adsRemovedImage } /> }
 				title={ translate( 'Advertising Removed' ) }
-				description={
-					isEnglishLocale ||
-					i18n.hasTranslation(
-						'With your plan, all WordPress.com advertising has been removed from your site. ' +
-							'You can upgrade to a %(businessPlanName)s plan to also remove the WordPress.com footer credit.'
-					)
-						? translate(
-								'With your plan, all WordPress.com advertising has been removed from your site. ' +
-									'You can upgrade to a %(businessPlanName)s plan to also remove the WordPress.com footer credit.',
-								{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() } }
-						  )
-						: translate(
-								'With your plan, all WordPress.com advertising has been removed from your site. ' +
-									'You can upgrade to a Business plan to also remove the WordPress.com footer credit.'
-						  )
-				}
+				description={ translate(
+					'With your plan, all WordPress.com advertising has been removed from your site. ' +
+						'You can upgrade to a %(businessPlanName)s plan to also remove the WordPress.com footer credit.',
+					{ args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() } }
+				) }
 			/>
 		</div>
 	);

--- a/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
+++ b/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
@@ -1,6 +1,5 @@
 import { FEATURE_SFTP, PLAN_BUSINESS, WPCOM_PLANS, getPlan } from '@automattic/calypso-products';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { preventWidows } from 'calypso/lib/formatting';
 import iconCloud from './icons/icon-cloud.svg';
@@ -33,25 +32,16 @@ interface HostingUpsellNudgeProps {
 
 export function HostingUpsellNudge( { siteId, targetPlan }: HostingUpsellNudgeProps ) {
 	const translate = useTranslate();
-
 	const features = useFeatureList();
-	const isEnglishLocale = useIsEnglishLocale();
-	const callToActionText =
-		isEnglishLocale || i18n.hasTranslation( 'Upgrade to %(businessPlanName)s Plan' )
-			? translate( 'Upgrade to %(businessPlanName)s Plan', {
-					args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-			  } )
-			: translate( 'Upgrade to Business Plan' );
-	const titleText =
-		isEnglishLocale ||
-		i18n.hasTranslation(
-			'Upgrade to the %(businessPlanName)s plan to access all hosting features:'
-		)
-			? translate( 'Upgrade to the %(businessPlanName)s plan to access all hosting features:', {
-					args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-			  } )
-			: translate( 'Upgrade to the Business plan to access all hosting features:' );
-
+	const callToActionText = translate( 'Upgrade to %(businessPlanName)s Plan', {
+		args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+	} );
+	const titleText = translate(
+		'Upgrade to the %(businessPlanName)s plan to access all hosting features:',
+		{
+			args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+		}
+	);
 	const callToAction = targetPlan ? targetPlan.callToAction : callToActionText;
 	const feature = targetPlan ? targetPlan.feature : FEATURE_SFTP;
 	const href = targetPlan ? targetPlan.href : `/checkout/${ siteId }/business`;

--- a/client/my-sites/marketing/tools/index.tsx
+++ b/client/my-sites/marketing/tools/index.tsx
@@ -2,8 +2,8 @@ import config from '@automattic/calypso-config';
 import { PLAN_BUSINESS, PLAN_ECOMMERCE, getPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
-import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
-import i18n, { useTranslate, getLocaleSlug } from 'i18n-calypso';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useTranslate, getLocaleSlug } from 'i18n-calypso';
 import { Fragment, FunctionComponent } from 'react';
 import fiverrLogo from 'calypso/assets/images/customer-home/fiverr-logo.svg';
 import rocket from 'calypso/assets/images/customer-home/illustration--rocket.svg';
@@ -29,8 +29,6 @@ export const MarketingTools: FunctionComponent = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const recordTracksEvent = ( event: string ) => dispatch( recordTracksEventAction( event ) );
-	const isEnglishLocale = useIsEnglishLocale();
-
 	const selectedSiteSlug: T.SiteSlug | null = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( getSelectedSiteId ) || 0;
 
@@ -126,32 +124,18 @@ export const MarketingTools: FunctionComponent = () => {
 				{ ! facebookPluginInstalled && (
 					<MarketingToolsFeature
 						title={ translate( 'Want to connect with your audience on Facebook and Instagram?' ) }
-						description={
-							isEnglishLocale ||
-							i18n.hasTranslation(
-								'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. {{em}}Available on %(businessPlanName)s and %(commercePlanName)s plans{{/em}}.'
-							)
-								? translate(
-										'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. {{em}}Available on %(businessPlanName)s and %(commercePlanName)s plans{{/em}}.',
-										{
-											components: {
-												em: <em />,
-											},
-											args: {
-												businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
-												commercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
-											},
-										}
-								  )
-								: translate(
-										'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. {{em}}Available on Business and Commerce plans{{/em}}.',
-										{
-											components: {
-												em: <em />,
-											},
-										}
-								  )
-						}
+						description={ translate(
+							'Discover an easy way to advertise your brand across Facebook and Instagram. Capture website actions to help you target audiences and measure results. {{em}}Available on %(businessPlanName)s and %(commercePlanName)s plans{{/em}}.',
+							{
+								components: {
+									em: <em />,
+								},
+								args: {
+									businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '',
+									commercePlanName: getPlan( PLAN_ECOMMERCE )?.getTitle() ?? '',
+								},
+							}
+						) }
 						imagePath={ facebookLogo }
 						imageAlt={ translate( 'Facebook logo' ) }
 					>

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -1,9 +1,8 @@
 import { PLAN_BUSINESS, WPCOM_FEATURES_ATOMIC, getPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { WordPressWordmark, Button } from '@automattic/components';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { ThemeProvider } from '@emotion/react';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState, useMemo, useRef } from 'react';
 import QueryActiveTheme from 'calypso/components/data/query-active-theme';
 import QueryJetpackPlugins from 'calypso/components/data/query-jetpack-plugins';
@@ -138,8 +137,6 @@ const MarketplaceProductInstall = ( {
 		isSiteAutomatedTransfer( state, selectedSite?.ID ?? null )
 	);
 	const isJetpackSelfHosted = selectedSite && isJetpack && ! isAtomic;
-
-	const isEnglishLocale = useIsEnglishLocale();
 
 	const hasAtomicFeature = useSelector( ( state ) =>
 		siteHasFeature( state, selectedSite?.ID ?? null, WPCOM_FEATURES_ATOMIC )
@@ -358,28 +355,15 @@ const MarketplaceProductInstall = ( {
 				<EmptyContent
 					illustration="/calypso/images/illustrations/error.svg"
 					title={ null }
-					line={
-						isEnglishLocale ||
-						i18n.hasTranslation(
-							"Your current plan doesn't allow plugin installation. Please upgrade to %(businessPlanName)s plan first."
-						)
-							? translate(
-									"Your current plan doesn't allow plugin installation. Please upgrade to %(businessPlanName)s plan first.",
-									{
-										args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-									}
-							  )
-							: translate(
-									"Your current plan doesn't allow plugin installation. Please upgrade to Business plan first."
-							  )
-					}
-					action={
-						isEnglishLocale || i18n.hasTranslation( 'Upgrade to %(planName)s Plan' )
-							? translate( 'Upgrade to %(planName)s Plan', {
-									args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
-							  } )
-							: translate( 'Upgrade to Business Plan' )
-					}
+					line={ translate(
+						"Your current plan doesn't allow plugin installation. Please upgrade to %(businessPlanName)s plan first.",
+						{
+							args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+						}
+					) }
+					action={ translate( 'Upgrade to %(planName)s Plan', {
+						args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+					} ) }
 					actionURL={ `/checkout/${ selectedSite?.slug }/business?redirect_to=/marketplace/plugin/${ pluginSlug }/install/${ selectedSite?.slug }#step2` }
 				/>
 			);

--- a/client/my-sites/migrate/step-confirm-migration.jsx
+++ b/client/my-sites/migrate/step-confirm-migration.jsx
@@ -6,7 +6,7 @@ import {
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, CompactCard, Gridicon } from '@automattic/components';
-import i18n, { localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -69,8 +69,7 @@ class StepConfirmMigration extends Component {
 	}
 
 	renderCardBusinessFooter() {
-		const { translate, locale } = this.props;
-		const isEnglishLocale = [ 'en', 'en-gb' ].includes( locale );
+		const { translate } = this.props;
 
 		// If the site is has an appropriate plan, no upgrade footer is required
 		if ( this.isTargetSitePlanCompatible() ) {
@@ -81,14 +80,11 @@ class StepConfirmMigration extends Component {
 			<CompactCard className="migrate__card-footer">
 				<Gridicon className="migrate__card-footer-gridicon" icon="info-outline" size={ 12 } />
 				<span className="migrate__card-footer-text">
-					{ isEnglishLocale ||
-					i18n.hasTranslation( 'A %(businessPlanName)s Plan is required to import everything.' )
-						? translate( 'A %(businessPlanName)s Plan is required to import everything.', {
-								args: {
-									businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle(),
-								},
-						  } )
-						: translate( 'A Business Plan is required to import everything.' ) }
+					{ translate( 'A %(businessPlanName)s Plan is required to import everything.', {
+						args: {
+							businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle(),
+						},
+					} ) }
 				</span>
 			</CompactCard>
 		);

--- a/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
@@ -8,8 +8,7 @@ import {
 	TYPE_BUSINESS,
 	WPCOM_FEATURES_INSTALL_PURCHASED_PLUGINS,
 } from '@automattic/calypso-products';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import getPlansForFeature from 'calypso/state/selectors/get-plans-for-feature';
@@ -50,7 +49,6 @@ const UpgradeNudge = ( { siteSlug, paidPlugins, handleUpsellNudgeClick, isBusy }
 	);
 
 	const pluginsPlansPageFlag = isEnabled( 'plugins-plans-page' );
-	const isEnglishLocale = useIsEnglishLocale();
 
 	const pluginsPlansPage = `/plugins/plans/yearly/${ selectedSite?.slug }`;
 
@@ -125,31 +123,18 @@ const UpgradeNudge = ( { siteSlug, paidPlugins, handleUpsellNudgeClick, isBusy }
 		);
 	}
 
-	const title =
-		isEnglishLocale ||
-		i18n.hasTranslation(
-			'You need to upgrade to a %(businessPlanName)s Plan to install plugins. Get a free domain with an annual plan.'
-		)
-			? translate(
-					'You need to upgrade to a %(businessPlanName)s Plan to install plugins. Get a free domain with an annual plan.',
-					{ args: { businessPlanName: getPlan( plan )?.getTitle() } }
-			  )
-			: translate(
-					'You need to upgrade to a Business Plan to install plugins. Get a free domain with an annual plan.'
-			  );
-
+	const title = translate(
+		'You need to upgrade to a %(businessPlanName)s Plan to install plugins. Get a free domain with an annual plan.',
+		{ args: { businessPlanName: getPlan( plan )?.getTitle() } }
+	);
 	// This banner upsells the ability to install free and paid plugins on a Business plan.
 	return (
 		<UpsellNudge
 			event="calypso_plugins_browser_upgrade_nudge"
 			className="plugins-discovery-page__upsell"
-			callToAction={
-				isEnglishLocale || i18n.hasTranslation( 'Upgrade to %(planName)s' )
-					? translate( 'Upgrade to %(planName)s', {
-							args: { planName: getPlan( plan )?.getTitle() },
-					  } )
-					: translate( 'Upgrade to Business' )
-			}
+			callToAction={ translate( 'Upgrade to %(planName)s', {
+				args: { planName: getPlan( plan )?.getTitle() },
+			} ) }
 			icon="notice-outline"
 			showIcon={ true }
 			onClick={ handleUpsellNudgeClick }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/85284

## Proposed Changes

This is part of the plans-rename work. Follow up to https://github.com/Automattic/wp-calypso/pull/85284 to remove the `hasTranslation` calls used initially for the update strings.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow instructions in https://github.com/Automattic/wp-calypso/pull/85284 to confirm the translated strings render correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?