### PR TITLE
Jetpack Manage: Implement submit product feedback

### DIFF
--- a/client/jetpack-cloud/components/user-feedback-modal-form/index.tsx
+++ b/client/jetpack-cloud/components/user-feedback-modal-form/index.tsx
@@ -6,6 +6,7 @@ import { ChangeEvent, useCallback, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import ReviewsRatingsStars from 'calypso/components/reviews-rating-stars/reviews-ratings-stars';
+import useSubmitProductFeedback from './use-submit-product-feedback';
 
 import './style.scss';
 
@@ -23,6 +24,8 @@ export default function UserFeedbackModalForm( { show, onClose }: Props ) {
 	const [ feedback, setFeedback ] = useState( DEFAULT_FEEDBACK_VALUE );
 	const [ rating, setRating ] = useState( DEFAULT_RATING_VALUE );
 
+	const { isSubmittingFeedback, submitFeedback } = useSubmitProductFeedback();
+
 	const onFeedbackChange = useCallback( ( event: ChangeEvent< HTMLInputElement > ) => {
 		setFeedback( event.currentTarget.value );
 	}, [] );
@@ -37,9 +40,10 @@ export default function UserFeedbackModalForm( { show, onClose }: Props ) {
 		if ( ! hasCompletedForm ) {
 			return;
 		}
-
-		// TODO: send feedback to backend
-	}, [ hasCompletedForm ] );
+		// Remove the hash from the URL.
+		const sourceUrl = window.location.href.split( '#' )[ 0 ];
+		submitFeedback( { feedback, rating, source_url: sourceUrl } );
+	}, [ feedback, hasCompletedForm, rating, submitFeedback ] );
 
 	const onModalClose = useCallback( () => {
 		setFeedback( DEFAULT_FEEDBACK_VALUE );
@@ -100,6 +104,7 @@ export default function UserFeedbackModalForm( { show, onClose }: Props ) {
 
 			<div className="user-feedback-modal-form__footer">
 				<Button
+					busy={ isSubmittingFeedback }
 					className="user-feedback-modal-form__footer-submit"
 					primary
 					disabled={ ! hasCompletedForm }

--- a/client/jetpack-cloud/components/user-feedback-modal-form/use-submit-product-feedback.ts
+++ b/client/jetpack-cloud/components/user-feedback-modal-form/use-submit-product-feedback.ts
@@ -1,0 +1,45 @@
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { SubmitProductFeedbackParams } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import { useDispatch } from 'calypso/state';
+import useSubmitProductFeedbackMutation from 'calypso/state/jetpack-agency-dashboard/hooks/use-submit-product-feedback-mutation';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+
+export default function useSubmitProductFeedback(): {
+	isSubmittingFeedback: boolean;
+	submitFeedback: ( params: SubmitProductFeedbackParams ) => void;
+} {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const {
+		isError,
+		isSuccess,
+		mutate,
+		isLoading: isSubmittingFeedback,
+	} = useSubmitProductFeedbackMutation();
+
+	useEffect( () => {
+		if ( isError ) {
+			dispatch(
+				errorNotice( translate( 'Something went wrong. Please try again.' ), {
+					id: 'submit-product-feedback-failure',
+					duration: 5000,
+				} )
+			);
+		}
+	}, [ translate, isError, dispatch ] );
+
+	useEffect( () => {
+		if ( isSuccess ) {
+			dispatch(
+				successNotice( translate( 'Thank you for your feedback!' ), {
+					id: 'submit-product-feedback-success',
+					duration: 5000,
+				} )
+			);
+		}
+	}, [ translate, isSuccess, dispatch ] );
+
+	return { isSubmittingFeedback, submitFeedback: mutate };
+}

--- a/client/jetpack-cloud/components/user-feedback-modal-form/use-submit-product-feedback.ts
+++ b/client/jetpack-cloud/components/user-feedback-modal-form/use-submit-product-feedback.ts
@@ -3,11 +3,12 @@ import { useEffect } from 'react';
 import { SubmitProductFeedbackParams } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
 import { useDispatch } from 'calypso/state';
 import useSubmitProductFeedbackMutation from 'calypso/state/jetpack-agency-dashboard/hooks/use-submit-product-feedback-mutation';
-import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { errorNotice } from 'calypso/state/notices/actions';
 
 export default function useSubmitProductFeedback(): {
 	isSubmittingFeedback: boolean;
 	submitFeedback: ( params: SubmitProductFeedbackParams ) => void;
+	isSubmissionSuccessful: boolean;
 } {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -30,16 +31,5 @@ export default function useSubmitProductFeedback(): {
 		}
 	}, [ translate, isError, dispatch ] );
 
-	useEffect( () => {
-		if ( isSuccess ) {
-			dispatch(
-				successNotice( translate( 'Thank you for your feedback!' ), {
-					id: 'submit-product-feedback-success',
-					duration: 5000,
-				} )
-			);
-		}
-	}, [ translate, isSuccess, dispatch ] );
-
-	return { isSubmittingFeedback, submitFeedback: mutate };
+	return { isSubmittingFeedback, submitFeedback: mutate, isSubmissionSuccessful: isSuccess };
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -303,6 +303,12 @@ export interface UpdateMonitorSettingsArgs {
 	params: UpdateMonitorSettingsParams;
 }
 
+export interface SubmitProductFeedbackParams {
+	rating: number;
+	feedback: string;
+	source_url: string;
+}
+
 export type SiteMonitorStatus = {
 	[ siteId: number ]: 'loading' | 'completed';
 };

--- a/client/state/jetpack-agency-dashboard/hooks/use-submit-product-feedback-mutation.ts
+++ b/client/state/jetpack-agency-dashboard/hooks/use-submit-product-feedback-mutation.ts
@@ -1,0 +1,29 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+import type {
+	APIError,
+	SubmitProductFeedbackParams,
+} from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+
+interface APIResponse {
+	success: boolean;
+}
+
+function mutationSubmitProductFeedback(
+	params: SubmitProductFeedbackParams
+): Promise< APIResponse > {
+	return wpcomJpl.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: '/jetpack-manage/user-feedback',
+		body: params,
+	} );
+}
+
+export default function useSubmitProductFeedbackMutation< TContext = unknown >(
+	options?: UseMutationOptions< APIResponse, APIError, SubmitProductFeedbackParams, TContext >
+): UseMutationResult< APIResponse, APIError, SubmitProductFeedbackParams, TContext > {
+	return useMutation< APIResponse, APIError, SubmitProductFeedbackParams, TContext >( {
+		...options,
+		mutationFn: mutationSubmitProductFeedback,
+	} );
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/165
Resolves https://github.com/Automattic/jetpack-genesis/issues/166

## Proposed Changes

This PR implements submit product feedback.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Apply patch: D133680-code
2. Visit the Jetpack Cloud link > Append the URL with `?flags=jetpack/user-feedback-form` 
3. Click the 'Share user feedback' menu item on the bottom left of the sidebar.

<img width="292" alt="screen-shot-2023-12-20-at-7 39 21-pm" src="https://github.com/Automattic/wp-calypso/assets/56598660/eef6bf7f-7106-43aa-ad02-0d83b3340313">

4. Enter the feedback text and select the rating.
5. Click the `Submit your feedback` button > Verify that the busy state of the button is displayed when the request is being made > Verify that the feedback is submitted with the fields: `rating`, `feedback`, and `source_url`. `source_url` is the current page the user is viewing. 

<img width="867" alt="Screenshot 2024-01-04 at 3 46 20 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8e8c3cf5-a61c-41c3-a2ec-72efd04bc63d">


6. Also, verify that the success message is displayed once the feedback is submitted and you have received an email for the same.

<img width="372" alt="Screenshot 2024-01-05 at 9 08 07 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/628e56a2-8012-412f-a3f1-fa880b0e3782">

<img width="1289" alt="Screenshot 2024-01-05 at 9 18 12 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/07bd154f-2de7-4b90-9c93-bdfb866e13aa">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?