### PR TITLE
Update a plan required message for Blogger plan users

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -1,4 +1,4 @@
-import { PLAN_100_YEARS } from '@automattic/calypso-products';
+import { PLAN_100_YEARS, PLAN_PERSONAL, getPlan } from '@automattic/calypso-products';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -48,7 +48,9 @@ class DomainProductPrice extends Component {
 				}
 				break;
 			case 'UPGRADE_TO_HIGHER_PLAN_TO_BUY':
-				message = translate( 'Personal plan required' );
+				message = translate( '%(planName)s plan required', {
+					args: { planName: getPlan( PLAN_PERSONAL )?.getTitle() ?? '' },
+				} );
 				break;
 		}
 


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Users on the Blogger plan can only use .blog domain and are required to switch to Starter/Personal for buying a .com domain.

## Testing Instructions

* Use Store Admin to add yourself a Blogger plan on an otherwise Free site
* Go to domains and search for a domain
* You should see Starter plan required

Before and After screenshots:

Before:
<img width="1003" alt="Screenshot 2023-12-21 at 15 50 32" src="https://github.com/Automattic/wp-calypso/assets/82778/98d39dc0-f60c-4fe7-882a-9a67f33814b8">

After:
<img width="997" alt="Screenshot 2023-12-21 at 15 56 25" src="https://github.com/Automattic/wp-calypso/assets/82778/ec013124-e32b-4d9e-88a5-7c63d6ee439e">
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
