### PR TITLE
Hosting Command Palette: Filter sites based on capability

### DIFF
--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -107,11 +107,15 @@ export const useCommandsArrayWpcom = ( {
 
 	const siteFilters = {
 		hostingEnabled: {
-			filter: ( site: SiteExcerptData ) => site?.is_wpcom_atomic,
+			capabilityFilter: 'manage_options',
+			filter: ( site: SiteExcerptData ) => {
+				return site?.is_wpcom_atomic;
+			},
 			filterNotice: __( 'Only listing sites with hosting features enabled.' ),
 			emptyListNotice: __( 'No sites with hosting features enabled.' ),
 		},
 		hostingEnabledAndPublic: {
+			capabilityFilter: 'manage_options',
 			filter: ( site: SiteExcerptData ) =>
 				site?.is_wpcom_atomic && ! site?.is_coming_soon && ! site?.is_private,
 			filterNotice: __( 'Only listing public sites with hosting features enabled.' ),
@@ -423,6 +427,7 @@ export const useCommandsArrayWpcom = ( {
 				__( 'Select site to open hosting configuration' )
 			),
 			siteFunctions: {
+				capabilityFilter: 'manage_options',
 				onClick: ( param ) => commandNavigation( `/hosting-config/${ param.site.slug }` )( param ),
 				filter: ( site: SiteExcerptData ) => ! isP2Site( site ) && ! isNotAtomicJetpack( site ),
 				filterNotice: __( 'Only listing sites hosted on WordPress.com.' ),
@@ -476,6 +481,7 @@ export const useCommandsArrayWpcom = ( {
 				__( 'Select site to open Jetpack settings' )
 			),
 			siteFunctions: {
+				capabilityFilter: 'manage_options',
 				onClick: ( param ) =>
 					commandNavigation( `${ param.site.URL }/wp-admin/admin.php?page=jetpack#/dashboard` )(
 						param
@@ -507,6 +513,7 @@ export const useCommandsArrayWpcom = ( {
 				__( 'Select site to manage Jetpack modules' )
 			),
 			siteFunctions: {
+				capabilityFilter: 'manage_options',
 				onClick: ( param ) =>
 					commandNavigation( `${ param.site.URL }/wp-admin/admin.php?page=jetpack_modules` )(
 						param
@@ -603,6 +610,7 @@ export const useCommandsArrayWpcom = ( {
 			context: [ '/sites' ],
 			callback: setStateCallback( 'manageDns', __( 'Select site to open DNS records' ) ),
 			siteFunctions: {
+				capabilityFilter: 'manage_options',
 				onClick: ( param ) =>
 					commandNavigation( `/domains/manage/${ param.site.slug }/dns/${ param.site.slug }` )(
 						param
@@ -689,6 +697,7 @@ export const useCommandsArrayWpcom = ( {
 			label: __( 'Open Jetpack Backup' ),
 			callback: setStateCallback( 'openJetpackBackup', __( 'Select site to open Jetpack Backup' ) ),
 			siteFunctions: {
+				capabilityFilter: 'manage_options',
 				onClick: ( param ) => commandNavigation( `/backup/${ param.site.slug }` )( param ),
 				filter: ( site: SiteExcerptData ) => ! isP2Site( site ) && ! isNotAtomicJetpack( site ),
 				filterNotice: __( 'Only listing sites with Jetpack Backup enabled.' ),
@@ -814,6 +823,7 @@ export const useCommandsArrayWpcom = ( {
 			context: [ '/posts' ],
 			callback: setStateCallback( 'addNewPost', __( 'Select site to add new post' ) ),
 			siteFunctions: {
+				capabilityFilter: 'edit_posts',
 				onClick: ( param ) => {
 					const link = generateSiteInterfaceLink( param.site, {
 						calypso: '/post',
@@ -833,6 +843,7 @@ export const useCommandsArrayWpcom = ( {
 			].join( ' ' ),
 			callback: setStateCallback( 'managePosts', __( 'Select site to manage posts' ) ),
 			siteFunctions: {
+				capabilityFilter: 'edit_posts',
 				onClick: ( param ) => {
 					const link = generateSiteInterfaceLink( param.site, {
 						calypso: '/posts',
@@ -852,6 +863,7 @@ export const useCommandsArrayWpcom = ( {
 			].join( ' ' ),
 			callback: setStateCallback( 'viewMediaUploads', __( 'Select site to view media uploads' ) ),
 			siteFunctions: {
+				capabilityFilter: 'upload_files',
 				onClick: ( param ) => {
 					const link = generateSiteInterfaceLink( param.site, {
 						calypso: '/media',
@@ -867,6 +879,7 @@ export const useCommandsArrayWpcom = ( {
 			label: __( 'Upload media' ),
 			callback: setStateCallback( 'uploadMedia', __( 'Select site to upload media' ) ),
 			siteFunctions: {
+				capabilityFilter: 'upload_files',
 				onClick: ( param ) => {
 					const link = generateSiteInterfaceLink( param.site, {
 						calypso: '/media',
@@ -887,6 +900,7 @@ export const useCommandsArrayWpcom = ( {
 			].join( ' ' ),
 			callback: setStateCallback( 'managePages', __( 'Select site to manage pages' ) ),
 			siteFunctions: {
+				capabilityFilter: 'edit_pages',
 				onClick: ( param ) => {
 					const link = generateSiteInterfaceLink( param.site, {
 						calypso: '/pages',
@@ -908,6 +922,7 @@ export const useCommandsArrayWpcom = ( {
 			context: [ '/pages' ],
 			callback: setStateCallback( 'addNewPage', __( 'Select site to add new page' ) ),
 			siteFunctions: {
+				capabilityFilter: 'edit_pages',
 				onClick: ( param ) => {
 					const link = generateSiteInterfaceLink( param.site, {
 						calypso: '/page',
@@ -928,6 +943,7 @@ export const useCommandsArrayWpcom = ( {
 			].join( ' ' ),
 			callback: setStateCallback( 'manageComments', __( 'Select site to manage comments' ) ),
 			siteFunctions: {
+				capabilityFilter: 'moderate_comments',
 				onClick: ( param ) => {
 					const link = generateSiteInterfaceLink( param.site, {
 						calypso: '/comments',
@@ -949,6 +965,7 @@ export const useCommandsArrayWpcom = ( {
 			].join( ' ' ),
 			callback: setStateCallback( 'manageThemes', __( 'Select site to manage themes' ) ),
 			siteFunctions: {
+				capabilityFilter: 'install_themes',
 				onClick: ( param ) => {
 					const link = generateSiteInterfaceLink( param.site, {
 						calypso: '/themes',
@@ -970,6 +987,7 @@ export const useCommandsArrayWpcom = ( {
 			].join( ' ' ),
 			callback: setStateCallback( 'installTheme', __( 'Select site to install theme' ) ),
 			siteFunctions: {
+				capabilityFilter: 'install_themes',
 				onClick: ( param ) => {
 					const link = generateSiteInterfaceLink( param.site, {
 						calypso: '/themes',
@@ -994,6 +1012,7 @@ export const useCommandsArrayWpcom = ( {
 			].join( ' ' ),
 			callback: setStateCallback( 'managePlugins', __( 'Select site to manage plugins' ) ),
 			siteFunctions: {
+				capabilityFilter: 'install_plugins',
 				onClick: ( param ) => {
 					const link = generateSiteInterfaceLink( param.site, {
 						calypso: '/plugins',
@@ -1015,6 +1034,7 @@ export const useCommandsArrayWpcom = ( {
 			].join( ' ' ),
 			callback: setStateCallback( 'installPlugin', __( 'Select site to install plugin' ) ),
 			siteFunctions: {
+				capabilityFilter: 'install_plugins',
 				onClick: ( param ) => {
 					const link = generateSiteInterfaceLink( param.site, {
 						calypso: '/plugins',
@@ -1037,6 +1057,7 @@ export const useCommandsArrayWpcom = ( {
 			context: [ '/sites' ],
 			callback: setStateCallback( 'changePlan', __( 'Select site to change plan' ) ),
 			siteFunctions: {
+				capabilityFilter: 'manage_options',
 				onClick: ( param ) => commandNavigation( `/plans/${ param.site.slug }` )( param ),
 				filter: ( site: SiteExcerptData ) => ! isP2Site( site ) && ! site?.is_wpcom_staging_site,
 			},
@@ -1052,6 +1073,7 @@ export const useCommandsArrayWpcom = ( {
 			].join( ' ' ),
 			callback: setStateCallback( 'manageMyPlan', __( 'Select site to manage your plan' ) ),
 			siteFunctions: {
+				capabilityFilter: 'manage_options',
 				onClick: ( param ) => commandNavigation( `/plans/my-plan/${ param.site.slug }` )( param ),
 				filter: ( site: SiteExcerptData ) => ! isP2Site( site ) && ! site?.is_wpcom_staging_site,
 			},
@@ -1070,6 +1092,7 @@ export const useCommandsArrayWpcom = ( {
 			].join( ' ' ),
 			callback: setStateCallback( 'manageUsers', __( 'Select site to manage users' ) ),
 			siteFunctions: {
+				capabilityFilter: 'list_users',
 				onClick: ( param ) => {
 					const link = generateSiteInterfaceLink( param.site, {
 						calypso: '/people/team',
@@ -1090,6 +1113,7 @@ export const useCommandsArrayWpcom = ( {
 			].join( ' ' ),
 			callback: setStateCallback( 'addNewUser', __( 'Select site to add new user' ) ),
 			siteFunctions: {
+				capabilityFilter: 'list_users',
 				onClick: ( param ) => {
 					const link = generateSiteInterfaceLink( param.site, {
 						calypso: '/people/new',
@@ -1111,6 +1135,7 @@ export const useCommandsArrayWpcom = ( {
 			context: [ '/subscribers' ],
 			callback: setStateCallback( 'addSubscribers', __( 'Select site to add subscribers' ) ),
 			siteFunctions: {
+				capabilityFilter: 'manage_options',
 				onClick: ( param ) =>
 					commandNavigation( `/subscribers/${ param.site.slug }#add-subscribers` )( param ),
 			},
@@ -1121,6 +1146,7 @@ export const useCommandsArrayWpcom = ( {
 			label: __( 'Manage subscribers' ),
 			callback: setStateCallback( 'manageSubscribers', __( 'Select site to manage subscribers' ) ),
 			siteFunctions: {
+				capabilityFilter: 'manage_options',
 				onClick: ( param ) => commandNavigation( `/subscribers/${ param.site.slug }` )( param ),
 			},
 			icon: subscriberIcon,
@@ -1134,6 +1160,7 @@ export const useCommandsArrayWpcom = ( {
 				__( 'Select site to download subscribers' )
 			),
 			siteFunctions: {
+				capabilityFilter: 'manage_options',
 				onClick: ( { site, close } ) => {
 					close();
 					window.location.assign(
@@ -1149,6 +1176,7 @@ export const useCommandsArrayWpcom = ( {
 			context: [ '/posts' ],
 			callback: setStateCallback( 'import', __( 'Select site to import content' ) ),
 			siteFunctions: {
+				capabilityFilter: 'manage_options',
 				onClick: ( param ) => commandNavigation( `/import/${ param.site.slug }` )( param ),
 			},
 			icon: downloadIcon,
@@ -1161,6 +1189,7 @@ export const useCommandsArrayWpcom = ( {
 				__( 'Select site to open WooCommerce settings' )
 			),
 			siteFunctions: {
+				capabilityFilter: 'manage_options',
 				onClick: ( param ) => {
 					if ( param.site.options?.is_wpcom_store ) {
 						commandNavigation( `${ param.site.URL }/wp-admin/admin.php?page=wc-admin` )( param );
@@ -1182,6 +1211,7 @@ export const useCommandsArrayWpcom = ( {
 				__( 'Select site to manage general settings' )
 			),
 			siteFunctions: {
+				capabilityFilter: 'manage_options',
 				onClick: ( param ) => {
 					const link = generateSiteInterfaceLink( param.site, {
 						calypso: '/settings/general',
@@ -1201,6 +1231,7 @@ export const useCommandsArrayWpcom = ( {
 				__( 'Select site to manage writing settings' )
 			),
 			siteFunctions: {
+				capabilityFilter: 'manage_options',
 				onClick: ( param ) => {
 					const link = generateSiteInterfaceLink( param.site, {
 						calypso: '/settings/writing',
@@ -1220,6 +1251,7 @@ export const useCommandsArrayWpcom = ( {
 				__( 'Select site to manage reading settings' )
 			),
 			siteFunctions: {
+				capabilityFilter: 'manage_options',
 				onClick: ( param ) => {
 					const link = generateSiteInterfaceLink( param.site, {
 						calypso: '/settings/reading',
@@ -1239,6 +1271,7 @@ export const useCommandsArrayWpcom = ( {
 				__( 'Select site to manage discussion settings' )
 			),
 			siteFunctions: {
+				capabilityFilter: 'manage_options',
 				onClick: ( param ) => {
 					const link = generateSiteInterfaceLink( param.site, {
 						calypso: '/settings/discussion',
@@ -1258,6 +1291,7 @@ export const useCommandsArrayWpcom = ( {
 				__( 'Select site to manage newsletter settings' )
 			),
 			siteFunctions: {
+				capabilityFilter: 'manage_options',
 				onClick: ( param ) =>
 					commandNavigation( `/settings/newsletter/${ param.site.slug }` )( param ),
 			},
@@ -1272,6 +1306,7 @@ export const useCommandsArrayWpcom = ( {
 				__( 'Select site to manage podcast settings' )
 			),
 			siteFunctions: {
+				capabilityFilter: 'manage_options',
 				onClick: ( param ) =>
 					commandNavigation( `/settings/podcasting/${ param.site.slug }` )( param ),
 			},


### PR DESCRIPTION
Related https://github.com/Automattic/dotcom-forge/issues/4708

## Proposed Changes

Filters the sites listed based on the required capability. This will help prevent a user from navigating to a page they don't have access to.

## Testing Instructions

1. Create a new Business site.
2. As the site owner, open the Hosting Command Palette, search for "Manage subscribers", and verify the site is listed as expected.
3. Add a second user to the site as an author.
4. As the second user, open the Hosting Command Palette, search for "Manage subscribers", and verify the site isn't included in the list.
5. Continue to test a variety of pages and capabilities.