### PR TITLE
Jetpack AI Logo generator: add prompt and basic skeleton

### DIFF
--- a/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
@@ -9,6 +9,7 @@ import React, { useState, useEffect } from 'react';
  */
 import { FirstLoadScreen } from './first-load-screen';
 import { LogoPresenter } from './logo-presenter';
+import { Prompt } from './prompt';
 import './generator-modal.scss';
 
 interface GeneratorModalProps {
@@ -24,7 +25,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( { isOpen, onClo
 		if ( isOpen ) {
 			setTimeout( () => {
 				setIsLoading( false );
-			}, 6000 );
+			}, 1000 );
 		} else {
 			setIsLoading( true );
 		}
@@ -44,7 +45,12 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( { isOpen, onClo
 						{ isLoading ? (
 							<FirstLoadScreen />
 						) : (
-							<LogoPresenter description="A publishing company in the form of a greek statue." />
+							<>
+								<Prompt />
+								<LogoPresenter description="A publishing company in the form of a greek statue." />
+								<div className="jetpack-ai-logo-generator__carousel">{ /** carousel row */ }</div>
+								<div className="jetpack-ai-logo-generator__footer">{ /** footer row */ }</div>
+							</>
 						) }
 					</div>
 				</Modal>

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.scss
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.scss
@@ -1,0 +1,6 @@
+.jetpack-ai-logo-generator__prompt-header {
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-start;
+	align-self: stretch;
+}

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
@@ -1,0 +1,25 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+/**
+ * Internal dependencies
+ */
+import './prompt.scss';
+
+export const Prompt: React.FC = () => {
+	return (
+		<div className="jetpack-ai-logo-generator__prompt">
+			<div className="jetpack-ai-logo-generator__prompt-header">
+				<div className="jetpack-ai-logo-generator__prompt-label">Describe your site/logo:</div>
+				<div className="jetpack-ai-logo-generator__prompt-actions">
+					<Button variant="link">Enhance prompt</Button>
+				</div>
+			</div>
+			<div className="jetpack-ai-logo-generator__prompt-query">
+				<textarea placeholder="describe your site or simply ask for a logo specifying some details about it"></textarea>
+				<Button className="jetpack-ai-logo-generator__prompt-submit">Generate</Button>
+			</div>
+		</div>
+	);
+};


### PR DESCRIPTION
Add prompt component for Logo Generator modal

Figma file: kJj8rPzRgHXAMHzhsmrfpy-fi-4125%3A2137
Related to #85557
Closes #85755 

## Proposed Changes

* add Prompt component (not fully styled)
* add basic `<div>` structure for carousel and footer

## Testing Instructions

These are just structural placeholders so we can better split the implementation of each component separately. See that they fit the design file