### PR TITLE
Signup: Fix 2FA error text color

### DIFF
--- a/client/blocks/signup-form/style.scss
+++ b/client/blocks/signup-form/style.scss
@@ -152,7 +152,10 @@ body.is-section-accept-invite {
 				width: 327px;
 				margin-left: 0;
 				margin-right: 0;
-				color: var(--studio-gray-80, #2c3338);
+
+				&.is-transparent-info {
+					color: var(--studio-gray-80, #2c3338);
+				}
 			}
 
 			.auth-form__social {


### PR DESCRIPTION

## Issue

Visit /start and try to social signup with an account (I tried with google) linked to a wpcom account with 2FA enabled. You get an error:

![image](https://github.com/Automattic/wp-calypso/assets/52076348/716a40ff-566c-49bf-b079-7db358215208)

## Solution

![image](https://github.com/Automattic/wp-calypso/assets/52076348/d209a4ba-5779-4588-8e23-431430db57dd)


Fixes https://github.com/Automattic/wp-calypso/issues/85631