### PR TITLE
Earn: Ensure min currency is always a number

### DIFF
--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -60,10 +60,15 @@ function minimumCurrencyTransactionAmount(
 	currency: string,
 	connectedAccountDefaultCurrency: string
 ): number {
-	if ( connectedAccountDefaultCurrency?.toUpperCase() === currency ) {
-		return currency_min[ currency ];
+	const currencyMin = currency_min?.[ currency ];
+	if ( ! currencyMin ) {
+		return 0;
 	}
-	return currency_min[ currency ] * 2;
+
+	if ( connectedAccountDefaultCurrency?.toUpperCase() === currency ) {
+		return currencyMin;
+	}
+	return currencyMin * 2;
 }
 
 const MAX_LENGTH_CUSTOM_CONFIRMATION_EMAIL_MESSAGE = 2000;


### PR DESCRIPTION
## Proposed Changes

As [reported in Sentry](https://a8c.sentry.io/issues/4752975169/?project=6313676), we're attempting to use a potential `null` value as an object and do math calculations with it. This ensures that the minimum value is `0` in that case.