### PR TITLE
Update copy for do you love Jetpack notice

### DIFF
--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import NoticeBanner from '@automattic/components/src/notice-banner';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -29,6 +30,8 @@ const DoYouLoveJetpackStatsNotice = ( {
 }: StatsNoticeProps ) => {
 	const translate = useTranslate();
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
+	const isWPCOMPaidStatsFlow =
+		isEnabled( 'stats/paid-wpcom-v2' ) && isWPCOMSite && ! isOdysseyStats;
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
 	const { mutateAsync: postponeNoticeAsync } = useNoticeVisibilityMutation(
 		siteId,
@@ -70,12 +73,22 @@ const DoYouLoveJetpackStatsNotice = ( {
 		return null;
 	}
 
-	const noPurchaseTitle = translate( 'Do you love Jetpack Stats?' );
+	const noPurchaseTitle = isWPCOMPaidStatsFlow
+		? translate( 'Grow faster with Advanced Stats' )
+		: translate( 'Do you love Jetpack Stats?' );
 	const freeTitle = translate( 'Want to get the most out of Jetpack Stats?' );
 
 	const learnMoreLink = isWPCOMSite
 		? 'https://wordpress.com/support/stats/#purchase-the-stats-add-on'
 		: 'https://jetpack.com/redirect/?source=jetpack-stats-learn-more-about-new-pricing';
+
+	const description = isWPCOMPaidStatsFlow
+		? translate(
+				'Finesse your scaling up strategy with detailed insights and data. Upgrade to a Personal plan for a richer understanding and smarter decision-making.'
+		  )
+		: translate( 'Upgrade to get priority support and access to upcoming advanced features.' );
+
+	const CTAText = isWPCOMPaidStatsFlow ? translate( 'Upgrade' ) : translate( 'Upgrade my Stats' );
 
 	return (
 		<div
@@ -88,31 +101,25 @@ const DoYouLoveJetpackStatsNotice = ( {
 				title={ hasFreeStats ? freeTitle : noPurchaseTitle }
 				onClose={ dismissNotice }
 			>
-				{ translate(
-					'{{p}}Upgrade to get priority support and access to upcoming advanced features.{{/p}}{{p}}{{jetpackStatsProductLink}}Upgrade my Stats{{/jetpackStatsProductLink}} {{learnMoreLink}}{{learnMoreLinkText}}Learn more{{/learnMoreLinkText}}{{externalIcon /}}{{/learnMoreLink}}{{/p}}',
-					{
-						components: {
-							p: <p />,
-							jetpackStatsProductLink: (
-								<button
-									type="button"
-									className="notice-banner__action-button"
-									onClick={ gotoJetpackStatsProduct }
-								/>
-							),
-							learnMoreLink: (
-								<a
-									className="notice-banner__action-link"
-									href={ localizeUrl( learnMoreLink ) }
-									target="_blank"
-									rel="noreferrer"
-								/>
-							),
-							learnMoreLinkText: <span />,
-							externalIcon: <Icon className="stats-icon" icon={ external } size={ 24 } />,
-						},
-					}
-				) }
+				<p>{ description }</p>
+				<p>
+					<button
+						type="button"
+						className="notice-banner__action-button"
+						onClick={ gotoJetpackStatsProduct }
+					>
+						{ CTAText }
+					</button>
+					<a
+						className="notice-banner__action-link"
+						href={ localizeUrl( learnMoreLink ) }
+						target="_blank"
+						rel="noreferrer"
+					>
+						{ translate( 'Learn more' ) }
+						<Icon className="stats-icon" icon={ external } size={ 24 } />
+					</a>
+				</p>
 			</NoticeBanner>
 		</div>
 	);

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -84,7 +84,7 @@ const DoYouLoveJetpackStatsNotice = ( {
 
 	const description = isWPCOMPaidStatsFlow
 		? translate(
-				'Finesse your scaling up strategy with detailed insights and data. Upgrade to a Personal plan for a richer understanding and smarter decision-making.'
+				'Finesse your scaling up strategy with detailed insights and data. Upgrade to an Explorer plan for a richer understanding and smarter decision-making.'
 		  )
 		: translate( 'Upgrade to get priority support and access to upcoming advanced features.' );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4914

## Proposed Changes

* Change copy for stats in calypso

Note: There will be a followup PR for opening the Modal for upgrade, not included in this PR.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure `stats/paid-wpcom-v2` is activated by adding `?flags=stats/paid-wpcom-v2` to the end of the url (activated by default for dev environment)
* Test in calypso and in odyssey
* Make sure the copy in Odyssey is same as before
### Odyssey, Calypso + Jetpack site
![odyssey](https://github.com/Automattic/wp-calypso/assets/6586048/7091ab0c-e8d7-4c93-9e56-e43e5ee9a9f6)
### Calypso + WP.com site
![calypso](https://github.com/Automattic/wp-calypso/assets/6586048/d8f7b0e9-8520-4a61-b2a6-756832ff61da)
* Clicking on Upgrade should go to PWYW screen
* Clicking on Learn more should go to WP.com doc for WP.com sites, and Jetpack docs for Jetpack sites


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?