### PR TITLE
Stats: Display upgrade price for tiers when users already have a paid tier

### DIFF
--- a/client/my-sites/stats/hooks/use-plan-usage-query.ts
+++ b/client/my-sites/stats/hooks/use-plan-usage-query.ts
@@ -1,5 +1,6 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
+import { PriceTierListItemProps } from '../stats-purchase/types';
 
 interface PeriodUsage {
 	current_start: string | null;
@@ -13,6 +14,7 @@ export interface PlanUsage {
 	recent_usages: Array< PeriodUsage >;
 	views_limit: number;
 	over_limit_months: number;
+	current_tier: PriceTierListItemProps;
 }
 
 function selectPlanUsage( payload: PlanUsage ): PlanUsage {

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -32,7 +32,7 @@ function useTranslatedStrings() {
 	};
 }
 
-function getStepsForTiers( tiers: StatsPlanTierUI[] ) {
+function getStepsForTiers( tiers: StatsPlanTierUI[], currencyCode: string ) {
 	// TODO: Review tier values from API.
 	// Should consider validating the inputs before displaying them.
 	return tiers.map( ( tier ) => {
@@ -52,10 +52,17 @@ function getStepsForTiers( tiers: StatsPlanTierUI[] ) {
 			views = formatNumber( tier.views );
 		}
 
+		const tierUpgradePricePerMonth = ( tier.upgrade_price || 0 ) / 12;
+
 		// Return the new step with string values.
 		return {
 			lhValue: views,
 			rhValue: price,
+			originalPrice: tier.price,
+			upgradePrice: formatCurrency( tierUpgradePricePerMonth, currencyCode, {
+				isSmallestUnit: true,
+				stripZeros: true,
+			} ),
 			tierViews: tier.views === null ? EXTENSION_THRESHOLD_IN_MILLION * 1000000 : tier.views,
 		};
 	} );
@@ -120,7 +127,7 @@ function StatsCommercialUpgradeSlider( {
 	}
 
 	// Transform the tiers into a format that the slider can use.
-	const steps = getStepsForTiers( tiers );
+	const steps = getStepsForTiers( tiers, currencyCode );
 
 	const handleSliderChanged = ( index: number ) => {
 		const quantity = getTierQuentity( tiers[ index ], true );

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -59,10 +59,12 @@ function getStepsForTiers( tiers: StatsPlanTierUI[], currencyCode: string ) {
 			lhValue: views,
 			rhValue: price,
 			originalPrice: tier.price,
-			upgradePrice: formatCurrency( tierUpgradePricePerMonth, currencyCode, {
-				isSmallestUnit: true,
-				stripZeros: true,
-			} ),
+			upgradePrice: tierUpgradePricePerMonth
+				? formatCurrency( tierUpgradePricePerMonth, currencyCode, {
+						isSmallestUnit: true,
+						stripZeros: true,
+				  } )
+				: '',
 			tierViews: tier.views === null ? EXTENSION_THRESHOLD_IN_MILLION * 1000000 : tier.views,
 		};
 	} );

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
@@ -12,7 +12,7 @@ type TierUIStrings = {
 interface TierStep {
 	lhValue: string;
 	rhValue: string;
-	fullPrice?: string;
+	upgradePrice?: string;
 }
 
 type TierUpgradeSliderProps = {
@@ -84,10 +84,10 @@ function TierUpgradeSlider( {
 	const infoReferenceElement = useRef( null );
 	const showPopup = currentPlanIndex === sliderMax && popupInfoString !== undefined;
 	const lhValue = steps[ currentPlanIndex ]?.lhValue;
-	const rhValue = steps[ currentPlanIndex ]?.rhValue;
-	const fullPrice = steps[ currentPlanIndex ]?.fullPrice || '';
+	const originalPrice = steps[ currentPlanIndex ]?.rhValue;
+	const discountedPrice = steps[ currentPlanIndex ]?.upgradePrice || '';
 
-	const secondaryCalloutIsHidden = rhValue === '';
+	const secondaryCalloutIsHidden = originalPrice === '';
 
 	return (
 		<div className={ componentClassNames }>
@@ -100,7 +100,7 @@ function TierUpgradeSlider( {
 					<div className="tier-upgrade-slider__step-callout right-aligned">
 						<h2>{ uiStrings.price }</h2>
 						<p ref={ infoReferenceElement }>
-							{ rhValue } <span className="full-price-label">{ fullPrice }</span>
+							{ discountedPrice } <span className="full-price-label">{ originalPrice }</span>
 						</p>
 					</div>
 				) }

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
@@ -85,7 +85,7 @@ function TierUpgradeSlider( {
 	const showPopup = currentPlanIndex === sliderMax && popupInfoString !== undefined;
 	const lhValue = steps[ currentPlanIndex ]?.lhValue;
 	const originalPrice = steps[ currentPlanIndex ]?.rhValue;
-	const discountedPrice = steps[ currentPlanIndex ]?.upgradePrice || '';
+	const discountedPrice = steps[ currentPlanIndex ]?.upgradePrice;
 
 	const secondaryCalloutIsHidden = originalPrice === '';
 
@@ -100,7 +100,14 @@ function TierUpgradeSlider( {
 					<div className="tier-upgrade-slider__step-callout right-aligned">
 						<h2>{ uiStrings.price }</h2>
 						<p ref={ infoReferenceElement }>
-							{ discountedPrice } <span className="full-price-label">{ originalPrice }</span>
+							{ discountedPrice ? (
+								<>
+									<span>{ discountedPrice }</span>
+									<span className="full-price-label">{ originalPrice }</span>
+								</>
+							) : (
+								<span>{ originalPrice }</span>
+							) }
 						</p>
 					</div>
 				) }

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
@@ -12,6 +12,7 @@ type TierUIStrings = {
 interface TierStep {
 	lhValue: string;
 	rhValue: string;
+	fullPrice?: string;
 }
 
 type TierUpgradeSliderProps = {
@@ -84,6 +85,8 @@ function TierUpgradeSlider( {
 	const showPopup = currentPlanIndex === sliderMax && popupInfoString !== undefined;
 	const lhValue = steps[ currentPlanIndex ]?.lhValue;
 	const rhValue = steps[ currentPlanIndex ]?.rhValue;
+	const fullPrice = steps[ currentPlanIndex ]?.fullPrice || '';
+
 	const secondaryCalloutIsHidden = rhValue === '';
 
 	return (
@@ -96,7 +99,9 @@ function TierUpgradeSlider( {
 				{ ! secondaryCalloutIsHidden && (
 					<div className="tier-upgrade-slider__step-callout right-aligned">
 						<h2>{ uiStrings.price }</h2>
-						<p ref={ infoReferenceElement }>{ rhValue }</p>
+						<p ref={ infoReferenceElement }>
+							{ rhValue } <span className="full-price-label">{ fullPrice }</span>
+						</p>
 					</div>
 				) }
 			</div>

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
@@ -116,6 +116,10 @@ $track-height: 4px;
 	.right-aligned {
 		text-align: right;
 	}
+	.full-price-label {
+		color: var(--studio-gray-40);
+		text-decoration: line-through;
+	}
 }
 
 .tier-upgrade-slider__extension-popover-wrapper {

--- a/client/my-sites/stats/stats-purchase/types.ts
+++ b/client/my-sites/stats/stats-purchase/types.ts
@@ -13,6 +13,7 @@ export type PriceTierListItemProps = {
 
 export type StatsPlanTierUI = {
 	minimum_price: number;
+	upgrade_price?: number;
 	price: string | undefined;
 	description?: string;
 	views: number | null;

--- a/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
+++ b/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
@@ -149,8 +149,13 @@ function useAvailableUpgradeTiers(
 		( tier: PriceTierListItemProps ): StatsPlanTierUI => {
 			// TODO: Some description of transform logic here.
 			// So as to clarify what we should expect from the API.
-			const tierUpgradePrice =
-				tier.minimum_price > currentTierPrice ? tier.minimum_price - currentTierPrice : 0;
+			let tierUpgradePrice = 0;
+
+			// If there is a purchased paid tier,
+			// the upgrade price is the difference between the current tier and the target tier.
+			if ( currentTierPrice && tier.minimum_price > currentTierPrice ) {
+				tierUpgradePrice = tier.minimum_price - currentTierPrice;
+			}
 
 			if ( tier?.maximum_units === null ) {
 				// Special transformation for highest tier extension.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85124.

## Proposed Changes

* Display the upgrade price of every tier compared to the current tier price.

<img width="587" alt="SCR-20231221-sicr" src="https://github.com/Automattic/wp-calypso/assets/40267301/d305aa56-d64d-4b21-8b4a-27c46f52ad89">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the latest Diff D129634-code and sandbox `public-api.wordpress.com` and `Store Sandbox`.
* Spin this change up on `local` Calypso.
* Create a new JN site and connect it to Jetpack.
* Navigate to the Commercial purchase page for the new JN site: `/stats/purchase/{site-slug}?productType=commercial`.
* Ensure the pricing slider works as previously when there is no purchased paid tier.
<img width="593" alt="截圖 2023-12-28 上午1 01 36" src="https://github.com/Automattic/wp-calypso/assets/6869813/99fc08e2-37cc-4695-8d70-70c5063ce1e3">

* Ensure the price of the `10K` tier is correct and then purchase it.
* Return to the purchase page and ensure the price of the `100K` tier is discounted to the difference between the `10K` tier and the `100K` tier.
<img width="596" alt="截圖 2023-12-28 上午1 03 09" src="https://github.com/Automattic/wp-calypso/assets/6869813/995390ba-4814-4aba-87d1-e452ac78def4">

* Ensure the `2M` tier is also applied with the correct upgrade price and then purchase it.
<img width="842" alt="截圖 2023-12-28 上午1 03 53" src="https://github.com/Automattic/wp-calypso/assets/6869813/65310f04-4300-4170-9d3f-e9a91151f70a">

* Return to the purchase page and ensure the price of the `3M` tier or higher tier is discounted to the difference between the `2M` tier and the corresponding tier, which is the monthly price of each `1M` views cost.
<img width="587" alt="截圖 2023-12-28 上午1 05 20" src="https://github.com/Automattic/wp-calypso/assets/6869813/857ed315-ee8d-4b48-a45b-834efc5a03f6">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?