### PR TITLE
Replace hardcoded Business in import flow

### DIFF
--- a/client/blocks/importer/wordpress/import-content-only/index.tsx
+++ b/client/blocks/importer/wordpress/import-content-only/index.tsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState, useEffect, useCallback } from 'react';
@@ -46,6 +47,7 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 	const [ renderState, setRenderState ] = useState< RenderState >( 'idle' );
 	const { job, importer, siteItem, siteSlug, siteAnalyzedData, stepNavigator } = props;
 	const isSiteCompatible = siteItem && isTargetSitePlanCompatible( siteItem );
+	const planName = getPlan( PLAN_BUSINESS )?.getTitle() || '';
 
 	/**
 	 ↓ Callbacks
@@ -164,8 +166,22 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 			{ renderState === 'upgrade-plan' && (
 				<UpgradePlan
 					site={ siteItem }
-					ctaText={ translate( 'Get Business' ) }
-					subTitleText={ translate( 'Importing a backup file requires a Business plan' ) }
+					ctaText={
+						// translators: %(plan)s is the plan name - e.g. Business or Creator
+						translate( 'Get %(plan)s', {
+							args: {
+								plan: planName,
+							},
+						} ) as string
+					}
+					subTitleText={
+						// translators: %(plan)s is the plan name - e.g. Business or Creator
+						translate( 'Importing a backup file requires a %(planName)s plan', {
+							args: {
+								planName,
+							},
+						} ) as string
+					}
 					isBusy={ false }
 					onCtaClick={ () => {
 						stepNavigator?.goToCheckoutPage?.( WPImportOption.CONTENT_ONLY );


### PR DESCRIPTION
## Proposed Changes

* Replace hardcoded Business

## Testing Instructions

* With an existing Free site
* Go to /setup/import-focused?siteSlug=...
* Type some site, like arstechnica.com 

<img width="584" alt="Screenshot 2023-12-21 at 14 34 52" src="https://github.com/Automattic/wp-calypso/assets/82778/f30ec1c4-c62d-4863-be04-433e668343b4">

* Creator should be everwhere, no Business


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
