### PR TITLE
Assembler: Disallow large preview scaling beyond 100%

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -13,6 +13,12 @@
 	box-sizing: border-box;
 	z-index: 1;
 	transition: margin-inline-start 0.2s ease-out;
+
+	&.device-switcher__container--is-computer:has(.pattern-large-preview__placeholder) {
+		.device-switcher__frame {
+			max-width: 1080px;
+		}
+	}
 }
 
 .pattern-large-preview__patterns {

--- a/packages/components/src/device-switcher/fixed-viewport.tsx
+++ b/packages/components/src/device-switcher/fixed-viewport.tsx
@@ -25,7 +25,7 @@ export const useViewportScale = ( device: string, viewportWidth: number ) => {
 		width = deviceWidth;
 	}
 
-	return width / deviceWidth;
+	return Math.min( width / deviceWidth, 1 );
 };
 
 interface Props {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85317

## Proposed Changes

This PR sets a maximum scale to the large preview so that it doesn't scale beyond 100%.

| Before | After |
| --- | --- |
| <img width="1716" alt="Screenshot 2023-12-28 at 4 39 45 PM" src="https://github.com/Automattic/wp-calypso/assets/797888/575a1558-d83f-49c0-a1c9-eca29553d6d7"> | <img width="1715" alt="Screenshot 2023-12-28 at 4 38 48 PM" src="https://github.com/Automattic/wp-calypso/assets/797888/47b21130-12de-44c4-a907-0a4c3cf71a83"> |
<img width="1715" alt="Screenshot 2023-12-28 at 4 39 29 PM" src="https://github.com/Automattic/wp-calypso/assets/797888/d99d8ec7-1377-4405-9077-a8bf4690fbda"> | <img width="1717" alt="Screenshot 2023-12-28 at 4 39 06 PM" src="https://github.com/Automattic/wp-calypso/assets/797888/bc2fee6b-97bb-4933-a7fb-4dc794205128">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a wide monitor.
* Head to the Assembler.
* Ensure that the large preview placeholder in the desktop viewport has a width of 1080px. 
* Select any patterns.
* Ensure that the large preview width never exceeds its viewport of 1080px.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?