### PR TITLE
Jetpack Manage: 159 - small tweaks as follow-on to #85488 

### DIFF
--- a/client/jetpack-cloud/components/guided-tour/index.tsx
+++ b/client/jetpack-cloud/components/guided-tour/index.tsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { Popover, Button } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getJetpackDashboardPreference as getPreference } from 'calypso/state/jetpack-agency-dashboard/selectors';

--- a/client/jetpack-cloud/components/guided-tour/index.tsx
+++ b/client/jetpack-cloud/components/guided-tour/index.tsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import { Popover, Button } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -106,7 +107,7 @@ const GuidedTour = ( { className, tours, preferenceName }: Props ) => {
 			} )
 		);
 		if ( redirectOnButtonClick ) {
-			window.location.href = redirectOnButtonClick;
+			page.redirect( redirectOnButtonClick );
 		}
 	}, [ dispatch, preferenceName, preference, redirectOnButtonClick ] );
 

--- a/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-2/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-2/index.tsx
@@ -21,7 +21,7 @@ export default function AddNewSiteTourStep2( { siteItems }: Props ) {
 	const shouldRenderAddSiteTourStep2 = hasFinishedStep1 && mostRecentConnectedSite;
 
 	const tourHTMLTarget =
-		siteItems.length > 20
+		siteItems.length <= 20
 			? 'tr.is-most-recent-jetpack-connected-site td:first-of-type'
 			: '.site-table__table th:first-of-type';
 

--- a/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-2/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-2/index.tsx
@@ -21,7 +21,7 @@ export default function AddNewSiteTourStep2( { siteItems }: Props ) {
 	const shouldRenderAddSiteTourStep2 = hasFinishedStep1 && mostRecentConnectedSite;
 
 	const tourHTMLTarget =
-		siteItems.length <= 20
+		siteItems.length < 20
 			? 'tr.is-most-recent-jetpack-connected-site td:first-of-type'
 			: '.site-table__table th:first-of-type';
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Minor adjustments after #85488.

## Proposed Changes

After #85488 was merged I spotted a few issues:

* We were using `window.location` to redirect, which was preventing tracks and prefs from sending.
* We flipped the targeting logic on step two.

I fixed these and removed an unneeded import.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verify step 2 targets the newly-connected site.

Verify the tracks and preference requests are properly sent (you can look in the network tab).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
