### PR TITLE
Reblogging flow: add tracking

### DIFF
--- a/client/components/empty-content/no-sites-message/index.tsx
+++ b/client/components/empty-content/no-sites-message/index.tsx
@@ -12,6 +12,7 @@ interface NoSitesMessageProps {
 	line?: ReactNode;
 	action?: string;
 	actionURL?: string;
+	actionCallback?: () => void;
 	illustration?: false;
 }
 
@@ -20,6 +21,7 @@ const NoSitesMessage = ( {
 	line,
 	action,
 	actionURL,
+	actionCallback,
 	illustration,
 }: NoSitesMessageProps ) => {
 	const { __ } = useI18n();
@@ -44,6 +46,7 @@ const NoSitesMessage = ( {
 			}
 			action={ action ?? __( 'Create a site' ) }
 			actionURL={ actionURL ?? onboardingUrl() + '?ref=calypso-nosites' }
+			actionCallback={ actionCallback }
 			illustration={ illustration === false ? null : noSitesIllustration }
 			illustrationWidth={ 124 }
 			illustrationHeight={ 101 }

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -163,6 +163,9 @@ export function renderRebloggingEmptySites( context ) {
 					  )
 					: null,
 			actionURL,
+			actionCallback: () => {
+				recordTracksEvent( 'calypso_post_share_no_sites_create_site_click' );
+			},
 		} )
 	);
 


### PR DESCRIPTION
This PR adds a tracking event when the user clicks on `Create Site` in the Empty site 

## Testing

 1. Incognito, visit a post, click like and register a new user. It will not have any sites.
 2. Visit [this link](http://calypso.localhost:3000/post?url=https%3A%2F%2Fmmm434.wordpress.com%2F2023%2F09%2F26%2Fhello-world%2F%3Fpage_id%3D3&is_post_share=true&v=5) (or using Live link)
 3. You should see the button to start the reblogging flow, and the flow should work.
 4. Check that the tracking events are triggered