### PR TITLE
Hosting trial: Remove arrow from paid plan button

### DIFF
--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -14,7 +14,6 @@ import {
 	isWpcomEnterpriseGridPlan,
 	isFreePlan,
 } from '@automattic/calypso-products';
-import { Gridicon } from '@automattic/components';
 import { WpcomPlansUI } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
 import { isMobile } from '@automattic/viewport';
@@ -125,7 +124,7 @@ const SignupFlowPlanFeatureActionButton = ( {
 						onClick={ () => handleUpgradeButtonClick( false ) }
 						borderless
 					>
-						{ btnText } <Gridicon icon="arrow-right" />
+						{ btnText }
 					</PlanButton>
 				) }
 			</div>


### PR DESCRIPTION
Related to p9Jlb4-at5-p2

## Proposed Changes

The arrow pushes the label to the right and is too prominent. Let's remove it according to the related P2 post.

| Before | After |
| -------| ------|
| <img width="339" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/c1efb0cc-38aa-4fcb-b3f1-ed4773fbc7c8"> | <img width="340" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/99b93935-d912-4462-b90a-fe6cb2d1a5ab"> |

## Testing Instructions

Visit `/setup/new-hosted-site` and verify that the arrow does not show up to the right of the paid plan button.