### PR TITLE
Site Options Step: Rename the title and description for the build intent

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/site-options.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-options/site-options.tsx
@@ -102,13 +102,21 @@ export const SiteOptions = ( { navigation }: Pick< StepProps, 'navigation' > ) =
 					taglineExplanation: translate( 'In a few words, explain what your store is about.' ),
 				};
 			case 'write':
-			default:
 				return {
 					headerText: translate( "First, let's give your blog a name" ),
 					headerImage: siteOptionsUrl,
 					siteTitleLabel: translate( 'Blog name' ),
 					taglineLabel: translate( 'Tagline' ),
 					taglineExplanation: translate( 'In a few words, explain what your blog is about.' ),
+				};
+			case 'build':
+			default:
+				return {
+					headerText: translate( "Let's give your site a name" ),
+					headerImage: siteOptionsUrl,
+					siteTitleLabel: translate( 'Site name' ),
+					taglineLabel: translate( 'Tagline' ),
+					taglineExplanation: translate( 'In a few words, explain what your site is about.' ),
 				};
 		}
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/85847

## Proposed Changes

* Rename the title and description of the site options step as the “Blog” is for the “write” flow

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/c20f4b89-aa1d-4883-85cb-6a30d4910dab) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/5163d93f-b952-40f1-910d-7038ddd4118b) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site
* When you land on the onboarding flow, continue anyway to finish the flow
* When you land on the Launchpad, pick “Set up your site”
* Make sure the title is “Let's give your site a name”

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?