### PR TITLE
Update hardcoded plan name in Fediverse settings

### DIFF
--- a/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
+++ b/client/my-sites/site-settings/fediverse-settings/WpcomFediverseSettingsSection.js
@@ -1,4 +1,4 @@
-import { PLAN_BUSINESS } from '@automattic/calypso-products';
+import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { Card, Button } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
@@ -101,6 +101,7 @@ const BusinessPlanUpsellCard = ( { siteId } ) => {
 	const recordClick = () => {
 		recordTracksEvent( 'calypso_activitypub_business_plan_upsell_click' );
 	};
+	const planName = getPlan( PLAN_BUSINESS )?.getTitle() ?? '';
 	if ( isBusinessPlan ) {
 		// show a card that links to the plugin page to install the ActivityPub plugin
 		return (
@@ -120,11 +121,13 @@ const BusinessPlanUpsellCard = ( { siteId } ) => {
 		<Card className="site-settings__card">
 			<p>
 				{ translate(
-					'Take your fediverse presence to the next level! The Business plan unlocks per-author profiles, fine-grained controls, and more, with the ActivityPub plugin.'
+					// Translators: %(planName)s is the name of a plan, eg "Business" or "Creator"
+					'Take your fediverse presence to the next level! The %(planName)s plan unlocks per-author profiles, fine-grained controls, and more, with the ActivityPub plugin.',
+					{ args: { planName } }
 				) }
 			</p>
 			<Button primary href={ linkUrl } onClick={ recordClick }>
-				{ translate( 'Upgrade to Business' ) }
+				{ translate( 'Upgrade to %(planName)s', { args: { planName } } ) }
 			</Button>
 		</Card>
 	);


### PR DESCRIPTION



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Update hardcoded plan name in Fediverse ad

## Testing Instructions

* On a launched free site with a domain that's already provisioned
* Go to Settings -> Discussion

See Creator instead of Business

<img width="778" alt="Screenshot 2023-12-22 at 10 03 46" src="https://github.com/Automattic/wp-calypso/assets/82778/8a63116d-5035-4bbe-93e2-caaa3d59506a">


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
