### PR TITLE
Marketplace Reviews: Update list spacing style

### DIFF
--- a/client/my-sites/marketplace/components/reviews-list/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-list/index.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Gridicon } from '@automattic/components';
+import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { useState } from 'react';
@@ -71,12 +72,16 @@ export const MarketplaceReviewsList = ( props: MarketplaceReviewsQueryProps ) =>
 		);
 	}
 
+	const allReviews = [ ...userReviews, ...reviews ];
+
 	return (
 		<div className="marketplace-reviews-list__container">
 			<div className="marketplace-reviews-list__customer-reviews">
-				{ [ ...userReviews, ...reviews ].map( ( review: MarketplaceReviewResponse ) => (
+				{ allReviews.map( ( review: MarketplaceReviewResponse, i ) => (
 					<div
-						className="marketplace-reviews-list__review-container"
+						className={ classnames( 'marketplace-reviews-list__review-container', {
+							last: i === allReviews.length - 1,
+						} ) }
 						key={ `review-${ review.id }` }
 					>
 						<div className="marketplace-reviews-list__review-container-header">
@@ -113,8 +118,8 @@ export const MarketplaceReviewsList = ( props: MarketplaceReviewsQueryProps ) =>
 							} }
 							className="marketplace-reviews-list__content"
 						></div>
-						<div className="marketplace-reviews-list__review-actions">
-							{ review.author === currentUserId && (
+						{ review.author === currentUserId && (
+							<div className="marketplace-reviews-list__review-actions">
 								<div className="marketplace-reviews-list__review-actions-editable">
 									<button
 										className="marketplace-reviews-list__review-actions-editable-button"
@@ -141,8 +146,8 @@ export const MarketplaceReviewsList = ( props: MarketplaceReviewsQueryProps ) =>
 										/>
 									</div>
 								</div>
-							) }
-						</div>
+							</div>
+						) }
 					</div>
 				) ) }
 				<InfiniteScroll nextPageMethod={ fetchNextPage } />

--- a/client/my-sites/marketplace/components/reviews-list/style.scss
+++ b/client/my-sites/marketplace/components/reviews-list/style.scss
@@ -19,7 +19,7 @@ $border-color: #eee;
 				padding-top: 0;
 			}
 
-			&:last-of-type {
+			&.last {
 				padding-bottom: 0;
 			}
 


### PR DESCRIPTION


## Proposed Changes

Fixes some styling issues affecting spacing.

* Avoid the creation of an empty `marketplace-reviews-list__review-action` div, as it will apply an unneeded margin.
* Create a class called `last` and apply it to the last element to avoid extra padding in the last element.
  * `last-of-type` selector is not the best choice anymore as the `InfiniteScroll` component creates an empty div at the end.
 
| Top of the dialog  | Bottom of the dialog |
| ------------- | ------------- |
|![CleanShot 2024-01-03 at 11 24 45@2x](https://github.com/Automattic/wp-calypso/assets/5039531/ee6aa79a-cb47-48c3-a227-4fbb37037cdb)|![CleanShot 2024-01-03 at 11 24 30@2x](https://github.com/Automattic/wp-calypso/assets/5039531/4b255871-523a-4afc-9c13-fede35b11606)|

## Testing Instructions

* Go to a plugin with reviews. Ex: `/plugins/woocommerce-bookings`
* On the bottom of the page click on `Read all reviews`
* Check if the layout match the above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
