### PR TITLE
Blogging prompt card - align text vertically and remove orphans when possible

### DIFF
--- a/client/components/blogging-prompt-card/style.scss
+++ b/client/components/blogging-prompt-card/style.scss
@@ -32,7 +32,7 @@
 		width: 100%;
 
 		.blogging-prompt__prompt-navigation {
-			align-items: flex-start;
+			align-items: center;
 			display: flex;
 			gap: 20px;
 		}
@@ -41,6 +41,7 @@
 			font-size: $font-title-small;
 			font-weight: 500;
 			line-height: 26px;
+			text-wrap: pretty;
 		}
 		button.navigation-link {
 			border-radius: 50%;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1704302953476049-slack-C03NLNTPZ2T

## Proposed Changes

* Updates the flex alignment to `center` for items in the navigation, creating proper vertical alignment between the slider buttons and the text shown.
* Adds `text-wrap: pretty` to the text area to remove orphans for supporting browsers.

Before:
<img width="702" alt="Screenshot 2024-01-03 at 12 40 33 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/c21d91a0-c324-4055-bc1f-ab7e21e6b70d">
<img width="708" alt="Screenshot 2024-01-03 at 12 40 39 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/0feca3d6-a6cb-4cdf-b7e0-f9bd11dcce6c">

After:
<img width="711" alt="Screenshot 2024-01-03 at 12 38 59 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/ba5260e7-defc-43f7-bbb5-796e0c9e416c">
<img width="700" alt="Screenshot 2024-01-03 at 12 45 57 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/2b949ff7-20c0-4222-b819-f3153e86f563">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch
* select to manage a site that recieves the blogging prompts card on my home
* verify single line prompts are now centered vertically
* verify multi line prompts no longer have orphans on supporting browsers such as chrome.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?