### PR TITLE
Add Nextdoor to Jetpack Social features list

### DIFF
--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1,4 +1,4 @@
-import { translate, useTranslate } from 'i18n-calypso';
+import { translate, useTranslate, getLocaleSlug } from 'i18n-calypso';
 import { createElement, useCallback, useMemo } from 'react';
 import {
 	PRODUCT_JETPACK_ANTI_SPAM_BI_YEARLY,
@@ -1185,12 +1185,24 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Optimize CSS loading' ),
 		translate( 'Lazy image loading' ),
 	];
+
+	const listFormatter = new Intl.ListFormat( getLocaleSlug() || 'en' );
+
+	const socialNetworksList = listFormatter.format( [
+		translate( 'Facebook' ),
+		translate( 'Instagram' ),
+		translate( 'LinkedIn' ),
+		translate( 'Mastodon' ),
+		translate( 'Tumblr' ),
+		translate( 'Nextdoor' ),
+	] );
+
 	const socialBasicIncludesInfo = [
 		translate( 'Automatically share your posts and products on social media' ),
 		translate( 'Post to multiple channels at once' ),
 		translate( 'Manage all of your channels from a single hub' ),
 		translate( 'Scheduled posts' ),
-		translate( 'Share to Facebook, Instagram, LinkedIn, Mastodon & Tumblr' ),
+		translate( 'Share to %(socialNetworksList)s', { args: { socialNetworksList } } ),
 		translate( 'Recycle content' ),
 	];
 	const socialAdvancedIncludesInfo = [
@@ -1198,7 +1210,7 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Post to multiple channels at once' ),
 		translate( 'Manage all of your channels from a single hub' ),
 		translate( 'Scheduled posts' ),
-		translate( 'Share to Facebook, Instagram, LinkedIn, Mastodon & Tumblr' ),
+		translate( 'Share to %(socialNetworksList)s', { args: { socialNetworksList } } ),
 		translate( 'Engagement Optimizer' ),
 		translate( 'Recycle content' ),
 		translate( 'Image generator' ),

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1202,7 +1202,10 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Post to multiple channels at once' ),
 		translate( 'Manage all of your channels from a single hub' ),
 		translate( 'Scheduled posts' ),
-		translate( 'Share to %(socialNetworksList)s', { args: { socialNetworksList } } ),
+		translate( 'Share to %(socialNetworksList)s', {
+			args: { socialNetworksList },
+			comment: 'Comma separated list of social networks like "Facebook, Mastodon and Tumblr".',
+		} ),
 		translate( 'Recycle content' ),
 	];
 	const socialAdvancedIncludesInfo = [
@@ -1210,7 +1213,10 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Post to multiple channels at once' ),
 		translate( 'Manage all of your channels from a single hub' ),
 		translate( 'Scheduled posts' ),
-		translate( 'Share to %(socialNetworksList)s', { args: { socialNetworksList } } ),
+		translate( 'Share to %(socialNetworksList)s', {
+			args: { socialNetworksList },
+			comment: 'Comma separated list of social networks like "Facebook, Mastodon and Tumblr".',
+		} ),
 		translate( 'Engagement Optimizer' ),
 		translate( 'Recycle content' ),
 		translate( 'Image generator' ),


### PR DESCRIPTION
We recently added nextdoor.com integration to Jetpack Social but that is not shown for Jetpack Social on the Jetpack pricing page.

## Proposed Changes

* Make the networks list easier to handle for future translations by using [`Intl.ListFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat/format)
* Add Nextdoor to the features list.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this PR and run `yarn start-jetpack-cloud` OR click in the Jetpack Cloud live link below.
* Goto `http://jetpack.cloud.localhost:3000/pricing` or `/pricing` on the Jetpack Cloud Live link.
* Click on "More about Social" to open the features list modal
* Confirm that the networks list is displayed as expected
* Confirm that "Nextdoor" is in the list

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

<img width="1091" alt="Screenshot 2023-12-26 at 10 39 00 AM" src="https://github.com/Automattic/wp-calypso/assets/18226415/96cae7be-0e83-4cfd-9945-c46beb941d5f">

<img width="1093" alt="Screenshot 2023-12-26 at 10 39 38 AM" src="https://github.com/Automattic/wp-calypso/assets/18226415/3ba91aa2-da71-4b80-9ad8-c49e00fa09c6">
