### PR TITLE
Help Center: do not use isOpeningChatWidget for form control

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -124,7 +124,7 @@ export const HelpCenterContactForm = () => {
 		isEligibleForChat,
 		isLoading: isLoadingChatStatus,
 	} = useChatStatus();
-	const { isOpeningChatWidget, openChatWidget } = useChatWidget(
+	const { openChatWidget } = useChatWidget(
 		'zendesk_support_chat_key',
 		isEligibleForChat || hasActiveChats
 	);
@@ -155,7 +155,7 @@ export const HelpCenterContactForm = () => {
 	);
 
 	const ownershipStatusLoading = ownershipResult?.result === 'LOADING';
-	const isSubmitting = submittingTicket || submittingTopic || isOpeningChatWidget;
+	const isSubmitting = submittingTicket || submittingTopic;
 
 	// if the user picked a site from the picker, we don't need to analyze the ownership
 	if ( currentSite && sitePickerChoice === 'CURRENT_SITE' ) {

--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -124,7 +124,7 @@ export const HelpCenterContactForm = () => {
 		isEligibleForChat,
 		isLoading: isLoadingChatStatus,
 	} = useChatStatus();
-	const { openChatWidget } = useChatWidget(
+	const { isOpeningChatWidget, openChatWidget } = useChatWidget(
 		'zendesk_support_chat_key',
 		isEligibleForChat || hasActiveChats
 	);
@@ -155,7 +155,7 @@ export const HelpCenterContactForm = () => {
 	);
 
 	const ownershipStatusLoading = ownershipResult?.result === 'LOADING';
-	const isSubmitting = submittingTicket || submittingTopic;
+	const isSubmitting = submittingTicket || submittingTopic || isOpeningChatWidget;
 
 	// if the user picked a site from the picker, we don't need to analyze the ownership
 	if ( currentSite && sitePickerChoice === 'CURRENT_SITE' ) {

--- a/packages/help-center/src/hooks/use-chat-widget.ts
+++ b/packages/help-center/src/hooks/use-chat-widget.ts
@@ -60,7 +60,7 @@ export default function useChatWidget(
 	};
 
 	return {
-		isOpeningChatWidget: isSubmittingZendeskUserFields || ! isMessagingScriptLoaded,
+		isOpeningChatWidget: enabled && ( isSubmittingZendeskUserFields || ! isMessagingScriptLoaded ),
 		openChatWidget,
 	};
 }


### PR DESCRIPTION
The way we're loading `useChatWidget` means that it will only load the chat script if the user is eligible for chat. So, if a user isn't, `isOpeningChatWidget` will always be `false`. In turn, this prevents users from contacting us through non-chat methods (forums, email)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes
This removes `isOpeningChatWidget` from the conditions affecting the button disabled status.

## Testing Instructions
* Open the help center and make sure that after clicking "Still need help" and filling out the form, the "Continue" button is not disabled
* Test with:
  - User with chat access: `149607292`
  - User with email access: `244665893`
  - User with free access: `229865819`

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?