### PR TITLE
Make some minor tweaks to bloganuary banner

### DIFF
--- a/client/components/bloganuary-header/style.scss
+++ b/client/components/bloganuary-header/style.scss
@@ -2,27 +2,28 @@
 @import "~@wordpress/base-styles/mixins";
 
 .bloganuary-header {
-	background-color: var(--studio-gray-100);
-	color: var(--studio-white);
+	background-color: var(--color-sidebar-background);
+	border-radius: 2px;
+	color: var(--color-sidebar-text);
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
 	flex-wrap: wrap;
 	gap: 10px;
-	padding: 20px 40px;
+	padding: 20px 32px;
 	vertical-align: middle;
 	margin-bottom: 20px;
 
 	.blogging-bloganuary-icon {
 		vertical-align: middle;
-		padding-right: 10px;
+		padding-right: 12px;
 		display: inline-block;
 
 		> svg {
-			width: 44px;
-			height: 44px;
+			width: 36px;
+			height: 36px;
 			> path {
-				fill: var(--studio-white);
+				fill: var(--color-sidebar-text);
 			}
 		}
 	}
@@ -30,16 +31,16 @@
 	.bloganuary-header__title {
 		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
 		vertical-align: middle;
-		font-size: 22px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+		font-size: $font-title-medium;
 
 		@include break-small {
-			font-size: 40px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: $font-title-large;
 		}
 	}
 
 	.bloganuary-header__button {
 		vertical-align: middle;
-		font-size: 1rem;
+		font-size: 0.875rem;
 		margin-right: 10px;
 		background-color: var(--color-surface);
 		display: inline-flex;
@@ -48,7 +49,9 @@
 	}
 
 	.bloganuary-header__link {
+		color: var(--color-sidebar-text);
+		font-size: 0.875rem;
+		margin-left: 12px;
 		vertical-align: middle;
-		color: var(--studio-white);
 	}
 }


### PR DESCRIPTION
## Description

When customers are using admin color schemes outside of the default, the dark bloganuary banner had the potential to stand out starkly against the rest of the UI. I made a few minor updates to soften the overall appearance, especially when other admin color schemes are being used.

## Before:

![strong](https://github.com/Automattic/wp-calypso/assets/5634774/d39ba5f4-e63f-47ad-bfed-13204c3ed281)

## After
![after-1](https://github.com/Automattic/wp-calypso/assets/5634774/de1b9002-496f-448f-bebf-8c7dbfe22a1f)
![after-2](https://github.com/Automattic/wp-calypso/assets/5634774/c21faebf-5c68-4d53-a03f-6130e7a674dd)
![after-3](https://github.com/Automattic/wp-calypso/assets/5634774/fde060cd-19bb-4a42-a871-d51881024341)

## Testing

- Apply these changes
- Visit the reader
