### PR TITLE
Jetpack Manage: 188 - add mobile menu to overview page

### DIFF
--- a/client/jetpack-cloud/components/content-sidebar/index.tsx
+++ b/client/jetpack-cloud/components/content-sidebar/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Main from 'calypso/components/main';
+import SidebarNavigation from 'calypso/jetpack-cloud/sections/partner-portal/sidebar-navigation';
 
 import './style.scss';
 
@@ -10,11 +11,13 @@ type Props = {
 
 const ContentSidebar = ( { mainContent, rightSidebar }: Props ) => {
 	return (
-		// todo: We have to add here the header for the mobile menu
-		<Main wideLayout className="content-sidebar">
-			<div className="content-sidebar__main-content">{ mainContent }</div>
-			<aside className="content-sidebar__right-sidebar">{ rightSidebar }</aside>
-		</Main>
+		<>
+			<SidebarNavigation />
+			<Main wideLayout className="content-sidebar">
+				<div className="content-sidebar__main-content">{ mainContent }</div>
+				<aside className="content-sidebar__right-sidebar">{ rightSidebar }</aside>
+			</Main>
+		</>
 	);
 };
 

--- a/client/jetpack-cloud/components/content-sidebar/style.scss
+++ b/client/jetpack-cloud/components/content-sidebar/style.scss
@@ -2,6 +2,7 @@
 @import "@wordpress/base-styles/mixins";
 
 .content-sidebar {
+
 	&.main {
 		margin-top: 32px;
 	}
@@ -29,4 +30,8 @@
 			grid-column: 9 / span 4;
 		}
 	}
+}
+
+header.current-section {
+	padding: 0 16px;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves Automattic/jetpack-manage#188 - add mobile menu to overview page

## Proposed Changes

This adds a mobile menu to the `ContentSidebar` component, currently only used by the Overview page. It took a bit of digging but in the end, it's a pretty straight-forward addition (and even had a comment about adding it).

This is accomplished by adding the `SidebarNavigation`, and then adding a padding adjustment as done in other JP Manage pages.

## Testing Instructions

Verify the desktop view is unaffected:

![image](https://github.com/Automattic/wp-calypso/assets/32492176/d752aa33-b3e5-4f7b-a2b9-5c4c79b975c5)

Verify the mobile view (660px or less) shows the mobile menu:

![image](https://github.com/Automattic/wp-calypso/assets/32492176/efaeb118-9ec6-4c03-b272-35eea6dcb8e5)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
