### PR TITLE
Pages List: Allow Changing Homepage Directly

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -74,6 +74,10 @@ const contextLinks = {
 		link: 'https://wordpress.com/support/export-your-media-library',
 		post_id: 278472,
 	},
+	'front-page': {
+		link: 'https://wordpress.com/support/pages/front-page/',
+		post_id: 1698,
+	},
 	followers: {
 		link: 'https://wordpress.com/support/followers/',
 		post_id: 5444,

--- a/client/my-sites/pages/blog-posts-page/index.jsx
+++ b/client/my-sites/pages/blog-posts-page/index.jsx
@@ -1,10 +1,17 @@
-import { Card, Gridicon } from '@automattic/components';
-import classNames from 'classnames';
+import { Button, FoldableCard, Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
-import { Component } from 'react';
+import React, { useState } from 'react';
 import { connect } from 'react-redux';
+import ExternalLink from 'calypso/components/external-link';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
+import FormSelect from 'calypso/components/forms/form-select';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import useDropdownPagesQuery from 'calypso/data/dropdown-pages/use-dropdown-pages';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { successNotice } from 'calypso/state/notices/actions';
+import { updateSiteFrontPage } from 'calypso/state/sites/actions';
 import {
 	getSiteFrontPageType,
 	getSitePostsPage,
@@ -15,75 +22,138 @@ import './style.scss';
 
 const noop = () => {};
 
-class BlogPostsPage extends Component {
-	static propTypes = {
-		site: PropTypes.object,
-		recordCalloutClick: PropTypes.func,
+const BlogPostsPage = ( props ) => {
+	const { site, frontPageType, translate, recordCalloutClick, updateFrontPage, displayNotice } =
+		props;
+	const isCurrentlySetAsHomepage = frontPageType === 'posts';
+
+	const [ selectedPageId, setSelectedPageId ] = useState( '' );
+	const [ isExpanded, setIsExpanded ] = useState( false );
+
+	const getPostsPageLink = () => site.URL;
+
+	const renderPageOptions = ( pages, level = 0 ) => {
+		const indentation = Array.from( { length: level }, () => '—' ).join( '' );
+
+		return pages.map( ( page ) => (
+			<React.Fragment key={ page.ID }>
+				<option key={ page.ID } value={ page.ID }>
+					{ indentation } { page.title }
+				</option>
+				{ page.children && renderPageOptions( page.children, level + 1 ) }
+			</React.Fragment>
+		) );
 	};
 
-	static defaultProps = {
-		recordCalloutClick: noop,
-	};
-
-	getPostsPageLink() {
-		return this.props.site.URL;
-	}
-
-	renderPostsPageInfo() {
-		const { translate } = this.props;
-
+	const renderPostsPageInfo = () => {
 		return (
 			<span>
 				<Gridicon size={ 12 } icon="house" className="blog-posts-page__front-page-icon" />
 				{ translate( 'The homepage is showing your latest posts.' ) }
 			</span>
 		);
-	}
-
-	recordCalloutClick = () => {
-		this.props.recordCalloutClick( this.props.site.ID );
 	};
 
-	render() {
-		const isCurrentlySetAsHomepage = this.props.frontPageType === 'posts';
-
-		if ( ! isCurrentlySetAsHomepage ) {
-			return null;
-		}
+	const useChangeDefaultHomepageOption = () => {
+		const { data: pages } = useDropdownPagesQuery( site.ID );
 
 		return (
-			<Card
-				href={ this.getPostsPageLink() }
-				target="_blank"
-				rel="noopener noreferrer"
-				className="blog-posts-page"
-				onClick={ this.recordCalloutClick }
+			<FormSelect
+				onChange={ ( event ) => setSelectedPageId( event.target.value ) }
+				value={ selectedPageId }
 			>
-				<div className="blog-posts-page__details">
-					<div
-						className={ classNames( {
-							'blog-posts-page__info': true,
-						} ) }
-					>
-						{ this.renderPostsPageInfo() }
-					</div>
-				</div>
-			</Card>
+				<option value="">{ translate( '—— Default ——' ) }</option>
+				{ pages?.dropdown_pages && renderPageOptions( pages.dropdown_pages ) }
+			</FormSelect>
 		);
+	};
+
+	const setFrontPage = () => {
+		updateFrontPage( site.ID, {
+			show_on_front: 'page',
+			page_on_front: selectedPageId,
+		} );
+		displayNotice( translate( 'Default homepage successfully updated!' ), {
+			id: 'default-homepage-notice',
+			duration: 4000,
+		} );
+	};
+
+	const handleClick = () => {
+		setIsExpanded( ! isExpanded );
+		recordCalloutClick( site.ID );
+	};
+
+	const changeDefaultHomepageOption = useChangeDefaultHomepageOption();
+
+	if ( ! isCurrentlySetAsHomepage ) {
+		return;
 	}
-}
+
+	return (
+		<FoldableCard
+			className="blog-posts-page__info"
+			header={ renderPostsPageInfo() }
+			onClick={ handleClick }
+			icon={ isExpanded ? 'chevron-down' : 'cog' }
+		>
+			<FormFieldset className="blog-posts-page__change-option">
+				<FormLabel>{ translate( 'Change homepage:' ) } </FormLabel>
+				{ changeDefaultHomepageOption }
+				<p className="blog-posts-page__explanation">
+					{ translate(
+						"The default homepage's content and layout is determined by your active theme. {{aboutTemplatesLink}}Learn more{{/aboutTemplatesLink}}.",
+						{
+							components: {
+								aboutTemplatesLink: (
+									<InlineSupportLink supportContext="front-page" showIcon={ false } />
+								),
+							},
+						}
+					) }
+				</p>
+			</FormFieldset>
+			<div className="blog-posts-page__actions">
+				<ExternalLink href={ getPostsPageLink() } target="_blank" rel="noopener noreferrer" icon>
+					{ translate( 'Preview homepage' ) }
+				</ExternalLink>
+				<Button disabled={ ! selectedPageId.length } onClick={ setFrontPage }>
+					{ translate( 'Save' ) }
+				</Button>
+			</div>
+		</FoldableCard>
+	);
+};
+
+BlogPostsPage.propTypes = {
+	site: PropTypes.object,
+	frontPageType: PropTypes.string,
+	postsPage: PropTypes.object,
+	translate: PropTypes.func,
+	recordCalloutClick: PropTypes.func,
+	updateSiteFrontPage: PropTypes.func,
+	successNotice: PropTypes.func,
+};
+
+BlogPostsPage.defaultProps = {
+	recordCalloutClick: noop,
+};
 
 const mapDispatchToProps = ( dispatch ) => ( {
 	recordCalloutClick: ( siteId ) => {
 		dispatch( recordTracksEvent( 'calypso_pages_blog_posts_callout_click', { blog_id: siteId } ) );
 	},
+	updateFrontPage: ( siteId, frontPageData ) =>
+		dispatch( updateSiteFrontPage( siteId, frontPageData ) ),
+	displayNotice: ( text, options ) => dispatch( successNotice( text, options ) ),
 } );
 
-export default connect( ( state, props ) => {
-	return {
+export default connect(
+	( state, props ) => ( {
 		frontPageType: getSiteFrontPageType( state, props.site.ID ),
 		isFrontPage: getSiteFrontPageType( state, props.site.ID ) === 'posts',
 		postsPage: getSitePostsPage( state, props.site.ID ),
 		frontPage: getSiteFrontPage( state, props.site.ID ),
-	};
-}, mapDispatchToProps )( localize( BlogPostsPage ) );
+	} ),
+	mapDispatchToProps
+)( localize( BlogPostsPage ) );

--- a/client/my-sites/pages/blog-posts-page/style.scss
+++ b/client/my-sites/pages/blog-posts-page/style.scss
@@ -1,24 +1,3 @@
-.blog-posts-page {
-	display: flex;
-	align-items: center;
-	padding: 16px;
-
-	@include breakpoint-deprecated( ">480px" ) {
-		padding: 16px 24px;
-	}
-}
-
-.blog-posts-page__front-page-icon,
-.blog-posts-page__not-used-icon {
-	margin-top: -1px;
-	margin-right: 6px;
-	vertical-align: middle;
-}
-
-.blog-posts-page__details {
-	flex: 1 1 auto;
-}
-
 .blog-posts-page__info {
 	&.is-expanded .foldable-card__header {
 		min-height: 0;
@@ -29,14 +8,12 @@
 		font-size: $font-body-extra-small;
 		padding: 16px 24px;
 		min-height: 0;
+	}
 
-		&.is-disabled {
-			color: var(--color-neutral-20);
-		}
-
-		.blog-posts-page__info-icon {
-			margin: 0 4px -4px 0;
-		}
+	.blog-posts-page__front-page-icon {
+		margin-top: -1px;
+		margin-right: 6px;
+		vertical-align: middle;
 	}
 
 	.blog-posts-page__change-option {
@@ -44,19 +21,16 @@
 	}
 
 	.blog-posts-page__explanation {
-		color: var(--color-text-subtle);
-		font-size: $font-body-small;
-		margin: 6px 0 0;
+		font-style: normal;
 	}
 
 	.blog-posts-page__actions {
 		display: flex;
 		justify-content: flex-end;
+	}
 
-		a {
-			font-size: $font-body-small;
-			margin: auto;
-			margin-right: 14px;
-		}
+	.blog-posts-page__link {
+		font-size: $font-body-small;
+		margin: auto 14px;
 	}
 }

--- a/client/my-sites/pages/blog-posts-page/style.scss
+++ b/client/my-sites/pages/blog-posts-page/style.scss
@@ -19,31 +19,44 @@
 	flex: 1 1 auto;
 }
 
-.blog-posts-page__title {
-	@extend %content-font;
-	color: var(--color-neutral-70);
-	font-weight: 700;
-	font-size: $font-title-small;
-	line-height: 1.2;
-
-	display: inline;
-	margin-bottom: 2px;
-
-	&.is-disabled {
-		color: var(--color-neutral-light);
-	}
-}
-
 .blog-posts-page__info {
-	color: var(--color-text-subtle);
-	font-size: $font-body-extra-small;
-	margin: 0 33px 0 0;
-
-	&.is-disabled {
-		color: var(--color-neutral-20);
+	&.is-expanded .foldable-card__header {
+		min-height: 0;
 	}
 
-	.blog-posts-page__info-icon {
-		margin: 0 4px -4px 0;
+	.foldable-card__header {
+		color: var(--color-text-subtle);
+		font-size: $font-body-extra-small;
+		padding: 16px 24px;
+		min-height: 0;
+
+		&.is-disabled {
+			color: var(--color-neutral-20);
+		}
+
+		.blog-posts-page__info-icon {
+			margin: 0 4px -4px 0;
+		}
+	}
+
+	.blog-posts-page__change-option {
+		margin: 4px 16px;
+	}
+
+	.blog-posts-page__explanation {
+		color: var(--color-text-subtle);
+		font-size: $font-body-small;
+		margin: 6px 0 0;
+	}
+
+	.blog-posts-page__actions {
+		display: flex;
+		justify-content: flex-end;
+
+		a {
+			font-size: $font-body-small;
+			margin: auto;
+			margin-right: 14px;
+		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #64072

## Proposed Changes

Ensures users are now able to change their default homepage directly from the Pages screen - as mentioned in the original issue - which makes it significantly less confusing for them. 

**Before:**

The card linked to the site URL, but there was no real way to guess this.

<img width="1064" alt="Screenshot 2024-01-01 at 10 14 47" src="https://github.com/Automattic/wp-calypso/assets/43215253/b304b564-6b75-4c64-9546-b1378380738e">

**After:**

| Folded | Expanded |
|--------|--------|
| <img width="1593" alt="Screenshot 2024-01-01 at 10 14 24" src="https://github.com/Automattic/wp-calypso/assets/43215253/0389d63b-62d0-48f9-9465-c4161cba795e"> | <img width="1578" alt="Screenshot 2024-01-01 at 10 14 34" src="https://github.com/Automattic/wp-calypso/assets/43215253/1d4efd79-0aa4-4fa9-9107-065b55a13b14"> | 

## Testing Instructions

* Go to Settings > Readings and change "Your homepage displays" to "Your latest posts" (this message won't display otherwise)
* Go to `/pages` for that site in Calypso
* Verify that the card appears, and that you're able to expand it
* Confirm that you can successfully update your homepage from within this screen

## Pre-merge Checklist

I don't have access to these P2s, so I can't see if I'm missing anything, but I have tested this on a Simple and Atomic site.

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

cc @simison @Copons