### PR TITLE
[Odie] Send chat id to email and chats

### DIFF
--- a/client/odie/data/index.ts
+++ b/client/odie/data/index.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-type OdieStorageKey = 'chat_id' | 'support_chat_id';
+type OdieStorageKey = 'chat_id' | 'last_chat_id';
 
 const buildOdieStorageKey = ( key: OdieStorageKey ) => `odie_${ key }`;
 
@@ -15,13 +15,13 @@ export const setOdieStorage = ( key: OdieStorageKey, value: string ) => {
 	const storageKey = buildOdieStorageKey( key );
 	localStorage.setItem( storageKey, value );
 
-	// Duplicate the value to support_chat_id
+	// Duplicate the value to last_chat_id
 	if ( key === 'chat_id' ) {
-		localStorage.setItem( buildOdieStorageKey( 'support_chat_id' ), value );
+		localStorage.setItem( buildOdieStorageKey( 'last_chat_id' ), value );
 		window.dispatchEvent(
 			new CustomEvent( storageEventName, {
 				detail: {
-					key: buildOdieStorageKey( 'support_chat_id' ),
+					key: buildOdieStorageKey( 'last_chat_id' ),
 					value: value,
 				},
 			} )

--- a/client/odie/data/index.ts
+++ b/client/odie/data/index.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-type OdieStorageKey = 'chat_id';
+type OdieStorageKey = 'chat_id' | 'support_chat_id';
 
 const buildOdieStorageKey = ( key: OdieStorageKey ) => `odie_${ key }`;
 
@@ -14,6 +14,19 @@ export const getOdieStorage = ( key: OdieStorageKey ) => {
 export const setOdieStorage = ( key: OdieStorageKey, value: string ) => {
 	const storageKey = buildOdieStorageKey( key );
 	localStorage.setItem( storageKey, value );
+
+	// Duplicate the value to support_chat_id
+	if ( key === 'chat_id' ) {
+		localStorage.setItem( buildOdieStorageKey( 'support_chat_id' ), value );
+		window.dispatchEvent(
+			new CustomEvent( storageEventName, {
+				detail: {
+					key: buildOdieStorageKey( 'support_chat_id' ),
+					value: value,
+				},
+			} )
+		);
+	}
 
 	const event = new CustomEvent( storageEventName, {
 		detail: {

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -114,7 +114,7 @@ export const HelpCenterContactForm = () => {
 			userDeclaredSiteUrl: helpCenterSelect.getUserDeclaredSiteUrl(),
 		};
 	}, [] );
-	const supportChatId = getOdieStorage( 'support_chat_id' );
+	const lastChatSessionId = getOdieStorage( 'last_chat_id' );
 
 	const { setSite, resetStore, setUserDeclaredSite, setShowMessagingChat, setSubject, setMessage } =
 		useDispatch( HELP_CENTER_STORE );
@@ -318,15 +318,15 @@ export const HelpCenterContactForm = () => {
 						initialChatMessage += `<strong>Automated AI response from ${ gptResponse.source } that was presented to user before they started chat</strong>:<br />`;
 						initialChatMessage += gptResponse.response;
 					}
+
 					if ( wapuuFlow ) {
 						initialChatMessage += '<br /><br />';
-						if ( supportChatId ) {
-							initialChatMessage += `<strong>Wapuu chat reference: ${ supportChatId }</strong>:<br />`;
-						} else {
-							initialChatMessage += `<strong>Wapuu chat referene is not available </strong>:<br />`;
-						}
+						initialChatMessage += lastChatSessionId
+							? `<strong>Wapuu chat reference: ${ lastChatSessionId }</strong>:<br />`
+							: '<strong>Wapuu chat reference is not available</strong>:<br />';
 						initialChatMessage += 'User was chatting with Wapuu before they started chat<br />';
 					}
+
 					openChatWidget( initialChatMessage, supportSite.URL, () =>
 						setHasSubmittingError( true )
 					);
@@ -358,7 +358,7 @@ export const HelpCenterContactForm = () => {
 						is_chat_overflow: overflow,
 						source: 'source_wpcom_help_center',
 						blog_url: supportSite.URL,
-						ai_chat_id: wapuuFlow ? supportChatId ?? '' : gptResponse?.answer_id,
+						ai_chat_id: wapuuFlow ? lastChatSessionId ?? '' : gptResponse?.answer_id,
 						ai_message: gptResponse?.response,
 					} )
 						.then( () => {

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -114,7 +114,7 @@ export const HelpCenterContactForm = () => {
 			userDeclaredSiteUrl: helpCenterSelect.getUserDeclaredSiteUrl(),
 		};
 	}, [] );
-	const lastChatSessionId = getOdieStorage( 'last_chat_id' );
+	const wapuuChatId = getOdieStorage( 'last_chat_id' );
 
 	const { setSite, resetStore, setUserDeclaredSite, setShowMessagingChat, setSubject, setMessage } =
 		useDispatch( HELP_CENTER_STORE );
@@ -321,8 +321,8 @@ export const HelpCenterContactForm = () => {
 
 					if ( wapuuFlow ) {
 						initialChatMessage += '<br /><br />';
-						initialChatMessage += lastChatSessionId
-							? `<strong>Wapuu chat reference: ${ lastChatSessionId }</strong>:<br />`
+						initialChatMessage += wapuuChatId
+							? `<strong>Wapuu chat reference: ${ wapuuChatId }</strong>:<br />`
 							: '<strong>Wapuu chat reference is not available</strong>:<br />';
 						initialChatMessage += 'User was chatting with Wapuu before they started chat<br />';
 					}
@@ -358,7 +358,7 @@ export const HelpCenterContactForm = () => {
 						is_chat_overflow: overflow,
 						source: 'source_wpcom_help_center',
 						blog_url: supportSite.URL,
-						ai_chat_id: wapuuFlow ? lastChatSessionId ?? '' : gptResponse?.answer_id,
+						ai_chat_id: wapuuFlow ? wapuuChatId ?? '' : gptResponse?.answer_id,
 						ai_message: gptResponse?.response,
 					} )
 						.then( () => {

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -19,6 +19,7 @@ import { useDebounce } from 'use-debounce';
 import { decodeEntities, preventWidows } from 'calypso/lib/formatting';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import { getQueryArgs } from 'calypso/lib/query-args';
+import { getOdieStorage } from 'calypso/odie/data';
 import { getCurrentUserEmail, getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getSectionName } from 'calypso/state/ui/selectors';
 /**
@@ -113,6 +114,7 @@ export const HelpCenterContactForm = () => {
 			userDeclaredSiteUrl: helpCenterSelect.getUserDeclaredSiteUrl(),
 		};
 	}, [] );
+	const supportChatId = getOdieStorage( 'support_chat_id' );
 
 	const { setSite, resetStore, setUserDeclaredSite, setShowMessagingChat, setSubject, setMessage } =
 		useDispatch( HELP_CENTER_STORE );
@@ -316,6 +318,15 @@ export const HelpCenterContactForm = () => {
 						initialChatMessage += `<strong>Automated AI response from ${ gptResponse.source } that was presented to user before they started chat</strong>:<br />`;
 						initialChatMessage += gptResponse.response;
 					}
+					if ( wapuuFlow ) {
+						initialChatMessage += '<br /><br />';
+						if ( supportChatId ) {
+							initialChatMessage += `<strong>Wapuu chat reference: ${ supportChatId }</strong>:<br />`;
+						} else {
+							initialChatMessage += `<strong>Wapuu chat referene is not available </strong>:<br />`;
+						}
+						initialChatMessage += 'User was chatting with Wapuu before they started chat<br />';
+					}
 					openChatWidget( initialChatMessage, supportSite.URL, () =>
 						setHasSubmittingError( true )
 					);
@@ -347,7 +358,7 @@ export const HelpCenterContactForm = () => {
 						is_chat_overflow: overflow,
 						source: 'source_wpcom_help_center',
 						blog_url: supportSite.URL,
-						ai_chat_id: gptResponse?.answer_id,
+						ai_chat_id: wapuuFlow ? supportChatId ?? '' : gptResponse?.answer_id,
 						ai_message: gptResponse?.response,
 					} )
 						.then( () => {


### PR DESCRIPTION
Related to #

## Proposed Changes

- Pass chat ID when passing the issue to chat or email

## Testing Instructions

- Talk with wapuu
- Ask him to contact customer support
- Send a message (either to email or chat)
- Open console
- Type: localStorage.getItem("odie_support_chat_id")
- There should be a id there. Means it has been sent to our Happines Support.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
