### PR TITLE
Fix theme not set properly on Atomic after sensei onboarding

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/index.tsx
@@ -1,3 +1,4 @@
+import { setThemeOnSite } from '@automattic/onboarding';
 import { __ } from '@wordpress/i18n';
 import { useMemo } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -62,6 +63,12 @@ const SenseiLaunch: Step = ( { navigation: { submit } } ) => {
 			},
 			async function switchToDefaultAdminPanelView() {
 				await setAdminInterfaceStyle( siteId, 'wp-admin' );
+				return true;
+			},
+			async function refreshThemeOnAtomic() {
+				await wait( 1200 );
+				await setThemeOnSite( siteId.toString(), 'pub/twentytwentytwo' );
+				await setThemeOnSite( siteId.toString(), 'pub/course' );
 				return true;
 			},
 			async function done() {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/create-sensei-site.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/create-sensei-site.ts
@@ -114,7 +114,6 @@ export const useCreateSenseiSite = () => {
 			if ( styleVariation && userGlobalStylesId ) {
 				await updateGlobalStyles( siteId, userGlobalStylesId, styleVariation );
 			}
-			wait( 1200 );
 		}
 		setProgress( {
 			percentage: 100,

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -166,7 +166,6 @@ export function* createSenseiSite( {
 			lang_id: lang_id,
 			site_creation_flow: 'sensei',
 			enable_fse: true,
-			theme: 'pub/course',
 			timezone_string: guessTimezone(),
 			...( selectedDesign?.template && { template: selectedDesign.template } ),
 			...( selectedFonts && {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/85107

## Proposed Changes

As per the issue, I first tried to change the URL of the task to edit the menu bar to the new URL for FSE themes in this part of code - https://github.com/Automattic/wp-calypso/blob/d024a412e86dc64b0320777072e2f9cae9966a7d/client/my-sites/customer-home/cards/tasks/site-setup-list/index.jsx#L353-L385. But it wasn't working, and I found out that `isFSEActive` is always being false for us in the frontend.

Looking into it, I found that the HOC that figures out the `isFSEActive` value, sends a call to the API `https://public-api.wordpress.com/wp/v2/sites/<site-id>/themes?status=active`, and for some reason, our site's backend is returning that there is active theme currently!!! I initially thought this could be just a delay issue, but after waiting a lot of time and testing in many sites, it still was null, our site's API was thinking that no theme is active. Even though the Course theme was installed.

After some more digging, I figured out that we first create the site as a simple site, and then we convert it to Jetpack site and then install our plugins. Even though the theme is transferred, it isn't properly updated and activated properly.

I tried all the different APIs to fix it. The only thing that worked for me was a theme switch, and then switch back. Once we switch the theme, it's properly set. If we call the aforementioned API after switching theme, it returns the active theme as expected!

The perfect solution would be to dig into the Jetpack transfer's code and figure out why theme isn't working perfectly, but for now for our specific case, I've added two calls to switch to another theme and get back to course, and that fixed the issue.

Now the second part - before the theme was properly set, even the backend didn't know which theme was currently active and if it is a block theme or not. But after our fix, now it knows. If you check wpcom's function `get_site_menu_updated_task` which is used for retrieving the task to set the menu, you'll see that this particular task is meant to be shown to only those sites that are not using a block theme, which makes sense as navbar setting makes more sense for non-block themes. So after we fixed the theme issue, we don't see the task anymore.

Personally I like it, because too many tasks generate friction, adding a task only when necessary and important makes more sense, and moreover, it's the default behavior. So we can keep it as it is after fixed, which is better than before, because we're not taking our users to wrong page and making them confused.

But if we choose to decide that we should add a task there for it, I think we can add a separate task or update the current task to be shown even for block themes, and add completion logics for it, and show it only when Sensei is installed so that we don't change the behaviors of other sites' tasklists that are not creating by sensei flow. But I'm not sure if that'd be too useful.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Disable any proxy first, so that you can replicate the flow fully from user's perspective
2. Switch to `trunk` first, keep the devtools in your browser open
3. Go to `http://calypso.localhost:3000/setup/sensei` and complete the setup
4. Find out the call to `https://public-api.wordpress.com/wp/v2/sites/<site-id>/themes?status=active` API in your network tab of devtool
5. Check that the reply to that call sent an empty theme as current active theme
6. Check that you have a task named "Customize your site menu"
7. Now switch to this branch
8. Go to `http://calypso.localhost:3000/setup/sensei` and complete the setup
9. Find out the API call as above
10. Make sure that this time it's returning the Course theme  as it should
11. Check that the task "Customize your site menu" is no longer there

![Screenshot 2023-12-28 at 7 15 36 PM](https://github.com/Automattic/wp-calypso/assets/6820724/5c662b22-0b53-483b-a900-840b4ad3bf53)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?