### PR TITLE
Siteslug / siteid swapout

### DIFF
--- a/client/my-sites/stats/stats-period-navigation/index.jsx
+++ b/client/my-sites/stats/stats-period-navigation/index.jsx
@@ -25,7 +25,7 @@ import {
 	STATS_PERIOD,
 } from 'calypso/my-sites/stats/constants';
 import { recordGoogleEvent as recordGoogleEventAction } from 'calypso/state/analytics/actions';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { getSelectedSiteSlug, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { shouldGateStats } from '../hooks/use-should-gate-stats';
 import NavigationArrows from '../navigation-arrows';
 import StatsCardUpsell from '../stats-card-upsell';
@@ -43,6 +43,7 @@ class StatsPeriodNavigation extends PureComponent {
 		startDate: PropTypes.bool,
 		endDate: PropTypes.bool,
 		isWithNewDateControl: PropTypes.bool,
+		siteSlug: PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -180,8 +181,8 @@ class StatsPeriodNavigation extends PureComponent {
 			dateRange,
 			shortcutList,
 			gateDateControl,
-			siteId,
 			intervals,
+			siteSlug,
 		} = this.props;
 
 		const isToday = moment( date ).isSame( moment(), period );
@@ -204,7 +205,7 @@ class StatsPeriodNavigation extends PureComponent {
 								gateDateControl && (
 									<StatsCardUpsell
 										className="stats-module__upsell"
-										siteId={ siteId }
+										siteSlug={ siteSlug }
 										statType={ STATS_FEATURE_DATE_CONTROL }
 									/>
 								)
@@ -261,6 +262,7 @@ const onGatedClick = ( siteId ) => ( events, source ) => {
 const connectComponent = connect(
 	( state, { period } ) => {
 		const siteId = getSelectedSiteId( state );
+		const siteSlug = getSelectedSiteSlug( state );
 		const gateDateControl = shouldGateStats( state, siteId, STATS_FEATURE_DATE_CONTROL );
 		const gatePeriodInterval = shouldGateStats(
 			state,
@@ -340,7 +342,7 @@ const connectComponent = connect(
 			},
 		};
 
-		return { siteId, shortcutList, gateDateControl, gatePeriodInterval, intervals };
+		return { shortcutList, gateDateControl, gatePeriodInterval, intervals, siteSlug };
 	},
 	{ recordGoogleEvent: recordGoogleEventAction }
 );


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5011

Related to https://github.com/Automattic/wp-calypso/pull/85457

## Proposed Changes

* Replaces siteId with siteSlug in the time period selector after swapping it out in #85457 but missing this the new usage in the period selector

## Testing Instructions

* Time period selector Unlock button flow should correctly take you to the checkout

![Screenshot_2023-12-22_16-54-33](https://github.com/Automattic/wp-calypso/assets/811776/2e50313f-24d4-4db7-b33c-a637820fb073)

