### PR TITLE
Business trial: Use more relevant CTA links on cards

### DIFF
--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import { pick } from 'lodash';
+import { useEffect } from 'react';
 import { connect } from 'react-redux';
 import blazeIllustration from 'calypso/assets/images/customer-home/illustration--blaze.svg';
 import PromoCardBlock from 'calypso/blocks/promo-card-block';
@@ -40,82 +41,91 @@ const SiteSettingsTraffic = ( {
 	siteSlug,
 	shouldShowAdvertisingOption,
 	translate,
-} ) => (
-	// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-	<Main className="settings-traffic site-settings" wideLayout>
-		<PageViewTracker path="/marketing/traffic/:site" title="Marketing > Traffic" />
-		{ ! isAdmin && (
-			<EmptyContent
-				illustration="/calypso/images/illustrations/illustration-404.svg"
-				title={ translate( 'You are not authorized to view this page' ) }
-			/>
-		) }
-		<JetpackDevModeNotice />
-		{ isAdmin && shouldShowAdvertisingOption && (
-			<PromoCardBlock
-				productSlug="blaze"
-				impressionEvent="calypso_marketing_traffic_blaze_banner_view"
-				clickEvent="calypso_marketing_traffic_blaze_banner_click"
-				headerText={ translate( 'Reach new readers and customers' ) }
-				contentText={ translate(
-					'Use WordPress Blaze to increase your reach by promoting your work to the larger WordPress.com community of blogs and sites. '
-				) }
-				ctaText={ translate( 'Get started' ) }
-				image={ blazeIllustration }
-				href={ `/advertising/${ siteSlug || '' }` }
-			/>
-		) }
-		{ isAdmin && <SeoSettingsHelpCard disabled={ isRequestingSettings || isSavingSettings } /> }
-		{ isAdmin && (
-			<AsyncLoad
-				key={ siteId }
-				require="calypso/my-sites/site-settings/seo-settings/form"
-				placeholder={ null }
-			/>
-		) }
-		{ isAdmin && (
-			<RelatedPosts
-				onSubmitForm={ handleSubmitForm }
-				handleToggle={ handleAutosavingToggle }
-				isSavingSettings={ isSavingSettings }
-				isRequestingSettings={ isRequestingSettings }
-				fields={ fields }
-			/>
-		) }
-		{ ! isJetpack && isAdmin && config.isEnabled( 'cloudflare' ) && (
-			<CloudflareAnalyticsSettings />
-		) }
+} ) => {
+	useEffect( () => {
+		/* Elements are loaded contionnaly so the browser gets lost and can't find the node */
+		if ( window.location.hash ) {
+			document.getElementById( window.location.hash.substring( 1 ) )?.scrollIntoView();
+		}
+	}, [] );
 
-		{ isJetpackAdmin && (
-			<JetpackSiteStats
-				handleAutosavingToggle={ handleAutosavingToggle }
-				setFieldValue={ setFieldValue }
-				isSavingSettings={ isSavingSettings }
-				isRequestingSettings={ isRequestingSettings }
-				fields={ fields }
-			/>
-		) }
-		{ isAdmin && <AnalyticsSettings /> }
-		{ isJetpackAdmin && (
-			<Shortlinks
-				handleAutosavingRadio={ handleAutosavingRadio }
-				handleAutosavingToggle={ handleAutosavingToggle }
-				isSavingSettings={ isSavingSettings }
-				isRequestingSettings={ isRequestingSettings }
-				fields={ fields }
-				onSubmitForm={ handleSubmitForm }
-			/>
-		) }
-		{ isAdmin && (
-			<Sitemaps
-				isSavingSettings={ isSavingSettings }
-				isRequestingSettings={ isRequestingSettings }
-				fields={ fields }
-			/>
-		) }
-		{ isAdmin && <SiteVerification /> }
-	</Main>
-);
+	return (
+		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+		<Main className="settings-traffic site-settings" wideLayout>
+			<PageViewTracker path="/marketing/traffic/:site" title="Marketing > Traffic" />
+			{ ! isAdmin && (
+				<EmptyContent
+					illustration="/calypso/images/illustrations/illustration-404.svg"
+					title={ translate( 'You are not authorized to view this page' ) }
+				/>
+			) }
+			<JetpackDevModeNotice />
+			{ isAdmin && shouldShowAdvertisingOption && (
+				<PromoCardBlock
+					productSlug="blaze"
+					impressionEvent="calypso_marketing_traffic_blaze_banner_view"
+					clickEvent="calypso_marketing_traffic_blaze_banner_click"
+					headerText={ translate( 'Reach new readers and customers' ) }
+					contentText={ translate(
+						'Use WordPress Blaze to increase your reach by promoting your work to the larger WordPress.com community of blogs and sites. '
+					) }
+					ctaText={ translate( 'Get started' ) }
+					image={ blazeIllustration }
+					href={ `/advertising/${ siteSlug || '' }` }
+				/>
+			) }
+			{ isAdmin && <SeoSettingsHelpCard disabled={ isRequestingSettings || isSavingSettings } /> }
+			{ isAdmin && (
+				<AsyncLoad
+					key={ siteId }
+					require="calypso/my-sites/site-settings/seo-settings/form"
+					placeholder={ null }
+				/>
+			) }
+			{ isAdmin && (
+				<RelatedPosts
+					onSubmitForm={ handleSubmitForm }
+					handleToggle={ handleAutosavingToggle }
+					isSavingSettings={ isSavingSettings }
+					isRequestingSettings={ isRequestingSettings }
+					fields={ fields }
+				/>
+			) }
+			{ ! isJetpack && isAdmin && config.isEnabled( 'cloudflare' ) && (
+				<CloudflareAnalyticsSettings />
+			) }
+
+			{ isJetpackAdmin && (
+				<JetpackSiteStats
+					handleAutosavingToggle={ handleAutosavingToggle }
+					setFieldValue={ setFieldValue }
+					isSavingSettings={ isSavingSettings }
+					isRequestingSettings={ isRequestingSettings }
+					fields={ fields }
+				/>
+			) }
+			{ isAdmin && <AnalyticsSettings /> }
+			{ isJetpackAdmin && (
+				<Shortlinks
+					handleAutosavingRadio={ handleAutosavingRadio }
+					handleAutosavingToggle={ handleAutosavingToggle }
+					isSavingSettings={ isSavingSettings }
+					isRequestingSettings={ isRequestingSettings }
+					fields={ fields }
+					onSubmitForm={ handleSubmitForm }
+				/>
+			) }
+			{ isAdmin && (
+				<Sitemaps
+					isSavingSettings={ isSavingSettings }
+					isRequestingSettings={ isRequestingSettings }
+					fields={ fields }
+				/>
+			) }
+			{ isAdmin && <SiteVerification /> }
+		</Main>
+	);
+};
 
 const connectComponent = connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );

--- a/client/my-sites/marketing/traffic/style.scss
+++ b/client/my-sites/marketing/traffic/style.scss
@@ -292,4 +292,8 @@
 	.promo-card-block img {
 		max-width: 170px;
 	}
+
+	#analytics {
+		scroll-margin-top: 60px;
+	}
 }

--- a/client/my-sites/plans/current-plan/trials/use-business-trial-included-features.ts
+++ b/client/my-sites/plans/current-plan/trials/use-business-trial-included-features.ts
@@ -26,7 +26,7 @@ export default function useBusinessTrialIncludedFeatures(
 			illustration: beautifulThemes,
 			showButton: true,
 			buttonText: translate( 'Browse themes' ),
-			buttonClick: () => page.redirect( `/themes/${ siteSlug }` ),
+			buttonClick: () => page( `/themes/${ siteSlug }` ),
 		},
 		{
 			id: 'advanced-design-tools',
@@ -61,7 +61,7 @@ export default function useBusinessTrialIncludedFeatures(
 			illustration: jetpackBackupsAndRestores,
 			showButton: true,
 			buttonText: 'View your backup activity',
-			buttonClick: () => page.redirect( `/backup/${ siteSlug }` ),
+			buttonClick: () => page( `/backup/${ siteSlug }` ),
 		},
 		{
 			id: 'spam-protection',
@@ -85,7 +85,7 @@ export default function useBusinessTrialIncludedFeatures(
 			illustration: seoTools,
 			showButton: true,
 			buttonText: translate( 'Increase visibility' ),
-			buttonClick: () => page.redirect( `/marketing/traffic/${ siteSlug }` ),
+			buttonClick: () => page( `/marketing/traffic/${ siteSlug }` ),
 		},
 		{
 			id: 'google-analytics',
@@ -94,7 +94,7 @@ export default function useBusinessTrialIncludedFeatures(
 			illustration: googleAnalytics,
 			showButton: true,
 			buttonText: translate( 'Connect Google Analytics' ),
-			buttonClick: () => page.redirect( `/marketing/traffic/${ siteSlug }` ),
+			buttonClick: () => page( `/marketing/traffic/${ siteSlug }` ),
 		},
 		{
 			id: 'hosting',

--- a/client/my-sites/plans/current-plan/trials/use-business-trial-included-features.ts
+++ b/client/my-sites/plans/current-plan/trials/use-business-trial-included-features.ts
@@ -94,7 +94,7 @@ export default function useBusinessTrialIncludedFeatures(
 			illustration: googleAnalytics,
 			showButton: true,
 			buttonText: translate( 'Connect Google Analytics' ),
-			buttonClick: () => page( `/marketing/traffic/${ siteSlug }` ),
+			buttonClick: () => page( `/marketing/traffic/${ siteSlug }#analytics` ),
 		},
 		{
 			id: 'hosting',

--- a/client/my-sites/plans/current-plan/trials/use-business-trial-included-features.ts
+++ b/client/my-sites/plans/current-plan/trials/use-business-trial-included-features.ts
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { localizeUrl, useHasEnTranslation } from '@automattic/i18n-utils';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import advancedDesignTools from 'calypso/assets/images/plans/wpcom/business-trial/advanced-design-tools.svg';
 import beautifulThemes from 'calypso/assets/images/plans/wpcom/business-trial/beautiful-themes.svg';
@@ -73,7 +73,10 @@ export default function useBusinessTrialIncludedFeatures(
 			showButton: true,
 			buttonText: translate( 'Keep your site safe' ),
 			buttonClick: () =>
-				( location.href = localizeUrl( 'https://jetpack.com/blog/what-is-spam/' ) ),
+				( location.href = `//${ siteSlug.replace(
+					'::',
+					'/'
+				) }/wp-admin/admin.php?page=akismet-key-config` ),
 		},
 		{
 			id: 'seo-tools',
@@ -82,8 +85,7 @@ export default function useBusinessTrialIncludedFeatures(
 			illustration: seoTools,
 			showButton: true,
 			buttonText: translate( 'Increase visibility' ),
-			buttonClick: () =>
-				( location.href = localizeUrl( 'https://wordpress.com/support/seo-tools/' ) ),
+			buttonClick: () => page.redirect( `/marketing/traffic/${ siteSlug }` ),
 		},
 		{
 			id: 'google-analytics',
@@ -92,8 +94,7 @@ export default function useBusinessTrialIncludedFeatures(
 			illustration: googleAnalytics,
 			showButton: true,
 			buttonText: translate( 'Connect Google Analytics' ),
-			buttonClick: () =>
-				( location.href = localizeUrl( 'https://wordpress.com/support/google-analytics/' ) ),
+			buttonClick: () => page.redirect( `/marketing/traffic/${ siteSlug }` ),
 		},
 		{
 			id: 'hosting',


### PR DESCRIPTION
Related to p9Jlb4-at5-p2.

## Proposed Changes

Let's use more relevant links for folks browsing the Business trial cards.

Changes:
- Spam protection now links to Akismet configuration;
- SEO tools links to the marketing/traffic page;
- Google Analytics links to the GA configuration card.

~I tried redirecting automatically to the Google Analytics cards by using the anchor (`#analytics`), however it doesn't scroll the page on load. Some additional JS would be necessary. I wonder if we want to keep that last change, considering the user won't see the GA card and will find the experience confusing.~

## Testing Instructions

Open `/plans/my-plan/%s` of a trial site and verify that the above mentioned links redirect to the specified places.