### PR TITLE
Live Preview: Return to the Theme Showcase with the persisted filter

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -187,7 +187,7 @@ ThemesList.defaultProps = {
 };
 
 export function ThemeBlock( props ) {
-	const { theme, index, tabFilter } = props;
+	const { theme, index, tabFilter, tier } = props;
 	const [ selectedStyleVariation, setSelectedStyleVariation ] = useState( null );
 
 	if ( isEmpty( theme ) ) {
@@ -204,6 +204,7 @@ export function ThemeBlock( props ) {
 			buttonContents={ props.getButtonOptions( theme.id, selectedStyleVariation ) }
 			screenshotClickUrl={ props.getScreenshotUrl?.( theme.id, {
 				tabFilter,
+				tierFilter: tier,
 				styleVariationSlug: selectedStyleVariation?.slug,
 			} ) }
 			onScreenshotClick={ props.onScreenshotClick }

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1121,6 +1121,7 @@ class ThemeSheet extends Component {
 			isExternallyManagedTheme,
 			isLoggedIn,
 			tabFilter,
+			tier,
 			selectedStyleVariationSlug: styleVariationSlug,
 			themeType,
 			siteId,
@@ -1132,7 +1133,7 @@ class ThemeSheet extends Component {
 				href={
 					getUrl &&
 					( key === 'customize' || ! isExternallyManagedTheme || ! isLoggedIn || ! siteId )
-						? getUrl( this.props.themeId, { tabFilter, styleVariationSlug } )
+						? getUrl( this.props.themeId, { tabFilter, tierFilter: tier, styleVariationSlug } )
 						: null
 				}
 				onClick={ () => {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -20,7 +20,6 @@ import { THEME_TIERS } from 'calypso/components/theme-tier/constants';
 import getSiteAssemblerUrl from 'calypso/components/themes-list/get-site-assembler-url';
 import { getOptionLabel } from 'calypso/landing/subscriptions/helpers';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { buildRelativeSearchUrl } from 'calypso/lib/build-url';
 import ActivationModal from 'calypso/my-sites/themes/activation-modal';
 import { THEME_COLLECTIONS } from 'calypso/my-sites/themes/collections/collection-definitions';
 import ShowcaseThemeCollection from 'calypso/my-sites/themes/collections/showcase-theme-collection';
@@ -36,6 +35,7 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isSiteOnWooExpress, isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
 import { getSite, getSiteSlug } from 'calypso/state/sites/selectors';
 import { setBackPath } from 'calypso/state/themes/actions';
+import { STATIC_FILTERS, DEFAULT_STATIC_FILTER } from 'calypso/state/themes/constants';
 import {
 	arePremiumThemesEnabled,
 	getThemeFilterTerms,
@@ -46,7 +46,14 @@ import {
 } from 'calypso/state/themes/selectors';
 import { getThemesBookmark } from 'calypso/state/themes/themes-ui/selectors';
 import EligibilityWarningModal from './atomic-transfer-dialog';
-import { addTracking, getSubjectsFromTermTable, trackClick, localizeThemesPath } from './helpers';
+import {
+	addTracking,
+	getSubjectsFromTermTable,
+	trackClick,
+	localizeThemesPath,
+	isStaticFilter,
+	constructThemeShowcaseUrl,
+} from './helpers';
 import PatternAssemblerButton from './pattern-assembler-button';
 import ThemePreview from './theme-preview';
 import ThemeShowcaseHeader from './theme-showcase-header';
@@ -63,18 +70,22 @@ const optionShape = PropTypes.shape( {
 
 const staticFilters = {
 	MYTHEMES: {
-		key: 'my-themes',
+		key: STATIC_FILTERS.MYTHEMES,
 		text: translate( 'My Themes' ),
 	},
 	RECOMMENDED: {
-		key: 'recommended',
+		key: STATIC_FILTERS.RECOMMENDED,
 		text: translate( 'Recommended' ),
 	},
 	ALL: {
-		key: 'all',
+		key: STATIC_FILTERS.ALL,
 		text: translate( 'All' ),
 	},
 };
+
+const defaultStaticFilter = Object.values( staticFilters ).find(
+	( staticFilter ) => staticFilter.key === DEFAULT_STATIC_FILTER
+);
 
 class ThemeShowcase extends Component {
 	constructor( props ) {
@@ -150,13 +161,9 @@ class ThemeShowcase extends Component {
 
 	isThemeDiscoveryEnabled = () => config.isEnabled( 'themes/discovery' );
 
-	getDefaultStaticFilter = () => staticFilters.RECOMMENDED;
+	getDefaultStaticFilter = () => defaultStaticFilter;
 
-	isStaticFilter = ( tabFilter ) => {
-		return Object.values( staticFilters ).some(
-			( staticFilter ) => tabFilter.key === staticFilter.key
-		);
-	};
+	isStaticFilter = ( tabFilter ) => isStaticFilter( tabFilter.key );
 
 	getSubjectFilters = ( props ) => {
 		const { subjects } = props;
@@ -300,36 +307,10 @@ class ThemeShowcase extends Component {
 	 * @returns {string} Theme showcase url
 	 */
 	constructUrl = ( sections ) => {
-		const {
-			category,
-			vertical,
-			tier,
-			filter,
-			siteSlug,
-			search,
-			locale,
-			isLoggedIn,
-			isCollectionView,
-		} = {
+		return constructThemeShowcaseUrl( {
 			...this.props,
 			...sections,
-		};
-		const siteIdSection = siteSlug ? `/${ siteSlug }` : '';
-		const categorySection =
-			category && category !== this.getDefaultStaticFilter().key ? `/${ category }` : '';
-		const verticalSection = vertical ? `/${ vertical }` : '';
-		const tierSection = tier && tier !== 'all' ? `/${ tier }` : '';
-
-		let filterSection = filter ? `/filter/${ filter }` : '';
-		filterSection = filterSection.replace( /\s/g, '+' );
-
-		const collectionSection = isCollectionView ? `/collection` : '';
-
-		let url = `/themes${ categorySection }${ verticalSection }${ tierSection }${ filterSection }${ collectionSection }${ siteIdSection }`;
-
-		url = localizeThemesPath( url, locale, ! isLoggedIn );
-
-		return buildRelativeSearchUrl( url, search );
+		} );
 	};
 
 	onTierSelectFilter = ( { value: tier } ) => {

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -137,10 +137,14 @@ class ThemesSelection extends Component {
 	getOptions = ( themeId, styleVariation, context ) => {
 		let options = this.props.getOptions( themeId, styleVariation );
 
-		const { tabFilter } = this.props;
+		const { tabFilter, tier } = this.props;
 		const wrappedActivateAction = ( action ) => {
 			return ( t ) => {
-				this.props.setThemePreviewOptions( themeId, null, null, { styleVariation, tabFilter } );
+				this.props.setThemePreviewOptions( themeId, null, null, {
+					styleVariation,
+					tabFilter,
+					tierFilter: tier,
+				} );
 				return action( t, context );
 			};
 		};
@@ -184,6 +188,7 @@ class ThemesSelection extends Component {
 		if ( options ) {
 			options = addOptionsToGetUrl( options, {
 				tabFilter,
+				tierFilter: tier,
 				styleVariationSlug: styleVariation?.slug,
 			} );
 			if ( options.activate ) {

--- a/client/state/themes/actions/redirect-to-live-preview.ts
+++ b/client/state/themes/actions/redirect-to-live-preview.ts
@@ -4,7 +4,9 @@ import { AppState } from 'calypso/types';
 
 export function redirectToLivePreview( themeId: string, siteId: number ) {
 	return ( dispatch: CalypsoDispatch, getState: () => AppState ) => {
-		const url = getLivePreviewUrl( getState(), themeId, siteId );
+		const url = getLivePreviewUrl( getState(), themeId, siteId, {
+			wpcomBackUrl: window.location.href,
+		} );
 		if ( url ) {
 			window.location.href = url;
 		}

--- a/client/state/themes/constants.js
+++ b/client/state/themes/constants.js
@@ -13,3 +13,11 @@ export const DEFAULT_THEME_QUERY = {
 // instead of querying them one by one when showing the search result.
 // See https://github.com/Automattic/wp-calypso/issues/77991
 export const RETIRED_THEME_SLUGS_SET = new Set( [ 'blank-canvas' ] );
+
+export const STATIC_FILTERS = {
+	MYTHEMES: 'my-themes',
+	RECOMMENDED: 'recommended',
+	ALL: 'all',
+};
+
+export const DEFAULT_STATIC_FILTER = STATIC_FILTERS.RECOMMENDED;

--- a/client/state/themes/selectors/get-theme-details-url.js
+++ b/client/state/themes/selectors/get-theme-details-url.js
@@ -17,10 +17,14 @@ export function getThemeDetailsUrl( state, themeId, siteId, options = {} ) {
 	}
 
 	const sitePart = siteId ? `/${ getSiteSlug( state, siteId ) }` : '';
-	const { tabFilter, styleVariationSlug } = options;
+	const { tabFilter, tierFilter, styleVariationSlug } = options;
 	const searchParams = {};
 	if ( tabFilter ) {
 		searchParams.tab_filter = tabFilter;
+	}
+
+	if ( tierFilter ) {
+		searchParams.tier_filter = tierFilter;
 	}
 
 	if ( styleVariationSlug ) {

--- a/client/state/themes/themes-ui/selectors.js
+++ b/client/state/themes/themes-ui/selectors.js
@@ -1,4 +1,8 @@
+import { getLocaleSlug } from 'i18n-calypso';
 import { includes } from 'lodash';
+import { isStaticFilter, constructThemeShowcaseUrl } from 'calypso/my-sites/themes/helpers';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 import 'calypso/state/themes/init';
@@ -7,10 +11,23 @@ import 'calypso/state/themes/init';
 export function getBackPath( state ) {
 	const backPath = state.themes.themesUI.backPath;
 	const siteSlug = getSelectedSiteSlug( state );
+	const queryArgs = getCurrentQueryArguments( state );
 
 	if ( ! siteSlug || includes( backPath, siteSlug ) ) {
 		return backPath;
 	}
+
+	if ( queryArgs?.tab_filter || queryArgs?.tier_filter ) {
+		const tabFilterType = isStaticFilter( queryArgs?.tab_filter ) ? 'category' : 'filter';
+		return constructThemeShowcaseUrl( {
+			isLoggedIn: isUserLoggedIn( state ),
+			locale: getLocaleSlug(),
+			siteSlug,
+			tier: queryArgs?.tier_filter,
+			[ tabFilterType ]: queryArgs?.tab_filter,
+		} );
+	}
+
 	return `/themes/${ siteSlug }`;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/85848

## Proposed Changes

* Pass the `wpcom_dashboard_link` to the live preview URL so we can redirect people back to the Theme Showcase with the persisted filters
* Add the `tier_filter` to the query parameter of the theme details page
* Construct the theme showcase URL based on the `tab_filter` and the `tier_filter` if the `backPath` is not set

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply https://github.com/Automattic/jetpack/pull/34836 to your sandbox
* Sandbox your site
* Go to the Theme Showcase
* Pick a category filter or a tier filter
* Pick a theme
* Click the “Preview & Customize”
* When you land on the editor, click the “<” button on the sidebar
* Make sure you're back to the previous page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?