### PR TITLE
Stats: add upgrade copy for the purchase page

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -8,6 +8,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import getSiteAdminUrl from 'calypso/state/sites/selectors/get-site-admin-url';
+import useStatsPurchases from '../hooks/use-stats-purchases';
 import { StatsCommercialUpgradeSlider, getTierQuentity } from './stats-commercial-upgrade-slider';
 import gotoCheckoutPage from './stats-purchase-checkout-redirect';
 import PersonalPurchase from './stats-purchase-personal';
@@ -75,6 +76,24 @@ interface StatsPersonalPurchaseProps {
 
 const COMPONENT_CLASS_NAME = 'stats-purchase-single';
 
+const StatsUpgradeInstructions = () => {
+	const translate = useTranslate();
+	return (
+		<div>
+			<p>
+				{ translate(
+					'Upgrade and increase your site views limit to continue using our advanced stats features.'
+				) }
+			</p>
+			<div className="stats-purchase-wizard__notice">
+				{ translate(
+					'The remainder of your current plan will be credited towards the upgrade, ensuring you only pay the price difference. Starting from the next billing cycle, standard charges will apply.'
+				) }
+			</div>
+		</div>
+	);
+};
+
 const StatsCommercialPurchase = ( {
 	siteId,
 	siteSlug,
@@ -89,6 +108,7 @@ const StatsCommercialPurchase = ( {
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
 	const isTierUpgradeSliderEnabled = config.isEnabled( 'stats/tier-upgrade-slider' );
 	const tiers = useAvailableUpgradeTiers( siteId ) || [];
+	const { isCommercialOwned } = useStatsPurchases( siteId );
 
 	// The button of @automattic/components has built-in color scheme support for Calypso.
 	const ButtonComponent = isWPCOMSite ? CalypsoButton : Button;
@@ -132,8 +152,10 @@ Thanks\n\n`;
 	return (
 		<>
 			<h1>{ translate( 'Jetpack Stats' ) }</h1>
-			<p>{ translate( 'The most advanced stats Jetpack has to offer.' ) }</p>
-			<StatsBenefitsCommercial />
+			{ ! isCommercialOwned && (
+				<p>{ translate( 'The most advanced stats Jetpack has to offer.' ) }</p>
+			) }
+			{ ! isCommercialOwned ? <StatsBenefitsCommercial /> : <StatsUpgradeInstructions /> }
 			{ ! isTierUpgradeSliderEnabled && (
 				<>
 					<StatsCommercialPriceDisplay planValue={ planValue } currencyCode={ currencyCode } />

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -159,9 +159,6 @@ Thanks\n\n`;
 				</>
 			) }
 			{ isCommercialOwned && <StatsUpgradeInstructions /> }
-				<p>{ translate( 'The most advanced stats Jetpack has to offer.' ) }</p>
-			) }
-			{ ! isCommercialOwned ? <StatsBenefitsCommercial /> : <StatsUpgradeInstructions /> }
 			{ ! isTierUpgradeSliderEnabled && (
 				<>
 					<StatsCommercialPriceDisplay planValue={ planValue } currencyCode={ currencyCode } />

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -153,6 +153,12 @@ Thanks\n\n`;
 		<>
 			<h1>{ translate( 'Jetpack Stats' ) }</h1>
 			{ ! isCommercialOwned && (
+				<>
+					<p>{ translate( 'The most advanced stats Jetpack has to offer.' ) }</p>
+					<StatsBenefitsCommercial />
+				</>
+			) }
+			{ isCommercialOwned && <StatsUpgradeInstructions /> }
 				<p>{ translate( 'The most advanced stats Jetpack has to offer.' ) }</p>
 			) }
 			{ ! isCommercialOwned ? <StatsBenefitsCommercial /> : <StatsUpgradeInstructions /> }


### PR DESCRIPTION
Related to #85117

## Proposed Changes

Changes copy for tier upgrades, i.e. when user has a plan for the site already. I intentionally tweaked the copy a bit with GPT, so that they are more accurate.

## Testing Instructions

* Apply the latest Diff D129634-code and sandbox `public-api.wordpress.com` and `Store Sandbox`.
* Spin this change up on `local` Calypso.
* Purchase a plan for a site `/stats/purchase/:siteSlug?productType=commercial&flags=stats/tier-upgrade-slider`

![image](https://github.com/Automattic/wp-calypso/assets/1425433/8b84b354-5958-4bbc-9240-e3ac627465c8)



* Open the purchase page again
* Ensure the copy is like the following

<img width="607" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/dec0516c-05ad-4121-a0c0-410f6751639e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?