### PR TITLE
Marketplace Reviews: Remove border in Add Review modal

### DIFF
--- a/client/my-sites/marketplace/components/review-modal/styles.scss
+++ b/client/my-sites/marketplace/components/review-modal/styles.scss
@@ -1,6 +1,6 @@
 @import "@automattic/typography/styles/variables.scss";
 
-.marketplace-reviews-modal__card {
+.marketplace-review-modal__card {
 	padding: 0 1rem;
 	box-shadow: none;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Remove border from the Add New Review modal

|Before | After|
|-------|------|
|  ![CleanShot 2023-12-28 at 16 50 17@2x](https://github.com/Automattic/wp-calypso/assets/3519124/f21605b8-12cf-4cdf-8195-12120ef7f052)   |    ![CleanShot 2023-12-28 at 16 49 59@2x](https://github.com/Automattic/wp-calypso/assets/3519124/58ff8d0d-5724-4adb-be46-2e70060ea9b2)       |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On an environment with the `marketplace-add-review` flag enabled, e.g. `wpcalypso.wordpress.com/themes/`
* Add a review to a theme and make sure the modal does not contain any unwanted border

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?