### PR TITLE
Hosting configuration: poll Atomic transfer status when loading the page (v2)

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -36,7 +36,6 @@ import {
 	isAutomatedTransferActive,
 } from 'calypso/state/automated-transfer/selectors';
 import { getAtomicHostingIsLoadingSftpData } from 'calypso/state/selectors/get-atomic-hosting-is-loading-sftp-data';
-import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { requestSite } from 'calypso/state/sites/actions';
@@ -45,6 +44,7 @@ import {
 	isSiteOnHostingTrial,
 	isSiteOnMigrationTrial,
 } from 'calypso/state/sites/plans/selectors';
+import { getSite } from 'calypso/state/sites/selectors';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -395,7 +395,8 @@ export default connect(
 		const hasAtomicFeature = siteHasFeature( state, siteId, WPCOM_FEATURES_ATOMIC );
 		const hasSftpFeature = siteHasFeature( state, siteId, FEATURE_SFTP );
 		const hasStagingSitesFeature = siteHasFeature( state, siteId, FEATURE_SITE_STAGING_SITES );
-		const isSiteAtomic = isSiteAutomatedTransfer( state, siteId );
+		const site = getSite( state, siteId );
+		const isSiteAtomic = site?.domain.endsWith( '.wpcomstaging.com' );
 
 		return {
 			teams: getReaderTeams( state ),

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -205,8 +205,9 @@ const Hosting = ( props ) => {
 
 	const isSiteAtomic =
 		transferStatus === transferStates.COMPLETE || transferStatus === transferStates.COMPLETED;
-
 	const canSiteGoAtomic = ! isSiteAtomic && hasSftpFeature;
+	const showHostingActivationBanner =
+		canSiteGoAtomic && hasFetchedTransferStatusAtLeastOnce.current;
 
 	const getUpgradeBanner = () => {
 		// The eCommerce Trial requires a different upsell path.
@@ -246,7 +247,7 @@ const Hosting = ( props ) => {
 				icon="bug"
 			/>
 		);
-		if ( canSiteGoAtomic && hasFetchedTransferStatusAtLeastOnce.current ) {
+		if ( showHostingActivationBanner ) {
 			return (
 				<>
 					{ failureNotice }

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -36,11 +36,7 @@ import { getAtomicHostingIsLoadingSftpData } from 'calypso/state/selectors/get-a
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { requestSite } from 'calypso/state/sites/actions';
-import {
-	isSiteOnECommerceTrial,
-	isSiteOnHostingTrial,
-	isSiteOnMigrationTrial,
-} from 'calypso/state/sites/plans/selectors';
+import { isSiteOnBusinessTrial, isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -89,7 +85,7 @@ const MainCards = ( {
 	isBasicHostingDisabled,
 	isGithubIntegrationEnabled,
 	isWpcomStagingSite,
-	isMigrationTrial,
+	isBusinessTrial,
 	siteId,
 } ) => {
 	const mainCards = [
@@ -157,7 +153,7 @@ const MainCards = ( {
 		<ShowEnabledFeatureCards
 			cards={ mainCards }
 			availableTypes={ availableTypes }
-			showDisabledCards={ ! isMigrationTrial }
+			showDisabledCards={ ! isBusinessTrial }
 		/>
 	);
 };
@@ -185,8 +181,7 @@ const Hosting = ( props ) => {
 		teams,
 		clickActivate,
 		isECommerceTrial,
-		isMigrationTrial,
-		isHostingTrial,
+		isBusinessTrial,
 		isWpcomStagingSite,
 		siteId,
 		siteSlug,
@@ -300,7 +295,7 @@ const Hosting = ( props ) => {
 								isBasicHostingDisabled={ ! hasAtomicFeature || ! isSiteAtomic }
 								isGithubIntegrationEnabled={ isGithubIntegrationEnabled }
 								isWpcomStagingSite={ isWpcomStagingSite }
-								isMigrationTrial={ isMigrationTrial }
+								isBusinessTrial={ isBusinessTrial }
 								siteId={ siteId }
 							/>
 						</Column>
@@ -321,8 +316,6 @@ const Hosting = ( props ) => {
 	const shouldShowUpgradeBanner =
 		! hasAtomicFeature || ( ! isTransferring && ! hasSftpFeature && ! isWpcomStagingSite );
 	const banner = shouldShowUpgradeBanner ? getUpgradeBanner() : getAtomicActivationNotice();
-
-	const isBusinessTrial = isMigrationTrial || isHostingTrial;
 
 	return (
 		<Main wideLayout className="hosting">
@@ -363,8 +356,7 @@ export default connect(
 			teams: getReaderTeams( state ),
 			isJetpack: isJetpackSite( state, siteId ),
 			isECommerceTrial: isSiteOnECommerceTrial( state, siteId ),
-			isMigrationTrial: isSiteOnMigrationTrial( state, siteId ),
-			isHostingTrial: isSiteOnHostingTrial( state, siteId ),
+			isBusinessTrial: isSiteOnBusinessTrial( state, siteId ),
 			transferState: getAutomatedTransferStatus( state, siteId ),
 			hasSftpFeature,
 			hasAtomicFeature,

--- a/client/my-sites/hosting/test/index.js
+++ b/client/my-sites/hosting/test/index.js
@@ -188,10 +188,11 @@ describe( 'Hosting Configuration', () => {
 	} );
 
 	describe( 'Site on free plan', () => {
-		it( 'should show upsell banner and all cards should be within FeatureExample', () => {
+		it( 'should show upsell banner and all cards should be within FeatureExample', async () => {
 			const testConfig = getTestConfig( { planSlug: PLAN_FREE } );
 
 			renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );
+			await waitFor( () => expect( wpcomGetStub ).toHaveBeenCalled() );
 
 			expect(
 				screen.getByText( 'Upgrade to the Creator plan to access all hosting features:' )
@@ -208,13 +209,16 @@ describe( 'Hosting Configuration', () => {
 	} );
 
 	describe( 'Site on Personal plan', () => {
-		it( 'should show upsell banner and all cards should be within FeatureExample', () => {
+		it( 'should show upsell banner and all cards should be within FeatureExample', async () => {
 			const testConfig = getTestConfig( { planSlug: PLAN_PERSONAL } );
+
 			renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );
+			await waitFor( () => expect( wpcomGetStub ).toHaveBeenCalled() );
 
 			expect(
 				screen.getByText( 'Upgrade to the Creator plan to access all hosting features:' )
 			).toBeVisible();
+
 			expect( screen.getByText( 'Upgrade to Creator Plan' ) ).toBeVisible();
 
 			const [ mainFeatureExampleElement ] = screen.getAllByTestId( 'feature-example-wrapper' );
@@ -332,7 +336,7 @@ describe( 'Hosting Configuration', () => {
 	} );
 
 	describe( 'Staging site', () => {
-		it( 'should show the primary site card and not show the upsell nudge', () => {
+		it( 'should show the primary site card and not show the upsell nudge', async () => {
 			const testConfig = getTestConfig( {
 				isAtomicSite: true,
 				isWpcomStagingSite: true,
@@ -342,6 +346,7 @@ describe( 'Hosting Configuration', () => {
 			} );
 
 			renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );
+			await waitFor( () => expect( wpcomGetStub ).toHaveBeenCalled() );
 
 			expect(
 				screen.queryByText( 'Upgrade to the Creator plan to access all hosting features:' )

--- a/client/my-sites/hosting/test/index.js
+++ b/client/my-sites/hosting/test/index.js
@@ -170,7 +170,6 @@ const verifyStringsAreWithinFeatureExample = ( strings, featureExampleElement ) 
 
 describe( 'Hosting Configuration', () => {
 	beforeAll( () => {
-		jest.resetAllMocks();
 		// Mock the missing `window.matchMedia` function that's not even in JSDOM
 		Object.defineProperty( window, 'matchMedia', {
 			writable: true,
@@ -185,6 +184,10 @@ describe( 'Hosting Configuration', () => {
 				dispatchEvent: jest.fn(),
 			} ) ),
 		} );
+	} );
+
+	afterAll( () => {
+		jest.resetAllMocks();
 	} );
 
 	describe( 'Site on free plan', () => {

--- a/client/my-sites/hosting/test/index.js
+++ b/client/my-sites/hosting/test/index.js
@@ -16,6 +16,11 @@ jest.mock( '../staging-site-card/staging-site-production-card', () => () => (
 		<span>Staging site</span>
 	</div>
 ) );
+jest.mock( 'calypso/lib/wp', () => ( {
+	req: {
+		get: jest.fn(),
+	},
+} ) );
 
 import {
 	FEATURE_SFTP,
@@ -27,25 +32,32 @@ import {
 	WPCOM_FEATURES_ATOMIC,
 } from '@automattic/calypso-products';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
+import wp from 'calypso/lib/wp';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import Hosting from '../main';
+
+const wpcomGetStub = wp.req.get;
 
 const getTestConfig = ( {
 	isAtomicSite = false,
 	isWpcomStagingSite = false,
 	planSlug = PLAN_FREE,
 	siteFeatures = [],
-	transferState = transferStates.NONE,
+	transferStatus = transferStates.NONE,
 } ) => {
+	wpcomGetStub.mockResolvedValue( {
+		status: transferStatus,
+	} );
+
 	return {
 		isAtomicSite,
 		isWpcomStagingSite,
 		planSlug,
 		siteFeatures,
-		transferState,
+		transferStatus,
 	};
 };
 
@@ -54,7 +66,7 @@ const createTestStore = ( {
 	isWpcomStagingSite,
 	planSlug,
 	siteFeatures,
-	transferState,
+	transferStatus,
 } ) => {
 	const TEST_SITE_ID = 1;
 	return createStore( ( state ) => state, {
@@ -65,7 +77,7 @@ const createTestStore = ( {
 		},
 		automatedTransfer: {
 			[ TEST_SITE_ID ]: {
-				status: transferState,
+				status: transferStatus,
 			},
 		},
 		documentHead: { unreadCount: 0 },
@@ -92,6 +104,7 @@ const createTestStore = ( {
 					jetpack: false,
 					options: {
 						is_automated_transfer: isAtomicSite,
+						is_wpcom_atomic: isAtomicSite,
 					},
 					URL: 'test-site-example.wordpress.com',
 				},
@@ -157,6 +170,7 @@ const verifyStringsAreWithinFeatureExample = ( strings, featureExampleElement ) 
 
 describe( 'Hosting Configuration', () => {
 	beforeAll( () => {
+		jest.resetAllMocks();
 		// Mock the missing `window.matchMedia` function that's not even in JSDOM
 		Object.defineProperty( window, 'matchMedia', {
 			writable: true,
@@ -213,13 +227,15 @@ describe( 'Hosting Configuration', () => {
 	} );
 
 	describe( 'Site on Creator plan', () => {
-		it( 'should show activation notice when the site is not Atomic', () => {
+		it( 'should show activation notice when the site is not Atomic', async () => {
 			const testConfig = getTestConfig( {
 				planSlug: PLAN_BUSINESS_MONTHLY,
 				siteFeatures: [ WPCOM_FEATURES_ATOMIC, FEATURE_SFTP, FEATURE_SITE_STAGING_SITES ],
+				transferStatus: 'none',
 			} );
 
 			renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );
+			await waitFor( () => expect( wpcomGetStub ).toHaveBeenCalled() );
 
 			expect(
 				screen.getByText( 'Please activate the hosting access to begin using these features.' )
@@ -234,15 +250,16 @@ describe( 'Hosting Configuration', () => {
 			verifyStringsAreWithinFeatureExample( expectedStrings, mainFeatureExampleElement );
 		} );
 
-		it( 'should not show the activation notice when the site is Atomic', () => {
+		it( 'should not show the activation notice when the site is Atomic', async () => {
 			const testConfig = getTestConfig( {
 				isAtomicSite: true,
 				planSlug: PLAN_BUSINESS_MONTHLY,
 				siteFeatures: [ WPCOM_FEATURES_ATOMIC, FEATURE_SFTP, FEATURE_SITE_STAGING_SITES ],
-				transferState: transferStates.COMPLETE,
+				transferStatus: transferStates.COMPLETE,
 			} );
 
 			renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );
+			await waitFor( () => expect( wpcomGetStub ).toHaveBeenCalled() );
 
 			expect(
 				screen.queryByText( 'Please activate the hosting access to begin using these features.' )
@@ -256,15 +273,16 @@ describe( 'Hosting Configuration', () => {
 			} );
 		} );
 
-		it( 'should show the transferring notice when the site is transferring to Atomic', () => {
+		it( 'should show the transferring notice when the site is transferring to Atomic', async () => {
 			const testConfig = getTestConfig( {
 				isAtomicSite: false,
 				planSlug: PLAN_BUSINESS_MONTHLY,
 				siteFeatures: [ WPCOM_FEATURES_ATOMIC, FEATURE_SFTP, FEATURE_SITE_STAGING_SITES ],
-				transferState: transferStates.START,
+				transferStatus: transferStates.START,
 			} );
 
 			renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );
+			await waitFor( () => expect( wpcomGetStub ).toHaveBeenCalled() );
 
 			expect(
 				screen.getByText( 'Please wait while we activate the hosting features.' )
@@ -280,15 +298,16 @@ describe( 'Hosting Configuration', () => {
 	} );
 
 	describe( 'Site on Woo Express/eCommerce Trial plan', () => {
-		it( 'should show the upsell banner with alternate text and show the basic features', () => {
+		it( 'should show the upsell banner with alternate text and show the basic features', async () => {
 			const testConfig = getTestConfig( {
 				isAtomicSite: true,
 				planSlug: PLAN_ECOMMERCE_TRIAL_MONTHLY,
 				siteFeatures: [ WPCOM_FEATURES_ATOMIC ],
-				transferState: transferStates.COMPLETE,
+				transferStatus: transferStates.COMPLETE,
 			} );
 
 			renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );
+			await waitFor( () => expect( wpcomGetStub ).toHaveBeenCalled() );
 
 			expect(
 				screen.getByText( 'Upgrade your plan to access all hosting features' )
@@ -306,7 +325,6 @@ describe( 'Hosting Configuration', () => {
 
 			stringsForBasicFeatureCards.forEach( ( string ) => {
 				const elementForString = screen.getByText( string );
-
 				expect( elementForString ).toBeVisible();
 				expect( mainFeatureExampleElement ).not.toContainElement( elementForString );
 			} );
@@ -320,7 +338,7 @@ describe( 'Hosting Configuration', () => {
 				isWpcomStagingSite: true,
 				planSlug: PLAN_BUSINESS_MONTHLY,
 				siteFeatures: [ WPCOM_FEATURES_ATOMIC, FEATURE_SFTP, FEATURE_SITE_STAGING_SITES ],
-				transferState: transferStates.COMPLETE,
+				transferStatus: transferStates.COMPLETE,
 			} );
 
 			renderComponentWithStoreAndQueryClient( createTestStore( testConfig ) );

--- a/client/state/atomic-transfer/use-atomic-transfer-query.ts
+++ b/client/state/atomic-transfer/use-atomic-transfer-query.ts
@@ -23,7 +23,7 @@ interface UseAtomicTransferQueryOptions {
 	refetchInterval?: number;
 }
 
-export const endStates: TransferStates[] = [
+const endStates: TransferStates[] = [
 	transferStates.NONE,
 	transferStates.COMPLETE,
 	transferStates.COMPLETED,

--- a/client/state/atomic-transfer/use-atomic-transfer-query.ts
+++ b/client/state/atomic-transfer/use-atomic-transfer-query.ts
@@ -3,17 +3,11 @@ import wpcom from 'calypso/lib/wp';
 import { transferStates, TransferStates } from 'calypso/state/automated-transfer/constants';
 import { SiteSlug } from 'calypso/types';
 
-interface ErrorResponse {
-	code: 'no_transfer_record';
-}
-
 interface SuccessResponse {
 	status: TransferStates;
 }
 
-const fetchLatestAtomicTransfer = (
-	siteSlug: SiteSlug
-): Promise< ErrorResponse | SuccessResponse > =>
+const fetchLatestAtomicTransfer = ( siteSlug: SiteSlug ): Promise< SuccessResponse > =>
 	wpcom.req.get( {
 		path: `/sites/${ siteSlug }/atomic/transfers/latest`,
 		apiNamespace: 'wpcom/v2',
@@ -32,19 +26,18 @@ const endStates: TransferStates[] = [
 	transferStates.REVERTED,
 ];
 
-export function useAtomicTransferQueryQueryKey( siteSlug ) {
+export function useAtomicTransferQueryQueryKey( siteSlug: string ) {
 	return [ 'sites', siteSlug, 'atomic', 'transfers', 'latest' ];
 }
 
 export const useAtomicTransferQuery = (
 	siteSlug: SiteSlug,
-	{ refetchInterval, enabled }: UseAtomicTransferQueryOptions
+	{ refetchInterval }: UseAtomicTransferQueryOptions
 ) => {
 	const { data, failureReason } = useQuery( {
 		queryKey: useAtomicTransferQueryQueryKey( siteSlug ),
 		queryFn: () => fetchLatestAtomicTransfer( siteSlug ),
 		refetchInterval,
-		enabled,
 	} );
 
 	if ( ! data && ! failureReason ) {
@@ -63,8 +56,10 @@ export const useAtomicTransferQuery = (
 		};
 	}
 
+	const { status } = data as SuccessResponse;
+
 	return {
-		transferStatus: data.status,
-		isTransferring: ! endStates.includes( data.status ),
+		transferStatus: status,
+		isTransferring: ! endStates.includes( status ),
 	};
 };

--- a/client/state/atomic-transfer/use-atomic-transfer-query.ts
+++ b/client/state/atomic-transfer/use-atomic-transfer-query.ts
@@ -1,0 +1,63 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import { transferStates, TransferStates } from 'calypso/state/automated-transfer/constants';
+import { SiteSlug } from 'calypso/types';
+
+interface ErrorResponse {
+	code: 'no_transfer_record';
+}
+
+interface SuccessResponse {
+	status: TransferStates;
+}
+
+const fetchLatestAtomicTransfer = (
+	siteSlug: SiteSlug
+): Promise< ErrorResponse | SuccessResponse > =>
+	wpcom.req.get( {
+		path: `/sites/${ siteSlug }/atomic/transfers/latest`,
+		apiNamespace: 'wpcom/v2',
+	} );
+
+interface UseAtomicTransferQueryOptions {
+	refetchInterval?: number;
+}
+
+const endStates: TransferStates[] = [
+	transferStates.NONE,
+	transferStates.COMPLETE,
+	transferStates.COMPLETED,
+	transferStates.FAILURE,
+	transferStates.ERROR,
+	transferStates.REVERTED,
+];
+
+export const useAtomicTransferQuery = (
+	siteSlug: SiteSlug,
+	{ refetchInterval }: UseAtomicTransferQueryOptions
+) => {
+	const { data } = useQuery( {
+		queryKey: [ 'sites', siteSlug, 'atomic', 'transfers', 'latest' ],
+		queryFn: () => fetchLatestAtomicTransfer( siteSlug ),
+		refetchInterval,
+	} );
+
+	if ( ! data ) {
+		return {
+			isTransferring: false,
+			transferStatus: transferStates.NONE,
+		};
+	}
+
+	if ( 'code' in data ) {
+		return {
+			transferStatus: transferStates.NONE,
+			isTransferring: false,
+		};
+	}
+
+	return {
+		transferStatus: data.status,
+		isTransferring: ! endStates.includes( data.status ),
+	};
+};

--- a/client/state/automated-transfer/constants.ts
+++ b/client/state/automated-transfer/constants.ts
@@ -15,6 +15,7 @@ export const transferStates = {
 	BACKFILLING: 'backfilling',
 	RELOCATING: 'relocating_switcheroo',
 	COMPLETE: 'complete',
+	COMPLETED: 'completed', // there seems to be two spellings for this state
 	/**
 	 * Similar to 'none' there is no existing transfer, but this is when the site has been already reverted from atomic
 	 */

--- a/client/state/automated-transfer/selectors/is-automated-transfer-active.js
+++ b/client/state/automated-transfer/selectors/is-automated-transfer-active.js
@@ -17,6 +17,8 @@ export const isActive = ( status ) =>
 				transferStates.FAILURE,
 				transferStates.ERROR,
 				transferStates.REVERTED,
+				transferStates.CONFLICTS,
+				transferStates.INQUIRING,
 		  ].includes( status )
 		: false;
 /**

--- a/client/state/automated-transfer/selectors/is-automated-transfer-active.js
+++ b/client/state/automated-transfer/selectors/is-automated-transfer-active.js
@@ -8,8 +8,17 @@ import 'calypso/state/automated-transfer/init';
  * @param {string} status name of current state in automated transfer
  * @returns {?boolean} is transfer currently active? null if unknown
  */
-export const isActive = ( status ) => ( status ? status === transferStates.START : null );
-
+export const isActive = ( status ) =>
+	status
+		? ! [
+				transferStates.NONE,
+				transferStates.COMPLETE,
+				transferStates.COMPLETED,
+				transferStates.FAILURE,
+				transferStates.ERROR,
+				transferStates.REVERTED,
+		  ].includes( status )
+		: false;
 /**
  * Indicates whether or not an automated transfer is active for a given site
  * @param {Object} state app state

--- a/client/state/automated-transfer/test/is-automated-transfer-active.js
+++ b/client/state/automated-transfer/test/is-automated-transfer-active.js
@@ -4,8 +4,8 @@ import { isActive } from '../selectors/is-automated-transfer-active';
 describe( 'Automated Transfer', () => {
 	describe( 'isActive()', () => {
 		test( 'should return `null` if no information is available', () => {
-			expect( isActive( null ) ).toBeNull();
-			expect( isActive( '' ) ).toBeNull(); // plausible that the status could wind up as an empty string
+			expect( isActive( null ) ).toBeFalsy();
+			expect( isActive( '' ) ).toBeFalsy(); // plausible that the status could wind up as an empty string
 		} );
 
 		test( 'should return `true` for active transfer states', () => {

--- a/client/state/sites/plans/selectors/index.js
+++ b/client/state/sites/plans/selectors/index.js
@@ -23,6 +23,7 @@ export { default as isSiteOnEcommerce } from './trials/is-site-on-ecommerce';
 export { default as isSiteOnECommerceTrial } from './trials/is-site-on-ecommerce-trial';
 export { default as isSiteOnWooExpressEcommerceTrial } from './is-site-on-woo-express-ecommerce-trial';
 export { default as isSiteOnHostingTrial } from './trials/is-site-on-hosting-trial';
+export { default as isSiteOnBusinessTrial } from './trials/is-site-on-business-trial';
 export { default as getHostingTrialDaysLeft } from './trials/get-hosting-trial-days-left';
 export { default as getHostingTrialExpiration } from './trials/get-hosting-trial-expiration';
 export { default as isHostingTrialExpired } from './trials/is-hosting-trial-expired';

--- a/client/state/sites/plans/selectors/trials/is-site-on-business-trial.ts
+++ b/client/state/sites/plans/selectors/trials/is-site-on-business-trial.ts
@@ -1,0 +1,12 @@
+import { isSiteOnHostingTrial, isSiteOnMigrationTrial } from '..';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Checks whether the current site is on any type of Business trial.
+ * @param {AppState} state Global state tree
+ * @param {number} siteId - Site ID
+ * @returns {boolean} Returns true if the site is on a Business trial
+ */
+export default function isSiteOnBusinessTrial( state: AppState, siteId: number ): boolean {
+	return isSiteOnMigrationTrial( state, siteId ) || isSiteOnHostingTrial( state, siteId );
+}

--- a/test/client/jest.config.js
+++ b/test/client/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
 	...base,
 	rootDir: '../../client',
 	cacheDirectory: path.join( __dirname, '../../.cache/jest' ),
-	testPathIgnorePatterns: [ '<rootDir>/server/' ],
+	testPathIgnorePatterns: [ '<rootDir>/server/', '**/hosting/test/index.js' ],
 
 	moduleNameMapper: {
 		'^@automattic/calypso-config$': '<rootDir>/server/config/index.js',

--- a/test/client/jest.config.js
+++ b/test/client/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
 	...base,
 	rootDir: '../../client',
 	cacheDirectory: path.join( __dirname, '../../.cache/jest' ),
-	testPathIgnorePatterns: [ '<rootDir>/server/', '**/hosting/test/index.js' ],
+	testPathIgnorePatterns: [ '<rootDir>/server/' ],
 
 	moduleNameMapper: {
 		'^@automattic/calypso-config$': '<rootDir>/server/config/index.js',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/72371
Related https://github.com/Automattic/wp-calypso/pull/77112 (I ported this original PR to the latest trunk and made some small improvements along the way)

## Proposed Changes

* Make sure the `/hosting-config` UI updates correctly when the Atomic transfer completes ( see https://github.com/Automattic/wp-calypso/issues/72371)
* When transferring, make the client-side status polling mechanism robust enough to survive a hard page refresh. 
* Now that the polling mechanism can pick up existing jobs, there does not seem to be a good reason to lock them into this page until the job is complete. I have removed the "click outside" logic in this PR. We still might want to include this. I would like @aidvu's input here, as they added the original restriction. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

There's been quite a few changes to boolean logic so there are two main things to test:

1. The state of `/hosting-config` for various plan + site type combos
2. The robustness of the Atomic transfer mechanism. See https://github.com/Automattic/wp-calypso/issues/72371 for inspiration. In short, it should be fine to go to another page and come back or do a hard refresh. The process should always complete and not get stuck. 

First, try this feature on prod and see that the process is broken and gets stuck. In my tests, it completed occasionally but mostly did not until I refreshed the page.  

Next, test viewing `/hosting-config` when you have:
 
**A Free site**: 
       * should see the upsell
       * should not see the activation banner
       * features should be masked

![image](https://github.com/Automattic/wp-calypso/assets/6851384/636bc92d-7375-485a-a8a7-2e068253baaf)
    
**a Creator plan but haven't gone Atomic**
       * You should see an activation banner but no upsell
       * Feature cards should be masked and unusable

![image](https://github.com/Automattic/wp-calypso/assets/6851384/1a7104f2-f745-499b-9a83-34c600b29878)
 
**an Atomic site**:
        * upsell should be gone
        * The activation banner should be gone 
        * All features should be unmasked and usable
        
<img width="1145" alt="Screenshot 2567-01-05 at 13 56 12" src="https://github.com/Automattic/wp-calypso/assets/6851384/a9e60841-87c5-4230-90e7-fb4b289a81db">
      
* **Test upgrading a Free plan to Creator**
       * should initially be like **A Free site** above
       * Then, when the process completes, it should be like **an Atomic site** above

* General robustness. We are polling the server for updates and should handle a refresh. Do your best to try and break it. 

[screen-capture (9).webm](https://github.com/Automattic/wp-calypso/assets/6851384/3c4e1a89-680f-404d-8f09-bf18021ccab0)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?