### PR TITLE
Jetpack Manage: Remove hardcoded plan names from the Host column

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/use-wp-plan-name.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/use-wp-plan-name.ts
@@ -1,27 +1,21 @@
-import {
-	PLAN_BUSINESS,
-	PLAN_ECOMMERCE,
-	PLAN_PREMIUM,
-	PLAN_PERSONAL,
-} from '@automattic/calypso-products';
+import { planMatches, GROUP_WPCOM } from '@automattic/calypso-products';
 import { getPlan } from '@automattic/calypso-products/src';
 
 /**
  * Custom hook to get the name of a WordPress.com plan.
  *
- * This hook iterates over an array of plan slugs and returns the name of the first plan that matches one of the WordPress.com plans.
- * The matching is done by checking if the plan slug starts with the slug of a WordPress.com plan.
+ * This hook iterates over an array of plan slugs. If a slug matches a WordPress.com plan,
+ * it returns the name of that plan. The matching is done using the `planMatches` function,
+ * which checks if the plan belongs to the WordPress.com group.
  * @param {Array<string>} plans - An array of plan slugs.
  * @returns {string} The name of the first matching WordPress.com plan, or an empty string if no matching plan is found.
  */
-const PLANS = [ PLAN_BUSINESS, PLAN_ECOMMERCE, PLAN_PREMIUM, PLAN_PERSONAL ];
-
 const useWPPlanName = ( plans: Array< string > ) => {
 	const getPlanName = () => {
 		for ( const plan of plans ) {
-			const matchingPlan = PLANS.find( ( planConstant ) => plan.startsWith( planConstant ) );
-			if ( matchingPlan ) {
-				return getPlan( matchingPlan )?.getTitle();
+			const isWPCOMPlan = planMatches( plan, { group: GROUP_WPCOM } );
+			if ( isWPCOMPlan ) {
+				return getPlan( plan )?.getTitle();
 			}
 		}
 		return '';

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/use-wp-plan-name.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/use-wp-plan-name.ts
@@ -4,26 +4,16 @@ import {
 	PLAN_PREMIUM,
 	PLAN_PERSONAL,
 } from '@automattic/calypso-products';
-import { useTranslate } from 'i18n-calypso';
+import { getPlan } from '@automattic/calypso-products/src';
+
+const PLANS = [ PLAN_BUSINESS, PLAN_ECOMMERCE, PLAN_PREMIUM, PLAN_PERSONAL ];
 
 const useWPPlanName = ( plans: Array< string > ) => {
-	const translate = useTranslate();
-
 	const getPlanName = () => {
 		for ( const plan of plans ) {
-			switch ( true ) {
-				// Plans could be either monthly, 1 year, 2 years, or 3 years.
-				// So we need to check if the plan starts with the plan slug.
-				case plan.startsWith( PLAN_BUSINESS ):
-					return translate( 'WordPress.com Business Plan' );
-				case plan.startsWith( PLAN_ECOMMERCE ):
-					return translate( 'WordPress.com Commerce Plan' );
-				case plan.startsWith( PLAN_PREMIUM ):
-					return translate( 'WordPress.com Premium Plan' );
-				case plan.startsWith( PLAN_PERSONAL ):
-					return translate( 'WordPress.com Personal Plan' );
-				default:
-					return '';
+			const matchingPlan = PLANS.find( ( planConstant ) => plan.startsWith( planConstant ) );
+			if ( matchingPlan ) {
+				return getPlan( matchingPlan )?.getTitle();
 			}
 		}
 		return '';

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/use-wp-plan-name.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/use-wp-plan-name.ts
@@ -11,17 +11,11 @@ import { getPlan } from '@automattic/calypso-products/src';
  * @returns {string} The name of the first matching WordPress.com plan, or an empty string if no matching plan is found.
  */
 const useWPPlanName = ( plans: Array< string > ) => {
-	const getPlanName = () => {
-		for ( const plan of plans ) {
-			const isWPCOMPlan = planMatches( plan, { group: GROUP_WPCOM } );
-			if ( isWPCOMPlan ) {
-				return getPlan( plan )?.getTitle();
-			}
-		}
+	const wpcomPlan = plans.find( ( plan ) => planMatches( plan, { group: GROUP_WPCOM } ) );
+	if ( ! wpcomPlan ) {
 		return '';
-	};
-
-	return getPlanName();
+	}
+	return getPlan( wpcomPlan )?.getTitle();
 };
 
 export default useWPPlanName;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/use-wp-plan-name.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/hooks/use-wp-plan-name.ts
@@ -6,6 +6,14 @@ import {
 } from '@automattic/calypso-products';
 import { getPlan } from '@automattic/calypso-products/src';
 
+/**
+ * Custom hook to get the name of a WordPress.com plan.
+ *
+ * This hook iterates over an array of plan slugs and returns the name of the first plan that matches one of the WordPress.com plans.
+ * The matching is done by checking if the plan slug starts with the slug of a WordPress.com plan.
+ * @param {Array<string>} plans - An array of plan slugs.
+ * @returns {string} The name of the first matching WordPress.com plan, or an empty string if no matching plan is found.
+ */
 const PLANS = [ PLAN_BUSINESS, PLAN_ECOMMERCE, PLAN_PREMIUM, PLAN_PERSONAL ];
 
 const useWPPlanName = ( plans: Array< string > ) => {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-wp-plan-name.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-wp-plan-name.ts
@@ -2,20 +2,17 @@ import { planMatches, GROUP_WPCOM } from '@automattic/calypso-products';
 import { getPlan } from '@automattic/calypso-products/src';
 
 /**
- * Custom hook to get the name of a WordPress.com plan.
+ * Function to get the name of a WordPress.com plan.
  *
- * This hook iterates over an array of plan slugs. If a slug matches a WordPress.com plan,
+ * This function iterates over an array of plan slugs. If a slug matches a WordPress.com plan,
  * it returns the name of that plan. The matching is done using the `planMatches` function,
  * which checks if the plan belongs to the WordPress.com group.
  * @param {Array<string>} plans - An array of plan slugs.
  * @returns {string} The name of the first matching WordPress.com plan, or an empty string if no matching plan is found.
  */
-const useWPPlanName = ( plans: Array< string > ) => {
+const getWPPlanName = ( plans: Array< string > ) => {
 	const wpcomPlan = plans.find( ( plan ) => planMatches( plan, { group: GROUP_WPCOM } ) );
-	if ( ! wpcomPlan ) {
-		return '';
-	}
-	return getPlan( wpcomPlan )?.getTitle();
+	return wpcomPlan ? getPlan( wpcomPlan )?.getTitle() : '';
 };
 
-export default useWPPlanName;
+export default getWPPlanName;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-wpcom-plan-name.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/lib/get-wpcom-plan-name.ts
@@ -10,9 +10,9 @@ import { getPlan } from '@automattic/calypso-products/src';
  * @param {Array<string>} plans - An array of plan slugs.
  * @returns {string} The name of the first matching WordPress.com plan, or an empty string if no matching plan is found.
  */
-const getWPPlanName = ( plans: Array< string > ) => {
+const getWPCOMPlanName = ( plans: Array< string > ) => {
 	const wpcomPlan = plans.find( ( plan ) => planMatches( plan, { group: GROUP_WPCOM } ) );
 	return wpcomPlan ? getPlan( wpcomPlan )?.getTitle() : '';
 };
 
-export default getWPPlanName;
+export default getWPCOMPlanName;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-host-info.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-host-info.tsx
@@ -3,7 +3,7 @@ import { WordPressLogo, Tooltip } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
-import getWPPlanName from './lib/get-wp-plan-name';
+import getWPCOMPlanName from './lib/get-wpcom-plan-name';
 import type { Site } from '../types';
 
 export const SiteHostInfo = ( {
@@ -25,7 +25,7 @@ export const SiteHostInfo = ( {
 
 	const isWPCOMAtomicSite = site.is_atomic;
 
-	const planName = getWPPlanName( site.active_paid_subscription_slugs ?? [] );
+	const planName = getWPCOMPlanName( site.active_paid_subscription_slugs ?? [] );
 
 	const props = {
 		className: 'site-host-info',

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-host-info.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-host-info.tsx
@@ -3,7 +3,7 @@ import { WordPressLogo, Tooltip } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
-import useWPPlanName from './hooks/use-wp-plan-name';
+import getWPPlanName from './lib/get-wp-plan-name';
 import type { Site } from '../types';
 
 export const SiteHostInfo = ( {
@@ -25,7 +25,7 @@ export const SiteHostInfo = ( {
 
 	const isWPCOMAtomicSite = site.is_atomic;
 
-	const planName = useWPPlanName( site.active_paid_subscription_slugs ?? [] );
+	const planName = getWPPlanName( site.active_paid_subscription_slugs ?? [] );
 
 	const props = {
 		className: 'site-host-info',


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-manage/issues/195

## Proposed Changes

This PR removes hardcoded plan names from the Host column.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Visit the Dashboard
2. Hover over the Host column & verify that the plan name is displayed for the WP.com sites. You can create new sites by clicking on the dropdown next to `Add new site` > `Create a new WordPress.com site`.

<img width="157" alt="Screenshot 2023-12-22 at 8 43 54 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/60fe7e5f-13e5-4825-b3e1-9b047ace0964">

<img width="173" alt="Screenshot 2023-12-22 at 8 43 57 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/71fd436d-e95b-4b24-94e3-e436c4c6380e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?