### PR TITLE
Fix Stats summary page header navigation styles

### DIFF
--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -343,7 +343,7 @@ class StatsSummary extends Component {
 					path={ `/stats/${ period }/${ module }/:site` }
 					title={ `Stats > ${ titlecase( period ) } > ${ titlecase( module ) }` }
 				/>
-				<NavigationHeader navigationItems={ navigationItems } />
+				<NavigationHeader className="stats-summary-view" navigationItems={ navigationItems } />
 
 				<div id="my-stats-content" className="stats-summary-view stats-summary__positioned">
 					{ summaryViews }

--- a/client/my-sites/stats/summary/style.scss
+++ b/client/my-sites/stats/summary/style.scss
@@ -8,6 +8,12 @@
 		}
 	}
 
+	&.navigation-header {
+		@media ( min-width: 661px ) and ( max-width: 1380px ) {
+			padding: 0 32px 24px 32px;
+		}
+	}
+
 	tbody tr:nth-child(odd),
 	.is-fixed-row-header tbody > tr:nth-child(odd) > th {
 		background-color: var(--studio-gray-0);


### PR DESCRIPTION
## Proposed Changes

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/ed7fd724-7816-47a7-a2b7-6a6ecbf9fdfb">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/8b6f21d5-17ec-4057-a97c-0613b9c7c428">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /stats with `?flags=stats/paid-wpcom-v2` attached to the end of the url
* Click on "View details" or "View all" in `Posts & pages` or `Countries`
* Check the layout on different screen sizes

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?