### PR TITLE
[Spike] Assembler: Fetch patterns using wp_block pattern categories

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -93,3 +93,6 @@ export const ORDERED_PATTERN_PAGES_CATEGORIES = [
 	'posts',
 	'contact',
 ];
+
+// Category slugs used to fetch wp_block patterns
+export const PATTERN_CATEGORIES_FOR_QUERY = [ 'assembler', 'assembler-page' ];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-dotcom-patterns.ts
@@ -1,7 +1,11 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
-import { PATTERN_CATEGORIES, getPatternSourceSiteID } from '../constants';
+import {
+	PATTERN_CATEGORIES,
+	PATTERN_CATEGORIES_FOR_QUERY,
+	getPatternSourceSiteID,
+} from '../constants';
 import type { Pattern } from '../types';
 
 const useDotcomPatterns = (
@@ -20,6 +24,7 @@ const useDotcomPatterns = (
 						? {
 								site: getPatternSourceSiteID(),
 								post_type: 'wp_block',
+								categories: PATTERN_CATEGORIES_FOR_QUERY.join( ',' ),
 						  }
 						: {
 								tags:

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -101,7 +101,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 	const [ searchParams ] = useSearchParams();
 	const [ callAIAssembler, , aiAssemblerPrompt, aiAssemblerLoading ] = useAIAssembler();
 
-	// The categories api triggers the ETK plugin before the PTK api request
+	// Fetching pattern categories from the patterns registry
 	const categories = usePatternCategories( site?.ID );
 	// Fetching curated patterns and categories from PTK api
 	const dotcomPatterns = useDotcomPatterns( locale );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -33,4 +33,4 @@ export const isPriorityPattern = ( { tags: { assembler_priority } }: Pattern ) =
 	isEnabled( 'pattern-assembler/v2' ) ? true : Boolean( assembler_priority );
 
 export const isPagePattern = ( { categories, tags: { assembler_page } }: Pattern ) =>
-	Boolean( isEnabled( 'pattern-assembler/v2' ) ? categories.page : assembler_page );
+	Boolean( isEnabled( 'pattern-assembler/v2' ) ? categories[ 'assembler-page' ] : assembler_page );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1703219193223819/1703168103.859459-slack-CRWCHQGUB

## Proposed Changes

* Fetch patterns using `wp_block` pattern categories
  * `Assembler` is for all patterns used in Assembler
  * `Assembler Page` is for page patterns only. This category is not required for fetching but for managing patterns in a better way from the Patterns UI 
* Update the util `isPagePattern` to identify page patterns using the category slug `assembler-page`


### Changes on assemblerv2patterns

- Renamed pages to remove "page #2" from names like "Portfolio page #2".
 - This is required to show a proper name "Portfolio" in the pages screen 
 - This will probably break e2e tests because patterns names are duplicated and a test uses them in aria-labels as a selector. Maybe we can update that test to get the first pattern with that label?
- Added all patterns to the category "assembler"
- Added page patterns to the category "assembler-page".
  - Note that the category "page" is still required because it will be used to fetch page patterns from the editor "Add a page" modal.
- Rename categories used to fetch patterns with the prefix "_ " so they appear at the top of the list and all together. 
 - Note that these are not meant to be shown to customers. They don't appear in the Assembler because we use a hardcoded list in https://github.com/Automattic/wp-calypso/blob/146e56bee4d6b9d468b7d3f4b2cfd8a00105710d/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts#L35  

<img width="349" alt="Screenshot 2566-12-29 at 19 32 06" src="https://github.com/Automattic/wp-calypso/assets/1881481/c44f6afb-bcef-4fa3-af09-8992b5f59ca9">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler passing the flag `pattern-assembler/v2`
* Verify you see the list of categories and patterns as expected
* Continue until the pages screen to verify you see the list of page patterns as expected 


https://github.com/Automattic/wp-calypso/assets/1881481/61b66ee5-e39d-4e7e-8654-fb652a81b9b4



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?