### PR TITLE
Add link to the plan on the tooltip shown when checking a theme's styles

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/test/theme-tier-style-variation-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/test/theme-tier-style-variation-badge.js
@@ -37,10 +37,10 @@ describe( 'ThemeTierStyleVariationBadge', () => {
 	} );
 
 	test( 'should render a link to the plan on the tooltip content', async () => {
-		const title = 'Premium';
+		const title = 'Explorer';
 		const pathSlug = 'premium';
 		getPlan.mockImplementation( () => ( {
-			getTitle: () => 'Premium',
+			getTitle: () => title,
 			getPathSlug: () => pathSlug,
 		} ) );
 

--- a/client/components/theme-tier/theme-tier-badge/test/theme-tier-style-variation-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/test/theme-tier-style-variation-badge.js
@@ -1,0 +1,62 @@
+/** @jest-environment jsdom */
+import { getPlan } from '@automattic/calypso-products';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useSelector } from 'calypso/state';
+import ThemeTierStyleVariationBadge from '../theme-tier-style-variation-badge';
+
+jest.mock( 'calypso/state' );
+jest.mock( '@automattic/calypso-products' );
+
+describe( 'ThemeTierStyleVariationBadge', () => {
+	const siteSlug = 'example.wordpress.com';
+	let originalWindowLocation;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+
+		originalWindowLocation = global.window.location;
+		delete global.window.location;
+		global.window.location = {
+			href: 'http://wwww.example.com',
+			origin: 'http://www.example.com',
+		};
+
+		useSelector.mockImplementation( () => siteSlug );
+	} );
+
+	afterEach( () => {
+		global.window.location = originalWindowLocation;
+	} );
+
+	test( 'should render upgrade label', () => {
+		render( <ThemeTierStyleVariationBadge /> );
+
+		const upgradeLabel = screen.getByText( 'Upgrade' );
+		expect( upgradeLabel ).toBeInTheDocument();
+	} );
+
+	test( 'should render a link to the plan on the tooltip content', async () => {
+		const title = 'Premium';
+		const pathSlug = 'premium';
+		getPlan.mockImplementation( () => ( {
+			getTitle: () => 'Premium',
+			getPathSlug: () => pathSlug,
+		} ) );
+
+		render( <ThemeTierStyleVariationBadge /> );
+
+		userEvent.hover( screen.getByText( 'Upgrade' ) );
+
+		const button = await screen.findByRole( 'button', { name: `${ title } plan` } );
+		await act( async () => {
+			await userEvent.click( button );
+		} );
+
+		await waitFor( () =>
+			expect( global.window.location.href ).toBe(
+				`/checkout/${ siteSlug }/${ pathSlug }?redirect_to=http%3A%2F%2Fwwww.example.com`
+			)
+		);
+	} );
+} );

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-style-variation-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-style-variation-badge.js
@@ -1,22 +1,28 @@
 import { PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
 import { PremiumBadge } from '@automattic/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
+import ThemeTierBadgeCheckoutLink from './theme-tier-badge-checkout-link';
 import ThemeTierBadgeTracker from './theme-tier-badge-tracker';
 import ThemeTierTooltipTracker from './theme-tier-tooltip-tracker';
 
 export default function ThemeTierStyleVariationBadge() {
 	const translate = useTranslate();
 
+	const premiumPlan = getPlan( PLAN_PREMIUM );
+
 	const tooltipContent = (
 		<>
 			<ThemeTierTooltipTracker />
 			<div data-testid="upsell-header" className="theme-tier-badge-tooltip__header" />
 			<div data-testid="upsell-message">
-				{ translate(
-					'Unlock this style, and tons of other features, by upgrading to a %(premiumPlanName)s plan.',
-					{
-						args: { premiumPlanName: getPlan( PLAN_PREMIUM )?.getTitle() },
-					}
+				{ createInterpolateElement(
+					// Translators: %(premiumPlanName)s is the name of the premium plan that includes this theme. Examples: "Explorer" or "Premium".
+					translate(
+						'Unlock this style, and tons of other features, by upgrading to a <Link>%(premiumPlanName)s plan</Link>.',
+						{ args: { premiumPlanName: premiumPlan?.getTitle() } }
+					),
+					{ Link: <ThemeTierBadgeCheckoutLink plan={ premiumPlan?.getPathSlug() } /> }
 				) }
 			</div>
 		</>

--- a/client/components/theme-type-badge/tooltip.tsx
+++ b/client/components/theme-type-badge/tooltip.tsx
@@ -12,7 +12,6 @@ import { Button as LinkButton } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import i18n, { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
-import ThemeTierBadgeCheckoutLink from 'calypso/components/theme-tier/theme-tier-badge/theme-tier-badge-checkout-link';
 import { useBundleSettingsByTheme } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
 import { useSelector } from 'calypso/state';
 import {
@@ -116,8 +115,15 @@ const ThemeTypeBadgeTooltip = ( {
 				'Unlock this style, and tons of other features, by upgrading to a <Link>%(premiumPlanName)s plan</Link>.',
 				{ args: { premiumPlanName: premiumPlan?.productNameShort || '' }, textOnly: true }
 			),
-			// @ts-expect-error -- Property children is missing, but provided by the createInterpolateElement function.
-			{ Link: <ThemeTierBadgeCheckoutLink plan={ premiumPlan?.planSlug } /> }
+			{
+				Link: (
+					<ThemeTypeBadgeTooltipUpgradeLink
+						canGoToCheckout={ canGoToCheckout }
+						plan={ premiumPlan?.planSlug || '' }
+						siteSlug={ siteSlug }
+					/>
+				),
+			}
 		);
 	} else if ( type === PREMIUM_THEME ) {
 		if ( isPurchased ) {

--- a/client/components/theme-type-badge/tooltip.tsx
+++ b/client/components/theme-type-badge/tooltip.tsx
@@ -12,6 +12,7 @@ import { Button as LinkButton } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import i18n, { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
+import ThemeTierBadgeCheckoutLink from 'calypso/components/theme-tier/theme-tier-badge/theme-tier-badge-checkout-link';
 import { useBundleSettingsByTheme } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
 import { useSelector } from 'calypso/state';
 import {
@@ -106,11 +107,17 @@ const ThemeTypeBadgeTooltip = ( {
 		} );
 	}, [ themeId ] );
 
+	const premiumPlan = plans?.data?.[ PLAN_PREMIUM ];
 	let message;
 	if ( isLockedStyleVariation ) {
-		message = translate(
-			'Unlock this style, and tons of other features, by upgrading to a %(premiumPlanName)s plan.',
-			{ args: { premiumPlanName: plans?.data?.[ PLAN_PREMIUM ]?.productNameShort ?? '' } }
+		message = createInterpolateElement(
+			// Translators: %(premiumPlanName)s is the name of the premium plan that includes this theme. Examples: "Explorer" or "Premium".
+			translate(
+				'Unlock this style, and tons of other features, by upgrading to a <Link>%(premiumPlanName)s plan</Link>.',
+				{ args: { premiumPlanName: premiumPlan?.productNameShort || '' }, textOnly: true }
+			),
+			// @ts-expect-error -- Property children is missing, but provided by the createInterpolateElement function.
+			{ Link: <ThemeTierBadgeCheckoutLink plan={ premiumPlan?.planSlug } /> }
 		);
 	} else if ( type === PREMIUM_THEME ) {
 		if ( isPurchased ) {


### PR DESCRIPTION
Fixes #85537 

## Proposed Changes

The popover is currently shown without linking to the plan, this PR adds the correct link.

|Before|After|
|---|---|
|![image](https://github.com/Automattic/wp-calypso/assets/8511199/3220a883-c505-4f61-8e1b-9647a9495cb6)|![image](https://github.com/Automattic/wp-calypso/assets/8511199/e721d362-afea-4163-9e90-95eb9248a5d7)|

## Testing Instructions

1. Be on a free plan
2. Go to /themes using the calypso live link below and adding `?flags=themes/tiers` to the URL
4. Find a free theme with style variations 
5. Click on a style option that's not the default one (as can be seen on the screenshots above)
6. Hover on the `Premium`/`Upgrade` button
7. Check that the `Explorer plan` bit is a link
8. Check that clicking on it takes you to the checkout page for **WordPress.com Explorer**

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
