### PR TITLE
Jetpack Manage: Redirect to WP Admin for Atomic site Boost purchase

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/license-info-modal/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/license-info-modal/index.tsx
@@ -20,6 +20,8 @@ interface Props {
 	extraAsideContent?: JSX.Element;
 	isDisabled?: boolean;
 	onCtaClick?: () => void;
+	isCTAExternalLink?: boolean;
+	ctaHref?: string;
 }
 
 export default function LicenseInfoModal( {
@@ -31,6 +33,8 @@ export default function LicenseInfoModal( {
 	extraAsideContent,
 	isDisabled,
 	onCtaClick,
+	isCTAExternalLink,
+	ctaHref,
 }: Props ) {
 	const isMobile = useMobileBreakpoint();
 	const translate = useTranslate();
@@ -84,6 +88,8 @@ export default function LicenseInfoModal( {
 				className={ className }
 				product={ currentLicenseProduct }
 				ctaLabel={ label ?? translate( 'Issue License' ) }
+				isCTAExternalLink={ isCTAExternalLink }
+				ctaHref={ ctaHref }
 				isDisabled={ ! partnerCanIssueLicense || isDisabled }
 				onActivate={ onIssueLicense }
 				onClose={ onHideLicenseInfo }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
@@ -25,7 +25,7 @@ export default function BoostLicenseInfoModal( { onClose, site, upgradeOnly }: P
 
 	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( [ site ], isLargeScreen );
 
-	const { blog_id: siteId, url: siteUrl } = site;
+	const { blog_id: siteId, url: siteUrl, is_atomic, url_with_scheme } = site;
 
 	// queryKey is needed to optimistically update the site list
 	const queryKey = useMemo(
@@ -67,6 +67,10 @@ export default function BoostLicenseInfoModal( { onClose, site, upgradeOnly }: P
 			onClose={ onClose }
 			siteId={ siteId }
 			onCtaClick={ handlePurchaseBoost }
+			isCTAExternalLink={ is_atomic }
+			ctaHref={
+				is_atomic ? `${ url_with_scheme }/wp-admin/admin.php?page=jetpack#/dashboard` : undefined
+			}
 			extraAsideContent={
 				<>
 					{ ! upgradeOnly && (

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';
 import { FunctionComponent, useCallback } from 'react';
@@ -24,11 +24,15 @@ export type LicenseLightBoxProps = {
 	extraAsideContent?: JSX.Element;
 	className?: string;
 	quantity?: number;
+	isCTAExternalLink?: boolean;
+	ctaHref?: string;
 };
 
 const LicenseLightbox: FunctionComponent< LicenseLightBoxProps > = ( {
 	ctaLabel,
 	isCTAPrimary = true,
+	isCTAExternalLink = false,
+	ctaHref,
 	isDisabled,
 	onActivate,
 	onClose,
@@ -66,10 +70,15 @@ const LicenseLightbox: FunctionComponent< LicenseLightBoxProps > = ( {
 				<Button
 					className="license-lightbox__cta-button"
 					primary={ isCTAPrimary }
-					onClick={ onCTAClick }
+					onClick={ ! isCTAExternalLink ? onCTAClick : undefined }
 					disabled={ isDisabled }
+					href={ ctaHref }
+					target={ isCTAExternalLink ? '_blank' : undefined }
 				>
 					{ ctaLabel }
+					{ isCTAExternalLink && (
+						<Gridicon className="license-lightbox__cta-button-external-link" icon="external" />
+					) }
 				</Button>
 				{ extraAsideContent }
 			</JetpackLightboxAside>

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/style.scss
@@ -16,4 +16,14 @@
 	display: block;
 	width: 100%;
 	padding: 10px 16px;
+
+	.license-lightbox__cta-button-external-link {
+		inset-inline-start: 4px;
+		width: 20px;
+		height: 20px;
+	}
+
+	&.is-primary .license-lightbox__cta-button-external-link {
+		color: var(--studio-white);
+	}
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-manage/issues/193

## Proposed Changes

This PR 

- Redirects to WP admin for atomic site Boost purchases

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Once you are redirected to the Dashboard, click on the `Get Score` button on the Boost column for any atomic site and verify that an external link icon is shown for the `Purchase Boost License` button and clicking the button redirects to `{{site}}/wp-admin/admin.php?page=jetpack#/dashboard`

<img width="443" alt="Screenshot 2024-01-03 at 11 57 35 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/6072acc0-28d5-4212-a659-35ac0ff95d20">

2. Now, click the `Start Free` button and wait for the score to be updated > Expand the site row > Click the `Auto-optimize` button and verify that an external link icon is shown for the `Upgrade to Auto-optimize` button and clicking the button redirects to `{{site}}/wp-admin/admin.php?page=jetpack#/dashboard`.

<img width="442" alt="Screenshot 2024-01-03 at 11 57 42 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/a703cf48-3bd3-4673-9977-70db40fd20fe">

3. Verify that you are redirected to the partner portal for steps 1 & 2 for non-atomic sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?