### PR TITLE
Live Preview Change the save button override keydown event listener to useCapture

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-override-save-button.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-override-save-button.ts
@@ -129,9 +129,9 @@ export const useOverrideSaveButton = ( {
 				} );
 			}
 		};
-		document.addEventListener( 'keydown', overrideSaveButtonKeyboardShortcut );
+		document.addEventListener( 'keydown', overrideSaveButtonKeyboardShortcut, true );
 		return () => {
-			document.removeEventListener( 'keydown', overrideSaveButtonKeyboardShortcut );
+			document.removeEventListener( 'keydown', overrideSaveButtonKeyboardShortcut, true );
 		};
 	}, [ canvasMode, previewingTheme.id, previewingTheme.type, setIsThemeUpgradeModalOpen ] );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85682

## Proposed Changes

This PR set the `keydown` event listener to `useCapture: true` in order to prevent the Activate & Save modal to be triggered by the same shortcut <kdb>cmd + S</kbd>.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox your site and widgets.wp.com.
* Run `install-plugin.sh wpcom-block-editor update/live-preview-override-save-button-keydown-use-capture` on your sandbox.
* Go to the Theme Showcase page and pick a Premium or Woo theme.
* Go to canvas edit mode and make any change.
* Open the sidebar to switch to canvas view mode and press <kdb>cmd + S</kbd>.
* Ensure that only the Upsell modal is opened, and the Activate & Save modal is not opened.
* Ensure that the shortcut works as expected in both canvas edit and view mode.
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?