### PR TITLE
Fixed responsive layout issues on domains onboarding screen

### DIFF
--- a/client/signup/steps/domains/style.scss
+++ b/client/signup/steps/domains/style.scss
@@ -305,8 +305,9 @@ body.is-section-signup.is-white-signup {
 		.register-domain-step .domains__domain-side-content-container {
 			display: flex;
 
-			@include break-small {
+			@include break-medium {
 				flex-direction: row;
+				justify-content: center;
 
 				.domains__domain-side-content {
 					padding-top: 0;
@@ -334,6 +335,11 @@ body.is-section-signup.is-white-signup {
 			margin: 0;
 
 			@include break-small {
+				width: 80%;
+				margin: 0 auto;
+			}
+
+			@include break-medium {
 				width: 290px;
 				margin: 0 20px;
 			}


### PR DESCRIPTION
## Description

@Addison-Stavlo highlighted in Slack that the layout of the domains step in onboarding was behaving a bit weird at certain breakpoints. I offered to take a look.

## Before

![before](https://github.com/Automattic/wp-calypso/assets/5634774/c5c0f00e-ac2b-4396-bdbe-0035dc8c1f4b)

## After

![after](https://github.com/Automattic/wp-calypso/assets/5634774/cb859bf3-e36b-440d-b357-70a9b85d577a)


