### PR TITLE
Tracks Super Props: Revert log for path type and add a check

### DIFF
--- a/client/lib/analytics/utils/should-report-omit-blog-id.js
+++ b/client/lib/analytics/utils/should-report-omit-blog-id.js
@@ -1,4 +1,3 @@
-import { withScope, captureMessage } from '@automattic/calypso-sentry';
 import { getSiteFragment } from 'calypso/lib/route';
 
 const SITE_FRAGMENT_REGEX = /\/(:site|:site_id|:siteid|:blogid|:blog_id|:siteslug)(\/|$|\?)/i;
@@ -12,19 +11,13 @@ const SITE_FRAGMENT_REGEX = /\/(:site|:site_id|:siteid|:blogid|:blog_id|:siteslu
  * @returns {boolean} If the report should null `blog_id`.
  */
 export default ( path ) => {
-	if ( ! path ) {
+	// Path could be a number but it should not. See Sentry issue with ID 4645035069
+	if ( typeof path !== 'string' ) {
 		return true;
 	}
 
 	if ( SITE_FRAGMENT_REGEX.test( path ) ) {
 		return false;
-	}
-
-	if ( typeof path !== 'string' ) {
-		withScope( ( scope ) => {
-			scope.setTag( 'path', path );
-			captureMessage( 'Path is not a string' );
-		} );
 	}
 
 	// Stepper routes start with /setup/, and might contain site slug or ID via URL parameters.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #84441 

## Proposed Changes

* Remove Sentry log
* Add a check for `string` path type

>[!NOTE]
> This [error](https://a8c.sentry.io/issues/4645035069/events/f9fd355a4d544901a83c24fc7c9168a3/) has not been reproduced (or reported in Sentry) since December 4, which makes me guess that there was a bug that has been fixed by us because the error doesn't look specific to any browser, OS, or site.
>
> We added a [log](https://a8c.sentry.io/issues/4664461948/events/090c869f376040b98283934c87956dea/) to know more about the type of path and the answer is a "random" [number](https://a8c.sentry.io/issues/4664461948/tags/path/?referrer=tag-distribution-meter) between 1 and 103, which sounds like a counter.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?