### PR TITLE
Subscribers page: Open Help Center when clicking "paid newsletters"

### DIFF
--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -1,6 +1,8 @@
 import page from '@automattic/calypso-router';
 import { Button, Gridicon } from '@automattic/components';
+import { HelpCenter } from '@automattic/data-stores';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
+import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { navItems } from 'calypso/blocks/stats-navigation/constants';
@@ -28,24 +30,34 @@ type SubscribersHeaderProps = {
 	selectedSiteId: number | undefined;
 };
 
+const HELP_CENTER_STORE = HelpCenter.register();
+
 const SubscribersHeader = ( { selectedSiteId }: SubscribersHeaderProps ) => {
 	const { setShowAddSubscribersModal } = useSubscribersPage();
 	const localizeUrl = useLocalizeUrl();
+	const { setShowHelpCenter, setShowSupportDoc } = useDataStoreDispatch( HELP_CENTER_STORE );
+
+	const openHelpCenter = () => {
+		setShowHelpCenter( true );
+		setShowSupportDoc( localizeUrl( 'https://wordpress.com/support/paid-newsletters/' ), 168381 );
+	};
 
 	return (
 		<NavigationHeader
 			className="stats__section-header modernized-header"
 			title={ translate( 'Subscribers' ) }
 			subtitle={ translate(
-				'Add subscribers to your site and send them a free or paid {{link}}newsletter{{/link}}.',
+				'Add subscribers to your site and send them a free or {{link}}paid newsletter{{/link}}.',
 				{
 					components: {
 						link: (
 							<a
-								href={ localizeUrl(
-									'https://wordpress.com/support/launch-a-newsletter/#about-your-subscribers'
-								) }
+								href={ localizeUrl( 'https://wordpress.com/support/paid-newsletters/' ) }
 								target="blank"
+								onClick={ ( event ) => {
+									event.preventDefault();
+									openHelpCenter();
+								} }
 							/>
 						),
 					},

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -1,8 +1,9 @@
 import page from '@automattic/calypso-router';
 import { Button, Gridicon } from '@automattic/components';
 import { HelpCenter } from '@automattic/data-stores';
-import { useLocalizeUrl } from '@automattic/i18n-utils';
+import { useIsEnglishLocale, useLocalizeUrl } from '@automattic/i18n-utils';
 import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
+import { useI18n } from '@wordpress/react-i18n';
 import { translate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { navItems } from 'calypso/blocks/stats-navigation/constants';
@@ -36,33 +37,48 @@ const SubscribersHeader = ( { selectedSiteId }: SubscribersHeaderProps ) => {
 	const { setShowAddSubscribersModal } = useSubscribersPage();
 	const localizeUrl = useLocalizeUrl();
 	const { setShowHelpCenter, setShowSupportDoc } = useDataStoreDispatch( HELP_CENTER_STORE );
+	const { hasTranslation } = useI18n();
+	const isEnglishLocale = useIsEnglishLocale();
 
 	const openHelpCenter = () => {
 		setShowHelpCenter( true );
 		setShowSupportDoc( localizeUrl( 'https://wordpress.com/support/paid-newsletters/' ), 168381 );
 	};
 
+	const subtitleOptions = {
+		components: {
+			link: (
+				<a
+					href={ localizeUrl( 'https://wordpress.com/support/paid-newsletters/' ) }
+					target="blank"
+					onClick={ ( event ) => {
+						event.preventDefault();
+						openHelpCenter();
+					} }
+				/>
+			),
+		},
+	};
+
+	const subtitle =
+		isEnglishLocale ||
+		hasTranslation(
+			'Add subscribers to your site and send them a free or {{link}}paid newsletter{{/link}}.'
+		)
+			? translate(
+					'Add subscribers to your site and send them a free or {{link}}paid newsletter{{/link}}.',
+					subtitleOptions
+			  )
+			: translate(
+					'Add subscribers to your site and send them a free or paid {{link}}newsletter{{/link}}.',
+					subtitleOptions
+			  );
+
 	return (
 		<NavigationHeader
 			className="stats__section-header modernized-header"
 			title={ translate( 'Subscribers' ) }
-			subtitle={ translate(
-				'Add subscribers to your site and send them a free or {{link}}paid newsletter{{/link}}.',
-				{
-					components: {
-						link: (
-							<a
-								href={ localizeUrl( 'https://wordpress.com/support/paid-newsletters/' ) }
-								target="blank"
-								onClick={ ( event ) => {
-									event.preventDefault();
-									openHelpCenter();
-								} }
-							/>
-						),
-					},
-				}
-			) }
+			subtitle={ subtitle }
 			screenReader={ navItems.insights?.label }
 			navigationItems={ [] }
 		>


### PR DESCRIPTION
Closes #85716

## Proposed Changes

* Changes link from 'newsletter' to 'paid newsletter'
* Open Help Center when clicking it, instead of opening a new tab.


| English | Dutch |
|-|-|
| ![CleanShot 2023-12-22 at 13 56 47@2x](https://github.com/Automattic/wp-calypso/assets/528287/93e5ca9d-6a71-4fd2-8262-8ab682e9b675) | ![CleanShot 2023-12-22 at 13 55 24@2x](https://github.com/Automattic/wp-calypso/assets/528287/d57d04e4-0bba-4b68-ba5d-111c30886572) |



## Testing Instructions

1. Apply PR
2. Visit `http://calypso.localhost:3000/subscribers/<yoursite>`
3. Click "paid newsletter"
4. Also try with another locale set. (Note: only newsletter will be clickable until translations come in)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?