### PR TITLE
Theme details CTA for personal tiers

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1572,6 +1572,7 @@ const ThemeSheetWithOptions = ( props ) => {
 		isActive,
 		isLoggedIn,
 		isPremium,
+		isThemeAllowedOnSite,
 		isThemePurchased,
 		isStandaloneJetpack,
 		demoUrl,
@@ -1609,7 +1610,10 @@ const ThemeSheetWithOptions = ( props ) => {
 		! isThemeInstalled
 	) {
 		defaultOption = 'subscribe';
-	} else if ( isPremium && ! isThemePurchased && ! isBundledSoftwareSet ) {
+	} else if (
+		( isPremium && ! isThemePurchased && ! isBundledSoftwareSet ) ||
+		! isThemeAllowedOnSite
+	) {
 		defaultOption = 'purchase';
 	} else if (
 		! canInstallPlugins &&

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -1,9 +1,11 @@
-import { WPCOM_FEATURES_INSTALL_PLUGINS } from '@automattic/calypso-products';
+import { WPCOM_FEATURES_INSTALL_PLUGINS, getPlan } from '@automattic/calypso-products';
 import { addQueryArgs } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
 import { mapValues, pickBy, flowRight as compose } from 'lodash';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { THEME_TIERS } from 'calypso/components/theme-tier/constants';
+import getThemeTier from 'calypso/components/theme-tier/get-theme-tier';
 import withIsFSEActive from 'calypso/data/themes/with-is-fse-active';
 import { localizeThemesPath } from 'calypso/my-sites/themes/helpers';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -57,7 +59,12 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 				} )
 			);
 
-			return `/checkout/${ slug }/value_bundle?redirect_to=${ redirectTo }`;
+			const { themeTier } = getThemeTier( state, siteId, themeId );
+			const tierMinimumUpsellPlan = THEME_TIERS[ themeTier?.slug ]?.minimumUpsellPlan;
+			const mappedPlan = getPlan( tierMinimumUpsellPlan );
+			const planPathSlug = mappedPlan?.getPathSlug();
+
+			return `/checkout/${ slug }/${ planPathSlug }?redirect_to=${ redirectTo }`;
 		},
 		hideForTheme: ( state, themeId, siteId ) =>
 			( isJetpackSite( state, siteId ) && ! isSiteWpcomAtomic( state, siteId ) ) || // No individual theme purchase on a JP site


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Change the CTA for a personal tiered plan on a free site to "Upgrade to activate" and to link to buy the personal plan.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use the Calypso live link below
2. Navigate to a premium theme and observe it works as before - on a Free site it says "Upgrade to activate" and on a Explorer site it says "Activate this design"
3. Add the `flags=themes/tiers` get var and repeat step two, again, it should work as before
4. Go to a personal theme while the flag is on (e.g. Epi). On a free site it should say "Upgrade to activate" and take users to the checkout with the Starter plan, on sites with a plan it should say "Activate this design"

Before | After
-------|------
<img width="938" alt="Screenshot 2024-01-03 at 18 25 22" src="https://github.com/Automattic/wp-calypso/assets/93301/80f7f7cb-8b17-4045-8245-fc7f9b07ab6d"> | <img width="938" alt="Screenshot 2024-01-03 at 18 24 41" src="https://github.com/Automattic/wp-calypso/assets/93301/6782f3f5-284e-403b-a5f8-5c45432c984d">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?