### PR TITLE
Trigger paid stats upsell modal for do-you-love-jetpack-stats-notice

### DIFF
--- a/client/my-sites/stats/constants.ts
+++ b/client/my-sites/stats/constants.ts
@@ -60,3 +60,6 @@ export const STATS_FEATURE_SUMMARY_LINKS_30_DAYS = 'StatsModuleSummaryLinks/30_d
 export const STATS_FEATURE_SUMMARY_LINKS_QUARTER = 'StatsModuleSummaryLinks/quarter';
 export const STATS_FEATURE_SUMMARY_LINKS_YEAR = 'StatsModuleSummaryLinks/year';
 export const STATS_FEATURE_SUMMARY_LINKS_ALL = 'StatsModuleSummaryLinks/all';
+
+// other
+export const STATS_DO_YOU_LOVE_JETPACK_STATS_NOTICE = 'DoYouLoveJetpackStatsNotice';

--- a/client/state/stats/paid-stats-upsell/actions.ts
+++ b/client/state/stats/paid-stats-upsell/actions.ts
@@ -9,7 +9,7 @@ import 'calypso/state/stats/init';
  * @returns {Object} Action object
  */
 
-export function toggleUpsellModal( siteId: number, statType: string ) {
+export function toggleUpsellModal( siteId: number | null, statType: string ) {
 	return {
 		type: STATS_PAID_STATS_UPSELL_MODAL_TOGGLE,
 		siteId,


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4915

## Proposed Changes

https://github.com/Automattic/wp-calypso/assets/6586048/2b8b603e-f97e-447e-b87d-b4099ca31822

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /stats with `?flags=stats/paid-wpcom-v2` attached to the end of the url
* Click on the banner
* Upsell modal should pop up
* You should not be getting this banner for Jetpack sites, only the copy is different so the largest behavior difference is clicking on the button will redirect to Jetpack's PWYW screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?