### PR TITLE
Use debug instead of console.error

### DIFF
--- a/packages/design-picker/src/components/style-variation-badges/utils.ts
+++ b/packages/design-picker/src/components/style-variation-badges/utils.ts
@@ -1,4 +1,5 @@
 import { hexToRgb } from '@automattic/onboarding';
+import debugFactory from 'debug';
 import type {
 	StyleVariation,
 	StyleVariationSettingsColorPalette,
@@ -10,6 +11,8 @@ interface Hsl {
 	s: number;
 	l: number;
 }
+
+const debug = debugFactory( 'design-picker:style-variation-badges' );
 
 const COLOR_BASE_CANDIDATE_KEYS = [ 'base', 'background', 'primary' ];
 const HSL_BEST_DIFFERENCE_VALUE = 155;
@@ -112,8 +115,7 @@ export function getStylesColorFromVariation(
 	try {
 		return { background: colorBase, text: findColorBestAnalogous( colorList, colorBase ) };
 	} catch ( e ) {
-		// eslint-disable-next-line no-console
-		console.error( e, variation );
+		debug( e.message, variation );
 		return null;
 	}
 }

--- a/packages/design-picker/src/components/style-variation-badges/utils.ts
+++ b/packages/design-picker/src/components/style-variation-badges/utils.ts
@@ -115,7 +115,7 @@ export function getStylesColorFromVariation(
 	try {
 		return { background: colorBase, text: findColorBestAnalogous( colorList, colorBase ) };
 	} catch ( e ) {
-		debug( e.message, variation );
+		debug( e instanceof Error ? e.message : e, variation );
 		return null;
 	}
 }

--- a/packages/design-picker/src/components/style-variation-badges/utils.ts
+++ b/packages/design-picker/src/components/style-variation-badges/utils.ts
@@ -115,7 +115,7 @@ export function getStylesColorFromVariation(
 	try {
 		return { background: colorBase, text: findColorBestAnalogous( colorList, colorBase ) };
 	} catch ( e ) {
-		debug( e instanceof Error ? e.message : e, variation );
+		debug( e, variation );
 		return null;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85764

## Proposed Changes

As suggested in https://github.com/Automattic/wp-calypso/pull/85764#discussion_r1439249833, let's use `debug` instead of `console.error` for debugging.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Ensure that there are no JavaScript errors caused by this PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?