### PR TITLE
Style Variations: Fix the fonts are not displayed correctly

### DIFF
--- a/packages/global-styles/src/components/global-styles-variations/preview.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/preview.tsx
@@ -55,8 +55,18 @@ interface Props {
 const GlobalStylesVariationPreview = ( { title, inlineCss, isFocused, onFocusOut }: Props ) => {
 	const [ fontWeight ] = useGlobalStyle( 'typography.fontWeight' );
 	const [ fontFamily = 'serif' ] = useGlobalStyle( 'typography.fontFamily' );
-	const [ headingFontFamily = fontFamily ] = useGlobalStyle( 'elements.h1.typography.fontFamily' );
-	const [ headingFontWeight = fontWeight ] = useGlobalStyle( 'elements.h1.typography.fontWeight' );
+	const [ baseHeadingFontFamily = fontFamily ] = useGlobalStyle(
+		'elements.heading.typography.fontFamily'
+	);
+	const [ baseHeadingFontWeight = fontWeight ] = useGlobalStyle(
+		'elements.heading.typography.fontWeight'
+	);
+	const [ headingFontFamily = baseHeadingFontFamily ] = useGlobalStyle(
+		'elements.h1.typography.fontFamily'
+	);
+	const [ headingFontWeight = baseHeadingFontWeight ] = useGlobalStyle(
+		'elements.h1.typography.fontWeight'
+	);
 	const [ textColor = 'black' ] = useGlobalStyle( 'color.text' );
 	const [ headingColor = textColor ] = useGlobalStyle( 'elements.h1.color.text' );
 	const [ backgroundColor = 'white' ] = useGlobalStyle( 'color.background' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to D132838-code

## Proposed Changes

* Fix the fonts on the style variations are not displayed correctly because the inline CSS doesn't include the font definitions.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D132838-code to your sandbox
* Go to the Theme Showcase or the Design Picker
* Pick the theme with the style variations, e.g.: TT4, Zaino
* Make sure the style variations are displayed correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?