### PR TITLE
Marketplace Test: Allow update of the reviews form fields

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-test/index.jsx
+++ b/client/my-sites/marketplace/pages/marketplace-test/index.jsx
@@ -176,22 +176,22 @@ export default function MarketplaceTest() {
 					>
 						<label>
 							Product type
-							<input type="text" value="plugin" />
+							<input type="text" defaultValue="plugin" />
 						</label>
 						<br />
 						<label>
 							Product slug
-							<input type="text" value="woocommerce-bookings" />
+							<input type="text" defaultValue="woocommerce-bookings" />
 						</label>
 						<br />
 						<label>
 							Comment
-							<input type="text" value="I like it" />
+							<input type="text" defaultValue="I like it" />
 						</label>
 						<br />
 						<label>
 							Rating
-							<input type="text" value="5" />
+							<input type="text" defaultValue="5" />
 						</label>
 						<br />
 						<Button type="submit">Add new review</Button>
@@ -220,22 +220,22 @@ export default function MarketplaceTest() {
 						<br />
 						<label>
 							Product type
-							<input type="text" value="plugin" />
+							<input type="text" defaultValue="plugin" />
 						</label>
 						<br />
 						<label>
 							Product slug
-							<input type="text" value="woocommerce-bookings" />
+							<input type="text" defaultValue="woocommerce-bookings" />
 						</label>
 						<br />
 						<label>
 							Comment
-							<input type="text" value="Updated review" />
+							<input type="text" defaultValue="Updated review" />
 						</label>
 						<br />
 						<label>
 							Rating
-							<input type="text" value="3" />
+							<input type="text" defaultValue="3" />
 						</label>
 						<br />
 						<Button type="submit">Update review</Button>


### PR DESCRIPTION
## Proposed Changes

Use the property `defaultValue` instead of `value` to allow the update of the input value.

## Testing Instructions

 * Go to `/marketplace/test/:site`
 * Check if you can edit values on the `Add new review` and `Update review` sections
 * The creation and update of reviews should keep behaving as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
