### PR TITLE
ETK: fix localizing global styles support URL

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -489,6 +489,7 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 					<?php
 					$support_url = function_exists( 'localized_wpcom_url' )
 						? localized_wpcom_url( 'https://wordpress.com/support/using-styles/' )
+						// phpcs:ignore WPCOM.I18nRules.LocalizedUrl.LocalizedUrlAssignedToVariable
 						: 'https://wordpress.com/support/using-styles/';
 
 					$message = sprintf(

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/index.php
@@ -487,13 +487,17 @@ function wpcom_display_global_styles_launch_bar( $bar_controls ) {
 				</div>
 				<div class="launch-bar-global-styles-message">
 					<?php
+					$support_url = function_exists( 'localized_wpcom_url' )
+						? localized_wpcom_url( 'https://wordpress.com/support/using-styles/' )
+						: 'https://wordpress.com/support/using-styles/';
+
 					$message = sprintf(
 						/* translators: %1$s - documentation URL, %2$s - the name of the required plan */
 						__(
 							'Your site includes <a href="%1$s" target="_blank">premium styles</a> that are only visible to visitors after upgrading to the %2$s plan or higher.',
 							'full-site-editing'
 						),
-						'https://wordpress.com/support/using-styles/',
+						$support_url,
 						get_store_product( WPCOM_VALUE_BUNDLE )->product_name
 					);
 					echo sprintf(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Fix issue of deploying ETK to .com:

> Lint: The URL string 'https://wordpress.com/support/using-styles/' should be wrapped in the `localized_wpcom_url` function call.
>
> The URL string 'https://wordpress.com/support/using-styles/' should be wrapped in the localized_wpcom_url function call.


## Proposed Changes

* Add localization function which covers at least simple sites. Not quite sure what to do with Atomic sites! Just add lint-ignore?

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Editing toolkit stuff PCYsg-ly5-p2

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
