### PR TITLE
Stepper: Fix the calypso_signup_step_start event may not be fired if the site is not requested

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/free-setup/test/index.tsx
@@ -1,13 +1,10 @@
 /**
  * @jest-environment jsdom
  */
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { Provider } from 'react-redux';
-import configureStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import FreeSetup from '../index';
 
 jest.mock( 'react-router-dom', () => ( {
@@ -18,24 +15,6 @@ jest.mock( 'react-router-dom', () => ( {
 		state: undefined,
 	} ) ),
 } ) );
-
-const middlewares = [ thunk ];
-
-const mockStore = configureStore( middlewares );
-
-const renderComponent = ( component, initialState = {} ) => {
-	const queryClient = new QueryClient();
-	const store = mockStore( {
-		'automattic/onboard': {},
-		...initialState,
-	} );
-
-	return render(
-		<Provider store={ store }>
-			<QueryClientProvider client={ queryClient }>{ component }</QueryClientProvider>
-		</Provider>
-	);
-};
 
 describe( 'Onboarding Free Flow - FreeSetup', () => {
 	const user = userEvent.setup();
@@ -51,7 +30,7 @@ describe( 'Onboarding Free Flow - FreeSetup', () => {
 
 	describe( 'Initial screen render', () => {
 		it( 'should render successfully', async () => {
-			renderComponent( <FreeSetup flow="free" navigation={ navigation } /> );
+			renderWithProvider( <FreeSetup flow="free" navigation={ navigation } /> );
 
 			await waitFor( () => {
 				expect( screen.getByText( 'Personalize your Site' ) ).toBeInTheDocument();
@@ -64,7 +43,7 @@ describe( 'Onboarding Free Flow - FreeSetup', () => {
 
 	describe( 'FreeSetup form submission', () => {
 		it( 'should submit form if Site name field is not empty', async () => {
-			const freeSetupComponent = renderComponent(
+			const freeSetupComponent = renderWithProvider(
 				<FreeSetup flow="free" navigation={ navigation } />
 			);
 
@@ -78,7 +57,7 @@ describe( 'Onboarding Free Flow - FreeSetup', () => {
 		} );
 
 		it( 'should not submit form if Site name field is empty', async () => {
-			const freeSetupComponent = renderComponent(
+			const freeSetupComponent = renderWithProvider(
 				<FreeSetup flow="free" navigation={ navigation } />
 			);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/test/index.tsx
@@ -139,7 +139,7 @@ describe( 'Launchpad', () => {
 	describe( 'when loading the Launchpad view', () => {
 		describe( 'and the site is launchpad enabled', () => {
 			it( 'does not redirect', () => {
-				( useLaunchpad as jest.Mock ).mockReturnValueOnce( {
+				( useLaunchpad as jest.Mock ).mockReturnValue( {
 					...MOCK_USE_QUERY_RESULT,
 					data: { launchpad_screen: 'full' },
 				} );
@@ -154,7 +154,7 @@ describe( 'Launchpad', () => {
 			} );
 
 			it( 'does not redirect when site id is used', () => {
-				( useLaunchpad as jest.Mock ).mockReturnValueOnce( {
+				( useLaunchpad as jest.Mock ).mockReturnValue( {
 					...MOCK_USE_QUERY_RESULT,
 					data: { launchpad_screen: 'full' },
 				} );

--- a/client/landing/stepper/hooks/use-site.ts
+++ b/client/landing/stepper/hooks/use-site.ts
@@ -12,7 +12,7 @@ export function useSite() {
 	const dispatch = useDispatch();
 	const siteSlug = useSiteSlugParam();
 	const siteIdParam = useSiteIdParam();
-	const siteIdOrSlug = siteIdParam ?? siteSlug;
+	const siteIdOrSlug = siteIdParam ?? siteSlug ?? '';
 	const selectedSite = useSelector( ( state ) => getSite( state, siteIdOrSlug ) );
 	const isRequestingSelectedSite = useSelector( ( state ) =>
 		isRequestingSite( state, siteIdOrSlug )

--- a/client/landing/stepper/hooks/use-site.ts
+++ b/client/landing/stepper/hooks/use-site.ts
@@ -29,7 +29,7 @@ export function useSite() {
 
 	// Request the site for the redux store
 	useEffect( () => {
-		if ( siteIdOrSlug && ! selectedSite && isRequestingSelectedSite ) {
+		if ( siteIdOrSlug && ! selectedSite && ! isRequestingSelectedSite ) {
 			dispatch( requestSite( siteIdOrSlug ) );
 		}
 	}, [ siteIdOrSlug, selectedSite, isRequestingSelectedSite ] );

--- a/client/landing/stepper/hooks/use-site.ts
+++ b/client/landing/stepper/hooks/use-site.ts
@@ -1,24 +1,42 @@
 import { useSelect } from '@wordpress/data';
+import { useEffect } from 'react';
+import { useSelector, useDispatch } from 'calypso/state';
+import { requestSite } from 'calypso/state/sites/actions';
+import { getSite, isRequestingSite } from 'calypso/state/sites/selectors';
 import { SITE_STORE } from '../stores';
 import { useSiteIdParam } from './use-site-id-param';
 import { useSiteSlugParam } from './use-site-slug-param';
 import type { SiteSelect } from '@automattic/data-stores';
 
 export function useSite() {
+	const dispatch = useDispatch();
 	const siteSlug = useSiteSlugParam();
 	const siteIdParam = useSiteIdParam();
+	const siteIdOrSlug = siteIdParam ?? siteSlug;
+	const selectedSite = useSelector( ( state ) => getSite( state, siteIdOrSlug ) );
+	const isRequestingSelectedSite = useSelector( ( state ) =>
+		isRequestingSite( state, siteIdOrSlug )
+	);
 
 	const site = useSelect(
 		( select ) => {
 			const siteStore = select( SITE_STORE ) as SiteSelect;
-			const siteKey = siteIdParam ?? siteSlug;
 
-			return siteKey ? siteStore.getSite( siteKey as string | number ) : null;
+			return siteIdOrSlug ? siteStore.getSite( siteIdOrSlug ) : null;
 		},
-		[ siteSlug, siteIdParam ]
+		[ siteIdOrSlug ]
 	);
-	if ( ( siteSlug || siteIdParam ) && site ) {
+
+	// Request the site for the redux store
+	useEffect( () => {
+		if ( siteIdOrSlug && ! selectedSite && isRequestingSelectedSite ) {
+			dispatch( requestSite( siteIdOrSlug ) );
+		}
+	}, [ siteIdOrSlug, selectedSite, isRequestingSelectedSite ] );
+
+	if ( siteIdOrSlug && site ) {
 		return site;
 	}
+
 	return null;
 }

--- a/client/landing/stepper/hooks/use-user-can-manage-options.ts
+++ b/client/landing/stepper/hooks/use-user-can-manage-options.ts
@@ -1,22 +1,12 @@
-import { useEffect } from 'react';
-import { useSelector, useDispatch } from 'calypso/state';
+import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import { requestSite } from 'calypso/state/sites/actions';
 import { useSiteData } from './use-site-data';
 
 export function useCanUserManageOptions() {
-	const dispatch = useDispatch();
 	const { site, siteSlugOrId } = useSiteData();
 	const canManageOptions = useSelector( ( state ) =>
 		canCurrentUser( state, site?.ID, 'manage_options' )
 	);
-
-	// Request the site for the redux store
-	useEffect( () => {
-		if ( siteSlugOrId ) {
-			dispatch( requestSite( siteSlugOrId ) );
-		}
-	}, [ siteSlugOrId ] );
 
 	return {
 		canManageOptions,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* The calypso_signup_step_start event won't be fired if the site is not available in the redux store. As a result, request the site for the redux store inside the `useSite` hook to fire the calypso_signup_step_start event

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup/assembler-first flow
* When you land on the Assembler step, make sure the `calypso_signup_step_start` is fired

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?