### PR TITLE
Support showing a carousel of cards in My Home secondary area

### DIFF
--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -1,4 +1,5 @@
 import { createElement } from 'react';
+import DotPager from 'calypso/components/dot-pager';
 import {
 	SECTION_BLOGGING_PROMPT,
 	SECTION_BLOGANUARY_BLOGGING_PROMPT,
@@ -30,6 +31,16 @@ const getAdditionalPropsForCard = ( { card, siteId } ) => {
 	return additionalProps;
 };
 
+const SecondaryCard = ( { card, siteId } ) => {
+	if ( CARD_COMPONENTS[ card ] ) {
+		return createElement( CARD_COMPONENTS[ card ], {
+			...getAdditionalPropsForCard( { card, siteId } ),
+		} );
+	}
+
+	return null;
+};
+
 const Secondary = ( { cards, siteId } ) => {
 	if ( ! cards || ! cards.length ) {
 		return null;
@@ -37,14 +48,36 @@ const Secondary = ( { cards, siteId } ) => {
 
 	return (
 		<>
-			{ cards.map(
-				( card, index ) =>
-					CARD_COMPONENTS[ card ] &&
-					createElement( CARD_COMPONENTS[ card ], {
-						key: card + index,
-						...getAdditionalPropsForCard( { card, siteId } ),
-					} )
-			) }
+			{ cards.map( ( card, index ) => {
+				if ( Array.isArray( card ) ) {
+					return (
+						<DotPager
+							key={ 'my_home_secondary_pager_' + index }
+							className="secondary__customer-home-location-content"
+							showControlLabels="true"
+							hasDynamicHeight
+						>
+							{ card.map( ( innerCard, innerIndex ) => {
+								return (
+									<SecondaryCard
+										key={ 'my_home_secondary_pager_' + index + '_' + card + '_' + innerIndex }
+										card={ innerCard }
+										siteId={ siteId }
+									/>
+								);
+							} ) }
+						</DotPager>
+					);
+				}
+
+				return (
+					<SecondaryCard
+						key={ 'my_home_secondary_' + card + '_' + index }
+						card={ card }
+						siteId={ siteId }
+					/>
+				);
+			} ) }
 		</>
 	);
 };

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -242,7 +242,8 @@ body.is-section-home.theme-default.color-scheme {
 	}
 }
 
-.primary__customer-home-location-content {
+.primary__customer-home-location-content,
+.secondary__customer-home-location-content {
 	display: flex;
 	flex-direction: column;
 	padding: 0;
@@ -268,66 +269,66 @@ body.is-section-home.theme-default.color-scheme {
 	@include breakpoint-deprecated( ">660px" ) {
 		box-shadow: 0 0 0 1px var(--color-border-subtle);
 	}
-}
 
-.primary__customer-home-location-content .dot-pager__controls {
-	// The bottom margin is handled by the card
-	margin: 32px 32px 0;
-}
-
-.primary__customer-home-location-content .task {
-	box-shadow: none;
-
-	.task__text,
-	.task__illustration {
-		padding-top: 0;
-		padding-bottom: 0;
+	.dot-pager__controls {
+		// The bottom margin is handled by the card
+		margin: 32px 32px 0;
 	}
 
-	// Flush against the left and right
-	& > :first-child {
-		padding-left: 0;
-		margin-left: 0;
-	}
+	.task {
+		box-shadow: none;
 
-	& > :last-child {
-		padding-right: 0;
-		margin-right: 0;
-	}
-
-	.task__illustration {
-		text-align: right;
-	}
-
-	// 32px spacing for everything except the space before the CTA (48px)
-	.task__text {
-		gap: 32px;
-
-		& > * {
-			margin-top: 0;
-			margin-bottom: 0;
+		.task__text,
+		.task__illustration {
+			padding-top: 0;
+			padding-bottom: 0;
 		}
 
-		.task__actions {
-			// The extra space before the Call to Action
-			margin-top: 16px;
+		// Flush against the left and right
+		& > :first-child {
+			padding-left: 0;
+			margin-left: 0;
+		}
+
+		& > :last-child {
+			padding-right: 0;
+			margin-right: 0;
+		}
+
+		.task__illustration {
+			text-align: right;
+		}
+
+		// 32px spacing for everything except the space before the CTA (48px)
+		.task__text {
+			gap: 32px;
+
+			& > * {
+				margin-top: 0;
+				margin-bottom: 0;
+			}
+
+			.task__actions {
+				// The extra space before the Call to Action
+				margin-top: 16px;
+			}
 		}
 	}
-}
 
-.primary__customer-home-location-content .card.site-setup-list {
-	// The checklist here goes flush against the top, bottom & right
-	margin: 0;
-	box-shadow: none;
-
-	.site-setup-list__task {
+	.card.site-setup-list {
+		// The checklist here goes flush against the top, bottom & right
 		margin: 0;
-		padding: 32px 8px 32px 32px;
+		box-shadow: none;
 
-		// When the list switches to a single-column
-		@include breakpoint-deprecated( "<960px" ) {
-			// Less space at the top because the nav-item contributes
-			padding: 16px 32px 32px;
+		.site-setup-list__task {
+			margin: 0;
+			padding: 32px 8px 32px 32px;
+
+			// When the list switches to a single-column
+			@include breakpoint-deprecated( "<960px" ) {
+				// Less space at the top because the nav-item contributes
+				padding: 16px 32px 32px;
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
 * https://github.com/Automattic/wp-calypso/pull/83828
 * D127655-code

## Proposed Changes

* This PR makes it possible for the secondary area in My Home to include a carousel of cards, much like the main location in Customer Home. This change builds on the work in https://github.com/Automattic/wp-calypso/pull/83828 so that we can render a two-column layout more effectively, though we need some improvements to our cards and some back end work before we can roll out this adjusted layout.

## Testing Instructions

There are two main cases that we need to address during the testing:
1. The current layouts should continue to render as-is without any changes.
2. With the layouts from D127655-code, we should shift any existing carousels from the primary hero location to the left column, but retain the carousel UX.

### Regression test

* Run this branch locally or via the Calypso.live branch
* Navigate to My Home for multiple sites, but especially those that are showing cards and a card carousel in My Home
* Verify that things render exactly as they did before

### Test new rendering

* Run this branch locally or via the Calypso.live branch
* Ensure that you are running against a server that has D127655-code applied and enabled -- see the change itself for instructions for how to enable the new behaviour
* Navigate to My Home for the same sites as above, and verify that we show a carousel in the left column for sites that were previously showing a carouse in the hero/banner area

#### Screen share of new layout

https://github.com/Automattic/wp-calypso/assets/3376401/c704fd82-e414-405b-b14f-c0ee10330889


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?