### PR TITLE
[Odie] Wapuu handling 100% of the requests...

### DIFF
--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -15,7 +15,6 @@ import { getSectionName } from 'calypso/state/ui/selectors';
 /**
  * Internal Dependencies
  */
-import { useIsWapuuEnabled } from '../hooks';
 import { HELP_CENTER_STORE } from '../stores';
 import { HelpCenterContactForm } from './help-center-contact-form';
 import { HelpCenterContactPage } from './help-center-contact-page';
@@ -33,7 +32,6 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 	const navigate = useNavigate();
 	const containerRef = useRef< HTMLDivElement >( null );
 	const section = useSelector( getSectionName );
-	const isWapuuEnabled = useIsWapuuEnabled();
 	const { isMinimized } = useSelect( ( select ) => {
 		const store = select( HELP_CENTER_STORE ) as HelpCenterSelect;
 		return {
@@ -98,7 +96,6 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 						<OdieAssistantProvider
 							botNameSlug="wpcom-support-chat"
 							botName="Wapuu"
-							enabled={ isWapuuEnabled }
 							isMinimized={ isMinimized }
 							initialUserMessage={ searchTerm }
 							logger={ trackEvent }

--- a/packages/help-center/src/hooks/use-is-wapuu-enabled.ts
+++ b/packages/help-center/src/hooks/use-is-wapuu-enabled.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-restricted-imports */
-import config from '@automattic/calypso-config';
 import useChatStatus from './use-chat-status';
 
 /**
@@ -13,7 +12,5 @@ import useChatStatus from './use-chat-status';
  */
 export const useIsWapuuEnabled = () => {
 	const { wapuuAssistantEnabled } = useChatStatus();
-	// A way to enable it via flag
-	const isWapuuConfigEnabled = config.isEnabled( 'wapuu' );
-	return wapuuAssistantEnabled || isWapuuConfigEnabled;
+	return wapuuAssistantEnabled;
 };


### PR DESCRIPTION
## Proposed Changes

This patch has to be tested with D132994-code either deployed or applied in your sandbox.

## Testing Instructions

Find test instructions in the provided patch above.

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
