### PR TITLE
Code style: Remove duplicated style declaration

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/style.scss
@@ -2,10 +2,6 @@
 @import "@wordpress/base-styles/breakpoints";
 
 body.is-section-plans.is-expired-ecommerce-trial-plan {
-	.layout__content {
-		padding-left: 0 !important;
-	}
-
 	&.color-scheme {
 		--color-surface-backdrop: var(--color-surface);
 	}


### PR DESCRIPTION
## Proposed Changes

The PR https://github.com/Automattic/wp-calypso/pull/85104 introduces changes that have been introduced elsewhere in the meantime. Since the PR wasn't been rebased, these changes were merged without any failures.

The current PR removes the duplication, making the https://github.com/Automattic/wp-calypso/pull/85763 code style check pass again.

## Testing Instructions

Verify that the `/plans/my-plan/trial-expired/%s` page still has content centralized.