### PR TITLE
Fix Woo Express $1 offer Plans screen copy 

### DIFF
--- a/client/my-sites/plans/trials/trial-banner/use-banner-subtitle.ts
+++ b/client/my-sites/plans/trials/trial-banner/use-banner-subtitle.ts
@@ -36,9 +36,9 @@ export default function useBannerSubtitle(
 			if ( 'month' === anyWooExpressIntroOffer.intervalUnit ) {
 				introOfferSubtitle = translate(
 					'Your free trial will end in %(daysLeft)d day. Upgrade by %(expirationdate)s to start selling and take advantage of our limited time offer ' +
-						'— any Woo Express plan for just %(introOfferFormattedPrice)s a month for your first %(introOfferIntervalCount)d months.',
+						'— any Woo Express plan for just %(introOfferFormattedPrice)s for your first %(introOfferIntervalCount)d months.',
 					'Your free trial will end in %(daysLeft)d days. Upgrade by %(expirationdate)s to start selling and take advantage of our limited time offer ' +
-						'— any Woo Express plan for just %(introOfferFormattedPrice)s a month for your first %(introOfferIntervalCount)d months.',
+						'— any Woo Express plan for just %(introOfferFormattedPrice)s for your first %(introOfferIntervalCount)d months.',
 					{
 						count: trialDaysLeftToDisplay,
 						args: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/84681

## Proposed Changes

* Fix copy to just $1 for your first 3 months.

![Screenshot 2024-01-03 at 15 31 42](https://github.com/Automattic/wp-calypso/assets/4344253/d8d7b962-aa5d-4fe5-8bef-681276e7417c)

![Screenshot 2024-01-03 at 15 31 33](https://github.com/Automattic/wp-calypso/assets/4344253/f0b518f9-cc67-4c3d-b6ec-6f16abbb1f1e)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
 
* Go to https://woo.com/start
* Create a Woo Express free trial site 
* Go to /plans/\<site-slug\>
* Confirm the copy is `Woo Express plan for just US$1 for your first 3 months.` instead of `Woo Express plan for just US$1 **a month** for your first 3 months`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?