### PR TITLE
Jetpack Manage: Plugin management 'update plugin' link - show dialog, convert to button

### DIFF
--- a/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-row-formatter/index.tsx
@@ -33,6 +33,7 @@ interface Props {
 	isSmallScreen?: boolean;
 	className?: string;
 	updatePlugin?: ( plugin: PluginComponentProps ) => void;
+	siteCount?: number;
 }
 
 export default function PluginRowFormatter( {
@@ -247,6 +248,7 @@ export default function PluginRowFormatter( {
 					selectedSite={ selectedSite }
 					className={ className }
 					updatePlugin={ updatePlugin }
+					siteCount={ siteCount }
 				/>
 			);
 		case 'install':


### PR DESCRIPTION

Related to https://github.com/Automattic/jetpack-manage/issues/116

## Proposed Changes

* This PR adds a Dialog component to the 'Update to xxx' link that shows on the plugin management page when a plugin has an update available.
* This uses the ConfirmModal component, and adds a new prop to pass the site count through (to UpdatePlugin). This seemed better than excluding the sitecount or a link to the sites with the plugin in question, and omitting that information means the modal is still sparse in information.
* The wording is similar to the dialog wording that shows if you use the bulk edit 'Update Plugin' button at the top right of the plugin management page. That uses a different component, but for flexibility and ease of use I've opted for the ConfirmModal.

## Testing Instructions

* Within the Jetpack Manage dashboard, visit the plugin management page: http://jetpack.cloud.localhost:3000/plugins/manage
* Find a plugin that needs updating on a Jetpack connected site that needs updating (download an older version of a plugin on a site for testing purposes if needed).
* Click on the 'Update to' button
* Notice the modal. The wording should say the name of plugin, and the number of sites needing that plugin updated. Click ok and the plugin should update.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?