### PR TITLE
Assembler AI: Show selected pages in the pattern previews in all steps

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -492,6 +492,18 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 		return isSiteAssemblerFlow( flow );
 	};
 
+	const shouldIgnoreSelectedPagesInPreview = () => {
+		if ( flow === AI_ASSEMBLER_FLOW ) {
+			return false;
+		}
+
+		if ( currentScreen.name === 'confirmation' || currentScreen.name === 'activation' ) {
+			return false;
+		}
+
+		return true;
+	};
+
 	const customActionButtons = () => {
 		if (
 			flow === AI_ASSEMBLER_FLOW &&
@@ -690,6 +702,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 						selectedSections={ sections }
 						selectedFooter={ footer }
 						patternsMapByCategory={ layoutCategoryPatternsMap }
+						pages={ ! shouldIgnoreSelectedPagesInPreview() ? pages : undefined }
 						onSelect={ onSelect }
 						recordTracksEvent={ recordTracksEvent }
 						isNewSite={ isNewSite }
@@ -728,12 +741,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 					sections={ sections }
 					footer={ footer }
 					activePosition={ activePosition }
-					pages={
-						// Consider the selected pages in the final screen.
-						currentScreen.name === 'confirmation' || currentScreen.name === 'activation'
-							? pages
-							: undefined
-					}
+					pages={ ! shouldIgnoreSelectedPagesInPreview() ? pages : undefined }
 					onDeleteSection={ onDeleteSection }
 					onMoveUpSection={ onMoveUpSection }
 					onMoveDownSection={ onMoveDownSection }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
@@ -20,7 +20,7 @@ type PatternListPanelProps = {
 	label?: string;
 	description?: string;
 	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
-	isNewSite?: boolean;
+	isNewSite: boolean;
 };
 
 const PatternListPanel = ( {
@@ -51,7 +51,7 @@ const PatternListPanel = ( {
 	const transformPatternHtml = useCallback(
 		( patternHtml: string ) => {
 			const pageTitles = pages?.map( ( page ) => page.title );
-			const isCategoryHeader = category?.name === 'header';
+			const isCategoryHeader = category && category.name === 'header';
 			if ( isCategoryHeader && pageTitles ) {
 				return injectTitlesToPageListBlock( patternHtml, pageTitles, {
 					replaceCurrentPages: isNewSite,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
@@ -1,8 +1,9 @@
 import { Button } from '@wordpress/components';
 import { chevronDown } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
+import { injectTitlesToPageListBlock } from './html-transformers';
 import PatternSelector from './pattern-selector';
 import { isPriorityPattern } from './utils';
 import type { Pattern, Category } from './types';
@@ -15,9 +16,11 @@ type PatternListPanelProps = {
 	selectedCategory: string | null;
 	patternsMapByCategory: { [ key: string ]: Pattern[] };
 	selectedPatterns?: Pattern[];
+	pages?: Pattern[];
 	label?: string;
 	description?: string;
 	recordTracksEvent: ( name: string, eventProperties?: any ) => void;
+	isNewSite?: boolean;
 };
 
 const PatternListPanel = ( {
@@ -26,10 +29,12 @@ const PatternListPanel = ( {
 	selectedCategory,
 	categories,
 	patternsMapByCategory,
+	pages,
 	label,
 	description,
 	onSelect,
 	recordTracksEvent,
+	isNewSite,
 }: PatternListPanelProps ) => {
 	const translate = useTranslate();
 	const [ isShowMorePatterns, setIsShowMorePatterns ] = useState( false );
@@ -41,6 +46,20 @@ const PatternListPanel = ( {
 
 	const hasNonPriorityPatterns = categoryPatterns?.find(
 		( pattern ) => ! isPriorityPattern( pattern )
+	);
+
+	const transformPatternHtml = useCallback(
+		( patternHtml: string ) => {
+			const pageTitles = pages?.map( ( page ) => page.title );
+			const isCategoryHeader = category?.name === 'header';
+			if ( isCategoryHeader && pageTitles ) {
+				return injectTitlesToPageListBlock( patternHtml, pageTitles, {
+					replaceCurrentPages: isNewSite,
+				} );
+			}
+			return patternHtml;
+		},
+		[ isNewSite, pages, category ]
 	);
 
 	if ( ! category ) {
@@ -58,6 +77,7 @@ const PatternListPanel = ( {
 				onSelect={ onSelect }
 				selectedPattern={ selectedPattern }
 				selectedPatterns={ selectedPatterns }
+				transformPatternHtml={ transformPatternHtml }
 				isShowMorePatterns={ isShowMorePatterns }
 			/>
 			{ ! isShowMorePatterns && hasNonPriorityPatterns && (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
@@ -14,6 +14,7 @@ interface PatternListItemProps {
 	isShown: boolean;
 	isSelected?: boolean;
 	composite?: Record< string, unknown >;
+	transformPatternHtml?: ( patternHtml: string ) => string;
 	onSelect: ( selectedPattern: Pattern | null ) => void;
 }
 
@@ -24,6 +25,7 @@ interface PatternListRendererProps {
 	selectedPatterns?: Pattern[];
 	activeClassName: string;
 	composite?: Record< string, unknown >;
+	transformPatternHtml?: ( patternHtml: string ) => string;
 	onSelect: ( selectedPattern: Pattern | null ) => void;
 	isShowMorePatterns?: boolean;
 }
@@ -39,6 +41,7 @@ const PatternListItem = ( {
 	isShown,
 	isSelected,
 	composite,
+	transformPatternHtml,
 	onSelect,
 }: PatternListItemProps ) => {
 	const ref = useRef< HTMLButtonElement >();
@@ -82,6 +85,7 @@ const PatternListItem = ( {
 						viewportWidth={ DEFAULT_VIEWPORT_WIDTH }
 						viewportHeight={ DEFAULT_VIEWPORT_HEIGHT }
 						minHeight={ PLACEHOLDER_HEIGHT }
+						transformHtml={ transformPatternHtml }
 					/>
 				) : (
 					<div key={ pattern.ID } style={ { height: PLACEHOLDER_HEIGHT } } />
@@ -98,6 +102,7 @@ const PatternListRenderer = ( {
 	selectedPatterns,
 	activeClassName,
 	composite,
+	transformPatternHtml,
 	onSelect,
 	isShowMorePatterns,
 }: PatternListRendererProps ) => {
@@ -119,6 +124,7 @@ const PatternListRenderer = ( {
 					isShown={ shownPatterns.includes( pattern ) }
 					isSelected={ pattern.ID === selectedPattern?.ID }
 					composite={ composite }
+					transformPatternHtml={ transformPatternHtml }
 					onSelect={ onSelect }
 				/>
 			) ) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-selector.tsx
@@ -12,6 +12,7 @@ type PatternSelectorProps = {
 	onSelect: ( selectedPattern: Pattern | null ) => void;
 	selectedPattern: Pattern | null;
 	selectedPatterns?: Pattern[];
+	transformPatternHtml?: ( patternHtml: string ) => string;
 	isShowMorePatterns?: boolean;
 };
 
@@ -20,6 +21,7 @@ const PatternSelector = ( {
 	onSelect,
 	selectedPattern,
 	selectedPatterns,
+	transformPatternHtml,
 	isShowMorePatterns,
 }: PatternSelectorProps ) => {
 	const translate = useTranslate();
@@ -42,6 +44,7 @@ const PatternSelector = ( {
 						selectedPatterns={ selectedPatterns }
 						activeClassName="pattern-selector__block-list--selected-pattern"
 						composite={ composite }
+						transformPatternHtml={ transformPatternHtml }
 						onSelect={ onSelect }
 						isShowMorePatterns={ isShowMorePatterns }
 					/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-pattern-list-panel.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-pattern-list-panel.tsx
@@ -10,6 +10,7 @@ interface Props {
 	selectedFooter: Pattern | null;
 	selectedSections: Pattern[];
 	patternsMapByCategory: { [ key: string ]: Pattern[] };
+	pages?: Pattern[];
 	onSelect: (
 		type: PatternType,
 		selectedPattern: Pattern | null,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85473

## Proposed Changes

This PR implements the injection of selected pages to the patterns in the pattern panel list. Specifically, the header patterns. As a result, every header pattern will display the selected pages in its navigation block. This PR also updates the large preview, so that it always shows the list of selected pages in the selected header pattern. 

> [!NOTE]
> This PR only affects the `ai-assembler` flow, since the change was explicitly requested for this flow. The other flows will keep their existing behavior (see https://github.com/Automattic/wp-calypso/issues/85473#issuecomment-1867062582), which is to only show the selected pages in the large preview header from the Pages screen onwards.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/setup/ai-assembler`.
* In the AI prompt screen, enter any prompt that generates pre-selected pages.
* Once in the Assembler, ensure that every header pattern displays the same list of pre-selected pages.
* Ensure that the other flows still retains their existing behavior.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?