### PR TITLE
Add storage addon to cart in /setup/ecommerce signup flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -11,7 +11,6 @@ import React, { useEffect, useCallback, useMemo, Suspense, lazy } from 'react';
 import Modal from 'react-modal';
 import { Navigate, Route, Routes, generatePath, useNavigate, useLocation } from 'react-router-dom';
 import DocumentHead from 'calypso/components/data/document-head';
-import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { STEPPER_INTERNAL_STORE } from 'calypso/landing/stepper/stores';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
 import { recordSignupStart } from 'calypso/lib/analytics/signup';
@@ -22,6 +21,8 @@ import {
 } from 'calypso/signup/storageUtils';
 import { useSelector } from 'calypso/state';
 import { getSite, isRequestingSite } from 'calypso/state/sites/selectors';
+import { useQuery } from '../../hooks/use-query';
+import { useSaveQueryParams } from '../../hooks/use-save-query-params';
 import { useSiteData } from '../../hooks/use-site-data';
 import useSyncRoute from '../../hooks/use-sync-route';
 import { ONBOARD_STORE } from '../../stores';
@@ -75,28 +76,8 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		[]
 	);
 
-	const urlQueryParams = useQuery();
-	let ref = '';
-	const { setCouponCode, setStorageAddonSlug } = useDispatch( ONBOARD_STORE );
-	urlQueryParams.forEach( ( value, key ) => {
-		switch ( key ) {
-			case 'coupon':
-				// This stores the coupon code query param, and the flow declaration
-				// will append it to the checkout URL so that it auto-applies the coupon code at
-				// checkout. For example, /setup/ecommerce/?coupon=SOMECOUPON will auto-apply the
-				// coupon code at the checkout page.
-				value && setCouponCode( value );
-				break;
-
-			case 'ref':
-				ref = value ?? '';
-				break;
-
-			case 'storage':
-				value && setStorageAddonSlug( value );
-				break;
-		}
-	} );
+	useSaveQueryParams();
+	const ref = useQuery().get( 'ref' ) || '';
 
 	const { site, siteSlugOrId } = useSiteData();
 

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -76,7 +76,27 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	);
 
 	const urlQueryParams = useQuery();
-	const ref = urlQueryParams.get( 'ref' ) || '';
+	let ref = '';
+	const { setCouponCode, setStorageAddonSlug } = useDispatch( ONBOARD_STORE );
+	urlQueryParams.forEach( ( value, key ) => {
+		switch ( key ) {
+			case 'coupon':
+				// This stores the coupon code query param, and the flow declaration
+				// will append it to the checkout URL so that it auto-applies the coupon code at
+				// checkout. For example, /setup/ecommerce/?coupon=SOMECOUPON will auto-apply the
+				// coupon code at the checkout page.
+				value && setCouponCode( value );
+				break;
+
+			case 'ref':
+				ref = value ?? '';
+				break;
+
+			case 'storage':
+				value && setStorageAddonSlug( value );
+				break;
+		}
+	} );
 
 	const { site, siteSlugOrId } = useSiteData();
 

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -154,8 +154,13 @@ const ecommerceFlow: Flow = {
 
 	useStepNavigation( _currentStepName, navigate ) {
 		const flowName = this.name;
-		const { setPlanCartItem, setProductCartItems, setPluginsToVerify, resetCouponCode } =
-			useDispatch( ONBOARD_STORE );
+		const {
+			setPlanCartItem,
+			setProductCartItems,
+			setPluginsToVerify,
+			resetCouponCode,
+			resetStorageAddonSlug,
+		} = useDispatch( ONBOARD_STORE );
 		setPluginsToVerify( [ 'woocommerce' ] );
 		const { selectedDesign, recurType, couponCode, storageAddonSlug } = useSelect(
 			( select ) => ( {
@@ -189,14 +194,17 @@ const ecommerceFlow: Flow = {
 						extra: { headstart_theme: selectedDesign?.recipe?.stylesheet },
 					} );
 
-					setProductCartItems( [
-						{
-							product_slug: PRODUCT_1GB_SPACE,
-							quantity: getQuantityFromStorageType( storageAddonSlug ),
-							volume: 1,
-							extra: { feature_slug: storageAddonSlug },
-						},
-					] );
+					if ( storageAddonSlug ) {
+						setProductCartItems( [
+							{
+								product_slug: PRODUCT_1GB_SPACE,
+								quantity: getQuantityFromStorageType( storageAddonSlug ),
+								volume: 1,
+								extra: { feature_slug: storageAddonSlug },
+							},
+						] );
+						resetStorageAddonSlug();
+					}
 					return navigate( 'siteCreationStep' );
 
 				case 'siteCreationStep':

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -194,7 +194,7 @@ const ecommerceFlow: Flow = {
 						extra: { headstart_theme: selectedDesign?.recipe?.stylesheet },
 					} );
 
-					if ( storageAddonSlug ) {
+					if ( storageAddonSlug && recurType !== ecommerceFlowRecurTypes.MONTHLY ) {
 						setProductCartItems( [
 							{
 								product_slug: PRODUCT_1GB_SPACE,

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -50,7 +50,7 @@ function getPlanFromRecurType( recurType: string ) {
 		case ecommerceFlowRecurTypes[ '3Y' ]:
 			return PLAN_ECOMMERCE_3_YEARS;
 		default:
-			return PLAN_ECOMMERCE_MONTHLY;
+			return PLAN_ECOMMERCE;
 	}
 }
 

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -4,8 +4,6 @@ import {
 	PLAN_ECOMMERCE_2_YEARS,
 	PLAN_ECOMMERCE_3_YEARS,
 	PRODUCT_1GB_SPACE,
-	FEATURE_50GB_STORAGE_ADD_ON,
-	FEATURE_100GB_STORAGE_ADD_ON,
 } from '@automattic/calypso-products';
 import { useLocale } from '@automattic/i18n-utils';
 import { ECOMMERCE_FLOW, ecommerceFlowRecurTypes } from '@automattic/onboarding';
@@ -21,6 +19,7 @@ import {
 import { useSite } from '../hooks/use-site';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { USER_STORE, ONBOARD_STORE, SITE_STORE } from '../stores';
+import getQuantityFromStorageType from '../utils/get-quantity-from-storage-slug';
 import { getLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import CheckPlan from './internals/steps-repository/check-plan';
@@ -53,17 +52,6 @@ function getPlanFromRecurType( recurType: string ) {
 		default:
 			return PLAN_ECOMMERCE_MONTHLY;
 	}
-}
-
-function getQuantityFromStorageType( storageAddonSlug: string ) {
-	switch ( storageAddonSlug ) {
-		case FEATURE_50GB_STORAGE_ADD_ON:
-			return 50;
-		case FEATURE_100GB_STORAGE_ADD_ON:
-			return 100;
-	}
-
-	return null;
 }
 
 const ecommerceFlow: Flow = {
@@ -200,10 +188,15 @@ const ecommerceFlow: Flow = {
 						product_slug: selectedPlan,
 						extra: { headstart_theme: selectedDesign?.recipe?.stylesheet },
 					} );
-					setProductCartItems( {
-						product_slug: PRODUCT_1GB_SPACE,
-						quantity: getQuantityFromStorageType( storageAddonSlug ),
-					} );
+
+					setProductCartItems( [
+						{
+							product_slug: PRODUCT_1GB_SPACE,
+							quantity: getQuantityFromStorageType( storageAddonSlug ),
+							volume: 1,
+							extra: { feature_slug: storageAddonSlug },
+						},
+					] );
 					return navigate( 'siteCreationStep' );
 
 				case 'siteCreationStep':

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -98,9 +98,11 @@ const ecommerceFlow: Flow = {
 		const pathLocaleSlug = getLocaleFromPathname();
 		const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
 
-		const { recurType } = useSelect(
+		const { recurType, couponCode, storageAddonSlug } = useSelect(
 			( select ) => ( {
 				recurType: ( select( ONBOARD_STORE ) as OnboardSelect ).getEcommerceFlowRecurType(),
+				couponCode: ( select( ONBOARD_STORE ) as OnboardSelect ).getCouponCode(),
+				storageAddonSlug: ( select( ONBOARD_STORE ) as OnboardSelect ).getStorageAddonSlug(),
 			} ),
 			[]
 		);
@@ -116,6 +118,12 @@ const ecommerceFlow: Flow = {
 			if ( locale && locale !== 'en' ) {
 				flowParams.set( 'locale', locale );
 				hasFlowParams = true;
+			}
+
+			if ( couponCode || storageAddonSlug ) {
+				hasFlowParams = true;
+				flowParams.set( 'storage', storageAddonSlug );
+				flowParams.set( 'coupon', couponCode );
 			}
 
 			const redirectTarget =

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -3,6 +3,9 @@ import {
 	PLAN_ECOMMERCE_MONTHLY,
 	PLAN_ECOMMERCE_2_YEARS,
 	PLAN_ECOMMERCE_3_YEARS,
+	PRODUCT_1GB_SPACE,
+	FEATURE_50GB_STORAGE_ADD_ON,
+	FEATURE_100GB_STORAGE_ADD_ON,
 } from '@automattic/calypso-products';
 import { useLocale } from '@automattic/i18n-utils';
 import { ECOMMERCE_FLOW, ecommerceFlowRecurTypes } from '@automattic/onboarding';
@@ -50,6 +53,17 @@ function getPlanFromRecurType( recurType: string ) {
 		default:
 			return PLAN_ECOMMERCE_MONTHLY;
 	}
+}
+
+function getQuantityFromStorageType( storageAddonSlug: string ) {
+	switch ( storageAddonSlug ) {
+		case FEATURE_50GB_STORAGE_ADD_ON:
+			return 50;
+		case FEATURE_100GB_STORAGE_ADD_ON:
+			return 100;
+	}
+
+	return null;
 }
 
 const ecommerceFlow: Flow = {
@@ -152,13 +166,15 @@ const ecommerceFlow: Flow = {
 
 	useStepNavigation( _currentStepName, navigate ) {
 		const flowName = this.name;
-		const { setPlanCartItem, setPluginsToVerify, resetCouponCode } = useDispatch( ONBOARD_STORE );
+		const { setPlanCartItem, setProductCartItems, setPluginsToVerify, resetCouponCode } =
+			useDispatch( ONBOARD_STORE );
 		setPluginsToVerify( [ 'woocommerce' ] );
-		const { selectedDesign, recurType, couponCode } = useSelect(
+		const { selectedDesign, recurType, couponCode, storageAddonSlug } = useSelect(
 			( select ) => ( {
 				selectedDesign: ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),
 				recurType: ( select( ONBOARD_STORE ) as OnboardSelect ).getEcommerceFlowRecurType(),
 				couponCode: ( select( ONBOARD_STORE ) as OnboardSelect ).getCouponCode(),
+				storageAddonSlug: ( select( ONBOARD_STORE ) as OnboardSelect ).getStorageAddonSlug(),
 			} ),
 			[]
 		);
@@ -183,6 +199,10 @@ const ecommerceFlow: Flow = {
 					setPlanCartItem( {
 						product_slug: selectedPlan,
 						extra: { headstart_theme: selectedDesign?.recipe?.stylesheet },
+					} );
+					setProductCartItems( {
+						product_slug: PRODUCT_1GB_SPACE,
+						quantity: getQuantityFromStorageType( storageAddonSlug ),
 					} );
 					return navigate( 'siteCreationStep' );
 

--- a/client/landing/stepper/hooks/use-save-query-params.ts
+++ b/client/landing/stepper/hooks/use-save-query-params.ts
@@ -1,3 +1,4 @@
+import { ecommerceFlowRecurTypes } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { ONBOARD_STORE } from '../stores';
 import { useQuery } from './use-query';
@@ -10,7 +11,8 @@ import { useQuery } from './use-query';
  */
 export function useSaveQueryParams() {
 	const urlQueryParams = useQuery();
-	const { setCouponCode, setStorageAddonSlug } = useDispatch( ONBOARD_STORE );
+	const { setCouponCode, setStorageAddonSlug, setEcommerceFlowRecurType } =
+		useDispatch( ONBOARD_STORE );
 	urlQueryParams.forEach( ( value, key ) => {
 		switch ( key ) {
 			case 'coupon':
@@ -25,6 +27,15 @@ export function useSaveQueryParams() {
 				// This stores a storage addon, supplied as a query param by landing pages when
 				// an addon is selected in the pricing grid.
 				value && setStorageAddonSlug( value );
+				break;
+
+			case 'recur':
+				{
+					const isValidRecurType =
+						value && Object.values( ecommerceFlowRecurTypes ).includes( value );
+					const recurType = isValidRecurType ? value : ecommerceFlowRecurTypes.YEARLY;
+					setEcommerceFlowRecurType( recurType );
+				}
 				break;
 		}
 	} );

--- a/client/landing/stepper/hooks/use-save-query-params.ts
+++ b/client/landing/stepper/hooks/use-save-query-params.ts
@@ -1,0 +1,31 @@
+import { useDispatch } from '@wordpress/data';
+import { ONBOARD_STORE } from '../stores';
+import { useQuery } from './use-query';
+
+/**
+ * This method saves some query params to the store. For example,
+ * coupon code or storage addons provided in the query param will be
+ * persisted to the Store so that they can later be retrieved and applied
+ * at checkout.
+ */
+export function useSaveQueryParams() {
+	const urlQueryParams = useQuery();
+	const { setCouponCode, setStorageAddonSlug } = useDispatch( ONBOARD_STORE );
+	urlQueryParams.forEach( ( value, key ) => {
+		switch ( key ) {
+			case 'coupon':
+				// This stores the coupon code query param, and the flow declaration
+				// will append it to the checkout URL so that it auto-applies the coupon code at
+				// checkout. For example, /setup/ecommerce/?coupon=SOMECOUPON will auto-apply the
+				// coupon code at the checkout page.
+				value && setCouponCode( value );
+				break;
+
+			case 'storage':
+				// This stores a storage addon, supplied as a query param by landing pages when
+				// an addon is selected in the pricing grid.
+				value && setStorageAddonSlug( value );
+				break;
+		}
+	} );
+}

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -4,7 +4,6 @@ import { initializeAnalytics } from '@automattic/calypso-analytics';
 import { CurrentUser } from '@automattic/calypso-analytics/dist/types/utils/current-user';
 import config from '@automattic/calypso-config';
 import { User as UserStore } from '@automattic/data-stores';
-import { ECOMMERCE_FLOW, ecommerceFlowRecurTypes } from '@automattic/onboarding';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
 import defaultCalypsoI18n from 'i18n-calypso';
@@ -30,8 +29,7 @@ import { AsyncHelpCenter } from './declarative-flow/internals/components';
 import 'calypso/components/environment-badge/style.scss';
 import 'calypso/assets/stylesheets/style.scss';
 import availableFlows from './declarative-flow/registered-flows';
-import { useQuery } from './hooks/use-query';
-import { ONBOARD_STORE, USER_STORE } from './stores';
+import { USER_STORE } from './stores';
 import { setupWpDataDebug } from './utils/devtools';
 import { WindowLocaleEffectManager } from './utils/window-locale-effect-manager';
 import type { Flow } from './declarative-flow/internals/types';
@@ -57,20 +55,6 @@ const FlowSwitch: React.FC< { user: UserStore.CurrentUser | undefined; flow: Flo
 	flow,
 } ) => {
 	const { receiveCurrentUser } = useDispatch( USER_STORE );
-	const { setEcommerceFlowRecurType } = useDispatch( ONBOARD_STORE );
-
-	const recurType = useQuery().get( 'recur' );
-
-	if ( flow.name === ECOMMERCE_FLOW ) {
-		const isValidRecurType =
-			recurType && Object.values( ecommerceFlowRecurTypes ).includes( recurType );
-		if ( isValidRecurType ) {
-			setEcommerceFlowRecurType( recurType );
-		} else {
-			setEcommerceFlowRecurType( ecommerceFlowRecurTypes.YEARLY );
-		}
-	}
-
 	user && receiveCurrentUser( user as UserStore.CurrentUser );
 
 	return <FlowRenderer flow={ flow } />;

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -71,16 +71,6 @@ const FlowSwitch: React.FC< { user: UserStore.CurrentUser | undefined; flow: Flo
 		}
 	}
 
-	// This stores the coupon code query param, and the flow declaration
-	// will append it to the checkout URL so that it auto-applies the coupon code at
-	// checkout. For example, /setup/ecommerce/?coupon=SOMECOUPON will auto-apply the
-	// coupon code at the checkout page.
-	const couponCode = useQuery().get( 'coupon' );
-	const { setCouponCode } = useDispatch( ONBOARD_STORE );
-	if ( couponCode ) {
-		setCouponCode( couponCode );
-	}
-
 	user && receiveCurrentUser( user as UserStore.CurrentUser );
 
 	return <FlowRenderer flow={ flow } />;

--- a/client/landing/stepper/utils/get-quantity-from-storage-slug.ts
+++ b/client/landing/stepper/utils/get-quantity-from-storage-slug.ts
@@ -1,0 +1,24 @@
+import {
+	FEATURE_50GB_STORAGE_ADD_ON,
+	FEATURE_100GB_STORAGE_ADD_ON,
+} from '@automattic/calypso-products';
+
+/**
+ * Since 50GB and 100GB storage addons are essentially a 1GB space product with
+ * quantity 50/100, this function returns the quantity based on the storage addon slug.
+ * This is used to build the shopping cart item for the storage addon.
+ * @param storageAddonSlug Slug for the storage addon.
+ * @returns Quantity of the 1GB storage product that corresponds to the addon slug.
+ */
+function getQuantityFromStorageType( storageAddonSlug: string ): number {
+	switch ( storageAddonSlug ) {
+		case FEATURE_50GB_STORAGE_ADD_ON:
+			return 50;
+		case FEATURE_100GB_STORAGE_ADD_ON:
+			return 100;
+	}
+
+	return 0;
+}
+
+export default getQuantityFromStorageType;

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -384,6 +384,15 @@ export const resetCouponCode = () => ( {
 	type: 'RESET_COUPON_CODE' as const,
 } );
 
+export const setStorageAddonSlug = ( storageAddonSlug: string ) => ( {
+	type: 'SET_STORAGE_ADDON' as const,
+	storageAddonSlug,
+} );
+
+export const resetStorageAddonSlug = () => ( {
+	type: 'RESET_STORAGE_ADDON' as const,
+} );
+
 export const setDomainForm = ( step: Record< string, string > ) => {
 	const lastUpdated = Date.now();
 
@@ -446,6 +455,8 @@ export type OnboardAction = ReturnType<
 	| typeof resetFonts
 	| typeof resetOnboardStore
 	| typeof resetOnboardStoreWithSkipFlags
+	| typeof resetStorageAddonSlug
+	| typeof resetCouponCode
 	| typeof setStoreType
 	| typeof setDomainsTransferData
 	| typeof setShouldImportDomainTransferDnsRecords
@@ -487,6 +498,7 @@ export type OnboardAction = ReturnType<
 	| typeof setStoreLocationCountryCode
 	| typeof setEcommerceFlowRecurType
 	| typeof setCouponCode
+	| typeof setStorageAddonSlug
 	| typeof setHideFreePlan
 	| typeof setHidePlansFeatureComparison
 	| typeof setProductCartItems

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -385,12 +385,12 @@ export const resetCouponCode = () => ( {
 } );
 
 export const setStorageAddonSlug = ( storageAddonSlug: string ) => ( {
-	type: 'SET_STORAGE_ADDON' as const,
+	type: 'SET_STORAGE_ADDON_SLUG' as const,
 	storageAddonSlug,
 } );
 
 export const resetStorageAddonSlug = () => ( {
-	type: 'RESET_STORAGE_ADDON' as const,
+	type: 'RESET_STORAGE_ADDON_SLUG' as const,
 } );
 
 export const setDomainForm = ( step: Record< string, string > ) => {

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -57,6 +57,7 @@ export function register(): typeof STORE_KEY {
 			'storeLocationCountryCode',
 			'ecommerceFlowRecurType',
 			'couponCode',
+			'storageAddonSlug',
 			'domainCartItem',
 			'planCartItem',
 			'productCartItems',

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -381,10 +381,10 @@ const couponCode: Reducer< string, OnboardAction > = ( state = '', action ) => {
 };
 
 const storageAddonSlug: Reducer< string, OnboardAction > = ( state = '', action ) => {
-	if ( action.type === 'SET_STORAGE_ADDON' ) {
+	if ( action.type === 'SET_STORAGE_ADDON_SLUG' ) {
 		return action.storageAddonSlug;
 	}
-	if ( [ 'RESET_STORAGE_ADDON', 'RESET_ONBOARD_STORE' ].includes( action.type ) ) {
+	if ( [ 'RESET_STORAGE_ADDON_SLUG', 'RESET_ONBOARD_STORE' ].includes( action.type ) ) {
 		return '';
 	}
 	return state;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -380,6 +380,16 @@ const couponCode: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	return state;
 };
 
+const storageAddonSlug: Reducer< string, OnboardAction > = ( state = '', action ) => {
+	if ( action.type === 'SET_STORAGE_ADDON' ) {
+		return action.storageAddonSlug;
+	}
+	if ( [ 'RESET_STORAGE_ADDON', 'RESET_ONBOARD_STORE' ].includes( action.type ) ) {
+		return '';
+	}
+	return state;
+};
+
 const domainForm: Reducer< DomainForm, OnboardAction > = ( state = {}, action ) => {
 	if ( action.type === 'SET_DOMAIN_FORM' ) {
 		return {
@@ -575,6 +585,7 @@ const reducer = combineReducers( {
 	storeLocationCountryCode,
 	ecommerceFlowRecurType,
 	couponCode,
+	storageAddonSlug,
 	planCartItem,
 	productCartItems,
 	isMigrateFromWp,

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -50,6 +50,7 @@ export const getGoals = ( state: State ) => state.goals;
 export const getStoreLocationCountryCode = ( state: State ) => state.storeLocationCountryCode;
 export const getEcommerceFlowRecurType = ( state: State ) => state.ecommerceFlowRecurType;
 export const getCouponCode = ( state: State ) => state.couponCode;
+export const getStorageAddonSlug = ( state: State ) => state.storageAddonSlug;
 export const getState = ( state: State ) => state;
 export const hasPaidDesign = ( state: State ): boolean => {
 	if ( ! state.selectedDesign ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pau2Xa-4MT-p2.


## Proposed Changes

* This is a follow up to https://github.com/Automattic/wp-calypso/pull/85968. In this PR, we add the ability to include a storage addon to the ecommerce setup flow via a query param, so that it is auto-applied at checkout.
* This feature is needed to support the inclusion of storage addons in landing pages, which is being worked on in  D128661-code. When a user selects a storage addon from the landing page pricing grid and clicks on "Get Commerce" CTA, then the Stepper-based ecommerce setup flow should carry over the addon to checkout. 

* In this PR, I have also refactored the way query params are handled to make it cleaner. The query params are now handled in `<FlowRenderer />` component. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/setup/ecommerce/?storage=50gb-storage-add-on` and go through the signup flow. Verify that the 50GB addon is automatically added at checkout. Repeat this in both logged-out and logged-in scenarios.
* Repeat previous step with the URL `/setup/ecommerce/?storage=100gb-storage-add-on`.
* Visit `/setup/ecommerce` and `/setup/ecommerce/?recur=monthly`, and in both scenarios verify that the behaviour is unchanged. Checkout page shouldn't add any storage addons.
* Add both coupons and storage addon and verify they are both applied at checkout. For this, fetch a valid coupon code from 33094-pb, then visit `/setup/ecommerce/?storage=50gb-storage-add-on&coupon=your-coupon-code-goes-here`. At checkout, the coupon should be applied AND the storage addon should be in cart.
* Visit `/setup/ecommerce/?ref=pricing-lp&storage=100gb-storage-add-on` and verify that the sigup start Tracks event includes the `ref` param in its props.

