### PR TITLE
Marketplace: reinstates default plugin version

### DIFF
--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -115,7 +115,8 @@ const PluginDetailsHeader = ( {
 				<div className="plugin-details-header__info">
 					<div className="plugin-details-header__info-title">{ translate( 'Version' ) }</div>
 					<div className="plugin-details-header__info-value">
-						{ currentVersionsRange?.min }
+						{ /* Show the default version if plugin is not installed */ }
+						{ currentVersionsRange?.min || plugin.version }
 						{ currentVersionsRange?.max && ` - ${ currentVersionsRange.max }` }
 					</div>
 				</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/81712, we didn't account for cases where the plugin is not yet installed. This PR shows the default version ( coming from the plugins repository ) if the plugin is not yet installed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In WordPress.com, go to a free site
* Go to `https://wordpress.com/plugins/woocommerce/[siteId]`
* Make sure the version is displayed

|Before | After|
|-------|------|
|![CleanShot 2023-12-29 at 13 16 32@2x](https://github.com/Automattic/wp-calypso/assets/12430020/e2ac91e0-1bd8-4662-a05d-bd7f8a8749f5)|![CleanShot 2023-12-29 at 13 17 26@2x](https://github.com/Automattic/wp-calypso/assets/12430020/2197a557-0c99-4f6c-b837-ca04e5a30e86)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?