### PR TITLE
Replace CTA button component in upsell modal by <PlanButton>

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/index.tsx
@@ -41,6 +41,10 @@ export const ButtonContainer = styled.div`
 	margin-top: 16px;
 	@media ( min-width: 780px ) {
 		margin-top: 24px;
+		button {
+			max-width: 220px;
+			flex-basis: 196px;
+		}
 	}
 `;
 
@@ -70,7 +74,7 @@ export const DomainName = styled.div`
 	overflow-wrap: break-word;
 	max-width: 100%;
 	@media ( min-width: 780px ) {
-		max-width: 55%;
+		max-width: 50%;
 	}
 `;
 

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/index.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@automattic/components';
 import styled from '@emotion/styled';
 
 export const DialogContainer = styled.div`
@@ -75,53 +74,5 @@ export const DomainName = styled.div`
 	max-width: 100%;
 	@media ( min-width: 780px ) {
 		max-width: 50%;
-	}
-`;
-
-export const StyledButton = styled( Button )< { maxwidth?: string } >`
-	padding: 10px 24px;
-	border-radius: 4px;
-	font-weight: 500;
-	font-size: 14px;
-	line-height: 20px;
-	flex: 1;
-	&.is-primary,
-	&.is-primary.is-busy,
-	&.is-primary:hover,
-	&.is-primary:focus {
-		background-color: var( --studio-blue-50 );
-		border: unset;
-	}
-	&:hover {
-		opacity: 0.85;
-		transition: 0.7s;
-	}
-	&:focus:not( .is-borderless ) {
-		box-shadow:
-			0 0 0 2px var( --studio-white ),
-			0 0 0 4px var( --studio-blue-50 );
-	}
-	width: 100%;
-
-	&.is-borderless {
-		text-decoration: underline;
-		border: none;
-		font-weight: 600;
-		padding: 0px;
-		color: var( --studio-gray-50 );
-	}
-
-	&:first-of-type {
-		margin-bottom: 20px;
-	}
-	@media ( min-width: 780px ) {
-		max-width: ${ ( { maxwidth } ) => maxwidth ?? 'fit-content' };
-		width: unset;
-		&:first-of-type {
-			margin-bottom: 0;
-		}
-		&:nth-of-type( 2 ) {
-			margin-left: 31.5px;
-		}
 	}
 `;

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
@@ -2,11 +2,12 @@ import { PlanSlug, getPlan } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
+import PlanButton from 'calypso/my-sites/plans-grid/components/plan-button';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getPlanPrices } from 'calypso/state/plans/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
-import { DomainName, StyledButton } from '.';
+import { DomainName } from '.';
 
 const FreeDomainText = styled.div`
 	font-size: 14px;
@@ -46,7 +47,7 @@ export default function SuggestedPlanSection( {
 				<div>{ paidDomainName }</div>
 				<FreeDomainText>{ translate( 'Free for one year' ) }</FreeDomainText>
 			</DomainName>
-			<StyledButton busy={ isBusy } primary onClick={ onButtonClick }>
+			<PlanButton planSlug={ suggestedPlanSlug } busy={ isBusy } onClick={ onButtonClick }>
 				{ currencyCode &&
 					translate( 'Get %(planTitle)s - %(planPrice)s/month', {
 						comment: 'Eg: Get Personal - $4/month',
@@ -55,7 +56,7 @@ export default function SuggestedPlanSection( {
 							planPrice: formatCurrency( planPriceMonthly, currencyCode, { stripZeros: true } ),
 						},
 					} ) }
-			</StyledButton>
+			</PlanButton>
 		</>
 	);
 }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
@@ -6,12 +6,13 @@ import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import PlanButton from 'calypso/my-sites/plans-grid/components/plan-button';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getPlanPrices } from 'calypso/state/plans/selectors/get-plan-prices';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
-import { DialogContainer, Heading, StyledButton } from './components';
+import { DialogContainer, Heading } from './components';
 import { DomainPlanDialogProps, MODAL_VIEW_EVENT_NAME } from '.';
 import type { TranslateResult } from 'i18n-calypso';
 
@@ -222,11 +223,9 @@ export function FreePlanFreeDomainDialog( {
 			</TextBox>
 
 			<ButtonRow>
-				<StyledButton
-					className="free-plan-free-domain-dialog__plan-button is-upsell-modal-personal-plan"
+				<PlanButton
+					planSlug={ suggestedPlanSlug }
 					disabled={ generatedWPComSubdomain.isLoading || ! generatedWPComSubdomain.result }
-					primary
-					maxwidth="260px"
 					onClick={ () => {
 						onPlanSelected();
 					} }
@@ -237,19 +236,17 @@ export function FreePlanFreeDomainDialog( {
 								planTitle,
 							},
 						} ) }
-				</StyledButton>
+				</PlanButton>
 
-				<StyledButton
-					className="free-plan-free-domain-dialog__plan-button is-upsell-modal-free-plan"
+				<PlanButton
 					disabled={ generatedWPComSubdomain.isLoading || ! generatedWPComSubdomain.result }
 					onClick={ () => {
 						onFreePlanSelected();
 					} }
 					borderless
-					color="gray"
 				>
 					{ translate( 'Continue with Free' ) }
-				</StyledButton>
+				</PlanButton>
 			</ButtonRow>
 			<TextBox fontSize={ 12 } color="gray" noBottomGap>
 				{ planTitle &&

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-paid-domain-dialog.tsx
@@ -3,6 +3,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { useEffect, useState } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import PlanButton from 'calypso/my-sites/plans-grid/components/plan-button';
 import {
 	ButtonContainer,
 	DialogContainer,
@@ -10,7 +11,6 @@ import {
 	Row,
 	RowWithBorder,
 	SubHeading,
-	StyledButton,
 	DomainName,
 } from './components';
 import SuggestedPlanSection from './components/suggested-plan-section';
@@ -88,13 +88,13 @@ export function FreePlanPaidDomainDialog( {
 								comment: '%(wpcomFreeDomain)s is a WordPress.com subdomain, e.g. foo.wordpress.com',
 							} ) }
 					</DomainName>
-					<StyledButton
+					<PlanButton
 						disabled={ generatedWPComSubdomain.isLoading || ! generatedWPComSubdomain.result }
 						busy={ isBusy }
 						onClick={ handleFreePlanClick }
 					>
 						{ translate( 'Continue with Free plan' ) }
-					</StyledButton>
+					</PlanButton>
 				</Row>
 			</ButtonContainer>
 		</DialogContainer>

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from '@wordpress/element';
 import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import PlanButton from 'calypso/my-sites/plans-grid/components/plan-button';
 import {
 	ButtonContainer,
 	DialogContainer,
@@ -12,7 +13,6 @@ import {
 	Row,
 	RowWithBorder,
 	DomainName,
-	StyledButton,
 } from './components';
 import SuggestedPlanSection from './components/suggested-plan-section';
 import { DomainPlanDialogProps, MODAL_VIEW_EVENT_NAME } from '.';
@@ -78,13 +78,13 @@ export default function PaidPlanIsRequiredDialog( {
 							<div>{ generatedWPComSubdomain.result.domain_name }</div>
 						) }
 					</DomainName>
-					<StyledButton
+					<PlanButton
 						disabled={ generatedWPComSubdomain.isLoading || ! generatedWPComSubdomain.result }
 						busy={ isBusy }
 						onClick={ handleFreeDomainClick }
 					>
 						{ translate( 'Continue with Free plan' ) }
-					</StyledButton>
+					</PlanButton>
 				</Row>
 			</ButtonContainer>
 		</DialogContainer>

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -17,7 +17,7 @@ import {
 	UrlFriendlyTermType,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { Button, Spinner, LoadingPlaceholder } from '@automattic/components';
+import { Button, Spinner } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
 import { isAnyHostingFlow } from '@automattic/onboarding';
 import styled from '@emotion/styled';

--- a/client/my-sites/plans-grid/components/plan-button/index.tsx
+++ b/client/my-sites/plans-grid/components/plan-button/index.tsx
@@ -34,7 +34,7 @@ const PlanButton = ( {
 	const className = classNames(
 		classes,
 		'plan-features-2023-grid__actions-button',
-		planSlug ? getPlanClass( planSlug ) : '',
+		planSlug ? getPlanClass( planSlug ) : 'is-default',
 		{
 			'is-current-plan': current,
 			'is-stuck': isStuck,

--- a/client/my-sites/plans-grid/components/plan-button/style.scss
+++ b/client/my-sites/plans-grid/components/plan-button/style.scss
@@ -10,9 +10,6 @@
 	flex: 1;
 	width: 100%;
 
-	background-color: var(--studio-white);
-	color: var(--studio-gray-100);
-
 	&:hover {
 		opacity: 0.85;
 		transition: 0.7s;
@@ -124,7 +121,11 @@
 		}
 	}
 
-	&.is-current-plan {
+	// Currently these two are identical, but the both are kept
+	// since it's too early to say the current plan button will always
+	// be the default style, i.e. the secondary CTA button style
+	&.is-current-plan,
+	&.is-default {
 		background-color: var(--studio-white);
 		color: var(--studio-gray-100);
 		box-shadow: inset 0 0 0 1px var(--studio-gray-10);
@@ -150,5 +151,15 @@
 		height: 48px;
 		line-height: 15px;
 		padding: 9px 12px;
+	}
+
+	&.is-borderless {
+		box-shadow: unset;
+		text-decoration: underline;
+		font-weight: 600;
+
+		&:hover {
+			box-shadow: unset;
+		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/growth-foundations/issues/286

## Proposed Changes

This PR replaces `<StyledButton>` by `<PlanButton>` introduced by https://github.com/Automattic/wp-calypso/pull/85691 in the plan upsell modals. Along with it, a few style tweaks are also introduced to make `<PlanButton>` has more sensicle styles when `planSlug` is absent and `borderless` is set. 

## Testing Instructions

No functional changes should be introduced to all the upsell modal. The CTAs are expected to be slightly different, since the previous version is isolated from how the plan CTAs look in the plans grid. They should now fully in-sync. 

* Free domain/Free plan: picking a free domain and the Free plan in `/start/onboarding-pm` flow, the Free domain/Free plan upsell modal should appear and work as expected.
* Paid domain/Free plan: picking a paid domain and the Free plan in `/start/onboarding-pm` flow, the Paid domain/Free plan upsell modal should appear and work as expected.
* A paid plan is required: picking a paid domain and the Free plan in `/start/onboarding` flow, the "paid plan is required" upsell modal should appear and work as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
