### PR TITLE
Jetpack Manage: 207 - fix Tracks event name

### DIFF
--- a/client/jetpack-cloud/sections/overview/foldable-nav/index.tsx
+++ b/client/jetpack-cloud/sections/overview/foldable-nav/index.tsx
@@ -60,7 +60,7 @@ const FoldableNav = ( {
 					icon={ navItem.icon ?? <></> }
 					path="/"
 					onClickMenuItem={ () =>
-						dispatch( recordTracksEvent( navItem.trackEventName, { nav_item: navItem.title } ) )
+						dispatch( recordTracksEvent( navItem.trackEventName, { nav_item: navItem.slug } ) )
 					}
 					{ ...navItem }
 				/>

--- a/client/jetpack-cloud/sections/overview/foldable-nav/types.ts
+++ b/client/jetpack-cloud/sections/overview/foldable-nav/types.ts
@@ -12,6 +12,7 @@ export interface Props {
 export interface FoldableNavItem {
 	icon?: JSX.Element;
 	link: string;
+	slug: string;
 	title: TranslateResult;
 	trackEventName: string;
 	isExternalLink?: boolean;

--- a/client/jetpack-cloud/sections/overview/primary/get-help-nav/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/get-help-nav/index.tsx
@@ -13,30 +13,35 @@ export default function GetHelpNav() {
 	const navItems: FoldableNavItem[] = [
 		{
 			link: localizeUrl( 'https://jetpack.com/support/jetpack-manage-instructions/' ),
+			slug: 'kb_getting_started',
 			title: translate( 'Get started guide' ),
 		},
 		{
 			link: localizeUrl(
 				'https://jetpack.com/support/jetpack-manage-instructions/jetpack-manage-dashboard/'
 			),
+			slug: 'kb_site_management',
 			title: translate( 'All sites management' ),
 		},
 		{
 			link: localizeUrl(
 				'https://jetpack.com/support/jetpack-manage-instructions/jetpack-manage-licensing/'
 			),
+			slug: 'kb_licenses',
 			title: translate( 'Issuing, assigning, and revoking licenses' ),
 		},
 		{
 			link: localizeUrl(
 				'https://jetpack.com/support/jetpack-manage-instructions/jetpack-manage-issuing-assigning-and-revoking-licenses/'
 			),
+			slug: 'kb_billing_faqs',
 			title: translate( 'Billing/payment FAQs' ),
 		},
 		{
 			link: localizeUrl(
 				'https://jetpack.com/support/jetpack-manage-instructions/jetpack-manage-managing-plugins/'
 			),
+			slug: 'kb_plugin_management',
 			title: translate( 'Managing plugins' ),
 			isExternalLink: true,
 		},

--- a/client/jetpack-cloud/sections/overview/primary/get-help-nav/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/get-help-nav/index.tsx
@@ -8,7 +8,7 @@ export default function GetHelpNav() {
 	const translate = useTranslate();
 
 	const header = translate( 'Get help' );
-	const tracksName = 'calypso_jetpack_manage_overview_quick_links';
+	const tracksName = 'calypso_jetpack_manage_overview_get_help';
 
 	const navItems: FoldableNavItem[] = [
 		{

--- a/client/jetpack-cloud/sections/overview/primary/quick-links-nav/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/quick-links-nav/index.tsx
@@ -22,36 +22,43 @@ export default function QuickLinksNav() {
 		{
 			icon: category,
 			link: JETPACK_MANAGE_DASHBOARD_LINK,
+			slug: 'manage_sites',
 			title: translate( 'Manage all sites' ),
 		},
 		{
 			icon: plus,
 			link: localizeUrl( 'https://wordpress.com/jetpack/connect' ),
+			slug: 'add_sites',
 			title: translate( 'Add sites to Jetpack Manage' ),
 		},
 		{
 			icon: plugins,
 			link: JETPACK_MANAGE_PLUGINS_LINK,
+			slug: 'manage_plugins',
 			title: translate( 'Manage plugins' ),
 		},
 		{
 			icon: key,
 			link: JETPACK_MANAGE_LICENCES_LINK,
+			slug: 'view_licenses',
 			title: translate( 'View all licenses' ),
 		},
 		{
 			icon: store,
 			link: JETPACK_MANAGE_BILLING_LINK,
+			slug: 'view_billing',
 			title: translate( 'View billing' ),
 		},
 		{
 			icon: receipt,
 			link: JETPACK_MANAGE_INVOICES_LINK,
+			slug: 'view_invoices',
 			title: translate( 'View invoices' ),
 		},
 		{
 			icon: tag,
 			link: '/partner-portal/issue-license',
+			slug: 'view_prices',
 			title: translate( 'View prices' ),
 		},
 	].map( ( props ) => ( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Resolves Automattic/jetpack-manage#207

## Proposed Changes

This updates an errant copy/pasted `calypso_jetpack_manage_overview_quick_links` event name to `calypso_jetpack_manage_overview_get_help`. It also updates the `nav_item` Tracks param on `FoldableNav` to use a link slug instead of link text, the latter which can be translated and result in messy data.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Try expanding/collapsing the `GetHelp` component. It will correctly fire the `calypso_jetpack_manage_overview_get_help` event.
2. Click on any link in the `QuickLinks` or `GetHelp` components. They will send a `nav_item` param with the link slug instead of the link label.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?