### PR TITLE
Paid Stats: Update styles so that the blur for paid stats is pretty

### DIFF
--- a/packages/components/src/horizontal-bar-list/stats-card.scss
+++ b/packages/components/src/horizontal-bar-list/stats-card.scss
@@ -106,6 +106,7 @@
 		.stats-card__content .stats-card--footer {
 			filter: blur(10px);
 			z-index: 0;
+			margin-bottom: 24px;
 		}
 
 		.stats-card__overlay {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5067

## Proposed Changes

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/8d5b137b-325d-436f-a68f-933bec79e342">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/1f1ddb1f-76ff-44c7-a34e-bd2ff6444803">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /stats with the flag `?flags=stats/paid-wpcom-v2` on a free site
* Check the blur

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?