### PR TITLE
Update button name in e2e test

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/published/published-post-page.ts
@@ -103,7 +103,7 @@ export class PublishedPostPage {
 		// can choose from.
 		// However, we don't know for sure whether a site owner has set up any
 		// newsletter plans.
-		const continueButton = iframe.getByRole( 'button', { name: 'Continue', exact: true } );
+		const continueButton = iframe.getByRole( 'button', { name: 'Got it', exact: true } );
 		const freeTrialLink = iframe.getByRole( 'link', {
 			name: 'Free - Get a glimpse of the newsletter',
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1703188689151709/1703185825.796699-slack-C01U2KGS2PQ

## Proposed Changes

* This changes the expected button name in the E2E test from "Continue" to "Got it"

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* E2E tests should pass automatically.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?