### PR TITLE
ToS Screenshots: Fix sporadic timeout errors

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -106,7 +106,8 @@ export class CartCheckoutPage {
 	 * Validates that the card payment input fields are visible.
 	 */
 	async validatePaymentForm(): Promise< void > {
-		await this.page.waitForSelector( selectors.cardholderName );
+		const cardholderNameLocator = this.page.locator( selectors.cardholderName );
+		await cardholderNameLocator.waitFor( { timeout: 20 * 1000 } );
 	}
 	/**
 	 * Validates that an item is in the cart with the expected text. Throws if it isn't.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* The checkout screenshot sporadically errors out in 10s waiting for cardholder input field. E.g in p1703862097999499-slack-C0313NGSK8R.
<img width="1085" alt="Screenshot 2023-12-29 at 8 15 04 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/b0b2c309-0e58-4262-9ff7-378c9e8fefe6">

* This PR fixes the issue by increasing the timeout to 20s.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Same as https://github.com/Automattic/wp-calypso/pull/85822.
