### PR TITLE
Login: Fix 2FA browser back 

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -605,9 +605,8 @@ class Login extends Component {
 	}
 
 	renderToS() {
-		const { isSocialFirst, translate, twoFactorEnabled } = this.props;
-
-		if ( ! isSocialFirst || twoFactorEnabled ) {
+		const { isSocialFirst, translate, twoFactorAuthType } = this.props;
+		if ( ! isSocialFirst || twoFactorAuthType ) {
 			return null;
 		}
 
@@ -715,7 +714,7 @@ class Login extends Component {
 			);
 		}
 
-		if ( twoFactorEnabled ) {
+		if ( twoFactorEnabled && twoFactorAuthType ) {
 			return (
 				<Fragment>
 					<AsyncLoad

--- a/client/login/wp-login/login-footer.tsx
+++ b/client/login/wp-login/login-footer.tsx
@@ -3,6 +3,10 @@ interface LoginFooterProps {
 }
 
 const LoginFooter = ( { lostPasswordLink }: LoginFooterProps ) => {
+	if ( ! lostPasswordLink ) {
+		return null;
+	}
+
 	return <div className="wp-login__main-footer">{ lostPasswordLink }</div>;
 };
 


### PR DESCRIPTION
During login, when you authenticate and are in the 2FA page, going back will put the page in a weird state

![Screen Capture on 2023-12-13 at 11-36-37](https://github.com/Automattic/wp-calypso/assets/52076348/08fbc4ef-bb40-42aa-bfa3-7568f4859a74)

## Testing

1. Live link
2. Visit `log-in` while in Incognito
3. Put email and password and get to the 2FA page
4. Use the browser back button
5. You should land in a functional login page

Fixes https://github.com/Automattic/wp-calypso/issues/85206