### PR TITLE
Update styling for some interval toggles and popovers

### DIFF
--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
@@ -17,8 +17,6 @@
 	text-align: center;
 
 	.billing-interval-toggle {
-		display: flex;
-
 		.segmented-control.is-primary {
 			background-color: var(--studio-gray-0);
 			border: 1px solid var(--studio-gray-5);
@@ -30,45 +28,10 @@
 				max-width: unset;
 			}
 
-			.segmented-control__item {
-				border-radius: 6px; /* stylelint-disable-line scales/radii */
-				border: 1px solid var(--studio-gray-0);
-				padding: 2px;
-
-				.segmented-control__link .segmented-control__text span {
-					padding: 6px 9px;
-				}
-
-				&:hover:not(.is-selected) {
-					border-color: var(--studio-gray-30);
-				}
-
-				&:first-child {
-					margin-right: 5px;
-				}
-
-				& .segmented-control__link {
-					color: var(--color-text);
-					border: 0;
-					&:hover {
-						background-color: unset;
-					}
-				}
-
-				&.is-selected .segmented-control__link {
-					border-radius: 5px; /* stylelint-disable-line scales/radii */
-					background-color: var(--studio-white);
-					border-color: var(--studio-white);
-					box-shadow:
-						0 4px 4px rgba(0, 0, 0, 0.25),
-						0 3px 8px rgba(0, 0, 0, 0.12),
-						inset 0 0 0 rgba(0, 0, 0, 0.2);
-					color: var(--color-text);
-
-					&:hover,
-					&:focus {
-						background-color: var(--studio-white);
-					}
+			.segmented-control__item.is-selected .segmented-control__link {
+				&:hover,
+				&:focus {
+					background-color: unset;
 				}
 			}
 		}

--- a/client/my-sites/email/email-providers-comparison/billing-interval-toggle/style.scss
+++ b/client/my-sites/email/email-providers-comparison/billing-interval-toggle/style.scss
@@ -2,9 +2,12 @@
 @import "@wordpress/base-styles/mixins";
 
 .billing-interval-toggle {
-	align-content: space-between;
+	align-items: center;
+	display: flex;
 
 	.segmented-control.is-compact {
+		background-color: var(--studio-gray-5);
+		border-radius: 6px; /* stylelint-disable-line scales/radii */
 		margin: 25px auto 75px;
 		max-width: 480px;
 
@@ -12,22 +15,68 @@
 			margin-bottom: 25px;
 		}
 
-		.segmented-control__link {
-			padding: 0;
+		.segmented-control__item {
+			border: 6px;
+			padding: 2px;
 
-			.segmented-control__text span {
-				display: block;
-				padding: 8px 12px;
+			&.is-selected + .segmented-control__item .segmented-control__link {
+				border-left-color: transparent;
+
+				&:hover {
+					border-left-color: var(--studio-gray-10);
+				}
+			}
+
+			.segmented-control__link {
+				color: var(--studio-gray-90);
+				font-weight: 500;
+				padding: 6px 11px;
+				border: 1px solid transparent;
+				border-radius: 4px;
+
+				&:hover {
+					border: 1px solid var(--studio-gray-10);
+					background-color: unset;
+				}
+
+				&:focus {
+					box-shadow: 0 0 0 1px var(--studio-gray-90);
+					outline: none;
+				}
+			}
+
+			&.is-selected .segmented-control__link {
+				color: var(--studio-gray-80);
+				font-weight: 400;
+				border: 0.5px solid rgba(0, 0, 0, 0.04);
+				box-shadow: 0 3px 8px rgba(0, 0, 0, 0.12), 0 3px 1px rgba(0, 0, 0, 0.04);
+				background-color: var(--studio-white);
+
+				&:hover {
+					background-color: var(--studio-white);
+					border-color: rgba(0, 0, 0, 0.04);
+				}
+			}
+
+			.segmented-control__text {
+				white-space: initial;
 			}
 		}
 	}
 }
 
 .emails-save-paying-annually__popover {
+	transform: translateX(20px);
 	z-index: z-index("root", ".masterbar") - 1;
 
 	.popover__inner {
-		padding: 10px;
+		padding: 8px 10px;
+		max-width: 210px;
+		background-color: var(--color-neutral-100);
+		border-color: var(--color-neutral-100);
+		color: var(--color-neutral-0);
+		border-radius: 2px;
+		text-align: left;
 	}
 
 	&.is-right {
@@ -41,6 +90,14 @@
 	&.is-bottom {
 		@include break-wide {
 			display: none;
+		}
+	}
+
+	&.is-right .popover__arrow {
+		border-right-color: var(--color-neutral-100);
+
+		&::before {
+			border-right-color: var(--color-neutral-100);
 		}
 	}
 }

--- a/client/my-sites/email/email-providers-comparison/billing-interval-toggle/style.scss
+++ b/client/my-sites/email/email-providers-comparison/billing-interval-toggle/style.scss
@@ -52,7 +52,8 @@
 				box-shadow: 0 3px 8px rgba(0, 0, 0, 0.12), 0 3px 1px rgba(0, 0, 0, 0.04);
 				background-color: var(--studio-white);
 
-				&:hover {
+				&:hover,
+				.notouch &:hover {
 					background-color: var(--studio-white);
 					border-color: rgba(0, 0, 0, 0.04);
 				}

--- a/client/my-sites/email/email-providers-comparison/billing-interval-toggle/style.scss
+++ b/client/my-sites/email/email-providers-comparison/billing-interval-toggle/style.scss
@@ -68,7 +68,6 @@
 }
 
 .emails-save-paying-annually__popover {
-	transform: translateX(20px);
 	z-index: z-index("root", ".masterbar") - 1;
 
 	.popover__inner {
@@ -83,6 +82,7 @@
 
 	&.is-right {
 		display: none;
+		transform: translateX(20px);
 
 		@include break-wide {
 			display: block;
@@ -90,6 +90,8 @@
 	}
 
 	&.is-bottom {
+		transform: translateY(5px);
+
 		@include break-wide {
 			display: none;
 		}
@@ -100,6 +102,14 @@
 
 		&::before {
 			border-right-color: var(--color-neutral-100);
+		}
+	}
+
+	&.is-bottom .popover__arrow {
+		border-bottom-color: var(--color-neutral-100);
+
+		&::before {
+			border-bottom-color: var(--color-neutral-100);
 		}
 	}
 }

--- a/client/my-sites/email/email-providers-comparison/billing-interval-toggle/style.scss
+++ b/client/my-sites/email/email-providers-comparison/billing-interval-toggle/style.scss
@@ -53,7 +53,8 @@
 				background-color: var(--studio-white);
 
 				&:hover,
-				.notouch &:hover {
+				.notouch &:hover,
+				&:focus {
 					background-color: var(--studio-white);
 					border-color: rgba(0, 0, 0, 0.04);
 				}

--- a/client/my-sites/email/email-providers-comparison/stacked/style.scss
+++ b/client/my-sites/email/email-providers-comparison/stacked/style.scss
@@ -45,10 +45,6 @@
 
 	.billing-interval-toggle {
 		margin: 15px auto;
-		padding: 10px 0;
-		box-sizing: border-box;
-		background: var(--color-surface);
-		box-shadow: 0 0 0 1px var(--color-border-subtle);
 	}
 
 	.billing-interval-toggle > .segmented-control.is-compact {

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-toggle.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-toggle.tsx
@@ -28,7 +28,7 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 	const segmentClasses = classNames( 'price-toggle', {
 		'is-signup': isInSignup,
 	} );
-	const popupIsVisible = Boolean( intervalType === 'monthly' && isInSignup && props.plans.length );
+	const popupIsVisible = Boolean( intervalType === 'monthly' && props.plans.length );
 	const maxDiscount = useMaxDiscount( props.plans, usePricingMetaForGridPlans, selectedSiteId );
 	// TODO clk pricing
 	const pricingMeta = usePricingMetaForGridPlans( {

--- a/client/my-sites/plans-grid/components/test/plan-type-selector.tsx
+++ b/client/my-sites/plans-grid/components/test/plan-type-selector.tsx
@@ -1,24 +1,24 @@
 /** @jest-environment jsdom */
 import { PLAN_FREE } from '@automattic/calypso-products';
 import { screen, render } from '@testing-library/react';
+import React from 'react';
 import PlanTypeSelector from '../plan-type-selector';
 
 describe( '<PlanTypeSelector />', () => {
-	const myProps = {
-		selectedPlan: PLAN_FREE,
-		hideFreePlan: true,
-		withWPPlanTabs: true,
-		displayedIntervals: [ 'monthly', 'yearly' ],
-		usePricingMetaForGridPlans: () => null,
-	};
-
 	test( 'Should show IntervalTypeToggle when kind is set to `interval`', () => {
 		render(
 			<PlanTypeSelector
-				{ ...myProps }
-				kind="interval"
-				intervalType="monthly"
+				customerType="personal"
+				displayedIntervals={ [ 'monthly', 'yearly' ] }
 				eligibleForWpcomMonthlyPlans
+				intervalType="monthly"
+				isInSignup
+				isPlansInsideStepper={ false }
+				isStepperUpgradeFlow={ false }
+				kind="interval"
+				plans={ [] }
+				selectedPlan={ PLAN_FREE }
+				usePricingMetaForGridPlans={ () => null }
 			/>
 		);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5081

## Proposed Changes

As flagged in the walkthrough p58i-g5m-p2#comment-60918, we have inconsistent treatment for the “Pay monthly / Pay annually” toggle in various pages.

**EDIT:** #86182 changed the interval switcher on the plans pages to a dropdown instead (by flipping a feature flag). We can disable that feature flag by appending `?flags=-onboarding/interval-dropdown` to the URL's, but this isn't enough to restore the previous behaviour (the switcher toggles between `Pay 1 year / Pay 2 year` now instead of `Pay monthly / Pay annually`). However, the change to the Plans page in this PR will still be relevant if the previous behavior is ever restored.

This PR tweaks the toggle/popover for those pages:

| Page | Before | After |
| - | - | - |
| <del>`Upgrades > Plans` for sites on free plan</del> | ![toggle - plans before](https://github.com/Automattic/wp-calypso/assets/1101677/e784ad1e-4bd6-4a97-9b52-77b81df9779f) | ![toggle - plans](https://github.com/Automattic/wp-calypso/assets/1101677/2dc45c95-2f5b-4bc0-8bd3-7a31efd7ed43) |
| Emails comparison page | ![toggle - comparison before](https://github.com/Automattic/wp-calypso/assets/1101677/5d4ed66a-7eb2-42b4-845d-44803ee6795c) | ![toggle - comparison](https://github.com/Automattic/wp-calypso/assets/1101677/9ca8a244-e8e4-4d53-8f7c-3d68c4aa135d) |
| Post-checkout email upsell | ![toggle - upsell before](https://github.com/Automattic/wp-calypso/assets/1101677/8373e63c-bef7-4ef7-9d6b-287892e5e04a) | ![toggle - upsell](https://github.com/Automattic/wp-calypso/assets/1101677/fd782a89-0ead-4206-96e3-037bd6e12a5d) |
| Domain checkout flow email upsell, i.e. `Upgrades > Domains > Add` | ![toggle - calypso domain upsell before](https://github.com/Automattic/wp-calypso/assets/1101677/a26247c6-9c4c-4c0f-8e3a-a8f49ff79a5e) | ![toggle - calypso domain upsell](https://github.com/Automattic/wp-calypso/assets/1101677/d23520be-1303-4db1-890f-029878975b14) |


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

This test plan tests the pages in the same order that they're presented above.

1. Have a site with a free plan
2. <del>Navigate to `/plans/monthly/:site_slug`</del>
3. <del>Ensure that the toggle and the popover looks as in the screenshot above</del>
4. Have a domain without email
5. Navigate to `/email/:domain/purchase/:site_slug?interval=monthly`
6. Ensure that the toggle and the popover looks as in the screenshot above
7. Navigate to `/checkout/offer-professional-email/:domain_name/123/:site_slug`
8. Ensure that the toggle and the popover looks as in the screenshot above
9. Navigate to `/domains/add/:site_slug`
10. Proceed with any domain name
11. On the next page, ensure that the toggle and the popover looks as in the screenshot above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?