### PR TITLE
Checkout: Show error when stripe says card field complete but can't find it

### DIFF
--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -7,7 +7,9 @@ import { useI18n } from '@wordpress/react-i18n';
 import debugFactory from 'debug';
 import { useDispatch } from 'react-redux';
 import { validatePaymentDetails } from 'calypso/lib/checkout/validation';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice } from 'calypso/state/notices/actions';
+import { logStashEvent } from '../../lib/analytics';
 import { actions, selectors } from './store';
 import type { WpcomCreditCardSelectors } from './store';
 import type { CardFieldState, CardStoreType } from './types';
@@ -82,6 +84,14 @@ export default function CreditCardPayButton( {
 									'Something seems to be wrong with the credit card form. Please try again or contact support for help.'
 								)
 							);
+							reduxDispatch(
+								recordTracksEvent( 'calypso_checkout_card_missing_element', {
+									error: 'No card number element found on page when submtting form.',
+								} )
+							);
+							logStashEvent( 'calypso_checkout_card_missing_element', {
+								error: 'No card number element found on page when submtting form.',
+							} );
 							return;
 						}
 						onClick( {

--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -71,6 +71,19 @@ export default function CreditCardPayButton( {
 				if ( isCreditCardFormValid( store, paymentPartner, __, setDisplayFieldsError ) ) {
 					if ( paymentPartner === 'stripe' ) {
 						debug( 'submitting stripe payment' );
+						if ( ! cardNumberElement ) {
+							// This should never happen because they won't get
+							// to this point if the credit card fields are not
+							// filled-in (see isCreditCardFormValid) but it
+							// seems to happen so let's tell the user
+							// something.
+							setDisplayFieldsError(
+								__(
+									'Something seems to be wrong with the credit card form. Please try again or contact support for help.'
+								)
+							);
+							return;
+						}
 						onClick( {
 							stripe,
 							name: cardholderName?.value,

--- a/client/my-sites/checkout/src/test/credit-card.tsx
+++ b/client/my-sites/checkout/src/test/credit-card.tsx
@@ -134,7 +134,7 @@ describe( 'Credit card payment method', () => {
 				countryCode: '',
 				postalCode: '',
 				stripe: null,
-				cardNumberElement: undefined,
+				cardNumberElement: {},
 				stripeConfiguration,
 				useForAllSubscriptions: false,
 			} );

--- a/client/my-sites/checkout/src/test/credit-card.tsx
+++ b/client/my-sites/checkout/src/test/credit-card.tsx
@@ -23,6 +23,25 @@ import {
 import { createTestReduxStore, fetchStripeConfiguration, stripeConfiguration } from './util';
 import type { CardStoreType } from 'calypso/my-sites/checkout/src/payment-methods/credit-card/types';
 
+jest.mock( '@stripe/react-stripe-js', () => {
+	const mockUseElements = () => ( {
+		getElement: () => {
+			// The credit card payment method submit button requires passing
+			// the cardNumberElement to the payment processor. If the element
+			// cannot be found, it displays an error to the user. In order to
+			// test that the payment processor is called, we must mock the
+			// element, but mocking the whole field itself is quite difficult,
+			// so instead here we just mock the `useElements()` function which
+			// the submit button (`CreditCardPayButton`) uses to find the field
+			// and return a mock object.
+			return {};
+		},
+	} );
+
+	const stripe = jest.requireActual( '@stripe/react-stripe-js' );
+	return { ...stripe, useElements: mockUseElements };
+} );
+
 function TestWrapper( { paymentProcessors = undefined } ) {
 	const [ store ] = useState( () => createTestReduxStore() );
 	const [ queryClient ] = useState( () => new QueryClient() );


### PR DESCRIPTION
## Proposed Changes

When you click the submit button for the new credit card payment method in checkout, it first checks to make sure that all the card fields are filled out and that stripe says they are valid. This is done by asking stripe because we don't have access to those fields directly for security. If that check succeeds, then we activate the payment processor function which collects and validates all the data before contacting the transactions endpoint. One of the required pieces of data is the reference to the card number field element on the page. That comes from stripe's `useElements()` hook. If for some reason that field cannot be found, a fatal error is thrown, that reads "Transaction requires credit card field and none was provided". This should not be possible since by that point we've already verified that the field is filled-in with a valid number.

However, we've seen quite a few of these errors recently and it's not a good UX for the user.

In this diff, we notice the missing field reference early, before calling the payment processor function, and display a slightly more helpful error message to the user, suggesting that they try again or contact support.

## Screenshots

Before             |  After
:-------------------------:|:-------------------------:
<img width="1495" alt="Screenshot 2024-01-01 at 8 04 59 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/a9afcf54-c0f2-4551-858f-7bcb5deb728f"> | <img width="1473" alt="Screenshot 2024-01-01 at 8 02 52 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/0944e70b-ddf6-4998-8944-977480177962">

## Testing Instructions

I don't know how to test this because I have no idea how to replicate the error. However, we can manually make it work by modifying the code like this: 

```diff
diff --git a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
index e6bb2c9efb4..1c1ba89c9cc 100644
--- a/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/credit-card-pay-button.tsx
@@ -44,7 +44,7 @@ export default function CreditCardPayButton( {
        const { formStatus } = useFormStatus();
        const paymentPartner = shouldUseEbanx ? 'ebanx' : 'stripe';
        const elements = useElements();
-       const cardNumberElement = elements?.getElement( CardNumberElement ) ?? undefined;
+       const cardNumberElement = undefined;

        const [ displayFieldsError, setDisplayFieldsError ] = useState( '' );
        const reduxDispatch = useDispatch();
```

Then, visit checkout with a product in your cart, select "Credit or debit card" as the payment method, fill out the form, and click submit. Verify that you see the new error message and no fatal error (no white screen that reads "Sorry, there was an error loading this page").