### PR TITLE
Login: Top padding only from medium

### DIFF
--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -459,7 +459,7 @@ $image-height: 47px;
 		max-width: 758px;
 		margin-top: 24px;
 
-		@include break-mobile {
+		@include break-medium {
 			margin-top: 20.5vh;
 		}
 


### PR DESCRIPTION
## Issue

The login page is not great on mobile, especially in the popup that opens when you click on like or reblog.

![image](https://github.com/Automattic/wp-calypso/assets/52076348/1fbe549c-166b-42c4-ae66-91f2f862eead)

## Solution

This PR makes the padding appear only from medium (782px) size.

![image](https://github.com/Automattic/wp-calypso/assets/52076348/6a1af3b3-bbfa-49dd-adec-740b2d8de0a6)

## Testing

1. Live link
2. Go incognito in a blog post and click like
3. Check that the popup is as desired