### PR TITLE
Add the Premium plan upsell to the domain/plan upsell modals.

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/index.tsx
@@ -11,12 +11,9 @@ export const Heading = styled.div< { shrinkMobileFont?: boolean } >`
 	font-family: Recoleta;
 	color: var( --studio-gray-100 );
 	font-size: ${ ( { shrinkMobileFont } ) => ( shrinkMobileFont ? '22px' : '32px' ) };
-	line-height: 26px;
-	letter-spacing: 0.38px;
 	@media ( min-width: 780px ) {
 		font-size: 32px;
 		line-height: 40px;
-		letter-spacing: -0.32px;
 	}
 `;
 
@@ -26,11 +23,9 @@ export const SubHeading = styled.div`
 	color: var( --studio-gray-60 );
 	font-size: 14px;
 	line-height: 20px;
-	letter-spacing: -0.15px;
 	@media ( min-width: 780px ) {
 		font-size: 16px;
 		line-height: 24px;
-		letter-spacing: -0.1px;
 	}
 `;
 
@@ -68,7 +63,6 @@ export const RowWithBorder = styled( Row )`
 export const DomainName = styled.div`
 	font-size: 16px;
 	line-height: 20px;
-	letter-spacing: -0.24px;
 	color: var( --studio-gray-80 );
 	overflow-wrap: break-word;
 	max-width: 100%;

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/plan-upsell-button.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/plan-upsell-button.tsx
@@ -7,10 +7,12 @@ function PlanUpsellButton( {
 	planUpsellInfo,
 	onPlanSelected,
 	disabled = false,
+	isBusy = false,
 }: {
 	planUpsellInfo: PlanUpsellInfo;
 	onPlanSelected: ( planSlug: PlanSlug ) => void;
 	disabled?: boolean;
+	isBusy?: boolean;
 } ) {
 	const translate = useTranslate();
 
@@ -18,6 +20,7 @@ function PlanUpsellButton( {
 		<PlanButton
 			planSlug={ planUpsellInfo.planSlug }
 			disabled={ disabled }
+			busy={ isBusy }
 			onClick={ () => {
 				onPlanSelected( planUpsellInfo.planSlug );
 			} }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/plan-upsell-button.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/plan-upsell-button.tsx
@@ -1,0 +1,36 @@
+import { useTranslate } from 'i18n-calypso';
+import PlanButton from 'calypso/my-sites/plans-grid/components/plan-button';
+import type { PlanUpsellInfo } from '../hooks/use-plan-upsell-info';
+import type { PlanSlug } from '@automattic/calypso-products';
+
+function PlanUpsellButton( {
+	planUpsellInfo,
+	onPlanSelected,
+	disabled = false,
+}: {
+	planUpsellInfo: PlanUpsellInfo;
+	onPlanSelected: ( planSlug: PlanSlug ) => void;
+	disabled?: boolean;
+} ) {
+	const translate = useTranslate();
+
+	return (
+		<PlanButton
+			planSlug={ planUpsellInfo.planSlug }
+			disabled={ disabled }
+			onClick={ () => {
+				onPlanSelected( planUpsellInfo.planSlug );
+			} }
+		>
+			{ translate( 'Get %(planTitle)s - %(planPrice)s/month', {
+				comment: 'Eg: Get Personal $4/month',
+				args: {
+					planTitle: planUpsellInfo.title,
+					planPrice: planUpsellInfo.formattedPriceMonthly,
+				},
+			} ) }
+		</PlanButton>
+	);
+}
+
+export default PlanUpsellButton;

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
@@ -23,7 +23,7 @@ export default function SuggestedPlanSection( {
 	onButtonClick,
 	isBusy,
 }: {
-	paidDomainName: string;
+	paidDomainName?: string;
 	suggestedPlanSlug: PlanSlug;
 	onButtonClick: () => void;
 	isBusy: boolean;
@@ -43,10 +43,12 @@ export default function SuggestedPlanSection( {
 
 	return (
 		<>
-			<DomainName>
-				<div>{ paidDomainName }</div>
-				<FreeDomainText>{ translate( 'Free for one year' ) }</FreeDomainText>
-			</DomainName>
+			{ paidDomainName && (
+				<DomainName>
+					<div>{ paidDomainName }</div>
+					<FreeDomainText>{ translate( 'Free for one year' ) }</FreeDomainText>
+				</DomainName>
+			) }
 			<PlanButton planSlug={ suggestedPlanSlug } busy={ isBusy } onClick={ onButtonClick }>
 				{ currencyCode &&
 					translate( 'Get %(planTitle)s - %(planPrice)s/month', {

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
@@ -40,7 +40,7 @@ export default function SuggestedPlanSection( {
 			<PlanUpsellButton
 				planUpsellInfo={ basicPlanUpsellInfo }
 				onPlanSelected={ onPlanSelected }
-				disabled={ isBusy }
+				isBusy={ isBusy }
 			/>
 			{ paidDomainName && (
 				<DomainName>
@@ -53,7 +53,7 @@ export default function SuggestedPlanSection( {
 			<PlanUpsellButton
 				planUpsellInfo={ advancePlanUpsellInfo }
 				onPlanSelected={ onPlanSelected }
-				disabled={ isBusy }
+				isBusy={ isBusy }
 			/>
 		</>
 	);

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/components/suggested-plan-section.tsx
@@ -1,12 +1,10 @@
-import { PlanSlug, getPlan } from '@automattic/calypso-products';
-import { formatCurrency } from '@automattic/format-currency';
+import { type PlanSlug, PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import PlanButton from 'calypso/my-sites/plans-grid/components/plan-button';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
-import { getPlanPrices } from 'calypso/state/plans/selectors';
-import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+import { usePlanUpsellInfo } from '../hooks/use-plan-upsell-info';
+import PlanUpsellButton from './plan-upsell-button';
 import { DomainName } from '.';
 
 const FreeDomainText = styled.div`
@@ -19,27 +17,17 @@ const FreeDomainText = styled.div`
 
 export default function SuggestedPlanSection( {
 	paidDomainName,
-	suggestedPlanSlug,
-	onButtonClick,
+	onPlanSelected,
 	isBusy,
 }: {
 	paidDomainName?: string;
-	suggestedPlanSlug: PlanSlug;
-	onButtonClick: () => void;
+	onPlanSelected: ( planSlug: PlanSlug ) => void;
 	isBusy: boolean;
 } ) {
 	const translate = useTranslate();
-	const planPriceMonthly = useSelector( ( state ) => {
-		const siteId = getSelectedSiteId( state ) ?? null;
-		const rawPlanPrices = getPlanPrices( state, {
-			planSlug: suggestedPlanSlug,
-			siteId,
-			returnMonthly: true,
-		} );
-		return ( rawPlanPrices.discountedRawPrice || rawPlanPrices.rawPrice ) ?? 0;
-	} );
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
-	const planTitle = getPlan( suggestedPlanSlug )?.getTitle();
+	const currencyCode = useSelector( getCurrentUserCurrencyCode ) ?? 'USD';
+	const basicPlanUpsellInfo = usePlanUpsellInfo( PLAN_PERSONAL, currencyCode );
+	const advancePlanUpsellInfo = usePlanUpsellInfo( PLAN_PREMIUM, currencyCode );
 
 	return (
 		<>
@@ -49,16 +37,24 @@ export default function SuggestedPlanSection( {
 					<FreeDomainText>{ translate( 'Free for one year' ) }</FreeDomainText>
 				</DomainName>
 			) }
-			<PlanButton planSlug={ suggestedPlanSlug } busy={ isBusy } onClick={ onButtonClick }>
-				{ currencyCode &&
-					translate( 'Get %(planTitle)s - %(planPrice)s/month', {
-						comment: 'Eg: Get Personal - $4/month',
-						args: {
-							planTitle: planTitle as string,
-							planPrice: formatCurrency( planPriceMonthly, currencyCode, { stripZeros: true } ),
-						},
-					} ) }
-			</PlanButton>
+			<PlanUpsellButton
+				planUpsellInfo={ basicPlanUpsellInfo }
+				onPlanSelected={ onPlanSelected }
+				disabled={ isBusy }
+			/>
+			{ paidDomainName && (
+				<DomainName>
+					<div>{ paidDomainName }</div>
+					<FreeDomainText>
+						{ translate( 'Free for one year. Includes Premium themes.' ) }
+					</FreeDomainText>
+				</DomainName>
+			) }
+			<PlanUpsellButton
+				planUpsellInfo={ advancePlanUpsellInfo }
+				onPlanSelected={ onPlanSelected }
+				disabled={ isBusy }
+			/>
 		</>
 	);
 }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
@@ -32,8 +32,15 @@ const ButtonRow = styled.div`
 	justify-content: flex-start;
 	margin: 16px 0;
 	flex-direction: column;
+	gap: 12px;
+
 	@media ( min-width: 780px ) {
 		flex-direction: row;
+		justify-content: space-between;
+
+		button {
+			max-width: 282px;
+		}
 	}
 `;
 
@@ -41,7 +48,8 @@ type TextBoxProps = {
 	fontSize?: number;
 	bold?: boolean;
 	color?: 'gray';
-	noBottomGap?: boolean;
+	marginTop?: number;
+	marginBottom?: number;
 };
 const TextBox = styled.div< TextBoxProps >`
 	font-size: ${ ( { fontSize } ) => fontSize || 14 }px;
@@ -53,7 +61,8 @@ const TextBox = styled.div< TextBoxProps >`
 		}
 		return 'var(--color-text)';
 	} };
-	margin-bottom: ${ ( { noBottomGap } ) => ( noBottomGap ? 0 : '8px' ) };
+	margin-top: ${ ( { marginTop } ) => ( marginTop ? `${ marginTop }px` : 'inherit' ) };
+	margin-bottom: ${ ( { marginBottom } ) => ( marginBottom ? `${ marginBottom }px` : 'inherit' ) };
 `;
 
 const CrossIcon = styled( Gridicon )`
@@ -168,7 +177,7 @@ export function FreePlanFreeDomainDialog( {
 
 	const featureUpsells = [
 		translate(
-			'No free custom domain: Your site will be shown to visitors as {{strong}}{{subdomain}}{{/subdomain}}{{/strong}}',
+			'No free custom domain: Your site will be shown to visitors as {{subdomain}}{{/subdomain}}',
 			{
 				components: {
 					subdomain: (
@@ -177,7 +186,6 @@ export function FreePlanFreeDomainDialog( {
 							isLoading={ generatedWPComSubdomain?.isLoading }
 						/>
 					),
-					strong: <strong></strong>,
 				},
 			}
 		),
@@ -191,7 +199,7 @@ export function FreePlanFreeDomainDialog( {
 		<DialogContainer>
 			<QueryProductsList />
 			<Heading id="plan-upsell-modal-title">{ translate( "Don't miss out" ) }</Heading>
-			<TextBox id="plan-upsell-modal-description">
+			<TextBox id="plan-upsell-modal-description" marginTop={ 8 }>
 				{ translate( 'With a Free plan, you miss out on a lot of great features:' ) }
 			</TextBox>
 			<List>
@@ -200,11 +208,11 @@ export function FreePlanFreeDomainDialog( {
 						<div>
 							<CrossIcon icon="cross" size={ 24 } />
 						</div>
-						<TextBox>{ upsellItem }</TextBox>
+						<TextBox bold>{ upsellItem }</TextBox>
 					</ListItem>
 				) ) }
 			</List>
-			<TextBox>
+			<TextBox marginBottom={ 8 }>
 				{ translate(
 					'Unlock all of these features with a %(planTitle)s plan, starting at just %(planPrice)s/month.',
 					{
@@ -243,18 +251,16 @@ export function FreePlanFreeDomainDialog( {
 					onPlanSelected={ onPlanSelected }
 				/>
 			</ButtonRow>
-			<ButtonRow>
-				<PlanButton
-					disabled={ buttonDisabled }
-					onClick={ () => {
-						onFreePlanSelected();
-					} }
-					borderless
-				>
-					{ translate( 'Continue with Free' ) }
-				</PlanButton>
-			</ButtonRow>
-			<TextBox fontSize={ 12 } color="gray" noBottomGap>
+			<PlanButton
+				disabled={ buttonDisabled }
+				onClick={ () => {
+					onFreePlanSelected();
+				} }
+				borderless
+			>
+				{ translate( 'Continue with Free' ) }
+			</PlanButton>
+			<TextBox fontSize={ 12 } color="gray">
 				{ translate(
 					'%(planTitle1)s plan: %(monthlyPlanPrice1)s/mo, %(annualPlanPrice1)s billed annually. %(planTitle2)s plan: %(monthlyPlanPrice2)s/mo, %(annualPlanPrice2)s billed annually. Excluding taxes.',
 					{

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
@@ -181,7 +181,7 @@ export function FreePlanFreeDomainDialog( {
 			<QueryProductsList />
 			<Heading id="plan-upsell-modal-title">{ translate( "Don't miss out" ) }</Heading>
 			<TextBox id="plan-upsell-modal-description">
-				{ translate( "With a Free plan, you'll miss out on a lot of great features:" ) }
+				{ translate( 'With a Free plan, you miss out on a lot of great features:' ) }
 			</TextBox>
 			<List>
 				<ListItem>

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
@@ -193,19 +193,22 @@ export function FreePlanFreeDomainDialog( {
 				{ translate( 'Continue with Free' ) }
 			</PlanButton>
 			<TextBox fontSize={ 12 } color="gray">
-				{ translate(
-					'%(planTitle1)s plan: %(monthlyPlanPrice1)s/mo, %(annualPlanPrice1)s billed annually. %(planTitle2)s plan: %(monthlyPlanPrice2)s/mo, %(annualPlanPrice2)s billed annually. Excluding taxes.',
-					{
-						args: {
-							planTitle1: basicPlanUpsellInfo.title,
-							monthlyPlanPrice1: basicPlanUpsellInfo.formattedPriceMonthly,
-							annualPlanPrice1: basicPlanUpsellInfo.formattedPriceFull,
-							planTitle2: advancePlanUpsellInfo.title,
-							monthlyPlanPrice2: advancePlanUpsellInfo.formattedPriceMonthly,
-							annualPlanPrice2: advancePlanUpsellInfo.formattedPriceFull,
-						},
-					}
-				) }
+				{
+					/* translators: /mo is the abbreviation form of "per month" */
+					translate(
+						'%(planTitle1)s plan: %(monthlyPlanPrice1)s/mo, %(annualPlanPrice1)s billed annually. %(planTitle2)s plan: %(monthlyPlanPrice2)s/mo, %(annualPlanPrice2)s billed annually. Excluding taxes.',
+						{
+							args: {
+								planTitle1: basicPlanUpsellInfo.title,
+								monthlyPlanPrice1: basicPlanUpsellInfo.formattedPriceMonthly,
+								annualPlanPrice1: basicPlanUpsellInfo.formattedPriceFull,
+								planTitle2: advancePlanUpsellInfo.title,
+								monthlyPlanPrice2: advancePlanUpsellInfo.formattedPriceMonthly,
+								annualPlanPrice2: advancePlanUpsellInfo.formattedPriceFull,
+							},
+						}
+					)
+				}
 			</TextBox>
 		</DialogContainer>
 	);

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
@@ -177,6 +177,7 @@ export function FreePlanFreeDomainDialog( {
 							isLoading={ generatedWPComSubdomain?.isLoading }
 						/>
 					),
+					strong: <strong></strong>,
 				},
 			}
 		),

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
@@ -1,9 +1,4 @@
-import {
-	domainProductSlugs,
-	getPlan,
-	type PlanSlug,
-	PLAN_PREMIUM,
-} from '@automattic/calypso-products';
+import { getPlan, type PlanSlug, PLAN_PREMIUM } from '@automattic/calypso-products';
 import { Gridicon, LoadingPlaceholder } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import styled from '@emotion/styled';
@@ -15,7 +10,6 @@ import PlanButton from 'calypso/my-sites/plans-grid/components/plan-button';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { getPlanPrices } from 'calypso/state/plans/selectors/get-plan-prices';
-import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import { DialogContainer, Heading } from './components';
 import { DomainPlanDialogProps, MODAL_VIEW_EVENT_NAME } from '.';
@@ -161,11 +155,7 @@ export function FreePlanFreeDomainDialog( {
 	suggestedPlanSlug,
 }: DomainPlanDialogProps ) {
 	const translate = useTranslate();
-	const domainRegistrationProduct = useSelector( ( state ) =>
-		getProductBySlug( state, domainProductSlugs.DOTCOM_DOMAIN_REGISTRATION )
-	);
 	const currencyCode = useSelector( getCurrentUserCurrencyCode ) ?? 'USD';
-	const domainProductCost = domainRegistrationProduct?.cost;
 	const primaryUpsellPlanInfo = usePlanUpsellInfo( suggestedPlanSlug, currencyCode );
 	const secondaryUpsellPlanInfo = usePlanUpsellInfo( PLAN_PREMIUM, currencyCode );
 	const buttonDisabled = generatedWPComSubdomain.isLoading || ! generatedWPComSubdomain.result;
@@ -176,6 +166,26 @@ export function FreePlanFreeDomainDialog( {
 		} );
 	}, [] );
 
+	const featureUpsells = [
+		translate(
+			'No free custom domain: Your site will be shown to visitors as {{strong}}{{subdomain}}{{/subdomain}}{{/strong}}',
+			{
+				components: {
+					subdomain: (
+						<LazyDisplayText
+							displayText={ generatedWPComSubdomain?.result?.domain_name }
+							isLoading={ generatedWPComSubdomain?.isLoading }
+						/>
+					),
+				},
+			}
+		),
+		translate( 'No ad-free experience: Your visitors will see external ads on your site.' ),
+		translate( 'No unlimited professional customer support (only community forums)' ),
+		translate( 'No extra storage. You only get 1GB for photos, videos, media, and documents.' ),
+		translate( 'Monetize your site through paid subscribers' ),
+	];
+
 	return (
 		<DialogContainer>
 			<QueryProductsList />
@@ -184,96 +194,40 @@ export function FreePlanFreeDomainDialog( {
 				{ translate( 'With a Free plan, you miss out on a lot of great features:' ) }
 			</TextBox>
 			<List>
-				<ListItem>
-					<div>
-						<CrossIcon icon="cross" size={ 24 } />
-					</div>
-					<TextBox>
-						{ translate(
-							'{{strong}}No free custom domain:{{/strong}} Your site will be shown to visitors as {{strong}}{{subdomain}}{{/subdomain}}{{/strong}}',
-							{
-								components: {
-									strong: <strong></strong>,
-									subdomain: (
-										<LazyDisplayText
-											displayText={ generatedWPComSubdomain?.result?.domain_name }
-											isLoading={ generatedWPComSubdomain?.isLoading }
-										/>
-									),
-								},
-							}
-						) }
-					</TextBox>
-				</ListItem>
-				<ListItem>
-					<div>
-						<CrossIcon icon="cross" size={ 24 } />
-					</div>
-					<TextBox>
-						{ translate(
-							'{{strong}}No ad-free experience:{{/strong}} Your visitors will see external ads on your site.',
-							{
-								components: { strong: <strong></strong> },
-							}
-						) }
-					</TextBox>
-				</ListItem>
-				<ListItem>
-					<div>
-						<CrossIcon icon="cross" size={ 24 } />
-					</div>
-					<TextBox>
-						{ translate(
-							'{{strong}}No unlimited professional customer support{{/strong}} (only community forums)',
-							{
-								components: { strong: <strong></strong> },
-							}
-						) }
-					</TextBox>
-				</ListItem>
-				<ListItem>
-					<div>
-						<CrossIcon icon="cross" size={ 24 } />
-					</div>
-					<TextBox noBottomGap>
-						{ translate(
-							'{{strong}}No extra storage:{{/strong}} You only get 1GB for photos, videos, media, and documents.',
-							{
-								components: { strong: <strong></strong> },
-							}
-						) }
-					</TextBox>
-				</ListItem>
+				{ featureUpsells.map( ( upsellItem ) => (
+					<ListItem>
+						<div>
+							<CrossIcon icon="cross" size={ 24 } />
+						</div>
+						<TextBox>{ upsellItem }</TextBox>
+					</ListItem>
+				) ) }
 			</List>
 			<TextBox>
 				{ translate(
-					'Unlock {{strong}}all of{{/strong}} these features with a %(planTitle)s plan, starting at just %(planPrice)s/month, {{break}}{{/break}} with a 14-day money back guarantee.',
+					'Unlock all of these features with a %(planTitle)s plan, starting at just %(planPrice)s/month.',
 					{
 						args: {
 							planTitle: primaryUpsellPlanInfo.title,
 							planPrice: primaryUpsellPlanInfo.formattedPriceMonthly,
 						},
-						components: { break: <br />, strong: <strong></strong> },
 					}
 				) }
 			</TextBox>
 			<TextBox>
-				{ domainProductCost &&
-					translate(
-						'As a bonus, you will get a custom domain - like {{strong}}{{italic}}yourgroovydomain.com{{/italic}}{{/strong}} - {{break}}{{/break}} free for the first year (%(domainPrice)s value).',
-						{
-							args: {
-								domainPrice: formatCurrency( domainProductCost, currencyCode, {
-									stripZeros: true,
-								} ),
-							},
-							components: {
-								strong: <strong></strong>,
-								italic: <i></i>,
-								break: <br />,
-							},
-						}
-					) }
+				{ translate(
+					'{{strong}}Need premium themes, live chat support, and advanced design tools?{{/strong}}{{break}}{{/break}}Go with our %(planTitle)s plan, starting at just %(planPrice)s/month. All annual plans come with a 14-day money-back guarantee.',
+					{
+						args: {
+							planTitle: secondaryUpsellPlanInfo.title,
+							planPrice: secondaryUpsellPlanInfo.formattedPriceMonthly,
+						},
+						components: {
+							strong: <strong></strong>,
+							break: <br />,
+						},
+					}
+				) }
 			</TextBox>
 
 			<ButtonRow>
@@ -301,12 +255,15 @@ export function FreePlanFreeDomainDialog( {
 			</ButtonRow>
 			<TextBox fontSize={ 12 } color="gray" noBottomGap>
 				{ translate(
-					'%(planTitle)s plan: %(monthlyPlanPrice)s per month, %(annualPlanPrice)s billed annually. Excluding taxes.',
+					'%(planTitle1)s plan: %(monthlyPlanPrice1)s/mo, %(annualPlanPrice1)s billed annually. %(planTitle2)s plan: %(monthlyPlanPrice2)s/mo, %(annualPlanPrice2)s billed annually. Excluding taxes.',
 					{
 						args: {
-							planTitle: primaryUpsellPlanInfo.title,
-							monthlyPlanPrice: primaryUpsellPlanInfo.formattedPriceMonthly,
-							annualPlanPrice: primaryUpsellPlanInfo.formattedPriceFull,
+							planTitle1: primaryUpsellPlanInfo.title,
+							monthlyPlanPrice1: primaryUpsellPlanInfo.formattedPriceMonthly,
+							annualPlanPrice1: primaryUpsellPlanInfo.formattedPriceFull,
+							planTitle2: secondaryUpsellPlanInfo.title,
+							monthlyPlanPrice2: secondaryUpsellPlanInfo.formattedPriceMonthly,
+							annualPlanPrice2: secondaryUpsellPlanInfo.formattedPriceFull,
 						},
 					}
 				) }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
@@ -95,8 +95,8 @@ export function FreePlanFreeDomainDialog( {
 }: DomainPlanDialogProps ) {
 	const translate = useTranslate();
 	const currencyCode = useSelector( getCurrentUserCurrencyCode ) ?? 'USD';
-	const primaryUpsellPlanInfo = usePlanUpsellInfo( PLAN_PERSONAL, currencyCode );
-	const secondaryUpsellPlanInfo = usePlanUpsellInfo( PLAN_PREMIUM, currencyCode );
+	const basicPlanUpsellInfo = usePlanUpsellInfo( PLAN_PERSONAL, currencyCode );
+	const advancePlanUpsellInfo = usePlanUpsellInfo( PLAN_PREMIUM, currencyCode );
 	const buttonDisabled = generatedWPComSubdomain.isLoading || ! generatedWPComSubdomain.result;
 
 	useEffect( () => {
@@ -147,8 +147,8 @@ export function FreePlanFreeDomainDialog( {
 					'Unlock all of these features with a %(planTitle)s plan, starting at just %(planPrice)s/month.',
 					{
 						args: {
-							planTitle: primaryUpsellPlanInfo.title,
-							planPrice: primaryUpsellPlanInfo.formattedPriceMonthly,
+							planTitle: basicPlanUpsellInfo.title,
+							planPrice: basicPlanUpsellInfo.formattedPriceMonthly,
 						},
 					}
 				) }
@@ -158,8 +158,8 @@ export function FreePlanFreeDomainDialog( {
 					'{{strong}}Need premium themes, live chat support, and advanced design tools?{{/strong}}{{break}}{{/break}}Go with our %(planTitle)s plan, starting at just %(planPrice)s/month. All annual plans come with a 14-day money-back guarantee.',
 					{
 						args: {
-							planTitle: secondaryUpsellPlanInfo.title,
-							planPrice: secondaryUpsellPlanInfo.formattedPriceMonthly,
+							planTitle: advancePlanUpsellInfo.title,
+							planPrice: advancePlanUpsellInfo.formattedPriceMonthly,
 						},
 						components: {
 							strong: <strong></strong>,
@@ -171,12 +171,12 @@ export function FreePlanFreeDomainDialog( {
 
 			<ButtonRow>
 				<PlanUpsellButton
-					planUpsellInfo={ primaryUpsellPlanInfo }
+					planUpsellInfo={ basicPlanUpsellInfo }
 					disabled={ buttonDisabled }
 					onPlanSelected={ onPlanSelected }
 				/>
 				<PlanUpsellButton
-					planUpsellInfo={ secondaryUpsellPlanInfo }
+					planUpsellInfo={ advancePlanUpsellInfo }
 					disabled={ buttonDisabled }
 					onPlanSelected={ onPlanSelected }
 				/>
@@ -195,12 +195,12 @@ export function FreePlanFreeDomainDialog( {
 					'%(planTitle1)s plan: %(monthlyPlanPrice1)s/mo, %(annualPlanPrice1)s billed annually. %(planTitle2)s plan: %(monthlyPlanPrice2)s/mo, %(annualPlanPrice2)s billed annually. Excluding taxes.',
 					{
 						args: {
-							planTitle1: primaryUpsellPlanInfo.title,
-							monthlyPlanPrice1: primaryUpsellPlanInfo.formattedPriceMonthly,
-							annualPlanPrice1: primaryUpsellPlanInfo.formattedPriceFull,
-							planTitle2: secondaryUpsellPlanInfo.title,
-							monthlyPlanPrice2: secondaryUpsellPlanInfo.formattedPriceMonthly,
-							annualPlanPrice2: secondaryUpsellPlanInfo.formattedPriceFull,
+							planTitle1: basicPlanUpsellInfo.title,
+							monthlyPlanPrice1: basicPlanUpsellInfo.formattedPriceMonthly,
+							annualPlanPrice1: basicPlanUpsellInfo.formattedPriceFull,
+							planTitle2: advancePlanUpsellInfo.title,
+							monthlyPlanPrice2: advancePlanUpsellInfo.formattedPriceMonthly,
+							annualPlanPrice2: advancePlanUpsellInfo.formattedPriceFull,
 						},
 					}
 				) }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
@@ -1,4 +1,4 @@
-import { getPlan, type PlanSlug, PLAN_PREMIUM } from '@automattic/calypso-products';
+import { getPlan, type PlanSlug, PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
 import { Gridicon, LoadingPlaceholder } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import styled from '@emotion/styled';
@@ -161,11 +161,10 @@ export function FreePlanFreeDomainDialog( {
 	generatedWPComSubdomain,
 	onFreePlanSelected,
 	onPlanSelected,
-	suggestedPlanSlug,
 }: DomainPlanDialogProps ) {
 	const translate = useTranslate();
 	const currencyCode = useSelector( getCurrentUserCurrencyCode ) ?? 'USD';
-	const primaryUpsellPlanInfo = usePlanUpsellInfo( suggestedPlanSlug, currencyCode );
+	const primaryUpsellPlanInfo = usePlanUpsellInfo( PLAN_PERSONAL, currencyCode );
 	const secondaryUpsellPlanInfo = usePlanUpsellInfo( PLAN_PREMIUM, currencyCode );
 	const buttonDisabled = generatedWPComSubdomain.isLoading || ! generatedWPComSubdomain.result;
 

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-free-domain-dialog.tsx
@@ -50,10 +50,10 @@ type TextBoxProps = {
 	marginTop?: number;
 	marginBottom?: number;
 };
-const TextBox = styled.div< TextBoxProps >`
+const TextBox = styled.p< TextBoxProps >`
 	font-size: ${ ( { fontSize } ) => fontSize || 14 }px;
 	font-weight: ${ ( { bold } ) => ( bold ? 600 : 400 ) };
-	line-height: 20px;
+	line-height: 1.5;
 	color: ${ ( { color } ) => {
 		if ( color === 'gray' ) {
 			return 'var(--studio-gray-50)';
@@ -62,10 +62,12 @@ const TextBox = styled.div< TextBoxProps >`
 	} };
 	margin-top: ${ ( { marginTop } ) => ( marginTop ? `${ marginTop }px` : 'inherit' ) };
 	margin-bottom: ${ ( { marginBottom } ) => ( marginBottom ? `${ marginBottom }px` : 'inherit' ) };
+	padding-bottom: 3px;
 `;
 
 const CrossIcon = styled( Gridicon )`
 	color: #e53e3e;
+	padding-top: 1px; // a brute-force way of aligning the icon and the sentence.
 `;
 
 function LazyDisplayText( {
@@ -136,13 +138,13 @@ export function FreePlanFreeDomainDialog( {
 				{ featureUpsells.map( ( upsellItem ) => (
 					<ListItem>
 						<div>
-							<CrossIcon icon="cross" size={ 24 } />
+							<CrossIcon icon="cross" size={ 20 } />
 						</div>
 						<TextBox bold>{ upsellItem }</TextBox>
 					</ListItem>
 				) ) }
 			</List>
-			<TextBox marginBottom={ 8 }>
+			<TextBox marginBottom={ 20 }>
 				{ translate(
 					'Unlock all of these features with a %(planTitle)s plan, starting at just %(planPrice)s/month.',
 					{

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-paid-domain-dialog.tsx
@@ -31,11 +31,6 @@ export function FreePlanPaidDomainDialog( {
 		} );
 	}, [] );
 
-	function handlePaidPlanClick() {
-		setIsBusy( true );
-		onPlanSelected( suggestedPlanSlug );
-	}
-
 	function handleFreePlanClick() {
 		setIsBusy( true );
 		onFreePlanSelected( true );
@@ -68,9 +63,8 @@ export function FreePlanPaidDomainDialog( {
 				<RowWithBorder>
 					<SuggestedPlanSection
 						paidDomainName={ paidDomainName }
-						suggestedPlanSlug={ suggestedPlanSlug }
 						isBusy={ isBusy }
-						onButtonClick={ handlePaidPlanClick }
+						onPlanSelected={ onPlanSelected }
 					/>
 				</RowWithBorder>
 				<Row>

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-paid-domain-dialog.tsx
@@ -22,9 +22,7 @@ export function FreePlanPaidDomainDialog( {
 	suggestedPlanSlug,
 	onFreePlanSelected,
 	onPlanSelected,
-}: DomainPlanDialogProps & {
-	paidDomainName: string;
-} ) {
+}: DomainPlanDialogProps ) {
 	const translate = useTranslate();
 	const [ isBusy, setIsBusy ] = useState( false );
 
@@ -36,7 +34,7 @@ export function FreePlanPaidDomainDialog( {
 
 	function handlePaidPlanClick() {
 		setIsBusy( true );
-		onPlanSelected();
+		onPlanSelected( suggestedPlanSlug );
 	}
 
 	function handleFreePlanClick() {
@@ -80,6 +78,7 @@ export function FreePlanPaidDomainDialog( {
 					<DomainName>
 						{ generatedWPComSubdomain.isLoading && <LoadingPlaceholder /> }
 						{ generatedWPComSubdomain.result &&
+							paidDomainName &&
 							translate( '%(paidDomainName)s redirects to %(wpcomFreeDomain)s', {
 								args: {
 									paidDomainName,

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-paid-domain-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/free-plan-paid-domain-dialog.tsx
@@ -19,7 +19,6 @@ import { DomainPlanDialogProps, MODAL_VIEW_EVENT_NAME } from '.';
 export function FreePlanPaidDomainDialog( {
 	paidDomainName,
 	generatedWPComSubdomain,
-	suggestedPlanSlug,
 	onFreePlanSelected,
 	onPlanSelected,
 }: DomainPlanDialogProps ) {

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-plan-upsell-info.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/hooks/use-plan-upsell-info.tsx
@@ -1,0 +1,44 @@
+import { getPlan, type PlanSlug } from '@automattic/calypso-products';
+import formatCurrency from '@automattic/format-currency';
+import { useSelector } from 'calypso/state';
+import { getPlanPrices } from 'calypso/state/plans/selectors/get-plan-prices';
+import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
+import type { TranslateResult } from 'i18n-calypso';
+
+export type PlanUpsellInfo = {
+	planSlug: PlanSlug;
+	title: TranslateResult;
+	formattedPriceMonthly: string;
+	formattedPriceFull: string;
+};
+
+// TODO:
+// Replace `getPlanPrices` with the selectors from the Plans datastore.
+export const usePlanUpsellInfo = ( planSlug: PlanSlug, currencyCode: string ): PlanUpsellInfo => {
+	const title = getPlan( planSlug )?.getTitle() || '';
+	const priceMonthly = useSelector( ( state ) => {
+		const siteId = getSelectedSiteId( state ) ?? null;
+		const rawPlanPrices = getPlanPrices( state, {
+			planSlug,
+			siteId,
+			returnMonthly: true,
+		} );
+		return ( rawPlanPrices.discountedRawPrice || rawPlanPrices.rawPrice ) ?? 0;
+	} );
+	const priceFull = useSelector( ( state ) => {
+		const siteId = getSelectedSiteId( state ) ?? null;
+		const rawPlanPrices = getPlanPrices( state, {
+			planSlug,
+			siteId,
+			returnMonthly: false,
+		} );
+		return ( rawPlanPrices.discountedRawPrice || rawPlanPrices.rawPrice ) ?? 0;
+	} );
+
+	return {
+		planSlug,
+		title,
+		formattedPriceMonthly: formatCurrency( priceMonthly, currencyCode, { stripZeros: true } ),
+		formattedPriceFull: formatCurrency( priceFull, currencyCode, { stripZeros: true } ),
+	};
+};

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/index.tsx
@@ -20,7 +20,6 @@ export type ModalType =
 export type DomainPlanDialogProps = {
 	paidDomainName?: string;
 	generatedWPComSubdomain: DataResponse< { domain_name: string } >;
-	suggestedPlanSlug: PlanSlug;
 	upsellPremiumPlan?: boolean;
 	onFreePlanSelected: ( isDomainRetained?: boolean ) => void;
 	onPlanSelected: ( planSlug: PlanSlug ) => void;

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/index.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/index.tsx
@@ -1,4 +1,4 @@
-import { PLAN_PERSONAL, PlanSlug } from '@automattic/calypso-products';
+import { PlanSlug } from '@automattic/calypso-products';
 import { Dialog } from '@automattic/components';
 import { Global, css } from '@emotion/react';
 import { FreePlanFreeDomainDialog } from './free-plan-free-domain-dialog';
@@ -18,77 +18,42 @@ export type ModalType =
 	| typeof MODAL_LOADER;
 
 export type DomainPlanDialogProps = {
+	paidDomainName?: string;
 	generatedWPComSubdomain: DataResponse< { domain_name: string } >;
 	suggestedPlanSlug: PlanSlug;
+	upsellPremiumPlan?: boolean;
 	onFreePlanSelected: ( isDomainRetained?: boolean ) => void;
-	onPlanSelected: () => void;
+	onPlanSelected: ( planSlug: PlanSlug ) => void;
 };
 
 type ModalContainerProps = {
 	isModalOpen: boolean;
-	paidDomainName?: string;
 	modalType?: ModalType | null;
-	generatedWPComSubdomain: DataResponse< { domain_name: string } >;
 	onClose: () => void;
-	onFreePlanSelected: ( isDomainRetained?: boolean ) => void;
-	onPlanSelected: ( planSlug: string ) => void;
-};
+} & DomainPlanDialogProps;
 
 // See p2-pbxNRc-2Ri#comment-4703 for more context
 export const MODAL_VIEW_EVENT_NAME = 'calypso_plan_upsell_modal_view';
 
-function DisplayedModal( {
-	paidDomainName,
-	modalType,
-	generatedWPComSubdomain,
-	onFreePlanSelected,
-	onPlanSelected,
-}: Omit< ModalContainerProps, 'selectedPlan' > ) {
+function getDisplayedModal( modalType: ModalType, dialogProps: DomainPlanDialogProps ) {
 	switch ( modalType ) {
 		case FREE_PLAN_PAID_DOMAIN_DIALOG:
-			return (
-				<FreePlanPaidDomainDialog
-					paidDomainName={ paidDomainName as string }
-					generatedWPComSubdomain={ generatedWPComSubdomain }
-					suggestedPlanSlug={ PLAN_PERSONAL }
-					onFreePlanSelected={ onFreePlanSelected }
-					onPlanSelected={ () => {
-						onPlanSelected( PLAN_PERSONAL );
-					} }
-				/>
-			);
+			return <FreePlanPaidDomainDialog { ...dialogProps } />;
 		case FREE_PLAN_FREE_DOMAIN_DIALOG:
-			return (
-				<FreePlanFreeDomainDialog
-					suggestedPlanSlug={ PLAN_PERSONAL }
-					generatedWPComSubdomain={ generatedWPComSubdomain }
-					onFreePlanSelected={ onFreePlanSelected }
-					onPlanSelected={ () => {
-						onPlanSelected( PLAN_PERSONAL );
-					} }
-				/>
-			);
+			return <FreePlanFreeDomainDialog { ...dialogProps } />;
 		case PAID_PLAN_IS_REQUIRED_DIALOG:
-			return (
-				<PaidPlanIsRequiredDialog
-					paidDomainName={ paidDomainName as string }
-					suggestedPlanSlug={ PLAN_PERSONAL }
-					generatedWPComSubdomain={ generatedWPComSubdomain }
-					onFreePlanSelected={ onFreePlanSelected }
-					onPlanSelected={ () => {
-						onPlanSelected( PLAN_PERSONAL );
-					} }
-				/>
-			);
+			return <PaidPlanIsRequiredDialog { ...dialogProps } />;
 		default:
-			break;
+			return null;
 	}
-
-	return null;
 }
 
 export default function ModalContainer( props: ModalContainerProps ) {
 	const { isModalOpen, modalType } = props;
+
+	if ( ! modalType ) {
+		return null;
+	}
 
 	const modalWidth = () => {
 		switch ( modalType ) {
@@ -120,7 +85,7 @@ export default function ModalContainer( props: ModalContainerProps ) {
 					}
 				` }
 			/>
-			<DisplayedModal { ...props } />
+			{ getDisplayedModal( modalType, props ) }
 		</Dialog>
 	);
 }

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
@@ -1,7 +1,5 @@
 import { LoadingPlaceholder } from '@automattic/components';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useEffect, useState } from '@wordpress/element';
-import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import PlanButton from 'calypso/my-sites/plans-grid/components/plan-button';
@@ -20,7 +18,6 @@ import { DomainPlanDialogProps, MODAL_VIEW_EVENT_NAME } from '.';
 export default function PaidPlanIsRequiredDialog( {
 	paidDomainName,
 	generatedWPComSubdomain,
-	suggestedPlanSlug,
 	onFreePlanSelected,
 	onPlanSelected,
 }: DomainPlanDialogProps ) {
@@ -33,42 +30,27 @@ export default function PaidPlanIsRequiredDialog( {
 		} );
 	}, [] );
 
-	function handlePaidPlanClick() {
-		setIsBusy( true );
-		onPlanSelected( suggestedPlanSlug );
-	}
-
 	function handleFreeDomainClick() {
 		setIsBusy( true );
 		onFreePlanSelected();
 	}
-
-	const isEnglish = useIsEnglishLocale();
-	const upsellDescription =
-		isEnglish ||
-		hasTranslation(
-			"Custom domains are only available with a paid plan. Choose annual billing and receive the domain's first year free."
-		)
-			? translate(
-					"Custom domains are only available with a paid plan. Choose annual billing and receive the domain's first year free."
-			  )
-			: translate(
-					'Custom domains are only available with a paid plan. And they are free for the first year with an annual paid plan.'
-			  );
 
 	return (
 		<DialogContainer>
 			<Heading id="plan-upsell-modal-title" shrinkMobileFont>
 				{ translate( 'A paid plan is required for your domain.' ) }
 			</Heading>
-			<SubHeading id="plan-upsell-modal-description">{ upsellDescription }</SubHeading>
+			<SubHeading id="plan-upsell-modal-description">
+				{ translate(
+					'Custom domains are only available with a paid plan. And they are free for the first year with an annual paid plan.'
+				) }
+			</SubHeading>
 			<ButtonContainer>
 				<RowWithBorder>
 					<SuggestedPlanSection
 						paidDomainName={ paidDomainName }
-						suggestedPlanSlug={ suggestedPlanSlug }
 						isBusy={ isBusy }
-						onButtonClick={ handlePaidPlanClick }
+						onPlanSelected={ onPlanSelected }
 					/>
 				</RowWithBorder>
 				<Row>

--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
@@ -23,7 +23,7 @@ export default function PaidPlanIsRequiredDialog( {
 	suggestedPlanSlug,
 	onFreePlanSelected,
 	onPlanSelected,
-}: DomainPlanDialogProps & { paidDomainName: string } ) {
+}: DomainPlanDialogProps ) {
 	const translate = useTranslate();
 	const [ isBusy, setIsBusy ] = useState( false );
 
@@ -35,7 +35,7 @@ export default function PaidPlanIsRequiredDialog( {
 
 	function handlePaidPlanClick() {
 		setIsBusy( true );
-		onPlanSelected();
+		onPlanSelected( suggestedPlanSlug );
 	}
 
 	function handleFreeDomainClick() {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -714,6 +714,7 @@ const PlansFeaturesMain = ( {
 					paidDomainName={ paidDomainName }
 					modalType={ resolveModal( lastClickedPlan ) }
 					generatedWPComSubdomain={ resolvedSubdomainName }
+					suggestedPlanSlug={ PLAN_PERSONAL }
 					onClose={ () => setIsModalOpen( false ) }
 					onFreePlanSelected={ ( isDomainRetained ) => {
 						if ( ! isDomainRetained ) {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -714,7 +714,6 @@ const PlansFeaturesMain = ( {
 					paidDomainName={ paidDomainName }
 					modalType={ resolveModal( lastClickedPlan ) }
 					generatedWPComSubdomain={ resolvedSubdomainName }
-					suggestedPlanSlug={ PLAN_PERSONAL }
 					onClose={ () => setIsModalOpen( false ) }
 					onFreePlanSelected={ ( isDomainRetained ) => {
 						if ( ! isDomainRetained ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fix Automattic/growth-foundations#286

## Proposed Changes

This PR is the final closure for a series of PRs addressing Automattic/growth-foundations#286, adding the Premium plan upsell to the domain/plan upsell modals. For the updated design, please refer to:

* The experiment post: pbxNRc-3pt-p2, even though it's no longer an experiment based on the request.
* The project thread: peP6yB-1II-p2#comment-856

Free domain/Free plan:
<img width="643" alt="CleanShot 2023-12-26 at 13 46 44@2x" src="https://github.com/Automattic/wp-calypso/assets/1842898/81d924d1-b532-4154-acf7-895048140f14">

Paid domain/Free plan:
<img width="673" alt="CleanShot 2023-12-26 at 13 47 07@2x" src="https://github.com/Automattic/wp-calypso/assets/1842898/fcc4735a-4923-4a76-88a1-52532381e06b">

A paid plan is requried:
<img width="689" alt="CleanShot 2023-12-26 at 13 47 29@2x" src="https://github.com/Automattic/wp-calypso/assets/1842898/46c272e9-0b6c-459a-a096-67781dd2b32e">

I think the responsiveness still has room to improve, but it's not in the scope of this iteration.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In `/start/onboarding-pm`:
    * Pick a free domain and the Free plan; confirm that the Free domain/Free plan modal works as expected and matches the design.
    * Pick a paid domain and the Free plan; confirm that the Paid domain/Free plan modal works as expeced and matches the design.
* In `/start/`:
    * Pick a paid domain and the Free plan; confirm that the paid-plan-is-requred modal works as expected and matches the design.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
