### PR TITLE
Jetpack Manage: Make User feedback form URL accessible. 

### DIFF
--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -69,10 +69,11 @@ const JetpackCloudSidebar = ( {
 
 	const isUserFeedbackEnabled = isEnabled( 'jetpack/user-feedback-form' );
 
-	const [ showUserFeedbackForm, setShowUserFeedbackForm ] = useState(
-		// Set the initial state to true if the URL hash is set to the feedback form.
-		isUserFeedbackEnabled && window.location.hash === USER_FEEDBACK_FORM_URL_HASH
-	);
+	// Determine whether to initially show the user feedback form.
+	const shouldShowUserFeedbackForm =
+		isUserFeedbackEnabled && window.location.hash === USER_FEEDBACK_FORM_URL_HASH;
+
+	const [ showUserFeedbackForm, setShowUserFeedbackForm ] = useState( shouldShowUserFeedbackForm );
 
 	const onShowUserFeedbackForm = useCallback( () => {
 		setShowUserFeedbackForm( true );

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -47,6 +47,8 @@ type Props = {
 	};
 };
 
+const USER_FEEDBACK_FORM_URL_HASH = '#product-feedback';
+
 const JetpackCloudSidebar = ( {
 	className,
 	isJetpackManage,
@@ -65,15 +67,20 @@ const JetpackCloudSidebar = ( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const [ showUserFeedbackForm, setShowUserFeedbackForm ] = useState( false );
-
 	const isUserFeedbackEnabled = isEnabled( 'jetpack/user-feedback-form' );
+
+	const [ showUserFeedbackForm, setShowUserFeedbackForm ] = useState(
+		// Set the initial state to true if the URL hash is set to the feedback form.
+		isUserFeedbackEnabled && window.location.hash === USER_FEEDBACK_FORM_URL_HASH
+	);
 
 	const onShowUserFeedbackForm = useCallback( () => {
 		setShowUserFeedbackForm( true );
 	}, [] );
 
 	const onCloseUserFeedbackForm = useCallback( () => {
+		// Remove any hash from the URL.
+		history.pushState( null, '', window.location.pathname + window.location.search );
 		setShowUserFeedbackForm( false );
 	}, [] );
 
@@ -142,7 +149,7 @@ const JetpackCloudSidebar = ( {
 							title={ translate( 'Share product feedback', {
 								comment: 'Jetpack Cloud sidebar navigation item',
 							} ) }
-							link="#product-feedback"
+							link={ USER_FEEDBACK_FORM_URL_HASH }
 							path=""
 							icon={ <Icon icon={ starEmpty } /> }
 							onClickMenuItem={ onShowUserFeedbackForm }

--- a/client/jetpack-cloud/components/user-feedback-modal-form/index.tsx
+++ b/client/jetpack-cloud/components/user-feedback-modal-form/index.tsx
@@ -11,14 +11,17 @@ import './style.scss';
 
 type Props = {
 	show: boolean;
-	onClose: () => void;
+	onClose?: () => void;
 };
+
+const DEFAULT_FEEDBACK_VALUE = '';
+const DEFAULT_RATING_VALUE = 0;
 
 export default function UserFeedbackModalForm( { show, onClose }: Props ) {
 	const translate = useTranslate();
 
-	const [ feedback, setFeedback ] = useState( '' );
-	const [ rating, setRating ] = useState( 0 );
+	const [ feedback, setFeedback ] = useState( DEFAULT_FEEDBACK_VALUE );
+	const [ rating, setRating ] = useState( DEFAULT_RATING_VALUE );
 
 	const onFeedbackChange = useCallback( ( event: ChangeEvent< HTMLInputElement > ) => {
 		setFeedback( event.currentTarget.value );
@@ -38,17 +41,27 @@ export default function UserFeedbackModalForm( { show, onClose }: Props ) {
 		// TODO: send feedback to backend
 	}, [ hasCompletedForm ] );
 
+	const onModalClose = useCallback( () => {
+		setFeedback( DEFAULT_FEEDBACK_VALUE );
+		setRating( DEFAULT_RATING_VALUE );
+		onClose?.();
+	}, [ onClose ] );
+
 	if ( ! show ) {
 		return null;
 	}
 
 	return (
-		<Modal className="user-feedback-modal-form" onRequestClose={ onClose } __experimentalHideHeader>
+		<Modal
+			className="user-feedback-modal-form"
+			onRequestClose={ onModalClose }
+			__experimentalHideHeader
+		>
 			<div className="user-feedback-modal-form__main">
 				<Button
 					className="user-feedback-modal-form__close-button"
 					plain
-					onClick={ onClose }
+					onClick={ onModalClose }
 					aria-label={ translate( 'Close' ) }
 				>
 					<Icon size={ 24 } icon={ close } />


### PR DESCRIPTION
This pull request aims to make the new user feedback form URL accessible. With this PR, The **#product-feedback** URL hash fragment will trigger the page to display the modal.


Depends on https://github.com/Automattic/wp-calypso/pull/85920
Closes https://github.com/Automattic/jetpack-genesis/issues/164

## Proposed Changes

* Add logic to parse the hash fragment and check if `#product-feedback` exists in the URL. If it does, show the User feedback form by default.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Use the Jetpack cloud live link below and go to the Dashboard page with the **#product-feedback** hash (`/dashboard?flags=jetpack/user-feedback-form#product-feedback`)
* Confirm the User Feedback form is displayed.


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?