### PR TITLE
Site Settings: Add a drop shadow to the Site tool links when :focus state is active

### DIFF
--- a/client/my-sites/site-settings/site-tools/style.scss
+++ b/client/my-sites/site-settings/site-tools/style.scss
@@ -48,6 +48,11 @@
 	color: inherit;
 }
 
+.site-tools__link:focus {
+	box-shadow: 0 0 0 2px var(--color-primary-light);
+	z-index: 1;
+}
+
 .site-tools__option-marker {
 	flex: 0 0 auto;
 	padding-left: 24px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5033

The Site tools links should have a dark border that is the same style as the Upsell Nudge.

## Proposed Changes

* Add a drop-shadow and z-index to a focussed site tools link on the general settings page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Settings -> General page
* Scroll down to the bottom where the site-tools are
* Apply a focus state to any of the site tool links. You can do this via the developer tools or by tabbing until the link is focused.

Before:
<img width="744" alt="CleanShot 2567-01-04 at 16 36 45@2x" src="https://github.com/Automattic/wp-calypso/assets/10244734/6e6224d5-98d0-4467-8b4b-de7423e2e3fd">

After:
<img width="758" alt="CleanShot 2567-01-04 at 16 36 15@2x" src="https://github.com/Automattic/wp-calypso/assets/10244734/ef129584-73ad-4d55-90f2-472d4f75bc39">

Manually focus element via developer tools:
![CleanShot 2567-01-04 at 16 37 32@2x](https://github.com/Automattic/wp-calypso/assets/10244734/db196f4d-55af-49b3-a5d3-125342c26ae8)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?