### PR TITLE
Migration flow: Fix layout (regression) issues on import everything

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -2,7 +2,6 @@ import { ProgressBar } from '@automattic/components';
 import { Hooray, Progress, SubTitle, Title, NextButton } from '@automattic/onboarding';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
-import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import { connect } from 'react-redux';
@@ -205,27 +204,29 @@ export class ImportEverything extends SectionMigrate {
 		const { translate, sourceSite, targetSite } = this.props;
 
 		return (
-			<>
+			<div className="import-layout__center">
 				<Progress>
 					<Interval onTick={ this.updateFromAPI } period={ EVERY_TEN_SECONDS } />
-					<Title>
-						{ ( MigrationStatus.BACKING_UP === this.state.migrationStatus ||
-							MigrationStatus.NEW === this.state.migrationStatus ) &&
-							sprintf( translate( 'Backing up %(website)s' ), { website: sourceSite.slug } ) +
-								'...' }
-						{ MigrationStatus.RESTORING === this.state.migrationStatus &&
-							sprintf( translate( 'Restoring to %(website)s' ), { website: targetSite.slug } ) +
-								'...' }
-					</Title>
-					<ProgressBar compact={ true } value={ this.state.percent ? this.state.percent : 0 } />
-					<SubTitle>
-						{ translate(
-							"This may take a few minutes. We'll notify you by email when it's done."
-						) }
-					</SubTitle>
+					<div className="import__heading import__heading-center">
+						<Title>
+							{ ( MigrationStatus.BACKING_UP === this.state.migrationStatus ||
+								MigrationStatus.NEW === this.state.migrationStatus ) &&
+								sprintf( translate( 'Backing up %(website)s' ), { website: sourceSite.slug } ) +
+									'...' }
+							{ MigrationStatus.RESTORING === this.state.migrationStatus &&
+								sprintf( translate( 'Restoring to %(website)s' ), { website: targetSite.slug } ) +
+									'...' }
+						</Title>
+						<ProgressBar compact={ true } value={ this.state.percent ? this.state.percent : 0 } />
+						<SubTitle>
+							{ translate(
+								"This may take a few minutes. We'll notify you by email when it's done."
+							) }
+						</SubTitle>
+					</div>
 				</Progress>
 				<GettingStartedVideo />
-			</>
+			</div>
 		);
 	}
 
@@ -233,16 +234,20 @@ export class ImportEverything extends SectionMigrate {
 		const { translate } = this.props;
 
 		return (
-			<Progress className="onboarding-progress-simple">
-				<Interval onTick={ this.updateFromAPI } period={ EVERY_TEN_SECONDS } />
-				<Title>{ translate( 'We’re safely migrating all your data' ) }</Title>
-				<ProgressBar compact={ true } value={ this.state.percent ? this.state.percent : 0 } />
-				<SubTitle tagName="h3">
-					{ translate(
-						'Feel free to close this window. We’ll email you when your new site is ready.'
-					) }
-				</SubTitle>
-			</Progress>
+			<div className="import-layout__center">
+				<Progress className="onboarding-progress-simple">
+					<Interval onTick={ this.updateFromAPI } period={ EVERY_TEN_SECONDS } />
+					<div className="import__heading import__heading-center">
+						<Title>{ translate( 'We’re safely migrating all your data' ) }</Title>
+						<ProgressBar compact={ true } value={ this.state.percent ? this.state.percent : 0 } />
+						<SubTitle tagName="h3">
+							{ translate(
+								'Feel free to close this window. We’ll email you when your new site is ready.'
+							) }
+						</SubTitle>
+					</div>
+				</Progress>
+			</div>
 		);
 	}
 
@@ -261,16 +266,18 @@ export class ImportEverything extends SectionMigrate {
 		const { translate } = this.props;
 
 		return (
-			<div className={ classnames( 'import__header' ) }>
-				<div className={ classnames( 'import__heading import__heading-center' ) }>
-					<Title>{ translate( 'Import failed' ) }</Title>
-					<SubTitle>
-						{ translate( 'There was an error with your import.' ) }
-						<br />
-						{ translate( 'Please try again soon or contact support for help.' ) }
-					</SubTitle>
-					<div className={ classnames( 'import__buttons-group' ) }>
-						<NextButton onClick={ this.resetMigration }>{ translate( 'Try again' ) }</NextButton>
+			<div className="import-layout__center">
+				<div>
+					<div className="import__heading import__heading-center">
+						<Title>{ translate( 'Import failed' ) }</Title>
+						<SubTitle>
+							{ translate( 'There was an error with your import.' ) }
+							<br />
+							{ translate( 'Please try again soon or contact support for help.' ) }
+						</SubTitle>
+						<div className="import__buttons-group">
+							<NextButton onClick={ this.resetMigration }>{ translate( 'Try again' ) }</NextButton>
+						</div>
 					</div>
 				</div>
 			</div>
@@ -281,7 +288,7 @@ export class ImportEverything extends SectionMigrate {
 		const { translate, stepNavigator } = this.props;
 
 		return (
-			<>
+			<div className="import__heading import__heading-center">
 				<Title>{ translate( 'Hooray!' ) }</Title>
 				<SubTitle>
 					{ translate( 'Congratulations. Your content was successfully imported.' ) }
@@ -293,14 +300,14 @@ export class ImportEverything extends SectionMigrate {
 						stepNavigator?.goToSiteViewPage?.();
 					} }
 				/>
-			</>
+			</div>
 		);
 	}
 
 	renderHoorayScreenWithDomainInfo() {
 		const { translate, stepNavigator, targetSite } = this.props;
 		return (
-			<>
+			<div className="import__heading import__heading-center">
 				<Title>{ translate( "Migration done! You're all set!" ) }</Title>
 				<SubTitle>
 					{ createInterpolateElement(
@@ -328,7 +335,7 @@ export class ImportEverything extends SectionMigrate {
 						stepNavigator?.goToSiteViewPage?.();
 					} }
 				/>
-			</>
+			</div>
 		);
 	}
 


### PR DESCRIPTION
## Proposed Changes

* Fixed layout issue; regression made during the "Import from Backup file" project

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to`/setup/import-focused?siteSlug={SLUG}`
* Enter a self-hosted site URL
* Start import everything flow
* Check if layout looks ok

**Before:**

<img width="921" alt="Screenshot 2023-12-25 at 11 56 44" src="https://github.com/Automattic/wp-calypso/assets/1241413/5b1dd604-5673-4380-88f7-6d414af27e61">
<img width="925" alt="Screenshot 2023-12-25 at 11 55 04" src="https://github.com/Automattic/wp-calypso/assets/1241413/3299da6d-7aa5-464d-8ca5-7bf48f3050e3">

**After:**

<img width="780" alt="Screenshot 2023-12-25 at 12 12 11" src="https://github.com/Automattic/wp-calypso/assets/1241413/d7384f32-3e44-47e4-bf68-37e9fdb07144">
<img width="657" alt="Screenshot 2023-12-25 at 12 15 47" src="https://github.com/Automattic/wp-calypso/assets/1241413/d44f58aa-c484-4853-8733-5c5ed9def2d5">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?