### PR TITLE
Jetpack Manage: 194 - connect Overview page next steps to onboarding tours

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/dashboard-bulk-actions/index.tsx
@@ -4,7 +4,6 @@ import { useTranslate } from 'i18n-calypso';
 import { useState, createRef, useContext } from 'react';
 import ButtonGroup from 'calypso/components/button-group';
 import SelectDropdown from 'calypso/components/select-dropdown';
-import EnableMonitorTourStep2 from '../../onboarding-tours/enable-monitor-tour-step-2';
 import NotificationSettings from '../downtime-monitoring/notification-settings';
 import { useJetpackAgencyDashboardRecordTrackEvent } from '../hooks';
 import SitesOverviewContext from '../sites-overview/context';
@@ -143,7 +142,6 @@ export default function DashboardBulkActions( {
 					</Button>
 				</ButtonGroup>
 			</div>
-			<EnableMonitorTourStep2 isMonitorPopupVisible={ showNotificationSettingsPopup } />
 			{ showNotificationSettingsPopup && (
 				<NotificationSettings
 					sites={ selectedSites }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content-header.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content-header.tsx
@@ -2,7 +2,9 @@ import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import MissingPaymentNotification from 'calypso/jetpack-cloud/components/missing-payment-notification';
 import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
+import AddNewSiteTourStep1 from '../../onboarding-tours/add-new-site-tour-step-1';
 import DashboardWalkthroughTour from '../../onboarding-tours/dashboard-walkthrough-tour';
+import EnableMonitorTourStep1 from '../../onboarding-tours/enable-monitor-tour-step-1';
 import type { ReactNode } from 'react';
 import './style.scss';
 
@@ -39,6 +41,8 @@ export default function SiteContentHeader( { content, pageTitle, showStickyConte
 					{ content }
 				</div>
 			</div>
+			<AddNewSiteTourStep1 />
+			<EnableMonitorTourStep1 />
 			<DashboardWalkthroughTour />
 		</>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content-header.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content-header.tsx
@@ -5,6 +5,7 @@ import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
 import AddNewSiteTourStep1 from '../../onboarding-tours/add-new-site-tour-step-1';
 import DashboardWalkthroughTour from '../../onboarding-tours/dashboard-walkthrough-tour';
 import EnableMonitorTourStep1 from '../../onboarding-tours/enable-monitor-tour-step-1';
+import EnableMonitorTourStep2 from '../../onboarding-tours/enable-monitor-tour-step-2';
 import type { ReactNode } from 'react';
 import './style.scss';
 
@@ -43,6 +44,7 @@ export default function SiteContentHeader( { content, pageTitle, showStickyConte
 			</div>
 			<AddNewSiteTourStep1 />
 			<EnableMonitorTourStep1 />
+			<EnableMonitorTourStep2 />
 			<DashboardWalkthroughTour />
 		</>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table/index.tsx
@@ -2,7 +2,6 @@ import { Icon, starFilled, info } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useContext, useState, forwardRef, Ref } from 'react';
 import AddNewSiteTourStep2 from 'calypso/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-2';
-import EnableMonitorTourStep1 from 'calypso/jetpack-cloud/sections/onboarding-tours/enable-monitor-tour-step-1';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import './style.scss';
 import EditButton from '../../dashboard-bulk-actions/edit-button';
@@ -122,7 +121,6 @@ const SiteTable = ( { isLoading, columns, items }: Props, ref: Ref< HTMLTableEle
 				</tbody>
 			</table>
 			<AddNewSiteTourStep2 siteItems={ items } />
-			<EnableMonitorTourStep1 />
 		</>
 	);
 };

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
@@ -5,7 +5,6 @@ import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useRef, useState } from 'react';
 import AddNewSiteButton from 'calypso/components/jetpack/add-new-site-button';
-import AddNewSiteTourStep1 from 'calypso/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-1';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentPartner } from 'calypso/state/partner-portal/partner/selectors';
@@ -73,7 +72,6 @@ export default function SiteTopHeaderButtons() {
 							)
 						}
 					/>
-					<AddNewSiteTourStep1 />
 					<WPCOMHostingPopover
 						context={ buttonRef.current }
 						// Show the popover only when the split button is closed

--- a/client/jetpack-cloud/sections/onboarding-tours/enable-monitor-tour-step-2/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/enable-monitor-tour-step-2/index.tsx
@@ -6,19 +6,14 @@ import { JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME } from '../constants';
 
 import '../style.scss';
 
-interface Props {
-	isMonitorPopupVisible: boolean;
-}
-
-export default function EnableMonitorTourStep2( { isMonitorPopupVisible }: Props ) {
+export default function EnableMonitorTourStep2() {
 	const translate = useTranslate();
 	const hasFinishedStep1 = useSelector( ( state ) =>
 		getPreference( state, JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME[ 'enableMonitorStep1' ] )
 	);
-	const shouldRenderEnableMonitorTourStep2 = hasFinishedStep1 && ! isMonitorPopupVisible;
 
 	return (
-		shouldRenderEnableMonitorTourStep2 && (
+		hasFinishedStep1 && (
 			<GuidedTour
 				className="onboarding-tours__guided-tour"
 				preferenceName={ JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME[ 'enableMonitorStep2' ] }

--- a/client/jetpack-cloud/sections/onboarding-tours/enable-monitor-tour-step-2/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/enable-monitor-tour-step-2/index.tsx
@@ -10,7 +10,7 @@ interface Props {
 	isMonitorPopupVisible: boolean;
 }
 
-export default function EnableMonitorTourStep1( { isMonitorPopupVisible }: Props ) {
+export default function EnableMonitorTourStep2( { isMonitorPopupVisible }: Props ) {
 	const translate = useTranslate();
 	const hasFinishedStep1 = useSelector( ( state ) =>
 		getPreference( state, JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME[ 'enableMonitorStep1' ] )

--- a/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
@@ -21,7 +21,7 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 				dispatch( recordTracksEvent( tracksPrefix + '_get_familiar_click' ) );
 			},
 			id: 'get_familiar',
-			title: 'Get familiar with the sites management dashboard',
+			title: translate( 'Get familiar with the sites management dashboard' ),
 			useCalypsoPath: true,
 		},
 		{
@@ -32,7 +32,7 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 				dispatch( recordTracksEvent( tracksPrefix + '_add_sites_click' ) );
 			},
 			id: 'add_sites',
-			title: 'Learn how to add new sites',
+			title: translate( 'Learn how to add new sites' ),
 			useCalypsoPath: true,
 		},
 		{
@@ -43,7 +43,7 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 				dispatch( recordTracksEvent( tracksPrefix + '_bulk_editing_click' ) );
 			},
 			id: 'bulk_editing',
-			title: 'Learn bulk editing and enabling downtime monitoring',
+			title: translate( 'Learn bulk editing and enabling downtime monitoring' ),
 			useCalypsoPath: true,
 		},
 		{
@@ -54,7 +54,7 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 				dispatch( recordTracksEvent( tracksPrefix + '_plugin_management_click' ) );
 			},
 			id: 'plugin_management',
-			title: 'Explore plugin management',
+			title: translate( 'Explore plugin management' ),
 			useCalypsoPath: true,
 		},
 	];

--- a/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
@@ -14,8 +14,8 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 
 	const tasks: Task[] = [
 		{
-			calypso_path: '',
 			completed: false,
+			calypso_path: '/dashboard?tour=dashboard-walkthrough',
 			disabled: false,
 			actionDispatch: () => {
 				dispatch( recordTracksEvent( tracksPrefix + '_get_familiar_click' ) );
@@ -25,8 +25,8 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 			useCalypsoPath: true,
 		},
 		{
-			calypso_path: '',
 			completed: false,
+			calypso_path: '/dashboard?tour=add-new-site',
 			disabled: false,
 			actionDispatch: () => {
 				dispatch( recordTracksEvent( tracksPrefix + '_add_sites_click' ) );
@@ -36,8 +36,8 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 			useCalypsoPath: true,
 		},
 		{
-			calypso_path: '',
 			completed: false,
+			calypso_path: '/dashboard?tour=enable-monitor',
 			disabled: false,
 			actionDispatch: () => {
 				dispatch( recordTracksEvent( tracksPrefix + '_bulk_editing_click' ) );
@@ -47,8 +47,8 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 			useCalypsoPath: true,
 		},
 		{
-			calypso_path: '',
 			completed: false,
+			calypso_path: '/plugins/manage?tour=plugin-management',
 			disabled: false,
 			actionDispatch: () => {
 				dispatch( recordTracksEvent( tracksPrefix + '_plugin_management_click' ) );

--- a/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
@@ -1,57 +1,80 @@
 import { CircularProgressBar } from '@automattic/components';
 import { Checklist, type Task } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
-import { useDispatch } from 'calypso/state';
+import { JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME } from 'calypso/jetpack-cloud/sections/onboarding-tours/constants';
+import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { getAllRemotePreferences } from 'calypso/state/preferences/selectors';
 
 import './style.scss';
 
 export default function NextSteps( { onDismiss = () => {} } ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-
 	const tracksPrefix = 'calypso_jetpack_manage_overview_next_steps';
+
+	const preferences = useSelector( getAllRemotePreferences );
+
+	const checkTourCompletion = ( prefSlug: string ): boolean => {
+		if ( JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME[ prefSlug ] ) {
+			return JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME[ prefSlug ] in preferences;
+		}
+		return false;
+	};
+
+	const resetTour = ( prefSlugs: string[] ): void => {
+		prefSlugs.forEach( ( slug ) => {
+			if ( JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME[ slug ] ) {
+				dispatch( savePreference( JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME[ slug ], null ) );
+			}
+		} );
+	};
 
 	const tasks: Task[] = [
 		{
-			completed: false,
 			calypso_path: '/dashboard?tour=dashboard-walkthrough',
+			completed: checkTourCompletion( 'dashboardWalkthrough' ),
 			disabled: false,
 			actionDispatch: () => {
 				dispatch( recordTracksEvent( tracksPrefix + '_get_familiar_click' ) );
+				resetTour( [ 'dashboardWalkthrough' ] );
 			},
 			id: 'get_familiar',
 			title: translate( 'Get familiar with the sites management dashboard' ),
 			useCalypsoPath: true,
 		},
 		{
-			completed: false,
 			calypso_path: '/dashboard?tour=add-new-site',
+			completed: checkTourCompletion( 'addSiteStep2' ),
 			disabled: false,
 			actionDispatch: () => {
 				dispatch( recordTracksEvent( tracksPrefix + '_add_sites_click' ) );
+				resetTour( [ 'addSiteStep1', 'addSiteStep2' ] );
 			},
 			id: 'add_sites',
 			title: translate( 'Learn how to add new sites' ),
 			useCalypsoPath: true,
 		},
 		{
-			completed: false,
 			calypso_path: '/dashboard?tour=enable-monitor',
+			completed: checkTourCompletion( 'enableMonitorStep2' ),
 			disabled: false,
 			actionDispatch: () => {
 				dispatch( recordTracksEvent( tracksPrefix + '_bulk_editing_click' ) );
+				resetTour( [ 'enableMonitorStep1', 'enableMonitorStep2' ] );
 			},
 			id: 'bulk_editing',
 			title: translate( 'Learn bulk editing and enabling downtime monitoring' ),
 			useCalypsoPath: true,
 		},
 		{
-			completed: false,
 			calypso_path: '/plugins/manage?tour=plugin-management',
+			completed: checkTourCompletion( 'pluginOverview' ),
 			disabled: false,
 			actionDispatch: () => {
 				dispatch( recordTracksEvent( tracksPrefix + '_plugin_management_click' ) );
+				resetTour( [ 'pluginOverview' ] );
 			},
 			id: 'plugin_management',
 			title: translate( 'Explore plugin management' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves Automattic/jetpack-manage#194 - connect Overview page next steps to onboarding tours

## Proposed Changes

Now that the tours exist, we need to have the Next Steps component actually trigger said tours. This PR:

* Detects the completed state of the tours in question
* Starts or restarts the tour on click

## Testing Instructions

Make sure all the tours can be started/completed from the Overview page. The initial state should look like this:

![image](https://github.com/Automattic/wp-calypso/assets/32492176/971e45e4-500b-4954-837b-ec7282e434fc)

Some completed:

![image](https://github.com/Automattic/wp-calypso/assets/32492176/78f60b6f-2d64-44ed-b180-6d201722819e)

All completed:
![image](https://github.com/Automattic/wp-calypso/assets/32492176/49405a2b-43a4-4506-9ef3-88ca236af1ec)

~There does appear to be a quirk with the second tour (add new sites). If one completes it, goes back to overview, and starts it again, the tour popup only shows upon clicking the arrow. I believe this is a GuidedTour or Popover bug, but haven't yet isolated it.~

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
