### PR TITLE
Remove hardcoded Business from the Premium thank-you screen

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/premium-plan-details.jsx
@@ -4,6 +4,7 @@ import {
 	isGSuiteOrExtraLicenseOrGoogleWorkspace,
 	getPlan,
 	PLAN_PREMIUM,
+	PLAN_BUSINESS,
 } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { find } from 'lodash';
@@ -63,7 +64,8 @@ const PremiumPlanDetails = ( {
 					isPremiumPlan
 						? translate(
 								'With your plan, all WordPress.com advertising has been removed from your site.' +
-									' You can upgrade to a Business plan to also remove the WordPress.com footer credit.'
+									' You can upgrade to a %(planName)s plan to also remove the WordPress.com footer credit.',
+								{ args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' } }
 						  )
 						: translate(
 								'With your plan, all WordPress.com advertising has been removed from your site.'


### PR DESCRIPTION

## Proposed Changes

* Remove hardcoded instance of semi-dead code in the thank-you screen

## Testing Instructions

* hack isRedesignV2 to return false
* purchase Explorer/Premium

<img width="791" alt="Screenshot 2023-12-22 at 14 09 04" src="https://github.com/Automattic/wp-calypso/assets/82778/443b84cf-8f98-490d-a086-d68a7812f672">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
