### PR TITLE
Site Settings: Change the style of the Privacy settings help icon

### DIFF
--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -27,6 +27,7 @@ class InlineSupportLink extends Component {
 		showIcon: PropTypes.bool,
 		supportContext: PropTypes.string,
 		iconSize: PropTypes.number,
+		iconStyle: PropTypes.string,
 		linkTitle: PropTypes.string,
 		tracksEvent: PropTypes.string,
 		tracksOptions: PropTypes.object,
@@ -41,6 +42,7 @@ class InlineSupportLink extends Component {
 		supportLink: null,
 		showText: true,
 		showIcon: true,
+		iconStyle: 'help-outline',
 		iconSize: 14,
 		showSupportModal: true,
 		noWrap: true,
@@ -70,8 +72,17 @@ class InlineSupportLink extends Component {
 	}
 
 	render() {
-		const { className, showText, showIcon, linkTitle, iconSize, translate, children, noWrap } =
-			this.props;
+		const {
+			className,
+			showText,
+			showIcon,
+			linkTitle,
+			iconSize,
+			iconStyle,
+			translate,
+			children,
+			noWrap,
+		} = this.props;
 
 		let { supportPostId, supportLink } = this.props;
 		if ( this.state.supportDataFromContext ) {
@@ -94,7 +105,7 @@ class InlineSupportLink extends Component {
 		let content = (
 			<>
 				{ showText && text }
-				{ supportPostId && showIcon && <Gridicon icon="help-outline" size={ iconSize } /> }
+				{ supportPostId && showIcon && <Gridicon icon={ iconStyle } size={ iconSize } /> }
 			</>
 		);
 		/* Prevent widows, sometimes:

--- a/client/components/inline-support-link/index.jsx
+++ b/client/components/inline-support-link/index.jsx
@@ -27,7 +27,6 @@ class InlineSupportLink extends Component {
 		showIcon: PropTypes.bool,
 		supportContext: PropTypes.string,
 		iconSize: PropTypes.number,
-		iconStyle: PropTypes.string,
 		linkTitle: PropTypes.string,
 		tracksEvent: PropTypes.string,
 		tracksOptions: PropTypes.object,
@@ -42,7 +41,6 @@ class InlineSupportLink extends Component {
 		supportLink: null,
 		showText: true,
 		showIcon: true,
-		iconStyle: 'help-outline',
 		iconSize: 14,
 		showSupportModal: true,
 		noWrap: true,
@@ -72,17 +70,8 @@ class InlineSupportLink extends Component {
 	}
 
 	render() {
-		const {
-			className,
-			showText,
-			showIcon,
-			linkTitle,
-			iconSize,
-			iconStyle,
-			translate,
-			children,
-			noWrap,
-		} = this.props;
+		const { className, showText, showIcon, linkTitle, iconSize, translate, children, noWrap } =
+			this.props;
 
 		let { supportPostId, supportLink } = this.props;
 		if ( this.state.supportDataFromContext ) {
@@ -105,7 +94,7 @@ class InlineSupportLink extends Component {
 		let content = (
 			<>
 				{ showText && text }
-				{ supportPostId && showIcon && <Gridicon icon={ iconStyle } size={ iconSize } /> }
+				{ supportPostId && showIcon && <Gridicon icon="help-outline" size={ iconSize } /> }
 			</>
 		);
 		/* Prevent widows, sometimes:

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -730,7 +730,7 @@ export class SiteSettingsFormGeneral extends Component {
 								<InfoPopover position="bottom right">
 									{ translate( 'Control who can view your site. ' ) }
 									<InlineSupportLink showIcon={ false } supportContext="privacy">
-										{ translate( 'Learn more.' ) }
+										{ translate( 'Learn more' ) }
 									</InlineSupportLink>
 								</InfoPopover>
 							),

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -30,6 +30,7 @@ import FormLabel from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormInput from 'calypso/components/forms/form-text-input';
+import InfoPopover from 'calypso/components/info-popover';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import SiteLanguagePicker from 'calypso/components/language-picker/site-language-picker';
 import Notice from 'calypso/components/notice';
@@ -726,11 +727,12 @@ export class SiteSettingsFormGeneral extends Component {
 					title={ translate( 'Privacy {{learnMoreLink/}}', {
 						components: {
 							learnMoreLink: (
-								<InlineSupportLink
-									supportContext="privacy"
-									showText={ false }
-									iconStyle="info-outline"
-								/>
+								<InfoPopover position="bottom right">
+									{ translate( 'Control who can view your site. ' ) }
+									<InlineSupportLink showIcon={ false } supportContext="privacy">
+										{ translate( 'Learn more' ) }
+									</InlineSupportLink>
+								</InfoPopover>
 							),
 						},
 						comment: 'Privacy Settings header',

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -730,7 +730,7 @@ export class SiteSettingsFormGeneral extends Component {
 								<InfoPopover position="bottom right">
 									{ translate( 'Control who can view your site. ' ) }
 									<InlineSupportLink showIcon={ false } supportContext="privacy">
-										{ translate( 'Learn more' ) }
+										{ translate( 'Learn more.' ) }
 									</InlineSupportLink>
 								</InfoPopover>
 							),

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -725,7 +725,13 @@ export class SiteSettingsFormGeneral extends Component {
 					showButton
 					title={ translate( 'Privacy {{learnMoreLink/}}', {
 						components: {
-							learnMoreLink: <InlineSupportLink supportContext="privacy" showText={ false } />,
+							learnMoreLink: (
+								<InlineSupportLink
+									supportContext="privacy"
+									showText={ false }
+									iconStyle="info-outline"
+								/>
+							),
 						},
 						comment: 'Privacy Settings header',
 					} ) }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -724,19 +724,16 @@ export class SiteSettingsFormGeneral extends Component {
 					isSaving={ isSavingSettings }
 					onButtonClick={ handleSubmitForm }
 					showButton
-					title={ translate( 'Privacy {{learnMoreLink/}}', {
-						components: {
-							learnMoreLink: (
-								<InfoPopover position="bottom right">
-									{ translate( 'Control who can view your site. ' ) }
-									<InlineSupportLink showIcon={ false } supportContext="privacy">
-										{ translate( 'Learn more' ) }
-									</InlineSupportLink>
-								</InfoPopover>
-							),
-						},
-						comment: 'Privacy Settings header',
-					} ) }
+					title={ translate(
+						'Privacy {{infoPopover}} Control who can view your site. {{a}} Learn more {{/a}}. {{/infoPopover}}',
+						{
+							components: {
+								a: <InlineSupportLink showIcon={ false } supportContext="privacy" />,
+								infoPopover: <InfoPopover position="bottom right" />,
+							},
+							comment: 'Privacy Settings header',
+						}
+					) }
 				/>
 				<Card>
 					<form> { this.visibilityOptionsComingSoon() }</form>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -725,7 +725,7 @@ export class SiteSettingsFormGeneral extends Component {
 					onButtonClick={ handleSubmitForm }
 					showButton
 					title={ translate(
-						'Privacy {{infoPopover}} Control who can view your site. {{a}} Learn more {{/a}}. {{/infoPopover}}',
+						'Privacy {{infoPopover}} Control who can view your site. {{a}}Learn more{{/a}}. {{/infoPopover}}',
 						{
 							components: {
 								a: <InlineSupportLink showIcon={ false } supportContext="privacy" />,

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -586,14 +586,8 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 	pointer-events: none;
 }
 
-#site-privacy-settings .inline-support-link {
-	color: var(--color-text-subtle);
-
-	svg {
-		vertical-align: middle;
-		height: 18px;
-		width: 18px;
-	}
+#site-privacy-settings .section-header__label-text button {
+	vertical-align: middle;
 }
 
 .site-settings__writing-settings {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -586,6 +586,16 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 	pointer-events: none;
 }
 
+#site-privacy-settings .inline-support-link {
+	color: var(--color-text-subtle);
+
+	svg {
+		vertical-align: middle;
+		height: 18px;
+		width: 18px;
+	}
+}
+
 .site-settings__writing-settings {
 	.theme-enhancements__card {
 		.form-fieldset.minileven {


### PR DESCRIPTION
The style of the help icon next to the privacy section of the general settings page has a style that looks a bit out of place. It should have the same style as the Site Icon Setting popover icon.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5033

## Proposed Changes

* Allow overriding of the icon style of the inline-support-link component.
* Changed the style of the help icon next to the Privacy heading of the general settings page to look the same as the Site Icon Setting popover icon.

Before:
![CleanShot 2567-01-02 at 22 25 05@2x](https://github.com/Automattic/wp-calypso/assets/10244734/04c35e27-3339-4a5f-8035-4cd654e67649)

After:

<img width="749" alt="Screenshot 2024-01-09 at 11 32 45" src="https://github.com/Automattic/wp-calypso/assets/779993/52482f35-c74a-4cf8-a1ec-7a34219e5bc7">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Settings -> General and confirm that the icon next to the Privacy heading has the correct style.
* Check the style in various viewport sizes to ensure it renders correctly in all scenarios.
* Ensure that the icon looks as in the 'After' screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?