### PR TITLE
Jetpack Manage: 210 - track Overview page visit

### DIFF
--- a/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
@@ -12,7 +12,6 @@ import './style.scss';
 export default function NextSteps( { onDismiss = () => {} } ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const tracksPrefix = 'calypso_jetpack_manage_overview_next_steps';
 
 	const preferences = useSelector( getAllRemotePreferences );
 
@@ -37,7 +36,9 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 			completed: checkTourCompletion( 'dashboardWalkthrough' ),
 			disabled: false,
 			actionDispatch: () => {
-				dispatch( recordTracksEvent( tracksPrefix + '_get_familiar_click' ) );
+				dispatch(
+					recordTracksEvent( 'calypso_jetpack_manage_overview_next_steps_get_familiar_click' )
+				);
 				resetTour( [ 'dashboardWalkthrough' ] );
 			},
 			id: 'get_familiar',
@@ -49,7 +50,9 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 			completed: checkTourCompletion( 'addSiteStep2' ),
 			disabled: false,
 			actionDispatch: () => {
-				dispatch( recordTracksEvent( tracksPrefix + '_add_sites_click' ) );
+				dispatch(
+					recordTracksEvent( 'calypso_jetpack_manage_overview_next_steps_add_sites_click' )
+				);
 				resetTour( [ 'addSiteStep1', 'addSiteStep2' ] );
 			},
 			id: 'add_sites',
@@ -61,7 +64,9 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 			completed: checkTourCompletion( 'enableMonitorStep2' ),
 			disabled: false,
 			actionDispatch: () => {
-				dispatch( recordTracksEvent( tracksPrefix + '_bulk_editing_click' ) );
+				dispatch(
+					recordTracksEvent( 'calypso_jetpack_manage_overview_next_steps_bulk_editing_click' )
+				);
 				resetTour( [ 'enableMonitorStep1', 'enableMonitorStep2' ] );
 			},
 			id: 'bulk_editing',
@@ -73,7 +78,9 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 			completed: checkTourCompletion( 'pluginOverview' ),
 			disabled: false,
 			actionDispatch: () => {
-				dispatch( recordTracksEvent( tracksPrefix + '_plugin_management_click' ) );
+				dispatch(
+					recordTracksEvent( 'calypso_jetpack_manage_overview_next_steps_plugin_management_click' )
+				);
 				resetTour( [ 'pluginOverview' ] );
 			},
 			id: 'plugin_management',
@@ -106,7 +113,9 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 					<button
 						className="dismiss"
 						onClick={ () => {
-							dispatch( recordTracksEvent( tracksPrefix + '_dismiss_click' ) );
+							dispatch(
+								recordTracksEvent( 'calypso_jetpack_manage_overview_next_steps_dismiss_click' )
+							);
 							onDismiss();
 						} }
 					>

--- a/client/jetpack-cloud/sections/overview/primary/overview/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/overview/index.tsx
@@ -1,8 +1,10 @@
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import OverviewProducts from 'calypso/jetpack-cloud/sections/overview/primary/overview-products';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import IntroCards from '../intro-cards';
 import NextSteps from '../next-steps';
 
@@ -10,6 +12,11 @@ import './style.scss';
 
 export default function Overview() {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_manage_overview_visit' ) );
+	}, [ dispatch ] );
 
 	const getPrefFromLocalStorage = ( key: string ): boolean => {
 		const rawPref = localStorage.getItem( key ) ?? 'false';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves Automattic/jetpack-manage#210 - track Overview page visit

## Proposed Changes

This adds a `calypso_jetpack_manage_overview_visit` Tracks event when visiting the Overview page. It also hard-codes Tracks event names in the `NextSteps` component rather than generating them programmatically.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Visit the Overview page and ensure the `calypso_jetpack_manage_overview_visit` fires as expected.
2. Click on items within the `NextSteps` component and confirm events fire as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
