### PR TITLE
Signup form: Remove email ToS translation structure

### DIFF
--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -1,8 +1,7 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { localizeUrl, isDefaultLocale, useLocale } from '@automattic/i18n-utils';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Button } from '@wordpress/components';
 import { useState, createInterpolateElement } from '@wordpress/element';
-import { hasTranslation } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import MailIcon from 'calypso/components/social-icons/mail';
 import { isGravatarOAuth2Client, isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
@@ -71,7 +70,6 @@ const SignupFormSocialFirst = ( {
 	const isWooCoreProfilerFlow = useSelector( isWooCommerceCoreProfilerFlow );
 	const isWoo = isWooOAuth2Client( oauth2Client ) || isWooCoreProfilerFlow;
 	const isGravatar = isGravatarOAuth2Client( oauth2Client );
-	const locale = useLocale();
 
 	const renderTermsOfService = () => {
 		let tosText;
@@ -81,30 +79,12 @@ const SignupFormSocialFirst = ( {
 				__( 'By continuing, you agree to our <tosLink>Terms of Service</tosLink>.' ),
 				options
 			);
-			return (
-				<p className="signup-form-social-first__tos-link">
-					{ createInterpolateElement(
-						__( 'By continuing, you agree to our <tosLink>Terms of Service</tosLink>.' ),
-						options
-					) }
-				</p>
-			);
 		} else if ( isGravatar ) {
 			tosText = createInterpolateElement(
 				__(
 					'By entering your email address, you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
 				),
 				options
-			);
-			return (
-				<p className="signup-form-social-first__tos-link">
-					{ createInterpolateElement(
-						__(
-							'By entering your email address, you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
-						),
-						options
-					) }
-				</p>
 			);
 		} else if ( currentStep === 'initial' ) {
 			tosText = createInterpolateElement(
@@ -120,29 +100,11 @@ const SignupFormSocialFirst = ( {
 
 	const renderEmailStepTermsOfService = () => {
 		if ( currentStep === 'email' ) {
-			if (
-				isDefaultLocale( locale ) ||
-				hasTranslation(
-					'By clicking "Continue," you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
-				)
-			) {
-				return (
-					<p className="signup-form-social-first__email-tos-link">
-						{ createInterpolateElement(
-							__(
-								'By clicking "Continue," you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
-							),
-							options
-						) }
-					</p>
-				);
-			}
-
 			return (
 				<p className="signup-form-social-first__email-tos-link">
 					{ createInterpolateElement(
 						__(
-							'By creating an account you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+							'By clicking "Continue," you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
 						),
 						options
 					) }


### PR DESCRIPTION
This PR simply removes the translation machinery needed in https://github.com/Automattic/wp-calypso/pull/85384

## Testing

1. Live link
2. Visit `/start/es/`
3. Check that the ToS in the email signup page is translated

![image](https://github.com/Automattic/wp-calypso/assets/52076348/f068cc52-a477-4cd3-ae65-12d4e3d41ddb)
