### PR TITLE
Help Center: Don't reset the current site

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -115,7 +115,7 @@ export const HelpCenterContactForm = () => {
 		};
 	}, [] );
 
-	const { setSite, resetStore, setUserDeclaredSite, setShowMessagingChat, setSubject, setMessage } =
+	const { resetStore, setUserDeclaredSite, setShowMessagingChat, setSubject, setMessage } =
 		useDispatch( HELP_CENTER_STORE );
 
 	const {
@@ -238,9 +238,7 @@ export const HelpCenterContactForm = () => {
 			section: sectionName,
 		} );
 
-		const savedCurrentSite = currentSite;
 		resetStore();
-		setSite( savedCurrentSite );
 
 		navigate( '/' );
 	}

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -76,10 +76,13 @@ const HelpCenter: React.FC< Container > = ( {
 	currentRoute = window.location.pathname + window.location.search,
 } ) => {
 	const portalParent = useRef( document.createElement( 'div' ) ).current;
-	const isHelpCenterShown = useSelect(
-		( select ) => ( select( HELP_CENTER_STORE ) as HelpCenterSelect ).isHelpCenterShown(),
-		[]
-	);
+	const { isHelpCenterShown, storedSite } = useSelect( ( select ) => {
+		const helpCenterSelect: HelpCenterSelect = select( HELP_CENTER_STORE );
+		return {
+			storedSite: helpCenterSelect.getSite(),
+			isHelpCenterShown: helpCenterSelect.isHelpCenterShown(),
+		};
+	}, [] );
 	const { setSite } = useDispatch( HELP_CENTER_STORE );
 
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
@@ -103,7 +106,7 @@ const HelpCenter: React.FC< Container > = ( {
 
 	useEffect( () => {
 		setSite( usedSite );
-	}, [ usedSite, setSite ] );
+	}, [ usedSite, setSite, storedSite ] );
 
 	useStillNeedHelpURL();
 


### PR DESCRIPTION
Noticed by @bcotrim when testing #85501.
When the Help Center's store is reset using `resetStore`, the current site (`site`) is emptied. However, the initial value is only set during Help Center's initialization. So if the user is in a context that does not have a current site (like `/help` or `/me/purchases`), they will not be able to submit the contact form, as `supportSite` will be `undefined`.

https://github.com/Automattic/wp-calypso/assets/3392497/04e695a0-9ee3-4016-8803-1d3d5c45c96b

## Proposed Changes

* Make sure we re-set the `site` to default value after it's emptied.

[See discussion below on the reasoning behind this change](https://github.com/Automattic/wp-calypso/pull/85639#discussion_r1435584020).

## Testing Instructions

Make sure the normal flows in Help Center are working as expected (submitting an email, chat or forum request). Especially be careful with the Jetpack/Atomic/Forums cases where the site is more explicitly selected.

To test the case seen in the video above:

- Go to `/me/purchases`.
- Try to cancel a paid plan: Plan => "Cancel plan" => "Cancel subscription" (don't worry, it won't cancel it just yet).
- On the pre-cancelation screen, you should get a "Need help? Chat with us" nudge in top right corner.
- Click on it.
- It should open the Messaging chat immediately.
- Now open Help Center and try submitting an Email or Chat request.
- The "Continue" button will remain inactive without the patch. With the patch, it should let you proceed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
