### PR TITLE
Assembler AI: Save site settings wpcom_ai_site_prompt

### DIFF
--- a/client/landing/stepper/declarative-flow/ai-assembler.ts
+++ b/client/landing/stepper/declarative-flow/ai-assembler.ts
@@ -171,6 +171,12 @@ const withAIAssemblerFlow: Flow = {
 				}
 
 				case 'site-prompt': {
+					if ( providedDependencies?.aiSitePrompt ) {
+						await saveSiteSettings( siteId, {
+							wpcom_ai_site_prompt: providedDependencies.aiSitePrompt,
+						} );
+					}
+
 					return navigate( 'patternAssembler' );
 				}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
@@ -52,7 +52,7 @@ const AISitePrompt: Step = function ( props ) {
 	const onSubmit = async ( event: FormEvent ) => {
 		event.preventDefault();
 		callAIAssembler()
-			?.then( () => submit?.() )
+			?.then( () => submit?.( { aiSitePrompt: prompt } ) )
 			?.catch( () => goNext?.() );
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84839

## Proposed Changes

This PR saves the site settings `wpcom_ai_site_prompt` when users submit their input in the AI prompt screen. In the future, we might want to save the input in either ONBOARD_STORE or SITE_STORE, but that's not needed at the moment since we are not using that value anywhere else yet.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/setup/ai-assembler`.
* Continue until landing on the AI prompt screen.
* Enter any prompt.
* Then head to `https://${ site_domain }/wp-admin/options.php`.
* Ensure that the site option `wpcom_ai_site_prompt` exists, and that it contains the user prompt.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?