### PR TITLE
Stats: Extend Stats Commercial plan price tiers based on the highest tier

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -1,6 +1,7 @@
 import formatNumber from '@automattic/components/src/number-formatters/lib/format-number';
 import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import TierUpgradeSlider from 'calypso/my-sites/stats/stats-purchase/tier-upgrade-slider';
 import { useSelector } from 'calypso/state';
@@ -133,6 +134,12 @@ function StatsCommercialUpgradeSlider( {
 
 		onSliderChange( quantity as number );
 	};
+
+	useEffect( () => {
+		// Update the first step with the fetched tier quantity back to the parent component.
+		const firstStepQuantity = getTierQuentity( tiers[ 0 ], true );
+		onSliderChange( firstStepQuantity as number );
+	} );
 
 	return (
 		<TierUpgradeSlider

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -136,10 +136,10 @@ function StatsCommercialUpgradeSlider( {
 	};
 
 	useEffect( () => {
-		// Update the first step with the fetched tier quantity back to the parent component.
+		// Update fetched tier quantity of the first step back to the parent component for checkout.
 		const firstStepQuantity = getTierQuentity( tiers[ 0 ], true );
 		onSliderChange( firstStepQuantity as number );
-	} );
+	}, [ JSON.stringify( tiers ), onSliderChange ] );
 
 	return (
 		<TierUpgradeSlider

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import { Button as CalypsoButton } from '@automattic/components';
 import { Button, Panel, PanelBody, CheckboxControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import React, { useState } from 'react';
+import React, { useState, useCallback } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
@@ -125,9 +125,9 @@ Thanks\n\n`;
 		setTimeout( () => ( window.location.href = emailHref ), 250 );
 	};
 
-	const handleSliderChanged = ( value: number ) => {
+	const handleSliderChanged = useCallback( ( value: number ) => {
 		setPurchaseTierQuantity( value );
-	};
+	}, [] );
 
 	return (
 		<>

--- a/client/my-sites/stats/stats-purchase/types.ts
+++ b/client/my-sites/stats/stats-purchase/types.ts
@@ -12,6 +12,7 @@ export type PriceTierListItemProps = {
 };
 
 export type StatsPlanTierUI = {
+	minimum_price: number;
 	price: string | undefined;
 	description?: string;
 	views: number | null;

--- a/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
+++ b/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
@@ -11,7 +11,7 @@ import { PriceTierListItemProps, StatsPlanTierUI } from './types';
 
 // Special case for per-unit fees over the max tier.
 export const EXTENSION_THRESHOLD_IN_MILLION = 2;
-const EXTENDED_TIERS_AMOUNT = 5;
+const EXTENDED_TIERS_AMOUNT = 6;
 
 // TODO: Remove the mock data after release.
 // No need to translate mock data.
@@ -116,7 +116,7 @@ function extendTiersBeyondHighestTier(
 
 		for (
 			let extendedTierCount = extendedTierCountStart;
-			extendedTierCount <= extendedTierCountEnd;
+			extendedTierCount < extendedTierCountEnd;
 			extendedTierCount++
 		) {
 			const totalPrice =

--- a/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
+++ b/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
@@ -154,6 +154,7 @@ function useAvailableUpgradeTiers(
 	const commercialProduct = useSelector( ( state ) =>
 		getProductBySlug( state, PRODUCT_JETPACK_STATS_YEARLY )
 	) as ProductsList.ProductsListItem | null;
+	// TODO: Add the loading state of the plan usage query to avoid redundant re-rendering.
 	const { data: usageData } = usePlanUsageQuery( siteId );
 
 	if ( ! commercialProduct || ! usageData ) {

--- a/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
+++ b/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
@@ -11,47 +11,47 @@ import { PriceTierListItemProps, StatsPlanTierUI } from './types';
 
 // Special case for per-unit fees over the max tier.
 export const EXTENSION_THRESHOLD_IN_MILLION = 2;
-const EXTENDED_TIER_COUNT = 5;
+const EXTENDED_TIERS_AMOUNT = 5;
 
 // TODO: Remove the mock data after release.
 // No need to translate mock data.
 const MOCK_PLAN_DATA = [
 	{
 		minimum_price: 10000,
-		price: '$9',
+		price: '$8.34',
 		views: 10000,
 		description: '$9/month for 10k views',
 	},
 	{
 		minimum_price: 20000,
-		price: '$19',
+		price: '$16.67',
 		views: 100000,
 		description: '$19/month for 100k views',
 	},
 	{
 		minimum_price: 30000,
-		price: '$29',
+		price: '$25',
 		views: 250000,
 		description: '$29/month for 250k views',
 	},
 	{
 		minimum_price: 50000,
-		price: '$49',
+		price: '$41.67',
 		views: 500000,
 		description: '$49/month for 500k views',
 	},
 	{
 		minimum_price: 70000,
-		price: '$69',
+		price: '$58.34',
 		views: 1000000,
 		description: '$69/month for 1M views',
 	},
 	{
 		minimum_price: 95000,
-		price: '$89.99',
+		price: '$79.17',
 		views: null,
 		extension: true,
-		per_unit_fee: 1799,
+		per_unit_fee: 25000,
 		description: '$25/month per million views if views exceed 1M',
 	},
 ];
@@ -60,11 +60,11 @@ function transformTier( tier: PriceTierListItemProps ): StatsPlanTierUI {
 	// TODO: Some description of transform logic here.
 	// So as to clarify what we should expect from the API.
 	if ( tier?.maximum_units === null ) {
-		// highest tier extension
+		// Special transformation for highest tier extension.
 		return {
 			minimum_price: tier?.minimum_price,
 			price: tier?.minimum_price_monthly_display,
-			views: EXTENSION_THRESHOLD_IN_MILLION * ( tier?.transform_quantity_divide_by ?? 0 ),
+			views: EXTENSION_THRESHOLD_IN_MILLION * ( tier?.transform_quantity_divide_by || 1 ),
 			extension: true,
 			transform_quantity_divide_by: tier?.transform_quantity_divide_by,
 			per_unit_fee: tier?.per_unit_fee,
@@ -102,14 +102,21 @@ function filterPurchasedTiers(
 
 function extendTiersBeyondHighestTier(
 	availableTiers: StatsPlanTierUI[],
-	currencyCode: string
+	currencyCode: string,
+	usageData: PlanUsage
 ): StatsPlanTierUI[] {
 	if ( availableTiers.length === 1 && !! availableTiers[ 0 ].transform_quantity_divide_by ) {
 		const highestTier = availableTiers[ 0 ];
 
+		const purchasedExtendedTierCount =
+			usageData?.views_limit / ( highestTier.transform_quantity_divide_by || 1 ) -
+			EXTENSION_THRESHOLD_IN_MILLION;
+		const extendedTierCountStart = purchasedExtendedTierCount + 1;
+		const extendedTierCountEnd = extendedTierCountStart + EXTENDED_TIERS_AMOUNT;
+
 		for (
-			let extendedTierCount = 1;
-			extendedTierCount <= EXTENDED_TIER_COUNT;
+			let extendedTierCount = extendedTierCountStart;
+			extendedTierCount <= extendedTierCountEnd;
 			extendedTierCount++
 		) {
 			const totalPrice =
@@ -127,11 +134,13 @@ function extendTiersBeyondHighestTier(
 				price: monthlyPriceDisplay,
 				views: views,
 				extension: true,
-				transform_quantity_divide_by: highestTier?.transform_quantity_divide_by,
-				// The price is yearly for yearly plans, so we need to divide by 12.
+				transform_quantity_divide_by: highestTier.transform_quantity_divide_by,
 				per_unit_fee: highestTier?.per_unit_fee,
 			} );
 		}
+
+		// Remove the first tier, which is used to extend higher tiers.
+		availableTiers = availableTiers.slice( 1 );
 	}
 
 	return availableTiers;
@@ -147,7 +156,7 @@ function useAvailableUpgradeTiers(
 	) as ProductsList.ProductsListItem | null;
 	const { data: usageData } = usePlanUsageQuery( siteId );
 
-	if ( ! commercialProduct ) {
+	if ( ! commercialProduct || ! usageData ) {
 		return MOCK_PLAN_DATA;
 	}
 
@@ -161,7 +170,7 @@ function useAvailableUpgradeTiers(
 		tiersForUi = filterPurchasedTiers( tiersForUi, usageData );
 	}
 
-	tiersForUi = extendTiersBeyondHighestTier( tiersForUi, currencyCode );
+	tiersForUi = extendTiersBeyondHighestTier( tiersForUi, currencyCode, usageData );
 
 	// 3. Return the relevant upgrade options as a list.
 	return tiersForUi;

--- a/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
+++ b/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
@@ -1,5 +1,6 @@
 import { PRODUCT_JETPACK_STATS_YEARLY } from '@automattic/calypso-products';
 import { ProductsList } from '@automattic/data-stores';
+import formatCurrency from '@automattic/format-currency';
 import {
 	default as usePlanUsageQuery,
 	PlanUsage,
@@ -8,35 +9,45 @@ import { useSelector } from 'calypso/state';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { PriceTierListItemProps, StatsPlanTierUI } from './types';
 
+// Special case for per-unit fees over the max tier.
+export const EXTENSION_THRESHOLD_IN_MILLION = 2;
+const EXTENDED_TIER_COUNT = 5;
+
 // TODO: Remove the mock data after release.
 // No need to translate mock data.
 const MOCK_PLAN_DATA = [
 	{
+		minimum_price: 10000,
 		price: '$9',
 		views: 10000,
 		description: '$9/month for 10k views',
 	},
 	{
+		minimum_price: 20000,
 		price: '$19',
 		views: 100000,
 		description: '$19/month for 100k views',
 	},
 	{
+		minimum_price: 30000,
 		price: '$29',
 		views: 250000,
 		description: '$29/month for 250k views',
 	},
 	{
+		minimum_price: 50000,
 		price: '$49',
 		views: 500000,
 		description: '$49/month for 500k views',
 	},
 	{
+		minimum_price: 70000,
 		price: '$69',
 		views: 1000000,
 		description: '$69/month for 1M views',
 	},
 	{
+		minimum_price: 95000,
 		price: '$89.99',
 		views: null,
 		extension: true,
@@ -51,16 +62,17 @@ function transformTier( tier: PriceTierListItemProps ): StatsPlanTierUI {
 	if ( tier?.maximum_units === null ) {
 		// highest tier extension
 		return {
+			minimum_price: tier?.minimum_price,
 			price: tier?.minimum_price_monthly_display,
-			views: tier?.maximum_units,
+			views: EXTENSION_THRESHOLD_IN_MILLION * ( tier?.transform_quantity_divide_by ?? 0 ),
 			extension: true,
 			transform_quantity_divide_by: tier?.transform_quantity_divide_by,
-			// The price is yearly for yearly plans, so we need to divide by 12.
-			per_unit_fee: ( tier?.per_unit_fee ?? 0 ) / 12,
+			per_unit_fee: tier?.per_unit_fee,
 		};
 	}
 
 	return {
+		minimum_price: tier?.minimum_price,
 		price: tier?.maximum_price_monthly_display,
 		views: tier?.maximum_units,
 	};
@@ -79,12 +91,50 @@ function filterPurchasedTiers(
 	} else {
 		tiers = availableTiers.filter( ( availableTier ) => {
 			return (
-				availableTier.views === null || ( availableTier?.views as number ) > usageData?.views_limit
+				!! availableTier.transform_quantity_divide_by ||
+				( availableTier?.views as number ) > usageData?.views_limit
 			);
 		} );
 	}
 
 	return tiers;
+}
+
+function extendTiersBeyondHighestTier(
+	availableTiers: StatsPlanTierUI[],
+	currencyCode: string
+): StatsPlanTierUI[] {
+	if ( availableTiers.length === 1 && !! availableTiers[ 0 ].transform_quantity_divide_by ) {
+		const highestTier = availableTiers[ 0 ];
+
+		for (
+			let extendedTierCount = 1;
+			extendedTierCount <= EXTENDED_TIER_COUNT;
+			extendedTierCount++
+		) {
+			const totalPrice =
+				highestTier?.minimum_price + ( highestTier.per_unit_fee ?? 0 ) * extendedTierCount;
+			const monthlyPriceDisplay = formatCurrency( totalPrice / 12, currencyCode, {
+				isSmallestUnit: true,
+				stripZeros: true,
+			} );
+			const views =
+				( highestTier?.views ?? 0 ) +
+				( highestTier.transform_quantity_divide_by ?? 0 ) * extendedTierCount;
+
+			availableTiers.push( {
+				minimum_price: totalPrice,
+				price: monthlyPriceDisplay,
+				views: views,
+				extension: true,
+				transform_quantity_divide_by: highestTier?.transform_quantity_divide_by,
+				// The price is yearly for yearly plans, so we need to divide by 12.
+				per_unit_fee: highestTier?.per_unit_fee,
+			} );
+		}
+	}
+
+	return availableTiers;
 }
 
 function useAvailableUpgradeTiers(
@@ -97,14 +147,21 @@ function useAvailableUpgradeTiers(
 	) as ProductsList.ProductsListItem | null;
 	const { data: usageData } = usePlanUsageQuery( siteId );
 
-	let tiersForUi = commercialProduct?.price_tier_list?.map( transformTier );
+	if ( ! commercialProduct ) {
+		return MOCK_PLAN_DATA;
+	}
 
-	tiersForUi = tiersForUi?.length > 0 ? tiersForUi : MOCK_PLAN_DATA;
+	let tiersForUi = commercialProduct.price_tier_list.map( transformTier );
+	const currencyCode = commercialProduct.currency_code || 'USD';
+
+	tiersForUi = tiersForUi.length > 0 ? tiersForUi : MOCK_PLAN_DATA;
 
 	// 2. Filter based on current plan.
 	if ( shouldFilterPurchasedTiers ) {
 		tiersForUi = filterPurchasedTiers( tiersForUi, usageData );
 	}
+
+	tiersForUi = extendTiersBeyondHighestTier( tiersForUi, currencyCode );
 
 	// 3. Return the relevant upgrade options as a list.
 	return tiersForUi;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85246

## Proposed Changes

* Add `6` extended plan tiers when the current view limit reaches the `2M` tier.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a new JN site and connect it to Jetpack.
2. Apply the Diff D129634-code and sandbox `public-api.wordpress.com` along with `Store Sandbox`.
3. Spin this change on _local_ Calypso.
4. Navigate to the Commercial purchase page for the new JN site: `/stats/purchase/{site-slug}?productType=commercial`.
5. Ensure the pricing slider works as previously.
<img width="568" alt="截圖 2023-12-26 下午11 44 45" src="https://github.com/Automattic/wp-calypso/assets/6869813/cc245faf-76a6-49c7-8d72-6bf36a750ea7">

6. Purchase any tier before the `2M` tier.
<img width="587" alt="截圖 2023-12-26 下午11 38 26" src="https://github.com/Automattic/wp-calypso/assets/6869813/dd5e388b-3d66-4dec-92b5-f263e7af7ab9">

7. Ensure the checkout amount is correct.
8. Go to the purchase page again (_step 4_).
9. Ensure the remaining tiers are reasonable.
<img width="592" alt="截圖 2023-12-26 下午11 39 50" src="https://github.com/Automattic/wp-calypso/assets/6869813/4ff06c39-6c0e-449e-ae11-0d33014db562">

10. Purchase the highest tier `2M`.
<img width="834" alt="截圖 2023-12-26 下午11 39 58" src="https://github.com/Automattic/wp-calypso/assets/6869813/c609a7aa-876a-46ed-bb11-e65899e87959">

11. Ensure the checkout amount is correct.
<img width="599" alt="截圖 2023-12-26 下午11 40 42" src="https://github.com/Automattic/wp-calypso/assets/6869813/e65d0737-c079-48da-b533-40d5ae298ddb">

12. Go to the purchase page again (_step 4_).
13. Ensure there are `6` extended tiers beyond the `2M` tier.
<img width="591" alt="截圖 2023-12-26 下午11 41 31" src="https://github.com/Automattic/wp-calypso/assets/6869813/6ca3c7b0-4d4f-4ea9-a9f1-ff722ebf20c3">

14. Purchase any extended tier.
15. Ensure the checkout amount is correct.
<img width="598" alt="截圖 2023-12-26 下午11 42 05" src="https://github.com/Automattic/wp-calypso/assets/6869813/23cb2f68-7875-492b-a458-4ccbf3c84715">

> Note: The price of tier beyond `1M` on the checkout page is set to `0` as a discount, which is unreasonable. We need to address it as a follow-up task.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?