### PR TITLE
Move state constants to their own module

### DIFF
--- a/client/components/sympathy-dev-warning/index.tsx
+++ b/client/components/sympathy-dev-warning/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { getStoredItem, setStoredItem } from 'calypso/lib/browser-storage';
 import { useDispatch } from 'calypso/state';
-import { WAS_STATE_RANDOMLY_CLEARED_KEY } from 'calypso/state/initial-state';
+import { WAS_STATE_RANDOMLY_CLEARED_KEY } from 'calypso/state/constants';
 import { warningNotice } from 'calypso/state/notices/actions';
 
 export function SympathyDevWarning() {

--- a/client/data/marketplace/use-get-related-plugins.ts
+++ b/client/data/marketplace/use-get-related-plugins.ts
@@ -7,7 +7,7 @@ import {
 } from '@tanstack/react-query';
 import { normalizePluginData, mapStarRatingToPercent } from 'calypso/lib/plugins/utils';
 import wpcom from 'calypso/lib/wp';
-import { BASE_STALE_TIME } from 'calypso/state/initial-state';
+import { BASE_STALE_TIME } from 'calypso/state/constants';
 import { ESRelatedPluginsResult, RelatedPlugin } from './types';
 
 const mapESDataToReatedPluginData = (

--- a/client/data/marketplace/use-marketplace-reviews.ts
+++ b/client/data/marketplace/use-marketplace-reviews.ts
@@ -7,7 +7,7 @@ import {
 	useInfiniteQuery,
 } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
-import { BASE_STALE_TIME } from 'calypso/state/initial-state';
+import { BASE_STALE_TIME } from 'calypso/state/constants';
 
 const apiBase = '/sites/marketplace.wordpress.com';
 const reviewsApiBase = `${ apiBase }/comments`;

--- a/client/data/marketplace/use-wpcom-plugins-query.ts
+++ b/client/data/marketplace/use-wpcom-plugins-query.ts
@@ -12,7 +12,7 @@ import {
 	normalizePluginData,
 } from 'calypso/lib/plugins/utils';
 import wpcom from 'calypso/lib/wp';
-import { BASE_STALE_TIME } from 'calypso/state/initial-state';
+import { BASE_STALE_TIME } from 'calypso/state/constants';
 
 type Type = 'all' | 'featured' | 'launched';
 

--- a/client/data/marketplace/use-wporg-plugin-query.ts
+++ b/client/data/marketplace/use-wporg-plugin-query.ts
@@ -15,8 +15,8 @@ import {
 } from 'calypso/lib/plugins/utils';
 import { fetchPluginsList } from 'calypso/lib/wporg';
 import { useSelector } from 'calypso/state';
+import { BASE_STALE_TIME } from 'calypso/state/constants';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
-import { BASE_STALE_TIME } from 'calypso/state/initial-state';
 import { WPORG_CACHE_KEY } from './constants';
 import { Plugin, PluginQueryOptions } from './types';
 import { getPluginsListKey } from './utils';

--- a/client/data/wp-version/use-wp-version-query.ts
+++ b/client/data/wp-version/use-wp-version-query.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchWordPressVersions } from 'calypso/lib/wporg';
-import { MAX_AGE } from 'calypso/state/initial-state';
+import { MAX_AGE } from 'calypso/state/constants';
 
 /**
  * A custom hook that fetches the latest WordPress version and returns it as a query result.

--- a/client/state/constants.ts
+++ b/client/state/constants.ts
@@ -1,0 +1,6 @@
+const DAY_IN_HOURS = 24;
+const HOUR_IN_MS = 3600000;
+export const SERIALIZE_THROTTLE = 5000;
+export const MAX_AGE = 7 * DAY_IN_HOURS * HOUR_IN_MS;
+export const BASE_STALE_TIME = 2 * HOUR_IN_MS;
+export const WAS_STATE_RANDOMLY_CLEARED_KEY = 'was-state-randomly-cleared';

--- a/client/state/initial-state.js
+++ b/client/state/initial-state.js
@@ -3,25 +3,19 @@ import debugModule from 'debug';
 import { map, pick, throttle } from 'lodash';
 import { setStoredItem } from 'calypso/lib/browser-storage';
 import { isSupportSession } from 'calypso/lib/user/support-user-interop';
-import { APPLY_STORED_STATE } from 'calypso/state/action-types';
-import { serialize, deserialize } from 'calypso/state/utils';
+import { APPLY_STORED_STATE } from './action-types';
+import { MAX_AGE, SERIALIZE_THROTTLE, WAS_STATE_RANDOMLY_CLEARED_KEY } from './constants';
 import {
 	clearPersistedState,
 	getPersistedStateItem,
 	storePersistedStateItem,
 } from './persisted-state';
+import { serialize, deserialize } from './utils';
 
 /**
  * Module variables
  */
 const debug = debugModule( 'calypso:state' );
-
-const DAY_IN_HOURS = 24;
-const HOUR_IN_MS = 3600000;
-export const SERIALIZE_THROTTLE = 5000;
-export const MAX_AGE = 7 * DAY_IN_HOURS * HOUR_IN_MS;
-export const BASE_STALE_TIME = 2 * HOUR_IN_MS;
-export const WAS_STATE_RANDOMLY_CLEARED_KEY = 'was-state-randomly-cleared';
 
 // Store the timestamp at which the module loads as a proxy for the timestamp
 // when the server data (if any) was generated.

--- a/client/state/query-client-ssr.ts
+++ b/client/state/query-client-ssr.ts
@@ -1,5 +1,5 @@
 import { QueryClient, QueryCache, dehydrate, QueryOptions, QueryKey } from '@tanstack/react-query';
-import { MAX_AGE, BASE_STALE_TIME } from 'calypso/state/initial-state';
+import { MAX_AGE, BASE_STALE_TIME } from 'calypso/state/constants';
 import type { Query, QueryState } from '@tanstack/react-query';
 
 const fetchedQueryHashes = new WeakMap< QueryClient, Set< string > >();

--- a/client/state/query-client.ts
+++ b/client/state/query-client.ts
@@ -1,7 +1,8 @@
 import { hydrate, QueryClient } from '@tanstack/react-query';
 import { persistQueryClient } from '@tanstack/react-query-persist-client';
 import { throttle } from 'lodash';
-import { shouldPersist, MAX_AGE, SERIALIZE_THROTTLE } from 'calypso/state/initial-state';
+import { MAX_AGE, SERIALIZE_THROTTLE } from 'calypso/state/constants';
+import { shouldPersist } from 'calypso/state/initial-state';
 import {
 	getPersistedStateItem,
 	loadPersistedState,

--- a/client/state/test/initial-state.js
+++ b/client/state/test/initial-state.js
@@ -7,14 +7,9 @@ import * as browserStorage from 'calypso/lib/browser-storage';
 import { isSupportSession } from 'calypso/lib/user/support-user-interop';
 import { createReduxStore } from 'calypso/state';
 import { addReducerToStore } from 'calypso/state/add-reducer';
+import { MAX_AGE, SERIALIZE_THROTTLE } from 'calypso/state/constants';
 import currentUser from 'calypso/state/current-user/reducer';
-import {
-	getInitialState,
-	getStateFromCache,
-	persistOnChange,
-	MAX_AGE,
-	SERIALIZE_THROTTLE,
-} from 'calypso/state/initial-state';
+import { getInitialState, getStateFromCache, persistOnChange } from 'calypso/state/initial-state';
 import { loadPersistedState } from 'calypso/state/persisted-state';
 import postTypes from 'calypso/state/post-types/reducer';
 import reader from 'calypso/state/reader/reducer';


### PR DESCRIPTION
Moves `state` constants to their own module, so that server modules like `query-client-ssr` don't have to import a big `initial-state` module with browser-specific code like persistence or support sessions. This makes the server bundle more tidy and maybe it will also have some impact on the browser bundle.

Found this opportunity when working on #84243.