### PR TITLE
New hosted site: use bold back button on plans

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/style.scss
@@ -135,9 +135,8 @@
 	}
 }
 
-// Domain upsell flow
-
-.domain-upsell.plans {
+.domain-upsell.plans,
+.new-hosted-site.plans {
 	.signup-header h1 {
 		display: none;
 	}


### PR DESCRIPTION
Related to p9Jlb4-at5-p2.

## Proposed Changes

Uses the standard bold back button in the plans step from the new hosted site flow.

| Before | After |
| ------ | ------ |
| ![image](https://github.com/Automattic/wp-calypso/assets/26530524/876d3e31-f862-44e1-ae4b-c1b20a7aa8fb) | ![image](https://github.com/Automattic/wp-calypso/assets/26530524/c89714e7-9bde-4b6d-a6d9-a88fb38813f4) |

## Testing Instructions

Visit `/setup/new-hosted-site` and verify that there is no underline and the button's label is bold.