### PR TITLE
Earn: Fix `toUpperCase()` on a null

### DIFF
--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -60,7 +60,7 @@ function minimumCurrencyTransactionAmount(
 	currency: string,
 	connectedAccountDefaultCurrency: string
 ): number {
-	if ( connectedAccountDefaultCurrency.toUpperCase() === currency ) {
+	if ( connectedAccountDefaultCurrency?.toUpperCase() === currency ) {
 		return currency_min[ currency ];
 	}
 	return currency_min[ currency ] * 2;


### PR DESCRIPTION
## Proposed Changes

As [reported in Sentry](https://a8c.sentry.io/issues/4748713581/?project=6313676), we're calling `toUpperCase()` on a value that's potentially `null` by design, so let's do that only if it's actually not a null.