### PR TITLE
Marketplace Reviews List: Add Infinite scrolling

### DIFF
--- a/client/data/marketplace/use-marketplace-reviews.ts
+++ b/client/data/marketplace/use-marketplace-reviews.ts
@@ -230,9 +230,6 @@ export const useMarketplaceReviewsQuery = (
 	} );
 };
 
-const extractPages = ( pages: MarketplaceReviewsQueryResponse[] = [] ) =>
-	pages.flatMap( ( page ) => page.data );
-
 export const useInfiniteMarketplaceReviewsQuery = (
 	{ productType, slug, page, perPage, author, author_exclude }: MarketplaceReviewsQueryProps,
 	{ enabled = true, staleTime = BASE_STALE_TIME }: MarketplaceReviewsQueryOptions = {}
@@ -250,7 +247,7 @@ export const useInfiniteMarketplaceReviewsQuery = (
 	const queryFn = ( { pageParam = 1 } ) =>
 		fetchMarketplaceReviews( productType, slug, pageParam, perPage, author, author_exclude );
 
-	return useInfiniteQuery( {
+	return useInfiniteQuery< MarketplaceReviewsQueryResponse >( {
 		queryKey,
 		queryFn,
 		getNextPageParam: ( lastPage, allPages ) => {
@@ -259,10 +256,6 @@ export const useInfiniteMarketplaceReviewsQuery = (
 			}
 			return allPages.length + 1;
 		},
-		select: ( data ) => ( {
-			...data,
-			reviews: extractPages( data.pages ),
-		} ),
 		enabled,
 		staleTime,
 	} );

--- a/client/my-sites/marketplace/components/reviews-list/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-list/index.tsx
@@ -2,12 +2,14 @@ import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { useSelector } from 'react-redux';
+import InfiniteScroll from 'calypso/components/infinite-scroll';
 import Rating from 'calypso/components/rating';
 import {
 	useMarketplaceReviewsQuery,
 	MarketplaceReviewResponse,
 	MarketplaceReviewsQueryProps,
 	useDeleteMarketplaceReviewMutation,
+	useInfiniteMarketplaceReviewsQuery,
 } from 'calypso/data/marketplace/use-marketplace-reviews';
 import './style.scss';
 import { getAvatarURL } from 'calypso/data/marketplace/utils';
@@ -18,10 +20,17 @@ export const MarketplaceReviewsList = ( props: MarketplaceReviewsQueryProps ) =>
 	const translate = useTranslate();
 	const currentUserId = useSelector( getCurrentUserId );
 	const {
-		data: reviews,
+		data,
 		refetch: reviewsRefetch,
+		fetchNextPage,
 		error,
-	} = useMarketplaceReviewsQuery( { ...props, author_exclude: currentUserId ?? undefined } );
+	} = useInfiniteMarketplaceReviewsQuery( {
+		...props,
+		author_exclude: currentUserId ?? undefined,
+	} );
+
+	const { reviews } = data ?? {};
+
 	const { data: userReviews = [] } = useMarketplaceReviewsQuery( {
 		...props,
 		perPage: 1,
@@ -128,6 +137,7 @@ export const MarketplaceReviewsList = ( props: MarketplaceReviewsQueryProps ) =>
 						</div>
 					</div>
 				) ) }
+				<InfiniteScroll nextPageMethod={ fetchNextPage } />
 			</div>
 		</div>
 	);

--- a/client/my-sites/marketplace/components/reviews-list/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-list/index.tsx
@@ -28,8 +28,7 @@ export const MarketplaceReviewsList = ( props: MarketplaceReviewsQueryProps ) =>
 		...props,
 		author_exclude: currentUserId ?? undefined,
 	} );
-
-	const { reviews } = data ?? {};
+	const reviews = data?.pages.flatMap( ( page ) => page.data );
 
 	const { data: userReviews = [] } = useMarketplaceReviewsQuery( {
 		...props,


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4841

## Proposed Changes

* Promisify the `fetchMarketplaceReviews` method using the callback structure of `wpcom.req.get` to get the headers
* Create the `useInfiniteMarketplaceReviewsQuery` method to allow infinite loading
* Use this created method on the list and call more queries when needed after scrolling

## Testing Instructions

* On this branch
* Go to a plugin details page with more than 10 reviews. Ex: `/plugins/woocommerce-bookings/`
* On the bottom, click on `Read all reviews`
* Scroll the list down and check if more results are being appended to the list until the end 
* Check if the right number of calls are being made. Ex: For 14 items, only 2 calls of max 10 results are being made.


[suggestion] To be easily visible, you can change the `client/my-sites/marketplace/components/reviews-list/index.tsx` on the line ~23 to have the property `perPage: 3`.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
