### PR TITLE
Hosting plan: fix paid plan button

### DIFF
--- a/client/my-sites/plans-grid/components/plan-button/style.scss
+++ b/client/my-sites/plans-grid/components/plan-button/style.scss
@@ -50,19 +50,14 @@
 			box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px #7f54b3;
 		}
 
-		+ .button {
+		+ .button.is-borderless {
+			background: transparent;
 			font-size: $font-body-small;
 			color: #7f54b3;
 			text-decoration: none;
 
 			&:focus {
 				box-shadow: 0 0 0 2px var(--studio-white), 0 0 0 4px #7f54b3;
-			}
-
-			.gridicon {
-				width: 18px;
-				height: 18px;
-				top: 4px;
 			}
 		}
 	}


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/85691.

## Proposed Changes

The related PR introduces a regression that makes the styles of the paid plan button broken. See before and after. The PR restores the "after" behavior.

| Before | After |
| ------ | ------ |
| <img width="342" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/68fd8e0b-56ef-44ca-9653-39b93cd97200"> | <img width="348" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/b926d1c9-fb97-4f81-8ddb-493c41f12bff"> |

## Testing Instructions

Visit `/setup/new-hosted-site` and verify that the paid plan button is transparent.