### PR TITLE
Signup: move isFlow utils to separate module

### DIFF
--- a/client/blocks/authentication/social/index.tsx
+++ b/client/blocks/authentication/social/index.tsx
@@ -7,7 +7,7 @@ import AppleLoginButton from 'calypso/components/social-buttons/apple';
 import GoogleSocialButton from 'calypso/components/social-buttons/google';
 import { preventWidows } from 'calypso/lib/formatting';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
-import { isWpccFlow } from 'calypso/signup/utils';
+import { isWpccFlow } from 'calypso/signup/is-flow';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -50,7 +50,7 @@ import {
 import { login, lostPassword } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/url';
 import wpcom from 'calypso/lib/wp';
-import { isP2Flow } from 'calypso/signup/utils';
+import { isP2Flow } from 'calypso/signup/is-flow';
 import { recordTracksEventWithClientId } from 'calypso/state/analytics/actions';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { SocialAuthenticationForm } from 'calypso/blocks/authentication';
 import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
-import { isWpccFlow } from 'calypso/signup/utils';
+import { isWpccFlow } from 'calypso/signup/is-flow';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/index.tsx
@@ -26,7 +26,7 @@ import './style.scss';
 
 type LaunchpadProps = {
 	navigation: NavigationControls;
-	flow: string | null;
+	flow: string;
 };
 
 const Launchpad: Step = ( { navigation, flow }: LaunchpadProps ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -36,7 +36,7 @@ type SidebarProps = {
 	submit: NavigationControls[ 'submit' ];
 	goNext: NavigationControls[ 'goNext' ];
 	goToStep?: NavigationControls[ 'goToStep' ];
-	flow: string | null;
+	flow: string;
 };
 
 function getUrlInfo( url: string ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/step-content.tsx
@@ -17,7 +17,7 @@ type StepContentProps = {
 	submit: NavigationControls[ 'submit' ];
 	goNext: NavigationControls[ 'goNext' ];
 	goToStep?: NavigationControls[ 'goToStep' ];
-	flow: string | null;
+	flow: string;
 };
 
 function sortByRegistrationDate( domainObjectA: ResponseDomain, domainObjectB: ResponseDomain ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -49,7 +49,7 @@ interface GetEnhancedTasksProps {
 	setShowPlansModal: Dispatch< SetStateAction< boolean > >;
 	queryClient: QueryClient;
 	goToStep?: NavigationControls[ 'goToStep' ];
-	flow: string | null;
+	flow: string;
 	isEmailVerified?: boolean;
 	checklistStatuses?: ChecklistStatuses;
 	planCartItem?: MinimalRequestCartProduct | null;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -33,7 +33,7 @@ import { Dispatch, SetStateAction } from 'react';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ADD_TIER_PLAN_HASH } from 'calypso/my-sites/earn/memberships/constants';
-import { isVideoPressFlow } from 'calypso/signup/utils';
+import { isVideoPressFlow } from 'calypso/signup/is-flow';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import { goToCheckout } from '../../../../utils/checkout';
 import { launchpadFlowTasks } from './tasks';

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -19,6 +19,7 @@ import { getSiteId } from 'calypso/state/sites/selectors';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getStepComponent } from './config/step-components';
+import { isReskinnedFlow } from './is-flow';
 import SignupComponent from './main';
 import {
 	retrieveSignupDestination,
@@ -35,7 +36,6 @@ import {
 	getValidPath,
 	getFlowPageTitle,
 	shouldForceLogin,
-	isReskinnedFlow,
 } from './utils';
 
 /**

--- a/client/signup/is-flow.ts
+++ b/client/signup/is-flow.ts
@@ -1,0 +1,21 @@
+import config from '@automattic/calypso-config';
+
+export const isReskinnedFlow = ( flowName: string ) => {
+	return config< string[] >( 'reskinned_flows' ).includes( flowName );
+};
+
+export const isP2Flow = ( flowName: string ) => {
+	return flowName === 'p2' || flowName === 'p2v1';
+};
+
+export const isVideoPressFlow = ( flowName: string ) => {
+	return flowName === 'videopress' || flowName === 'videopress-account';
+};
+
+export const isVideoPressTVFlow = ( flowName: string ) => {
+	return flowName === 'videopress-tv' || flowName === 'videopress-tv-purchase';
+};
+
+export const isWpccFlow = ( flowName: string ) => {
+	return flowName === 'wpcc';
+};

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -75,6 +75,7 @@ import flows from './config/flows';
 import { getStepComponent } from './config/step-components';
 import steps from './config/steps';
 import { addP2SignupClassName } from './controller';
+import { isReskinnedFlow, isP2Flow } from './is-flow';
 import {
 	persistSignupDestination,
 	setSignupCompleteSlug,
@@ -87,8 +88,6 @@ import {
 	getDestination,
 	getFirstInvalidStep,
 	getStepUrl,
-	isReskinnedFlow,
-	isP2Flow,
 } from './utils';
 import WpcomLoginForm from './wpcom-login-form';
 import './style.scss';

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types';
 import { Component } from 'react';
 import FormattedHeader from 'calypso/components/formatted-header';
 import NavigationLink from 'calypso/signup/navigation-link';
-import { isReskinnedFlow } from '../utils';
+import { isReskinnedFlow } from '../is-flow';
 import './style.scss';
 
 class StepWrapper extends Component {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -26,6 +26,7 @@ import { login } from 'calypso/lib/paths';
 import { WPCC } from 'calypso/lib/url/support';
 import flows from 'calypso/signup/config/flows';
 import GravatarStepWrapper from 'calypso/signup/gravatar-step-wrapper';
+import { isP2Flow, isVideoPressFlow } from 'calypso/signup/is-flow';
 import P2StepWrapper from 'calypso/signup/p2-step-wrapper';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import {
@@ -34,8 +35,6 @@ import {
 	getNextStepName,
 	getPreviousStepName,
 	getStepUrl,
-	isP2Flow,
-	isVideoPressFlow,
 } from 'calypso/signup/utils';
 import VideoPressStepWrapper from 'calypso/signup/videopress-step-wrapper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';

--- a/client/signup/steps/user/test/index.js
+++ b/client/signup/steps/user/test/index.js
@@ -27,8 +27,6 @@ jest.mock( 'calypso/signup/utils', () => ( {
 	getNextStepName: ( x ) => x,
 	getStepUrl: ( x ) => x,
 	getPreviousStepName: ( x ) => x,
-	isVideoPressFlow: () => false,
-	isP2Flow: () => false,
 } ) );
 
 describe( '#signupStep User', () => {

--- a/client/signup/utils.js
+++ b/client/signup/utils.js
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { filter, find, includes, isEmpty, pick, sortBy } from 'lodash';
 import { addQueryArgs } from 'calypso/lib/url';
@@ -179,26 +178,6 @@ export function canResumeFlow( flowName, progress, isUserLoggedIn ) {
 export const shouldForceLogin = ( flowName, userLoggedIn ) => {
 	const flow = flows.getFlow( flowName, userLoggedIn );
 	return !! flow && flow.forceLogin;
-};
-
-export const isReskinnedFlow = ( flowName ) => {
-	return config( 'reskinned_flows' ).includes( flowName );
-};
-
-export const isP2Flow = ( flowName ) => {
-	return flowName === 'p2' || flowName === 'p2v1';
-};
-
-export const isVideoPressFlow = ( flowName ) => {
-	return flowName === 'videopress' || flowName === 'videopress-account';
-};
-
-export const isVideoPressTVFlow = ( flowName ) => {
-	return flowName === 'videopress-tv' || flowName === 'videopress-tv-purchase';
-};
-
-export const isWpccFlow = ( flowName ) => {
-	return flowName === 'wpcc';
 };
 
 /**


### PR DESCRIPTION
There are some simple utils functions in `client/signup/utils` that are used across the codebase, outside signup. But importing the module means dragging in a signficant part of the Signup framework -- all the flows, steps, step components.

This PR moves the simple utilities to a separate `is-flow` module. It should have a significant impact on the size of the `login` entrypoint and many other Calypso chunks.

Discovered this when working on #84243 and trying to figure out why even the server bundle contains so much Signup code.