### PR TITLE
Add GTM to Jetpack Cloud and Checkout

### DIFF
--- a/client/lib/analytics/ad-tracking/constants.js
+++ b/client/lib/analytics/ad-tracking/constants.js
@@ -61,6 +61,7 @@ export const TRACKING_IDS = {
 	wpcomGoogleAdsGtagPurchase: 'AW-946162814/taG8CPW8spQBEP6YlcMD', // "WordPress.com Purchase Gtag"
 	wpcomGoogleAdsGtagDomainTransferPurchase: 'AW-946162814/8T2PCL3d7rsYEP6YlcMD',
 	wpcomGoogleGA4Gtag: 'G-1H4VG5F5JF',
+	jetpackGoogleTagManagerId: 'GTM-MWWK6WM',
 	jetpackGoogleAnalyticsGtag: 'UA-52447-43', // Jetpack Gtag (Analytics) for use in Jetpack x WordPress.com Flows
 	jetpackGoogleGA4Gtag: 'G-K8CRH0LL00',
 	jetpackGoogleAdsGtagPurchase: 'AW-946162814/kIF1CL3ApfsBEP6YlcMD',

--- a/client/lib/analytics/ad-tracking/load-tracking-scripts.js
+++ b/client/lib/analytics/ad-tracking/load-tracking-scripts.js
@@ -105,6 +105,10 @@ function getTrackingScriptsToLoad() {
 		scripts.push( GOOGLE_GTM_SCRIPT_URL + TRACKING_IDS.akismetGoogleTagManagerId );
 	}
 
+	if ( mayWeInitTracker( 'googleTagManager' ) && ( isJetpackCloud() || isJetpackCheckout() ) ) {
+		scripts.push( GOOGLE_GTM_SCRIPT_URL + TRACKING_IDS.jetpackGoogleTagManagerId );
+	}
+
 	if ( mayWeTrackByTracker( 'clarity' ) ) {
 		scripts.push( WPCOM_CLARITY_URI );
 	}

--- a/client/lib/analytics/tracker-buckets.ts
+++ b/client/lib/analytics/tracker-buckets.ts
@@ -76,7 +76,7 @@ export const AdTrackersBuckets: { [ key in AdTracker ]: Bucket | null } = {
 
 const checkGtagInit = (): boolean => 'dataLayer' in window && 'gtag' in window;
 
-const checkWooGTMInit = (): boolean => {
+const checkGtmInit = (): boolean => {
 	return 'dataLayer' in window && 'google_tag_manager' in window;
 };
 
@@ -85,7 +85,7 @@ export const AdTrackersInitGuards: Partial< { [ key in AdTracker ]: () => boolea
 	gaEnhancedEcommerce: checkGtagInit,
 	floodlight: checkGtagInit,
 	googleAds: checkGtagInit,
-	googleTagManager: checkWooGTMInit,
+	googleTagManager: checkGtmInit,
 	bing: () => 'uetq' in window,
 	outbrain: () => 'obApi' in window,
 	pinterest: () => 'pintrk' in window,


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-marketing/issues/471

## Proposed Changes

We're adding a GTM script to load on Jetpack Cloud and Checkout pages.

## Testing Instructions

* Run Calypso Live or `yarn start` on local env
* Open http://calypso.localhost:3000/checkout/jetpack/jetpack_creator_yearly?flags=ad-tracking,cookie-banner
* Accept cookie banner if necessary
* Make sure you see "https://www.googletagmanager.com/gtm.js?id=GTM-MWWK6WM" script in DOM

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?