### PR TITLE
Stats: Improve Loading State for Highlight Cards

### DIFF
--- a/packages/components/src/highlight-cards/count-comparison-card.tsx
+++ b/packages/components/src/highlight-cards/count-comparison-card.tsx
@@ -61,7 +61,9 @@ export default function CountComparisonCard( {
 				onMouseLeave={ () => setTooltipVisible( false ) }
 			>
 				<span
-					className="highlight-card-count-value"
+					className={ classNames( 'highlight-card-count-value', {
+						'is-loading': ! Number.isFinite( count ),
+					} ) }
 					title={ Number.isFinite( count ) ? String( count ) : undefined }
 					ref={ textRef }
 				>

--- a/packages/components/src/highlight-cards/style.scss
+++ b/packages/components/src/highlight-cards/style.scss
@@ -173,6 +173,10 @@ $highlight-card-tooltip-font: Inter, $sans !default;
 	font-family: $highlight-card-count-font;
 	line-height: 1;
 	margin-right: 8px;
+
+	&.is-loading {
+			@include placeholder();
+	}
 }
 
 .highlight-card-difference {


### PR DESCRIPTION
Fixes #85446 - also just something I stumbled into and thought could do with improving

## Proposed Changes

* Improves the loading state for the Highlight Cards in the Stats section to make it more clear that the Stats will load. The original issue suggested using Spinners, but I felt that four spinners seemed a bit...much. Also, Calypso seems to use the placeholder animation for text, so I thought it'd be more fitting here. 

## Testing Instructions

You might need to throttle your connection under the "Network" tab to slow down the amount of time it takes for Stats to appear. However, you should see this under the `/stats` section. 

**Before:**
![291433784-d1483890-0259-4ef7-b462-617901d2f255 (1)](https://github.com/Automattic/wp-calypso/assets/43215253/38665931-4712-421a-b3d3-1291e86b77b9)

**After:** (it's an animation!)
<img width="1178" alt="Screenshot 2023-12-22 at 10 36 13" src="https://github.com/Automattic/wp-calypso/assets/43215253/d2fe6367-58fe-4b57-8ea8-70b25b095318">

cc @jsnmoon 