### PR TITLE
Fix bug with longer domains in onboarding flow - domain selection step

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -180,13 +180,11 @@
 
 	&.domain-registration-suggestion__title-domain {
 		@include breakpoint-deprecated( ">480px" ) {
-			max-width: 50%;
 			min-width: 50%;
 			margin-right: 1em;
 		}
 
 		@include breakpoint-deprecated( ">800px" ) {
-			max-width: 55%;
 			min-width: 55%;
 			margin-right: 1em;
 		}


### PR DESCRIPTION
## Description

I was going through the onboarding flow this morning and noticed that when you enter a longer domain, we break the domain up onto two lines. This feels really confusing. Rather than raise an issue, I decided to just fix it.

## Before

![CleanShot 2024-01-01 at 12 55 38](https://github.com/Automattic/wp-calypso/assets/5634774/142d0e43-dfec-4924-8cd5-b3ef7968ca20)

## After

![CleanShot 2024-01-01 at 12 58 00](https://github.com/Automattic/wp-calypso/assets/5634774/0c97e8d7-24a9-4098-93dc-1a1f1d48aafc)

## Testing

- Go to WP.com in incognito window
- Click "Get Started" 
- Enter a longish domain 