### PR TITLE
Support alpha value in hexToRgb util function

### DIFF
--- a/packages/design-picker/src/components/style-variation-badges/utils.ts
+++ b/packages/design-picker/src/components/style-variation-badges/utils.ts
@@ -104,7 +104,7 @@ function findColorBestAnalogous( hexCodes: string[], baseHex: string ) {
 
 export function getStylesColorFromVariation(
 	variation: StyleVariation
-): StyleVariationStylesColor {
+): StyleVariationStylesColor | null {
 	const palette = getColors( variation );
 	const colorBase = getColorBaseFromColors( palette );
 	const colorList = palette.map( ( item ) => item.color );

--- a/packages/design-picker/src/components/style-variation-badges/utils.ts
+++ b/packages/design-picker/src/components/style-variation-badges/utils.ts
@@ -109,8 +109,11 @@ export function getStylesColorFromVariation(
 	const colorBase = getColorBaseFromColors( palette );
 	const colorList = palette.map( ( item ) => item.color );
 
-	return {
-		background: colorBase,
-		text: findColorBestAnalogous( colorList, colorBase ),
-	};
+	try {
+		return { background: colorBase, text: findColorBestAnalogous( colorList, colorBase ) };
+	} catch ( e ) {
+		// eslint-disable-next-line no-console
+		console.error( e, variation );
+		return null;
+	}
 }

--- a/packages/onboarding/src/utils/contrastChecker.ts
+++ b/packages/onboarding/src/utils/contrastChecker.ts
@@ -36,14 +36,17 @@ export const hasMinContrast = (
 // Works also with shorthand hex triplets such as "#03F"
 export const hexToRgb = ( hex: string ) => {
 	const rgbHex = hex
-		.replace( /^#?([a-f\d])([a-f\d])([a-f\d])$/i, ( _m, r, g, b ) => '#' + r + r + g + g + b + b )
+		.replace(
+			/^#?([a-f\d])([a-f\d])([a-f\d])([a-f\d])?$/i,
+			( _m, r, g, b, a ) => '#' + r + r + g + g + b + b + ( a ? a + a : '' )
+		)
 		.substring( 1 )
 		.match( /.{2}/g );
 
-	if ( rgbHex?.length !== 3 ) {
+	if ( rgbHex?.length !== 3 && rgbHex?.length !== 4 ) {
 		throw 'Unexpected RGB hex value';
 	}
 
-	const [ r, g, b ] = rgbHex.map( ( x ) => parseInt( x, 16 ) );
-	return { r, g, b };
+	const [ r, g, b, a ] = rgbHex.map( ( x ) => parseInt( x, 16 ) );
+	return { r, g, b, a };
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #82823

## Proposed Changes

This PR updates the utility function `hexToRgb` to account for the alpha value.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Edit a theme (e.g.: Pixl) style variation in your sandbox so that one of the colors has alpha value.
* Bypass the style variation cache.
* Head to the Design Picker or the Theme Showcase.
* Ensure that the page renders correctly without any fatal errors.
* Ensure that the style variation badges are rendered the same as in production.
 
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?