### PR TITLE
Jetpack Logo Generator: Add site and aifeature store

### DIFF
--- a/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
@@ -38,7 +38,9 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 
 	useEffect( () => {
 		if ( isOpen ) {
-			getAiAssistantFeature( String( siteId ) );
+			if ( siteId ) {
+				getAiAssistantFeature( String( siteId ) );
+			}
 
 			setTimeout( () => {
 				setIsLoading( false );

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
@@ -2,13 +2,14 @@
  * External dependencies
  */
 import { Icon, Modal, Button } from '@wordpress/components';
-import { useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { external } from '@wordpress/icons';
 import React, { useState, useEffect } from 'react';
 /**
  * Internal dependencies
  */
+import useLogoGenerator from '../hooks/use-logo-generator';
 import { STORE_NAME } from '../store';
 import { FirstLoadScreen } from './first-load-screen';
 import { HistoryCarousel } from './history-carousel';
@@ -19,24 +20,28 @@ import './generator-modal.scss';
  * Types
  */
 import type { GeneratorModalProps } from '../../types';
-import type { Selectors } from '../store/types';
 
-export const GeneratorModal: React.FC< GeneratorModalProps > = ( { isOpen, onClose } ) => {
+export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
+	isOpen,
+	onClose,
+	siteDetails,
+} ) => {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	const { setSiteDetails } = useDispatch( STORE_NAME );
 	const [ isLoading, setIsLoading ] = useState( true );
-	const { selectedLogo } = useSelect( ( select ) => {
-		const selectors: Selectors = select( STORE_NAME );
-		return { selectedLogo: selectors.getSelectedLogo() };
-	}, [] );
-
+	const { selectedLogo, getAiAssistantFeature } = useLogoGenerator();
+	const siteId = siteDetails?.ID;
+	// setSiteDetails( siteDetails );
 	useEffect( () => {
 		if ( isOpen ) {
+			getAiAssistantFeature( String( siteId ) );
 			setTimeout( () => {
 				setIsLoading( false );
 			}, 1000 );
 		} else {
 			setIsLoading( true );
 		}
-	}, [ isOpen ] );
+	}, [ isOpen, getAiAssistantFeature, siteId ] );
 
 	const handleApplyLogo = () => {
 		onClose();

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
@@ -31,10 +31,15 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	const [ isLoading, setIsLoading ] = useState( true );
 	const { selectedLogo, getAiAssistantFeature } = useLogoGenerator();
 	const siteId = siteDetails?.ID;
-	// setSiteDetails( siteDetails );
+
+	useEffect( () => {
+		setSiteDetails( siteDetails );
+	}, [ siteDetails, setSiteDetails ] );
+
 	useEffect( () => {
 		if ( isOpen ) {
 			getAiAssistantFeature( String( siteId ) );
+
 			setTimeout( () => {
 				setIsLoading( false );
 			}, 1000 );

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
@@ -57,7 +57,7 @@ export const Prompt: React.FC = () => {
 
 	const featureData = getAiAssistantFeature( String( site?.id || '' ) );
 	const isFreeTier = featureData?.hasFeature ? false : true;
-	const currentLimit = featureData?.currentTier?.limit || 0;
+	const currentLimit = featureData?.currentTier?.value || 0;
 	const currentUsage = featureData?.usagePeriod?.requestsCount || 0;
 	const isUnlimited = currentLimit === 1;
 

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
@@ -59,6 +59,7 @@ export const Prompt: React.FC = () => {
 	const isFreeTier = featureData?.hasFeature ? false : true;
 	const currentLimit = featureData?.currentTier?.limit || 0;
 	const currentUsage = featureData?.usagePeriod?.requestsCount || 0;
+	const isUnlimited = currentLimit === 1;
 
 	useEffect( () => {
 		setRequestsRemaining( currentLimit - currentUsage );
@@ -141,13 +142,17 @@ export const Prompt: React.FC = () => {
 				</Button>
 			</div>
 			<div className="jetpack-ai-logo-generator__prompt-footer">
-				<div>{ usage }</div>
-				&nbsp;
-				<Button variant="link" href="https://automattic.com/ai-guidelines" target="_blank">
-					{ __( 'Upgrade', 'jetpack' ) }
-				</Button>
-				&nbsp;
-				<Icon className="prompt-footer__icon" icon={ info } />
+				{ ! isUnlimited && (
+					<>
+						<div>{ usage }</div>
+						&nbsp;
+						<Button variant="link" href="https://automattic.com/ai-guidelines" target="_blank">
+							{ __( 'Upgrade', 'jetpack' ) }
+						</Button>
+						&nbsp;
+						<Icon className="prompt-footer__icon" icon={ info } />
+					</>
+				) }
 			</div>
 		</div>
 	);

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
@@ -56,7 +56,8 @@ export const Prompt: React.FC = () => {
 	}, [ enhancePrompt, prompt, setIsEnhancingPrompt ] );
 
 	const featureData = getAiAssistantFeature( String( site?.id || '' ) );
-	const isFreeTier = featureData?.hasFeature ? false : true;
+
+	const isFreeTier = featureData?.currentTier?.value === 0;
 	const currentLimit = featureData?.currentTier?.value || 0;
 	const currentUsage = featureData?.usagePeriod?.requestsCount || 0;
 	const isUnlimited = currentLimit === 1;

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
@@ -95,17 +95,16 @@ export const Prompt: React.FC = () => {
 		setPrompt( event.target.value );
 	}, [] );
 
-	const usage = isFreeTier
-		? sprintf(
-				// translators: %u is the number of requests
-				__( '%u free requests remaining.', 'jetpack' ),
-				requestsRemaining
-		  )
-		: sprintf(
-				// translators: %u is the number of requests
-				__( '%u requests remaining.', 'jetpack' ),
-				requestsRemaining
-		  );
+	const freeUsage = sprintf(
+		// translators: %u is the number of requests
+		__( '%u free requests remaining.', 'jetpack' ),
+		requestsRemaining
+	);
+	const tieredUsage = sprintf(
+		// translators: %u is the number of requests
+		__( '%u requests remaining.', 'jetpack' ),
+		requestsRemaining
+	);
 
 	return (
 		<div className="jetpack-ai-logo-generator__prompt">
@@ -144,7 +143,7 @@ export const Prompt: React.FC = () => {
 			<div className="jetpack-ai-logo-generator__prompt-footer">
 				{ ! isUnlimited && (
 					<>
-						<div>{ usage }</div>
+						<div>{ isFreeTier ? freeUsage : tieredUsage }</div>
 						&nbsp;
 						<Button variant="link" href="https://automattic.com/ai-guidelines" target="_blank">
 							{ __( 'Upgrade', 'jetpack' ) }

--- a/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
@@ -52,7 +52,7 @@ const useLogoGenerator = () => {
 		};
 	}, [] );
 
-	const { ID = null, name = null, description = null } = siteDetails;
+	const { ID = null, name = null, description = null } = siteDetails || {};
 	const siteId = ID ? String( ID ) : null;
 
 	const saveLogo = useCallback<

--- a/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
@@ -33,9 +33,10 @@ const useLogoGenerator = () => {
 		siteDetails,
 		isSavingLogoToLibrary,
 		isApplyingLogo,
-		isRequestingImage,
 		isEnhancingPrompt,
 		isBusy,
+		isRequestingImage,
+		getAiAssistantFeature,
 	} = useSelect( ( select ) => {
 		const selectors: Selectors = select( STORE_NAME );
 		return {
@@ -47,6 +48,7 @@ const useLogoGenerator = () => {
 			isRequestingImage: selectors.getIsRequestingImage(),
 			isEnhancingPrompt: selectors.getIsEnhancingPrompt(),
 			isBusy: selectors.getIsBusy(),
+			getAiAssistantFeature: selectors.getAiAssistantFeature,
 		};
 	}, [] );
 
@@ -221,6 +223,7 @@ For example: user's prompt: A logo for an ice cream shop. Returned prompt: A log
 		isSavingLogoToLibrary,
 		isApplyingLogo,
 		isBusy,
+		getAiAssistantFeature,
 	};
 };
 

--- a/packages/jetpack-ai-calypso/src/logo-generator/store/index.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/store/index.ts
@@ -22,8 +22,12 @@ const jetpackAiLogoGeneratorStore = createReduxStore( STORE_NAME, {
 	selectors,
 
 	resolvers: {
-		getAiAssistantFeature: ( siteId: string ) =>
-			actions.fetchAiAssistantFeature( String( siteId ) ),
+		getAiAssistantFeature: ( siteId: string ) => {
+			if ( ! siteId ) {
+				return;
+			}
+			return actions.fetchAiAssistantFeature( String( siteId ) );
+		},
 	},
 } );
 

--- a/packages/jetpack-ai-calypso/src/logo-generator/store/types.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/store/types.ts
@@ -146,7 +146,7 @@ export type LogoGeneratorStateProp = {
 };
 
 export type Selectors = {
-	getAiAssistantFeature(): Partial< AiFeatureProps >;
+	getAiAssistantFeature( siteId?: string ): Partial< AiFeatureProps >;
 	getIsRequestingAiAssistantFeature(): boolean;
 	getLogos(): Array< Logo >;
 	getSelectedLogo(): Logo;


### PR DESCRIPTION
The app needs to be aware of site details and be able to fetch ai-assistant-feature data

Related to #85557 

## Proposed Changes

* Expose necessary functions on useLogoGenerator 
* Set site details on modal open 
* Fetch ai-assistant feature data on modal open

## Testing Instructions

~The change is not complete, this PR is here to further investigate how to properly set the data store. Right now, line 34 of `src/logo-generator/components/generator-modal.tsx` is commented. Uncommenting causes an error. Without site details, fetching the ai assistant feature is not possible as there is no reference of the site ID.~

Keep the devtools open on the network tab. Search for "ai-assistant".

Reload Calypso home, see that no request is made to ai-assistant endpoint. Open the logo generator modal from the quick links. See that the request to ai-assistant endpoint is there.
Look below the prompt box, you should see your actual remaining requests there unless you are on the unlimited plan.
Make a request, for now, the requests count is increased by 1 (making the remaining requests decrease by 1)


