### PR TITLE
Site Monitoring: provide a GMT offset for the logs

### DIFF
--- a/client/my-sites/site-monitoring/components/site-logs-table/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-table/index.tsx
@@ -52,11 +52,11 @@ export const SiteLogsTable = memo( function SiteLogsTable( {
 		request_type: __( 'Request type' ),
 		request_url: __( 'Request URL' ),
 		// translators: %s is the timezone offset of the site, e.g. GMT, GMT +1, GMT -1.
-		date: sprintf( __( 'Date (%s)' ), siteGsmOffsetDisplay ),
+		date: sprintf( __( 'Date/Time (%s)' ), siteGsmOffsetDisplay ),
 		status: __( 'Status' ),
 		severity: 'Severity',
 		// translators: %s is the timezone offset of the site, e.g. GMT, GMT +1, GMT -1.
-		timestamp: sprintf( __( 'Timestamp (%s)' ), siteGsmOffsetDisplay ),
+		timestamp: sprintf( __( 'Date/Time (%s)' ), siteGsmOffsetDisplay ),
 		message: __( 'Message' ),
 	};
 

--- a/client/my-sites/site-monitoring/components/site-logs-table/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-table/index.tsx
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
 import { memo, useMemo } from 'react';
@@ -7,7 +7,6 @@ import { useCurrentSiteGmtOffset } from '../../hooks/use-current-site-gmt-offset
 import { LogType } from '../../logs-tab';
 import SiteLogsTableRow from './site-logs-table-row';
 import { Skeleton } from './skeleton';
-
 import './style.scss';
 
 type SiteLogs = SiteLogsData[ 'logs' ];
@@ -18,24 +17,6 @@ interface SiteLogsTableProps {
 	latestLogType?: LogType | null;
 	isLoading?: boolean;
 	headerTitles: string[];
-}
-
-export function formatColumnName( column: string ) {
-	if ( column === 'request_type' ) {
-		return __( 'Request type' );
-	} else if ( column === 'request_url' ) {
-		return __( 'Request URL' );
-	} else if ( column === 'date' ) {
-		return __( 'Date' );
-	} else if ( column === 'status' ) {
-		return __( 'Status' );
-	} else if ( column === 'severity' ) {
-		return 'Severity';
-	} else if ( column === 'timestamp' ) {
-		return __( 'Timestamp' );
-	} else if ( column === 'message' ) {
-		return __( 'Message' );
-	}
 }
 
 export const SiteLogsTable = memo( function SiteLogsTable( {
@@ -62,6 +43,24 @@ export const SiteLogsTable = memo( function SiteLogsTable( {
 
 	if ( ! isLoading && ! logsWithKeys.length ) {
 		return <>{ __( 'No log entries within this time range.' ) }</>;
+	}
+
+	const siteGsmOffsetDisplay =
+		siteGmtOffset === 0 ? 'GMT' : `GMT ${ siteGmtOffset > 0 ? '+' : '' }${ siteGmtOffset }`;
+
+	const columnNames: { [ key in string ]: string } = {
+		request_type: __( 'Request type' ),
+		request_url: __( 'Request URL' ),
+		date: __( 'Date' ),
+		status: __( 'Status' ),
+		severity: 'Severity',
+		// translators: %s is the timezone offset of the site, e.g. GMT, GMT +1, GMT -1.
+		timestamp: sprintf( __( 'Timestamp (%s)' ), siteGsmOffsetDisplay ),
+		message: __( 'Message' ),
+	};
+
+	function formatColumnName( column: string ) {
+		return columnNames[ column ] || column;
 	}
 
 	return (

--- a/client/my-sites/site-monitoring/components/site-logs-table/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-table/index.tsx
@@ -51,7 +51,8 @@ export const SiteLogsTable = memo( function SiteLogsTable( {
 	const columnNames: { [ key in string ]: string } = {
 		request_type: __( 'Request type' ),
 		request_url: __( 'Request URL' ),
-		date: __( 'Date' ),
+		// translators: %s is the timezone offset of the site, e.g. GMT, GMT +1, GMT -1.
+		date: sprintf( __( 'Date (%s)' ), siteGsmOffsetDisplay ),
 		status: __( 'Status' ),
 		severity: 'Severity',
 		// translators: %s is the timezone offset of the site, e.g. GMT, GMT +1, GMT -1.

--- a/client/my-sites/site-monitoring/components/site-logs-table/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-table/index.tsx
@@ -52,11 +52,11 @@ export const SiteLogsTable = memo( function SiteLogsTable( {
 		request_type: __( 'Request type' ),
 		request_url: __( 'Request URL' ),
 		// translators: %s is the timezone offset of the site, e.g. GMT, GMT +1, GMT -1.
-		date: sprintf( __( 'Date/Time (%s)' ), siteGsmOffsetDisplay ),
+		date: sprintf( __( 'Date/time (%s)' ), siteGsmOffsetDisplay ),
 		status: __( 'Status' ),
 		severity: 'Severity',
 		// translators: %s is the timezone offset of the site, e.g. GMT, GMT +1, GMT -1.
-		timestamp: sprintf( __( 'Date/Time (%s)' ), siteGsmOffsetDisplay ),
+		timestamp: sprintf( __( 'Date/time (%s)' ), siteGsmOffsetDisplay ),
 		message: __( 'Message' ),
 	};
 

--- a/client/my-sites/site-monitoring/components/site-logs-table/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-table/index.tsx
@@ -46,7 +46,7 @@ export const SiteLogsTable = memo( function SiteLogsTable( {
 	}
 
 	const siteGsmOffsetDisplay =
-		siteGmtOffset === 0 ? 'GMT' : `GMT ${ siteGmtOffset > 0 ? '+' : '' }${ siteGmtOffset }`;
+		siteGmtOffset === 0 ? 'UTC' : `UTC${ siteGmtOffset > 0 ? '+' : '' }${ siteGmtOffset }`;
 
 	const columnNames: { [ key in string ]: string } = {
 		request_type: __( 'Request type' ),

--- a/client/my-sites/site-monitoring/components/site-logs-table/site-logs-table-row.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-table/site-logs-table-row.tsx
@@ -92,7 +92,7 @@ function renderCell(
 	}
 
 	if ( ( column === 'date' || column === 'timestamp' ) && typeof value === 'string' ) {
-		const dateFormat = locale === 'en' ? 'h:mm A [on] ll' : 'h:mm A, ll';
+		const dateFormat = locale === 'en' ? 'll [at] h:mm A' : 'h:mm A, ll';
 		const formattedDate = moment( value )
 			.utcOffset( siteGmtOffset * 60 )
 			.format( dateFormat );

--- a/client/my-sites/site-monitoring/logs-tab.tsx
+++ b/client/my-sites/site-monitoring/logs-tab.tsx
@@ -2,6 +2,7 @@ import { ToggleControl } from '@wordpress/components';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback, useEffect, useState } from 'react';
+import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Pagination from 'calypso/components/pagination';
 import { useSiteLogsQuery, FilterType } from 'calypso/data/hosting/use-site-logs-query';
@@ -196,6 +197,7 @@ export const LogsTab = ( {
 
 	return (
 		<div className="site-logs-container">
+			{ siteId && <QuerySiteSettings siteId={ siteId } /> }
 			<SiteLogsToolbar
 				logType={ logType }
 				startDateTime={ dateRange.startTime }


### PR DESCRIPTION
It is not clear in what timezone the dates in the Site Monitoring logs are displayed. For clarity, we should indicate the GMT offset so that it is clear what timezone the timestamps in the log are in.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, to avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4854

## Proposed Changes

![CleanShot 2024-01-02 at 14 20 28@2x](https://github.com/Automattic/wp-calypso/assets/36432/991d47f1-b3a8-4ff8-8ce0-e14c438b1f24)

* Ensure that the site settings are loaded. This is needed to get the preferred GMT offset for the selected site. Previously, the GMT offset could not be determined because the settings were not (always) loaded.
* Display the GMT offset in the column header of the logs for both the Timestamp and Date column

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to the Tools -> Site Monitoring page
2. Go to the PHP logs tab and ensure you see a GMT offset in the Timestamp column
3. Go to the Webserver logs tab and ensure you see a GMT offset in the Date column
4. Take note of the dates displayed in the logs
5. Go to Settings -> General and change the Site Timezone setting to something different.
6. Repeat  steps 1-4

Please ensure that both the GMT offset and the time displayed for each log entry correspond to the selected timezone. To see the UTC time for each log you can use the web developer tools with the React tools and inspect each log row to see the UTC timestamp. You can use this to see that the displayed time has the correct GMT offset applied to it.

![CleanShot 2567-01-02 at 12 39 01@2x](https://github.com/Automattic/wp-calypso/assets/10244734/689f9f38-eaf4-4c3d-a3ea-7f6257df9433)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?