### PR TITLE
Tools/import: Show proper message when file type is a playground

### DIFF
--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -76,7 +76,7 @@ export class UploadingPane extends PureComponent {
 					break;
 				case 'playground':
 				case 'jetpack_backup':
-					this.props.startImporting( importerStatus );
+					// The startImporting action is dispatched from the onboarding flow
 					break;
 			}
 		}

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -133,8 +133,8 @@ export class UploadingPane extends PureComponent {
 						<div className="importer-upload-warning">
 							<p>
 								{ this.props.translate(
-									'You seem to have uploaded a Playground file.{{br/}}' +
-										'Please go {{a}}here{{/a}} to try the import again.',
+									'Playground imports are not yet available through this form.{{br/}}' +
+										'Please head over to {{a}}this page{{/a}} to resume the import process.',
 									{
 										components: {
 											br: <br />,

--- a/client/my-sites/importer/uploading-pane.jsx
+++ b/client/my-sites/importer/uploading-pane.jsx
@@ -83,7 +83,7 @@ export class UploadingPane extends PureComponent {
 	}
 
 	getMessage = () => {
-		const { importerState } = this.props.importerStatus;
+		const { importerState, importerFileType } = this.props.importerStatus;
 		const { filename, percentComplete = 0 } = this.props;
 
 		switch ( importerState ) {
@@ -128,6 +128,28 @@ export class UploadingPane extends PureComponent {
 				);
 			}
 			case appStates.UPLOAD_SUCCESS:
+				if ( importerFileType === 'playground' ) {
+					return (
+						<div className="importer-upload-warning">
+							<p>
+								{ this.props.translate(
+									'You seem to have uploaded a Playground file.{{br/}}' +
+										'Please go {{a}}here{{/a}} to try the import again.',
+									{
+										components: {
+											br: <br />,
+											a: (
+												<a
+													href={ `/setup/import-focused/importerWordpress?siteSlug=${ this.props.site.slug }&option=content` }
+												/>
+											),
+										},
+									}
+								) }{ ' ' }
+							</p>
+						</div>
+					);
+				}
 				return (
 					<div>
 						<p>{ this.props.translate( 'Success! File uploaded.' ) }</p>

--- a/client/my-sites/importer/uploading-pane.scss
+++ b/client/my-sites/importer/uploading-pane.scss
@@ -58,6 +58,10 @@
 	&.importer-upload-failure {
 		color: var(--color-error);
 	}
+
+	.importer-upload-warning {
+		color: var(--color-warning);
+	}
 }
 
 .importer__upload-progress {

--- a/client/my-sites/importer/uploading-pane.scss
+++ b/client/my-sites/importer/uploading-pane.scss
@@ -60,7 +60,12 @@
 	}
 
 	.importer-upload-warning {
-		color: var(--color-warning);
+		color: var(--studio-gray-90);
+
+		a {
+			color: inherit;
+			text-decoration: underline;
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/85635

## Proposed Changes

* Fixed the issue with the `startImporting` process being triggered twice.
* Shown message when the file type is `playground` with a link redirecting to the onboarding flow, starting the import process immediately

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/import/{SITE_SLUG}`
* Choose the WordPress
* Click on `upload it to import content`
* Upload a playground file
* Check if there is a warning message
* Click on the `here` link
* Check if it redirects to the onboarding flow
* Check if the import process starts

![Screen Capture on 2023-12-21 at 14-08-44](https://github.com/Automattic/wp-calypso/assets/1241413/ca8b189d-26e4-4c63-b9bd-10083cdbf75d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?