### PR TITLE
Assembler: Rename the step name to pattern-assembler

### DIFF
--- a/client/landing/stepper/declarative-flow/ai-assembler.ts
+++ b/client/landing/stepper/declarative-flow/ai-assembler.ts
@@ -177,7 +177,7 @@ const withAIAssemblerFlow: Flow = {
 						} );
 					}
 
-					return navigate( 'patternAssembler' );
+					return navigate( 'pattern-assembler' );
 				}
 
 				case 'processing': {
@@ -214,7 +214,7 @@ const withAIAssemblerFlow: Flow = {
 					return exitFlow( `/site-editor/${ siteSlug }?${ params }` );
 				}
 
-				case 'patternAssembler': {
+				case 'pattern-assembler': {
 					return navigate( 'processing' );
 				}
 
@@ -263,7 +263,7 @@ const withAIAssemblerFlow: Flow = {
 					return navigate( 'launchpad' );
 				}
 
-				case 'patternAssembler': {
+				case 'pattern-assembler': {
 					return navigate( 'site-prompt' );
 				}
 			}
@@ -272,7 +272,7 @@ const withAIAssemblerFlow: Flow = {
 		const goNext = () => {
 			switch ( _currentStep ) {
 				case 'site-prompt': {
-					return navigate( 'patternAssembler' );
+					return navigate( 'pattern-assembler' );
 				}
 
 				case 'launchpad':

--- a/client/landing/stepper/declarative-flow/assembler-first-flow.ts
+++ b/client/landing/stepper/declarative-flow/assembler-first-flow.ts
@@ -127,7 +127,7 @@ const assemblerFirstFlow: Flow = {
 				params.set( 'isNewSite', 'true' );
 			}
 
-			return navigate( `patternAssembler?${ params }` );
+			return navigate( `pattern-assembler?${ params }` );
 		};
 
 		const submit = async (
@@ -200,7 +200,7 @@ const assemblerFirstFlow: Flow = {
 					return exitFlow( `/site-editor/${ siteSlug }?${ params }` );
 				}
 
-				case 'patternAssembler': {
+				case 'pattern-assembler': {
 					return navigate( 'processing' );
 				}
 
@@ -248,7 +248,7 @@ const assemblerFirstFlow: Flow = {
 					return navigate( 'launchpad' );
 				}
 
-				case 'patternAssembler': {
+				case 'pattern-assembler': {
 					const params = new URLSearchParams( window.location.search );
 					params.delete( 'siteSlug' );
 					params.delete( 'siteId' );

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -142,12 +142,12 @@ const free: Flow = {
 					}
 
 					if ( providedDependencies?.shouldGoToAssembler ) {
-						return navigate( 'patternAssembler' );
+						return navigate( 'pattern-assembler' );
 					}
 
 					return navigate( `processing?siteSlug=${ siteSlug }` );
 
-				case 'patternAssembler': {
+				case 'pattern-assembler': {
 					return navigate( `processing?siteSlug=${ siteSlug }` );
 				}
 
@@ -160,7 +160,7 @@ const free: Flow = {
 
 		const goBack = () => {
 			switch ( _currentStep ) {
-				case 'patternAssembler':
+				case 'pattern-assembler':
 					return navigate( 'designSetup' );
 			}
 		};

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -50,7 +50,7 @@ const importFlow: Flow = {
 			{ slug: 'importerSquarespace', component: ImporterSquarespace },
 			{ slug: 'importerWordpress', component: ImporterWordpress },
 			{ slug: 'designSetup', component: DesignSetup },
-			{ slug: 'patternAssembler', component: PatternAssembler },
+			{ slug: 'pattern-assembler', component: PatternAssembler },
 			{ slug: 'processing', component: ProcessingStep },
 			{ slug: 'siteCreationStep', component: SiteCreationStep },
 			{ slug: 'migrationHandler', component: MigrationHandler },
@@ -171,13 +171,13 @@ const importFlow: Flow = {
 				case 'designSetup': {
 					const { selectedDesign: _selectedDesign } = providedDependencies;
 					if ( isAssemblerDesign( _selectedDesign as Design ) && isAssemblerSupported() ) {
-						return navigate( 'patternAssembler' );
+						return navigate( 'pattern-assembler' );
 					}
 
 					return navigate( 'processing' );
 				}
 
-				case 'patternAssembler':
+				case 'pattern-assembler':
 					return navigate( 'processing' );
 
 				case 'siteCreationStep':

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -125,7 +125,7 @@ export const STEPS = {
 	},
 
 	PATTERN_ASSEMBLER: {
-		slug: 'patternAssembler',
+		slug: 'pattern-assembler',
 		asyncComponent: () => import( './steps-repository/pattern-assembler' ),
 	},
 

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -50,7 +50,7 @@ const siteSetupFlow: Flow = {
 
 		useEffect( () => {
 			// Require to start the flow from the first step
-			if ( currentStep === 'patternAssembler' && ! selectedDesign ) {
+			if ( currentStep === 'pattern-assembler' && ! selectedDesign ) {
 				navigate( 'goals' );
 			}
 		}, [] );
@@ -236,12 +236,12 @@ const siteSetupFlow: Flow = {
 				case 'designSetup': {
 					const { selectedDesign: _selectedDesign } = providedDependencies;
 					if ( isAssemblerDesign( _selectedDesign as Design ) && isAssemblerSupported() ) {
-						return navigate( 'patternAssembler' );
+						return navigate( 'pattern-assembler' );
 					}
 
 					return navigate( 'processing' );
 				}
-				case 'patternAssembler':
+				case 'pattern-assembler':
 					return navigate( 'processing' );
 
 				case 'processing': {
@@ -458,7 +458,7 @@ const siteSetupFlow: Flow = {
 							return navigate( 'goals' );
 					}
 
-				case 'patternAssembler':
+				case 'pattern-assembler':
 					return navigate( 'designSetup' );
 
 				case 'importList':

--- a/client/landing/stepper/declarative-flow/update-design.ts
+++ b/client/landing/stepper/declarative-flow/update-design.ts
@@ -90,12 +90,12 @@ const updateDesign: Flow = {
 					}
 
 					if ( providedDependencies?.shouldGoToAssembler ) {
-						return navigate( 'patternAssembler' );
+						return navigate( 'pattern-assembler' );
 					}
 
 					return navigate( `processing?siteSlug=${ siteSlug }&flowToReturnTo=${ flowToReturnTo }` );
 
-				case 'patternAssembler': {
+				case 'pattern-assembler': {
 					return navigate( `processing?siteSlug=${ siteSlug }&flowToReturnTo=${ flowToReturnTo }` );
 				}
 			}
@@ -103,7 +103,7 @@ const updateDesign: Flow = {
 
 		const goBack = () => {
 			switch ( currentStep ) {
-				case 'patternAssembler':
+				case 'pattern-assembler':
 					return navigate( 'designSetup' );
 			}
 		};

--- a/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
@@ -95,7 +95,7 @@ const withThemeAssemblerFlow: Flow = {
 					return exitFlow( `/site-editor/${ siteSlug }?${ params }` );
 				}
 
-				case 'patternAssembler': {
+				case 'pattern-assembler': {
 					return navigate( 'processing' );
 				}
 
@@ -107,7 +107,7 @@ const withThemeAssemblerFlow: Flow = {
 
 		const goBack = () => {
 			switch ( _currentStep ) {
-				case 'patternAssembler': {
+				case 'pattern-assembler': {
 					return window.location.assign( `/themes/${ siteSlug }` );
 				}
 			}

--- a/client/landing/stepper/hooks/use-site-setup-flow-progress.ts
+++ b/client/landing/stepper/hooks/use-site-setup-flow-progress.ts
@@ -55,7 +55,7 @@ export function useSiteSetupFlowProgress( currentStep: string, intent: string ) 
 				case 'designSetup':
 					middleProgress = { progress: 1, count: 3 };
 					break;
-				case 'patternAssembler':
+				case 'pattern-assembler':
 					middleProgress = { progress: 2, count: 3 };
 					break;
 			}

--- a/test/e2e/specs/onboarding/onboarding__site-assembler.ts
+++ b/test/e2e/specs/onboarding/onboarding__site-assembler.ts
@@ -82,7 +82,7 @@ describe( 'Onboarding: Site Assembler', () => {
 
 		it( 'Select "Start designing" and land on the Site Assembler', async function () {
 			await startSiteFlow.clickButton( 'Design your own' );
-			await page.waitForURL( /setup\/site-setup\/patternAssembler/, {
+			await page.waitForURL( /setup\/site-setup\/pattern-assembler/, {
 				timeout: 30 * 1000,
 			} );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pbxlJb-5eS-p2

## Proposed Changes

* Rename the step name from `patternAssembler` to `pattern-assembler`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Onboarding Flow**

* Go to /setup?siteSlug=<your_site>
* Continue to Design Picker
* Pick the “Design your own” button
* Make sure the Assembler step still works as expected

**Theme Showcase**

* Go to /themes
* Scroll down to select the Assembler CTA
* Make sure the Assembler step still works as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?