### PR TITLE
Add getRazorpayConfiguration to lib/store-transactions

### DIFF
--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -68,3 +68,9 @@ export async function getStripeConfiguration( requestArgs ) {
 	debug( 'Stripe configuration', config );
 	return config;
 }
+
+export async function getRazorpayConfiguration( requestArgs ) {
+	const config = await wp.req.get( '/me/razorpay-configuration', requestArgs );
+	debug( 'RazorPay configuration', config );
+	return config;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85846. See also pbOQVh-4mH-p2.

## Proposed Changes

* Add helper method to `lib/store-transactions` for fetching RazorPay configuration options.

We're adding [RazorPay](https://razorpay.com/docs/payments/payment-gateway/web-integration/standard/build-integration/#12-integrate-with-checkout-on-client-side) support, ~~copying~~ taking inspiration from the architecture of the Stripe integration because there's a lot of similarity.   Responsibility for configuring and loading the RazorPay JS library is in a separate package, calypso-razorpay, in progress in #85846. That package is parameterized over a method which fetches configuration options, which in practice will come from an endpoint in the WPCOM API. This patch adds a method to [lib/store-transactions](https://github.com/Automattic/wp-calypso/blob/b25623d4ecd1a588896603d8aa4df2b4c9f603be/client/lib/store-transactions/index.js#L4) for calling that endpoint.

## Testing Instructions

There's no code in calypso yet that uses this, but we can hack in a test by manually editing [ChangePaymentMethodWrapper](https://github.com/Automattic/wp-calypso/blob/b25623d4ecd1a588896603d8aa4df2b4c9f603be/client/me/purchases/manage-purchase/change-payment-method/index.tsx#L116) to call `getRazorpayConfiguration` instead of `getStripeConfiguration` and then loading a change payment method screen (Upgrades > Purchases > choose purchase > Change Payment Method). Watch the network tab for a call to `/me/razorpay-configuration` and inspect the response:

<img width="537" alt="Screenshot 2024-01-02 at 12 50 32 PM" src="https://github.com/Automattic/wp-calypso/assets/9310939/e788f7f4-9132-441d-93e1-586220c8d5c0">

Currently the endpoint returns some test data.


*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- (NA - the result of this call is memoized elsewhere) Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- (NA - no new strings) Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- (NA - does not affect jetpack) For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
