### PR TITLE
Plans 2023: Hide unnecessary placeholder cell on mobile

### DIFF
--- a/client/my-sites/plans-grid/style.scss
+++ b/client/my-sites/plans-grid/style.scss
@@ -865,6 +865,10 @@ body.is-section-signup.is-white-signup,
 		padding-bottom: 20px;
 		min-width: 0;
 
+		&.is-placeholder-header-cell {
+			display: none;
+		}
+
 		@include plans-2023-break-small {
 			padding-top: 34px;
 
@@ -880,6 +884,10 @@ body.is-section-signup.is-white-signup,
 			&.plan-is-footer {
 				padding-top: 50px;
 				padding-bottom: 24px;
+			}
+
+			&.is-placeholder-header-cell {
+				display: initial;
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

The comparison grid plans header placeholder cell creates a misalignment in the comparison grid plans header on mobile. Because of this, we hide it on mobile and unhide it for tablets and desktops

## Screenshots
| Before      | After |
| ----- | ----- |
| <img width="406" alt="Screenshot 2023-12-22 at 3 08 15 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/a8149146-e437-49de-805f-3c6f1b0ab45c"> | <img width="428" alt="Screenshot 2023-12-22 at 3 04 51 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/a4dd07db-53f2-4926-af06-01ad9f94d99a"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Navigate to `/start/plans`
* Scroll down to the comparison grid and verify that the plans pricing headers are aligned for desktop, tablet, and mobile

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?