### PR TITLE
Jetpack Manage: Fixing up race conditions and preference issues affecting the onboarding tours

### DIFF
--- a/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-1/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-1/index.tsx
@@ -31,7 +31,7 @@ export default function AddNewSiteTourStep1() {
 								<br />
 								<br />
 								{ translate(
-									'Sites with jetpack installed will automatically appear in the site management view.'
+									'Sites with Jetpack installed will automatically appear in the site management view.'
 								) }
 							</>
 						),

--- a/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-1/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-1/index.tsx
@@ -12,7 +12,7 @@ export default function AddNewSiteTourStep1() {
 
 	if ( shouldRenderAddSiteTourStep1 ) {
 		ResetTour( 'addSiteStep', [ 'addSiteStep1', 'addSiteStep2' ] );
-		window.localStorage.removeItem( 'Jetpack_Manage_Preference_Reset_addSiteStep' );
+		window.localStorage.setItem( 'Jetpack_Manage_Preference_Viewed_addSiteStep', 'true' );
 	}
 
 	return (
@@ -36,7 +36,7 @@ export default function AddNewSiteTourStep1() {
 							</>
 						),
 
-						nextStepOnTargetClick: '#sites-overview-add-sites-button .split-button__toggle',
+						nextStepOnTargetClick: '#sites-overview-add-sites-button',
 					},
 				] }
 			/>

--- a/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-1/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-1/index.tsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import GuidedTour from 'calypso/jetpack-cloud/components/guided-tour';
 import { JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME } from '../constants';
+import ResetTour from '../reset-tour';
 
 import '../style.scss';
 
@@ -8,6 +9,11 @@ export default function AddNewSiteTourStep1() {
 	const translate = useTranslate();
 	const urlParams = new URLSearchParams( window.location.search );
 	const shouldRenderAddSiteTourStep1 = urlParams.get( 'tour' ) === 'add-new-site';
+
+	if ( shouldRenderAddSiteTourStep1 ) {
+		ResetTour( 'addSiteStep', [ 'addSiteStep1', 'addSiteStep2' ] );
+		window.localStorage.removeItem( 'Jetpack_Manage_Preference_Reset_addSiteStep' );
+	}
 
 	return (
 		shouldRenderAddSiteTourStep1 && (

--- a/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-2/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-2/index.tsx
@@ -40,7 +40,7 @@ export default function AddNewSiteTourStep2( { siteItems }: Props ) {
 		! resetApplied &&
 		hasStep1BeenViewed &&
 		! mostRecentConnectedSite &&
-		window.localStorage.getItem( 'Jetpack_Manage_Preference_Reset_addSiteStep' ) !== 'true'
+		window.localStorage.getItem( 'Jetpack_Manage_Preference_Reset_addSiteStep' ) === 'true'
 	) {
 		// Reset preferences
 		dispatch(

--- a/client/jetpack-cloud/sections/onboarding-tours/enable-monitor-tour-step-1/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/enable-monitor-tour-step-1/index.tsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import GuidedTour from 'calypso/jetpack-cloud/components/guided-tour';
 import { JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME } from '../constants';
+import ResetTour from '../reset-tour';
 
 import '../style.scss';
 
@@ -8,6 +9,11 @@ export default function EnableMonitorTourStep1() {
 	const translate = useTranslate();
 	const urlParams = new URLSearchParams( window.location.search );
 	const shouldRenderEnableMonitorTourStep1 = urlParams.get( 'tour' ) === 'enable-monitor';
+
+	if ( shouldRenderEnableMonitorTourStep1 ) {
+		ResetTour( 'enableMonitor', [ 'enableMonitorStep1', 'enableMonitorStep2' ] );
+		window.localStorage.removeItem( 'Jetpack_Manage_Preference_Reset_enableMonitor' );
+	}
 
 	return (
 		shouldRenderEnableMonitorTourStep1 && (

--- a/client/jetpack-cloud/sections/onboarding-tours/reset-tour.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/reset-tour.tsx
@@ -1,0 +1,19 @@
+import { useDispatch } from 'calypso/state';
+import { savePreference } from 'calypso/state/preferences/actions';
+import { JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME } from './constants';
+
+export default function ResetTour( tourName: string, tourSteps: string[] ) {
+	const storageItemName = 'Jetpack_Manage_Preference_Reset_' + tourName;
+
+	const dispatch = useDispatch();
+
+	const resetPreference = window.localStorage.getItem( storageItemName );
+
+	if ( resetPreference !== 'true' ) {
+		return;
+	}
+
+	tourSteps.forEach( ( tour ) => {
+		dispatch( savePreference( JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME[ tour ], null ) );
+	} );
+}

--- a/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
@@ -31,6 +31,11 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 		} );
 	};
 
+	const delayedTourReset = ( slug: string | string[] ) => {
+		const preferenceName = 'Jetpack_Manage_Preference_Reset_' + slug;
+		window.localStorage.setItem( preferenceName, 'true' );
+	};
+
 	const tasks: Task[] = [
 		{
 			calypso_path: '/dashboard?tour=dashboard-walkthrough',
@@ -49,8 +54,8 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 			completed: checkTourCompletion( 'addSiteStep2' ),
 			disabled: false,
 			actionDispatch: () => {
+				delayedTourReset( 'addSiteStep' );
 				dispatch( recordTracksEvent( tracksPrefix + '_add_sites_click' ) );
-				resetTour( [ 'addSiteStep1', 'addSiteStep2' ] );
 			},
 			id: 'add_sites',
 			title: translate( 'Learn how to add new sites' ),
@@ -61,8 +66,8 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 			completed: checkTourCompletion( 'enableMonitorStep2' ),
 			disabled: false,
 			actionDispatch: () => {
+				delayedTourReset( 'enableMonitor' );
 				dispatch( recordTracksEvent( tracksPrefix + '_bulk_editing_click' ) );
-				resetTour( [ 'enableMonitorStep1', 'enableMonitorStep2' ] );
 			},
 			id: 'bulk_editing',
 			title: translate( 'Learn bulk editing and enabling downtime monitoring' ),


### PR DESCRIPTION
## In progress

The issues this PR fixes are defined in this post: pf36In-xI-p2

Current fixes:
- Issue 2 - the issue was ultimately that on navigating away from the add sites tour after starting it, the tour never completes. This PR attempts to address that, as well as targeting the whole 'add sites' button for the next step. Only partial fix at the moment (does not consider successfully completing the tour which is now affected so needs further work), possibly also affected by race conditions.
- On further testing later on this is now no longer working:
- Issue 1 - fixing race conditions affecting the Monitor and Add Sites Tours (preventing the tours from fully running when begun from the Next Steps component, and the tour had already completed)

Still to do:
- All remaining fixes mentioned in the post.
- Issue 2 needs more work - I've added what I had once I reached what looked to be a working partial solution.
- The issue 1 fix (now no longer working) also generates console errors, so those also need to be addressed (if choosing to follow this route):
  - `Warning: React has detected a change in the order of Hooks called by AddNewSiteTourStep1. This will lead to bugs and errors if not fixed.`
  - `Warning: Cannot update a component ('AddNewSiteTourStep2') while rendering a different component ('AddNewSiteTourStep1').` or `Warning: Cannot update a component ('Connect(MomentProvider)') while rendering a different component ('AddNewSiteTourStep1'). To locate the bad setState() call inside 'AddNewSiteTourStep1'`
  - Both warnings occur when clicking on the Add New Site component, but the same console errors (component names changed) occur when clicking on the Monitor tour from Next Steps as well.

## Proposed Changes

* This PR attempts to fix the race conditions issue mentioned above, by moving the tour resetting functionality into the components that need them. This includes adding a new item to localStorage (which is then removed). I didn't use preferences here partly because there were issues accessing the preferences in the files where I was using them, and localStorage does work well here.

## Testing Instructions

* You must be an agency to be able to this this PR: 2c49b-pb. Make sure to switch it back to our original type after testing. 
* Switch to this branch and `yarn start-jetpack-cloud`.
* Open `http://jetpack.cloud.localhost:3000/overview`.
 
To test completing the add new sites tour if beginning it but not properly completing the steps:
* Begin the 'Add New Sites' tour.
* Do not click on the 'Add New Site' button
* Navigate away from the page, then come back to the sites dashboard. No tours should be showing
* Visit the overview page - the 'add new sites' tour should show as completed.

To test completing the add new sites tour if clicking anywhere on the 'Add New Site' button:
* Begin the 'Add New Sites' tour.
* Click anywhere on the 'Add New Site' button to add a new site, and complete the process to connect a new Jetpack site.
* The process should complete.

The below needs more work before testing:
To test the race condition issue fix -
* Begin the 'Add New Sites' tour.
* This should run to completion with no issues, connecting a new Jetpack site.
* Upon being redirected to the Overview page at the end, begin the same tour again. When connecting a new site, you should be taken through all the steps with no issue, and redirected back to the Overview page at the end.
* Follow the same steps again but for the Monitor tour.
* On subsequent runs of the tour, you should see all steps and run through to completion.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2