### PR TITLE
Migration flow: Remove FTP option from credential form in migration flow

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/pre-migration/credentials-form.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/credentials-form.tsx
@@ -7,6 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import CredentialsFormAdvanced from 'calypso/components/advanced-credentials/credentials-form';
 import {
 	FormMode,
+	FormState,
 	INITIAL_FORM_ERRORS,
 	INITIAL_FORM_STATE,
 	validate,
@@ -28,14 +29,20 @@ interface Props {
 	selectedHost: string;
 	migrationTrackingProps: StartImportTrackingProps;
 	onChangeProtocol: ( protocol: CredentialsProtocol ) => void;
+	allowFtp?: boolean;
 }
 
 export const CredentialsForm: React.FunctionComponent< Props > = ( props ) => {
-	const { sourceSite, targetSite, migrationTrackingProps, startImport } = props;
+	const { sourceSite, targetSite, migrationTrackingProps, startImport, allowFtp } = props;
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const { hostname } = new URL( sourceSite.URL );
-	const [ formState, setFormState ] = useState( { ...INITIAL_FORM_STATE, host: hostname } );
+	const [ formState, setFormState ] = useState( {
+		...INITIAL_FORM_STATE,
+		host: hostname,
+		protocol: 'ssh',
+		port: 22,
+	} as FormState );
 	const [ formErrors, setFormErrors ] = useState( INITIAL_FORM_ERRORS );
 	const [ formMode, setFormMode ] = useState( FormMode.Password );
 	const [ hasMissingFields, setHasMissingFields ] = useState( false );
@@ -190,6 +197,7 @@ export const CredentialsForm: React.FunctionComponent< Props > = ( props ) => {
 					onFormStateChange={ setFormState }
 					onModeChange={ setFormMode }
 					withHeader={ false }
+					allowFtp={ allowFtp }
 				/>
 
 				{ updateError && (

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/credentials-form.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/credentials-form.tsx
@@ -40,8 +40,7 @@ export const CredentialsForm: React.FunctionComponent< Props > = ( props ) => {
 	const [ formState, setFormState ] = useState( {
 		...INITIAL_FORM_STATE,
 		host: hostname,
-		protocol: 'ssh',
-		port: 22,
+		...( ! allowFtp ? { protocol: 'ssh', port: 22 } : {} ),
 	} as FormState );
 	const [ formErrors, setFormErrors ] = useState( INITIAL_FORM_ERRORS );
 	const [ formMode, setFormMode ] = useState( FormMode.Password );

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/credentials.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/credentials.tsx
@@ -11,13 +11,16 @@ interface Props {
 	targetSite: SiteDetails;
 	migrationTrackingProps: StartImportTrackingProps;
 	startImport: ( props?: StartImportTrackingProps ) => void;
+	allowFtp: boolean;
 }
 
 export function Credentials( props: Props ) {
 	const translate = useTranslate();
-	const { sourceSite, targetSite, migrationTrackingProps, startImport } = props;
+	const { sourceSite, targetSite, migrationTrackingProps, startImport, allowFtp } = props;
 	const [ selectedHost, setSelectedHost ] = useState( 'generic' );
-	const [ selectedProtocol, setSelectedProtocol ] = useState< 'ftp' | 'ssh' >( 'ssh' );
+	const [ selectedProtocol, setSelectedProtocol ] = useState< 'ftp' | 'ssh' >(
+		allowFtp ? 'ftp' : 'ssh'
+	);
 
 	const onChangeProtocol = ( protocol: 'ftp' | 'ssh' ) => {
 		setSelectedProtocol( protocol );
@@ -46,7 +49,7 @@ export function Credentials( props: Props ) {
 						selectedHost={ selectedHost }
 						migrationTrackingProps={ migrationTrackingProps }
 						onChangeProtocol={ onChangeProtocol }
-						allowFtp={ false }
+						allowFtp={ allowFtp }
 					/>
 				</div>
 				<div className="pre-migration__credentials-help">

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/credentials.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/credentials.tsx
@@ -17,7 +17,7 @@ export function Credentials( props: Props ) {
 	const translate = useTranslate();
 	const { sourceSite, targetSite, migrationTrackingProps, startImport } = props;
 	const [ selectedHost, setSelectedHost ] = useState( 'generic' );
-	const [ selectedProtocol, setSelectedProtocol ] = useState< 'ftp' | 'ssh' >( 'ftp' );
+	const [ selectedProtocol, setSelectedProtocol ] = useState< 'ftp' | 'ssh' >( 'ssh' );
 
 	const onChangeProtocol = ( protocol: 'ftp' | 'ssh' ) => {
 		setSelectedProtocol( protocol );
@@ -46,6 +46,7 @@ export function Credentials( props: Props ) {
 						selectedHost={ selectedHost }
 						migrationTrackingProps={ migrationTrackingProps }
 						onChangeProtocol={ onChangeProtocol }
+						allowFtp={ false }
 					/>
 				</div>
 				<div className="pre-migration__credentials-help">

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -206,6 +206,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 					targetSite={ targetSite }
 					migrationTrackingProps={ migrationTrackingProps }
 					startImport={ startImport }
+					allowFtp={ false }
 				/>
 			);
 

--- a/client/components/advanced-credentials/credentials-form/index.tsx
+++ b/client/components/advanced-credentials/credentials-form/index.tsx
@@ -29,6 +29,7 @@ interface Props {
 	role: string;
 	withHeader?: boolean;
 	children?: React.ReactNode;
+	allowFtp?: boolean;
 }
 
 const ServerCredentialsForm: FunctionComponent< Props > = ( {
@@ -42,6 +43,7 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 	host,
 	role = 'main',
 	withHeader = true,
+	allowFtp = true,
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -303,6 +305,13 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 		return translate( 'Your hosting provider will be able to supply this information to you.' );
 	};
 
+	const getFormHeaderText = () => {
+		if ( ! allowFtp ) {
+			return translate( 'Provide your SSH, SFTP server credentials' );
+		}
+		return translate( 'Provide your SSH, SFTP or FTP server credentials' );
+	};
+
 	const renderCredentialLinks = () => {
 		if ( hostInfo !== null && hostInfo.credentialLinks !== undefined ) {
 			if ( 'ftp' === formState.protocol && hostInfo.credentialLinks.ftp !== undefined ) {
@@ -386,9 +395,7 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 						) }
 				</FormFieldset>
 			) }
-			{ ! isAlternate && withHeader && (
-				<h3>{ translate( 'Provide your SSH, SFTP or FTP server credentials' ) }</h3>
-			) }
+			{ ! isAlternate && withHeader && <h3>{ getFormHeaderText() }</h3> }
 			{ withHeader && <p className="credentials-form__intro-text">{ getSubHeaderText() }</p> }
 			{ withHeader && renderCredentialLinks() }
 			<FormFieldset className="credentials-form__protocol-type">
@@ -412,7 +419,7 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 					onChange={ handleFormChange }
 					disabled={ disabled }
 				>
-					<option value="ftp">{ translate( 'FTP' ) }</option>
+					{ allowFtp && <option value="ftp">{ translate( 'FTP' ) }</option> }
 					<option value="ssh">{ translate( 'SSH/SFTP' ) }</option>
 				</FormSelect>
 			</FormFieldset>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/85704

## Proposed Changes

* Remove options for providing FTP credentials from the credential form screen (as this has no appreciable effect on performance).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `http://calypso.localhost:3000/setup/import-focused/import?siteSlug=ATOMIC_SITE_SLUG`
* Fill in a source site you'd like to migrate from, it can be a JN site.
* Make the Jetpack connection if needed and once you land on the `You are ready to migrate` screen, click `Provide the server credentials` link.
* Make sure you see SSH/SFTP as the default credential type in the form.
* Make sure the port number is `22`.
* When you select credential type dropdown, there will be no FTP option.

<img width="988" alt="Screen Shot 2023-12-28 at 3 27 30 PM" src="https://github.com/Automattic/wp-calypso/assets/4074459/a52fb1dc-b6b0-41f2-a819-0e05cc5134fb">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?