### PR TITLE
Update logic which is now handled by the main WooDNA config

### DIFF
--- a/client/jetpack-connect/woo-dna-config.js
+++ b/client/jetpack-connect/woo-dna-config.js
@@ -21,10 +21,7 @@ export default ( query ) =>
 		/**
 		 * @returns {string} Name of the service/plugin the user is signing up for. For example, "WooPayments".
 		 */
-		getServiceName: () =>
-			query.woodna_service_name === 'WooCommerce Payments'
-				? 'WooPayments'
-				: query.woodna_service_name,
+		getServiceName: () => query.woodna_service_name,
 
 		/**
 		 * @returns {string} URL with help about connecting Jetpack.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* We recently updated the WooDNA config ( D133454-code ) at the source, so this PR is just removing an additional check which is no longer needed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Adapted from https://github.com/Automattic/wp-calypso/pull/80060

Checkout this branch of `wp-calypso` and run it locally (`yarn && yarn start`, add `127.0.0.1 calypso.localhost` to your `/etc/hosts`). Wait until you see `Ready! All assets are re-compiled. Have fun!`

Add these constants to your local WordPress site:
```
define( 'WOOCOMMERCE_CALYPSO_ENVIRONMENT', 'development' );
define( 'JETPACK__SANDBOX_DOMAIN', 'yourtestblog.wordpress.com' );
```

To start a Jetpack connection from WooCommerce Payments you need:
- Check out `develop` branch of https://github.com/automattic/woocommerce-payments, install it locally. 
- Launch the tube (`npm run tube:start` because Jetpack does not support redirect to the localhost).
- If you already have Jetpack connected, disconnect your site from Jetpack using https://github.com/Automattic/client-example. You’ll need to use Hard disconnect to disconnect WCPay. (You can also use [Jetpack Debug Tools](https://github.com/Automattic/jetpack-debug-helper) with the Broken Token Utilities to achieve the same thing).
- Visit payments connect page https://example.jurassic.tube/wp-admin/admin.php?page=wc-admin&path=%2Fpayments%2Fconnect and click Connect
- Hopefully, you'll be redirected to `calypso.localhost:3000/...` - you should see no references to `WooCommerce Payments`, only `WooPayments`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?