### PR TITLE
Jetpack Manage: 192 - add NextSteps component to Overview page

### DIFF
--- a/client/jetpack-cloud/sections/overview/primary/intro-cards/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/intro-cards/index.tsx
@@ -88,7 +88,6 @@ export default function IntroCards( { onFinish = () => {} } ) {
 			navArrowSize={ 24 }
 			tracksPrefix="calypso_jetpack_manage_overview_intro_cards"
 			tracksFn={ tracksFn }
-			includePreviousButton
 			includeNextButton
 			includeFinishButton
 			onFinish={ onFinish }

--- a/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
@@ -1,0 +1,78 @@
+import { CircularProgressBar } from '@automattic/components';
+import { Checklist, type Task } from '@automattic/launchpad';
+import { useTranslate } from 'i18n-calypso';
+
+import './style.scss';
+
+export default function NextSteps( { onDismiss = () => {} } ) {
+	const translate = useTranslate();
+
+	const tasks: Task[] = [
+		{
+			calypso_path: '',
+			completed: false,
+			disabled: false,
+			actionDispatch: () => {},
+			id: 'jpmanage-overview-next-steps-get-familiar',
+			title: 'Get familiar with the sites management dashboard',
+			useCalypsoPath: true,
+		},
+		{
+			calypso_path: '',
+			completed: false,
+			disabled: false,
+			actionDispatch: () => {},
+			id: 'jpmanage-overview-next-steps-add-sites',
+			title: 'Learn how to add new sites',
+			useCalypsoPath: true,
+		},
+		{
+			calypso_path: '',
+			completed: false,
+			disabled: false,
+			actionDispatch: () => {},
+			id: 'jpmanage-overview-next-steps-bulk-editing',
+			title: 'Learn bulk editing and enabling downtime monitoring',
+			useCalypsoPath: true,
+		},
+		{
+			calypso_path: '',
+			completed: false,
+			disabled: false,
+			actionDispatch: () => {},
+			id: 'jpmanage-overview-next-steps-plugin_management',
+			title: 'Explore plugin management',
+			useCalypsoPath: true,
+		},
+	];
+
+	const numberOfTasks = tasks.length;
+	const completedTasks = tasks.filter( ( task ) => task.completed ).length;
+
+	const isCompleted = completedTasks === numberOfTasks;
+
+	return (
+		<div className="next-steps">
+			<div className="next-steps__header">
+				<h2>{ isCompleted ? translate( '🎉 Congratulations!' ) : translate( 'Next Steps' ) }</h2>
+				<CircularProgressBar
+					size={ 32 }
+					enableDesktopScaling
+					numberOfSteps={ numberOfTasks }
+					currentStep={ completedTasks }
+				/>
+			</div>
+			{ isCompleted && (
+				<p>
+					{ translate(
+						"Right now there's nothing left for you to do. We'll let you know when anything needs your attention."
+					) }{ ' ' }
+					<button className="dismiss" onClick={ onDismiss }>
+						{ translate( 'Hide' ) }
+					</button>
+				</p>
+			) }
+			<Checklist tasks={ tasks } />
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
@@ -1,46 +1,59 @@
 import { CircularProgressBar } from '@automattic/components';
 import { Checklist, type Task } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
 import './style.scss';
 
 export default function NextSteps( { onDismiss = () => {} } ) {
+	const dispatch = useDispatch();
 	const translate = useTranslate();
+
+	const tracksPrefix = 'calypso_jetpack_manage_overview_next_steps';
 
 	const tasks: Task[] = [
 		{
 			calypso_path: '',
-			completed: false,
+			completed: true,
 			disabled: false,
-			actionDispatch: () => {},
-			id: 'jpmanage-overview-next-steps-get-familiar',
+			actionDispatch: () => {
+				dispatch( recordTracksEvent( tracksPrefix + '_get_familiar_click' ) );
+			},
+			id: 'get_familiar',
 			title: 'Get familiar with the sites management dashboard',
 			useCalypsoPath: true,
 		},
 		{
 			calypso_path: '',
-			completed: false,
+			completed: true,
 			disabled: false,
-			actionDispatch: () => {},
-			id: 'jpmanage-overview-next-steps-add-sites',
+			actionDispatch: () => {
+				dispatch( recordTracksEvent( tracksPrefix + '_add_sites_click' ) );
+			},
+			id: 'add_sites',
 			title: 'Learn how to add new sites',
 			useCalypsoPath: true,
 		},
 		{
 			calypso_path: '',
-			completed: false,
+			completed: true,
 			disabled: false,
-			actionDispatch: () => {},
-			id: 'jpmanage-overview-next-steps-bulk-editing',
+			actionDispatch: () => {
+				dispatch( recordTracksEvent( tracksPrefix + '_bulk_editing_click' ) );
+			},
+			id: 'bulk_editing',
 			title: 'Learn bulk editing and enabling downtime monitoring',
 			useCalypsoPath: true,
 		},
 		{
 			calypso_path: '',
-			completed: false,
+			completed: true,
 			disabled: false,
-			actionDispatch: () => {},
-			id: 'jpmanage-overview-next-steps-plugin_management',
+			actionDispatch: () => {
+				dispatch( recordTracksEvent( tracksPrefix + '_plugin_management_click' ) );
+			},
+			id: 'plugin_management',
 			title: 'Explore plugin management',
 			useCalypsoPath: true,
 		},
@@ -67,7 +80,13 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 					{ translate(
 						"Right now there's nothing left for you to do. We'll let you know when anything needs your attention."
 					) }{ ' ' }
-					<button className="dismiss" onClick={ onDismiss }>
+					<button
+						className="dismiss"
+						onClick={ () => {
+							dispatch( recordTracksEvent( tracksPrefix + '_dismiss_click' ) );
+							onDismiss();
+						} }
+					>
 						{ translate( 'Hide' ) }
 					</button>
 				</p>

--- a/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
@@ -15,7 +15,7 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 	const tasks: Task[] = [
 		{
 			calypso_path: '',
-			completed: true,
+			completed: false,
 			disabled: false,
 			actionDispatch: () => {
 				dispatch( recordTracksEvent( tracksPrefix + '_get_familiar_click' ) );
@@ -26,7 +26,7 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 		},
 		{
 			calypso_path: '',
-			completed: true,
+			completed: false,
 			disabled: false,
 			actionDispatch: () => {
 				dispatch( recordTracksEvent( tracksPrefix + '_add_sites_click' ) );
@@ -37,7 +37,7 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 		},
 		{
 			calypso_path: '',
-			completed: true,
+			completed: false,
 			disabled: false,
 			actionDispatch: () => {
 				dispatch( recordTracksEvent( tracksPrefix + '_bulk_editing_click' ) );
@@ -48,7 +48,7 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 		},
 		{
 			calypso_path: '',
-			completed: true,
+			completed: false,
 			disabled: false,
 			actionDispatch: () => {
 				dispatch( recordTracksEvent( tracksPrefix + '_plugin_management_click' ) );

--- a/client/jetpack-cloud/sections/overview/primary/next-steps/style.scss
+++ b/client/jetpack-cloud/sections/overview/primary/next-steps/style.scss
@@ -34,8 +34,13 @@
 		color: var(--studio-gray-80);
 	}
 
-	button {
+	button.dismiss {
+		cursor: pointer;
 		text-decoration: underline;
+
+		&:hover {
+			color: var(--studio-jetpack-green-50);
+		}
 	}
 
 	.checklist-item__task {

--- a/client/jetpack-cloud/sections/overview/primary/next-steps/style.scss
+++ b/client/jetpack-cloud/sections/overview/primary/next-steps/style.scss
@@ -46,6 +46,10 @@
 			color: var(--studio-gray-80);
 		}
 
+		&.completed .checklist-item__text {
+			text-decoration: line-through;
+		}
+
 		&.completed.enabled:hover,
 		&.pending:hover,
 		&.completed.enabled > a:focus,

--- a/client/jetpack-cloud/sections/overview/primary/next-steps/style.scss
+++ b/client/jetpack-cloud/sections/overview/primary/next-steps/style.scss
@@ -1,0 +1,68 @@
+.next-steps {
+
+	&__header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		margin-bottom: 16px;
+
+		h2 {
+			font-size: rem(16px);
+			font-weight: 500;
+			color: var(--studio-gray-100);
+		}
+		.circular__progress-bar {
+			margin-right: 8px;
+
+			.circular__progress-bar-text {
+				font-size: rem(10px);
+				font-weight: 500;
+				line-height: 20px;
+				color: var(--studio-gray-100);
+			}
+
+			.circular__progress-bar-fill-circle {
+				stroke: var(--studio-jetpack-green-50);
+			}
+		}
+	}
+
+	p,
+	button {
+		font-size: rem(14px);
+		font-weight: 400;
+		color: var(--studio-gray-80);
+	}
+
+	button {
+		text-decoration: underline;
+	}
+
+	.checklist-item__task {
+
+		.checklist-item__text {
+			font-size: rem(14px);
+			font-weight: 400;
+			color: var(--studio-gray-80);
+		}
+
+		&.completed.enabled:hover,
+		&.pending:hover,
+		&.completed.enabled > a:focus,
+		&.pending > a:focus {
+			.checklist-item__text {
+				color: var(--studio-jetpack-green-50);
+			}
+
+			.checklist-item__chevron,
+			.checklist-item__checkmark {
+				fill: var(--studio-jetpack-green-50);
+			}
+		}
+	}
+
+}
+
+.card:has(.next-steps) {
+	padding: 16px 24px;
+}

--- a/client/jetpack-cloud/sections/overview/primary/overview/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/overview/index.tsx
@@ -3,24 +3,38 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import IntroCards from '../intro-cards';
+import NextSteps from '../next-steps';
 
 import './style.scss';
 
 export default function Overview() {
 	const translate = useTranslate();
 
-	const [ hideIntroCards, setHideIntroCards ] = useState( () => {
-		const rawPref = localStorage.getItem( 'jetpack_manage_hide_intro_cards' ) ?? 'false';
+	const getPrefFromLocalStorage = ( key: string ): boolean => {
+		const rawPref = localStorage.getItem( key ) ?? 'false';
 		try {
 			return JSON.parse( rawPref );
 		} catch {
 			return false;
 		}
-	} );
+	};
 
-	const finishHandler = () => {
+	const [ hideIntroCards, setHideIntroCards ] = useState( () =>
+		getPrefFromLocalStorage( 'jetpack_manage_hide_intro_cards' )
+	);
+
+	const [ hideNextSteps, setHideNextSteps ] = useState( () =>
+		getPrefFromLocalStorage( 'jetpack_manage_hide_next_steps' )
+	);
+
+	const introCardFinishHandler = (): void => {
 		setHideIntroCards( true );
 		localStorage.setItem( 'jetpack_manage_hide_intro_cards', JSON.stringify( true ) );
+	};
+
+	const nextStepsDismissHandler = (): void => {
+		setHideNextSteps( true );
+		localStorage.setItem( 'jetpack_manage_hide_next_steps', JSON.stringify( true ) );
 	};
 
 	return (
@@ -28,7 +42,7 @@ export default function Overview() {
 			<DocumentHead title={ translate( 'Overview' ) } />
 			{ ! hideIntroCards && (
 				<Card>
-					<IntroCards onFinish={ finishHandler } />
+					<IntroCards onFinish={ introCardFinishHandler } />
 				</Card>
 			) }
 			{ /*<Card className="overview__steps">*/ }

--- a/client/jetpack-cloud/sections/overview/primary/overview/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/overview/index.tsx
@@ -45,9 +45,11 @@ export default function Overview() {
 					<IntroCards onFinish={ introCardFinishHandler } />
 				</Card>
 			) }
-			{ /*<Card className="overview__steps">*/ }
-			{ /*	/!*<OverviewSteps />*!/*/ }
-			{ /*</Card>*/ }
+			{ ! hideNextSteps && (
+				<Card className="hide-on-mobile">
+					<NextSteps onDismiss={ nextStepsDismissHandler } />
+				</Card>
+			) }
 			{ /*<Card className="overview__tools">*/ }
 			{ /*	/!*<OverviewTools />*!/*/ }
 			{ /*</Card>*/ }

--- a/client/jetpack-cloud/sections/overview/primary/overview/style.scss
+++ b/client/jetpack-cloud/sections/overview/primary/overview/style.scss
@@ -1,9 +1,17 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.overview > .card {
-	margin-bottom: 32px;
-	@include break-xlarge {
-		margin-bottom: 16px;
+.overview {
+	> .card {
+		margin-bottom: 32px;
+		@include break-xlarge {
+			margin-bottom: 16px;
+		}
+	}
+
+	@media ( max-width: 660px ) {
+		.hide-on-mobile {
+			display: none;
+		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves Automattic/jetpack-manage#192 - add NextSteps component to Overview page

## Proposed Changes

This introduces a `NextSteps` component for the Overview page. Of note:

* The four tasks are currently static; they will be connected to the tour triggers in #194.
* Upon completion, one receives the option to dismiss the card.
* The card should not show on mobile size screens (`<=600px`).
* Tracks will fire when clicking on each task or when dismissing the card (possible upon completion).

Originally I found the `Launchpad` component, but in the end it is tightly integrated with Calypso Blue and would require implementing a new set of listeners + API calls, so I dug a bit deeper and used the `Checklist` component it uses internally.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
One can manually update the `completed` booleans for each task and see the correct states. Tracks should fire when clicking on each task and when dismissing the dialog.

The hidden task can be brought back by clearing the key out of `localStorage`:

`delete localStorage.jetpack_manage_hide_next_steps;`

No tasks completed:
![image](https://github.com/Automattic/wp-calypso/assets/32492176/59365d10-7e4d-44ab-8a4c-341408b1c2a3)

Two tasks completed:
![image](https://github.com/Automattic/wp-calypso/assets/32492176/959e87ea-873f-4958-84a9-d8a370ac4436)

Fully completed:
![image](https://github.com/Automattic/wp-calypso/assets/32492176/92cfa6fb-ba8a-482e-bbcc-a0eb8e150be2)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
