### PR TITLE
Extract the plan action button component from <PlanFeaturesActionButton> and clean up props

### DIFF
--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -14,19 +14,19 @@ import {
 	isWpcomEnterpriseGridPlan,
 	isFreePlan,
 } from '@automattic/calypso-products';
-import { Button, Gridicon } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
 import { isMobile } from '@automattic/viewport';
 import styled from '@emotion/styled';
 import { useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
-import classNames from 'classnames';
 import { localize, TranslateResult, useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useManageTooltipToggle } from 'calypso/my-sites/plans-grid/hooks/use-manage-tooltip-toggle';
 import { usePlansGridContext } from '../grid-context';
 import useDefaultStorageOption from '../hooks/npm-ready/data-store/use-default-storage-option';
+import PlanButton from './plan-button';
 import { Plans2023Tooltip } from './plans-2023-tooltip';
 import type { PlanActionOverrides } from '../types';
 
@@ -58,56 +58,6 @@ const DummyDisabledButton = styled.div`
 	border: unset;
 	text-align: center;
 `;
-
-const PlanActionButton = ( {
-	planSlug,
-	children,
-	classes,
-	href,
-	onClick = () => {},
-	busy = false,
-	borderless = false,
-	current = false,
-	disabled = false,
-	isStuck = false,
-	isLargeCurrency = false,
-}: {
-	planSlug: PlanSlug;
-	children: React.ReactNode;
-	classes?: string;
-	href?: string;
-	onClick?: () => void;
-	busy?: boolean;
-	borderless?: boolean;
-	current?: boolean;
-	disabled?: boolean;
-	isStuck?: boolean;
-	isLargeCurrency?: boolean;
-} ) => {
-	const className = classNames(
-		classes,
-		'plan-features-2023-grid__actions-button',
-		getPlanClass( planSlug ),
-		{
-			'is-current-plan': current,
-			'is-stuck': isStuck,
-			'is-large-currency': isLargeCurrency,
-		}
-	);
-
-	return (
-		<Button
-			className={ className }
-			onClick={ onClick }
-			busy={ busy }
-			borderless={ borderless }
-			disabled={ disabled }
-			href={ href }
-		>
-			{ children }
-		</Button>
-	);
-};
 
 const SignupFlowPlanFeatureActionButton = ( {
 	planSlug,
@@ -166,26 +116,26 @@ const SignupFlowPlanFeatureActionButton = ( {
 	if ( hasFreeTrialPlan ) {
 		return (
 			<div className="plan-features-2023-grid__multiple-actions-container">
-				<PlanActionButton planSlug={ planSlug } onClick={ onClick } busy={ busy }>
+				<PlanButton planSlug={ planSlug } onClick={ onClick } busy={ busy }>
 					{ translate( 'Try for free' ) }
-				</PlanActionButton>
+				</PlanButton>
 				{ ! isStuck && ( // along side with the free trial CTA, we also provide an option for purchasing the plan directly here
-					<PlanActionButton
+					<PlanButton
 						planSlug={ planSlug }
 						onClick={ () => handleUpgradeButtonClick( false ) }
 						borderless
 					>
 						{ btnText } <Gridicon icon="arrow-right" />
-					</PlanActionButton>
+					</PlanButton>
 				) }
 			</div>
 		);
 	}
 
 	return (
-		<PlanActionButton planSlug={ planSlug } onClick={ onClick } busy={ busy }>
+		<PlanButton planSlug={ planSlug } onClick={ onClick } busy={ busy }>
 			{ btnText }
-		</PlanActionButton>
+		</PlanButton>
 	);
 };
 
@@ -232,9 +182,9 @@ const LaunchPagePlanFeatureActionButton = ( {
 	}
 
 	return (
-		<PlanActionButton planSlug={ planSlug } onClick={ handleUpgradeButtonClick }>
+		<PlanButton planSlug={ planSlug } onClick={ handleUpgradeButtonClick }>
 			{ buttonText }
-		</PlanActionButton>
+		</PlanButton>
 	);
 };
 
@@ -299,13 +249,13 @@ const LoggedInPlansFeatureActionButton = ( {
 	) {
 		if ( planActionOverrides?.loggedInFreePlan ) {
 			return (
-				<PlanActionButton
+				<PlanButton
 					planSlug={ planSlug }
 					onClick={ planActionOverrides.loggedInFreePlan.callback }
 					current={ current }
 				>
 					{ planActionOverrides.loggedInFreePlan.text }
-				</PlanActionButton>
+				</PlanButton>
 			);
 		}
 
@@ -314,40 +264,40 @@ const LoggedInPlansFeatureActionButton = ( {
 		}
 
 		return (
-			<PlanActionButton planSlug={ planSlug } current={ current } disabled>
+			<PlanButton planSlug={ planSlug } current={ current } disabled>
 				{ translate( 'Contact support', { context: 'verb' } ) }
-			</PlanActionButton>
+			</PlanButton>
 		);
 	}
 
 	if ( current && planSlug !== PLAN_P2_FREE ) {
 		if ( canPurchaseStorageAddOns && nonDefaultStorageOptionSelected && ! isMonthlyPlan ) {
 			return (
-				<PlanActionButton
+				<PlanButton
 					planSlug={ planSlug }
 					classes="is-storage-upgradeable"
 					href={ storageAddOnCheckoutHref }
 				>
 					{ translate( 'Upgrade' ) }
-				</PlanActionButton>
+				</PlanButton>
 			);
 		} else if ( planActionOverrides?.currentPlan ) {
 			const { callback, text } = planActionOverrides.currentPlan;
 			return (
-				<PlanActionButton
+				<PlanButton
 					planSlug={ planSlug }
 					disabled={ ! callback }
 					onClick={ callback }
 					current={ current }
 				>
 					{ text }
-				</PlanActionButton>
+				</PlanButton>
 			);
 		}
 		return (
-			<PlanActionButton planSlug={ planSlug } current={ current } disabled>
+			<PlanButton planSlug={ planSlug } current={ current } disabled>
 				{ translate( 'Active Plan' ) }
-			</PlanActionButton>
+			</PlanButton>
 		);
 	}
 
@@ -367,9 +317,9 @@ const LoggedInPlansFeatureActionButton = ( {
 		currentPlanBillingPeriod > billingPeriod
 	) {
 		return (
-			<PlanActionButton planSlug={ planSlug } disabled={ true } current={ current }>
+			<PlanButton planSlug={ planSlug } disabled={ true } current={ current }>
 				{ translate( 'Contact support', { context: 'verb' } ) }
-			</PlanActionButton>
+			</PlanButton>
 		);
 	}
 
@@ -383,37 +333,25 @@ const LoggedInPlansFeatureActionButton = ( {
 	) {
 		if ( planMatches( planSlug, { term: TERM_TRIENNIALLY } ) ) {
 			return (
-				<PlanActionButton
-					planSlug={ planSlug }
-					onClick={ handleUpgradeButtonClick }
-					current={ current }
-				>
+				<PlanButton planSlug={ planSlug } onClick={ handleUpgradeButtonClick } current={ current }>
 					{ buttonText || translate( 'Upgrade to Triennial' ) }
-				</PlanActionButton>
+				</PlanButton>
 			);
 		}
 
 		if ( planMatches( planSlug, { term: TERM_BIENNIALLY } ) ) {
 			return (
-				<PlanActionButton
-					planSlug={ planSlug }
-					onClick={ handleUpgradeButtonClick }
-					current={ current }
-				>
+				<PlanButton planSlug={ planSlug } onClick={ handleUpgradeButtonClick } current={ current }>
 					{ buttonText || translate( 'Upgrade to Biennial' ) }
-				</PlanActionButton>
+				</PlanButton>
 			);
 		}
 
 		if ( planMatches( planSlug, { term: TERM_ANNUALLY } ) ) {
 			return (
-				<PlanActionButton
-					planSlug={ planSlug }
-					onClick={ handleUpgradeButtonClick }
-					current={ current }
-				>
+				<PlanButton planSlug={ planSlug } onClick={ handleUpgradeButtonClick } current={ current }>
 					{ buttonText || translate( 'Upgrade to Yearly' ) }
-				</PlanActionButton>
+				</PlanButton>
 			);
 		}
 	}
@@ -446,13 +384,9 @@ const LoggedInPlansFeatureActionButton = ( {
 
 	if ( availableForPurchase ) {
 		return (
-			<PlanActionButton
-				planSlug={ planSlug }
-				onClick={ handleUpgradeButtonClick }
-				current={ current }
-			>
+			<PlanButton planSlug={ planSlug } onClick={ handleUpgradeButtonClick } current={ current }>
 				{ buttonTextFallback }
-			</PlanActionButton>
+			</PlanButton>
 		);
 	}
 
@@ -518,9 +452,9 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 
 	if ( isWpcomEnterpriseGridPlan( planSlug ) ) {
 		return (
-			<PlanActionButton planSlug={ planSlug } onClick={ () => handleUpgradeButtonClick() }>
+			<PlanButton planSlug={ planSlug } onClick={ () => handleUpgradeButtonClick() }>
 				{ translate( 'Learn more' ) }
-			</PlanActionButton>
+			</PlanButton>
 		);
 	}
 

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -32,9 +32,7 @@ import type { PlanActionOverrides } from '../types';
 
 type PlanFeaturesActionsButtonProps = {
 	availableForPurchase: boolean;
-	// className: string;
 	currentSitePlanSlug?: string | null;
-	// freePlan: boolean;
 	isPopular?: boolean;
 	isInSignup?: boolean;
 	isLaunchPage?: boolean | null;
@@ -42,13 +40,8 @@ type PlanFeaturesActionsButtonProps = {
 	onUpgradeClick: ( overridePlanSlug?: PlanSlug ) => void;
 	planSlug: PlanSlug;
 	buttonText?: string;
-	// isWpcomEnterpriseGridPlan: boolean;
 	planActionOverrides?: PlanActionOverrides;
 	showMonthlyPrice: boolean;
-	/**
-	 * @deprecated Site id is not used here to be cleaned up
-	 */
-	siteId?: number | null;
 	isStuck: boolean;
 	isLargeCurrency?: boolean;
 	storageOptions?: StorageOption[];

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -1,7 +1,5 @@
 import {
 	getPlanClass,
-	isWpcomEnterpriseGridPlan,
-	isFreePlan,
 	isWooExpressPlan,
 	FEATURE_GROUP_ESSENTIAL_FEATURES,
 	getPlanFeaturesGrouped,
@@ -370,7 +368,6 @@ const ComparisonGridHeaderCell = ( {
 	onUpgradeClick,
 	planActionOverrides,
 	isPlanUpgradeCreditEligible,
-	siteId,
 	showRefundPeriod,
 	isStuck,
 }: ComparisonGridHeaderCellProps ) => {
@@ -443,7 +440,6 @@ const ComparisonGridHeaderCell = ( {
 				isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
 				isLargeCurrency={ isLargeCurrency }
 				currentSitePlanSlug={ currentSitePlanSlug }
-				siteId={ siteId }
 				visibleGridPlans={ visibleGridPlans }
 			/>
 			<div className="plan-comparison-grid__billing-info">
@@ -455,9 +451,6 @@ const ComparisonGridHeaderCell = ( {
 			<PlanFeatures2023GridActions
 				currentSitePlanSlug={ currentSitePlanSlug }
 				availableForPurchase={ gridPlan.availableForPurchase }
-				className={ getPlanClass( planSlug ) }
-				freePlan={ isFreePlan( planSlug ) }
-				isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planSlug ) }
 				isInSignup={ isInSignup }
 				isLaunchPage={ isLaunchPage }
 				planSlug={ planSlug }

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -237,8 +237,7 @@ class FeaturesGrid extends Component< FeaturesGridProps > {
 	}
 
 	renderPlanPrice( renderedGridPlans: GridPlan[], options?: PlanRowOptions ) {
-		const { isLargeCurrency, isPlanUpgradeCreditEligible, currentSitePlanSlug, siteId } =
-			this.props;
+		const { isLargeCurrency, isPlanUpgradeCreditEligible, currentSitePlanSlug } = this.props;
 		return renderedGridPlans.map( ( { planSlug } ) => {
 			return (
 				<PlanDivOrTdContainer
@@ -252,7 +251,6 @@ class FeaturesGrid extends Component< FeaturesGridProps > {
 						isPlanUpgradeCreditEligible={ isPlanUpgradeCreditEligible }
 						isLargeCurrency={ isLargeCurrency }
 						currentSitePlanSlug={ currentSitePlanSlug }
-						siteId={ siteId }
 						visibleGridPlans={ renderedGridPlans }
 					/>
 				</PlanDivOrTdContainer>
@@ -341,7 +339,6 @@ class FeaturesGrid extends Component< FeaturesGridProps > {
 			currentSitePlanSlug,
 			translate,
 			planActionOverrides,
-			siteId,
 			isLargeCurrency,
 			onUpgradeClick,
 		} = this.props;
@@ -386,7 +383,6 @@ class FeaturesGrid extends Component< FeaturesGridProps > {
 							buttonText={ buttonText }
 							planActionOverrides={ planActionOverrides }
 							showMonthlyPrice={ true }
-							siteId={ siteId }
 							isStuck={ options?.isStuck || false }
 							isLargeCurrency={ isLargeCurrency }
 							storageOptions={ storageOptions }

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -2,7 +2,6 @@ import {
 	FEATURE_CUSTOM_DOMAIN,
 	getPlanClass,
 	isBusinessTrial,
-	isFreePlan,
 	isWooExpressMediumPlan,
 	isWooExpressPlan,
 	isWooExpressSmallPlan,
@@ -376,9 +375,6 @@ class FeaturesGrid extends Component< FeaturesGridProps > {
 					>
 						<PlanFeatures2023GridActions
 							availableForPurchase={ availableForPurchase }
-							className={ getPlanClass( planSlug ) }
-							freePlan={ isFreePlan( planSlug ) }
-							isWpcomEnterpriseGridPlan={ isWpcomEnterpriseGridPlan( planSlug ) }
 							isInSignup={ isInSignup }
 							isLaunchPage={ isLaunchPage }
 							isMonthlyPlan={ isMonthlyPlan }

--- a/client/my-sites/plans-grid/components/header-price.tsx
+++ b/client/my-sites/plans-grid/components/header-price.tsx
@@ -10,10 +10,6 @@ interface PlanFeatures2023GridHeaderPriceProps {
 	isLargeCurrency: boolean;
 	isPlanUpgradeCreditEligible: boolean;
 	currentSitePlanSlug?: string | null;
-	/**
-	 * @deprecated Site id is not used here to be cleaned up
-	 */
-	siteId?: number | null;
 	visibleGridPlans: GridPlan[];
 }
 

--- a/client/my-sites/plans-grid/components/plan-button.tsx
+++ b/client/my-sites/plans-grid/components/plan-button.tsx
@@ -33,7 +33,7 @@ const PlanButton = ( {
 	const className = classNames(
 		classes,
 		'plan-features-2023-grid__actions-button',
-		getPlanClass( planSlug ),
+		planSlug ? getPlanClass( planSlug ) : '',
 		{
 			'is-current-plan': current,
 			'is-stuck': isStuck,

--- a/client/my-sites/plans-grid/components/plan-button.tsx
+++ b/client/my-sites/plans-grid/components/plan-button.tsx
@@ -1,0 +1,58 @@
+import { getPlanClass, type PlanSlug } from '@automattic/calypso-products';
+import { Button } from '@automattic/components';
+import classNames from 'classnames';
+
+// TODO:
+// The prop should simply be declared by extending the
+// props of Button, instead of listing everything needed like this.
+const PlanButton = ( {
+	planSlug,
+	children,
+	classes,
+	href,
+	onClick = () => {},
+	busy = false,
+	borderless = false,
+	current = false,
+	disabled = false,
+	isStuck = false,
+	isLargeCurrency = false,
+}: {
+	planSlug: PlanSlug;
+	children: React.ReactNode;
+	classes?: string;
+	href?: string;
+	onClick?: () => void;
+	busy?: boolean;
+	borderless?: boolean;
+	current?: boolean;
+	disabled?: boolean;
+	isStuck?: boolean;
+	isLargeCurrency?: boolean;
+} ) => {
+	const className = classNames(
+		classes,
+		'plan-features-2023-grid__actions-button',
+		getPlanClass( planSlug ),
+		{
+			'is-current-plan': current,
+			'is-stuck': isStuck,
+			'is-large-currency': isLargeCurrency,
+		}
+	);
+
+	return (
+		<Button
+			className={ className }
+			onClick={ onClick }
+			busy={ busy }
+			borderless={ borderless }
+			disabled={ disabled }
+			href={ href }
+		>
+			{ children }
+		</Button>
+	);
+};
+
+export default PlanButton;

--- a/client/my-sites/plans-grid/components/plan-button/index.tsx
+++ b/client/my-sites/plans-grid/components/plan-button/index.tsx
@@ -1,6 +1,7 @@
 import { getPlanClass, type PlanSlug } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import classNames from 'classnames';
+import './style.scss';
 
 // TODO:
 // The prop should simply be declared by extending the

--- a/client/my-sites/plans-grid/components/plan-button/index.tsx
+++ b/client/my-sites/plans-grid/components/plan-button/index.tsx
@@ -19,7 +19,7 @@ const PlanButton = ( {
 	isStuck = false,
 	isLargeCurrency = false,
 }: {
-	planSlug: PlanSlug;
+	planSlug?: PlanSlug;
 	children: React.ReactNode;
 	classes?: string;
 	href?: string;

--- a/client/my-sites/plans-grid/components/plan-button/style.scss
+++ b/client/my-sites/plans-grid/components/plan-button/style.scss
@@ -12,7 +12,6 @@
 
 	background-color: var(--studio-white);
 	color: var(--studio-gray-100);
-	box-shadow: inset 0 0 0 1px var(--studio-gray-10);
 
 	&:hover {
 		opacity: 0.85;

--- a/client/my-sites/plans-grid/components/plan-button/style.scss
+++ b/client/my-sites/plans-grid/components/plan-button/style.scss
@@ -10,6 +10,10 @@
 	flex: 1;
 	width: 100%;
 
+	background-color: var(--studio-white);
+	color: var(--studio-gray-100);
+	box-shadow: inset 0 0 0 1px var(--studio-gray-10);
+
 	&:hover {
 		opacity: 0.85;
 		transition: 0.7s;

--- a/client/my-sites/plans-grid/components/plan-button/style.scss
+++ b/client/my-sites/plans-grid/components/plan-button/style.scss
@@ -1,0 +1,151 @@
+@import "@automattic/onboarding/styles/mixins";
+
+.plan-features-2023-grid__actions-button {
+	font-weight: 500;
+	line-height: 20px;
+	border-radius: 4px;
+	padding: 10px 12px;
+	border: unset;
+	text-align: center;
+	flex: 1;
+	width: 100%;
+
+	&:hover {
+		opacity: 0.85;
+		transition: 0.7s;
+	}
+
+	&.is-free-plan {
+		background-color: var(--studio-blue-50);
+		color: var(--studio-blue-0);
+
+		&:focus {
+			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-blue-50);
+		}
+	}
+
+	&.is-personal-plan {
+		background-color: var(--studio-blue-60);
+		color: var(--studio-blue-0);
+
+		&:focus {
+			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-blue-50);
+		}
+	}
+
+	&.is-premium-plan {
+		background-color: #004687;
+		color: var(--studio-blue-0);
+
+		&:focus {
+			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px #004687;
+		}
+	}
+
+	&.is-business-plan {
+		background-color: #7f54b3;
+		color: var(--studio-purple-0);
+
+		&:focus {
+			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px #7f54b3;
+		}
+
+		+ .button {
+			font-size: $font-body-small;
+			color: #7f54b3;
+			text-decoration: none;
+
+			&:focus {
+				box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px #7f54b3;
+			}
+
+			.gridicon {
+				width: 18px;
+				height: 18px;
+				top: 4px;
+			}
+		}
+	}
+
+	&.is-wooexpress-medium-plan {
+		background-color: var(--color-accent);
+		color: var(--color-text-inverted);
+		font-weight: 400;
+
+		&:focus {
+			box-shadow: 0 0 0 2px var(--color-surface), 0 0 0 4px var(--color-accent);
+		}
+	}
+
+	&.is-wooexpress-small-plan {
+		background-color: var(--color-surface);
+		color: var(--color-accent);
+		border: 1px solid var(--color-accent);
+		font-weight: 400;
+	}
+
+	&.is-wooexpress-plus-plan {
+		display: inline-block;
+		width: 85%;
+		text-align: center;
+		background-color: var(--color-surface);
+		color: var(--color-accent);
+		border: 1px solid  var(--color-accent);
+		font-weight: 400;
+	}
+
+	&.is-ecommerce-plan {
+		background-color: #55347d;
+		color: var(--studio-purple-0);
+
+		&:focus {
+			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px #55347d;
+		}
+	}
+
+	&.is-wpcom-enterprise-grid-plan {
+		background-color: var(--studio-gray-80);
+		color: var(--studio-gray-0);
+
+		&:focus {
+			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-gray-80);
+		}
+	}
+
+	&.is-p2-plus-plan {
+		background-color: var(--color-accent);
+		color: var(--color-text-inverted);
+
+		&:focus {
+			box-shadow: 0 0 0 2px var(--color-surface), 0 0 0 4px var(--color-accent);
+		}
+	}
+
+	&.is-current-plan {
+		background-color: var(--studio-white);
+		color: var(--studio-gray-100);
+		box-shadow: inset 0 0 0 1px var(--studio-gray-10);
+
+		&.is-storage-upgradeable {
+			background-color: var(--color-accent);
+			color: var(--color-text-inverted);
+		}
+
+		&:hover {
+			box-shadow: inset 0 0 0 1px var(--studio-gray-80);
+		}
+	}
+
+	&.disabled,
+	&[disabled] {
+		background-color: var(--studio-white);
+		color: var(--color-neutral-light);
+		box-shadow: inset 0 0 0 1px #e0e0e0;
+	}
+
+	&.is-stuck.is-large-currency {
+		height: 48px;
+		line-height: 15px;
+		padding: 9px 12px;
+	}
+}

--- a/client/my-sites/plans-grid/style.scss
+++ b/client/my-sites/plans-grid/style.scss
@@ -8,159 +8,6 @@ $mobile-card-max-width: 440px;
 	margin-top: 300px;
 }
 
-.plan-features-2023-grid__table-item.is-top-buttons,
-.plan-comparison-grid {
-	.plan-features-2023-gridrison__actions-buttons {
-		.plan-features-2023-grid__actions-button {
-			font-weight: 500;
-			line-height: 20px;
-			border-radius: 4px;
-			padding: 10px 12px;
-			border: unset;
-
-			&:hover {
-				opacity: 0.85;
-				transition: 0.7s;
-			}
-
-			&.is-free-plan {
-				background-color: var(--studio-blue-50);
-				color: var(--studio-blue-0);
-
-				&:focus {
-					box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-blue-50);
-				}
-			}
-
-			&.is-personal-plan {
-				background-color: var(--studio-blue-60);
-				color: var(--studio-blue-0);
-
-				&:focus {
-					box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-blue-50);
-				}
-			}
-
-			&.is-premium-plan {
-				background-color: #004687;
-				color: var(--studio-blue-0);
-
-				&:focus {
-					box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px #004687;
-				}
-			}
-
-			&.is-business-plan {
-				background-color: #7f54b3;
-				color: var(--studio-purple-0);
-
-				&:focus {
-					box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px #7f54b3;
-				}
-
-				+ .button {
-					font-size: $font-body-small;
-					color: #7f54b3;
-					text-decoration: none;
-
-					&:focus {
-						box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px #7f54b3;
-					}
-
-					.gridicon {
-						width: 18px;
-						height: 18px;
-						top: 4px;
-					}
-				}
-			}
-
-			&.is-wooexpress-medium-plan {
-				background-color: var(--color-accent);
-				color: var(--color-text-inverted);
-				font-weight: 400;
-
-				&:focus {
-					box-shadow: 0 0 0 2px var(--color-surface), 0 0 0 4px var(--color-accent);
-				}
-			}
-
-			&.is-wooexpress-small-plan {
-				background-color: var(--color-surface);
-				color: var(--color-accent);
-				border: 1px solid var(--color-accent);
-				font-weight: 400;
-			}
-
-			&.is-wooexpress-plus-plan {
-				display: inline-block;
-				width: 85%;
-				text-align: center;
-				background-color: var(--color-surface);
-				color: var(--color-accent);
-				border: 1px solid  var(--color-accent);
-				font-weight: 400;
-			}
-
-			&.is-ecommerce-plan {
-				background-color: #55347d;
-				color: var(--studio-purple-0);
-
-				&:focus {
-					box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px #55347d;
-				}
-			}
-
-			&.is-wpcom-enterprise-grid-plan {
-				background-color: var(--studio-gray-80);
-				color: var(--studio-gray-0);
-
-				&:focus {
-					box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px var(--studio-gray-80);
-				}
-			}
-
-			&.is-p2-plus-plan {
-				background-color: var(--color-accent);
-				color: var(--color-text-inverted);
-
-				&:focus {
-					box-shadow: 0 0 0 2px var(--color-surface), 0 0 0 4px var(--color-accent);
-				}
-			}
-
-			&.is-current-plan {
-				background-color: var(--studio-white);
-				color: var(--studio-gray-100);
-				box-shadow: inset 0 0 0 1px var(--studio-gray-10);
-
-				&.is-storage-upgradeable {
-					background-color: var(--color-accent);
-					color: var(--color-text-inverted);
-				}
-
-				&:hover {
-					box-shadow: inset 0 0 0 1px var(--studio-gray-80);
-				}
-			}
-
-			&.disabled,
-			&[disabled] {
-				background-color: var(--studio-white);
-				color: var(--color-neutral-light);
-				box-shadow: inset 0 0 0 1px #e0e0e0;
-			}
-
-			&.is-stuck.is-large-currency {
-				height: 48px;
-				line-height: 15px;
-				padding: 9px 12px;
-			}
-		}
-	}
-}
-
-
 .plan-features-2023-grid__header {
 	position: relative;
 	display: flex;
@@ -199,10 +46,6 @@ $mobile-card-max-width: 440px;
 
 .plan-features-2023-grid__actions-signup-plan-text {
 	display: block;
-}
-
-.plan-features-2023-grid__actions-buttons {
-	text-align: center;
 }
 
 .plan-features-2023-grid__actions-downgrade-context-mobile {
@@ -525,16 +368,6 @@ $mobile-card-max-width: 440px;
 	gap: 8px;
 }
 
-.plan-features-2023-grid__actions-button {
-	flex: 1;
-	width: 100%;
-
-	&.disabled,
-	&[disabled] {
-		color: var(--color-neutral-light);
-	}
-}
-
 .plan-features-2023-grid__row:last-of-type .plan-features-2023-grid__table-item {
 	border-bottom: solid 1px var(--color-neutral-5);
 
@@ -620,10 +453,6 @@ $mobile-card-max-width: 440px;
 	.plan-features-2023-grid__table-bottom {
 		margin-top: 54px;
 	}
-}
-
-.plan-features__actions-button {
-	border-radius: 4px;
 }
 
 body.is-section-stepper,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/growth-foundations#286

## Proposed Changes

This PR extracts a `<PlanButton>` component from `<PlanFeaturesActionsButton>` as a simpler component which renders in correct style according to the given plan slug. Along with the extraction, there are also several props removed from `<PlanFeaturesActionsButton>`, in hope of keeping the component a bit more tidy:

* `siteId`: it is already not in used.
* `isWpcomEnterprisePlan`: it can be derived from the plan slug directly.
* `freePlan`: it can be derived from the plan slug.
* `className`: it now depends on `<PlanButton>`

The motivation is to address Automattic/growth-foundations#286. https://github.com/Automattic/wp-calypso/pull/85723/ demonstrates how the upsell models attempt to use the `<PlanButton>` extracted here.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

In the following cases, the plan action buttons should work and look as they are in production:

* /start/plans
* logged-in /plans
* /start/launch-site
* /setup/newsletter

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
