### PR TITLE
Jetpack Manage: Fix hardcoded WPCOM Premium and Business plan name.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/wpcom-atomic-hosting/card-content.tsx
@@ -1,4 +1,4 @@
-import { getPlan, PLAN_BUSINESS, PLAN_ECOMMERCE } from '@automattic/calypso-products';
+import { getPlan, PLAN_BUSINESS, PLAN_ECOMMERCE, PLAN_PREMIUM } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, JetpackLogo, WooLogo, CloudLogo, Tooltip } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
@@ -68,7 +68,8 @@ export default function CardContent( {
 	const getFeaturesHeading = ( planSlug: string ) => {
 		switch ( planSlug ) {
 			case PLAN_BUSINESS:
-				return translate( 'Everything in {{a}}Premium{{/a}}, plus:', {
+				return translate( 'Everything in {{a}}%(planName)s{{/a}}, plus:', {
+					args: { planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' },
 					components: {
 						a: (
 							// For Business plan, we want to redirect user to find out more about features included in the  Premium plan.
@@ -81,7 +82,9 @@ export default function CardContent( {
 					},
 				} );
 			case PLAN_ECOMMERCE:
-				return translate( 'Everything in Business, plus:' );
+				return translate( 'Everything in %(planName)s, plus:', {
+					args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+				} );
 			default:
 				return '';
 		}


### PR DESCRIPTION
This pull request fixes the issue of hardcoded plan names for Premium and Business in the WPCOM Site creation page.

**Before**
<img width="1418" alt="Screen Shot 2024-01-02 at 1 23 40 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/583b08ed-28ef-42b8-8f32-09cdabd014ba">

**After**
<img width="1392" alt="Screen Shot 2024-01-02 at 1 24 56 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/8ceb88e6-3d37-4c41-a622-0b14cd3cae5d">


Closes https://github.com/Automattic/jetpack-manage/issues/110
## Proposed Changes

* Update translations string to use plan name from Calypso products library.


## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Use the Jetpack cloud live link below and go to the Site creation page (`/partner-portal/create-site`)
* Confirm that the correct plan name for Explorer and Creator is rendered in the cards.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?