### PR TITLE
Notifications Accessibility: Navigate through the notifications and open/close notification details

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -190,7 +190,7 @@
 		border-left: 1px solid var(--color-neutral-0);
 	}
 
-	.wpnc__filter__segmented-control {
+	.wpnc__filter--segmented-control {
 		display: flex;
 		padding: 6px 8px;
 
@@ -199,7 +199,7 @@
 		}
 	}
 
-	.wpnc__filter__segmented-control-item {
+	.wpnc__filter--segmented-control-item {
 		background: var(--color-surface);
 		border: 1px solid var(--color-neutral-light);
 		border-right: none;

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -482,6 +482,11 @@
 			z-index: 100;
 			text-align: left;
 			position: sticky;
+
+			.wpnc__settings {
+				display: flex;
+				flex-grow: 1;
+			}
 		}
 	}
 

--- a/apps/notifications/src/panel/templates/filter-bar.jsx
+++ b/apps/notifications/src/panel/templates/filter-bar.jsx
@@ -17,7 +17,7 @@ export class FilterBar extends Component {
 	};
 
 	render() {
-		const { filterName } = this.props;
+		const { filterName, translate } = this.props;
 
 		const filterItems = Object.keys( Filters )
 			.map( ( name ) => Filters[ name ]() )
@@ -25,15 +25,28 @@ export class FilterBar extends Component {
 
 		return (
 			<div className="wpnc__filter">
-				<ul className="wpnc__filter__segmented-control">
+				<ul
+					className="wpnc__filter--segmented-control"
+					role="tablist"
+					aria-label={ translate( 'Filter notifications' ) }
+				>
 					{ filterItems.map( ( { label, name } ) => (
 						<li
 							key={ name }
 							data-filter-name={ name }
-							className={ classNames( 'wpnc__filter__segmented-control-item', {
+							className={ classNames( 'wpnc__filter--segmented-control-item', {
 								selected: name === filterName,
 							} ) }
 							onClick={ this.selectFilter }
+							onKeyDown={ ( e ) => {
+								if ( e.key === 'Enter' ) {
+									this.selectFilter( e );
+								}
+							} }
+							role="tab"
+							aria-selected={ name === filterName }
+							aria-controls="wpnc__note-list"
+							tabIndex={ 0 }
 						>
 							{ label }
 						</li>

--- a/apps/notifications/src/panel/templates/list-header.jsx
+++ b/apps/notifications/src/panel/templates/list-header.jsx
@@ -1,16 +1,36 @@
+import { useTranslate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import actions from '../state/actions';
 import Gridicon from './gridicons';
 
-export const ListHeader = ( { isFirst, title, viewSettings } ) => (
-	<li className="wpnc__time-group-wrap">
-		<div className="wpnc__time-group-title">
-			<Gridicon icon="time" size={ 18 } />
-			{ title }
-			{ isFirst && <Gridicon icon="cog" size={ 18 } onClick={ viewSettings } /> }
-		</div>
-	</li>
-);
+export const ListHeader = ( { isFirst, title, viewSettings } ) => {
+	const translate = useTranslate();
+
+	return (
+		<li className="wpnc__time-group-wrap">
+			<div className="wpnc__time-group-title">
+				<Gridicon icon="time" size={ 18 } />
+				{ title }
+				{ isFirst && (
+					<span
+						className="wpnc__settings"
+						onClick={ viewSettings }
+						onKeyDown={ ( e ) => {
+							if ( e.key === 'Enter' ) {
+								viewSettings();
+							}
+						} }
+						aria-label={ translate( 'Open notification settings' ) }
+						role="button"
+						tabIndex="0"
+					>
+						<Gridicon icon="cog" size={ 18 } />
+					</span>
+				) }
+			</div>
+		</li>
+	);
+};
 
 const mapDispatchToProps = {
 	viewSettings: actions.ui.viewSettings,

--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -343,7 +343,7 @@ export class NoteList extends Component {
 			<div className={ classes }>
 				<FilterBar controller={ this.props.filterController } />
 				<div ref={ this.storeScrollableContainer } className={ listViewClasses }>
-					<ol ref={ this.storeNoteList } className="wpnc__notes">
+					<ol ref={ this.storeNoteList } className="wpnc__notes" aria-live="polite">
 						<StatusBar
 							statusClasses={ this.state.statusClasses }
 							statusMessage={ this.state.statusMessage }

--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -365,6 +365,11 @@ export class NoteList extends Component {
 
 const mapStateToProps = ( state ) => ( {
 	isLoading: getIsLoading( state ),
+	/**
+	 * @todo Fixing this rule requires a larger refactor that isn't worth the time right now.
+	 * @see https://github.com/Automattic/wp-calypso/issues/14024
+	 */
+	// eslint-disable-next-line wpcalypso/redux-no-bound-selectors
 	isNoteHidden: ( noteId ) => getIsNoteHidden( state, noteId ),
 	isPanelOpen: getIsPanelOpen( state ),
 	selectedNoteId: getSelectedNoteId( state ),

--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -340,7 +340,7 @@ export class NoteList extends Component {
 		} );
 
 		return (
-			<div className={ classes }>
+			<div className={ classes } id="wpnc__note-list">
 				<FilterBar controller={ this.props.filterController } />
 				<div ref={ this.storeScrollableContainer } className={ listViewClasses }>
 					<ol ref={ this.storeNoteList } className="wpnc__notes" aria-live="polite">

--- a/apps/notifications/src/panel/templates/note.jsx
+++ b/apps/notifications/src/panel/templates/note.jsx
@@ -44,10 +44,14 @@ export const Note = React.forwardRef( ( props, ref ) => {
 	} );
 
 	return (
-		<li id={ 'note-' + note.id } className={ classes } ref={ ref }>
-			{ detailView && note.header && note.header.length > 0 && (
-				<SummaryInSingle key={ 'note-summary-single-' + note.id } note={ note } />
-			) }
+		<li
+			id={ detailView ? 'note-details-' + note.id : 'note-' + note.id }
+			className={ classes }
+			tabIndex={ detailView ? -1 : 0 }
+			role={ detailView ? 'article' : 'listitem' }
+			aria-controls={ detailView ? null : 'note-details-' + note.id }
+			aria-selected={ detailView ? null : currentNote === note.id }
+		>
 			{ ! detailView && (
 				<SummaryInList
 					currentNote={ currentNote }

--- a/apps/notifications/src/panel/templates/note.jsx
+++ b/apps/notifications/src/panel/templates/note.jsx
@@ -88,7 +88,7 @@ export const Note = React.forwardRef( ( props, ref ) => {
 					<NoteBody key={ 'note-body-' + note.id } note={ note } global={ global } />
 
 					<button
-						className="wpnc__back"
+						className="screen-reader-text"
 						onClick={ () => {
 							const noteItemElement = document.getElementById( 'note-' + note.id );
 
@@ -99,7 +99,7 @@ export const Note = React.forwardRef( ( props, ref ) => {
 							unselectNote();
 						} }
 					>
-						<span className="screen-reader-text">{ translate( 'Back to notifications' ) }</span>
+						{ translate( 'Back to notifications' ) }
 					</button>
 				</div>
 			) }


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/86475
Related to https://github.com/Automattic/wp-calypso/issues/86476

## Proposed Changes

* Navigate through the notifications (up and down) once the sidebar is opened by selecting the bell icon.
* The user can select each notification, which should display the details
* Once details for a selected notification are displayed, let the user navigate through those
* Allow the user to navigate back to notifications

## Testing Instructions

* Apply this PR to your local
* Go to http://calypso.localhost:3000/
* Enable the VoiceOver and open the notifications
* Navigate using tabs, you should be able to go through all the notifications
* Open one of the notifications by pressing Ctrl + Opt + Space
* The focus should be moved to the notification details
* Navigate through the details by pressing Tab (links only) or Ctrl + Opt + Arrow Down (to read the content)
* As the last element, a button "Back to notifications" is displayed on the top
* Close the notification details by pressing the "Back to notifications" button using Ctrl + Opt + Space
* The focus should be moved back to the previously selected notification item in the list
* Disable the VoiceOver, and reopen the notifications
* Navigate using the keyboard and search for regressions

<img width="445" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/db56acc8-9abb-45c5-b156-cdd7c13986ad">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?