### PR TITLE
Tools/import page update; replace it with import onboarding flow

### DIFF
--- a/client/blocks/import/capture/index.tsx
+++ b/client/blocks/import/capture/index.tsx
@@ -69,7 +69,9 @@ export const CaptureStep: React.FunctionComponent< StepProps > = ( {
 		data: urlData,
 		isFetching: isAnalyzing,
 		error: analyzerError,
+		isFetchedAfterMount,
 	} = useAnalyzeUrlQuery( url );
+	const showCapture = ! isAnalyzing || ( initialUrl && isFetchedAfterMount );
 
 	const decideStepRedirect = () => {
 		if ( ! urlData ) {
@@ -145,7 +147,7 @@ export const CaptureStep: React.FunctionComponent< StepProps > = ( {
 
 	return (
 		<>
-			{ ! isAnalyzing && (
+			{ showCapture && (
 				<Capture
 					onInputEnter={ ( url ) => {
 						onValidFormSubmit ? onValidFormSubmit( { url } ) : setUrl( url );

--- a/client/blocks/import/capture/index.tsx
+++ b/client/blocks/import/capture/index.tsx
@@ -42,8 +42,10 @@ export const Capture: FunctionComponent< Props > = ( props ) => {
 };
 
 type StepProps = {
-	goToStep: GoToStep;
+	initialUrl?: string;
 	disableImportListStep?: boolean;
+	goToStep: GoToStep;
+	onValidFormSubmit?: ( dependencies: Record< string, unknown > ) => void;
 };
 
 const trackEventName = 'calypso_signup_step_start';
@@ -53,12 +55,14 @@ const trackEventParams = {
 };
 
 export const CaptureStep: React.FunctionComponent< StepProps > = ( {
-	goToStep,
+	initialUrl = '',
 	disableImportListStep,
+	goToStep,
+	onValidFormSubmit,
 } ) => {
 	const currentUser = useSelector( getCurrentUser );
 	const isStartingPointEventTriggeredRef = useRef( false );
-	const [ url, setUrl ] = useState( '' );
+	const [ url, setUrl ] = useState( initialUrl );
 	const {
 		data: urlData,
 		isFetching: isAnalyzing,
@@ -139,7 +143,9 @@ export const CaptureStep: React.FunctionComponent< StepProps > = ( {
 		<>
 			{ ! isAnalyzing && (
 				<Capture
-					onInputEnter={ setUrl }
+					onInputEnter={ ( url ) => {
+						onValidFormSubmit ? onValidFormSubmit( { url } ) : setUrl( url );
+					} }
 					onDontHaveSiteAddressClick={ onDontHaveSiteAddressClick }
 					hasError={ !! analyzerError }
 					onInputChange={ () => {

--- a/client/blocks/import/capture/index.tsx
+++ b/client/blocks/import/capture/index.tsx
@@ -46,6 +46,7 @@ type StepProps = {
 	disableImportListStep?: boolean;
 	goToStep: GoToStep;
 	onValidFormSubmit?: ( dependencies: Record< string, unknown > ) => void;
+	onImportListClick?: () => void;
 };
 
 const trackEventName = 'calypso_signup_step_start';
@@ -59,6 +60,7 @@ export const CaptureStep: React.FunctionComponent< StepProps > = ( {
 	disableImportListStep,
 	goToStep,
 	onValidFormSubmit,
+	onImportListClick,
 } ) => {
 	const currentUser = useSelector( getCurrentUser );
 	const isStartingPointEventTriggeredRef = useRef( false );
@@ -128,7 +130,9 @@ export const CaptureStep: React.FunctionComponent< StepProps > = ( {
 		}
 	};
 
-	const onDontHaveSiteAddressClick = disableImportListStep ? undefined : () => goToStep( 'list' );
+	const onDontHaveSiteAddressClick = () => {
+		onImportListClick ? onImportListClick() : goToStep( 'list' );
+	};
 
 	/**
 	 ↓ Effects
@@ -146,7 +150,9 @@ export const CaptureStep: React.FunctionComponent< StepProps > = ( {
 					onInputEnter={ ( url ) => {
 						onValidFormSubmit ? onValidFormSubmit( { url } ) : setUrl( url );
 					} }
-					onDontHaveSiteAddressClick={ onDontHaveSiteAddressClick }
+					onDontHaveSiteAddressClick={
+						disableImportListStep ? undefined : onDontHaveSiteAddressClick
+					}
 					hasError={ !! analyzerError }
 					onInputChange={ () => {
 						// resets the error when the user starts typing again

--- a/client/blocks/import/list/index.tsx
+++ b/client/blocks/import/list/index.tsx
@@ -1,5 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Button, FormLabel, SelectDropdown } from '@automattic/components';
+import { Button, Gridicon, FormLabel, SelectDropdown } from '@automattic/components';
 import { Title, SubTitle } from '@automattic/onboarding';
 import { chevronRight, Icon } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
@@ -24,11 +24,12 @@ interface Props {
 	siteSlug: string | null;
 	submit?: ( dependencies: Record< string, unknown > ) => void;
 	getFinalImporterUrl: ( siteSlug: string, fromSite: string, platform: ImporterPlatform ) => string;
+	onNavBack?: () => void;
 }
 
 export default function ListStep( props: Props ) {
 	const { __ } = useI18n();
-	const { siteSlug, submit, getFinalImporterUrl } = props;
+	const { siteSlug, submit, getFinalImporterUrl, onNavBack } = props;
 
 	const primaryListOptions: ImporterOption[] = [
 		{ value: 'wordpress', label: 'WordPress', icon: 'wordpress' },
@@ -60,6 +61,14 @@ export default function ListStep( props: Props ) {
 
 	return (
 		<>
+			{ onNavBack && (
+				<div className="import__navigation">
+					<Button onClick={ onNavBack } borderless={ true } type="button">
+						<Gridicon icon="chevron-left" size={ 18 } />
+						Back
+					</Button>
+				</div>
+			) }
 			<div className="list__wrapper">
 				<div className="import__heading import__heading-center">
 					<Title>{ __( 'Import content from another platform' ) }</Title>

--- a/client/blocks/import/list/style.scss
+++ b/client/blocks/import/list/style.scss
@@ -36,6 +36,19 @@ html[dir="rtl"] {
 		flex-direction: column;
 	}
 
+	.import__navigation {
+		.button.is-borderless {
+			color: var(--color-text);
+			font-weight: 600;
+		}
+		.button.is-borderless svg {
+			top: 5px;
+			width: 20px;
+			height: 20px;
+			margin-right: 2px;
+		}
+	}
+
 	.list__wrapper {
 		padding-bottom: 2rem;
 

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -147,7 +147,11 @@ export class ImportEverything extends SectionMigrate {
 	};
 
 	renderLoading() {
-		return <LoadingEllipsis />;
+		return (
+			<div className="import-layout__center">
+				<LoadingEllipsis />;
+			</div>
+		);
 	}
 
 	renderMigrationConfirm() {

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -149,7 +149,7 @@ export class ImportEverything extends SectionMigrate {
 	renderLoading() {
 		return (
 			<div className="import-layout__center">
-				<LoadingEllipsis />;
+				<LoadingEllipsis />
 			</div>
 		);
 	}

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -192,7 +192,11 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 
 	switch ( renderState ) {
 		case 'loading':
-			return <LoadingEllipsis />;
+			return (
+				<div className="import-layout__center">
+					<LoadingEllipsis />
+				</div>
+			);
 
 		case 'not-authorized':
 			return (

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/migration-ready.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/migration-ready.tsx
@@ -98,7 +98,9 @@ export function MigrationReady( props: Props ) {
 				/>
 			) }
 			{ isFetchingUserSettingsSelector ? (
-				<LoadingEllipsis />
+				<div className="import-layout__center">
+					<LoadingEllipsis />
+				</div>
 			) : (
 				<div className="import__pre-migration import__import-everything import__import-everything--redesign">
 					<div className="import__heading import__heading-center">

--- a/client/blocks/importer/wordpress/index.tsx
+++ b/client/blocks/importer/wordpress/index.tsx
@@ -156,7 +156,11 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 					! hasAllSitesFetched ||
 					( WPImportOption.EVERYTHING === option && ! siteItem )
 				) {
-					return <LoadingEllipsis />;
+					return (
+						<div className="import-layout__center">
+							<LoadingEllipsis />;
+						</div>
+					);
 				} else if ( undefined === option && fromSite ) {
 					return (
 						<ContentChooser

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/index.tsx
@@ -22,6 +22,7 @@ const ImportReadyPreview: Step = function ImportStep( props ) {
 		( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIsMigrateFromWp(),
 		[]
 	);
+	const skipPreview = isMigrateFromWp || urlData?.platform === 'wordpress';
 
 	/**
 	 ↓ Methods
@@ -49,7 +50,7 @@ const ImportReadyPreview: Step = function ImportStep( props ) {
 
 	// redirect directly to importer page
 	useEffect( () => {
-		( isMigrateFromWp || urlData?.platform === 'wordpress' ) && goToImporterPage();
+		skipPreview && goToImporterPage();
 	}, [ urlData, isMigrateFromWp ] );
 
 	/**
@@ -59,7 +60,7 @@ const ImportReadyPreview: Step = function ImportStep( props ) {
 		<ImportWrapper { ...props }>
 			{ isFetching && <ScanningStep /> }
 
-			{ ! isFetching && urlData && (
+			{ ! skipPreview && ! isFetching && urlData && (
 				<ReadyPreviewStep
 					urlData={ urlData }
 					siteSlug={ siteSlug as string }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/import/index.tsx
@@ -9,6 +9,7 @@ import CaptureStep from 'calypso/blocks/import/capture';
 import DocumentHead from 'calypso/components/data/document-head';
 import { useCurrentRoute } from 'calypso/landing/stepper/hooks/use-current-route';
 import useMigrationConfirmation from 'calypso/landing/stepper/hooks/use-migration-confirmation';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useSiteSlug } from 'calypso/landing/stepper/hooks/use-site-slug';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { BASE_ROUTE } from './config';
@@ -84,10 +85,12 @@ export const ImportWrapper: Step = function ( props ) {
 const ImportStep: Step = function ImportStep( props ) {
 	const { navigation, flow } = props;
 	const siteSlug = useSiteSlug();
+	const fromUrl = useQuery().get( 'from' ) || '';
 
 	return (
 		<ImportWrapper { ...props }>
 			<CaptureStep
+				initialUrl={ fromUrl }
 				disableImportListStep={ IMPORT_HOSTED_SITE_FLOW === flow }
 				goToStep={ ( step, section, params ) => {
 					const stepPath = generateStepPath( step, section );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -155,7 +155,11 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		 */
 		const renderStepContent = () => {
 			if ( isLoading() ) {
-				return <LoadingEllipsis />;
+				return (
+					<div className="import-layout__center">
+						<LoadingEllipsis />
+					</div>
+				);
 			} else if ( ! siteSlug || ! site || ! siteId ) {
 				return <NotFound />;
 			} else if ( ! hasPermission() ) {

--- a/client/my-sites/importer/controller.js
+++ b/client/my-sites/importer/controller.js
@@ -49,6 +49,9 @@ export function importSite( context, next ) {
 
 								page( importerPath );
 							} }
+							onImportListClick={ () => {
+								page( `/import/list/${ siteSlug }` );
+							} }
 						/>
 					</div>
 				</BrowserRouter>
@@ -79,7 +82,7 @@ export function importerList( context, next ) {
 					getFinalImporterUrl={ getFinalImporterUrl }
 					submit={ ( { url } ) => {
 						url.startsWith( 'importer' )
-							? page( `${ onboardingFlowRoute }/${ url }?flow=onboarding` )
+							? page( `${ onboardingFlowRoute }/${ url }&flow=onboarding` )
 							: page( url );
 					} }
 				/>

--- a/client/my-sites/importer/controller.js
+++ b/client/my-sites/importer/controller.js
@@ -1,10 +1,19 @@
 import page from '@automattic/calypso-router';
+import { camelCase } from 'lodash';
+import { BrowserRouter } from 'react-router-dom';
+import CaptureScreen from 'calypso/blocks/import/capture';
 import { decodeURIComponentIfValid } from 'calypso/lib/url';
 import SectionImport from 'calypso/my-sites/importer/section-import';
+import 'calypso/blocks/import/style/base.scss';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 export function importSite( context, next ) {
+	const state = context.store.getState();
 	const engine = context.query?.engine;
-	const fromSite = decodeURIComponentIfValid( context.query?.[ 'from-site' ] );
+	const fromSite = decodeURIComponentIfValid(
+		context.query?.[ 'from-site' ] || context.query?.from
+	);
+	const siteSlug = getSelectedSiteSlug( state );
 
 	const afterStartImport = () => {
 		let path = context.pathname;
@@ -15,8 +24,34 @@ export function importSite( context, next ) {
 		page.replace( path );
 	};
 
-	context.primary = (
-		<SectionImport engine={ engine } fromSite={ fromSite } afterStartImport={ afterStartImport } />
-	);
+	switch ( context.query?.flow ) {
+		case 'onboarding': {
+			context.primary = (
+				<BrowserRouter>
+					<div className="import__onboarding-page">
+						<CaptureScreen
+							goToStep={ ( stepName, stepSectionName, params ) => {
+								const route = [ 'import', stepName, stepSectionName ].join( '_' );
+								const importerPath = `/setup/import-focused/${ camelCase(
+									route
+								) }?siteSlug=${ siteSlug }&from=${ encodeURIComponent( params?.fromUrl || '' ) }`;
+
+								page( importerPath );
+							} }
+						/>
+					</div>
+				</BrowserRouter>
+			);
+			break;
+		}
+		default:
+			context.primary = (
+				<SectionImport
+					engine={ engine }
+					fromSite={ fromSite }
+					afterStartImport={ afterStartImport }
+				/>
+			);
+	}
 	next();
 }

--- a/client/my-sites/importer/controller.js
+++ b/client/my-sites/importer/controller.js
@@ -85,6 +85,9 @@ export function importerList( context, next ) {
 							? page( `${ onboardingFlowRoute }/${ url }&flow=onboarding` )
 							: page( url );
 					} }
+					onNavBack={ () => {
+						page( `/import/${ siteSlug }?flow=onboarding` );
+					} }
 				/>
 			</div>
 		</BrowserRouter>

--- a/client/my-sites/importer/index.js
+++ b/client/my-sites/importer/index.js
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { get } from 'lodash';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, redirectWithoutSite, sites, siteSelection } from 'calypso/my-sites/controller';
-import { importSite } from 'calypso/my-sites/importer/controller';
+import { importSite, importerList } from 'calypso/my-sites/importer/controller';
 
 export default function () {
 	page( '/import', siteSelection, navigation, sites, makeLayout, clientRender );
@@ -13,6 +13,16 @@ export default function () {
 		navigation,
 		redirectWithoutSite( '/import' ),
 		importSite,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/import/list/:site_id',
+		siteSelection,
+		navigation,
+		redirectWithoutSite( '/import' ),
+		importerList,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/importer/section-import.scss
+++ b/client/my-sites/importer/section-import.scss
@@ -16,3 +16,9 @@
 		}
 	}
 }
+
+.import__onboarding-page {
+	.list__importers.list__importers-secondary {
+		min-height: 350px;
+	}
+}

--- a/client/my-sites/importer/section-import.scss
+++ b/client/my-sites/importer/section-import.scss
@@ -18,6 +18,19 @@
 }
 
 .import__onboarding-page {
+	margin-left: 1rem;
+	margin-right: 1rem;
+
+	.import__navigation {
+		position: absolute;
+		top: calc(var(--masterbar-height) + 1rem);
+		margin-left: -1rem;
+
+		@include breakpoint-deprecated( "<660px" ) {
+			top: calc(var(--masterbar-height));
+		}
+	}
+
 	.list__importers.list__importers-secondary {
 		min-height: 350px;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/86875

## Proposed Changes

* Integrate the onboarding Capture and List screens into the Tools/import page.
* Extend ImporterList component with navigation back logic

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Consume **Calypso live direct link** (see below)
* Go to `/import/{SLUG}?flow=onboarding`
* Check the `choose a content platform` link and `Back` button
* Try different scenarios
* Check if everything works smoothly

**NOTE:** The logic introduced with this PR is "hidden" behind the `flow=onboarding` query param; we are safe to merge this if everything looks OK, and after some time, we can add that param in the sidebar configuration for general usage.

![Screen Capture on 2024-01-25 at 22-30-23](https://github.com/Automattic/wp-calypso/assets/1241413/6a318934-40c5-4cc5-9953-d1faf841e870)

https://github.com/Automattic/wp-calypso/assets/1241413/736c8414-7e44-4724-9e8c-aba2147feddf

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?