### PR TITLE
Site Monitoring: Change the table headings of the site monitoring logs

### DIFF
--- a/client/my-sites/site-monitoring/components/site-logs-table/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-table/index.tsx
@@ -52,11 +52,11 @@ export const SiteLogsTable = memo( function SiteLogsTable( {
 		request_type: __( 'Request type' ),
 		request_url: __( 'Request URL' ),
 		// translators: %s is the timezone offset of the site, e.g. GMT, GMT +1, GMT -1.
-		date: sprintf( __( 'Date/time (%s)' ), siteGsmOffsetDisplay ),
+		date: sprintf( __( 'Date & time (%s)' ), siteGsmOffsetDisplay ),
 		status: __( 'Status' ),
 		severity: 'Severity',
 		// translators: %s is the timezone offset of the site, e.g. GMT, GMT +1, GMT -1.
-		timestamp: sprintf( __( 'Date/time (%s)' ), siteGsmOffsetDisplay ),
+		timestamp: sprintf( __( 'Date & time (%s)' ), siteGsmOffsetDisplay ),
 		message: __( 'Message' ),
 	};
 


### PR DESCRIPTION
Change the name of the column heading for site monitoring logs from Date/time to Date & time.

![CleanShot 2567-01-03 at 18 28 18@2x](https://github.com/Automattic/wp-calypso/assets/10244734/359aaddd-a301-4ef9-af3b-bafa8b6f004a)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4854

## Proposed Changes

* Change the name of the column heading for site monitoring logs from Date/time to Date & time.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Tools -> site monitoring and on the PHP logs and Webserver logs tab ensure that the column heading shows Date & time (UTC-x)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?