### PR TITLE
Popup Login: Add current query to signup url

### DIFF
--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -337,7 +337,7 @@ export class Login extends Component {
 			locale,
 			oauth2Client,
 			pathname,
-			query,
+			currentQuery,
 			translate,
 			usernameOrEmail,
 		} = this.props;
@@ -346,8 +346,8 @@ export class Login extends Component {
 			return null;
 		}
 
-		if ( isP2Login && query?.redirect_to ) {
-			const urlParts = getUrlParts( query.redirect_to );
+		if ( isP2Login && currentQuery?.redirect_to ) {
+			const urlParts = getUrlParts( currentQuery.redirect_to );
 			if ( urlParts.pathname.startsWith( '/accept-invite/' ) ) {
 				return null;
 			}
@@ -356,7 +356,7 @@ export class Login extends Component {
 		// use '?signup_url' if explicitly passed as URL query param
 		const signupUrl = this.props.signupUrl
 			? window.location.origin + pathWithLeadingSlash( this.props.signupUrl )
-			: getSignupUrl( query, currentRoute, oauth2Client, locale, pathname );
+			: getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname );
 
 		return (
 			<a


### PR DESCRIPTION
If you try to like a post while logged out, the login popup will open.
If you click `Create an account`, you will get to the signup page, but without the query parameters. And it this case, the flow continues until the launchpad, without closing the popup and liking the post.

This PR fixes this.

## Testing

1. Open a blog post while logged out, and click like.
2. Open the developer console in the popup and set the popup to use `calypso.localhost:3000` (window.location.href)
3. Create an account and complete the onboarding