### PR TITLE
Fixing longer domains in onboarding to prevent wrapping

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -180,11 +180,13 @@
 
 	&.domain-registration-suggestion__title-domain {
 		@include breakpoint-deprecated( ">480px" ) {
+			max-width: 55%;
 			min-width: 50%;
 			margin-right: 1em;
 		}
 
 		@include breakpoint-deprecated( ">800px" ) {
+			max-width: 55%;
 			min-width: 55%;
 			margin-right: 1em;
 		}
@@ -379,6 +381,11 @@ body.is-section-signup.is-white-signup {
 			justify-content: space-between;
 		}
 
+		.domain-product-price {
+			max-width: 180px;
+			width: unset;
+		}
+
 		.domain-product-price__free-text {
 			color: var(--color-neutral-60);
 			font-size: $font-body;
@@ -415,6 +422,7 @@ body.is-section-signup.is-white-signup {
 
 		& .domain-registration-suggestion__domain-title {
 			color: var(--studio-gray-90);
+			white-space: nowrap;
 		}
 
 		& .domain-product-price__free-price {


### PR DESCRIPTION
## Description

This PR is a continuation of #85873. After testing on staging I realized that I had not fully fixed the problem.

## Before

![CleanShot 2024-01-01 at 12 55 38](https://github.com/Automattic/wp-calypso/assets/5634774/142d0e43-dfec-4924-8cd5-b3ef7968ca20)

## After

![CleanShot 2024-01-01 at 12 58 00](https://github.com/Automattic/wp-calypso/assets/5634774/0c97e8d7-24a9-4098-93dc-1a1f1d48aafc)

## Testing

- Check out these changes
- Go to /start/domains
- Enter a really long domain like "somethinglongerhere"