### PR TITLE
Plans rename: remove hasTranslation calls from plans-faq

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-faq.jsx
+++ b/client/my-sites/plans-features-main/components/plan-faq.jsx
@@ -5,9 +5,8 @@ import {
 	PLAN_ECOMMERCE,
 	getPlan,
 } from '@automattic/calypso-products';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
 import ExternalLinkWithTracking from 'calypso/components/external-link/with-tracking';
@@ -29,7 +28,6 @@ const FoldableFAQ = styled( FoldableFAQComponent )`
 const PlanFAQ = ( { titanMonthlyRenewalCost = 0 } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
 	const onFaqToggle = useCallback(
 		( faqArgs ) => {
 			const { id, isExpanded } = faqArgs;
@@ -177,53 +175,33 @@ const PlanFAQ = ( { titanMonthlyRenewalCost = 0 } ) => {
 				question={ translate( 'Can I install plugins?' ) }
 				onToggle={ onFaqToggle }
 			>
-				{ isEnglishLocale ||
-				i18n.hasTranslation(
+				{ translate(
 					'Yes! When you subscribe to the WordPress.com %(businessPlanName)s or %(ecommercePlanName)s plans, you’ll be able to ' +
-						'search for and install over 50,000 available plugins in the WordPress repository.'
-				)
-					? translate(
-							'Yes! When you subscribe to the WordPress.com %(businessPlanName)s or %(ecommercePlanName)s plans, you’ll be able to ' +
-								'search for and install over 50,000 available plugins in the WordPress repository.',
-							{
-								args: {
-									businessPlanName: getPlan( PLAN_BUSINESS ).getTitle(),
-									ecommercePlanName: getPlan( PLAN_ECOMMERCE ).getTitle(),
-								},
-							}
-					  )
-					: translate(
-							'Yes! When you subscribe to the WordPress.com Business or eCommerce plans, you’ll be able to ' +
-								'search for and install over 50,000 available plugins in the WordPress repository.'
-					  ) }
+						'search for and install over 50,000 available plugins in the WordPress repository.',
+					{
+						args: {
+							businessPlanName: getPlan( PLAN_BUSINESS ).getTitle(),
+							ecommercePlanName: getPlan( PLAN_ECOMMERCE ).getTitle(),
+						},
+					}
+				) }
 			</FoldableFAQ>
 			<FoldableFAQ
 				id="faq-10"
 				question={ translate( 'Can I install my own theme?' ) }
 				onToggle={ onFaqToggle }
 			>
-				{ isEnglishLocale ||
-				i18n.hasTranslation(
+				{ translate(
 					'Yes! All plans give you access to our directory of free and premium themes that have been ' +
 						'handpicked and reviewed for quality by our team. With the WordPress.com %(businessPlanName)s or ' +
-						"%(ecommercePlanName)s plan, you can upload and install any theme you'd like."
-				)
-					? translate(
-							'Yes! All plans give you access to our directory of free and premium themes that have been ' +
-								'handpicked and reviewed for quality by our team. With the WordPress.com %(businessPlanName)s or ' +
-								"%(ecommercePlanName)s plan, you can upload and install any theme you'd like.",
-							{
-								args: {
-									businessPlanName: getPlan( PLAN_BUSINESS ).getTitle(),
-									ecommercePlanName: getPlan( PLAN_ECOMMERCE ).getTitle(),
-								},
-							}
-					  )
-					: translate(
-							'Yes! All plans give you access to our directory of free and premium themes that have been ' +
-								'handpicked and reviewed for quality by our team. With the WordPress.com Business or ' +
-								"eCommerce plan, you can upload and install any theme you'd like."
-					  ) }
+						"%(ecommercePlanName)s plan, you can upload and install any theme you'd like.",
+					{
+						args: {
+							businessPlanName: getPlan( PLAN_BUSINESS ).getTitle(),
+							ecommercePlanName: getPlan( PLAN_ECOMMERCE ).getTitle(),
+						},
+					}
+				) }
 			</FoldableFAQ>
 			<FoldableFAQ
 				id="faq-11"
@@ -253,41 +231,21 @@ const PlanFAQ = ( { titanMonthlyRenewalCost = 0 } ) => {
 				question={ translate( 'Can I talk to a live person?' ) }
 				onToggle={ onFaqToggle }
 			>
-				{ isEnglishLocale ||
-				i18n.hasTranslation(
+				{ translate(
 					'We’d love to chat with you! All paid plans include access to one-on-one support from our ' +
 						'team of WordPress experts (we call them Happiness Engineers). The %(personalPlanName)s plan includes ' +
 						'email support while the %(premiumPlanName)s plan and above all include live chat support.{{br /}}{{br /}}' +
 						'If you have pre-purchase questions, we offer live chat on the checkout page. Select the plan ' +
 						'that looks like the best fit for you and click the “Questions? Ask a Happiness Engineer” ' +
-						'link on the next page.'
-				)
-					? translate(
-							'We’d love to chat with you! All paid plans include access to one-on-one support from our ' +
-								'team of WordPress experts (we call them Happiness Engineers). The %(personalPlanName)s plan includes ' +
-								'email support while the %(premiumPlanName)s plan and above all include live chat support.{{br /}}{{br /}}' +
-								'If you have pre-purchase questions, we offer live chat on the checkout page. Select the plan ' +
-								'that looks like the best fit for you and click the “Questions? Ask a Happiness Engineer” ' +
-								'link on the next page.',
-							{
-								args: {
-									personalPlanName: getPlan( PLAN_PERSONAL ).getTitle(),
-									premiumPlanName: getPlan( PLAN_PREMIUM ).getTitle(),
-								},
-								components: { br: <br /> },
-							}
-					  )
-					: translate(
-							'We’d love to chat with you! All paid plans include access to one-on-one support from our ' +
-								'team of WordPress experts (we call them Happiness Engineers). The Personal plan includes ' +
-								'email support while the Premium plan and above all include live chat support.{{br /}}{{br /}}' +
-								'If you have pre-purchase questions, we offer live chat on the checkout page. Select the plan ' +
-								'that looks like the best fit for you and click the “Questions? Ask a Happiness Engineer” ' +
-								'link on the next page.',
-							{
-								components: { br: <br /> },
-							}
-					  ) }
+						'link on the next page.',
+					{
+						args: {
+							personalPlanName: getPlan( PLAN_PERSONAL ).getTitle(),
+							premiumPlanName: getPlan( PLAN_PREMIUM ).getTitle(),
+						},
+						components: { br: <br /> },
+					}
+				) }
 			</FoldableFAQ>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/85005

## Proposed Changes

This is part of the plans-rename work. Follow up to https://github.com/Automattic/wp-calypso/pull/85005 to remove the `hasTranslation` calls used initially for the update strings.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow instructions in https://github.com/Automattic/wp-calypso/pull/85005 to confirm the translated strings render correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?