### PR TITLE
Checkout e2e: Switch to using locator.or for selectSavedCard

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -270,7 +270,7 @@ export class CartCheckoutPage {
 			.first();
 		const editPaymentButton = this.page.locator( selectors.editPaymentStep );
 
-		await cardSelector.or( editPaymentButton ).waitFor( { state: 'visible' } );
+		await cardSelector.or( editPaymentButton ).first().waitFor( { state: 'visible' } );
 
 		if ( await editPaymentButton.isVisible() ) {
 			await editPaymentButton.click();

--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -265,13 +265,18 @@ export class CartCheckoutPage {
 		// the "Edit" button on the payment method step. There are cases where
 		// the step will not be collapsed, however, so this will only trigger
 		// if the edit button is visible.
-		const selector = this.page.locator( selectors.existingCreditCard( cardHolderName ) ).first();
-		try {
-			await selector.click();
-		} catch ( error ) {
-			await this.page.click( selectors.editPaymentStep );
-			await selector.click();
+		const cardSelector = this.page
+			.locator( selectors.existingCreditCard( cardHolderName ) )
+			.first();
+		const editPaymentButton = this.page.locator( selectors.editPaymentStep );
+
+		await cardSelector.or( editPaymentButton ).waitFor( { state: 'visible' } );
+
+		if ( await editPaymentButton.isVisible() ) {
+			await editPaymentButton.click();
 		}
+
+		await cardSelector.click();
 	}
 
 	/**


### PR DESCRIPTION
## Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/85586 and https://github.com/Automattic/wp-calypso/pull/85590

In this diff we use @WunderBart's suggestion (https://github.com/Automattic/wp-calypso/pull/85590#discussion_r1433882739) to use `locator.or()` to replace a try/catch so that the test does not have to time-out before it can continue.

I had to make one adjustment to his suggestion but it appears to work. I'm not 100% confident that I'm using `locator.or().first().waitFor()` correctly, though.

## Testing Instructions

You can run the tests manually by following the instructions here: https://github.com/Automattic/wp-calypso/blob/e7e11899710f88a4ab1f059ca520b7e562bc037f/test/e2e/README.md

Specifically this part at the end (once everything is prepared):

```
yarn workspace wp-e2e-tests build
yarn workspace wp-e2e-tests test test/e2e/specs/plans/plans__signup-business.ts
```

Make sure that when the test reaches checkout, it clicks the Edit button on the payment method step and selects the payment method quickly.