### PR TITLE
Jetpack Manage: Hide the Boost payment plans for atomic sites

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/license-info-modal/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/license-info-modal/index.tsx
@@ -22,6 +22,7 @@ interface Props {
 	onCtaClick?: () => void;
 	isCTAExternalLink?: boolean;
 	ctaHref?: string;
+	showPaymentPlan?: boolean;
 }
 
 export default function LicenseInfoModal( {
@@ -35,6 +36,7 @@ export default function LicenseInfoModal( {
 	onCtaClick,
 	isCTAExternalLink,
 	ctaHref,
+	showPaymentPlan,
 }: Props ) {
 	const isMobile = useMobileBreakpoint();
 	const translate = useTranslate();
@@ -94,6 +96,7 @@ export default function LicenseInfoModal( {
 				onActivate={ onIssueLicense }
 				onClose={ onHideLicenseInfo }
 				extraAsideContent={ extraAsideContent }
+				showPaymentPlan={ showPaymentPlan }
 			/>
 		)
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/boost-license-info-modal.tsx
@@ -71,6 +71,7 @@ export default function BoostLicenseInfoModal( { onClose, site, upgradeOnly }: P
 			ctaHref={
 				is_atomic ? `${ url_with_scheme }/wp-admin/admin.php?page=jetpack#/dashboard` : undefined
 			}
+			showPaymentPlan={ ! is_atomic }
 			extraAsideContent={
 				<>
 					{ ! upgradeOnly && (

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/index.tsx
@@ -26,6 +26,7 @@ export type LicenseLightBoxProps = {
 	quantity?: number;
 	isCTAExternalLink?: boolean;
 	ctaHref?: string;
+	showPaymentPlan?: boolean;
 };
 
 const LicenseLightbox: FunctionComponent< LicenseLightBoxProps > = ( {
@@ -40,6 +41,7 @@ const LicenseLightbox: FunctionComponent< LicenseLightBoxProps > = ( {
 	extraAsideContent,
 	className,
 	quantity,
+	showPaymentPlan = true,
 } ) => {
 	const isLargeScreen = useBreakpoint( '>782px' );
 	const { title, product: productInfo } = useLicenseLightboxData( product );
@@ -65,7 +67,9 @@ const LicenseLightbox: FunctionComponent< LicenseLightBoxProps > = ( {
 			</JetpackLightboxMain>
 
 			<JetpackLightboxAside ref={ sidebarRef }>
-				<LicenseLightboxPaymentPlan product={ product } quantity={ quantity } />
+				{ showPaymentPlan && (
+					<LicenseLightboxPaymentPlan product={ product } quantity={ quantity } />
+				) }
 
 				<Button
 					className="license-lightbox__cta-button"

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/style.scss
@@ -19,8 +19,8 @@
 
 	.license-lightbox__cta-button-external-link {
 		inset-inline-start: 4px;
-		width: 20px;
-		height: 20px;
+		width: 18px;
+		height: 18px;
 	}
 
 	&.is-primary .license-lightbox__cta-button-external-link {


### PR DESCRIPTION
Resolves  https://github.com/Automattic/jetpack-manage/issues/205

## Proposed Changes

This PR 

- Hides the Boost payment plans for atomic sites.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Once you are redirected to the Dashboard, click on the Get Score button on the Boost column for any atomic site and verify that the payment plan is not shown and only the buttons on the right side are shown.

<img width="435" alt="Screenshot 2024-01-08 at 6 16 35 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/165b8b1e-9473-431a-8b42-e74b9a7f2dc4">

2. Now, click the `Start Free` button and wait for the score to be updated > Expand the site row > Click the `Auto-optimize` button and verify that the payment plan is not shown and only the buttons on the right side are shown.

<img width="438" alt="Screenshot 2024-01-08 at 6 16 47 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/7a2b0cda-369c-457d-bc2d-60fcd3f46ef2">


3. Verify that the payment plans are shown for steps 1 & 2 for non-atomic sites.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?