### PR TITLE
Paid stats: gate date control picker (dropdown)

### DIFF
--- a/client/my-sites/stats/stats-module/all-time-nav.jsx
+++ b/client/my-sites/stats/stats-module/all-time-nav.jsx
@@ -56,10 +56,12 @@ export const StatsModuleSummaryLinks = ( props ) => {
 		props.recordGoogleEvent( 'Stats', `Clicked Summary Link: ${ path } ${ item.stat }` );
 	};
 
-	const handleClick = ( item ) => () => {
+	const handleClick = ( item ) => ( event ) => {
 		if ( item.isGated ) {
+			event.preventDefault();
 			dispatch( toggleUpsellModal( siteId, item.statType ) );
 		}
+		recordStats( item );
 	};
 
 	const summaryPath = `/stats/day/${ path }/${ siteSlug }?startDate=${ moment().format(
@@ -152,11 +154,17 @@ export const StatsModuleSummaryLinks = ( props ) => {
 					key={ 'navTabsDropdown-' + index }
 					path={ i.path }
 					selected={ i.value === selected.value }
-					onClick={ () => {
-						recordStats( i );
-					} }
+					onClick={ handleClick( i ) }
 				>
 					{ i.label }
+					{ i.isGated && (
+						<Icon
+							className="stats-summary-nav__gated-icon"
+							icon={ lock }
+							width={ 16 }
+							height={ 16 }
+						/>
+					) }
 				</SelectDropdown.Item>
 			) ) }
 		</SelectDropdown>

--- a/client/my-sites/stats/stats-module/summary-nav.scss
+++ b/client/my-sites/stats/stats-module/summary-nav.scss
@@ -105,6 +105,10 @@ $summary-nav-swap-width: 661px;
 		padding: 0;
 	}
 
+	.stats-summary-nav__gated-icon {
+		vertical-align: middle;
+	}
+
 	@media ( max-width: $break-medium ) {
 		padding: $summary-medium-padding;
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5036
Related https://github.com/Automattic/dotcom-forge/issues/4915

## Proposed Changes

https://github.com/Automattic/wp-calypso/assets/6586048/b539970b-eacb-4239-bc7c-8d27ded61f18

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /stats with `?flags=stats/paid-wpcom-v2` attached to the end of the url
* Click on "View Details" in `Posts & pages` or `Countries`
* Switch to mobile view
* Click on the Gated stats (should be gated for WPCom sites and not Jetpack sites)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?