### PR TITLE
Enable domain pending registration support link

### DIFF
--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -651,12 +651,11 @@ const Settings = ( {
 				showDismiss={ false }
 				status="is-warning"
 			>
-				{ /*
-					TO DO: Enable the link when the support page is ready
-					<NoticeAction href={ domain.pendingRegistrationAtRegistryUrl }>
+				{ domain?.pendingRegistrationAtRegistryUrl && (
+					<NoticeAction external href={ domain?.pendingRegistrationAtRegistryUrl }>
 						{ translate( 'More info' ) }
 					</NoticeAction>
-				*/ }
+				) }
 			</Notice>
 		);
 	};


### PR DESCRIPTION
## Proposed Changes

This PR enable `More info` link for domain with a pending registration (i.e. `.com.br` before registry approval).

## Testing Instructions

Depends on: D133031-code

Apply the PR locally or use the Calypso link below and visit the domain settings page for a domain with a pending registration (you can force `pending_registration_at_registry` to `true` in wpcom).

Verify that the _More info_ link is visible in the alert and that the link goes to:
'_https://wordpress.com/support/tlds-with-special-policies/about-br-domains_'

![pending-link](https://github.com/Automattic/wp-calypso/assets/2797601/720f76ff-affc-4901-81b7-b3643560877a)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?