### PR TITLE
ToS screenshots: Fix timeout error for checkout screenshots

### DIFF
--- a/test/e2e/specs/martech/tos-screenshots__checkout.ts
+++ b/test/e2e/specs/martech/tos-screenshots__checkout.ts
@@ -33,7 +33,7 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 		restAPIClient = new RestAPIClient( SecretsManager.secrets.testAccounts.martechTosUser );
 
 		await restAPIClient.setMySettings( { language: 'en' } );
-		await page.reload( { waitUntil: 'networkidle', timeout: EXTENDED_TIMEOUT } );
+		await page.reload( { waitUntil: 'domcontentloaded', timeout: EXTENDED_TIMEOUT } );
 	} );
 
 	it( 'Navigate to Upgrades > Plans', async function () {
@@ -57,7 +57,7 @@ describe( DataHelper.createSuiteTitle( 'ToS acceptance tracking screenshots' ), 
 				cartCheckoutPage = new CartCheckoutPage( page );
 
 				await restAPIClient.setMySettings( { language: locale } );
-				await page.reload( { waitUntil: 'networkidle', timeout: EXTENDED_TIMEOUT } );
+				await page.reload( { waitUntil: 'domcontentloaded', timeout: EXTENDED_TIMEOUT } );
 			} );
 
 			it( `Screenshot checkout page for ${ locale }`, async function () {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* The checkout page screenshots have been consistently timing out as reported in p1703710916248949-Slack-C0313NGSK8R. 
* The [error](https://teamcity.a8c.com/buildConfiguration/calypso_ToSAcceptanceTracking/11534480?buildTab=log&linesState=228.279.307.308.315.319.320&logView=flowAware&focusLine=410) points to a timeout error:
<img width="937" alt="Screenshot 2023-12-28 at 12 56 32 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/7688ecb2-f0fd-4103-b0aa-0c31fdb3d3c0">

* This patch fixes it by changing `networkidle` (which is not recommended) to `domcontentloaded`.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Decrypt the secret file as per the instructions in the FG page PCYsg-vnR.
* In tests/e2e folder run `yarn workspace wp-e2e-tests build --watch`.
* In tests/e2e folder, run the checkout spec `BABEL_ENV=test yarn jest specs/martech/tos-screenshots__checkout.ts`.
* Verify that all the screenshots are taken (check the tests/e2e folder in your local computer).
* The file upload will not work since your computer is not in the A8C IP range. If you also want to test file uploads, then sandbox public-api.wordpress.com and comment out the checks for the IP range in the file upload endpoint.

