### PR TITLE
Fix Woo Express free trial activate WooCommerce themes

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -70,6 +70,7 @@ import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
+import { isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import {
 	setThemePreviewOptions,
@@ -97,6 +98,7 @@ import {
 	isThemeActivationSyncStarted as getIsThemeActivationSyncStarted,
 	getIsLivePreviewSupported,
 	getThemeType,
+	isThemeWooCommerce,
 } from 'calypso/state/themes/selectors';
 import { getIsLoadingCart } from 'calypso/state/themes/selectors/get-is-loading-cart';
 import { getBackPath } from 'calypso/state/themes/themes-ui/selectors';
@@ -555,7 +557,14 @@ class ThemeSheet extends Component {
 			isVip,
 			retired,
 			isThemeAllowedOnSite,
+			isSiteWooExpressFreeTrial,
+			isThemeBundleWooCommerce,
 		} = this.props;
+
+		// Woo Express plans don't show banner on Woo themes.
+		if ( isThemeBundleWooCommerce && isSiteWooExpressFreeTrial ) {
+			return false;
+		}
 
 		// Show theme upsell banner on Simple sites.
 		return (
@@ -1012,6 +1021,8 @@ class ThemeSheet extends Component {
 			isThemeActivationSyncStarted,
 			isThemeAllowedOnSite,
 			isThemeInstalled,
+			isSiteWooExpressFreeTrial,
+			isThemeBundleWooCommerce,
 		} = this.props;
 		const { isAtomicTransferCompleted } = this.state;
 		if ( isActive ) {
@@ -1027,7 +1038,9 @@ class ThemeSheet extends Component {
 				( ( ! isThemeAllowedOnSite || isPremium ) &&
 					! isThemePurchased &&
 					! isExternallyManagedTheme ) ||
-				( isBundledSoftwareSet && ! canInstallPlugins )
+				( isBundledSoftwareSet &&
+					! canInstallPlugins &&
+					! ( isSiteWooExpressFreeTrial && isThemeBundleWooCommerce ) )
 			) {
 				// upgrade plan
 				return translate( 'Upgrade to activate', {
@@ -1568,6 +1581,8 @@ const ThemeSheetWithOptions = ( props ) => {
 		isExternallyManagedTheme,
 		isSiteEligibleForManagedExternalThemes,
 		isMarketplaceThemeSubscribed,
+		isSiteWooExpressFreeTrial,
+		isThemeBundleWooCommerce,
 	} = props;
 
 	let defaultOption;
@@ -1596,7 +1611,11 @@ const ThemeSheetWithOptions = ( props ) => {
 		defaultOption = 'subscribe';
 	} else if ( isPremium && ! isThemePurchased && ! isBundledSoftwareSet ) {
 		defaultOption = 'purchase';
-	} else if ( ! canInstallPlugins && isBundledSoftwareSet ) {
+	} else if (
+		! canInstallPlugins &&
+		isBundledSoftwareSet &&
+		! ( isSiteWooExpressFreeTrial && isThemeBundleWooCommerce )
+	) {
 		defaultOption = 'upgradePlanForBundledThemes';
 	} else {
 		defaultOption = 'activate';
@@ -1675,6 +1694,8 @@ export default connect(
 			isThemeInstalled: !! getTheme( state, siteId, themeId ),
 			isThemePurchased: isPremiumThemeAvailable( state, themeId, siteId ),
 			isBundledSoftwareSet: doesThemeBundleSoftwareSet( state, themeId ),
+			isThemeBundleWooCommerce: isThemeWooCommerce( state, themeId ),
+			isSiteWooExpressFreeTrial: isSiteOnECommerceTrial( state, siteId ),
 			isSiteBundleEligible: isSiteEligibleForBundledSoftware( state, siteId ),
 			forumUrl: getThemeForumUrl( state, themeId, siteId ),
 			hasUnlimitedPremiumThemes: siteHasFeature( state, siteId, WPCOM_FEATURES_PREMIUM_THEMES ),

--- a/client/state/themes/selectors/is-theme-woo-commerce.ts
+++ b/client/state/themes/selectors/is-theme-woo-commerce.ts
@@ -10,5 +10,8 @@ export function isThemeWooCommerce( state: IAppState, themeId: string ) {
 	const theme = getTheme( state, 'wpcom', themeId );
 	const themeSoftwareSetTaxonomy: ThemeSoftwareSet[] | undefined =
 		theme?.taxonomies?.theme_software_set;
-	return themeSoftwareSetTaxonomy?.some( ( { slug } ) => slug === 'woo-on-plan' );
+	return (
+		themeSoftwareSetTaxonomy?.some( ( softwareSet ) => softwareSet?.slug === 'woo-on-plans' ) ||
+		false
+	);
 }


### PR DESCRIPTION
Related to #85889 

## Proposed Changes

* Fixes logic so free trial users can activate WooCommerce themes such as `tazza`
* Fixes logic so that free trial users won't see "Creator plan" upsell banner on WooCommerce themes
* Fixes `woo-on-plan` typo and force boolean return value for `isThemeWooCommerce`

## Testing Instructions

### Test fix

1. Create a Woo Express free trial site by going to https://woo.com/start and follow through the NUX process
2. Navigate to `http://calypso.localhost:3000/theme/tsubaki/SITE_URL?from=customize-store`
6. Observe no upsell banner is shown
7. Click on `Activate this design`
8. Observe that Tazza theme is activated successfully

<img width="774" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3747241/ebf8a7f8-841d-4f73-ab54-bd6deca322ba">


### Regression test

Follow the instructions in [this PR](https://github.com/Automattic/wp-calypso/pull/84886) to ensure no regression.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
