### PR TITLE
Site Settings: Align the site icon setting info popover next to the label

### DIFF
--- a/client/my-sites/site-settings/site-icon-setting/style.scss
+++ b/client/my-sites/site-settings/site-icon-setting/style.scss
@@ -1,16 +1,6 @@
-.site-settings .form-label.site-icon-setting__heading {
+.form-label.site-icon-setting__heading {
 	display: flex;
 	align-items: center;
-	justify-content: normal;
-
-	@include breakpoint-deprecated( ">660px" ) {
-		justify-content: normal;
-		white-space: nowrap;
-	}
-
-	.info-popover {
-		margin-left: 6px;
-	}
 
 	.gridicon {
 		display: block;

--- a/client/my-sites/site-settings/site-icon-setting/style.scss
+++ b/client/my-sites/site-settings/site-icon-setting/style.scss
@@ -1,9 +1,15 @@
-.form-label.site-icon-setting__heading {
+.site-settings .form-label.site-icon-setting__heading {
 	display: flex;
 	align-items: center;
+	justify-content: normal;
+
+	@include breakpoint-deprecated( ">660px" ) {
+		justify-content: normal;
+		white-space: nowrap;
+	}
 
 	.info-popover {
-		margin-left: 8px;
+		margin-left: 6px;
 	}
 
 	.gridicon {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -198,8 +198,12 @@
 
 	.site-icon-setting__heading {
 		@include breakpoint-deprecated( ">660px" ) {
-			justify-content: space-between;
+			justify-content: normal;
 			white-space: nowrap;
+		}
+
+		.info-popover {
+			margin-left: 6px;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

The site icon setting popover icon is aligned to the right but it should appear closer to the label.

Related to https://github.com/Automattic/dotcom-forge/issues/5033

## Proposed Changes

* Set justify-content to normal
* Reduce the left margin of the popover button to 6px

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Settings -> General
* Verify that the Site Icon setting popover button is no longer aligned to the right and appears 6 pixels to the left of the label text.

Before:
![CleanShot 2567-01-02 at 14 13 47@2x](https://github.com/Automattic/wp-calypso/assets/10244734/c7589b8d-ef86-4e9c-88f9-2f3977e47cc9)

After:
![CleanShot 2567-01-02 at 14 12 49@2x](https://github.com/Automattic/wp-calypso/assets/10244734/2f0dbaa9-ee05-432e-b55d-0e970e40f268)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?