### PR TITLE
Domains: Fix wrong auto-renewal statuses in domains pages

### DIFF
--- a/packages/data-stores/src/queries/use-all-domains-query.ts
+++ b/packages/data-stores/src/queries/use-all-domains-query.ts
@@ -32,12 +32,17 @@ export interface AllDomainsQueryArgs {
 	no_wpcom?: boolean;
 }
 
+export const getAllDomainsQueryKey = ( queryArgs: AllDomainsQueryArgs = {} ) => [
+	'all-domains',
+	queryArgs,
+];
+
 export function useAllDomainsQuery< TError = unknown, TData = AllDomainsQueryFnData >(
 	queryArgs: AllDomainsQueryArgs = {},
 	options: Omit< UseQueryOptions< AllDomainsQueryFnData, TError, TData >, 'queryKey' > = {}
 ) {
 	return useQuery< AllDomainsQueryFnData, TError, TData >( {
-		queryKey: [ 'all-domains', queryArgs ],
+		queryKey: getAllDomainsQueryKey( queryArgs ),
 		queryFn: () =>
 			wpcomRequest< AllDomainsQueryFnData >( {
 				path: addQueryArgs( '/all-domains', queryArgs ),

--- a/packages/data-stores/src/queries/use-site-domains-query.ts
+++ b/packages/data-stores/src/queries/use-site-domains-query.ts
@@ -116,6 +116,11 @@ export interface SiteDomainsQueryFnData {
 	domains: DomainData[];
 }
 
+export const getSiteDomainsQueryKey = ( siteIdOrSlug: number | string | null | undefined ) => [
+	'site-domains',
+	siteIdOrSlug,
+];
+
 export function useSiteDomainsQuery< TError = unknown, TData = SiteDomainsQueryFnData >(
 	siteIdOrSlug: number | string | null | undefined,
 	options: Omit< UseQueryOptions< SiteDomainsQueryFnData, TError, TData >, 'queryKey' > = {}
@@ -128,7 +133,7 @@ export function getSiteDomainsQueryObject< TError = unknown, TData = SiteDomains
 	options: Omit< UseQueryOptions< SiteDomainsQueryFnData, TError, TData >, 'queryKey' > = {}
 ): UseQueryOptions< SiteDomainsQueryFnData, TError, TData > {
 	return {
-		queryKey: [ 'site-domains', siteIdOrSlug ],
+		queryKey: getSiteDomainsQueryKey( siteIdOrSlug ),
 		queryFn: () =>
 			wpcomRequest< SiteDomainsQueryFnData >( {
 				path: `/sites/${ siteIdOrSlug }/domains`,

--- a/packages/data-stores/src/types.d.ts
+++ b/packages/data-stores/src/types.d.ts
@@ -1,1 +1,3 @@
 declare const __i18n_text_domain__: string;
+
+declare module 'calypso/state/sites/domains/actions';

--- a/packages/domains-table/src/domains-table/domains-table-bulk-update-notice.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-bulk-update-notice.tsx
@@ -34,6 +34,7 @@ export const DomainsTableBulkUpdateNotice = () => {
 			if ( job.failed.length ) {
 				return (
 					<Notice
+						key={ job.id }
 						status="is-error"
 						text={ translate( 'Some domain updates were not successful ' ) }
 						onDismissClick={ () => handleDismissNotice( job.id ) }
@@ -53,8 +54,13 @@ export const DomainsTableBulkUpdateNotice = () => {
 					</Notice>
 				);
 			}
+
 			return (
-				<Notice status="is-success" onDismissClick={ () => handleDismissNotice( job.id ) }>
+				<Notice
+					key={ job.id }
+					status="is-success"
+					onDismissClick={ () => handleDismissNotice( job.id ) }
+				>
 					{ translate( 'Bulk domain updates finished successfully ' ) }
 				</Notice>
 			);

--- a/packages/domains-table/src/domains-table/domains-table.tsx
+++ b/packages/domains-table/src/domains-table/domains-table.tsx
@@ -340,10 +340,15 @@ export const useGenerateDomainsTableState = ( props: DomainsTableProps ) => {
 	};
 
 	const handleAutoRenew = ( enable: boolean ) => {
-		const domainsToBulkUpdate = ( domains ?? [] )
-			.filter( ( domain ) => selectedDomains.has( getDomainId( domain ) ) )
-			.map( ( domain ) => domain.domain );
-		setAutoRenew( domainsToBulkUpdate, enable );
+		const domainsToBulkUpdate = ( domains ?? [] ).filter( ( domain ) =>
+			selectedDomains.has( getDomainId( domain ) )
+		);
+
+		const domainNames = domainsToBulkUpdate.map( ( domain ) => domain.domain );
+		const blogIds = [ ...new Set( domainsToBulkUpdate.map( ( domain ) => domain.blog_id ) ) ];
+
+		setAutoRenew( domainNames, blogIds, enable );
+
 		handleRestartDomainStatusPolling();
 	};
 


### PR DESCRIPTION
This pull request seeks to address https://github.com/Automattic/nomado-issues/issues/605 by forcing a refresh of the list of domains that were bulk updated on the `Domains` page in order to show the right auto-renewal status on that page as well as the `Domain Settings` page.

#### Testing instructions

1. Run `git checkout fix/auto-renew-statuses-on-domains-pages` and start your server, or access a [live branch](URL)
2. Log into a WordPress.com account with a least one domain
3. Go to the [`Domains` page](http://calypso.localhost:3000/domains/manage)
4. Click a domain to access the `Domain Settings` page
5. Assert that auto-renewal is enabled
6. Go back, and tick the checkbox in front of that domain
7. Click the `Auto-renew settings` button
8. Select `Turn off auto-renew for x domains`
9. Wait until a `Bulk domain updates finished successfully` message is shown
10. Assert that the `Expires / renews on` column shows `Expires <some date>` for the domain now
11. Click the domain again to access the `Domain Settings` page
12. Assert that auto-renewal is now disabled
13. Enable again auto-renewal
14. Navigate back to the `Domains` page
15. Assert that the `Expires / renews on` column now shows `Renews <some date>`

You may also want to test all of this from the `All Sites` view.