### PR TITLE
Jetpack Manage: Add user feedback form feature flag and sidebar menu item.

### DIFF
--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -12,6 +12,7 @@ import Sidebar, {
 } from 'calypso/layout/sidebar-v2';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import getJetpackAdminUrl from 'calypso/state/sites/selectors/get-jetpack-admin-url';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SidebarHeader from './header';
@@ -62,6 +63,8 @@ const JetpackCloudSidebar = ( {
 	const dispatch = useDispatch();
 
 	const isUserFeedbackEnabled = isEnabled( 'jetpack/user-feedback-form' );
+
+	const isAgency = useSelector( isAgencyUser );
 
 	const onShowUserFeedbackForm = () => {
 		// TODO: Show user feedback form modal.
@@ -127,7 +130,7 @@ const JetpackCloudSidebar = ( {
 						} }
 					/>
 
-					{ isUserFeedbackEnabled && (
+					{ isUserFeedbackEnabled && isAgency && (
 						<SidebarNavigatorMenuItem
 							title={ translate( 'Share product feedback', {
 								comment: 'Jetpack Cloud sidebar navigation item',

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -1,3 +1,5 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { Icon, starEmpty } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import JetpackIcons from 'calypso/components/jetpack/sidebar/menu-items/jetpack-icons';
@@ -59,6 +61,12 @@ const JetpackCloudSidebar = ( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
+	const isUserFeedbackEnabled = isEnabled( 'jetpack/user-feedback-form' );
+
+	const onShowUserFeedbackForm = () => {
+		// TODO: Show user feedback form modal.
+	};
+
 	return (
 		<Sidebar className={ classNames( 'jetpack-cloud-sidebar', className ) }>
 			<SidebarHeader forceAllSitesView={ isJetpackManage } />
@@ -118,6 +126,18 @@ const JetpackCloudSidebar = ( {
 							);
 						} }
 					/>
+
+					{ isUserFeedbackEnabled && (
+						<SidebarNavigatorMenuItem
+							title={ translate( 'Share product feedback', {
+								comment: 'Jetpack Cloud sidebar navigation item',
+							} ) }
+							link="#product-feedback"
+							path=""
+							icon={ <Icon icon={ starEmpty } /> }
+							onClickMenuItem={ onShowUserFeedbackForm }
+						/>
+					) }
 				</ul>
 			</SidebarFooter>
 

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -60,6 +60,7 @@
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
+		"jetpack/user-feedback-form": false,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -53,6 +53,7 @@
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
+		"jetpack/user-feedback-form": false,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -55,6 +55,7 @@
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
+		"jetpack/user-feedback-form": false,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -56,6 +56,7 @@
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
+		"jetpack/user-feedback-form": false,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,


### PR DESCRIPTION
This pull request introduces a new feature flag for the User feedback mechanism in Jetpack Manage. Additionally, it adds a **'Share user feedback'** menu item in the sidebar for easier test validation with the new feature flag.

Closes https://github.com/Automattic/jetpack-genesis/issues/158
Closes https://github.com/Automattic/jetpack-genesis/issues/162

## Proposed Changes

* Add the `jetpack/user-feedback-form` feature flag.
* Add the **'Share user feedback'** menu item in the Jetpack cloud sidebar menu component.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Use the Jetpack cloud live link below and go to the Dashboard page (`/dashboard?flags=jetpack/user-feedback-form`)
* Confirm that the **'Share user feedback'** menu item is visible in the sidebar. 
   <img width="327" alt="Screen Shot 2024-01-02 at 2 10 42 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/624bff6f-e88a-410e-a724-4124a2755809">


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
