### PR TITLE
Login: Fix mobile breakpoint alignment

### DIFF
--- a/client/blocks/login/login-form.scss
+++ b/client/blocks/login/login-form.scss
@@ -19,14 +19,14 @@ form {
 
 		&.is-social-first {
 			display: flex;
-			flex-direction: row;
+			flex-direction: column;
+			margin-top: 24px;
 			justify-content: center;
 			max-width: 758px;
-			margin-top: 32px;
 
-			@media (max-width: $breakpoint-mobile ) {
-				flex-direction: column;
-				margin-top: 24px;
+			@media (min-width: $breakpoint-mobile ) {
+				flex-direction: row;
+				margin-top: 32px;
 			}
 
 			.card.login__form,


### PR DESCRIPTION
## Issue

On 782px viewport:

![image](https://github.com/Automattic/wp-calypso/assets/52076348/fe91f450-5fa0-442b-a835-1df4ea429114)


## Solution

![image](https://github.com/Automattic/wp-calypso/assets/52076348/22babe86-557d-4f20-8c48-19415881d172)


## Testing

1. Live link
2. Open login at 782px
3. Check that the result is correct

Fixes https://github.com/Automattic/wp-calypso/issues/85835