### PR TITLE
Business trial: Use conjunction instead of unit when list formatting

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/trial-plan.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/trial-acknowledge/trial-plan.tsx
@@ -24,7 +24,7 @@ export const TrialPlan = ( {
 
 	const formats = new Intl.ListFormat( i18n.getLocaleSlug() ?? 'en', {
 		style: 'long',
-		type: 'unit',
+		type: 'conjunction',
 	} ).format( trialLimitations );
 
 	return (


### PR DESCRIPTION
Related to p9Jlb4-at5-p2.

## Proposed Changes

Let's use "X, Y and Z" instead of "X, Y, Z" in the trial limitations section screen.

| Before | After |
| -------|------|
| <img width="333" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/259d4e08-ae0a-48a0-b038-abb647d8f424"> | <img width="339" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/272eb40e-0d6f-4f72-a11f-9c674bba653f"> |

## Testing Instructions

Browse the trial acknowledge screen and verify that there is a conjunction instead of a comma in the last trial limitation.