### PR TITLE
Login-Signup: Decouple social component from layout

### DIFF
--- a/client/blocks/authentication/social/style.scss
+++ b/client/blocks/authentication/social/style.scss
@@ -64,28 +64,6 @@
 	}
 }
 
-// This is only for compatibility with not social first login, it will be removed after the experiment ends.
-.is-white-login .auth-form__social:not(.is-social-first) {
-	.auth-form__social-buttons-container {
-		width: unset;
-		.social-buttons__button {
-			> svg {
-				border: 1px solid var(--studio-gray-10);
-				border-radius: 24px; /* stylelint-disable-line scales/radii */
-			}
-		}
-	}
-}
-
-.is-white-login .auth-form__social:not(.is-social-first),
-.is-white-signup .auth-form__social:not(.is-social-first) {
-	.social-buttons__button {
-		> svg {
-			padding: 12px;
-		}
-	}
-}
-
 .auth-form__social.is-social-first {
 	.auth-form__social-buttons-container {
 		gap: 16px;

--- a/client/blocks/login/style.scss
+++ b/client/blocks/login/style.scss
@@ -577,8 +577,21 @@ $breakpoint-mobile: 782px; //Mobile size.
 	}
 }
 
-.is-white-login.is-gravatar {
+.is-gravatar {
 	.login__form-terms {
 		display: block;
+	}
+
+	.auth-form__social {
+		.auth-form__social-buttons-container {
+			width: unset;
+			.social-buttons__button {
+				> svg {
+					border: 1px solid var(--studio-gray-10);
+					border-radius: 24px; /* stylelint-disable-line scales/radii */
+					padding: 12px;
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
The shared social component

![image](https://github.com/Automattic/wp-calypso/assets/52076348/f7c03508-082f-4f20-b311-8c76a328b8cb)

Needed some hack to work well in not social first white logins, like Gravatar.

This PR decouples the component CSS from `is-white-login` and layout stuff, since now the social first is the default login (other PRs will clean things up regarding that).

Gravatar is the only white login without the social first changes.

## Testing

1. Live link
2. Check `log-in` and [Gravatar login](https://wordpress.com/log-in?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%3Fclient_id%3D1854%26response_type%3Dcode%26blog_id%3D0%26state%3D500e79a3faed390d3ef5f2778ef39363706cc0609c02c3c25397c7499f3fa51c%26redirect_uri%3Dhttps%253A%252F%252Fen.gravatar.com%252Fconnect%252F%253Faction%253Drequest_access_token&client_id=1854)