### PR TITLE
Migrate: Fix Strings and Hardcoded Plan Name

### DIFF
--- a/client/my-sites/migrate/step-import-or-migrate.jsx
+++ b/client/my-sites/migrate/step-import-or-migrate.jsx
@@ -1,4 +1,9 @@
-import { FEATURE_UPLOAD_THEMES_PLUGINS, planHasFeature } from '@automattic/calypso-products';
+import {
+	FEATURE_UPLOAD_THEMES_PLUGINS,
+	PLAN_BUSINESS,
+	getPlan,
+	planHasFeature,
+} from '@automattic/calypso-products';
 import { Button, CompactCard } from '@automattic/components';
 import { Button as WpButton } from '@wordpress/components';
 import { localize } from 'i18n-calypso';
@@ -95,7 +100,13 @@ class StepImportOrMigrate extends Component {
 		}
 
 		if ( ! isTargetSiteAtomic ) {
-			return <p>{ translate( 'Import your entire site with the Business Plan.' ) }</p>;
+			return (
+				<p>
+					{ translate( 'Import your entire site with the %(planName)s plan.', {
+						args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+					} ) }
+				</p>
+			);
 		}
 	};
 
@@ -115,7 +126,7 @@ class StepImportOrMigrate extends Component {
 
 		return (
 			<>
-				<HeaderCake backHref={ backHref }>Import from WordPress</HeaderCake>
+				<HeaderCake backHref={ backHref }>{ translate( 'Import from WordPress' ) }</HeaderCake>
 
 				<SitesBlock
 					sourceSite={ sourceSite }
@@ -134,7 +145,7 @@ class StepImportOrMigrate extends Component {
 								title: translate( 'Everything' ),
 								labels: everythingLabels,
 								description: translate(
-									"All your site's content, themes, plugins, users and settings"
+									"All your site's content, themes, plugins, users and settings."
 								),
 								enabled: sourceHasJetpack,
 							},


### PR DESCRIPTION
## Proposed Changes

I noticed that the Importer uses the legacy Business plan name, and it also has some string issues (one isn't translated, and the punctuation is inconsistent on the other). This fixes that. 

cc @dzver - it looks like this is something you're working on?  

## Testing Instructions

- Go to `/migrate/choose/site`
- Select a self-hosted site which already has Jetpack connected (in practice, you could just force this to be displayed or review the code)
- Confirm the new plan name and strings appear

<img width="817" alt="Screenshot 2023-12-22 at 15 38 41" src="https://github.com/Automattic/wp-calypso/assets/43215253/2a9476a7-d19e-4453-9bad-d33c3b1e56a6">
