### PR TITLE
Add coupon code to ecommerce setup flow

### DIFF
--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -152,12 +152,13 @@ const ecommerceFlow: Flow = {
 
 	useStepNavigation( _currentStepName, navigate ) {
 		const flowName = this.name;
-		const { setPlanCartItem, setPluginsToVerify } = useDispatch( ONBOARD_STORE );
+		const { setPlanCartItem, setPluginsToVerify, resetCouponCode } = useDispatch( ONBOARD_STORE );
 		setPluginsToVerify( [ 'woocommerce' ] );
-		const { selectedDesign, recurType } = useSelect(
+		const { selectedDesign, recurType, couponCode } = useSelect(
 			( select ) => ( {
 				selectedDesign: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
 				recurType: ( select( ONBOARD_STORE ) as OnboardSelect ).getEcommerceFlowRecurType(),
+				couponCode: ( select( ONBOARD_STORE ) as OnboardSelect ).getCouponCode(),
 			} ),
 			[]
 		);
@@ -211,11 +212,13 @@ const ecommerceFlow: Flow = {
 						} );
 
 						const returnUrl = encodeURIComponent( `/setup/${ flowName }/checkPlan?${ urlParams }` );
+						const couponCodeParam = couponCode ? `coupon=${ couponCode }` : '';
+						resetCouponCode();
 
 						return window.location.assign(
 							`/checkout/${ encodeURIComponent(
 								( siteSlug as string ) ?? ''
-							) }?redirect_to=${ returnUrl }&signup=1`
+							) }?redirect_to=${ returnUrl }&signup=1&${ couponCodeParam }`
 						);
 					}
 					return navigate( `checkPlan?siteSlug=${ siteSlug }` );

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -71,6 +71,10 @@ const FlowSwitch: React.FC< { user: UserStore.CurrentUser | undefined; flow: Flo
 		}
 	}
 
+	// This stores the coupon code query param, and the flow declaration
+	// will append it to the checkout URL so that it auto-applies the coupon code at
+	// checkout. For example, /setup/ecommerce/?coupon=SOMECOUPON will auto-apply the
+	// coupon code at the checkout page.
 	const couponCode = useQuery().get( 'coupon' );
 	const { setCouponCode } = useDispatch( ONBOARD_STORE );
 	if ( couponCode ) {

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -71,6 +71,12 @@ const FlowSwitch: React.FC< { user: UserStore.CurrentUser | undefined; flow: Flo
 		}
 	}
 
+	const couponCode = useQuery().get( 'coupon' );
+	const { setCouponCode } = useDispatch( ONBOARD_STORE );
+	if ( couponCode ) {
+		setCouponCode( couponCode );
+	}
+
 	user && receiveCurrentUser( user as UserStore.CurrentUser );
 
 	return <FlowRenderer flow={ flow } />;

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -471,6 +471,15 @@ export const setEcommerceFlowRecurType = ( ecommerceFlowRecurType: string ) => (
 	ecommerceFlowRecurType,
 } );
 
+export const setCouponCode = ( couponCode: string ) => ( {
+	type: 'SET_COUPON_CODE' as const,
+	couponCode,
+} );
+
+export const resetCouponCode = () => ( {
+	type: 'RESET_COUPON_CODE' as const,
+} );
+
 export const setDomainForm = ( step: Record< string, string > ) => {
 	const lastUpdated = Date.now();
 
@@ -577,6 +586,7 @@ export type OnboardAction = ReturnType<
 	| typeof setVerticalId
 	| typeof setStoreLocationCountryCode
 	| typeof setEcommerceFlowRecurType
+	| typeof setCouponCode
 	| typeof setHideFreePlan
 	| typeof setHidePlansFeatureComparison
 	| typeof setProductCartItems

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -60,6 +60,7 @@ export function register(): typeof STORE_KEY {
 			'verticalId',
 			'storeLocationCountryCode',
 			'ecommerceFlowRecurType',
+			'couponCode',
 			'domainCartItem',
 			'planCartItem',
 			'productCartItems',

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -418,7 +418,7 @@ const couponCode: Reducer< string, OnboardAction > = ( state = '', action ) => {
 		return action.couponCode;
 	}
 	if ( [ 'RESET_COUPON_CODE', 'RESET_ONBOARD_STORE' ].includes( action.type ) ) {
-		return [];
+		return '';
 	}
 	return state;
 };

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -413,6 +413,16 @@ const ecommerceFlowRecurType: Reducer< string, OnboardAction > = ( state = '', a
 	return state;
 };
 
+const couponCode: Reducer< string, OnboardAction > = ( state = '', action ) => {
+	if ( action.type === 'SET_COUPON_CODE' ) {
+		return action.couponCode;
+	}
+	if ( [ 'RESET_COUPON_CODE', 'RESET_ONBOARD_STORE' ].includes( action.type ) ) {
+		return [];
+	}
+	return state;
+};
+
 const domainForm: Reducer< DomainForm, OnboardAction > = ( state = {}, action ) => {
 	if ( action.type === 'SET_DOMAIN_FORM' ) {
 		return {
@@ -611,6 +621,7 @@ const reducer = combineReducers( {
 	verticalId,
 	storeLocationCountryCode,
 	ecommerceFlowRecurType,
+	couponCode,
 	planCartItem,
 	productCartItems,
 	isMigrateFromWp,

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -53,6 +53,7 @@ export const getProgressTitle = ( state: State ) => state.progressTitle;
 export const getGoals = ( state: State ) => state.goals;
 export const getStoreLocationCountryCode = ( state: State ) => state.storeLocationCountryCode;
 export const getEcommerceFlowRecurType = ( state: State ) => state.ecommerceFlowRecurType;
+export const getCouponCode = ( state: State ) => state.couponCode;
 export const getState = ( state: State ) => state;
 export const hasPaidDesign = ( state: State ): boolean => {
 	if ( ! state.selectedDesign ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* This is a follow-up to https://github.com/Automattic/wp-calypso/pull/85551 which added the ability to include a coupon code to the signup flow, so that it gets auto-applied at checkout.
* This PR implements the same behaviour to the Stepper ecommerce flow, so that `/setup/ecommerce/?coupon=SOMECOUPON` will auto-apply the coupon code at checkout.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Fetch a valid coupon code from 33094-pb.
* While logged-out, start a fresh signup at `/setup/ecommerce/?coupon=COUPON_FROM_PREVIOUS_STEP` and go through the setup flow. Verify that the coupon is auto-applied when you're in the checkout page. 
* Repeat the previous step, but this time as a logged-in user. Verify that the coupon is auto-applied at checkout.
* Repeat, but this time use an invalid coupon code such as `/setup/ecommerce/?coupon=NEWYEAR2024`. Verify that the checkout page will show an error notification that the coupon is not valid.

