### PR TITLE
Jetpack Logo Generator: remove store tester link

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { getAllFeaturesForPlan } from '@automattic/calypso-products/';
 import { JetpackLogo, FoldableCard } from '@automattic/components';
-import { GeneratorModal, StoreTester } from '@automattic/jetpack-ai-calypso';
+import { GeneratorModal } from '@automattic/jetpack-ai-calypso';
 import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { connect, useSelector } from 'react-redux';
@@ -88,7 +88,6 @@ export const QuickLinks = ( {
 	const hasBackups = getAllFeaturesForPlan( currentSitePlanSlug ).includes( 'backups' );
 	const hasBoost = site?.options?.jetpack_connection_active_plugins?.includes( 'jetpack-boost' );
 	const [ isAILogoGeneratorOpen, setIsAILogoGeneratorOpen ] = useState( false );
-	const [ isStoreTesterOpen, setIsStoreTesterOpen ] = useState( false );
 
 	const addNewDomain = () => {
 		sendNudge( {
@@ -257,17 +256,6 @@ export const QuickLinks = ( {
 								siteDetails={ site }
 								isOpen={ isAILogoGeneratorOpen }
 								onClose={ () => setIsAILogoGeneratorOpen( false ) }
-							/>
-							<ActionBox
-								hideLinkIndicator
-								gridicon="plans"
-								label={ translate( 'Test Jetpack AI Store' ) }
-								onClick={ () => setIsStoreTesterOpen( true ) }
-							/>
-							<StoreTester
-								siteDetails={ site }
-								isOpen={ isStoreTesterOpen }
-								onClose={ () => setIsStoreTesterOpen( false ) }
 							/>
 						</>
 					) }


### PR DESCRIPTION
This is a clean up PR

Related to #85557 

## Proposed Changes

* remove store tester link, meant to only provide easy access to store functions

## Testing Instructions

Load calypso home and look for the quick links section. There should be no "Test Jetpack AI Store" entry/link