### PR TITLE
Hosting flow: use new signup component

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -27,7 +27,7 @@ export function generateFlows( {
 	const flows = [
 		{
 			name: HOSTING_LP_FLOW,
-			steps: [ 'user-hosting' ],
+			steps: [ userSocialStep ],
 			destination: getHostingFlowDestination,
 			description: 'Create an account and redirect the user to the hosted site flow forking step.',
 			lastModified: '2023-07-18',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -47,7 +47,6 @@ const stepNameToModuleName = {
 	test: 'test-step',
 	'themes-site-selected': 'theme-selection',
 	user: 'user',
-	'user-hosting': 'user',
 	'user-new': 'user',
 	'oauth2-user': 'user',
 	'oauth2-name': 'user',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -181,31 +181,6 @@ export function generateSteps( {
 			},
 		},
 
-		'user-hosting': {
-			stepName: 'user-hosting',
-			apiRequestFunction: createAccount,
-			providesToken: true,
-			providesDependencies: [
-				'bearer_token',
-				'username',
-				'marketing_price_group',
-				'redirect',
-				'allowUnauthenticated',
-				'oauth2_client_id',
-				'oauth2_redirect',
-			],
-			optionalDependencies: [
-				'redirect',
-				'allowUnauthenticated',
-				'oauth2_client_id',
-				'oauth2_redirect',
-			],
-			props: {
-				isSocialSignupEnabled: config.isEnabled( 'signup/social' ),
-				isPasswordless: true,
-			},
-		},
-
 		'user-new': {
 			stepName: 'user-new',
 			apiRequestFunction: createAccount,

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -821,7 +821,7 @@ class Signup extends Component {
 
 		return (
 			<div className="signup__step" key={ stepKey }>
-				<div className="signup__step is-user">
+				<div className={ `signup__step is-${ stepName }` }>
 					{ shouldRenderLocaleSuggestions && (
 						<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
 					) }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -814,8 +814,6 @@ class Signup extends Component {
 			};
 		}
 
-		const stepClassName = stepName === 'user-hosting' ? 'user' : stepName;
-
 		// If a coupon is provided as a query dependency, then hide the free plan.
 		// It's assumed here that the coupon applies to paid plans at the minimum, and
 		// in this scenario it wouldn't be necessary to show a free plan.
@@ -823,7 +821,7 @@ class Signup extends Component {
 
 		return (
 			<div className="signup__step" key={ stepKey }>
-				<div className={ `signup__step is-${ stepClassName }` }>
+				<div className="signup__step is-user">
 					{ shouldRenderLocaleSuggestions && (
 						<LocaleSuggestions path={ this.props.path } locale={ this.props.locale } />
 					) }


### PR DESCRIPTION
Related to p9Jlb4-at5-p2.

## Proposed Changes

As the new signup/login component is ready to be used, let's use it. 

| Before | After |
| ------ | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/26530524/264d5357-d937-487e-bedc-92df6ce5413e) | ![image](https://github.com/Automattic/wp-calypso/assets/26530524/6e17f548-7355-464b-969b-c4255028eda7) |

## Testing Instructions

- Browse `/start/hosting` and verify that the new version of the component is displayed.
- Sign up and login as normal and verify you're redirected to `/setup/new-hosted-site`
- Disable the `signup/social-first` feature flag and check that the old component shows up.
