### PR TITLE
Marketplace: adds styles to delete review flow.

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -227,6 +227,7 @@ $z-layers: (
 		".editor-media-modal .section-nav": 10,
 		".editor-media-modal .notice": 10,
 		".editor-media-modal-gallery__preview-toggle": 100,
+		".confirm-modal": 100300,
 		".memberships__dialog-section.is-visible": 2,
 	),
 	".site-settings__taxonomies": (

--- a/client/data/marketplace/use-marketplace-reviews.ts
+++ b/client/data/marketplace/use-marketplace-reviews.ts
@@ -300,12 +300,31 @@ export const useUpdateMarketplaceReviewMutation = () => {
 	} );
 };
 
-export const useDeleteMarketplaceReviewMutation = () => {
+export const useDeleteMarketplaceReviewMutation = ( {
+	productType,
+	slug,
+	page,
+	perPage,
+	author,
+	author_exclude,
+}: MarketplaceReviewsQueryProps ) => {
 	const queryClient = useQueryClient();
+	const queryKey: QueryKey = [
+		queryKeyBase,
+		productType,
+		slug,
+		author,
+		author_exclude,
+		page,
+		perPage,
+	];
 	return useMutation( {
 		mutationFn: deleteReview,
 		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: queryKeyBase } );
+			queryClient.invalidateQueries( { queryKey } );
+		},
+		onError: ( error: Error ) => {
+			alert( error.message );
 		},
 	} );
 };

--- a/client/my-sites/marketplace/components/reviews-list/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-list/index.tsx
@@ -29,20 +29,20 @@ export const MarketplaceReviewsList = ( props: MarketplaceReviewsQueryProps ) =>
 	} );
 	const reviews = data?.pages.flatMap( ( page ) => page.data );
 
-	const { data: userReviews = [], refetch: userReviewsRefetch } = useMarketplaceReviewsQuery( {
+	const { data: userReviews = [] } = useMarketplaceReviewsQuery( {
 		...props,
 		perPage: 1,
 		author: currentUserId ?? undefined,
 	} );
 
-	const deleteReviewMutation = useDeleteMarketplaceReviewMutation();
+	const deleteReviewMutation = useDeleteMarketplaceReviewMutation( {
+		...props,
+		perPage: 1,
+		author: currentUserId ?? undefined,
+	} );
 	const deleteReview = ( reviewId: number ) => {
 		setIsConfirmModalVisible( false );
-		deleteReviewMutation.mutate( {
-			reviewId: reviewId,
-		} );
-		userReviewsRefetch();
-		deleteReviewMutation?.isError && alert( ( deleteReviewMutation.error as Error ).message );
+		deleteReviewMutation.mutate( { reviewId: reviewId } );
 	};
 
 	if ( ! isEnabled( 'marketplace-reviews-show' ) ) {

--- a/client/my-sites/marketplace/components/reviews-list/style.scss
+++ b/client/my-sites/marketplace/components/reviews-list/style.scss
@@ -102,6 +102,13 @@ $border-color: #eee;
 			color: var(--studio-blue-50);
 			margin-right: 15px;
 			cursor: pointer;
+			display: flex;
+			align-items: center;
+		}
+
+		.gridicon {
+			margin-right: 5px;
+			color: var(--studio-gray-10);
 		}
 	}
 }
@@ -132,4 +139,8 @@ $border-color: #eee;
 		font-size: $font-body-small;
 		max-width: 400px;
 	}
+}
+
+.confirm-modal {
+	z-index: z-index(".dialog__backdrop", ".confirm-modal");
 }

--- a/client/my-sites/marketplace/pages/marketplace-test/index.jsx
+++ b/client/my-sites/marketplace/pages/marketplace-test/index.jsx
@@ -26,6 +26,7 @@ import {
 	requestEligibility,
 } from 'calypso/state/automated-transfer/actions';
 import { getAutomatedTransfer, getEligibility } from 'calypso/state/automated-transfer/selectors';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
 import {
 	getPluginOnSite,
@@ -54,6 +55,7 @@ export default function MarketplaceTest() {
 	const translate = useTranslate();
 
 	const selectedSite = useSelector( getSelectedSite );
+	const currentUserId = useSelector( getCurrentUserId );
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const isAtomicSite = useSelector( ( state ) => isSiteWpcomAtomic( state, selectedSiteId ?? 0 ) );
@@ -97,7 +99,11 @@ export default function MarketplaceTest() {
 
 	const createReview = useCreateMarketplaceReviewMutation();
 	const updateReview = useUpdateMarketplaceReviewMutation();
-	const deleteReview = useDeleteMarketplaceReviewMutation();
+	const deleteReview = useDeleteMarketplaceReviewMutation( {
+		productType: 'plugin',
+		perPage: 1,
+		author: currentUserId ?? undefined,
+	} );
 
 	const dispatch = useDispatch();
 	const transferDetails = useSelector( ( state ) => getAutomatedTransfer( state, selectedSiteId ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/3922

## Proposed Changes

* Adds icon
* Adds modal confirmation
* Updates the reviews list after deletion

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to http://calypso.localhost:3000/marketplace/test/[siteId]
- Leave a review
- Go to `woocommerce-bookings`
- Click read all reviews
- Check the styles of delete / update buttons
- Click Delete my Review
- Check that review is removed from the list

![CleanShot 2023-12-28 at 14 04 11](https://github.com/Automattic/wp-calypso/assets/12430020/2b51c01c-d614-497a-8794-73a58261ff2b)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?