### PR TITLE
Fix clicking on the same tab causing the loader to spin indefinitely in empty state

### DIFF
--- a/client/my-sites/stats/stats-module/index.jsx
+++ b/client/my-sites/stats/stats-module/index.jsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { includes } from 'lodash';
+import { includes, isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -61,7 +61,7 @@ class StatsModule extends Component {
 			this.setState( { loaded: true } );
 		}
 
-		if ( this.props.query !== prevProps.query && this.state.loaded ) {
+		if ( ! isEqual( this.props.query, prevProps.query ) ) {
 			// eslint-disable-next-line react/no-did-update-set-state
 			this.setState( { loaded: false } );
 		}


### PR DESCRIPTION
## Proposed Changes

Cause of bug
* when the component is re-rendered the `loaded` state will be reset to `false`, causing the infinite spinner.
* JS by default don't do deep comparisons for objects, `this.props.query` is a JS object.

Fix
* Use lodash `isEqual` (https://lodash.com/docs#isEqual), which does deep comparison.
* Only set loaded state back to false when the query changes.

### Before
https://github.com/Automattic/wp-calypso/assets/6586048/f9708465-2d79-4067-9c19-da6bbf9ffc5d

### After
https://github.com/Automattic/wp-calypso/assets/6586048/dd141084-50fe-4214-8eb2-c2e506789c4b

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/stats`, stats have to be in empty state
* Click on "View Details" in Posts & pages or Countries
* Click on the tab that's already active (see video)
* Should not show the spinner
* Check mobile/desktop

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?