### PR TITLE
Marketplace Reviews: Navigate to Reviews section

### DIFF
--- a/client/my-sites/marketplace/components/reviews-cards/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-cards/index.tsx
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { forwardRef } from 'react';
 import { useSelector } from 'react-redux';
 import {
 	useMarketplaceReviewsQuery,
@@ -12,65 +13,71 @@ import './style.scss';
 
 type MarketplaceReviewsCardsProps = { showMarketplaceReviews?: () => void } & ProductProps;
 
-export const MarketplaceReviewsCards = ( props: MarketplaceReviewsCardsProps ) => {
-	const translate = useTranslate();
-	const currentUserId = useSelector( getCurrentUserId );
-	const { data: userReviews = [] } = useMarketplaceReviewsQuery( {
-		...props,
-		perPage: 1,
-		author: currentUserId ?? undefined,
-	} );
-	const { data: reviews, error } = useMarketplaceReviewsQuery( { ...props, perPage: 2, page: 1 } );
+export const MarketplaceReviewsCards = forwardRef< HTMLDivElement, MarketplaceReviewsCardsProps >(
+	( props, ref ) => {
+		const translate = useTranslate();
+		const currentUserId = useSelector( getCurrentUserId );
+		const { data: userReviews = [] } = useMarketplaceReviewsQuery( {
+			...props,
+			perPage: 1,
+			author: currentUserId ?? undefined,
+		} );
+		const { data: reviews, error } = useMarketplaceReviewsQuery( {
+			...props,
+			perPage: 2,
+			page: 1,
+		} );
 
-	if ( ! isEnabled( 'marketplace-reviews-show' ) ) {
-		return null;
-	}
+		if ( ! isEnabled( 'marketplace-reviews-show' ) ) {
+			return null;
+		}
 
-	if ( ! Array.isArray( reviews ) || error ) {
-		return null;
-	}
+		if ( ! Array.isArray( reviews ) || error ) {
+			return null;
+		}
 
-	const hasReview = userReviews.length > 0;
-	const addLeaveAReviewCard = ! hasReview && reviews.length < 2;
+		const hasReview = userReviews.length > 0;
+		const addLeaveAReviewCard = ! hasReview && reviews.length < 2;
 
-	const addEmptyCard = reviews.length === 0;
+		const addEmptyCard = reviews.length === 0;
 
-	return (
-		<div className="marketplace-reviews-cards__container">
-			<div className="marketplace-reviews-cards__reviews">
-				<h2 className="marketplace-reviews-cards__reviews-title">
-					{ translate( 'Customer reviews' ) }
-				</h2>
-				<h3 className="marketplace-reviews-cards__reviews-subtitle">
-					{ translate( 'What other users are saying' ) }
-				</h3>
+		return (
+			<div ref={ ref } className="marketplace-reviews-cards__container">
+				<div className="marketplace-reviews-cards__reviews">
+					<h2 className="marketplace-reviews-cards__reviews-title">
+						{ translate( 'Customer reviews' ) }
+					</h2>
+					<h3 className="marketplace-reviews-cards__reviews-subtitle">
+						{ translate( 'What other users are saying' ) }
+					</h3>
 
-				<div className="marketplace-reviews-cards__read-all">
-					<Button
-						className="is-link"
-						borderless
-						primary
-						onClick={ () => props.showMarketplaceReviews && props.showMarketplaceReviews() }
-						href=""
-					>
-						{ translate( 'Read all reviews' ) }
-					</Button>
+					<div className="marketplace-reviews-cards__read-all">
+						<Button
+							className="is-link"
+							borderless
+							primary
+							onClick={ () => props.showMarketplaceReviews && props.showMarketplaceReviews() }
+							href=""
+						>
+							{ translate( 'Read all reviews' ) }
+						</Button>
+					</div>
+				</div>
+
+				<div className="marketplace-reviews-cards__content">
+					{ reviews.map( ( review ) => (
+						<MarketplaceReviewCard review={ review } key={ review.id } />
+					) ) }
+					{ addEmptyCard && <MarketplaceReviewCard empty={ true } key="empty-card" /> }
+					{ addLeaveAReviewCard && (
+						<MarketplaceReviewCard
+							leaveAReview={ true }
+							key="leave-a-review-card"
+							showMarketplaceReviews={ props.showMarketplaceReviews }
+						/>
+					) }
 				</div>
 			</div>
-
-			<div className="marketplace-reviews-cards__content">
-				{ reviews.map( ( review ) => (
-					<MarketplaceReviewCard review={ review } key={ review.id } />
-				) ) }
-				{ addEmptyCard && <MarketplaceReviewCard empty={ true } key="empty-card" /> }
-				{ addLeaveAReviewCard && (
-					<MarketplaceReviewCard
-						leaveAReview={ true }
-						key="leave-a-review-card"
-						showMarketplaceReviews={ props.showMarketplaceReviews }
-					/>
-				) }
-			</div>
-		</div>
-	);
-};
+		);
+	}
+);

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -475,6 +475,7 @@ function PluginDetails( props ) {
 						slug={ fullPlugin.slug }
 						productType="plugin"
 						showMarketplaceReviews={ () => setIsReviewsModalVisible( true ) }
+						ref={ reviewsListRef }
 					/>
 				</div>
 			) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add a ref to the new Reviews section
* Use that ref to navigate to the Reviews when clicking the link

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In an environment with the `marketplace-reviews-show` flag enabled, e.g. `wpcalypso.wordpress.com/plugins`
* Navigate to any plugin that has some reviews
* Click on the `X Review` hyperlink
* Make sure the window scrolls to the Reviews section

![CleanShot 2023-12-28 at 10 56 04@2x](https://github.com/Automattic/wp-calypso/assets/3519124/e2f30203-315c-4e2b-b47d-541e48084cc7)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?