### PR TITLE
Remove left padding on trial expired page, this caused the content to…

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/style.scss
@@ -6,6 +6,10 @@ body.is-section-plans.is-expired-ecommerce-trial-plan {
 		--color-surface-backdrop: var(--color-surface);
 	}
 
+	.layout__content {
+		padding-left: 0 !important;
+	}
+
 	.main.is-wide-layout {
 		@media ( max-width: $break-medium ) {
 			padding-left: 1.25rem;

--- a/client/my-sites/plans/trials/business-trial-expired/style.scss
+++ b/client/my-sites/plans/trials/business-trial-expired/style.scss
@@ -7,6 +7,10 @@ body.is-section-plans.is-expired-business-trial-plan {
 		--color-surface-backdrop: var(--color-surface);
 	}
 
+	.layout__content {
+		padding-left: 0 !important;
+	}
+
 	.main.is-wide-layout {
 		@media ( max-width: $break-medium ) {
 			padding-left: 1.25rem;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes
 https://github.com/Automattic/wp-calypso/pull/84651 introduce some styling changes for plans page which inadvertently affected the trial expired page alignment. It was adding some left padding that was not overwritten. This PR removes the padding on trial expired page 

* remove padding introduced

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `/plans/my-plan/trial-expired/siteSlug`
* Verify plans grid is centered

**Before**
![image](https://github.com/Automattic/wp-calypso/assets/47489215/f4510877-0736-4882-9f3b-c2e4872d52b9)

**After**
![image](https://github.com/Automattic/wp-calypso/assets/47489215/2cc00bad-b4f1-4b84-8d0c-cbe09f90c383)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?