### PR TITLE
Jetpack SSO screen: tidy up on mobile

### DIFF
--- a/client/jetpack-connect/sso.jsx
+++ b/client/jetpack-connect/sso.jsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { Button, Card, CompactCard, Dialog, Gridicon } from '@automattic/components';
+import { Button, Card, Dialog, Gridicon } from '@automattic/components';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
 import { flowRight, get, map } from 'lodash';
@@ -182,7 +182,7 @@ class JetpackSsoForm extends Component {
 			site = <Site site={ siteObject } />;
 		}
 
-		return <CompactCard className="jetpack-connect__site">{ site }</CompactCard>;
+		return <Card className="jetpack-connect__site">{ site }</Card>;
 	}
 
 	getSharedDetailLabel( key ) {

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -530,7 +530,6 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 
 .jetpack-connect__site.card,
 .jetpack-connect__logged-in-card.card {
-	max-width: 360px;
 	margin: 0 auto 16px;
 }
 

--- a/client/jetpack-connect/style.scss
+++ b/client/jetpack-connect/style.scss
@@ -588,6 +588,21 @@ $colophon-height: 50px; // wpcomColophon element at the bottom
 	color: transparent;
 }
 
+.jetpack-connect__sso {
+
+	.formatted-header__title {
+		margin-bottom: 5px;
+	}
+
+	.card.jetpack-connect__site {
+		max-width: 100%;
+	}
+
+	.logged-out-form__link-item {
+		font-size: unset !important;
+	}
+}
+
 .jetpack-connect__sso .email-verification-gate .notice {
 	margin-bottom: 0;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

<img width="459" alt="Screenshot 2566-12-22 at 14 28 23" src="https://github.com/Automattic/wp-calypso/assets/6851384/a0001b5a-62ad-49cf-ac46-553d5deec95b">

<img width="458" alt="Screenshot 2566-12-22 at 14 28 27" src="https://github.com/Automattic/wp-calypso/assets/6851384/b64d0f33-2c99-47a3-8021-1b5d77872810">

This is based on a Dotcom Walkthrough. I proposed the changes p58i-g5m-p2#comment-60744. What I am including is slightly different but along the same lines. 

Related to https://github.com/Automattic/wp-calypso/issues/85111

## Proposed Changes

* Make some small adjustments to try to make this layout look neater on mobile. 
   * Add some margin under the title (same as larger screens)
   * Make site card a regular `Card` instead of `CompactCard` which means we don't get margins applied that make it narrower than the email notice. 
   *  Make text in bottom regular size (16px)   
* There are a few different flows (migration, Woo Express) with style overrides in `style.css`.  I have not tested those yet. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

I found it hard to access this screen in Calypso. I kept getting redirected to the login page and asked to log in via the email link, which redirects to wordpress.com. One thing I noticed, which we can fix in another PR: logging in via email link does not verify the email. (Edit, added https://github.com/Automattic/dotcom-forge/issues/5014)

Comment out line 394
```js
		if ( ! ssoNonce || ! siteId || validationError ) {
			//return this.renderBadPathArgsError();
		}
```

In the `connect` function: 
```js
			blogDetails: {title: 'Fake blog'},// get( jetpackSSO, 'blogDetails' ),
			sharedDetails: get( jetpackSSO, 'sharedDetails' ),
			currentUser: { email_verified: false} //getCurrentUser( state ),
```

1. Apply the patch above
2. Navigate to `http://calypso.localhost:3000/jetpack/sso`



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?