### PR TITLE
Checkout: Fix font-size of delete button in checkout line items

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -190,7 +190,7 @@ const DeleteButtonWrapper = styled.div`
 
 const DeleteButton = styled( Button )< { theme?: Theme } >`
 	width: auto;
-	font-size: ${ hasCheckoutVersion( '2' ) ? '14px' : 'inherit' };
+	font-size: ${ hasCheckoutVersion( '2' ) ? '14px' : '0.75rem' };
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 `;
 


### PR DESCRIPTION
## Proposed Changes

When adding the initial work for the v2 checkout styling, I accidentally changed the font-size of the line item "Remove from cart" buttons from `0.75rem` to `inherit`, causing them to become much larger in checkout and in the masterbar cart. This PR restores the original size.

Props to @fredrikekelund for spotting this!

The regression was added in https://github.com/Automattic/wp-calypso/pull/83204 and here I've highlighted it:

<img width="654" alt="Screenshot 2024-01-04 at 10 33 09 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/4e6d46bf-6748-45ea-b61a-7a77b0ea0d9e">

## Screenshots

Before             |  After
:-------------------------:|:-------------------------:
<img width="494" alt="Screenshot 2024-01-04 at 10 29 08 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/340c54f9-d45e-4fd0-bcc3-7b78f52ccfee"> | <img width="489" alt="Screenshot 2024-01-04 at 10 34 23 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/662476cf-0165-4b48-9ee0-2803cffe567d">
<img width="663" alt="Screenshot 2024-01-04 at 10 29 15 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/0ab203de-1a69-4f77-b2d7-c287611dff40"> | <img width="666" alt="Screenshot 2024-01-04 at 10 34 13 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/2e5a8dca-da22-4b8d-9141-dfda1c065f91">

## Testing Instructions

View checkout and verify that the "Remove from cart" button is the correct size (see screenshots above).
