### PR TITLE
Site Settings: Fix flickering of the Public radio option in General Settings

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -347,6 +347,23 @@ export class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
+	PublicFormRadio = ( checked, onChange ) => {
+		const { isRequestingSettings, translate, eventTracker } = this.props;
+		return (
+			<FormLabel className="site-settings__visibility-label is-public">
+				<FormRadio
+					name="blog_public"
+					value="1"
+					checked={ checked }
+					onChange={ onChange }
+					disabled={ isRequestingSettings }
+					onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
+					label={ translate( 'Public' ) }
+				/>
+			</FormLabel>
+		);
+	};
+
 	visibilityOptionsComingSoon() {
 		const {
 			fields,
@@ -382,30 +399,6 @@ export class SiteSettingsFormGeneral extends Component {
 			}
 		);
 		const showPreviewLink = isComingSoon && hasSitePreviewLink;
-
-		const PublicFormRadio = () => (
-			<FormLabel className="site-settings__visibility-label is-public">
-				<FormRadio
-					name="blog_public"
-					value="1"
-					checked={
-						( wpcomPublicComingSoon && blogPublic === 0 && isComingSoonDisabled ) ||
-						( blogPublic === 0 && ! wpcomPublicComingSoon ) ||
-						blogPublic === 1
-					}
-					onChange={ () =>
-						this.handleVisibilityOptionChange( {
-							blog_public: isWpcomStagingSite ? 0 : 1,
-							wpcom_coming_soon: 0,
-							wpcom_public_coming_soon: 0,
-						} )
-					}
-					disabled={ isRequestingSettings }
-					onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
-					label={ translate( 'Public' ) }
-				/>
-			</FormLabel>
-		);
 
 		return (
 			<FormFieldset>
@@ -451,7 +444,17 @@ export class SiteSettingsFormGeneral extends Component {
 					) }
 				{ isWpcomStagingSite && (
 					<>
-						<PublicFormRadio />
+						{ this.PublicFormRadio(
+							( wpcomPublicComingSoon && blogPublic === 0 && isComingSoonDisabled ) ||
+								( blogPublic === 0 && ! wpcomPublicComingSoon ) ||
+								blogPublic === 1,
+							() =>
+								this.handleVisibilityOptionChange( {
+									blog_public: isWpcomStagingSite ? 0 : 1,
+									wpcom_coming_soon: 0,
+									wpcom_public_coming_soon: 0,
+								} )
+						) }
 						<FormSettingExplanation>
 							{ translate(
 								'Your site is visible to everyone, but search engines are discouraged from indexing staging sites.'
@@ -459,7 +462,19 @@ export class SiteSettingsFormGeneral extends Component {
 						</FormSettingExplanation>
 					</>
 				) }
-				{ ! isNonAtomicJetpackSite && ! isWpcomStagingSite && <PublicFormRadio /> }
+				{ ! isNonAtomicJetpackSite &&
+					! isWpcomStagingSite &&
+					this.PublicFormRadio(
+						( wpcomPublicComingSoon && blogPublic === 0 && isComingSoonDisabled ) ||
+							( blogPublic === 0 && ! wpcomPublicComingSoon ) ||
+							blogPublic === 1,
+						() =>
+							this.handleVisibilityOptionChange( {
+								blog_public: isWpcomStagingSite ? 0 : 1,
+								wpcom_coming_soon: 0,
+								wpcom_public_coming_soon: 0,
+							} )
+					) }
 				{ ! isWpcomStagingSite && (
 					<>
 						<FormSettingExplanation>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -429,22 +429,24 @@ export class SiteSettingsFormGeneral extends Component {
 						</>
 					) }
 				{ ! isNonAtomicJetpackSite && (
-					<FormLabel className="site-settings__visibility-label is-public">
-						<FormRadio
-							name="blog_public"
-							value="1"
-							checked={ isPublicChecked }
-							onChange={ () =>
-								this.handleVisibilityOptionChange( {
-									blog_public: isWpcomStagingSite ? 0 : 1,
-									wpcom_coming_soon: 0,
-									wpcom_public_coming_soon: 0,
-								} )
-							}
-							disabled={ isRequestingSettings }
-							onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
-							label={ translate( 'Public' ) }
-						/>
+					<>
+						<FormLabel className="site-settings__visibility-label is-public">
+							<FormRadio
+								name="blog_public"
+								value="1"
+								checked={ isPublicChecked }
+								onChange={ () =>
+									this.handleVisibilityOptionChange( {
+										blog_public: isWpcomStagingSite ? 0 : 1,
+										wpcom_coming_soon: 0,
+										wpcom_public_coming_soon: 0,
+									} )
+								}
+								disabled={ isRequestingSettings }
+								onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
+								label={ translate( 'Public' ) }
+							/>
+						</FormLabel>
 						<FormSettingExplanation>
 							{ isWpcomStagingSite
 								? translate(
@@ -452,7 +454,7 @@ export class SiteSettingsFormGeneral extends Component {
 								  )
 								: translate( 'Your site is visible to everyone.' ) }
 						</FormSettingExplanation>
-					</FormLabel>
+					</>
 				) }
 
 				{ ! isWpcomStagingSite && (

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -347,7 +347,7 @@ export class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
-	PublicFormRadio = ( checked, onChange ) => {
+	publicFormRadio = ( checked, onChange ) => {
 		const { isRequestingSettings, translate, eventTracker } = this.props;
 		return (
 			<FormLabel className="site-settings__visibility-label is-public">
@@ -444,7 +444,7 @@ export class SiteSettingsFormGeneral extends Component {
 					) }
 				{ isWpcomStagingSite && (
 					<>
-						{ this.PublicFormRadio(
+						{ this.publicFormRadio(
 							( wpcomPublicComingSoon && blogPublic === 0 && isComingSoonDisabled ) ||
 								( blogPublic === 0 && ! wpcomPublicComingSoon ) ||
 								blogPublic === 1,
@@ -464,7 +464,7 @@ export class SiteSettingsFormGeneral extends Component {
 				) }
 				{ ! isNonAtomicJetpackSite &&
 					! isWpcomStagingSite &&
-					this.PublicFormRadio(
+					this.publicFormRadio(
 						( wpcomPublicComingSoon && blogPublic === 0 && isComingSoonDisabled ) ||
 							( blogPublic === 0 && ! wpcomPublicComingSoon ) ||
 							blogPublic === 1,

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -347,23 +347,6 @@ export class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
-	publicFormRadio = ( checked, onChange ) => {
-		const { isRequestingSettings, translate, eventTracker } = this.props;
-		return (
-			<FormLabel className="site-settings__visibility-label is-public">
-				<FormRadio
-					name="blog_public"
-					value="1"
-					checked={ checked }
-					onChange={ onChange }
-					disabled={ isRequestingSettings }
-					onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
-					label={ translate( 'Public' ) }
-				/>
-			</FormLabel>
-		);
-	};
-
 	visibilityOptionsComingSoon() {
 		const {
 			fields,
@@ -392,6 +375,10 @@ export class SiteSettingsFormGeneral extends Component {
 		const isAnyComingSoonEnabled =
 			( 0 === blogPublic && wpcomPublicComingSoon ) || isPrivateAndUnlaunched || wpcomComingSoon;
 		const isComingSoonDisabled = isRequestingSettings || isAtomicAndEditingToolkitDeactivated;
+		const isPublicChecked =
+			( wpcomPublicComingSoon && blogPublic === 0 && isComingSoonDisabled ) ||
+			( blogPublic === 0 && ! wpcomPublicComingSoon ) ||
+			blogPublic === 1;
 		const comingSoonFormLabelClasses = classNames(
 			'site-settings__visibility-label is-coming-soon',
 			{
@@ -399,7 +386,6 @@ export class SiteSettingsFormGeneral extends Component {
 			}
 		);
 		const showPreviewLink = isComingSoon && hasSitePreviewLink;
-
 		return (
 			<FormFieldset>
 				{ ! isNonAtomicJetpackSite &&
@@ -442,44 +428,35 @@ export class SiteSettingsFormGeneral extends Component {
 							) }
 						</>
 					) }
-				{ isWpcomStagingSite && (
-					<>
-						{ this.publicFormRadio(
-							( wpcomPublicComingSoon && blogPublic === 0 && isComingSoonDisabled ) ||
-								( blogPublic === 0 && ! wpcomPublicComingSoon ) ||
-								blogPublic === 1,
-							() =>
+				{ ! isNonAtomicJetpackSite && (
+					<FormLabel className="site-settings__visibility-label is-public">
+						<FormRadio
+							name="blog_public"
+							value="1"
+							checked={ isPublicChecked }
+							onChange={ () =>
 								this.handleVisibilityOptionChange( {
 									blog_public: isWpcomStagingSite ? 0 : 1,
 									wpcom_coming_soon: 0,
 									wpcom_public_coming_soon: 0,
 								} )
-						) }
+							}
+							disabled={ isRequestingSettings }
+							onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
+							label={ translate( 'Public' ) }
+						/>
 						<FormSettingExplanation>
-							{ translate(
-								'Your site is visible to everyone, but search engines are discouraged from indexing staging sites.'
-							) }
+							{ isWpcomStagingSite
+								? translate(
+										'Your site is visible to everyone, but search engines are discouraged from indexing staging sites.'
+								  )
+								: translate( 'Your site is visible to everyone.' ) }
 						</FormSettingExplanation>
-					</>
+					</FormLabel>
 				) }
-				{ ! isNonAtomicJetpackSite &&
-					! isWpcomStagingSite &&
-					this.publicFormRadio(
-						( wpcomPublicComingSoon && blogPublic === 0 && isComingSoonDisabled ) ||
-							( blogPublic === 0 && ! wpcomPublicComingSoon ) ||
-							blogPublic === 1,
-						() =>
-							this.handleVisibilityOptionChange( {
-								blog_public: isWpcomStagingSite ? 0 : 1,
-								wpcom_coming_soon: 0,
-								wpcom_public_coming_soon: 0,
-							} )
-					) }
+
 				{ ! isWpcomStagingSite && (
 					<>
-						<FormSettingExplanation>
-							{ translate( 'Your site is visible to everyone.' ) }
-						</FormSettingExplanation>
 						<FormLabel className="site-settings__visibility-label is-checkbox is-hidden">
 							<FormInputCheckbox
 								name="blog_public"

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -256,10 +256,13 @@ describe( 'SiteSettingsFormGeneral', () => {
 			const { container, getByLabelText } = renderWithRedux(
 				<SiteSettingsFormGeneral { ...testProps } />
 			);
+
 			expect(
 				container.querySelectorAll( '.site-settings__general-settings-launch-site' ).length
 			).toBe( 0 );
 			expect( container.querySelectorAll( '[name="blog_public"]' ).length ).toBe( 4 );
+
+			console.log( container.innerHTML );
 
 			const publicRadio = getByLabelText( 'Public' );
 			const discourageRadio = getByLabelText( 'Discourage search engines from indexing this site', {

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -256,13 +256,10 @@ describe( 'SiteSettingsFormGeneral', () => {
 			const { container, getByLabelText } = renderWithRedux(
 				<SiteSettingsFormGeneral { ...testProps } />
 			);
-
 			expect(
 				container.querySelectorAll( '.site-settings__general-settings-launch-site' ).length
 			).toBe( 0 );
 			expect( container.querySelectorAll( '[name="blog_public"]' ).length ).toBe( 4 );
-
-			console.log( container.innerHTML );
 
 			const publicRadio = getByLabelText( 'Public' );
 			const discourageRadio = getByLabelText( 'Discourage search engines from indexing this site', {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/orgs/Automattic/projects/543/views/1?pane=issue&itemId=48325664

The Public radio option under the privacy section in the General settings form is flickering when the page is loading or when the form is saved/loading. This is caused by the fact that the PublicFormRadio function is a component and it re-renders everytime the parent component renders, which is not efficient and causes flickering of the input radio element.

## Proposed Changes

This PR refactors the PublicFormRadio from being a component defined within the SiteSettingsFormGeneral class to a class function that returns JSX markup. This change aims to improve the performance and readability of the component.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Settings -> General
* Ensure the public option is selected under the Privacy heading.
* When the page is loading, verify that the radio button is not flickering
* When saving the privacy settings, ensure that the public option is not flickering
* In all scenarios, you have to make sure the Public option remains selected as the flickering only occurs when it is selected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?