### PR TITLE
Jetpack Manage: Fixing a single typo in one tour on the Jetpack Manage 'add sites' tour

### DIFF
--- a/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-2/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-2/index.tsx
@@ -44,7 +44,7 @@ export default function AddNewSiteTourStep2( { siteItems }: Props ) {
 								<br />
 								<br />
 								{ translate(
-									'Sites with jetpack installed will automatically appear in the site management view.'
+									'Sites with Jetpack installed will automatically appear in the site management view.'
 								) }
 							</>
 						),


### PR DESCRIPTION

## Proposed Changes

* This PR changes one single typo (jetpack to Jetpack) in a tour on the Jetpack Manage dashboard.

## Testing Instructions

* No testing needed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)? This