### PR TITLE
Business trials: use consistent banner

### DIFF
--- a/client/my-sites/plans/current-plan/index.jsx
+++ b/client/my-sites/plans/current-plan/index.jsx
@@ -266,7 +266,7 @@ class CurrentPlan extends Component {
 
 						<PlansNavigation path={ path } />
 
-						<Main wideLayout>
+						<Main fullWidthLayout>
 							{ showDomainWarnings && (
 								<DomainWarnings
 									domains={ domains }

--- a/client/my-sites/plans/current-plan/style.scss
+++ b/client/my-sites/plans/current-plan/style.scss
@@ -1,5 +1,5 @@
 .current-plan main {
-	padding-top: 17px;
+	padding-top: 24px;
 }
 
 .current-plan__dialog.dialog__backdrop {

--- a/client/my-sites/plans/trials/business-trial-plans-page/index.tsx
+++ b/client/my-sites/plans/trials/business-trial-plans-page/index.tsx
@@ -1,7 +1,12 @@
+import { PLAN_BUSINESS } from '@automattic/calypso-products';
+import page from '@automattic/calypso-router';
+import { Button } from '@automattic/components';
 import { SiteDetails } from '@automattic/data-stores';
+import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import BodySectionCssClass from 'calypso/layout/body-section-css-class';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { getTrialCheckoutUrl } from '../../../../lib/trials/get-trial-checkout-url';
 import { BusinessTrialPlans } from '../business-trial-plans';
 import TrialBanner from '../trial-banner';
 
@@ -13,6 +18,7 @@ interface BusinessTrialPlansPageProps {
 
 const BusinessTrialPlansPage = ( props: BusinessTrialPlansPageProps ) => {
 	const { selectedSite } = props;
+	const translate = useTranslate();
 
 	const triggerPlansGridTracksEvent = useCallback( ( planSlug: string ) => {
 		recordTracksEvent( 'calypso_business_trial_plans_page_upgrade_cta_clicked', {
@@ -21,12 +27,35 @@ const BusinessTrialPlansPage = ( props: BusinessTrialPlansPageProps ) => {
 		} );
 	}, [] );
 
+	/**
+	 * Redirects to the checkout page with Plan on cart.
+	 */
+	const goToCheckoutWithPlan = () => {
+		recordTracksEvent( 'calypso_business_trial_plans_page_upgrade_cta_clicked', {
+			location: 'trial_card',
+			plan_slug: PLAN_BUSINESS,
+		} );
+
+		const checkoutUrl = getTrialCheckoutUrl( {
+			productSlug: PLAN_BUSINESS,
+			siteSlug: selectedSite?.slug ?? '',
+		} );
+
+		page.redirect( checkoutUrl );
+	};
+
+	const bannerCallToAction = (
+		<Button className="trial-current-plan__trial-card-cta" primary onClick={ goToCheckoutWithPlan }>
+			{ translate( 'Upgrade now' ) }
+		</Button>
+	);
+
 	return (
 		<>
 			<BodySectionCssClass bodyClass={ [ 'is-business-trial-plan' ] } />
 
 			<div className="business-trial-plans__banner-wrapper">
-				<TrialBanner />
+				<TrialBanner callToAction={ bannerCallToAction } />
 			</div>
 			<BusinessTrialPlans
 				siteId={ selectedSite.ID }


### PR DESCRIPTION
Related to p9Jlb4-at5-p2.

## Proposed Changes

Adds the CTA to the `/plans/%s` free trial banner:

<img width="981" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/b5332999-be12-4ed8-9501-3d9afd736ab7">

And make its width and top margin consistent with the "Free trial" tab.

## Testing Instructions

Verify that the Tracks event gets correctly logged, and that you're directed to checkout after clicking the banner within the plans page of a Business trial site.