### PR TITLE
Stepper: Remove progress bar

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/components/step-route/index.tsx
@@ -1,5 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
-import { ProgressBar } from '@automattic/components';
 import classnames from 'classnames';
 import kebabCase from 'calypso/landing/stepper/utils/kebabCase';
 import SignupHeader from 'calypso/signup/signup-header';
@@ -9,41 +7,12 @@ import { Flow, StepperStep } from '../../types';
 type StepRouteProps = {
 	step: StepperStep;
 	flow: Flow;
-	progressValue: number;
-	progressBarExtraStyle: React.CSSProperties;
 	showWooLogo: boolean;
 	renderStep: ( step: StepperStep ) => JSX.Element | null;
 };
 
-const StepRoute = ( {
-	step,
-	flow,
-	progressValue,
-	progressBarExtraStyle,
-	showWooLogo,
-	renderStep,
-}: StepRouteProps ) => {
+const StepRoute = ( { step, flow, showWooLogo, renderStep }: StepRouteProps ) => {
 	const stepContent = renderStep( step );
-	const renderProgressBar = () => {
-		// The visual progress bar is removed due to its fragility.
-		// The component will be cleaned up but it'll require more untangling as the component
-		// is involved in some framework mechanisms and Tracks events
-		// See https://github.com/Automattic/dotcom-forge/issues/3160
-
-		if ( ! isEnabled( 'onboarding/stepper-loading-bar' ) ) {
-			return null;
-		}
-
-		return (
-			<ProgressBar
-				// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-				className="flow-progress"
-				value={ progressValue * 100 }
-				total={ 100 }
-				style={ progressBarExtraStyle }
-			/>
-		);
-	};
 
 	return (
 		<div
@@ -56,7 +25,6 @@ const StepRoute = ( {
 			) }
 		>
 			{ 'videopress' === flow.name && 'intro' === step.slug && <VideoPressIntroBackground /> }
-			{ renderProgressBar() }
 			{ stepContent && <SignupHeader pageTitle={ flow.title } showWooLogo={ showWooLogo } /> }
 			{ stepContent }
 		</div>

--- a/client/landing/stepper/declarative-flow/internals/global.scss
+++ b/client/landing/stepper/declarative-flow/internals/global.scss
@@ -104,22 +104,6 @@ button {
 .link-in-bio-tld {
 	box-sizing: border-box;
 
-	.flow-progress {
-		position: absolute;
-		top: 0;
-		right: 0;
-		left: 0;
-		border-radius: 0;
-		z-index: 99;
-		height: 8px;
-		background-color: transparent;
-
-		.progress-bar__progress {
-			background-color: $onboarding-accent-blue;
-			border-radius: 0;
-		}
-	}
-
 	&.step-route {
 		padding: 60px 0 0;
 
@@ -359,15 +343,6 @@ button {
 		}
 	}
 
-	.progress-bar {
-		background-color: #fff;
-		position: absolute;
-
-		.progress-bar__progress {
-			border-radius: 0;
-		}
-	}
-
 	&.intro {
 		button.intro__button {
 			border-radius: 4px;
@@ -464,9 +439,6 @@ button {
 		font-family: proxima-nova, sans-serif;
 		font-weight: 600;
 		font-size: $font-title-large;
-	}
-	.flow-progress.progress-bar {
-		display: none;
 	}
 	.loading-bar {
 		background-color: var(--studio-woocommerce-purple-5);

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -6,7 +6,7 @@ import {
 } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
-import React, { useEffect, useState, useCallback, useMemo, Suspense, lazy } from 'react';
+import React, { useEffect, useCallback, useMemo, Suspense, lazy } from 'react';
 import Modal from 'react-modal';
 import { Navigate, Route, Routes, generatePath, useNavigate, useLocation } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -96,11 +96,6 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStepProgress(),
 		[]
 	);
-	const progressValue = stepProgress ? stepProgress.progress / stepProgress.count : 0;
-	const [ previousProgress, setPreviousProgress ] = useState(
-		stepProgress ? stepProgress.progress : 0
-	);
-	const previousProgressValue = stepProgress ? previousProgress / stepProgress.count : 0;
 
 	// this pre-loads all the lazy steps down the flow.
 	useEffect( () => {
@@ -133,7 +128,6 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 			: generatePath( `/${ flow.variantSlug ?? flow.name }/${ path }${ window.location.search }` );
 
 		navigate( _path, { state: stepPaths } );
-		setPreviousProgress( stepProgress?.progress ?? 0 );
 	};
 
 	const stepNavigation = flow.useStepNavigation(
@@ -225,14 +219,6 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		}
 	};
 
-	let progressBarExtraStyle: React.CSSProperties = {};
-	if ( 'videopress' === flow.name ) {
-		progressBarExtraStyle = {
-			'--previous-progress': Math.min( 100, Math.ceil( previousProgressValue * 100 ) ) + '%',
-			'--current-progress': Math.min( 100, Math.ceil( progressValue * 100 ) ) + '%',
-		} as React.CSSProperties;
-	}
-
 	return (
 		<Suspense fallback={ <StepperLoader /> }>
 			<DocumentHead title={ getDocumentHeadTitle() } />
@@ -245,8 +231,6 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 							<StepRoute
 								step={ step }
 								flow={ flow }
-								progressBarExtraStyle={ progressBarExtraStyle }
-								progressValue={ progressValue }
 								showWooLogo={ isWooExpressFlow( flow.name ) }
 								renderStep={ renderStep }
 							/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/sensei-step-progress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/sensei-step-progress/index.tsx
@@ -1,4 +1,3 @@
-import { Global } from '@emotion/react';
 import React from 'react';
 import bottomLeftImgSrc from 'calypso/assets/images/onboarding/sensei/progress-bg-bottom-left.png';
 import topRightImgSrc from 'calypso/assets/images/onboarding/sensei/progress-bg-top-right.png';
@@ -35,7 +34,6 @@ export const SenseiStepProgress: React.FC< SenseiStepProgressProps > = ( { progr
 				</Progress>
 			</Content>
 			<BottomLeftImg src={ bottomLeftImgSrc } />
-			<Global styles={ { '.sensei .flow-progress.progress-bar': { display: 'none' } } } />
 		</Container>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/videopress.scss
+++ b/client/landing/stepper/declarative-flow/internals/videopress.scss
@@ -31,30 +31,6 @@ body.is-videopress-tv-purchase-stepper {
 			outline: solid 2px $videopress-theme-yellow;
 		}
 
-		.flow-progress {
-			display: block;
-			border-radius: 0;
-			background-color: #fff3;
-
-			.progress-bar__progress {
-				background-color: $videopress-theme-yellow;
-				border-radius: 0;
-				animation: progress-lerp ease-in-out 250ms;
-				@keyframes progress-lerp {
-					0% {
-						width: calc(var(--previous-progress));
-					}
-					100% {
-						width: calc(var(--current-progress));
-					}
-				}
-			}
-		}
-
-		&.intro .flow-progress {
-			background: #0003;
-		}
-
 		.signup-header {
 			padding: 24px;
 


### PR DESCRIPTION
## Proposed Changes

This PR proposes the further removal of the Stepper progress bar (see pbxlJb-3wV-p2). This feature has been disabled in all environments for some time now due to its fragility. If there's any interest in bringing this back in the future, we should consider a new implementation.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test the [Sensei flow](https://wordpress.com/setup/sensei/intro), plus any other flow in Stepper.
Ensure that the code removal makes sense, and that there are no regressions caused by it.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?