### PR TITLE
Show discounted price in Plans step is a coupon exists in the signup dependency

### DIFF
--- a/client/components/data/query-plans/index.jsx
+++ b/client/components/data/query-plans/index.jsx
@@ -2,12 +2,12 @@ import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { requestPlans } from 'calypso/state/plans/actions';
 
-export default function QueryPlans() {
+export default function QueryPlans( { coupon } ) {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
-		dispatch( requestPlans() );
-	}, [ dispatch ] );
+		dispatch( requestPlans( coupon ) );
+	}, [ dispatch, coupon ] );
 
 	return null;
 }

--- a/client/components/data/query-plans/index.jsx
+++ b/client/components/data/query-plans/index.jsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { requestPlans } from 'calypso/state/plans/actions';
 
-export default function QueryPlans( { coupon } ) {
+export default function QueryPlans( { coupon } = {} ) {
 	const dispatch = useDispatch();
 
 	useEffect( () => {

--- a/client/components/data/query-plans/index.tsx
+++ b/client/components/data/query-plans/index.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { requestPlans } from 'calypso/state/plans/actions';
 
-export default function QueryPlans( { coupon } = {} ) {
+const QueryPlans = ( { coupon }: { coupon?: string } ) => {
 	const dispatch = useDispatch();
 
 	useEffect( () => {
@@ -10,4 +10,6 @@ export default function QueryPlans( { coupon } = {} ) {
 	}, [ dispatch, coupon ] );
 
 	return null;
-}
+};
+
+export default QueryPlans;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -140,6 +140,7 @@ export interface PlansFeaturesMainProps {
 	withDiscount?: string;
 	discountEndDate?: Date;
 	hidePlansFeatureComparison?: boolean;
+	coupon?: string;
 
 	/**
 	 * @deprecated use intent mechanism instead
@@ -240,6 +241,7 @@ const PlansFeaturesMain = ( {
 	showPressablePromoBanner = false,
 	isSpotlightOnCurrentPlan,
 	renderSiblingWhenLoaded,
+	coupon,
 }: PlansFeaturesMainProps ) => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ lastClickedPlan, setLastClickedPlan ] = useState< string | null >( null );
@@ -719,7 +721,7 @@ const PlansFeaturesMain = ( {
 					'is-pricing-grid-2023-plans-features-main'
 				) }
 			>
-				<QueryPlans />
+				<QueryPlans coupon={ coupon } />
 				<QuerySites siteId={ siteId } />
 				<QuerySitePlans siteId={ siteId } />
 				<QueryActivePromotions />

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -272,6 +272,8 @@ export class PlansStep extends Component {
 	}
 
 	render() {
+		const { signupDependencies } = this.props;
+		const { coupon } = signupDependencies;
 		const classes = classNames( 'plans plans-step', {
 			'has-no-sidebar': true,
 			'is-wide-layout': false,
@@ -280,7 +282,7 @@ export class PlansStep extends Component {
 
 		return (
 			<>
-				<QueryPlans />
+				<QueryPlans coupon={ coupon } />
 				<MarketingMessage path="signup/plans" />
 				<div className={ classes }>{ this.plansFeaturesSelection() }</div>
 			</>

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -126,7 +126,7 @@ export class PlansStep extends Component {
 		}
 
 		const { signupDependencies } = this.props;
-		const { siteUrl, domainItem, siteTitle, username } = signupDependencies;
+		const { siteUrl, domainItem, siteTitle, username, coupon } = signupDependencies;
 		const paidDomainName = domainItem?.meta;
 		let freeWPComSubdomain;
 		if ( typeof siteUrl === 'string' && siteUrl.includes( '.wordpress.com' ) ) {
@@ -160,6 +160,7 @@ export class PlansStep extends Component {
 					showPressablePromoBanner={ this.props.showPressablePromoBanner }
 					removePaidDomain={ this.removePaidDomain }
 					setSiteUrlAsFreeDomainSuggestion={ this.setSiteUrlAsFreeDomainSuggestion }
+					coupon={ coupon }
 				/>
 			</div>
 		);

--- a/client/state/data-layer/wpcom/plans/index.js
+++ b/client/state/data-layer/wpcom/plans/index.js
@@ -23,6 +23,9 @@ export const requestPlans = ( action ) =>
 			apiVersion: '1.5',
 			method: 'GET',
 			path: '/plans',
+			query: {
+				coupon_code: action.coupon,
+			},
 		},
 		action
 	);

--- a/client/state/plans/actions.js
+++ b/client/state/plans/actions.js
@@ -45,6 +45,7 @@ export const plansRequestFailureAction = ( error ) => {
  * Action creator to request WordPress.com plans: REQUEST
  * @returns {Object} action object
  */
-export const requestPlans = () => ( {
+export const requestPlans = ( coupon ) => ( {
 	type: PLANS_REQUEST,
+	coupon,
 } );

--- a/client/state/plans/actions.js
+++ b/client/state/plans/actions.js
@@ -43,7 +43,7 @@ export const plansRequestFailureAction = ( error ) => {
 
 /**
  * Action creator to request WordPress.com plans: REQUEST
- * @returns {Object} action object
+ * @returns {import('redux').AnyAction} Action
  */
 export const requestPlans = ( coupon ) => ( {
 	type: PLANS_REQUEST,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Depends on D132873-code.

* In https://github.com/Automattic/wp-calypso/pull/85551, we introduced the ability to add a coupon as a signup dependency so that it can be auto-applied at checkout. In this PR, if a coupon exists in signup dependency, then we will show the plan price discounted by the percentage defined for that coupon.
* For example, say the coupon `ILOVEWORDPRESS` offers a 20% discount, then https://wordpress.com/start/?coupon=ILOVEWORDPRESS will show the plan price discounted by 20% in the plans step. 

<img width="1543" alt="Screenshot 2023-12-21 at 8 15 08 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/c0c44fc2-3aac-42ae-a484-43f678c5a604">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D132873-code and sandbox public-api.wordpress.com.
* Navigate to `/start/?coupon=NEWYEAR2024` and verify that in the plans step you see the plan price discounted by 25%, and the original full price is displayed crossed-out. Since this coupon applies only for annual plans, verify that you don't see the discounted in the monthly tab.
* Add storage add-on and verify that the discounted price is maintained.
* Proceed to checkout and verify that the discounted price with coupon matches what you saw in the plans step.

