### PR TITLE
Paid stats: improve upsell modal responsive design

### DIFF
--- a/client/my-sites/stats/stats-upsell-modal/style.scss
+++ b/client/my-sites/stats/stats-upsell-modal/style.scss
@@ -3,6 +3,12 @@
 @import "@wordpress/base-styles/mixins";
 
 .stats-upsell-modal {
+	max-width: 375px;
+	margin: auto;
+	background: var(--studio-gray-0);
+	@include break-medium {
+		max-width: calc(100% - 32px);
+	}
 	.components-modal__content {
 		padding: 0;
 	}
@@ -16,6 +22,11 @@
 	.stats-upsell-modal__content {
 		display: flex;
 		align-items: flex-start;
+
+		flex-direction: column;
+		@include break-medium {
+			flex-direction: row;
+		}
 	}
 	.stats-upsell-modal__left,
 	.stats-upsell-modal__right {
@@ -24,30 +35,35 @@
 		flex-direction: column;
 		align-self: stretch;
 		align-items: flex-start;
+
+		min-width: 279px;
 	}
 
 	.stats-upsell-modal__left {
+		background: var(--studio-white);
 		gap: 24px;
-		width: 294px;
+		@include break-medium {
+			width: 294px;
+		}
 	}
 
 	.stats-upsell-modal__right {
-		display: none;
-		width: 0;
+
 		gap: 8px;
-
-		background: var(--studio-gray-0);
-
 		@include break-medium {
-			display: flex;
 			width: 245px;
 		}
 	}
 
 	.stats-upsell-modal__title {
 		@extend .wp-brand-font;
-		font-size: $font-title-large;
-		line-height: 40px; /* 125% */
+		/* stylelint-disable declaration-property-unit-allowed-list -- typography-exception */
+		font-size: 28px;
+		line-height: 34px; /* 125% */
+		@include break-medium {
+			font-size: $font-title-large;
+			line-height: 40px; /* 125% */
+		}
 	}
 
 	.stats-upsell-modal__text {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5008

## Proposed Changes

* Improves upsell modal design for mobile / small screens
* Implements suggestions from https://github.com/Automattic/wp-calypso/pull/85457#issuecomment-1866087718

## Testing Instructions

- Visit the calypso live link, append the query param to the url enable the paywall gating for the session: e.g. https://container-nifty-newton.calypso.live/?flags=stats/paid-wpcom-v2  
```
?flags=stats/paid-wpcom-v2
```
- Click on a stats specific upgrade button under /stats
- Check mobile design

After:

![Screenshot 2023-12-22 at 14-05-38 Jetpack Stats ‹ thetestblog a test — WordPress com](https://github.com/Automattic/wp-calypso/assets/811776/e12f0090-aa42-4872-8175-90644c848e86)

