### PR TITLE
SMP: Change hardcoded Business plan name on Sites page to dynamic one

### DIFF
--- a/client/sites-dashboard/components/docs/sample-site-data.jsx
+++ b/client/sites-dashboard/components/docs/sample-site-data.jsx
@@ -48,13 +48,13 @@ const siteSimpleBusinessComingSoon = {
 		...exampleSite.plan,
 		product_id: 1008,
 		product_slug: 'business-bundle',
-		product_name_short: 'Business',
+		product_name_short: 'Creator',
 		user_is_owner: true,
 		is_free: false,
 	},
 	is_coming_soon: true,
 	launch_status: 'unlaunched',
-	title: 'Business Simple Site with Coming Soon status',
+	title: 'Creator Simple Site with Coming Soon status',
 };
 
 const siteSimpleBusinessExpired = {
@@ -68,12 +68,12 @@ const siteSimpleBusinessExpired = {
 		...exampleSite.plan,
 		product_id: 1008,
 		product_slug: 'business-bundle',
-		product_name_short: 'Business',
+		product_name_short: 'Creator',
 		user_is_owner: true,
 		is_free: false,
 		expired: true,
 	},
-	title: 'Expired Business Simple Site',
+	title: 'Expired Creator Simple Site',
 };
 
 const siteJetpackComplete = {

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -17,6 +17,7 @@ import {
 import { css } from '@emotion/css';
 import styled from '@emotion/styled';
 import { DropdownMenu, MenuGroup, MenuItem as CoreMenuItem, Modal } from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { ComponentType, useEffect, useMemo, useState } from 'react';

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -1,7 +1,9 @@
 import { isEnabled } from '@automattic/calypso-config';
 import {
+	getPlan,
 	FEATURE_SFTP,
 	FEATURE_SITE_STAGING_SITES,
+	PLAN_BUSINESS,
 	WPCOM_FEATURES_MANAGE_PLUGINS,
 	WPCOM_FEATURES_SITE_PREVIEW_LINKS,
 } from '@automattic/calypso-products';
@@ -118,6 +120,7 @@ const ManagePluginsItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 	const [ href, label ] = hasManagePluginsFeature
 		? [ getManagePluginsUrl( site.slug ), __( 'Manage plugins' ) ]
 		: [ getPluginsUrl( site.slug ), __( 'Plugins' ) ];
+	const upsellPlanName = getPlan( PLAN_BUSINESS )?.getTitle() ?? '';
 
 	return (
 		<MenuItemLink
@@ -127,7 +130,16 @@ const ManagePluginsItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 					has_manage_plugins_feature: hasManagePluginsFeature,
 				} )
 			}
-			info={ ! hasManagePluginsFeature ? __( 'Requires a Business Plan' ) : undefined }
+			info={
+				! hasManagePluginsFeature
+					? sprintf(
+							/* translators: %s - the plan's product name, such as Creator or Explorer. */ __(
+								'Requires a %s Plan'
+							),
+							upsellPlanName
+					  )
+					: undefined
+			}
 		>
 			{ label }
 		</MenuItemLink>
@@ -318,6 +330,7 @@ function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps
 	const submenuProps = useSubmenuPopoverProps< HTMLDivElement >( {
 		offset: -8,
 	} );
+	const upsellPlanName = getPlan( PLAN_BUSINESS )?.getTitle() ?? '';
 
 	if ( submenuItems.length === 0 ) {
 		return null;
@@ -332,7 +345,17 @@ function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps
 					product_slug: site.plan?.product_slug,
 				} }
 			/>
-			<MenuItemLink info={ displayUpsell ? __( 'Requires a Business Plan' ) : undefined }>
+			<MenuItemLink
+				info={
+					displayUpsell
+						? sprintf(
+								/* translators: %s - the plan's product name, such as Creator or Explorer. */
+								__( 'Requires a %s Plan' ),
+								upsellPlanName
+						  )
+						: undefined
+				}
+			>
 				{ __( 'Hosting configuration' ) } <MenuItemGridIcon icon="chevron-right" size={ 18 } />
 			</MenuItemLink>
 			<SubmenuPopover
@@ -348,8 +371,12 @@ function HostingConfigurationSubmenu( { site, recordTracks }: SitesMenuItemProps
 								product_slug: site.plan?.product_slug,
 							} }
 						/>
-						{ __(
-							'Upgrade to the Business Plan to enable SFTP & SSH, database access, GitHub deploys, and more…'
+						{ sprintf(
+							/* translators: %s - the plan's product name, such as Creator or Explorer. */
+							__(
+								'Upgrade to the %s Plan to enable SFTP & SSH, database access, GitHub deploys, and more…'
+							),
+							upsellPlanName
 						) }
 						<Button
 							compact

--- a/client/sites-dashboard/components/sites-grid-action-renew.tsx
+++ b/client/sites-dashboard/components/sites-grid-action-renew.tsx
@@ -60,7 +60,7 @@ export function SitesGridActionRenew( { site, isUpgradeable }: SitesGridActionRe
 			<Notice status="is-error" icon="notice" showDismiss={ false }>
 				<span ref={ ref }>
 					{
-						/* translators: %s - the plan's product name, such as Business or Pro. */
+						/* translators: %s - the plan's product name, such as Creator or Explorer. */
 						sprintf( __( '%s Plan expired.' ), site.plan?.product_name_short )
 					}
 				</span>

--- a/client/sites-dashboard/components/test/sites-site-plan.tsx
+++ b/client/sites-dashboard/components/test/sites-site-plan.tsx
@@ -18,30 +18,30 @@ const stagingSite = {
 const activeBusinessSite = {
 	ID: 1,
 	site_owner: siteOwnerId,
-	title: 'Expired Business Site',
+	title: 'Expired Creator Site',
 	plan: {
 		expired: false,
-		product_name_short: 'Business',
+		product_name_short: 'Creator',
 	},
 };
 
 const expiredBusinessSite = {
 	ID: 1,
 	site_owner: siteOwnerId,
-	title: 'Expired Business Site',
+	title: 'Expired Creator Site',
 	plan: {
 		expired: true,
-		product_name_short: 'Business',
+		product_name_short: 'Creator',
 	},
 };
 
 const activeTrialSite = {
 	ID: 1,
 	site_owner: siteOwnerId,
-	title: 'Active Business Trial',
+	title: 'Active Creator Trial',
 	plan: {
 		expired: false,
-		product_name_short: 'Business Trial',
+		product_name_short: 'Creator Trial',
 		product_slug: PLAN_HOSTING_TRIAL_MONTHLY,
 	},
 };
@@ -49,10 +49,10 @@ const activeTrialSite = {
 const expiredTrialSite = {
 	ID: 1,
 	site_owner: siteOwnerId,
-	title: 'Expired Business Trial',
+	title: 'Expired Creator Trial',
 	plan: {
 		expired: true,
-		product_name_short: 'Business Trial',
+		product_name_short: 'Creator Trial',
 		product_slug: PLAN_HOSTING_TRIAL_MONTHLY,
 	},
 };
@@ -73,26 +73,26 @@ describe( '<SitePlan>', () => {
 		expect( container.textContent ).toBe( 'Staging' );
 	} );
 
-	test( 'shows "Business" as label for a site with an active Business plan', () => {
+	test( 'shows "Creator" as label for a site with an active Creator plan', () => {
 		const { container } = render(
 			<SitePlan site={ activeBusinessSite } userId={ otherAdminId } />
 		);
-		expect( container.textContent ).toBe( 'Business' );
+		expect( container.textContent ).toBe( 'Creator' );
 	} );
 
-	test( 'shows "Business" as label to an administrator for site with an expired Business plan', () => {
+	test( 'shows "Creator" as label to an administrator for site with an expired Creator plan', () => {
 		const { getByText, queryAllByRole } = render(
 			<SitePlan site={ expiredBusinessSite } userId={ otherAdminId } />
 		);
-		expect( getByText( 'Business - Expired' ) ).toBeInTheDocument();
+		expect( getByText( 'Creator - Expired' ) ).toBeInTheDocument();
 		expect( queryAllByRole( 'link' ) ).toHaveLength( 0 );
 	} );
 
-	test( 'shows "Business" as label to a site owner for a site with an expired Business plan', () => {
+	test( 'shows "Creator" as label to a site owner for a site with an expired Creator plan', () => {
 		const { getByText, queryAllByRole, getByRole } = render(
 			<SitePlan site={ expiredBusinessSite } userId={ siteOwnerId } />
 		);
-		expect( getByText( 'Business - Expired' ) ).toBeInTheDocument();
+		expect( getByText( 'Creator - Expired' ) ).toBeInTheDocument();
 		expect( queryAllByRole( 'link' ) ).toHaveLength( 1 );
 		expect( getByRole( 'link', { name: 'Renew plan' } ) ).toHaveAttribute(
 			'href',
@@ -100,27 +100,27 @@ describe( '<SitePlan>', () => {
 		);
 	} );
 
-	test( 'shows "Business Trial" as label for a site with an active Business Trial plan', () => {
+	test( 'shows "Creator Trial" as label for a site with an active Creator Trial plan', () => {
 		const { container, queryAllByRole } = render(
 			<SitePlan site={ activeTrialSite } userId={ siteOwnerId } />
 		);
-		expect( container.textContent ).toBe( 'Business Trial' );
+		expect( container.textContent ).toBe( 'Creator Trial' );
 		expect( queryAllByRole( 'link' ) ).toHaveLength( 0 );
 	} );
 
-	test( 'shows "Business Trial" as label to an administrator for site with an expired Business Trial plan', () => {
+	test( 'shows "Creator Trial" as label to an administrator for site with an expired Creator Trial plan', () => {
 		const { container, queryAllByRole } = render(
 			<SitePlan site={ expiredTrialSite } userId={ otherAdminId } />
 		);
-		expect( container.textContent ).toBe( 'Business Trial - Expired' );
+		expect( container.textContent ).toBe( 'Creator Trial - Expired' );
 		expect( queryAllByRole( 'link' ) ).toHaveLength( 0 );
 	} );
 
-	test( 'shows "Business Trial" as label to a site owner for a site with an expired Business Trial plan', () => {
+	test( 'shows "Creator Trial" as label to a site owner for a site with an expired Creator Trial plan', () => {
 		const { getByText, queryAllByRole, getByRole } = render(
 			<SitePlan site={ expiredTrialSite } userId={ siteOwnerId } />
 		);
-		expect( getByText( 'Business Trial - Expired' ) ).toBeInTheDocument();
+		expect( getByText( 'Creator Trial - Expired' ) ).toBeInTheDocument();
 		expect( queryAllByRole( 'link' ) ).toHaveLength( 1 );
 		expect( getByRole( 'link', { name: 'Upgrade' } ) ).toHaveAttribute(
 			'href',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5071

## Proposed Changes

In this diff, I propose to change the hardcoded Business plan name in the upsell on the Sites page to the dynamic one, which is currently Creator.

| Before | After |
|--|--|
| ![Screenshot 2024-01-03 at 13 34 56](https://github.com/Automattic/wp-calypso/assets/727413/467bc723-6b4a-468b-ab0e-37d1e50a7952) | ![Screenshot 2024-01-03 at 13 35 07](https://github.com/Automattic/wp-calypso/assets/727413/6938aa9a-0be2-40ad-b6a4-d3113f2d08c0) |


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a Free site
2. Navigate to Sites page
3. Confirm that upsell shows the new plan name which is Creator

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?