### PR TITLE
E2E: Fix atomic edge failures

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -106,11 +106,12 @@ export class EditorSettingsSidebarComponent {
 	 */
 	async clickTab( tabName: EditorSidebarTab ): Promise< void > {
 		const editorParent = await this.editor.parent();
+		const settingsPanel = editorParent.locator( panel );
 		// This is a temporary workaround for the fact that the tab button
 		// selectors changed in v17.3.0. The oldTabLocator can be removed once
 		// the new version is deployed to all environments.
-		const newTabLocator = editorParent.getByRole( 'tab', { name: tabName, exact: true } );
-		const oldTabLocator = editorParent.getByLabel( tabName );
+		const newTabLocator = settingsPanel.getByRole( 'tab', { name: tabName } ).first();
+		const oldTabLocator = settingsPanel.getByRole( 'button', { name: tabName } ).first();
 
 		await newTabLocator.or( oldTabLocator ).click();
 	}

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -99,15 +99,20 @@ export class EditorSettingsSidebarComponent {
 	}
 
 	/**
-	 * Clicks on one of the top tabs (e.g. 'Post' or 'Block') in the sidebar. Ensures that tab becomes active.
+	 * Clicks on one of the top tabs (e.g. 'Post' or 'Block') in the sidebar.
 	 *
 	 * @param {EditorSidebarTab} tabName Name of tab to click.
 	 * @returns {Promise<void>} No return value.
 	 */
 	async clickTab( tabName: EditorSidebarTab ): Promise< void > {
 		const editorParent = await this.editor.parent();
+		// This is a temporary workaround for the fact that the tab button
+		// selectors changed in v17.3.0. The oldTabLocator can be removed once
+		// the new version is deployed to all environments.
+		const newTabLocator = editorParent.getByRole( 'tab', { name: tabName, exact: true } );
+		const oldTabLocator = editorParent.getByLabel( tabName );
 
-		await editorParent.getByRole( 'tab', { name: tabName, exact: true } ).click();
+		await newTabLocator.or( oldTabLocator ).click();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -6,13 +6,6 @@ import type { ArticlePublishSchedule, EditorSidebarTab, ArticlePrivacyOptions } 
 const panel = '[aria-label="Editor settings"]';
 
 const selectors = {
-	// Tab
-	tabButton: ( tabName: EditorSidebarTab ) =>
-		`${ panel } button[role="tab"]:has-text("${ tabName }")`,
-	activeTabButton: ( tabName: EditorSidebarTab ) =>
-		`${ panel } button[aria-selected="true"][role="tab"]:has-text("${ tabName }")`,
-
-	// General section-related
 	section: ( name: string ) =>
 		`${ panel } .components-panel__body-title button:has-text("${ name }")`,
 	showRevisionButton: '.edit-post-last-revision__panel', // Revision is a link, not a panel.
@@ -113,11 +106,8 @@ export class EditorSettingsSidebarComponent {
 	 */
 	async clickTab( tabName: EditorSidebarTab ): Promise< void > {
 		const editorParent = await this.editor.parent();
-		const locator = editorParent.locator( selectors.tabButton( tabName ) );
-		await locator.click();
 
-		const activeTabLocator = editorParent.locator( selectors.activeTabButton( tabName ) );
-		await activeTabLocator.waitFor();
+		await editorParent.getByRole( 'tab', { name: tabName, exact: true } ).click();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -107,13 +107,8 @@ export class EditorSettingsSidebarComponent {
 	async clickTab( tabName: EditorSidebarTab ): Promise< void > {
 		const editorParent = await this.editor.parent();
 		const settingsPanel = editorParent.locator( panel );
-		// This is a temporary workaround for the fact that the tab button
-		// selectors changed in v17.3.0. The oldTabLocator can be removed once
-		// the new version is deployed to all environments.
-		const newTabLocator = settingsPanel.getByRole( 'tab', { name: tabName } ).first();
-		const oldTabLocator = settingsPanel.getByRole( 'button', { name: tabName } ).first();
 
-		await newTabLocator.or( oldTabLocator ).click();
+		await settingsPanel.getByRole( 'tab', { name: tabName } ).click();
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -15,7 +15,7 @@ const selectors = {
 	switchToDraftButton: `${ panel } button.editor-post-switch-to-draft`,
 
 	// Preview
-	previewButton: `${ panel } :text("Preview"):visible, [aria-label="View"]:visible`,
+	previewButton: `${ panel } :text("View"):visible, [aria-label="View"]:visible`,
 	desktopPreviewMenuItem: ( target: EditorPreviewOptions ) =>
 		`button[role="menuitem"] span:text("${ target }")`,
 	previewPane: `.edit-post-visual-editor`,


### PR DESCRIPTION
Related to p1703089653657809/1703080808.677289-slack-CBTN58FTJ 

## Proposed Changes

Fix Atomic Edge tests that failed after Gutenberg v17.3.0 upgrade.

## Testing Instructions

Atomic edge site tests should pass for both [mobile](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_gutenberg_atomic_edge_mobile?branch=fix%2Fe2e-atomic-edge-failures&buildTypeTab=overview&mode=builds) and [desktop](https://teamcity.a8c.com/buildConfiguration/calypso_WPComTests_gutenberg_atomic_edge_desktop?branch=fix%2Fe2e-atomic-edge-failures&buildTypeTab=overview&mode=builds) jobs.