### PR TITLE
Paid Stats: Adjust styles for upsell overlay

### DIFF
--- a/client/components/stats-date-control/style.scss
+++ b/client/components/stats-date-control/style.scss
@@ -23,14 +23,13 @@ $date-control-shortcut-min-width: 140px;
 
 		.stats-date-control-picker-dates__inputs,
 		.stats-date-control-picker-dates__buttons {
-			filter: blur(5px);
+			filter: blur(10px);
 			z-index: 0;
 		}
 
 		.stats-date-control-picker-date__overlay {
 			position: absolute;
 			z-index: 1;
-			background: rgba(255, 255, 255, 0.5);
 		}
 	}
 }

--- a/packages/components/src/horizontal-bar-list/stats-card.scss
+++ b/packages/components/src/horizontal-bar-list/stats-card.scss
@@ -104,13 +104,12 @@
 		.stats-card__content .stats-card--header-and-body .stats-card--body,
 		.stats-card__content .stats-card--hero,
 		.stats-card__content .stats-card--footer {
-			filter: blur(5px);
+			filter: blur(10px);
 			z-index: 0;
 		}
 
 		.stats-card__overlay {
 			z-index: 1;
-			background: rgba(255, 255, 255, 0.5);
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5013

## Proposed Changes

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/691c6447-cf7b-402f-a10f-f8201835f605">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/7023fa74-2d86-42c1-b939-f6712e664641">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /stats page and add `?flags=stats/paid-wpcom-v2` to the end
* Check the layout for the gated stats (should be able to see the gating with any site on a Dotcom plan that hasn't purchased paid stats AND not a Jetpack site)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?