### PR TITLE
Fix Woo Express free trial themes banner link

### DIFF
--- a/client/my-sites/themes/single-site-jetpack.jsx
+++ b/client/my-sites/themes/single-site-jetpack.jsx
@@ -41,7 +41,6 @@ const ConnectedSingleSiteJetpack = connectOptions( ( props ) => {
 					className="themes__showcase-banner"
 					event="calypso_themes_list_install_themes"
 					feature={ FEATURE_UPLOAD_THEMES }
-					plan={ PLAN_ECOMMERCE }
 					title={ translate( 'Upgrade to a plan to upload your own themes!' ) }
 					callToAction={ translate( 'Upgrade now' ) }
 					showIcon={ true }


### PR DESCRIPTION
Related to #85814.

I wasn't sure what was the root cause of having `plan=ecommerce-bundle` URL parameter in the plans page causing it to show WPCOM default plans. Removing it seems apt to me since:

1. There is precedence of not having the plan link with other upgrade buttons. Thus if not having the parameter is really an issue, we should fix all upgrade buttons instead.
2. The parameter doesn't seem to do anything visible in the first place.
3. It will only impact Woo Express free trial plan sites.

## Proposed Changes

- Fixes upsell banner link in themes screen for Woo Express free trial sites to show Woo Express plans

## Testing Instructions

* Use site with active Woo Express free trial plan, or create new with the NUX flow https://woo.com/start
* Go to Appearance > Themes
* Observe the [upsell banner](https://github.com/Automattic/wp-calypso/assets/3747241/a5c05f29-9435-4880-b269-1ca3b62aca26) is shown and click on `Upgrade now`
* Observe that you're redirected to the plans screen with [Woo Express plans](https://github.com/Automattic/wp-calypso/assets/3747241/52e1d63f-76c9-4d4a-a074-e5423b9bb287) (Performance, Essential)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
