### PR TITLE
Change "Advanced Stats" copy to "Jetpack Stats"

### DIFF
--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -90,7 +90,7 @@ const DoYouLoveJetpackStatsNotice = ( {
 	}
 
 	const noPurchaseTitle = isWPCOMPaidStatsFlow
-		? translate( 'Grow faster with Advanced Stats' )
+		? translate( 'Grow faster with Jetpack Stats' )
 		: translate( 'Do you love Jetpack Stats?' );
 	const freeTitle = translate( 'Want to get the most out of Jetpack Stats?' );
 

--- a/client/my-sites/stats/stats-upsell-modal/index.tsx
+++ b/client/my-sites/stats/stats-upsell-modal/index.tsx
@@ -65,7 +65,7 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 			<div className="stats-upsell-modal__content">
 				<div className="stats-upsell-modal__left">
 					<h1 className="stats-upsell-modal__title">
-						{ translate( 'Grow faster with Advanced Stats' ) }
+						{ translate( 'Grow faster with Jetpack Stats' ) }
 					</h1>
 					<div className="stats-upsell-modal__text">
 						{ translate( 'Finesse your scaling up strategy with detailed insights and data.' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5076

## Proposed Changes


* Change "Advanced Stats" copy to "Jetpack Stats" in two places.

<img width="1586" alt="Screenshot 2024-01-04 at 10 32 21 AM" src="https://github.com/Automattic/wp-calypso/assets/140841/4d27b809-c39d-476c-99ec-40a8665cd3f1">

<img width="1589" alt="Screenshot 2024-01-04 at 10 31 43 AM" src="https://github.com/Automattic/wp-calypso/assets/140841/86a2fed4-6312-4214-82fe-87605a3faad5">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/stats/day/<site>
* View that the "Advanced Stats" copy was changed to "Jetpack Stats" as seen in the pictures above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?