### PR TITLE
i18n-calypso: Use `react` importSource for transpiling

### DIFF
--- a/packages/calypso-babel-config/presets/default.js
+++ b/packages/calypso-babel-config/presets/default.js
@@ -27,7 +27,13 @@ module.exports = ( api, opts ) => ( {
 		],
 		[
 			require.resolve( '@babel/preset-react' ),
-			{ runtime: 'automatic', importSource: '@emotion/react' },
+			{
+				runtime: 'automatic',
+				importSource:
+					typeof process.env.IMPORT_SOURCE !== 'undefined'
+						? process.env.IMPORT_SOURCE
+						: '@emotion/react',
+			},
 		],
 		[ require.resolve( '@babel/preset-typescript' ), { allowDeclareFields: true } ],
 	],

--- a/packages/i18n-calypso/package.json
+++ b/packages/i18n-calypso/package.json
@@ -40,7 +40,7 @@
 	},
 	"scripts": {
 		"clean": "rm -rf dist",
-		"build": "transpile",
+		"build": "IMPORT_SOURCE=react run -T transpile",
 		"prepack": "yarn run clean && yarn run build"
 	}
 }


### PR DESCRIPTION
## Proposed Changes

* Update `calypso-babel-config` to allow configuring the `importSource` option in `@babel/preset-react` from env variable `IMPORT_SOURCE`.
* Update `i18n-calypso` build script to set the set the import source for `@babel/preset-react` to `react` as it previously defaulted to `@emotion/react` which is not used in the package, but introduced an unnecessary dependency. 

## Testing Instructions

* Checkout the changes locally.
* Build `i18n-calypso` with `yarn workspace i18n-calypso build`.
* Inspect the `dist` directory within the package directory and confirm it imports the JSX runtime from `react/jsx-runtime` intead of `@emotion/react/jsx-runtime`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
