### PR TITLE
Jetpack Logo Generator: add prompt box styles

### DIFF
--- a/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.scss
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.scss
@@ -1,6 +1,64 @@
+.jetpack-ai-logo-generator__prompt {
+	display: flex;
+	flex-direction: column;
+	gap: 8px;
+	font-size: $font-body-small;
+}
+
 .jetpack-ai-logo-generator__prompt-header {
 	display: flex;
 	justify-content: space-between;
 	align-items: flex-start;
 	align-self: stretch;
+
+	.jetpack-ai-logo-generator__prompt-label {
+		font-weight: 500;
+	}
+
+	.jetpack-ai-logo-generator__prompt-actions {
+		display: flex;
+		font-size: $font-body-extra-small;
+		line-height: 20px;
+	}
+}
+
+.jetpack-ai-logo-generator__prompt-query {
+	display: flex;
+	padding: 8px 8px 8px var(--grid-unit-15, 16px);
+	justify-content: space-between;
+	align-items: flex-end;
+	align-self: stretch;
+	border-radius: calc(4px * 2);
+	border: 1px solid var(--Gutenberg-Gray-400, #ccc);
+	background: var(--Gutenberg-White, #fff);
+	gap: 48px;
+
+	.prompt-query__input {
+		border: 0;
+		resize: none;
+		flex-grow: 1;
+		min-height: 60px; /* temporary while we figure out auto height */
+
+		&:focus,
+		&:active {
+			outline: 0;
+		}
+	}
+
+}
+
+.jetpack-ai-logo-generator__prompt-footer {
+	color: var(--Gray-Gray-50, #646970);
+	font-size: $font-body-extra-small;
+	line-height: 21px;
+	display: flex;
+
+	& .prompt-footer__icon {
+		height: 20px;
+		width: 20px;
+
+		path {
+			fill: var(--Gray-Gray-20, #a7aaad);
+		}
+	}
 }

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.scss
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.scss
@@ -29,8 +29,8 @@
 	align-items: flex-end;
 	align-self: stretch;
 	border-radius: calc(4px * 2);
-	border: 1px solid var(--Gutenberg-Gray-400, #ccc);
-	background: var(--Gutenberg-White, #fff);
+	border: 1px solid var(--studio-gray-10, #ccc);
+	background: var(--studio-white, #fff);
 	gap: 48px;
 
 	.prompt-query__input {
@@ -44,11 +44,10 @@
 			outline: 0;
 		}
 	}
-
 }
 
 .jetpack-ai-logo-generator__prompt-footer {
-	color: var(--Gray-Gray-50, #646970);
+	color: var(--studio-gray-50, #646970);
 	font-size: $font-body-extra-small;
 	line-height: 21px;
 	display: flex;
@@ -58,7 +57,7 @@
 		width: 20px;
 
 		path {
-			fill: var(--Gray-Gray-20, #a7aaad);
+			fill: var(--studio-gray-20, #a7aaad);
 		}
 	}
 }

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
@@ -3,6 +3,7 @@
  */
 import { Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
+import { Icon, info } from '@wordpress/icons';
 import { useState } from 'react';
 /**
  * Internal dependencies
@@ -30,14 +31,34 @@ export const Prompt: React.FC = () => {
 			<div className="jetpack-ai-logo-generator__prompt-header">
 				<div className="jetpack-ai-logo-generator__prompt-label">Describe your site/logo:</div>
 				<div className="jetpack-ai-logo-generator__prompt-actions">
-					<Button variant="link">Enhance prompt</Button>
+					<Button variant="link">
+						<svg viewBox="0 0 32 32" width="24" height="24" xmlns="http://www.w3.org/2000/svg">
+							<path d="M9.33301 5.33325L10.4644 8.20188L13.333 9.33325L10.4644 10.4646L9.33301 13.3333L8.20164 10.4646L5.33301 9.33325L8.20164 8.20188L9.33301 5.33325Z" />
+							<path d="M21.3333 5.33333L22.8418 9.15817L26.6667 10.6667L22.8418 12.1752L21.3333 16L19.8248 12.1752L16 10.6667L19.8248 9.15817L21.3333 5.33333Z" />
+							<path d="M14.6667 13.3333L16.5523 18.1144L21.3333 20L16.5523 21.8856L14.6667 26.6667L12.781 21.8856L8 20L12.781 18.1144L14.6667 13.3333Z" />
+						</svg>
+						Enhance prompt
+					</Button>
 				</div>
 			</div>
 			<div className="jetpack-ai-logo-generator__prompt-query">
-				<textarea placeholder="describe your site or simply ask for a logo specifying some details about it"></textarea>
-				<Button className="jetpack-ai-logo-generator__prompt-submit" onClick={ onClick }>
+				{ /* TODO: textarea doesn't resize, either import from block-editor or use custom contentEditable */ }
+				<textarea
+					className="prompt-query__input"
+					placeholder="describe your site or simply ask for a logo specifying some details about it"
+				></textarea>
+				<Button
+					variant="primary"
+					className="jetpack-ai-logo-generator__prompt-submit"
+					onClick={ onClick }
+				>
 					Generate
 				</Button>
+			</div>
+			<div className="jetpack-ai-logo-generator__prompt-footer">
+				<div>18 requests remaining.</div>&nbsp;
+				<a href="https://automattic.com/ai-guidelines">Upgrade</a>
+				<Icon className="prompt-footer__icon" icon={ info } />
 			</div>
 		</div>
 	);

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 /**
  * Internal dependencies
  */
+import AiIcon from '../assets/icons/ai';
 import { STORE_NAME } from '../store';
 import './prompt.scss';
 
@@ -32,11 +33,7 @@ export const Prompt: React.FC = () => {
 				<div className="jetpack-ai-logo-generator__prompt-label">Describe your site/logo:</div>
 				<div className="jetpack-ai-logo-generator__prompt-actions">
 					<Button variant="link">
-						<svg viewBox="0 0 32 32" width="24" height="24" xmlns="http://www.w3.org/2000/svg">
-							<path d="M9.33301 5.33325L10.4644 8.20188L13.333 9.33325L10.4644 10.4646L9.33301 13.3333L8.20164 10.4646L5.33301 9.33325L8.20164 8.20188L9.33301 5.33325Z" />
-							<path d="M21.3333 5.33333L22.8418 9.15817L26.6667 10.6667L22.8418 12.1752L21.3333 16L19.8248 12.1752L16 10.6667L19.8248 9.15817L21.3333 5.33333Z" />
-							<path d="M14.6667 13.3333L16.5523 18.1144L21.3333 20L16.5523 21.8856L14.6667 26.6667L12.781 21.8856L8 20L12.781 18.1144L14.6667 13.3333Z" />
-						</svg>
+						<AiIcon />
 						Enhance prompt
 					</Button>
 				</div>


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack/issues/34376

## Proposed Changes

* add styles and icons for the prompt box

Ref: kJj8rPzRgHXAMHzhsmrfpy-fi-4125%3A2146

Notes: 
- the input is a textarea, hence it lacks the ability to auto resize. We need to switch to contentEditable and handle all events or import `PlainText` from block-editor (but maybe the dependency is too much for a single component)
- it becomes more evident we need to really figure out how to properly handle the modal height

## Testing Instructions

Open the logo generator modal (quick links, "Create a logo with Jetpack AI"). See the prompt box at the top matches the design.
