### PR TITLE
Use site hook: Make sure same site only gets fetched once

### DIFF
--- a/client/landing/stepper/hooks/use-site.ts
+++ b/client/landing/stepper/hooks/use-site.ts
@@ -1,5 +1,6 @@
+import { usePrevious } from '@wordpress/compose';
 import { useSelect } from '@wordpress/data';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'calypso/state';
 import { requestSite } from 'calypso/state/sites/actions';
 import { getSite, isRequestingSite } from 'calypso/state/sites/selectors';
@@ -17,7 +18,7 @@ export function useSite() {
 	const isRequestingSelectedSite = useSelector( ( state ) =>
 		isRequestingSite( state, siteIdOrSlug )
 	);
-	const lastRequestedSiteIdOrSlug = useRef( '' );
+	const lastRequestedSiteIdOrSlug = usePrevious( siteIdOrSlug );
 
 	const site = useSelect(
 		( select ) => {
@@ -32,12 +33,11 @@ export function useSite() {
 	useEffect( () => {
 		if (
 			siteIdOrSlug &&
-			siteIdOrSlug !== lastRequestedSiteIdOrSlug.current &&
+			siteIdOrSlug !== lastRequestedSiteIdOrSlug &&
 			! selectedSite &&
 			! isRequestingSelectedSite
 		) {
 			dispatch( requestSite( siteIdOrSlug ) );
-			lastRequestedSiteIdOrSlug.current = siteIdOrSlug;
 		}
 	}, [ siteIdOrSlug, selectedSite, isRequestingSelectedSite ] );
 

--- a/client/landing/stepper/hooks/use-site.ts
+++ b/client/landing/stepper/hooks/use-site.ts
@@ -1,5 +1,5 @@
 import { useSelect } from '@wordpress/data';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useSelector, useDispatch } from 'calypso/state';
 import { requestSite } from 'calypso/state/sites/actions';
 import { getSite, isRequestingSite } from 'calypso/state/sites/selectors';
@@ -17,6 +17,7 @@ export function useSite() {
 	const isRequestingSelectedSite = useSelector( ( state ) =>
 		isRequestingSite( state, siteIdOrSlug )
 	);
+	const lastRequestedSiteIdOrSlug = useRef( '' );
 
 	const site = useSelect(
 		( select ) => {
@@ -29,8 +30,14 @@ export function useSite() {
 
 	// Request the site for the redux store
 	useEffect( () => {
-		if ( siteIdOrSlug && ! selectedSite && ! isRequestingSelectedSite ) {
+		if (
+			siteIdOrSlug &&
+			siteIdOrSlug !== lastRequestedSiteIdOrSlug.current &&
+			! selectedSite &&
+			! isRequestingSelectedSite
+		) {
 			dispatch( requestSite( siteIdOrSlug ) );
+			lastRequestedSiteIdOrSlug.current = siteIdOrSlug;
 		}
 	}, [ siteIdOrSlug, selectedSite, isRequestingSelectedSite ] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85892

## Proposed Changes

* We found there was tons of unnecessary site requests get fired and this only happens when:
    * The site is not exist
    * The site was a simple site but turns into an Atomic site during the import flow

It seems the behavior was introduced by https://github.com/Automattic/wp-calypso/pull/85791 where it'll keep fetching the site if the `selectedSite` is empty. In this PR, we introduced a ref and make sure same URL only gets fetched once so if it's not exist it won't create an infinite loop here.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Test flow 1:**
* Follow the test instructions found in #85791 and make sure everything stays the same.

**Test flow 2:**
* Navigate to `http://calypso.localhost:3000/setup/import-focused/import?siteSlug=RANDOM_STRING`
* You can type in any random site or strings that doesn't exist
* Look into your Network tab in Developer tool
* Make sure `https://public-api.wordpress.com/rest/v1.2/sites/${site}` didn't get fired continuously.

**Test flow 3:**
* Navigate to `http://calypso.localhost:3000/setup/import-focused/import?siteSlug=SIMPLE_SITE` and start with a simple site.
* Turn the site into a migration trial or purchase a creator plan.
* Continue on the import flow and make sure it's you see lots of site requests during the import flow when opening your Network tab in Developer tool. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?