### PR TITLE
Import flows: Refactoring: useQuery instead of redux; update CTA text...

### DIFF
--- a/client/blocks/import/capture/index.tsx
+++ b/client/blocks/import/capture/index.tsx
@@ -1,14 +1,13 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Title } from '@automattic/onboarding';
-import { localize, translate } from 'i18n-calypso';
-import React, { useEffect, useRef } from 'react';
-import { connect, ConnectedProps } from 'react-redux';
+import { useTranslate } from 'i18n-calypso';
+import React, { useEffect, useRef, useState } from 'react';
+import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { triggerMigrationStartingEvent } from 'calypso/my-sites/migrate/helpers';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { useSelector } from 'calypso/state';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
-import { analyzeUrl, resetError } from 'calypso/state/imports/url-analyzer/actions';
-import { isAnalyzing, getAnalyzerError } from 'calypso/state/imports/url-analyzer/selectors';
 import ScanningStep from '../scanning';
-import { GoToStep, UrlData } from '../types';
+import { GoToStep } from '../types';
 import CaptureInput from './capture-input';
 import type { OnInputEnter, OnInputChange } from './types';
 import type { FunctionComponent } from 'react';
@@ -16,14 +15,14 @@ import type { FunctionComponent } from 'react';
 import './style.scss';
 
 interface Props {
-	translate: typeof translate;
+	hasError?: boolean;
 	onInputEnter: OnInputEnter;
 	onInputChange?: OnInputChange;
-	hasError?: boolean;
 	onDontHaveSiteAddressClick?: () => void;
 }
-const Capture: FunctionComponent< Props > = ( props ) => {
-	const { translate, onInputEnter, onInputChange, onDontHaveSiteAddressClick, hasError } = props;
+export const Capture: FunctionComponent< Props > = ( props ) => {
+	const translate = useTranslate();
+	const { onInputEnter, onInputChange, onDontHaveSiteAddressClick, hasError } = props;
 
 	return (
 		<>
@@ -42,11 +41,7 @@ const Capture: FunctionComponent< Props > = ( props ) => {
 	);
 };
 
-const LocalizedCapture = localize( Capture );
-
-export { LocalizedCapture as Capture };
-
-type StepProps = ConnectedProps< typeof connector > & {
+type StepProps = {
 	goToStep: GoToStep;
 	disableImportListStep?: boolean;
 };
@@ -57,38 +52,42 @@ const trackEventParams = {
 	step: 'capture',
 };
 
-const CaptureStep: React.FunctionComponent< StepProps > = ( {
-	currentUser,
+export const CaptureStep: React.FunctionComponent< StepProps > = ( {
 	goToStep,
-	analyzeUrl,
-	resetError,
-	isAnalyzing,
-	analyzerError,
-	recordTracksEvent,
 	disableImportListStep,
 } ) => {
+	const currentUser = useSelector( getCurrentUser );
 	const isStartingPointEventTriggeredRef = useRef( false );
-	const runProcess = ( url: string ): void => {
-		// Analyze the URL and when we receive the urlData, decide where to go next.
-		analyzeUrl( url ).then( ( response: UrlData ) => {
-			let stepSectionName;
+	const [ url, setUrl ] = useState( '' );
+	const {
+		data: urlData,
+		isFetching: isAnalyzing,
+		error: analyzerError,
+	} = useAnalyzeUrlQuery( url );
 
-			switch ( response.platform ) {
-				case 'unknown':
-					stepSectionName = 'not';
-					break;
+	const decideStepRedirect = () => {
+		if ( ! urlData ) {
+			return;
+		}
 
-				case 'wordpress':
-					stepSectionName = response.platform_data?.is_wpcom ? 'wpcom' : 'preview';
-					break;
+		const stepName = 'ready';
+		let stepSectionName;
 
-				default:
-					stepSectionName = 'preview';
-					break;
-			}
+		switch ( urlData.platform ) {
+			case 'unknown':
+				stepSectionName = 'not';
+				break;
 
-			goToStep( 'ready', stepSectionName );
-		} );
+			case 'wordpress':
+				stepSectionName = urlData.platform_data?.is_wpcom ? 'wpcom' : 'preview';
+				break;
+
+			default:
+				stepSectionName = 'preview';
+				break;
+		}
+
+		goToStep( stepName, stepSectionName, { fromUrl: url } );
 	};
 
 	const recordScanningEvent = () => {
@@ -134,15 +133,19 @@ const CaptureStep: React.FunctionComponent< StepProps > = ( {
 	useEffect( recordScanningErrorEvent, [ analyzerError ] );
 	useEffect( recordMigrationStartingPointEvent, [ currentUser ] );
 	useEffect( recordCaptureScreen, [] );
+	useEffect( () => decideStepRedirect(), [ urlData ] );
 
 	return (
 		<>
 			{ ! isAnalyzing && (
-				<LocalizedCapture
-					onInputEnter={ runProcess }
+				<Capture
+					onInputEnter={ setUrl }
 					onDontHaveSiteAddressClick={ onDontHaveSiteAddressClick }
 					hasError={ !! analyzerError }
-					onInputChange={ () => resetError() }
+					onInputChange={ () => {
+						// resets the error when the user starts typing again
+						setUrl( '' );
+					} }
 				/>
 			) }
 			{ isAnalyzing && <ScanningStep /> }
@@ -150,17 +153,4 @@ const CaptureStep: React.FunctionComponent< StepProps > = ( {
 	);
 };
 
-const connector = connect(
-	( state ) => ( {
-		currentUser: getCurrentUser( state || {} ),
-		isAnalyzing: isAnalyzing( state ),
-		analyzerError: getAnalyzerError( state ),
-	} ),
-	{
-		analyzeUrl,
-		resetError,
-		recordTracksEvent,
-	}
-);
-
-export default connector( CaptureStep );
+export default CaptureStep;

--- a/client/blocks/import/ready/index.tsx
+++ b/client/blocks/import/ready/index.tsx
@@ -4,7 +4,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { UrlData, GoToStep, RecordTracksEvent, ImporterPlatform } from '../types';
 import { convertPlatformName, convertToFriendlyWebsiteName } from '../util';
@@ -12,8 +12,6 @@ import ImportPlatformDetails, { coveredPlatforms } from './platform-details';
 import ImportPreview from './preview';
 import type { OnboardSelect } from '@automattic/data-stores';
 import './style.scss';
-
-/* eslint-disable wpcalypso/jsx-classname-namespace */
 
 const trackEventName = 'calypso_signup_step_start';
 const trackEventParams = {
@@ -34,7 +32,7 @@ const ReadyPreviewStep: React.FunctionComponent< ReadyPreviewProps > = ( {
 	recordTracksEvent,
 } ) => {
 	const { __ } = useI18n();
-	const [ isModalDetailsOpen, setIsModalDetailsOpen ] = React.useState( false );
+	const [ isModalDetailsOpen, setIsModalDetailsOpen ] = useState( false );
 
 	const recordReadyScreenEvent = () => {
 		recordTracksEvent( trackEventName, {
@@ -56,8 +54,8 @@ const ReadyPreviewStep: React.FunctionComponent< ReadyPreviewProps > = ( {
 		} );
 	};
 
-	useEffect( recordReadyScreenEvent, [] );
-	useEffect( recordImportGuideEvent, [ isModalDetailsOpen ] );
+	useEffect( () => recordReadyScreenEvent(), [ urlData.platform ] );
+	useEffect( () => recordImportGuideEvent(), [ isModalDetailsOpen ] );
 
 	return (
 		<>

--- a/client/blocks/import/ready/index.tsx
+++ b/client/blocks/import/ready/index.tsx
@@ -143,12 +143,12 @@ const ReadyNotStep: React.FunctionComponent< ReadyNotProps > = ( {
 		goToStep( 'capture' );
 	};
 
-	const onStartBuildingBtnClick = () => {
+	const onBackToGoalsBtnClick = () => {
 		// clean up the import goal
 		const goalSet = new Set( goals );
 		goalSet.delete( Onboard.SiteGoal.Import );
 		setGoals( Array.from( goalSet ) );
-		goToStep( 'intent', '', 'setup-site' );
+		goToStep( 'goals' );
 	};
 
 	useEffect( recordReadyScreenEvent, [] );
@@ -165,7 +165,7 @@ const ReadyNotStep: React.FunctionComponent< ReadyNotProps > = ( {
 					</SubTitle>
 
 					<div className="import__buttons-group">
-						<NextButton onClick={ onStartBuildingBtnClick }>{ __( 'Start building' ) }</NextButton>
+						<NextButton onClick={ onBackToGoalsBtnClick }>{ __( 'Back to goals' ) }</NextButton>
 						<div>
 							<BackButton onClick={ onBackBtnClick }>{ __( 'Back to start' ) }</BackButton>
 						</div>
@@ -298,14 +298,14 @@ const ReadyAlreadyOnWPCOMStep: React.FunctionComponent< ReadyWpComProps > = ( {
 		goToStep( 'capture' );
 	};
 
-	const onStartBuildingBtnClick = () => {
+	const onBackToGoalsBtnClick = () => {
 		// event tracking
 		recordStartBuildingEvent();
 		// clean up the import goal
 		const goalSet = new Set( goals );
 		goalSet.delete( Onboard.SiteGoal.Import );
 		setGoals( Array.from( goalSet ) );
-		goToStep( 'intent', '', 'setup-site' );
+		goToStep( 'goals' );
 	};
 
 	useEffect( recordReadyScreenEvent, [] );
@@ -331,7 +331,7 @@ const ReadyAlreadyOnWPCOMStep: React.FunctionComponent< ReadyWpComProps > = ( {
 					</SubTitle>
 
 					<div className="import__buttons-group">
-						<NextButton onClick={ onStartBuildingBtnClick }>{ __( 'Start building' ) }</NextButton>
+						<NextButton onClick={ onBackToGoalsBtnClick }>{ __( 'Back to goals' ) }</NextButton>
 						<div>
 							<BackButton onClick={ onBackBtnClick }>{ __( 'Back to start' ) }</BackButton>
 						</div>

--- a/client/blocks/import/types.ts
+++ b/client/blocks/import/types.ts
@@ -1,4 +1,8 @@
-export type GoToStep = ( stepName: string, stepSectionName?: string, flowName?: string ) => void;
+export type GoToStep = (
+	stepName: string,
+	stepSectionName?: string,
+	params?: { fromUrl: string }
+) => void;
 export type GoToNextStep = () => void;
 export type RecordTracksEvent = ( name: string, properties: { [ key: string ]: string } ) => void;
 export type UrlData = {

--- a/client/data/site-profiler/use-analyze-url-query.ts
+++ b/client/data/site-profiler/use-analyze-url-query.ts
@@ -13,6 +13,7 @@ export const useAnalyzeUrlQuery = ( domain: string, isValid?: boolean ) => {
 		meta: {
 			persist: false,
 		},
+		staleTime: 5000, // 5 seconds
 		enabled: !! domain && isValid,
 		retry: false,
 		refetchOnWindowFocus: false,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/index.tsx
@@ -1,12 +1,13 @@
 import { useSelect } from '@wordpress/data';
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { ReadyPreviewStep } from 'calypso/blocks/import/ready';
+import ScanningStep from 'calypso/blocks/import/scanning';
+import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlugParam } from 'calypso/landing/stepper/hooks/use-site-slug-param';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useSelector } from 'calypso/state';
-import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
 import { ImportWrapper } from '../import';
 import { BASE_ROUTE } from '../import/config';
 import { getFinalImporterUrl } from '../import/helper';
@@ -15,63 +16,57 @@ import type { OnboardSelect } from '@automattic/data-stores';
 const ImportReadyPreview: Step = function ImportStep( props ) {
 	const { navigation } = props;
 	const siteSlug = useSiteSlugParam();
-	const urlData = useSelector( getUrlData );
+	const fromUrl = useQuery().get( 'from' ) || '';
+	const { data: urlData, isFetched, isFetching } = useAnalyzeUrlQuery( fromUrl );
 	const isMigrateFromWp = useSelect(
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIsMigrateFromWp(),
 		[]
 	);
 
 	/**
-	 ↓ Effects
-	 */
-	// redirect to home step if urlData is not available
-	useEffect( () => {
-		! urlData && goToHomeStep();
-	}, [ urlData, navigation ] );
-
-	// redirect directly to importer page
-	useEffect( () => {
-		if ( ! urlData ) {
-			return;
-		}
-
-		if ( isMigrateFromWp || urlData.platform === 'wordpress' ) {
-			goToImporterPage();
-		}
-	}, [ urlData, isMigrateFromWp ] );
-
-	/**
 	 ↓ Methods
 	 */
-	function goToImporterPage() {
+	const goToHomeStep = useCallback( () => {
+		navigation.goToStep?.( BASE_ROUTE );
+	}, [ navigation ] );
+
+	const goToImporterPage = useCallback( () => {
 		if ( ! urlData ) {
 			return;
 		}
 
 		const url = getFinalImporterUrl( siteSlug as string, urlData.url, urlData.platform );
-
 		navigation.submit?.( { url } );
-	}
+	}, [ urlData, siteSlug, navigation ] );
 
-	function goToHomeStep() {
-		navigation.goToStep?.( BASE_ROUTE );
-	}
+	/**
+	 ↓ Effects
+	 */
+	// redirect to home step if urlData is not available
+	useEffect( () => {
+		isFetched && ! urlData && goToHomeStep();
+	}, [ isFetched, urlData ] );
+
+	// redirect directly to importer page
+	useEffect( () => {
+		( isMigrateFromWp || urlData?.platform === 'wordpress' ) && goToImporterPage();
+	}, [ urlData, isMigrateFromWp ] );
 
 	/**
 	 ↓ Renders
 	 */
-	if ( ! urlData ) {
-		return null;
-	}
-
 	return (
 		<ImportWrapper { ...props }>
-			<ReadyPreviewStep
-				urlData={ urlData }
-				siteSlug={ siteSlug as string }
-				goToImporterPage={ goToImporterPage }
-				recordTracksEvent={ recordTracksEvent }
-			/>
+			{ isFetching && <ScanningStep /> }
+
+			{ ! isFetching && urlData && (
+				<ReadyPreviewStep
+					urlData={ urlData }
+					siteSlug={ siteSlug as string }
+					goToImporterPage={ goToImporterPage }
+					recordTracksEvent={ recordTracksEvent }
+				/>
+			) }
 		</ImportWrapper>
 	);
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-wpcom/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-wpcom/index.tsx
@@ -8,10 +8,10 @@ import { ImportWrapper } from '../import';
 import { BASE_ROUTE } from '../import/config';
 import { generateStepPath } from '../import/helper';
 
-const ImportReadyNot: Step = function ImportStep( props ) {
+const ImportReadyWpcom: Step = function ImportStep( props ) {
 	const { navigation } = props;
 	const fromUrl = useQuery().get( 'from' ) || '';
-	const { data: urlData, isFetched } = useAnalyzeUrlQuery( fromUrl );
+	const { data: urlData, isFetched, isFetching } = useAnalyzeUrlQuery( fromUrl );
 
 	const goToHomeStep = useCallback( () => {
 		navigation.goToStep?.( BASE_ROUTE );
@@ -24,13 +24,17 @@ const ImportReadyNot: Step = function ImportStep( props ) {
 
 	return (
 		<ImportWrapper { ...props }>
-			<ReadyAlreadyOnWPCOMStep
-				urlData={ urlData }
-				goToStep={ ( step, section ) => navigation.goToStep?.( generateStepPath( step, section ) ) }
-				recordTracksEvent={ recordTracksEvent }
-			/>
+			{ ! isFetching && urlData && (
+				<ReadyAlreadyOnWPCOMStep
+					urlData={ urlData }
+					goToStep={ ( step, section ) =>
+						navigation.goToStep?.( generateStepPath( step, section ) )
+					}
+					recordTracksEvent={ recordTracksEvent }
+				/>
+			) }
 		</ImportWrapper>
 	);
 };
 
-export default ImportReadyNot;
+export default ImportReadyWpcom;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-wpcom/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-wpcom/index.tsx
@@ -1,28 +1,26 @@
-import React from 'react';
+import React, { useEffect, useCallback } from 'react';
 import { ReadyAlreadyOnWPCOMStep } from 'calypso/blocks/import/ready';
+import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { Step } from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { useSelector } from 'calypso/state';
-import { getUrlData } from 'calypso/state/imports/url-analyzer/selectors';
 import { ImportWrapper } from '../import';
 import { BASE_ROUTE } from '../import/config';
 import { generateStepPath } from '../import/helper';
 
 const ImportReadyNot: Step = function ImportStep( props ) {
 	const { navigation } = props;
-	const urlData = useSelector( getUrlData );
+	const fromUrl = useQuery().get( 'from' ) || '';
+	const { data: urlData, isFetched } = useAnalyzeUrlQuery( fromUrl );
 
-	/**
-	 ↓ Effects
-	 */
-	if ( ! urlData ) {
-		goToHomeStep();
-		return null;
-	}
-
-	function goToHomeStep() {
+	const goToHomeStep = useCallback( () => {
 		navigation.goToStep?.( BASE_ROUTE );
-	}
+	}, [ navigation ] );
+
+	// redirect to home step if urlData is not available
+	useEffect( () => {
+		isFetched && ! urlData && goToHomeStep();
+	}, [ isFetched ] );
 
 	return (
 		<ImportWrapper { ...props }>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/helper.ts
@@ -44,14 +44,19 @@ export function getFinalImporterUrl(
  * Stepper's redirection handlers
  */
 export function generateStepPath( stepName: string, stepSectionName?: string ) {
-	if ( stepName === 'intent' ) {
-		return 'goals';
-	} else if ( stepName === 'capture' ) {
-		return BASE_ROUTE;
+	switch ( stepName ) {
+		case 'intent':
+		case 'goals':
+			return 'goals';
+
+		case 'capture':
+			return BASE_ROUTE;
+
+		default: {
+			const routes = [ BASE_ROUTE, stepName, stepSectionName ];
+			const path = routes.join( '_' );
+
+			return camelCase( path ) as string;
+		}
 	}
-
-	const routes = [ BASE_ROUTE, stepName, stepSectionName ];
-	const path = routes.join( '_' );
-
-	return camelCase( path ) as string;
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
@@ -9,6 +9,7 @@ import CaptureStep from 'calypso/blocks/import/capture';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useCurrentRoute } from 'calypso/landing/stepper/hooks/use-current-route';
 import useMigrationConfirmation from 'calypso/landing/stepper/hooks/use-migration-confirmation';
+import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { BASE_ROUTE } from './config';
 import { generateStepPath } from './helper';
@@ -82,12 +83,18 @@ export const ImportWrapper: Step = function ( props ) {
 
 const ImportStep: Step = function ImportStep( props ) {
 	const { navigation, flow } = props;
+	const siteSlug = useSiteSlug();
 
 	return (
 		<ImportWrapper { ...props }>
 			<CaptureStep
 				disableImportListStep={ IMPORT_HOSTED_SITE_FLOW === flow }
-				goToStep={ ( step, section ) => navigation.goToStep?.( generateStepPath( step, section ) ) }
+				goToStep={ ( step, section, params ) => {
+					const stepPath = generateStepPath( step, section );
+					const from = encodeURIComponent( params?.fromUrl || '' );
+
+					navigation.goToStep?.( `${ stepPath }?siteSlug=${ siteSlug }&from=${ from }` );
+				} }
 			/>
 		</ImportWrapper>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
@@ -92,8 +92,11 @@ const ImportStep: Step = function ImportStep( props ) {
 				goToStep={ ( step, section, params ) => {
 					const stepPath = generateStepPath( step, section );
 					const from = encodeURIComponent( params?.fromUrl || '' );
+					const path = siteSlug
+						? `${ stepPath }?siteSlug=${ siteSlug }&from=${ from }`
+						: `${ stepPath }?from=${ from }`;
 
-					navigation.goToStep?.( `${ stepPath }?siteSlug=${ siteSlug }&from=${ from }` );
+					navigation.goToStep?.( path );
 				} }
 			/>
 		</ImportWrapper>

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -557,7 +557,7 @@ const siteSetupFlow: Flow = {
 		const goToStep = ( step: string ) => {
 			switch ( step ) {
 				case 'import':
-					return navigate( `import?siteSlug=${ siteSlugParam }` );
+					return navigate( `import?siteSlug=${ siteSlug }` );
 
 				default:
 					return navigate( step );

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -555,7 +555,13 @@ const siteSetupFlow: Flow = {
 		};
 
 		const goToStep = ( step: string ) => {
-			navigate( step );
+			switch ( step ) {
+				case 'import':
+					return navigate( `import?siteSlug=${ siteSlugParam }` );
+
+				default:
+					return navigate( step );
+			}
 		};
 
 		return { goNext, goBack, goToStep, submit, exitFlow };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/85711

## Proposed Changes

* Simplified Import Ready components: Got rid of connect redux wrapper
* Ready components: Updated logic to allow direct step access
* Replaced redux with useQuery approach for analyzing entered url
* Renamed obsolete "Start building" CTA with "Go to goals"

## Testing Instructions

* Go to `/setup/import-focused?siteSlug={SLUG}`
  * or `/setup/site-setup?siteSlug={SLUG}`
  * or `/setup/import-hosted-site`
* Pass through the flow, and try different import options: import everything, content only for different platforms
* Check if everything works as before

Note: For easier review, follow commit list (e2e tests are green 👌)

Now, the import-ready preview screen is not redirected back to the capture screen if you press refresh. It will stay on the same page; the "from" query param is included.
This is the required changes for future moves related to the task: https://github.com/Automattic/wp-calypso/issues/85711

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?