### PR TITLE
Update hardcoded Business in preview-upgrade-nudge

### DIFF
--- a/client/components/seo/preview-upgrade-nudge/index.jsx
+++ b/client/components/seo/preview-upgrade-nudge/index.jsx
@@ -4,6 +4,8 @@ import {
 	TYPE_BUSINESS,
 	TYPE_SECURITY_DAILY,
 	FEATURE_SEO_PREVIEW_TOOLS,
+	PLAN_BUSINESS,
+	getPlan,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
@@ -27,6 +29,7 @@ export const SeoPreviewNudge = ( {
 	site,
 	isJetpack = false,
 } ) => {
+	const planName = getPlan( PLAN_BUSINESS )?.getTitle() ?? '';
 	return (
 		<div className="preview-upgrade-nudge">
 			<QueryPlans />
@@ -43,9 +46,12 @@ export const SeoPreviewNudge = ( {
 				}
 				title={
 					canCurrentUserUpgrade
-						? translate( 'Upgrade to a Business plan to unlock the power of our SEO tools!' )
+						? translate( 'Upgrade to a %(planName)s plan to unlock the power of our SEO tools!', {
+								args: { planName },
+						  } )
 						: translate(
-								"Unlock powerful SEO tools! Contact your site's administrator to upgrade to a Business plan."
+								"Unlock powerful SEO tools! Contact your site's administrator to upgrade to a %(planName)s plan.",
+								{ args: { planName } }
 						  )
 				}
 				forceDisplay


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Update seo preview nudge harcoded plan name

## Testing Instructions

* On a free site without domain, go to posts, then click the 3 dots and select view
* Change the device in the dropdown
<img width="376" alt="Screenshot 2023-12-22 at 10 55 50" src="https://github.com/Automattic/wp-calypso/assets/82778/60ab60bd-2179-4ee5-a53a-e676ef056abb">

* See the upsell appear

<img width="1181" alt="Screenshot 2023-12-22 at 10 48 28" src="https://github.com/Automattic/wp-calypso/assets/82778/0dca72d1-f554-4a62-9714-955c60c73d0e">

You can repeat on a site with a non-admin user to see the alternative copy or just hardcode it with the debugger.

<img width="910" alt="Screenshot 2023-12-22 at 10 59 02" src="https://github.com/Automattic/wp-calypso/assets/82778/de9a0709-b50e-4d3a-95ae-d42ddf48f3e5">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
