### PR TITLE
Post actions: rename Copy action to Duplicate

### DIFF
--- a/client/my-sites/pages/page/index.js
+++ b/client/my-sites/pages/page/index.js
@@ -336,7 +336,7 @@ class Page extends Component {
 		return (
 			<PopoverMenuItem onClick={ this.copyPage } href={ duplicateUrl }>
 				<Gridicon icon="clipboard" size={ 18 } />
-				{ this.props.translate( 'Copy page' ) }
+				{ this.props.translate( 'Duplicate page' ) }
 			</PopoverMenuItem>
 		);
 	}

--- a/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
+++ b/client/my-sites/post-type-list/post-actions-ellipsis-menu/duplicate.jsx
@@ -30,7 +30,7 @@ function PostActionsEllipsisMenuDuplicate( {
 	return (
 		<PopoverMenuItem href={ duplicateUrl } onClick={ onDuplicateClick } icon="clipboard">
 			<QueryJetpackModules siteId={ siteId } />
-			{ translate( 'Copy post' ) }
+			{ translate( 'Duplicate post' ) }
 		</PopoverMenuItem>
 	);
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/5078.

## Proposed Changes

The term "Copy" is misleading for the action of... duplicating... a post. Let's use "duplicate" instead. Here's a piece of feedback (p1702948754184619-slack-C0347E545HR) from a frustrated customer:

>Another simple but glaring example, is that it's not possible to duplicate a page... Why? The only way to do this is to download a 3rd party plugin. I mean, how long have you been doing this? Surely this is a standard function so that people can protect their version and start a new draft. Surely this is a simple solve?

| Before | After |
| ------ | ----- |
| <img width="977" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/41ad7938-0e18-418f-97c1-4c71f9fa5949">  | <img width="979" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/8fd1e864-adb0-4ccb-b323-d253fe8857cb"> |

## Testing Instructions

Visit post and page management and verify that the quick action says "Duplicate (post|page)" instead of "Copy."