### PR TITLE
JP Manage: 201 - Use Tracks param instead of programmatic name

### DIFF
--- a/client/jetpack-cloud/sections/overview/foldable-nav/index.tsx
+++ b/client/jetpack-cloud/sections/overview/foldable-nav/index.tsx
@@ -38,14 +38,14 @@ const FoldableNav = ( {
 	const onOpen = () => {
 		savePreferenceType( 'expanded', true );
 		if ( tracksName ) {
-			dispatch( recordTracksEvent( tracksName + '_expanded_true' ) );
+			dispatch( recordTracksEvent( tracksName, { expanded: true } ) );
 		}
 	};
 
 	const onClose = () => {
 		savePreferenceType( 'expanded', false );
 		if ( tracksName ) {
-			dispatch( recordTracksEvent( tracksName + '_expanded_false' ) );
+			dispatch( recordTracksEvent( tracksName, { expanded: false } ) );
 		}
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves Automattic/jetpack-manage#201 - Use Tracks param instead of programmatic name 

## Proposed Changes

Instead of using programmatic names, we should use Tracks params. For example, this is what we had before:

`recordTracksEvent( tracksName + '_expanded_false' )`

And this is the new code:

`recordTracksEvent( tracksName, { expanded: false } )`

## Testing Instructions
1. Go to the overview page: http://jetpack.cloud.localhost:3000/overview
2. Expand and collapse the right sidebar navs ("Quick links" and "Get help").

In `trunk`, the events fired will show as follows:
* `calypso_jetpack_manage_overview_quick_links_expanded_false`
* `calypso_jetpack_manage_overview_quick_links_expanded_true`

In the `fix/jp-manage/201-no_programmatic_tracks_names` branch, the Tracks name will show as `calypso_jetpack_manage_overview_quick_links` with an `expanded` param.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
