### PR TITLE
Login: Login footer fixed width

### DIFF
--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -502,7 +502,7 @@ $image-height: 47px;
 
 	.wp-login__main-footer {
 
-		width: var(--login-form-column-max-width);
+		max-width: var(--login-form-column-max-width);
 		margin: 0 auto;
 
 		.login__lost-password-link {


### PR DESCRIPTION
## Issue 

`Lost your password` is not centered when around 500px viewport.

![image](https://github.com/Automattic/wp-calypso/assets/52076348/5eb863e1-9f86-4b53-8d6c-55e6c30c6e80)

This PR centers it.

## Testing

1. Live link
2. Visit `/log-in`. Check it at 500px of width.