### PR TITLE
Stats page: Remove domain nudge

### DIFF
--- a/client/my-sites/stats/stats-insights/index.jsx
+++ b/client/my-sites/stats/stats-insights/index.jsx
@@ -4,14 +4,12 @@ import { localize } from 'i18n-calypso';
 import { flowRight } from 'lodash';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import DomainTip from 'calypso/blocks/domain-tip';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import DocumentHead from 'calypso/components/data/document-head';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import AllTimeHighlightsSection from '../all-time-highlights-section';
@@ -55,15 +53,6 @@ const StatsInsights = ( props ) => {
 					screenReader={ navItems.insights?.label }
 					navigationItems={ [] }
 				></NavigationHeader>
-				{ siteId && (
-					<div>
-						<DomainTip
-							siteId={ siteId }
-							event="stats_insights_domain"
-							vendor={ getSuggestionsVendor() }
-						/>
-					</div>
-				) }
 				<StatsNavigation selectedItem="insights" siteId={ siteId } slug={ siteSlug } />
 				<AnnualHighlightsSection siteId={ siteId } />
 				<AllTimeHighlightsSection siteId={ siteId } siteSlug={ siteSlug } />

--- a/client/my-sites/stats/stats-subscribers/index.tsx
+++ b/client/my-sites/stats/stats-subscribers/index.tsx
@@ -1,14 +1,12 @@
 import config from '@automattic/calypso-config';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import DomainTip from 'calypso/blocks/domain-tip';
 import StatsNavigation from 'calypso/blocks/stats-navigation';
 import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import DocumentHead from 'calypso/components/data/document-head';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
 import version_compare from 'calypso/lib/version-compare';
 import { SubscriberLaunchpad } from 'calypso/my-sites/subscribers/components/subscriber-launchpad';
 import { useSelector } from 'calypso/state';
@@ -88,15 +86,6 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 					screenReader={ navItems.subscribers?.label }
 					navigationItems={ [] }
 				></NavigationHeader>
-				{ siteId && (
-					<div>
-						<DomainTip
-							siteId={ siteId }
-							event="stats_subscribers_domain"
-							vendor={ getSuggestionsVendor() }
-						/>
-					</div>
-				) }
 				<StatsNavigation selectedItem="subscribers" siteId={ siteId } slug={ siteSlug } />
 				{ showLaunchpad ? (
 					<SubscriberLaunchpad launchpadContext="subscriber-stats" />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* As per the request in pau2Xa-5qf-p2, remove the domain upsell in the Stats page.

### BEFORE

<img width="980" alt="Screenshot 2023-12-29 at 12 07 39 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/871a581b-2d29-45b8-8167-d7abae368c56">
<img width="871" alt="Screenshot 2023-12-29 at 12 07 34 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/7ee36be1-cc27-4036-b867-d3caae2703b5">



### AFTER

<img width="845" alt="Screenshot 2023-12-29 at 12 07 26 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/8a972903-46f1-4e87-8500-741a670c8334">
<img width="898" alt="Screenshot 2023-12-29 at 12 07 20 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/d35195d9-a359-463f-a648-e5a87de86658">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/stats/insights/` page and verify that the domain upsell is removed.
* Navigate to `/stats/subscribers` and verify that the domain upsell is removed.

