### PR TITLE
Jetpack Backup: setup hooks for preflight checks

### DIFF
--- a/client/state/rewind/preflight/hooks.tsx
+++ b/client/state/rewind/preflight/hooks.tsx
@@ -1,10 +1,17 @@
-import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import { useMutation, UseMutationResult, useQuery, UseQueryResult } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 import { useDispatch, useSelector } from 'calypso/state';
 import { updatePreflightTests } from './actions';
 import { getPreflightStatus } from './selectors';
 import { APIPreflightStatusResponse } from './types';
 
+/**
+ * Custom hook to query the status of a preflight check for a specific site.
+ * Uses React Query's useQuery hook to periodically fetch the preflight status
+ * and update the Redux store with the latest status.
+ * @param {number} siteId - The ID of the site for which the preflight status is to be queried.
+ * @returns {UseQueryResult} - The result object from React Query's useQuery hook.
+ */
 export const usePreflightStatusQuery = ( siteId: number ): UseQueryResult => {
 	const dispatch = useDispatch();
 
@@ -28,6 +35,29 @@ export const usePreflightStatusQuery = ( siteId: number ): UseQueryResult => {
 			if ( data.ok ) {
 				dispatch( updatePreflightTests( siteId, data.status ) );
 			}
+		},
+	} );
+};
+
+/**
+ * Custom hook to enqueue a preflight check for a specific site.
+ * This hook uses the useMutation hook from React Query to perform an asynchronous POST request.
+ * @param {number} siteId - The ID of the site for which the preflight check is to be enqueued.
+ * @returns {UseMutationResult} - The result object from React Query's useMutation hook.
+ */
+export const useEnqueuePreflightCheck = ( siteId: number ): UseMutationResult => {
+	const dispatch = useDispatch();
+
+	return useMutation( {
+		mutationFn: async () => {
+			dispatch( updatePreflightTests( siteId, [] ) );
+			return wp.req.post(
+				{
+					path: `/sites/${ siteId }/rewind/preflight`,
+					apiNamespace: 'wpcom/v2',
+				},
+				{}
+			);
 		},
 	} );
 };

--- a/client/state/rewind/preflight/selectors.ts
+++ b/client/state/rewind/preflight/selectors.ts
@@ -5,7 +5,7 @@ import { PreflightTestStatus } from './types';
 // Selector to get the preflight overall status
 export const getPreflightStatus = ( state: AppState, siteId: number ) => {
 	// If the preflight check is disabled, return FAILED
-	if ( ! config.isEnabled( 'jetpack/backup-restore-preflight-check' ) ) {
+	if ( ! config.isEnabled( 'jetpack/backup-restore-preflight-checks' ) ) {
 		return PreflightTestStatus.FAILED;
 	}
 

--- a/client/state/rewind/preflight/test/selectors.test.ts
+++ b/client/state/rewind/preflight/test/selectors.test.ts
@@ -10,7 +10,7 @@ jest.mock( '@automattic/calypso-config', () => {
 
 const mockPreflightFeatureFlag = ( isEnabledValue: boolean ) => {
 	( isEnabled as jest.Mock ).mockImplementation( ( property: string ) => {
-		if ( property === 'jetpack/backup-restore-preflight-check' ) {
+		if ( property === 'jetpack/backup-restore-preflight-checks' ) {
 			return isEnabledValue;
 		}
 

--- a/client/state/rewind/preflight/test/utils.test.ts
+++ b/client/state/rewind/preflight/test/utils.test.ts
@@ -33,4 +33,9 @@ describe( 'calculateOverallStatus', () => {
 		];
 		expect( calculateOverallStatus( tests ) ).toEqual( PreflightTestStatus.PENDING );
 	} );
+
+	it( 'should return PENDING if tests are an empty array', () => {
+		const tests: PreflightTest[] = [];
+		expect( calculateOverallStatus( tests ) ).toEqual( PreflightTestStatus.PENDING );
+	} );
 } );

--- a/client/state/rewind/preflight/utils.ts
+++ b/client/state/rewind/preflight/utils.ts
@@ -12,6 +12,11 @@ import { PreflightTest, PreflightTestStatus } from './types';
  * @returns The overall status as a PreflightTestStatus enum value.
  */
 export const calculateOverallStatus = ( tests: PreflightTest[] ): PreflightTestStatus => {
+	// If there are no tests, the overall status is PENDING.
+	if ( tests.length === 0 ) {
+		return PreflightTestStatus.PENDING;
+	}
+
 	if ( tests.some( ( test ) => test.status === PreflightTestStatus.FAILED ) ) {
 		return PreflightTestStatus.FAILED;
 	} else if ( tests.some( ( test ) => test.status === PreflightTestStatus.IN_PROGRESS ) ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-backup-team/issues/289 and resolves https://github.com/Automattic/jetpack-backup-team/issues/291

## Proposed Changes

* Fix feature flag validation (there was a typo in the flag name)
* Update `calculateOverallStatus` function to handle the scenario when a preflight check was never enqueued for a specific site (empty test array).
* Add hook `useEnqueuePreflightCheck` that will allow us to enqueue the preflight check in the restore page.

## Testing Instructions
This code is a continuation of https://github.com/Automattic/wp-calypso/pull/85260 and will not impact any user at the moment, given we are just preparing all the redux setup needed to start managing preflight check status, so for the moment just ensure unit tests are passing:

```yarn run test-client client/state/rewind/preflight```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?