### PR TITLE
Login: Continue as user vh fix

### DIFF
--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -13,7 +13,7 @@
 	max-width: 400px;
 	min-height: 260px;
 
-	@include break-mobile {
+	@include break-medium {
 		height: 50vh;
 	}
 

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -14,7 +14,7 @@
 	min-height: 260px;
 
 	@include break-medium {
-		height: 50vh;
+		height: 48vh;
 	}
 
 	.continue-as-user__user-info {

--- a/client/blocks/login/continue-as-user.scss
+++ b/client/blocks/login/continue-as-user.scss
@@ -1,14 +1,21 @@
+@import "@automattic/onboarding/styles/mixins";
+@import "@wordpress/base-styles/breakpoints";
+
 .continue-as-user {
 	display: block;
 	animation: 1s appear 0s ease-in;
 	color: var(--color-text-subtle);
 	font-size: $font-body-small;
 	text-align: center;
-	height: calc(70vh - 80px); /* The values here are set so that the Not-you line gets pushed to the bottom of the screen on mobile */
+	height: calc(65vh - 80px); /* The values here are set so that the Not-you line gets pushed to the bottom of the screen on mobile */
 	margin: 48px auto 0;
 	position: relative;
 	max-width: 400px;
 	min-height: 260px;
+
+	@include break-mobile {
+		height: 50vh;
+	}
 
 	.continue-as-user__user-info {
 		height: auto;


### PR DESCRIPTION
## Before

<img width="1009" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/8ab53439-30d2-4e0c-bbca-fabc1e7fe6f6">

## After

<img width="1001" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/890c137e-88ed-40a6-a1f2-e0adc46658b1">

## Testing

1. Visit `/log-in` while logged in on desktop


Fixes https://github.com/Automattic/wp-calypso/issues/85967