### PR TITLE
Plugins: Add pre-sales chat for logged-out users

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -10,6 +10,7 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
 import MainComponent from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { usePresalesChat } from 'calypso/lib/presales-chat';
 import useScrollAboveElement from 'calypso/lib/use-scroll-above-element';
 import Categories from 'calypso/my-sites/plugins/categories';
 import { useCategories } from 'calypso/my-sites/plugins/categories/use-categories';
@@ -96,6 +97,8 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 
 	const categories = useCategories();
 	const categoryName = categories[ category ]?.menu || __( 'Plugins' );
+
+	usePresalesChat( 'wpcom', ! isLoggedIn );
 
 	// this is a temporary hack until we merge Phase 4 of the refactor
 	const renderList = () => {


### PR DESCRIPTION
See peCdcN-pX-p2.
We want to add pre-sales chat widget to the logged-out version of `/plugins`.

## Proposed Changes

* Add pre-sales chat widget to the logged-out version of `/plugins`

## Testing Instructions

Check that the presales chat widget is being loaded on the logged-out version of `/plugins`.