### PR TITLE
JP Manage: 144 - enable for Overview page on production

### DIFF
--- a/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
@@ -7,7 +7,7 @@ import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetp
 import CompanyDetailsForm from 'calypso/jetpack-cloud/sections/partner-portal/company-details-form';
 import formatApiPartner from 'calypso/jetpack-cloud/sections/partner-portal/lib/format-api-partner';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
-import { dashboardPath } from 'calypso/lib/jetpack/paths';
+import { dashboardPath, overviewPath } from 'calypso/lib/jetpack/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
@@ -80,8 +80,7 @@ export default function AgencySignupForm() {
 	useEffect( () => {
 		if ( createPartner.isSuccess ) {
 			// Redirect to dashboard until Overview page is built.
-			// page.redirect( overviewPath() );
-			page.redirect( dashboardPath() );
+			page.redirect( overviewPath() );
 		} else if ( partner ) {
 			page.redirect( dashboardPath() );
 		}

--- a/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-1/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-1/index.tsx
@@ -25,7 +25,7 @@ export default function AddNewSiteTourStep1() {
 								<br />
 								<br />
 								{ translate(
-									'Sites with jetpack installed will automatically appear in the site management view.'
+									'Sites with Jetpack installed will automatically appear in the site management view.'
 								) }
 							</>
 						),

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -71,7 +71,7 @@
 		"activity": true,
 		"backup": true,
 		"jetpack-cloud": true,
-		"jetpack-cloud-overview": false,
+		"jetpack-cloud-overview": true,
 		"jetpack-cloud-agency-dashboard": true,
 		"jetpack-cloud-agency-signup": true,
 		"jetpack-cloud-auth": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -74,7 +74,7 @@
 		"activity": true,
 		"backup": true,
 		"jetpack-cloud": true,
-		"jetpack-cloud-overview": false,
+		"jetpack-cloud-overview": true,
 		"jetpack-cloud-agency-dashboard": true,
 		"jetpack-cloud-agency-signup": true,
 		"jetpack-cloud-auth": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Resolves Automattic/jetpack-manage#144. This rolls the JP Manage Overview page live for all.

Out of scope: #85874, Automattic/jetpack-manage#200

## Proposed Changes

This PR does the following:

* Enables the Overview page in Jetpack Cloud's horizon and production environments
* Redirects to the Overview page after signing up for JP Manage
* Fixes a minor typo on a tour

## Testing Instructions
1. In a private browser window, go here: https://cloud.jetpack.com/agency/signup
2. Sign in with a new WP.com account and complete the form.

You should be redirected to the Overview page, and the Overview page menu item should show in first position when navigating to other pages.

![image](https://github.com/Automattic/wp-calypso/assets/32492176/7d4c7dd6-94fa-468c-b383-29bb14b5190c)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
