### PR TITLE
Site Settings: Fix the alignment of the icon in the fiverr logo maker button

### DIFF
--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -342,6 +342,10 @@
 		margin-left: auto;
 		margin-top: 0;
 	}
+
+	svg {
+		margin-right: 6px;
+	}
 }
 
 .site-settings__site-title-tagline {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

On the site settings page, the Fiverr Logo Maker button has no margin between the icon and button label. There should be a margin.

Related to https://github.com/Automattic/dotcom-forge/issues/5033

## Proposed Changes

* Add a margin of 6 pixels between the icon and the label text of the Fiverr Logo Maker button

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Settings -> General
* Observe that there is a 6 pixel margin between the external icon and the text of the Fiverr Logo Maker button.
Before:
![CleanShot 2567-01-02 at 14 34 51@2x](https://github.com/Automattic/wp-calypso/assets/10244734/d0117949-438f-4cba-a233-5f90e79afa04)

After:
![CleanShot 2567-01-02 at 14 33 56@2x](https://github.com/Automattic/wp-calypso/assets/10244734/e9098273-35ca-4ed6-891d-bdef6d04d45a)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?