### PR TITLE
Purchase Modal: fix redirection after checkout for post-purchase upsells

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/purchase-modal/index.tsx
@@ -110,7 +110,7 @@ function PurchaseModalWrapper( props: PurchaseModalProps ) {
 	const paymentCompleteCallback = useCreatePaymentCompleteCallback( {
 		isComingFromUpsell: true,
 		siteSlug: siteSlug,
-		isInModal: true,
+		isInModal: disabledThankYouPage,
 		disabledThankYouPage,
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This is a follow-up to #85613. Instead of setting `isInModal` to `true` for all cases, this PR sets it to `true` only if the `disabledThankYouPage` prop is `true`. This fixes the redirection for post-purchase Email/Business plan upsells.
## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that you have a saved credit card.
* Go to `/checkout/offer-professional-email/<domain>/12345/<site slug>`. Click on the CTA. After completing the purchase in the modal, confirm that you are redirected away from the page.
* Go to `/plugins/<site slug>` for a site on a Free/Starter/Explorer plan.
* Click on the "Upgrade to Creator" CTA.
* Confirm that you can see the 1-click checkout modal.
* Once the purchase is complete, confirm that
  * You are not redirected to any other page.
  * The Upgrade CTA is not visible.
  * You see a purchase success notice.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?