### PR TITLE
Jetpack Manage: Onboarding Tour - Enable Monitor

### DIFF
--- a/client/jetpack-cloud/components/guided-tour/index.tsx
+++ b/client/jetpack-cloud/components/guided-tour/index.tsx
@@ -119,23 +119,24 @@ const GuidedTour = ( { className, tours, preferenceName }: Props ) => {
 	}, [ currentStep, tours.length, endTour ] );
 
 	useEffect( () => {
-		let target: Element | null = null;
-		if ( nextStepOnTargetClick ) {
+		let nextStepClickTargetElement: Element | null = null;
+		// We should wait for targetElement before attaching any events to advance to the next step
+		if ( nextStepOnTargetClick && targetElement && ! isDismissed && hasFetched ) {
 			// Find the target element using the nextStepOnTargetClick selector
-			target = document.querySelector( nextStepOnTargetClick );
-			if ( target ) {
-				// Attach the event listener to the target
-				target.addEventListener( 'click', nextStep );
+			nextStepClickTargetElement = document.querySelector( nextStepOnTargetClick );
+			if ( nextStepClickTargetElement ) {
+				// Attach the event listener to the nextStepClickTargetElement
+				nextStepClickTargetElement.addEventListener( 'click', nextStep );
 			}
 		}
 
 		// Cleanup function to remove the event listener
 		return () => {
-			if ( target ) {
-				target.removeEventListener( 'click', nextStep );
+			if ( nextStepClickTargetElement ) {
+				nextStepClickTargetElement.removeEventListener( 'click', nextStep );
 			}
 		};
-	}, [ nextStepOnTargetClick, nextStep ] );
+	}, [ nextStepOnTargetClick, nextStep, targetElement, isDismissed, hasFetched ] );
 
 	if ( isDismissed ) {
 		return null;

--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/index.tsx
@@ -4,6 +4,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, createRef, useContext } from 'react';
 import ButtonGroup from 'calypso/components/button-group';
 import SelectDropdown from 'calypso/components/select-dropdown';
+import EnableMonitorTourStep2 from '../../onboarding-tours/enable-monitor-tour-step-2';
 import NotificationSettings from '../downtime-monitoring/notification-settings';
 import { useJetpackAgencyDashboardRecordTrackEvent } from '../hooks';
 import SitesOverviewContext from '../sites-overview/context';
@@ -62,11 +63,13 @@ export default function DashboardBulkActions( {
 			label: translate( 'Custom Notification' ),
 			action: () => toggleNotificationSettingsPopup(),
 			actionName: 'custom_notification_click',
+			className: 'dashboard-bulk-actions__custom_notification_button',
 		},
 		{
 			label: translate( 'Reset Notification' ),
 			action: () => handleResetNotification(),
 			actionName: 'reset_notification_click',
+			className: 'dashboard-bulk-actions__reset_notification_button',
 		},
 	];
 
@@ -91,12 +94,13 @@ export default function DashboardBulkActions( {
 					</Button>
 				) ) }
 			</ButtonGroup>
-			{ otherMonitorActions.map( ( { label, action, actionName } ) => (
+			{ otherMonitorActions.map( ( { label, action, actionName, className } ) => (
 				<ButtonGroup key={ label }>
 					<Button
 						compact
 						disabled={ disabled }
 						onClick={ () => handleAction( action, actionName ) }
+						className={ className }
 					>
 						{ label }
 					</Button>
@@ -139,6 +143,7 @@ export default function DashboardBulkActions( {
 					</Button>
 				</ButtonGroup>
 			</div>
+			<EnableMonitorTourStep2 isMonitorPopupVisible={ showNotificationSettingsPopup } />
 			{ showNotificationSettingsPopup && (
 				<NotificationSettings
 					sites={ selectedSites }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -2,6 +2,7 @@ import { Icon, starFilled, info } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useContext, useState, forwardRef, Ref } from 'react';
 import AddNewSiteTourStep2 from 'calypso/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-2';
+import EnableMonitorTourStep1 from 'calypso/jetpack-cloud/sections/onboarding-tours/enable-monitor-tour-step-1';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import './style.scss';
 import EditButton from '../../dashboard-bulk-actions/edit-button';
@@ -121,6 +122,7 @@ const SiteTable = ( { isLoading, columns, items }: Props, ref: Ref< HTMLTableEle
 				</tbody>
 			</table>
 			<AddNewSiteTourStep2 siteItems={ items } />
+			<EnableMonitorTourStep1 />
 		</>
 	);
 };

--- a/client/jetpack-cloud/sections/onboarding-tours/constants.ts
+++ b/client/jetpack-cloud/sections/onboarding-tours/constants.ts
@@ -4,4 +4,6 @@
 export const JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME: Record< string, string > = {
 	addSiteStep1: 'jetpack-cloud-site-dashboard-add-new-site-tour-step-1',
 	addSiteStep2: 'jetpack-cloud-site-dashboard-add-new-site-tour-step-2',
+	enableMonitorStep1: 'jetpack-cloud-site-dashboard-enable-monitor-tour-step-1',
+	enableMonitorStep2: 'jetpack-cloud-site-dashboard-enable-monitor-tour-step-2',
 };

--- a/client/jetpack-cloud/sections/onboarding-tours/enable-monitor-tour-step-1/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/enable-monitor-tour-step-1/index.tsx
@@ -1,0 +1,33 @@
+import { useTranslate } from 'i18n-calypso';
+import GuidedTour from 'calypso/jetpack-cloud/components/guided-tour';
+import { JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME } from '../constants';
+
+export default function EnableMonitorTourStep1() {
+	const translate = useTranslate();
+	const urlParams = new URLSearchParams( window.location.search );
+	const shouldRenderEnableMonitorTourStep1 = urlParams.get( 'tour' ) === 'enable-monitor';
+
+	return (
+		shouldRenderEnableMonitorTourStep1 && (
+			<GuidedTour
+				preferenceName={ JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME[ 'enableMonitorStep1' ] }
+				tours={ [
+					{
+						target: '.dashboard-bulk-actions__edit-button',
+						popoverPosition: 'bottom left',
+						title: translate( 'Bulk editing' ),
+						description: (
+							<>
+								{ translate(
+									"Looking to manage multiple sites efficiently? Click the 'Edit All' button."
+								) }
+							</>
+						),
+
+						nextStepOnTargetClick: '.dashboard-bulk-actions__edit-button',
+					},
+				] }
+			/>
+		)
+	);
+}

--- a/client/jetpack-cloud/sections/onboarding-tours/enable-monitor-tour-step-1/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/enable-monitor-tour-step-1/index.tsx
@@ -26,6 +26,23 @@ export default function EnableMonitorTourStep1() {
 
 						nextStepOnTargetClick: '.dashboard-bulk-actions__edit-button',
 					},
+					{
+						target: '.dashboard-bulk-actions__custom_notification_button',
+						popoverPosition: 'bottom left',
+						title: translate( 'Set up Custom Notifications' ),
+						description: (
+							<>
+								{ translate( 'Here are the notification settings for Uptime Monitoring.' ) }
+								<br />
+								<br />
+								{ translate(
+									'All sites are auto-selected; feel free to deselect any you prefer to exclude.'
+								) }
+							</>
+						),
+
+						nextStepOnTargetClick: '.dashboard-bulk-actions__custom_notification_button',
+					},
 				] }
 			/>
 		)

--- a/client/jetpack-cloud/sections/onboarding-tours/enable-monitor-tour-step-2/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/enable-monitor-tour-step-2/index.tsx
@@ -1,0 +1,44 @@
+import { useTranslate } from 'i18n-calypso';
+import GuidedTour from 'calypso/jetpack-cloud/components/guided-tour';
+import { useSelector } from 'calypso/state';
+import { getPreference } from 'calypso/state/preferences/selectors';
+import { JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME } from '../constants';
+
+interface Props {
+	isMonitorPopupVisible: boolean;
+}
+
+export default function EnableMonitorTourStep1( { isMonitorPopupVisible }: Props ) {
+	const translate = useTranslate();
+	const hasFinishedStep1 = useSelector( ( state ) =>
+		getPreference( state, JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME[ 'enableMonitorStep1' ] )
+	);
+	const shouldRenderEnableMonitorTourStep2 = hasFinishedStep1 && ! isMonitorPopupVisible;
+
+	return (
+		shouldRenderEnableMonitorTourStep2 && (
+			<GuidedTour
+				preferenceName={ JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME[ 'enableMonitorStep2' ] }
+				tours={ [
+					{
+						target: '.components-form-toggle__input:not([disabled])',
+						popoverPosition: 'bottom left',
+						title: translate( '🎉 Monitor Status' ),
+						description: (
+							<>
+								{ translate(
+									'Here you can see the current monitoring status of your sites. You can enable or disable this setting per site to receive notifications when your site is down.'
+								) }
+								<br />
+								<br />
+								{ translate( 'Let’s continue exploring, shall we?' ) }
+							</>
+						),
+
+						redirectOnButtonClick: '/overview',
+					},
+				] }
+			/>
+		)
+	);
+}


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/160

## Proposed Changes


* This PR adds an 'enable monitor' onboarding tour in Jetpack Manage. The first part is initiated via the overview page and begins on the 'sites' dashboard - `dashboard`. 
* Pressing on the 'Edit All' button will start the tour. The tour ends after 8 steps, or before if clicking on 'Skip.


## Testing Instructions

* You must be an agency to be able to this this PR: 2c49b-pb. Make sure to switch it back to our original type after testing. Or not. Your call!
* Switch to this branch and `yarn start-jetpack-cloud`.
* Open `http://jetpack.cloud.localhost:3000/`, and you'll be redirected to the /dashboard.
* Append the URL with `?tour=enable-monitor`
* You should see the first step of the enable monitor tour. Clicking the 'Edit All' button will take you to the next step
* To properly test adding a new site after clicking that button, I'd recommend creating a Jurassic Ninja site, and then following the prompts to connect it to Jetpack.
* More to add here...
* Once you finish the tour, to run it again you must erase the preference `jetpack-cloud-site-dashboard-enable-monitor-tour-step-1`. You can do this by hovering in the bottom right button called `Preferences`, then clicking over the `X` next to the preference name.

Preferences:
<img width="1046" alt="Screenshot 2023-12-19 at 14 58 00" src="https://github.com/Automattic/wp-calypso/assets/16754605/0ec75291-868e-4492-8d18-d570f18c25f7">

Tour step 1:
<img width="1317" alt="Screenshot 2023-12-22 at 15 54 59" src="https://github.com/Automattic/wp-calypso/assets/16754605/b5e3ff3d-1cbc-4226-b514-859614aed906">

Tour step 2:

<img width="811" alt="Screenshot 2023-12-22 at 18 59 38" src="https://github.com/Automattic/wp-calypso/assets/16754605/ad5bc446-aa5c-419a-915b-64e2129d4790">

Changing custom notifications:

<img width="720" alt="Screenshot 2023-12-22 at 18 59 54" src="https://github.com/Automattic/wp-calypso/assets/16754605/efac26f1-f1f3-4823-b738-fa8da76986ec">

Last step:
<img width="656" alt="Screenshot 2023-12-22 at 19 00 02" src="https://github.com/Automattic/wp-calypso/assets/16754605/b3b3582e-eebe-44b4-a21c-4ba351a5c9be">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?