### PR TITLE
Replace redirect with page call

### DIFF
--- a/client/my-sites/stats/stats-upsell-modal/index.tsx
+++ b/client/my-sites/stats/stats-upsell-modal/index.tsx
@@ -36,7 +36,7 @@ export default function StatsUpsellModal( {
 			stat_type: statType,
 		} );
 
-		page.redirect( `/checkout/${ siteSlug }/${ plan?.path_slug ?? 'premium' }` );
+		page( `/checkout/${ siteSlug }/${ plan?.path_slug ?? 'premium' }` );
 	};
 
 	return (


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5012
Related to https://github.com/Automattic/wp-calypso/pull/85457

## Proposed Changes

* Fixes an issue where if you enter the checkout through the upsell and hit the back button you're not taken to the screen you were on but the previous one instead.
* Replaces redirect with standard page call

## Testing Instructions

* View details on a stat
* Click the upgrade and download to csv button
* Click upgrade on the upsell modal
* Enter the checkout and hit the browser back button you should not go back to the main stats page but the view details page instead.