### PR TITLE
Migration flow: Toggle credential form if user is a developer account

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -1,6 +1,6 @@
 import { SiteDetails } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useState, useMemo, useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useSiteMigrateInfo } from 'calypso/blocks/importer/hooks/use-site-can-migrate';
 import { useSiteCredentialsInfo } from 'calypso/blocks/importer/hooks/use-site-credentials-info';
@@ -82,12 +82,12 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		};
 	}, [ sourceSiteId, sourceSiteUrl, targetSite.ID, targetSite.slug, isMigrateFromWp, isTrial ] );
 
-	const toggleCredentialsForm = () => {
-		setShowCredentials( ! showCredentials );
+	const toggleCredentialsForm = useCallback( () => {
+		setShowCredentials( ( prevShowCredentials ) => ! prevShowCredentials );
 		dispatch(
 			recordTracksEvent( 'calypso_site_migration_credentials_form_toggle', migrationTrackingProps )
 		);
-	};
+	}, [ dispatch, migrationTrackingProps ] );
 
 	const [ queryTargetSitePlanStatus, setQueryTargetSitePlanStatus ] = useState<
 		'init' | 'fetching' | 'fetched'

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/migration-ready.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/migration-ready.tsx
@@ -3,9 +3,13 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useState, useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { StartImportTrackingProps } from 'calypso/blocks/importer/wordpress/import-everything/pre-migration/types';
+import QueryUserSettings from 'calypso/components/data/query-user-settings';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import useMigrationConfirmation from 'calypso/landing/stepper/hooks/use-migration-confirmation';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import getUserSetting from 'calypso/state/selectors/get-user-setting';
 import { isNewSite } from 'calypso/state/sites/selectors';
+import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
 import ConfirmModal from './confirm-modal';
 import { CredentialsCta } from './credentials-cta';
 import type { SiteId, SiteSlug } from 'calypso/types';
@@ -35,6 +39,10 @@ export function MigrationReady( props: Props ) {
 	} = props;
 
 	const isNewlyCreatedSite = useSelector( ( state: object ) => isNewSite( state, targetSiteId ) );
+	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
+	const isFetchingUserSettingsSelector = useSelector( ( state: object ) =>
+		isFetchingUserSettings( state )
+	);
 
 	const [ showConfirmModal, setShowConfirmModal ] = useState( false );
 	const [ migrationConfirmed, setMigrationConfirmed ] = useMigrationConfirmation();
@@ -54,6 +62,12 @@ export function MigrationReady( props: Props ) {
 		}
 	}, [ isNewlyCreatedSite, setMigrationConfirmed ] );
 
+	useEffect( () => {
+		if ( isDevAccount ) {
+			onProvideCredentialsClick();
+		}
+	}, [ isDevAccount, onProvideCredentialsClick ] );
+
 	function displayConfirmModal() {
 		dispatch(
 			recordTracksEvent( 'calypso_site_migration_confirm_modal_display', migrationTrackingProps )
@@ -70,6 +84,7 @@ export function MigrationReady( props: Props ) {
 
 	return (
 		<>
+			<QueryUserSettings />
 			{ showConfirmModal && (
 				<ConfirmModal
 					sourceSiteSlug={ sourceSiteSlug }
@@ -82,26 +97,30 @@ export function MigrationReady( props: Props ) {
 					} }
 				/>
 			) }
-			<div className="import__pre-migration import__import-everything import__import-everything--redesign">
-				<div className="import__heading import__heading-center">
-					<Title>{ translate( 'You are ready to migrate' ) }</Title>
+			{ isFetchingUserSettingsSelector ? (
+				<LoadingEllipsis />
+			) : (
+				<div className="import__pre-migration import__import-everything import__import-everything--redesign">
+					<div className="import__heading import__heading-center">
+						<Title>{ translate( 'You are ready to migrate' ) }</Title>
+					</div>
+					{ ! sourceSiteHasCredentials && (
+						<CredentialsCta onButtonClick={ onProvideCredentialsClick } />
+					) }
+					<div className="import__footer-button-container pre-migration__proceed">
+						<NextButton
+							type="button"
+							onClick={ () => {
+								migrationConfirmed
+									? startImport( { type: 'without-credentials', ...migrationTrackingProps } )
+									: displayConfirmModal();
+							} }
+						>
+							{ translate( 'Start migration' ) }
+						</NextButton>
+					</div>
 				</div>
-				{ ! sourceSiteHasCredentials && (
-					<CredentialsCta onButtonClick={ onProvideCredentialsClick } />
-				) }
-				<div className="import__footer-button-container pre-migration__proceed">
-					<NextButton
-						type="button"
-						onClick={ () => {
-							migrationConfirmed
-								? startImport( { type: 'without-credentials', ...migrationTrackingProps } )
-								: displayConfirmModal();
-						} }
-					>
-						{ translate( 'Start migration' ) }
-					</NextButton>
-				</div>
-			</div>
+			) }
 		</>
 	);
 }

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/test/index.test.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/test/index.test.tsx
@@ -11,7 +11,9 @@ import { createReduxStore } from 'calypso/state';
 import { getInitialState, getStateFromCache } from 'calypso/state/initial-state';
 import initialReducer from 'calypso/state/reducer';
 import { setStore } from 'calypso/state/redux-store';
+import getUserSetting from 'calypso/state/selectors/get-user-setting';
 import isRequestingSiteCredentials from 'calypso/state/selectors/is-requesting-site-credentials';
+import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
 import PreMigration from '../index';
 
 const user = {
@@ -48,6 +50,8 @@ jest.mock( 'calypso/blocks/importer/hooks/use-site-can-migrate' );
 jest.mock( 'calypso/state/selectors/is-requesting-site-credentials' );
 jest.mock( 'calypso/state/selectors/get-jetpack-credentials' );
 jest.mock( 'calypso/data/plans/use-check-eligibility-migration-trial-plan' );
+jest.mock( 'calypso/state/user-settings/selectors' );
+jest.mock( 'calypso/state/selectors/get-user-setting' );
 
 function renderPreMigrationScreen( props?: any ) {
 	const initialState = getInitialState( initialReducer, user.ID );
@@ -198,6 +202,12 @@ describe( 'PreMigration', () => {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		isRequestingSiteCredentials.mockReturnValue( false );
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		isFetchingUserSettings.mockReturnValue( false );
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		getUserSetting.mockReturnValue( false );
 
 		expect( screen.getByText( 'You are ready to migrate' ) ).toBeInTheDocument();
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85704

## Proposed Changes

* Open SSH/SFTP credential form directly if a user is developer account and ready to migrate.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `https://wordpress.com/me` and make sure `I am a developer` setting is on.

<img width="748" alt="Screen Shot 2024-01-03 at 2 45 25 PM" src="https://github.com/Automattic/wp-calypso/assets/4074459/d55aa408-2eb8-4c97-ba5c-8dc543292440">

* Navigate to `http://calypso.localhost:3000/setup/import-focused/import?siteSlug=ATOMIC_SITE_SLUG`
* Fill in the URL with a self-hosted site, you can use a JN site.
* Go through the flow and make sure you're ready for migrate.
* Instead of seeing a `You are ready to migrate` screen, you should see the SSH/SFTP credential form directly.



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?