### PR TITLE
Messaging: Save AI chat ID when starting a new livechat

### DIFF
--- a/client/components/chat-button/index.tsx
+++ b/client/components/chat-button/index.tsx
@@ -108,7 +108,12 @@ const ChatButton: FC< Props > = ( {
 
 	const handleClick = () => {
 		if ( canConnectToZendesk ) {
-			openChatWidget( initialMessage, siteUrl, onError, onClick );
+			openChatWidget( {
+				message: initialMessage,
+				siteUrl,
+				onError,
+				onSuccess: onClick,
+			} );
 		} else {
 			setInitialRoute( '/contact-form?mode=CHAT' );
 			setShowHelpCenter( true );

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/educational-content-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/educational-content-step.tsx
@@ -254,11 +254,12 @@ export default function EducationalCotnentStep( { type, site, ...props }: StepPr
 												disabled={ isOpeningChatWidget }
 												onClick={ () => {
 													page( `/domains/manage/${ site.slug }` );
-													openChatWidget(
-														"User is contacting us from pre-cancellation form. Cancellation reason they've given: " +
+													openChatWidget( {
+														message:
+															"User is contacting us from pre-cancellation form. Cancellation reason they've given: " +
 															props.cancellationReason,
-														site.URL
-													);
+														siteUrl: site.URL,
+													} );
 												} }
 												variant="link"
 											/>

--- a/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
+++ b/client/components/marketing-survey/cancel-purchase-form/step-components/upsell-step.tsx
@@ -132,11 +132,12 @@ export default function UpsellStep( { upsell, site, purchase, ...props }: StepPr
 						} );
 						page( getLiveChatUrl( upsell, site, purchase ) );
 
-						openChatWidget(
-							"User is contacting us from pre-cancellation form. Cancellation reason they've given: " +
+						openChatWidget( {
+							message:
+								"User is contacting us from pre-cancellation form. Cancellation reason they've given: " +
 								props.cancellationReason,
-							site.URL
-						);
+							siteUrl: site.URL,
+						} );
 						props.closeDialog();
 					} }
 					onDecline={ props.onDeclineUpsell }

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -114,7 +114,6 @@ export const HelpCenterContactForm = () => {
 			userDeclaredSiteUrl: helpCenterSelect.getUserDeclaredSiteUrl(),
 		};
 	}, [] );
-	const wapuuChatId = getOdieStorage( 'last_chat_id' );
 
 	const { setSite, resetStore, setUserDeclaredSite, setShowMessagingChat, setSubject, setMessage } =
 		useDispatch( HELP_CENTER_STORE );
@@ -293,6 +292,8 @@ export const HelpCenterContactForm = () => {
 		const productId = plan?.getProductId();
 		const productName = plan?.getTitle();
 		const productTerm = getPlanTermLabel( productSlug, ( text ) => text );
+		const wapuuChatId = getOdieStorage( 'last_chat_id' );
+		const aiChatId = wapuuFlow ? wapuuChatId ?? '' : gptResponse?.answer_id;
 
 		switch ( mode ) {
 			case 'CHAT':
@@ -327,9 +328,12 @@ export const HelpCenterContactForm = () => {
 						initialChatMessage += 'User was chatting with Wapuu before they started chat<br />';
 					}
 
-					openChatWidget( initialChatMessage, supportSite.URL, () =>
-						setHasSubmittingError( true )
-					);
+					openChatWidget( {
+						aiChatId: aiChatId,
+						message: initialChatMessage,
+						siteUrl: supportSite.URL,
+						onError: () => setHasSubmittingError( true ),
+					} );
 					break;
 				}
 				break;
@@ -358,7 +362,7 @@ export const HelpCenterContactForm = () => {
 						is_chat_overflow: overflow,
 						source: 'source_wpcom_help_center',
 						blog_url: supportSite.URL,
-						ai_chat_id: wapuuFlow ? wapuuChatId ?? '' : gptResponse?.answer_id,
+						ai_chat_id: aiChatId,
 						ai_message: gptResponse?.response,
 					} )
 						.then( () => {

--- a/packages/help-center/src/data/use-update-zendesk-user-fields.ts
+++ b/packages/help-center/src/data/use-update-zendesk-user-fields.ts
@@ -3,6 +3,7 @@ import apiFetch, { APIFetchOptions } from '@wordpress/api-fetch';
 import wpcomRequest, { canAccessWpcomApis } from 'wpcom-proxy-request';
 
 type ZendeskUserFields = {
+	messaging_ai_chat_id?: string;
 	messaging_initial_message?: string;
 	messaging_plan?: string;
 	messaging_source?: string;

--- a/packages/help-center/src/hooks/use-chat-widget.ts
+++ b/packages/help-center/src/hooks/use-chat-widget.ts
@@ -12,6 +12,14 @@ import { useUpdateZendeskUserFieldsMutation } from '../data/use-update-zendesk-u
 import { HELP_CENTER_STORE } from '../stores';
 import type { ZendeskConfigName } from '@automattic/help-center/src/hooks/use-zendesk-messaging';
 
+type ChatMetadata = {
+	aiChatId?: string;
+	message?: string;
+	siteUrl?: string;
+	onError?: () => void;
+	onSuccess?: () => void;
+};
+
 export default function useChatWidget(
 	configName: ZendeskConfigName = 'zendesk_support_chat_key',
 	enabled = true
@@ -23,13 +31,15 @@ export default function useChatWidget(
 
 	const { isMessagingScriptLoaded } = useZendeskMessaging( configName, enabled, enabled );
 
-	const openChatWidget = (
-		message: string | undefined,
+	const openChatWidget = ( {
+		aiChatId,
+		message = 'No message from user',
 		siteUrl = 'No site selected',
-		onError?: () => void,
-		onSuccess?: () => void
-	) => {
+		onError,
+		onSuccess,
+	}: ChatMetadata ) => {
 		submitZendeskUserFields( {
+			messaging_ai_chat_id: aiChatId,
 			messaging_source: sectionName,
 			messaging_initial_message: message,
 			messaging_plan: '', // Will be filled out by backend


### PR DESCRIPTION
This will allow us to link the AI interaction with an escalation to human, hopefully giving us insights on how we can improve the flow and answers.

## Proposed Changes

* Save the AI Chat ID when starting a new livechat.

The field has already been added on the backend: D133036-code.

## Testing Instructions

- Make sure you are _not_ in the Wapuu Agent variation.
- Open Help Center in Calypso.
- Click "Still need help?".
- Select Chat.
- Type your question, click Continue.
- The AI response should start loading. In the Network tab, you should see a request to `jetpack-search/ai/search`. Note the `answer_id` in the response - that's the "AI Chat ID" we want to save.
- Click "Still chat with us".
- There should be a request to `update-user-fields`, with `messaging_ai_chat_id` being equal to the ID from the previous point.

Note that there will be a separate patch to actually use this data on the backend, so for now we just need to confirm the data is sent to the backend where the link will be made.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
