### PR TITLE
Live Preview: apply selected style variation to the preview (Simple sites only)

### DIFF
--- a/client/my-sites/theme/live-preview-button/index.tsx
+++ b/client/my-sites/theme/live-preview-button/index.tsx
@@ -5,17 +5,25 @@ import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { useDispatch, useSelector } from 'calypso/state';
 import { livePreview } from 'calypso/state/themes/actions';
 import { getIsLivePreviewSupported } from 'calypso/state/themes/selectors';
+import type { GlobalStyles } from '@automattic/data-stores';
 
 interface Props {
-	themeId: string;
 	siteId: number;
+	themeId: string;
+	stylesheet: string;
+	styleVariation?: GlobalStyles;
 }
 
 /**
  * Live Preview leveraging Gutenberg's Block Theme Previews
  * @see pbxlJb-3Uv-p2
  */
-export const LivePreviewButton: FC< Props > = ( { themeId, siteId } ) => {
+export const LivePreviewButton: FC< Props > = ( {
+	siteId,
+	themeId,
+	stylesheet,
+	styleVariation,
+} ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -30,7 +38,7 @@ export const LivePreviewButton: FC< Props > = ( { themeId, siteId } ) => {
 
 	const handleClick = () => {
 		setIsLoading( true );
-		dispatch( livePreview( themeId, siteId, 'detail' ) );
+		dispatch( livePreview( siteId, themeId, stylesheet, styleVariation, 'detail' ) );
 	};
 
 	return (

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -717,6 +717,7 @@ class ThemeSheet extends Component {
 			siteId,
 			softLaunched,
 			themeId,
+			stylesheet,
 			translate,
 		} = this.props;
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
@@ -745,7 +746,12 @@ class ThemeSheet extends Component {
 							( this.shouldRenderUnlockStyleButton()
 								? this.renderUnlockStyleButton()
 								: this.renderButton() ) }
-						<LivePreviewButton siteId={ siteId } themeId={ themeId } />
+						<LivePreviewButton
+							siteId={ siteId }
+							themeId={ themeId }
+							stylesheet={ stylesheet }
+							styleVariation={ this.getSelectedStyleVariation() }
+						/>
 						{ this.shouldRenderPreviewButton() && ! isLivePreviewSupported && (
 							<Button
 								onClick={ ( e ) => {
@@ -1154,7 +1160,8 @@ class ThemeSheet extends Component {
 	};
 
 	getSelectedStyleVariation = () => {
-		const { selectedStyleVariationSlug, styleVariations } = this.props;
+		const { selectedStyleVariationSlug = DEFAULT_GLOBAL_STYLES_VARIATION_SLUG, styleVariations } =
+			this.props;
 		return styleVariations.find( ( variation ) => variation.slug === selectedStyleVariationSlug );
 	};
 

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -1465,8 +1465,10 @@ describe( 'actions', () => {
 			test( 'should redirect users to the Live Preview', () => {
 				return new Promise( ( done ) => {
 					livePreview(
-						'pendant',
 						2211667,
+						'pendant',
+						'pub/pendant',
+						undefined,
 						'detail'
 					)( dispatch, state ).then( () => {
 						expect( dispatch ).toHaveBeenCalledWith( livePreviewStartAction );
@@ -1511,8 +1513,10 @@ describe( 'actions', () => {
 				test( 'should redirect users to the Live Preview', () => {
 					return new Promise( ( done ) => {
 						livePreview(
-							'pendant',
 							2211667,
+							'pendant',
+							'pub/pendant',
+							undefined,
 							'detail'
 						)( dispatch, state ).then( () => {
 							expect( dispatch ).toHaveBeenCalledWith( livePreviewStartAction );
@@ -1538,8 +1542,10 @@ describe( 'actions', () => {
 				test( 'should install the theme and then redirect users to the Live Preview', () => {
 					return new Promise( ( done ) => {
 						livePreview(
-							'pendant',
 							2211667,
+							'pendant',
+							'pub/pendant',
+							undefined,
 							'detail'
 						)( dispatch, state ).then( () => {
 							expect( dispatch ).toHaveBeenCalledWith( livePreviewStartAction );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

- https://github.com/Automattic/wp-calypso/issues/82914

## Proposed Changes

This is a proof of concept that we can apply selected style variation to live preview.

Please check and discuss on D133375-code instead.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?