### PR TITLE
Plans rename: remove hasTranslation calls from plugin detail sidebar

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/usps.tsx
+++ b/client/my-sites/plugins/plugin-details-CTA/usps.tsx
@@ -8,9 +8,8 @@ import {
 	getPlan,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { IntervalLength } from 'calypso/my-sites/marketplace/components/billing-interval-switcher/constants';
 import PluginDetailsSidebarUSP from 'calypso/my-sites/plugins/plugin-details-sidebar-usp';
 import usePluginsSupportText from 'calypso/my-sites/plugins/use-plugins-support-text/';
@@ -124,8 +123,6 @@ export const PlanUSPS: React.FC< Props > = ( {
 	billingPeriod,
 } ) => {
 	const translate = useTranslate();
-	const isEnglishLocale = useIsEnglishLocale();
-
 	const selectedSite = useSelector( getSelectedSite );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSite?.ID ) );
 	const isPreInstalledPlugin = ! isJetpack && PREINSTALLED_PLUGINS.includes( pluginSlug );
@@ -148,41 +145,29 @@ export const PlanUSPS: React.FC< Props > = ( {
 	switch ( requiredPlan ) {
 		case PLAN_PERSONAL:
 		case PLAN_PERSONAL_MONTHLY:
-			planText =
-				isEnglishLocale ||
-				i18n.hasTranslation(
-					'Included in the %(personalPlanName)s plan (%(cost)s/%(periodicity)s):'
-				)
-					? translate( 'Included in the %(personalPlanName)s plan (%(cost)s/%(periodicity)s):', {
-							args: {
-								personalPlanName: getPlan( PLAN_PERSONAL )?.getTitle() as string,
-								cost: planDisplayCost as string,
-								periodicity: periodicityLabel,
-							},
-					  } )
-					: translate( 'Included in the Personal plan (%(cost)s/%(periodicity)s):', {
-							args: {
-								cost: planDisplayCost as string,
-								periodicity: periodicityLabel,
-							},
-					  } );
+			planText = translate(
+				'Included in the %(personalPlanName)s plan (%(cost)s/%(periodicity)s):',
+				{
+					args: {
+						personalPlanName: getPlan( PLAN_PERSONAL )?.getTitle() as string,
+						cost: planDisplayCost as string,
+						periodicity: periodicityLabel,
+					},
+				}
+			);
 			break;
 		case PLAN_BUSINESS:
 		case PLAN_BUSINESS_MONTHLY:
-			planText = isEnglishLocale
-				? translate( 'Included in the %(businessPlanName)s plan (%(cost)s/%(periodicity)s):', {
-						args: {
-							businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() as string,
-							cost: planDisplayCost as string,
-							periodicity: periodicityLabel,
-						},
-				  } )
-				: translate( 'Included in the Business plan (%(cost)s/%(periodicity)s):', {
-						args: {
-							cost: planDisplayCost as string,
-							periodicity: periodicityLabel,
-						},
-				  } );
+			planText = translate(
+				'Included in the %(businessPlanName)s plan (%(cost)s/%(periodicity)s):',
+				{
+					args: {
+						businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() as string,
+						cost: planDisplayCost as string,
+						periodicity: periodicityLabel,
+					},
+				}
+			);
 			break;
 		case PLAN_ECOMMERCE_TRIAL_MONTHLY:
 			planText = translate( 'Included in ecommerce plans:' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/85006

## Proposed Changes

This is part of the plans-rename work. Follow up to https://github.com/Automattic/wp-calypso/pull/85006 to remove the `hasTranslation` calls used initially for the update strings.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow instructions in https://github.com/Automattic/wp-calypso/pull/85006 to confirm the translated strings render correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?