### PR TITLE
Earn: Fix wrong `Object.keys()` on a null

### DIFF
--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -94,7 +94,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 		product?.buyer_can_change_amount ?? false
 	);
 
-	const currencyList = Object.keys( connectedAccountMinimumCurrency );
+	const currencyList = Object.keys( connectedAccountMinimumCurrency ?? {} );
 
 	const defaultCurrency = useMemo( () => {
 		if ( product?.currency ) {


### PR DESCRIPTION
## Proposed Changes

As [reported in Sentry](https://sentry.io/organizations/a8c/issues/4743524541/?project=6313676), we're calling `Object.keys()` with a value that's potentially `null` by design, so let's fall back to an object in that case.