### PR TITLE
Add marketplace siteless checkout page

### DIFF
--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -77,6 +77,10 @@ export function checkoutAkismetSiteless( context, next ) {
 	sitelessCheckout( context, next, { sitelessCheckoutType: 'akismet' } );
 }
 
+export function checkoutMarketplaceSiteless( context, next ) {
+	sitelessCheckout( context, next, { sitelessCheckoutType: 'marketplace' } );
+}
+
 function sitelessCheckout( context, next, extraProps ) {
 	const state = context.store.getState();
 	const isLoggedOut = ! isUserLoggedIn( state );

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -13,6 +13,7 @@ import {
 	checkoutAkismetSiteless,
 	checkoutPending,
 	checkoutJetpackSiteless,
+	checkoutMarketplaceSiteless,
 	checkoutThankYou,
 	licensingThankYouManualActivationInstructions,
 	licensingThankYouManualActivationLicenseKey,
@@ -106,6 +107,17 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
+
+	if ( isEnabled( 'marketplace-siteless-checkout' ) ) {
+		page(
+			`/checkout/marketplace/:productSlug`,
+			setLocaleMiddleware(),
+			noSite,
+			checkoutMarketplaceSiteless,
+			makeLayout,
+			clientRender
+		);
+	}
 
 	// Akismet siteless checkout works logged-out, so do not include redirectLoggedOut or siteSelection.
 	if ( isEnabled( 'akismet/siteless-checkout' ) ) {

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -100,6 +100,7 @@ export interface CheckoutMainProps {
 	disabledThankYouPage?: boolean;
 	sitelessCheckoutType?: SitelessCheckoutType;
 	akismetSiteSlug?: string;
+	marketplaceSiteSlug?: string;
 	jetpackSiteSlug?: string;
 	jetpackPurchaseToken?: string;
 	isUserComingFromLoginForm?: boolean;
@@ -137,6 +138,7 @@ export default function CheckoutMain( {
 	disabledThankYouPage,
 	sitelessCheckoutType,
 	akismetSiteSlug,
+	marketplaceSiteSlug,
 	jetpackSiteSlug,
 	jetpackPurchaseToken,
 	isUserComingFromLoginForm,
@@ -170,8 +172,12 @@ export default function CheckoutMain( {
 			return akismetSiteSlug;
 		}
 
+		if ( sitelessCheckoutType === 'marketplace' ) {
+			return marketplaceSiteSlug;
+		}
+
 		return siteSlug;
-	}, [ akismetSiteSlug, jetpackSiteSlug, sitelessCheckoutType, siteSlug ] );
+	}, [ akismetSiteSlug, jetpackSiteSlug, marketplaceSiteSlug, sitelessCheckoutType, siteSlug ] );
 
 	const showErrorMessageBriefly = useCallback(
 		( error: string ) => {

--- a/client/my-sites/checkout/src/hooks/use-checkout-flow-track-key.ts
+++ b/client/my-sites/checkout/src/hooks/use-checkout-flow-track-key.ts
@@ -34,6 +34,10 @@ export default function useCheckoutFlowTrackKey( {
 			return 'akismet_siteless_checkout';
 		}
 
+		if ( sitelessCheckoutType === 'marketplace' ) {
+			return 'marketplace_siteless_checkout';
+		}
+
 		if ( isLoggedOutCart ) {
 			return 'wpcom_registrationless';
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR adds the basic code to handle marketplace siteless checkout. Also, add a flag to test this feature before shipping it to production.

* Add marketplace siteless function that calls `sitelessCheckout` to the checkout controller.
* Add the checkout page `/checkout/marketplace/:productSlug` under the flag `marketplace-siteless-checkout`
* Update the `CheckoutMain` component to return the marketplaceSiteSlug when the `sitelessCheckoutType` is `marketplace`
* 

## Testing Instructions
- Visit the URL `http://calypso.localhost:3000/checkout/marketplace/passport?flags=marketplace-siteless-checkout`
- Check that the checkout page loads with no items in the cart.

<img width="970" alt="Screenshot 2024-01-02 at 11 19 24 AM" src="https://github.com/Automattic/wp-calypso/assets/351784/60231d58-cea7-4abc-9410-96528813db2e">

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] Have you checked for TypeScript, React or other console errors?