### PR TITLE
Monetize: Update launchpad text for newsletters

### DIFF
--- a/client/my-sites/earn/launchpad/index.tsx
+++ b/client/my-sites/earn/launchpad/index.tsx
@@ -18,6 +18,7 @@ const EarnLaunchpad = ( { launchpad }: EarnLaunchpadProps ) => {
 	const { checklistSlug, taskFilter, numberOfSteps, completedSteps } = launchpad;
 	const translate = useTranslate();
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const isNewsletter = 'newsletter' === site?.options?.site_intent;
 
 	return (
 		<div className="earn__launchpad">
@@ -31,7 +32,9 @@ const EarnLaunchpad = ( { launchpad }: EarnLaunchpadProps ) => {
 					/>
 				</div>
 				<h2 className="earn__launchpad-title">
-					{ translate( 'Create your paid offering in two steps.' ) }
+					{ isNewsletter
+						? translate( 'Create your paid newsletter in two steps.' )
+						: translate( 'Create your paid offering in two steps.' ) }
 				</h2>
 				<p className="earn__launchpad-description">
 					{ translate( 'Let your fans support your art, writing, or project directly.' ) }


### PR DESCRIPTION
## Proposed Changes

Slight adjustment to launchpad description for newsletter sites based on designs at DqXCQr1dEWpF3P2dIEwiwd-fi-873_134229. I'll be tweaking the text for the actual tasks themselves, too, but that will be done via Jetpack. 

**Screenshot for translators**
<img width="1128" alt="monetize-newsletter-launchpad" src="https://github.com/Automattic/wp-calypso/assets/21228350/1c602b56-9906-4587-ab37-8ddb8eb149a6">

## Testing Instructions

1) Create a newsletters site at http://calypso.localhost:3000/setup/newsletter/intro
2) Go to http://calypso.localhost:3000/earn/YOURSITESLUG and confirm the launchpad title now says 'Create your paid newsletter in two steps.'

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?