### PR TITLE
Hosting trial: Use consistent Business/Creator plan names

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/hosting-trial-acknowledge.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/hosting-trial-acknowledge.tsx
@@ -26,6 +26,7 @@ interface CallToActionProps {
 
 const CallToAction = ( { onStartTrialClick }: CallToActionProps ) => {
 	const { __ } = useI18n();
+	const plan = getPlan( PLAN_BUSINESS );
 	const { isVerified, hasUser, isSending, email, resendEmail } = useVerifyEmail();
 	const startTrial = () => {
 		if ( ! isVerified ) {
@@ -40,7 +41,13 @@ const CallToAction = ( { onStartTrialClick }: CallToActionProps ) => {
 				<EmailVerification isSending={ isSending } email={ email } resendEmail={ resendEmail } />
 			) }
 			<NextButton isBusy={ false } onClick={ startTrial } disabled={ ! isVerified }>
-				{ __( 'Start the Business trial' ) }
+				{ sprintf(
+					/* translators: the name of the plan that the user will try */
+					__( 'Start the %(planName)s trial' ),
+					{
+						planName: plan?.getTitle(),
+					}
+				) }
 			</NextButton>
 		</>
 	);
@@ -90,15 +97,17 @@ function EmailVerification( {
 	resendEmail: () => void;
 } ) {
 	const { __ } = useI18n();
+	const plan = getPlan( PLAN_BUSINESS );
 	return (
 		<SubTitle>
 			<p>
 				{ sprintf(
-					/* translators: the email address of the account*/
+					/* translators: plan name, and the email address of the account */
 					__(
-						'To start your Business plan 7-day trial, verify your email address by clicking the link we sent to %(email)s.'
+						'To start your %(planName)s plan 7-day trial, verify your email address by clicking the link we sent to %(email)s.'
 					),
 					{
+						planName: plan?.getTitle(),
 						email: email,
 					}
 				) }


### PR DESCRIPTION
Related to p9Jlb4-at5-p2.

## Proposed Changes

Uses consistent plan names in the trial acknowledge screen:

![image](https://github.com/Automattic/wp-calypso/assets/26530524/b35b6c7c-3276-4591-a067-676726a32644)

## Testing Instructions

Start a free trial with a new, unverified account, and check that you see "Creator" everywhere in the trial acknowledge step.