### PR TITLE
Explorer upsell: Use image without business plan copy

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
+++ b/client/my-sites/checkout/upsell-nudge/business-plan-upgrade-upsell/index.jsx
@@ -2,7 +2,7 @@ import { PLAN_BUSINESS, PLAN_PREMIUM, getPlan } from '@automattic/calypso-produc
 import { Button, Gridicon } from '@automattic/components';
 import { PureComponent } from 'react';
 import formatCurrency from 'calypso/../packages/format-currency/src';
-import upsellImage from 'calypso/assets/images/checkout-upsell/upsell-rocket-2.png';
+import upsellImage from 'calypso/assets/images/checkout-upsell/upsell-rocket.png';
 import DocumentHead from 'calypso/components/data/document-head';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
@@ -51,7 +51,7 @@ export class BusinessPlanUpgradeUpsell extends PureComponent {
 				className="business-plan-upgrade-upsell-new-design__image"
 				src={ upsellImage }
 				alt=""
-				width="454"
+				width="320"
 			/>
 		);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5077

## Proposed Changes

* Use rocket image without embedded "Business plan" copy in the Explorer upsell.

Before | After
--|--
<img width="1106" alt="Screenshot 2024-01-03 at 6 13 51 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/a7967602-fa2f-4395-a253-c0f7aa825823">  | <img width="1105" alt="Screenshot 2024-01-03 at 6 13 58 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/a70efef1-7d60-4a34-aebf-c1b99d8a3f5b">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase an Explorer plan
* After checkout you'll see an upsell to the Creator plan.
* The image should match the screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?