### PR TITLE
Editor "Add a page" modal: fix for text overlapping on the page patterns preview on classic themes

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -39,6 +39,7 @@ class Starter_Page_Templates {
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_assets' ) );
 		add_action( 'delete_attachment', array( $this, 'clear_sideloaded_image_cache' ) );
 		add_action( 'switch_theme', array( $this, 'clear_templates_cache' ) );
+		add_action( 'block_editor_settings_all', array( $this, 'add_default_editor_styles_for_classic_themes' ), 10, 2 );
 	}
 
 	/**
@@ -399,5 +400,37 @@ class Starter_Page_Templates {
 		}
 
 		return $registered_categories;
+	}
+
+	/**
+	 * Fix for text overlapping on the page patterns preview on classic themes.
+	 *
+	 * @param object $editor_settings Editor settings.
+	 * @param object $editor_context  Editor context.
+	 *
+	 * Only for classic themes because the default styles for block themes include a line-height for the body.
+	 * This issue would not exist if the WordPress wp-admin common.css for the body element (line-height: 1.4em)
+	 * does not overwrite the Gutenberg block-library reset.css for .editor-styles-wrapper (line-height: normal).
+	 *
+	 * This fix adds the default editor styles as custom styles in the editor settings. These are used in the
+	 * editor canvas (.editor-styles-wrapper) and pattern previews (BlockPreview).
+	 * Custom styles are safe because they are overwritten by local block styles, global styles, or theme stylesheets.
+	 **/
+	public function add_default_editor_styles_for_classic_themes( $editor_settings, $editor_context ) {
+		$theme = wp_get_theme( normalize_theme_slug( get_stylesheet() ) );
+		if ( $theme->is_block_theme() ) {
+			// Only for classic themes
+			return $editor_settings;
+		}
+		if ( 'core/edit-post' !== $editor_context->name || 'page' !== $editor_context->post->post_type ) {
+			// Only for page editor
+			return $editor_settings;
+		}
+		$default_editor_styles_file  = gutenberg_dir_path() . 'build/block-editor/default-editor-styles.css';
+		$default_editor_styles       = file_get_contents( $default_editor_styles_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		$editor_settings['styles'][] = array(
+			'css' => $default_editor_styles,
+		);
+		return $editor_settings;
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -426,7 +426,10 @@ class Starter_Page_Templates {
 			// Only for page editor
 			return $editor_settings;
 		}
-		$default_editor_styles_file  = gutenberg_dir_path() . 'build/block-editor/default-editor-styles.css';
+		$default_editor_styles_file = gutenberg_dir_path() . 'build/block-editor/default-editor-styles.css';
+		if ( ! file_exists( $default_editor_styles_file ) ) {
+			return $editor_settings;
+		}
 		$default_editor_styles       = file_get_contents( $default_editor_styles_file ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
 		$editor_settings['styles'][] = array(
 			'css' => $default_editor_styles,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Related p1703242322606439-slack-C9EJ7KSGH

## Proposed Changes

* Add the [default editor styles](https://github.com/WordPress/gutenberg/blob/1129dcf586535923708055adc67c924685bcad5c/packages/block-editor/src/default-editor-styles.scss) as custom styles in the editor settings.
  * The default styles include `line-height: 1.5` for the body

> [!NOTE]
> This solution assumes the issue can exist on other classic themes that don't enqueue a stylesheet for the editor, including a line-height for the body. I think that case might be rare.
>
> We could also exclusively fix the theme "automattic-2011" (where the issue has been reported) by creating a stylesheet for the editor, including a `line-height` for the body. See how Lodestar does that in fbhepr%2Skers%2Sjcpbz%2Qcho%2Qgurzrf%2Sybqrfgne%2Sshapgvbaf.cuc%3Se%3Q863n5p2o%23325-og 
>
> Read more about [Enqueueing assets in the Editor](https://developer.wordpress.org/block-editor/how-to-guides/enqueueing-assets-in-the-editor)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox automattic.wordpress.com
* Patch this diff with `install-plugin.sh etk fix/page-patterns-modal-previews-classic-themes`
* Visit https://automattic.wordpress.com/wp-admin/post-new.php?post_type=page
* Click "Blog" category and verify you don't see the text overlapping

Test on Atomic:
- Download the ETK from Teamcity
- Deactivate ETK on your atomic site
- Install the ETK
- Using any theme (I still haven't searched to find a classic theme without editor styles)
- Add a new page and verify that the modal works as expected and you can insert a page pattern
- Add a new post and verify that the editor works as expected

|BEFORE|AFTER|
|--|--|
|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/f9ce64d6-caba-46e1-9c96-460e16fac182">|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/83c45f25-3223-4398-a458-012597154793">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?