### PR TITLE
Stepper: Remove getStepProgress references

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -1,4 +1,5 @@
 import {
+	SENSEI_FLOW,
 	isAnyHostingFlow,
 	isNewsletterOrLinkInBioFlow,
 	isSenseiFlow,
@@ -92,28 +93,22 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		? !! selectedSite && ! isRequestingSelectedSite
 		: true;
 
-	const stepProgress = useSelect(
-		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStepProgress(),
-		[]
-	);
-
 	// this pre-loads all the lazy steps down the flow.
 	useEffect( () => {
 		Promise.all( flowSteps.map( ( step ) => 'asyncComponent' in step && step.asyncComponent() ) );
 	}, stepPaths );
 
 	const isFlowStart = useCallback( () => {
-		if ( ! flow || ! stepProgress ) {
+		if ( ! flow || ! stepPaths.length ) {
 			return false;
 		}
-		if ( stepProgress?.progress === 0 ) {
-			return true;
+
+		if ( flow.name === SENSEI_FLOW ) {
+			return currentStepRoute === stepPaths[ 1 ];
 		}
-		if ( flow.name === 'sensei' && stepProgress?.progress === 1 ) {
-			return true;
-		}
-		return false;
-	}, [ flow, stepProgress ] );
+
+		return currentStepRoute === stepPaths[ 0 ];
+	}, [ flow, currentStepRoute, ...stepPaths ] );
 
 	const _navigate = async ( path: string, extraData = {} ) => {
 		// If any extra data is passed to the navigate() function, store it to the stepper-internal store.

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/ai-site-prompt/index.tsx
@@ -44,11 +44,6 @@ const AISitePrompt: Step = function ( props ) {
 
 	const [ callAIAssembler, setPrompt, prompt, loading ] = useAIAssembler();
 
-	const stepProgress = useSelect(
-		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStepProgress(),
-		[]
-	);
-
 	const onSubmit = async ( event: FormEvent ) => {
 		event.preventDefault();
 		callAIAssembler()
@@ -103,7 +98,6 @@ const AISitePrompt: Step = function ( props ) {
 						/>
 					}
 					stepContent={ getContent() }
-					stepProgress={ stepProgress }
 					recordTracksEvent={ recordTracksEvent }
 				/>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/assign-trial-plan/index.tsx
@@ -21,10 +21,6 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getProgress(),
 		[]
 	);
-	const stepProgress = useSelect(
-		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStepProgress(),
-		[]
-	);
 	const profilerData =
 		useSelect( ( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getProfilerData(), [] ) ||
 		{};
@@ -95,7 +91,6 @@ const AssignTrialPlanStep: Step = function AssignTrialPlanStep( { navigation, da
 						</div>
 					</>
 				}
-				stepProgress={ stepProgress }
 				showFooterWooCommercePowered={ false }
 			/>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-confirm/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-confirm/index.tsx
@@ -12,17 +12,13 @@ import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import WarningCard from 'calypso/components/warning-card';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { useSitePluginSlug } from 'calypso/landing/stepper/hooks/use-site-plugin-slug';
-import {
-	AUTOMATED_ELIGIBILITY_STORE,
-	SITE_STORE,
-	ONBOARD_STORE,
-} from 'calypso/landing/stepper/stores';
+import { AUTOMATED_ELIGIBILITY_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { addQueryArgs } from 'calypso/lib/url';
 import { eligibilityHolds as eligibilityHoldsConstants } from 'calypso/state/automated-transfer/constants';
 import SupportCard from '../store-address/support-card';
 import type { Step } from '../../types';
-import type { OnboardSelect, SiteSelect } from '@automattic/data-stores';
+import type { SiteSelect } from '@automattic/data-stores';
 import type { TransferEligibilityError } from '@automattic/data-stores/src/automated-transfer-eligibility/types';
 import './style.scss';
 
@@ -72,10 +68,6 @@ const BundleConfirm: Step = function BundleConfirm( { navigation } ) {
 		[ siteId ]
 	);
 	const { requestLatestAtomicTransfer } = useDispatch( SITE_STORE );
-	const stepProgress = useSelect(
-		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStepProgress(),
-		[]
-	);
 
 	useEffect( () => {
 		if ( ! siteId ) {
@@ -336,7 +328,6 @@ const BundleConfirm: Step = function BundleConfirm( { navigation } ) {
 				/>
 			}
 			stepContent={ getContent() }
-			stepProgress={ stepProgress }
 			recordTracksEvent={ recordTracksEvent }
 		/>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/business-info/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/business-info/index.tsx
@@ -58,11 +58,6 @@ const BusinessInfo: Step = function ( props ) {
 
 	const { saveSiteSettings } = useDispatch( SITE_STORE );
 
-	const stepProgress = useSelect(
-		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStepProgress(),
-		[]
-	);
-
 	function updateProductTypes( type: string ) {
 		const productTypes = getProfileValue( 'product_types' ) || [];
 
@@ -292,7 +287,6 @@ const BusinessInfo: Step = function ( props ) {
 						/>
 					}
 					stepContent={ getContent() }
-					stepProgress={ stepProgress }
 					recordTracksEvent={ recordTracksEvent }
 				/>
 			</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
@@ -9,21 +9,17 @@ import { useSourceMigrationStatusQuery } from 'calypso/data/site-migration/use-s
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
 import { SITE_PICKER_FILTER_CONFIG } from 'calypso/landing/stepper/constants';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
-import { ONBOARD_STORE, USER_STORE } from 'calypso/landing/stepper/stores';
+import { USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { triggerMigrationStartingEvent } from 'calypso/my-sites/migrate/helpers';
 import { redirect } from '../import/util';
 import type { Step } from '../../types';
-import type { OnboardSelect, UserSelect } from '@automattic/data-stores';
+import type { UserSelect } from '@automattic/data-stores';
 import './styles.scss';
 
 const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
-	const stepProgress = useSelect(
-		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStepProgress(),
-		[]
-	);
 	const currentUser = useSelect(
 		( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),
 		[]
@@ -103,7 +99,6 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 				stepName="migration-handler"
 				recordTracksEvent={ recordTracksEvent }
 				stepContent={ renderContent() }
-				stepProgress={ stepProgress }
 				showFooterWooCommercePowered={ false }
 				className="import__onboarding-page"
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
@@ -9,7 +9,7 @@ import { useSourceMigrationStatusQuery } from 'calypso/data/site-migration/use-s
 import { useSiteExcerptsQuery } from 'calypso/data/sites/use-site-excerpts-query';
 import { SITE_PICKER_FILTER_CONFIG } from 'calypso/landing/stepper/constants';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
-import { USER_STORE } from 'calypso/landing/stepper/stores';
+import { ONBOARD_STORE, USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { triggerMigrationStartingEvent } from 'calypso/my-sites/migrate/helpers';
 import { redirect } from '../import/util';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -63,10 +63,6 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getProgressTitle(),
 		[]
 	);
-	const stepProgress = useSelect(
-		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStepProgress(),
-		[]
-	);
 
 	const getCurrentMessage = () => {
 		return props.title || progressTitle || loadingMessages[ currentMessageIndex ]?.title;
@@ -157,7 +153,6 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 						</div>
 					</>
 				}
-				stepProgress={ stepProgress }
 				recordTracksEvent={ recordTracksEvent }
 				showJetpackPowered={ isJetpackPowered }
 				showFooterWooCommercePowered={ isWooCommercePowered }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -63,11 +63,6 @@ function hasSourceSlug( data: unknown ): data is { sourceSlug: string } {
 const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, data } ) {
 	const { submit } = navigation;
 	const { __ } = useI18n();
-	const stepProgress = useSelect(
-		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStepProgress(),
-		[]
-	);
-
 	const { mutateAsync: addHostingTrial } = useAddHostingTrialMutation();
 
 	const urlData = useSelector( getUrlData );
@@ -271,7 +266,6 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 						{ subTitle && <p className="processing-step__subtitle">{ subTitle }</p> }
 					</>
 				}
-				stepProgress={ stepProgress }
 				showFooterWooCommercePowered={ false }
 			/>
 		</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-address/index.tsx
@@ -68,10 +68,6 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 	const { __ } = useI18n();
 	const [ errors, setErrors ] = useState( {} as Record< FormFields, string > );
 	const { saveSiteSettings } = useDispatch( SITE_STORE );
-	const stepProgress = useSelect(
-		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getStepProgress(),
-		[]
-	);
 
 	const comingFromThemeActivation = useComingFromThemeActivationParam();
 
@@ -330,7 +326,6 @@ const StoreAddress: Step = function StoreAddress( { navigation } ) {
 			intent={ intent }
 			stepContent={ getContent() }
 			recordTracksEvent={ recordTracksEvent }
-			stepProgress={ stepProgress }
 			hideSkip
 			hideBack={ ! comingFromThemeActivation }
 		/>

--- a/packages/onboarding/src/step-container/index.tsx
+++ b/packages/onboarding/src/step-container/index.tsx
@@ -39,7 +39,6 @@ interface Props {
 	goNext?: () => void;
 	flowName?: string;
 	intent?: string;
-	stepProgress?: { count: number; progress: number };
 	recordTracksEvent: ( eventName: string, eventProperties: object ) => void;
 	showHeaderJetpackPowered?: boolean;
 	showJetpackPowered?: boolean;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85768

## Proposed Changes

This PR removes the usage of `getStepProgress()` across Calypso with the purpose of reducing unnecessary code execution. The clean can be summarized as follows:

1. In Stepper's `index.js` where it's used to determined whether to trigger the `calypso_signup_start` event.
2. In Stepper components where it's used to pass down to `<StepContainer />`, which is no longer used since it was removed in https://github.com/Automattic/wp-calypso/pull/64586.

> [!NOTE]
> Seems that the `getStepProgress()` and `setStepProgress()` can also be removed from the data store package. I'll address that in a follow up PR.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that the event `calypso_signup_start` is triggered as before, and only once (unless users go back to the step).
* Ensure that the removal of `getStepProgress()` in Stepper components doesn't create any regression issues. Just checking any JavaScript errors in their corresponding flows should do.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?