### PR TITLE
Comments: switch comment editor to blocks

### DIFF
--- a/client/my-sites/comments/comment/comment-edit.jsx
+++ b/client/my-sites/comments/comment/comment-edit.jsx
@@ -1,3 +1,4 @@
+import { CommentBlockEditor } from '@automattic/comment-block-editor';
 import { Button, Popover, Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get, pick } from 'lodash';
@@ -13,7 +14,7 @@ import InfoPopover from 'calypso/components/info-popover';
 import { withLocalizedMoment } from 'calypso/components/localized-moment';
 import PostSchedule from 'calypso/components/post-schedule';
 import { decodeEntities } from 'calypso/lib/formatting';
-import CommentHtmlEditor from 'calypso/my-sites/comments/comment/comment-html-editor';
+// import CommentHtmlEditor from 'calypso/my-sites/comments/comment/comment-html-editor';
 import {
 	bumpStat,
 	composeAnalytics,
@@ -25,8 +26,6 @@ import { getSiteComment } from 'calypso/state/comments/selectors';
 import { removeNotice, successNotice } from 'calypso/state/notices/actions';
 import getSiteSetting from 'calypso/state/selectors/get-site-setting';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-
-const noop = () => {};
 
 export class CommentEdit extends Component {
 	static propTypes = {
@@ -68,8 +67,7 @@ export class CommentEdit extends Component {
 
 	setAuthorUrlValue = ( event ) => this.setState( { authorUrl: event.target.value } );
 
-	setCommentContentValue = ( event, callback = noop ) =>
-		this.setState( { commentContent: event.target.value }, callback );
+	setCommentContentValue = ( value ) => this.setState( { commentContent: value } );
 
 	setCommentDateValue = ( commentDate ) =>
 		this.setState( { commentDate: this.props.moment( commentDate ).format() } );
@@ -199,8 +197,8 @@ export class CommentEdit extends Component {
 						</Popover>
 					</FormFieldset>
 
-					<CommentHtmlEditor
-						commentContent={ commentContent }
+					<CommentBlockEditor
+						initialContent={ commentContent }
 						onChange={ this.setCommentContentValue }
 					/>
 

--- a/client/package.json
+++ b/client/package.json
@@ -28,6 +28,7 @@
 		"@automattic/calypso-url": "workspace:^",
 		"@automattic/color-studio": "2.5.0",
 		"@automattic/components": "workspace:^",
+		"@automattic/comment-block-editor": "workspace:^",
 		"@automattic/composite-checkout": "workspace:^",
 		"@automattic/create-calypso-config": "workspace:^",
 		"@automattic/data-stores": "workspace:^",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This is part 2. Before this can be tested or merged we need to merge the package for the editor. #85742 

Things that need to be handled

1. This needs to be handled conditionally. We do not have block editor for all users yet so if Verbum is active we need to use the block editor otherwise use html editor which I commented out.
2. When editing in the main comment manager area the state is being shared across all instances of the block editor. We need to figure out how to prevent this from happening OR only allow one instance open at a time. I lean towards the latter because having multiple instances of Gutenberg sounds like a recipe for disaster.
3. There is an error when the editor loads that needs to be addressed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open calypso and go to Comments and edit a comment.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?