### PR TITLE
Fix: Remove setStepProgress from Reblogging

### DIFF
--- a/client/landing/stepper/declarative-flow/reblogging.ts
+++ b/client/landing/stepper/declarative-flow/reblogging.ts
@@ -1,6 +1,6 @@
 import { type UserSelect } from '@automattic/data-stores';
-import { useFlowProgress, REBLOGGING_FLOW } from '@automattic/onboarding';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { REBLOGGING_FLOW } from '@automattic/onboarding';
+import { useSelect } from '@wordpress/data';
 import { getQueryArg, addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import wpcom from 'calypso/lib/wp';
@@ -9,7 +9,7 @@ import {
 	persistSignupDestination,
 	setSignupCompleteFlowName,
 } from 'calypso/signup/storageUtils';
-import { USER_STORE, ONBOARD_STORE } from '../stores';
+import { USER_STORE } from '../stores';
 import { useLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { AssertConditionResult, AssertConditionState } from './internals/types';
@@ -37,10 +37,6 @@ const reblogging: Flow = {
 
 	useStepNavigation( _currentStepSlug, navigate ) {
 		const flowName = this.name;
-		const { setStepProgress } = useDispatch( ONBOARD_STORE );
-		const flowProgress = useFlowProgress( { stepName: _currentStepSlug, flowName } );
-
-		setStepProgress( flowProgress );
 
 		// trigger guides on step movement, we don't care about failures or response
 		wpcom.req.post(


### PR DESCRIPTION
Recently setStepProgress has been removed from the flows.

This PR updates the new Rebloggin flow, as `setStepProgress` may have slipped in the flow PR.

## Testing

 1. Incognito, visit a post, click like and register a new user. It will not have any sites.
 2. Visit [this link](http://calypso.localhost:3000/post?url=https%3A%2F%2Fmmm434.wordpress.com%2F2023%2F09%2F26%2Fhello-world%2F%3Fpage_id%3D3&is_post_share=true&v=5) (or using Live link)
 3. You should see the button to start the reblogging flow, and the flow should work.