### PR TITLE
Paid stats: use new upsell modal for download csv

### DIFF
--- a/client/my-sites/stats/stats-download-csv-upsell/index.tsx
+++ b/client/my-sites/stats/stats-download-csv-upsell/index.tsx
@@ -1,46 +1,45 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { isEnabled } from '@automattic/calypso-config';
-import page from '@automattic/calypso-router';
 import { Button, Gridicon } from '@automattic/components';
+import { useState } from '@wordpress/element';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { STATS_FEATURE_DOWNLOAD_CSV } from '../constants';
+import StatsUpsellModal from '../stats-upsell-modal';
 
 interface Props {
 	className: string;
-	statType: string;
-	siteId: number;
+	siteSlug: string;
 	borderless: boolean;
 }
 
-const StatsDownloadCsvUpsell: React.FC< Props > = ( {
-	className,
-	statType,
-	siteId,
-	borderless,
-} ) => {
+const StatsDownloadCsvUpsell: React.FC< Props > = ( { className, siteSlug, borderless } ) => {
 	const translate = useTranslate();
+	const [ isModalOpen, setOpen ] = useState( false );
+	const openModal = () => setOpen( true );
+	const closeModal = () => setOpen( false );
 
 	const onClick = ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => {
 		event.preventDefault();
-
-		const source = isEnabled( 'is_running_in_jetpack_site' ) ? 'jetpack' : 'calypso';
-		recordTracksEvent( 'jetpack_stats_csv_upsell_clicked', {
-			statType,
-			source,
-		} );
-
-		page( `/stats/purchase/${ siteId }?productType=personal&from=${ source }` );
+		openModal();
 	};
 
 	return (
-		<Button
-			className={ classNames( className, 'stats-download-csv-upsell', 'stats-download-csv' ) }
-			compact
-			borderless={ borderless }
-			onClick={ onClick }
-		>
-			<Gridicon icon="cloud-download" /> { translate( 'Upgrade & Download to CSV' ) }
-		</Button>
+		<>
+			<Button
+				className={ classNames( className, 'stats-download-csv-upsell', 'stats-download-csv' ) }
+				compact
+				borderless={ borderless }
+				onClick={ onClick }
+			>
+				<Gridicon icon="cloud-download" /> { translate( 'Upgrade & Download to CSV' ) }
+			</Button>
+			{ isModalOpen && (
+				<StatsUpsellModal
+					closeModal={ closeModal }
+					statType={ STATS_FEATURE_DOWNLOAD_CSV }
+					siteSlug={ siteSlug }
+				/>
+			) }
+		</>
 	);
 };
 

--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -204,7 +204,7 @@ class StatsModule extends Component {
 				{ isAllTime && (
 					<div className={ footerClass }>
 						{ gateDownloads ? (
-							<DownloadCsvUpsell statType={ statType } siteId={ siteId } borderless />
+							<DownloadCsvUpsell siteSlug={ siteSlug } borderless />
 						) : (
 							<DownloadCsv
 								statType={ statType }

--- a/client/my-sites/stats/stats-upsell-modal/index.tsx
+++ b/client/my-sites/stats/stats-upsell-modal/index.tsx
@@ -27,7 +27,7 @@ export default function StatsUpsellModal( {
 	const planMonthly = useSelector( ( state ) => getPlanBySlug( state, PLAN_PREMIUM_MONTHLY ) );
 	const planName = plan?.product_name_short ?? '';
 	const isLoading = ! plan || ! planMonthly;
-	const eventPrefix = isEnabled( 'is_running_in_jetpack_site' ) ? 'jetpack' : 'calypso';
+	const eventPrefix = isEnabled( 'is_running_in_jetpack_site' ) ? 'jetpack_odyssey' : 'calypso';
 
 	const onClick = ( event: React.MouseEvent< HTMLButtonElement, MouseEvent > ) => {
 		event.preventDefault();


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4915

## Proposed Changes

* Replaces PWYW flow for new upsell modal for download to csv feature
* Fixes tracks event for the upsell modal on normal stats cards

## Testing Instructions

- Visit the calypso live link, append the query param to the url enable the paywall gating for the session: e.g. https://container-nifty-newton.calypso.live/?flags=stats/paid-wpcom-v2  
```
?flags=stats/paid-wpcom-v2
```
- Click on a stats "View Details" link
- Click on "Upgrade & Download to CSV"
- You should see the new modal instead of being taken to the PWYW screen.
