### PR TITLE
Plans rename: remove hasTranslation calls from podcast settings

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -5,7 +5,7 @@ import {
 } from '@automattic/calypso-products';
 import { Button, Card } from '@automattic/components';
 import classNames from 'classnames';
-import i18n, { getLocaleSlug, localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { pick, flowRight } from 'lodash';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
@@ -185,9 +185,6 @@ class PodcastingDetails extends Component {
 			'is-disabled': ! error && ! isPodcastingEnabled,
 		} );
 
-		const currentLocale = getLocaleSlug();
-		const isEnglishLocale = currentLocale === 'en' || currentLocale === 'en-gb';
-
 		return (
 			<Main>
 				<DocumentHead title={ translate( 'Podcasting' ) } />
@@ -208,14 +205,9 @@ class PodcastingDetails extends Component {
 					{ ! error && plansDataLoaded && (
 						<UpsellNudge
 							plan={ PLAN_PERSONAL }
-							title={
-								isEnglishLocale ||
-								i18n.hasTranslation( 'Upload Audio with WordPress.com %(personalPlanName)s' )
-									? translate( 'Upload Audio with WordPress.com %(personalPlanName)s', {
-											args: { personalPlanName: getPlan( PLAN_PERSONAL ).getTitle() },
-									  } )
-									: translate( 'Upload Audio with WordPress.com Personal' )
-							}
+							title={ translate( 'Upload Audio with WordPress.com %(personalPlanName)s', {
+								args: { personalPlanName: getPlan( PLAN_PERSONAL ).getTitle() },
+							} ) }
 							description={ translate(
 								'Embed podcast episodes directly from your media library.'
 							) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/85007

## Proposed Changes

This is part of the plans-rename work. Follow up to https://github.com/Automattic/wp-calypso/pull/85007 to remove the `hasTranslation` calls used initially for the update strings.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow instructions in https://github.com/Automattic/wp-calypso/pull/85007 to confirm the translated strings render correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?