### PR TITLE
Update hardcoded Premium in mini carousel

### DIFF
--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -182,6 +182,7 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 	}
 
 	if ( showGoogleAnalyticsPromo ) {
+		const premiumPlanName = getPlan( PLAN_PREMIUM )?.getTitle() ?? '';
 		blocks.push(
 			<MiniCarouselBlock
 				clickEvent={ EVENT_GOOGLE_ANALYTICS_BANNER_CLICK }
@@ -191,10 +192,13 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 				contentText={ translate(
 					'Linking Google Analytics to your account is effortless with our %(premiumPlanName)s plan – no coding required. Gain valuable insights in seconds.',
 					{
-						args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() },
+						args: { premiumPlanName },
 					}
 				) }
-				ctaText={ translate( 'Get Premium' ) }
+				ctaText={
+					// Translators: %(plan) is the name of a plan, e.g. "Explorer" or "Premium"
+					translate( 'Get %(plan)s', { args: { plan: premiumPlanName } } )
+				}
 				href={ `/checkout/premium/${ slug || '' }` }
 				key="google-analytics"
 			/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This was recently missed while updating the same component
* On a Free site, go to stats
* The mini carousel is a little bit further down, wait until the Explorer promo shows

<img width="1040" alt="Screenshot 2023-12-22 at 14 27 18" src="https://github.com/Automattic/wp-calypso/assets/82778/253cec74-80d2-4787-93ef-ea5fbc3345db">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
