### PR TITLE
Pattern Assembler CTA: Make it more responsive

### DIFF
--- a/packages/design-picker/src/components/pattern-assembler-cta/style.scss
+++ b/packages/design-picker/src/components/pattern-assembler-cta/style.scss
@@ -39,6 +39,7 @@
 		display: flex;
 		flex-direction: column;
 		flex-grow: 1;
+		flex-shrink: 0;
 		gap: 24px;
 
 		@include break-wide {
@@ -133,20 +134,13 @@
 	}
 
 	.pattern-assembler-cta__image-wrapper {
-		flex-grow: 1;
 		padding-left: 35px;
 		text-align: right;
-
-		@include break-wide {
-			flex-grow: 0;
-		}
-
-		@media ( min-width: 1600px ) {
-			margin: 0;
-		}
 	}
 
 	.pattern-assembler-cta__image {
-		width: 405px;
+		width: 100%;
+		min-width: 380px;
+		max-width: 405px;
 	}
 }

--- a/packages/design-picker/src/components/style.scss
+++ b/packages/design-picker/src/components/style.scss
@@ -406,6 +406,16 @@
 				column-gap: 24px;
 			}
 		}
+
+		@include break-xlarge {
+			.pattern-assembler-cta-wrapper {
+				flex-direction: row-reverse;
+
+				.pattern-assembler-cta__content {
+					align-items: flex-start;
+				}
+			}
+		}
 	}
 
 	.unified-design-picker__title {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/85141

## Proposed Changes

* Make the CTA horizontal when the viewport width is 1080px and above on the Design Picker

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/bd90399a-9258-4972-81d1-ed88835eaaf9) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/e3293031-faf2-4b5b-979a-1c9d17f1a947) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=<your_site>
* Continue to the Design Picker
* Check the CTA looks good when the viewport width is 1080px

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?