### PR TITLE
Migration flow: Cleanup static old business name

### DIFF
--- a/client/blocks/import/ready/platform-details.tsx
+++ b/client/blocks/import/ready/platform-details.tsx
@@ -1,6 +1,8 @@
+import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Modal } from '@wordpress/components';
 import { createElement, createInterpolateElement } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
 import { Icon, close, check } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { FeatureName, FeatureList, ImporterPlatform, UrlData } from '../types';
@@ -43,6 +45,7 @@ const ImportPlatformDetails: React.FunctionComponent< DetailsProps > = ( data ) 
 	const { __ } = useI18n();
 	const { platform, onClose, fromSite } = data;
 	const learnMoreHref = localizeUrl( 'https://wordpress.com/support/import/' );
+	const plan = getPlan( PLAN_BUSINESS );
 
 	const translatedFeatureList: FeatureList = {
 		tags: __( 'Tags' ),
@@ -194,7 +197,16 @@ const ImportPlatformDetails: React.FunctionComponent< DetailsProps > = ( data ) 
 										) ) }
 								</ul>
 								<div className="import__details-footer">
-									<i>*{ __( 'Requires a Business plan.' ) }</i>
+									<i>
+										*
+										{ sprintf(
+											/* translators: %(plan)s: name of plan */
+											__( 'Requires a %(plan)s plan.' ),
+											{
+												plan: plan?.getTitle() ?? '',
+											}
+										) }
+									</i>
 								</div>
 							</>
 						) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85881

## Proposed Changes

* Cleanup the remaining old `Business` plan name in platform-details, the new plan name is `Creator` now.

<img width="1032" alt="Screen Shot 2024-01-02 at 12 35 58 PM" src="https://github.com/Automattic/wp-calypso/assets/4074459/1ed3a687-4da0-4b76-b06b-b417b4f5f2f8">

Preview ready screen is removed from WordPress platform earlier so we shouldn't see this anymore, but to keep the codebase consistently we'll need to clean this up. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Since import ready screen isn't there anymore, there's nothing to test here. If you really want to make sure it works with old behavior, you can follow the steps below:
* Apply this PR and comment out these two lines: https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/internals/steps-repository/import-ready-preview/index.tsx#L38-L39
* Navigate to `http://calypso.localhost:3000/setup/import-focused/import?siteSlug=SIMPLE_SITE_SLUG`
* Type in a self-hosted WordPress website, you can use a JN site or using `make.wordpress.org`
* Click `What can be imported` and open the modal
* Make sure at the bottom it says `Requires a Creator plan.` like the screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?