### PR TITLE
AI Logo Generator: Save logo to media library

### DIFF
--- a/packages/jetpack-ai-calypso/src/logo-generator/components/logo-presenter.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/logo-presenter.tsx
@@ -10,32 +10,62 @@ import { useState } from 'react';
  */
 import LogoIcon from '../assets/icons/logo';
 import MediaIcon from '../assets/icons/media';
+import useLogo from '../hooks/use-logo';
+import { saveToMediaLibrary } from '../lib/save-to-media-library';
+import { ImageLoader } from './image-loader';
 import './logo-presenter.scss';
 /**
  * Types
  */
-import { Logo } from '../store/types';
-import { ImageLoader } from './image-loader';
+import type { Logo } from '../store/types';
 import type React from 'react';
 
 const SaveInLibraryButton: React.FC = () => {
 	const [ saved, setSaved ] = useState( false );
+	const [ saving, setSaving ] = useState( false );
+
+	const {
+		selectedLogo,
+		site: { id },
+	} = useLogo();
 
 	return (
 		<button
 			className={ classnames( 'jetpack-ai-logo-generator-modal-presenter__action', {
-				clickable: ! saved,
+				clickable: ! saved && ! saving,
 			} ) }
-			onClick={ () => {
-				if ( ! saved ) {
-					setSaved( true );
+			onClick={ async () => {
+				if ( ! saving && ! saved ) {
+					try {
+						setSaving( true );
+
+						await saveToMediaLibrary( {
+							siteId: String( id ),
+							url: selectedLogo.url,
+							attrs: {
+								alt: selectedLogo.description,
+								caption: selectedLogo.description,
+								description: selectedLogo.description,
+								title: __( 'Site logo', 'jetpack' ),
+							},
+						} );
+						setSaved( true );
+					} catch ( error ) {
+						// TODO: Handle error
+					} finally {
+						setSaving( false );
+					}
 				}
 			} }
 		>
 			<Icon icon={ <MediaIcon /> } />
-			{ saved ? (
-				<span className="action-text">{ __( 'Saved', 'jetpack' ) }</span>
-			) : (
+			{ saving && (
+				<span className={ classnames( 'action-text', 'is-loading' ) }>
+					{ __( 'Saving…', 'jetpack' ) }
+				</span>
+			) }
+			{ ! saving && saved && <span className="action-text">{ __( 'Saved', 'jetpack' ) }</span> }
+			{ ! saving && ! saved && (
 				<span className="action-text">{ __( 'Save in Library', 'jetpack' ) }</span>
 			) }
 		</button>

--- a/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo.ts
@@ -1,13 +1,38 @@
 /**
+ * External dependencies
+ */
+import { useDispatch, useSelect } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import { STORE_NAME } from '../store';
+/**
  * Types
  */
-import { UseLogoProps } from '../../types';
+import type { Selectors } from '../store/types';
 
-const useLogo = ( { subject = 'World' }: UseLogoProps ) => {
-	const message: string = `Hello ${ subject }`;
+const useLogo = () => {
+	const { setSelectedLogoIndex } = useDispatch( STORE_NAME );
+
+	const { logos, selectedLogo, siteDetails } = useSelect( ( select ) => {
+		const selectors: Selectors = select( STORE_NAME );
+		return {
+			logos: selectors.getLogos(),
+			selectedLogo: selectors.getSelectedLogo(),
+			siteDetails: selectors.getSiteDetails(),
+		};
+	}, [] );
+	const { ID = null, name = null, description = null } = siteDetails;
 
 	return {
-		message,
+		setSelectedLogoIndex,
+		logos,
+		selectedLogo,
+		site: {
+			id: ID,
+			name,
+			description,
+		},
 	};
 };
 

--- a/packages/jetpack-ai-calypso/src/logo-generator/lib/save-to-media-library.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/lib/save-to-media-library.ts
@@ -1,0 +1,24 @@
+/**
+ * External dependencies
+ */
+import wpcomProxyRequest from 'wpcom-proxy-request';
+/**
+ * Types
+ */
+import { SaveToMediaLibraryProps, SaveToMediaLibraryResponseProps } from '../../types';
+
+export async function saveToMediaLibrary( { siteId, url, attrs = {} }: SaveToMediaLibraryProps ) {
+	const body = {
+		media_urls: [ url ],
+		attrs: [ attrs ],
+	};
+
+	const response = await wpcomProxyRequest< SaveToMediaLibraryResponseProps >( {
+		path: `/sites/${ String( siteId ) }/media/new`,
+		apiVersion: '1.1',
+		body,
+		method: 'POST',
+	} );
+
+	return response.media[ 0 ];
+}

--- a/packages/jetpack-ai-calypso/src/logo-generator/store/selectors.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/store/selectors.ts
@@ -2,6 +2,7 @@
  * Types
  */
 import type { AiFeatureProps, LogoGeneratorStateProp, Logo } from './types';
+import type { SiteDetails } from '@automattic/data-stores';
 
 const selectors = {
 	/**
@@ -15,6 +16,15 @@ const selectors = {
 		delete data._meta;
 
 		return data;
+	},
+
+	/**
+	 * Return the site details.
+	 * @param {LogoGeneratorStateProp} state       - The app state tree.
+	 * @returns {Partial<SiteDetails> | undefined}   The site details.
+	 */
+	getSiteDetails( state: LogoGeneratorStateProp ): Partial< SiteDetails > | undefined {
+		return state.siteDetails;
 	},
 
 	/**

--- a/packages/jetpack-ai-calypso/src/logo-generator/store/types.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/store/types.ts
@@ -144,6 +144,7 @@ export type Selectors = {
 	getIsRequestingAiAssistantFeature(): boolean;
 	getLogos(): Array< Logo >;
 	getSelectedLogo(): Logo;
+	getSiteDetails(): Partial< SiteDetails >;
 };
 
 /*

--- a/packages/jetpack-ai-calypso/src/types.ts
+++ b/packages/jetpack-ai-calypso/src/types.ts
@@ -1,11 +1,31 @@
+/**
+ * Types
+ */
 import type { SiteDetails } from '@automattic/data-stores';
-
-export type UseLogoProps = {
-	subject?: string;
-};
 
 export interface GeneratorModalProps {
 	siteDetails?: SiteDetails;
 	isOpen: boolean;
 	onClose: () => void;
 }
+
+export type SaveToMediaLibraryProps = {
+	siteId: string | number;
+	url: string;
+	attrs?: {
+		caption?: string;
+		description?: string;
+		title?: string;
+		alt?: string;
+	};
+};
+
+export type SaveToMediaLibraryResponseProps = {
+	code: number;
+	media: [
+		{
+			ID: number;
+			URL: string;
+		},
+	];
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #85842

## Proposed Changes

* Creates a lib folder with a function to save an image by URL to the library with attributes
* Centralized common data in the useLogo hook
* Link the function to the save button

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the logo generator modal
* Click on "Generate" to add a modal to the list*
* Click on "Save in Library"
* Check that it sends a request successfully
* Go to the media library
* Check that the sample WP logo is there with its attributes set to the description

*The first logo is not a valid public URL, as the file is served locally

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?