### PR TITLE
Marketplace: Show Add Review button if user is allowed to review

### DIFF
--- a/client/my-sites/marketplace/components/reviews-summary/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-summary/index.tsx
@@ -2,16 +2,14 @@ import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
-import { useSelector } from 'react-redux';
 import Rating from 'calypso/components/rating';
 import {
 	useMarketplaceReviewsStatsQuery,
+	useIsUserAllowedToReview,
 	type ProductProps,
 } from 'calypso/data/marketplace/use-marketplace-reviews';
 import { ReviewModal } from 'calypso/my-sites/marketplace/components/review-modal';
-import { canPublishProductReviews } from 'calypso/state/marketplace/selectors';
 import './styles.scss';
-import { type IAppState } from 'calypso/state/types';
 
 type Props = ProductProps & {
 	productName: string;
@@ -26,9 +24,7 @@ export const ReviewsSummary = ( { slug, productName, productType }: Props ) => {
 		slug,
 	} );
 
-	const userCanPublishReviews = useSelector( ( state: IAppState ) =>
-		canPublishProductReviews( state, productType, slug )
-	);
+	const { data: userCanPublishReviews } = useIsUserAllowedToReview( { productType, slug } );
 
 	let averageRating = null;
 	let numberOfReviews = null;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/4926

## Proposed Changes

* Call the new endpoint that validates if a review of a product can be added for the user.
* Use that endpoint to display the `Add Review` button only if the user can review that product.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* ~If the following diff is still in development, patch D132567-code and sandbox your environment~ Already deployed
* Use a development environment with the `marketplace-add-review` flag enabled, e.g. `wpcalypso.wordpress.com/themes`

#### Premium and Free
* Select a free or premium theme that you have not installed before and open the details, e.g. `/themes/hevor/:siteId` if you have not installed `Hevor`
* Check the `Add Review` button is not displayed
* Install and activate the theme
* Currently, the cache time is 2 hours, so to flush the cache, clear the `calypso` Indexed DB: Open Developer Tools > Application > [On Sotrage Section] > Select Indexed DB > calypso > [right click on calyspo_store] > clear
* Navigate to the theme installed in the previous step and open the details
* Check the `Add Review` button is displayed.
* Add your review
* Clear the cache as explained in the step above and refresh the page
* Check the `Add Review` button is not displayed

#### Marketplace
* Select a Marketplace theme that you have not purchased, e.g. `/themes/makoney/:siteId`
* Check the `Add Review` button is not displayed
* Purchase the Marketplace theme
* Clear the cache as explained above
* Navigate to the Marketplace theme and open the details page
* Check the `Add Review` button is displayed
* Add your review
* Clear the cache as explained in the step above and refresh the page
* Check the `Add Review` button is not displayed


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?