### PR TITLE
Evaluate typeof window at compile time

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -295,6 +295,7 @@ const webpackConfig = {
 	node: false,
 	plugins: [
 		new webpack.DefinePlugin( {
+			'typeof window': JSON.stringify( 'object' ),
 			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),
 			'process.env.NODE_DEBUG': JSON.stringify( process.env.NODE_DEBUG || false ),
 			'process.env.GUTENBERG_PHASE': JSON.stringify( 1 ),

--- a/client/webpack.config.node.js
+++ b/client/webpack.config.node.js
@@ -159,6 +159,7 @@ const webpackConfig = {
 			} ),
 		new webpack.ExternalsPlugin( 'commonjs', getExternals() ),
 		new webpack.DefinePlugin( {
+			'typeof window': JSON.stringify( 'undefined' ),
 			BUILD_TIMESTAMP: JSON.stringify( new Date().toISOString() ),
 			COMMIT_SHA: JSON.stringify( commitSha ),
 			'process.env.NODE_ENV': JSON.stringify( bundleEnv ),

--- a/packages/calypso-build/webpack.config.js
+++ b/packages/calypso-build/webpack.config.js
@@ -125,6 +125,7 @@ function getWebpackConfig(
 		node: false,
 		plugins: [
 			new webpack.DefinePlugin( {
+				'typeof window': JSON.stringify( 'object' ),
 				'process.env.NODE_ENV': JSON.stringify( process.env.NODE_ENV ),
 				'process.env.FORCE_REDUCED_MOTION': JSON.stringify(
 					!! process.env.FORCE_REDUCED_MOTION || false


### PR DESCRIPTION
A little webpack optimization that should help us eliminate some browser-only code from the server bundle and vice versa. Evaluate `typeof window` at compile time, to be either `"undefined"` or `"object"`. Next.js uses this optimization, too:

https://github.com/vercel/next.js/blob/5117cc6ea990a6ddda5585a5fe2bf6a1914285c8/packages/next/src/build/babel/loader/get-config.ts#L105

I got the idea when working on #84243 and wondering why the server bundle contains some modules for Redux middlewares that should be loaded only in browser:

https://github.com/Automattic/wp-calypso/blob/dfa89637b1b84d9f21f223cb3fc26d664b8793a6/client/state/index.ts#L39-L49
