### PR TITLE
Reader: Re-enable recommended posts block, re-add dismissal button, and fix layout issues.

### DIFF
--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -229,6 +229,8 @@
 	font-size: $font-body-small;
 	margin-top: 4px;
 	min-height: 38px;
+	width: calc(100% - 70px);
+	overflow: hidden;
 }
 
 .reader-related-card__byline-site {
@@ -291,7 +293,16 @@
 		.reader-related-card__link-block {
 			margin-bottom: 0;
 		}
-		.reader-stream__recommended-posts-list-item .card.reader-related-card {
+	}
+}
+
+.reader-stream__recommended-posts {
+	.reader-stream__recommended-posts-list-item {
+		min-width: 250px;
+		display: flex;
+		flex-direction: column;
+
+		.card.reader-related-card {
 			width: 100%;
 		}
 	}
@@ -351,11 +362,8 @@
 	border-radius: 0;
 	margin-bottom: 12px;
 	margin-top: -4px;
-	min-width: 70px;
-	position: relative;
 	padding: 0;
 	z-index: z-index(".reader-related-card__meta", ".follow-button");
-	left: 50px;
 
 	.reader-follow-feed {
 		fill: var(--color-primary);

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -231,6 +231,7 @@
 	min-height: 38px;
 	width: calc(100% - 70px);
 	overflow: hidden;
+	white-space: nowrap;
 }
 
 .reader-related-card__byline-site {
@@ -253,6 +254,8 @@
 	font-size: 12px;
 	margin-top: 2px;
 	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
 
 	&::after {
 		@include long-content-fade( $size: 10% );

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -242,6 +242,7 @@
 	height: 20px;
 	text-overflow: ellipsis;
 	width: calc(100% - 25px);
+	color: var(--color-primary);
 
 	&::after {
 		@include long-content-fade( $size: 10% );

--- a/client/blocks/reader-related-card/style.scss
+++ b/client/blocks/reader-related-card/style.scss
@@ -277,9 +277,7 @@
 		-webkit-box-orient: vertical;
 	}
 }
-.reader-stream__recommended-post-dismiss {
-	display: none;
-}
+
 @include breakpoint-deprecated( "<660px" ) {
 	.reader-stream__recommended-posts {
 		margin: 0 !important;

--- a/client/reader/stream/post-lifecycle.jsx
+++ b/client/reader/stream/post-lifecycle.jsx
@@ -6,6 +6,7 @@ import PostBlocked from 'calypso/blocks/reader-post-card/blocked';
 import BloggingPromptCard from 'calypso/components/blogging-prompt-card';
 import QueryReaderPost from 'calypso/components/data/query-reader-post';
 import compareProps from 'calypso/lib/compare-props';
+import { IN_STREAM_RECOMMENDATION } from 'calypso/reader/follow-sources';
 import ListGap from 'calypso/reader/list-gap';
 import XPostHelper, { isXPost } from 'calypso/reader/xpost-helper';
 import { recordReaderTracksEvent } from 'calypso/state/reader/analytics/actions';
@@ -14,6 +15,7 @@ import EmptySearchRecommendedPost from './empty-search-recommended-post';
 import Post from './post';
 import PostPlaceholder from './post-placeholder';
 import PostUnavailable from './post-unavailable';
+import RecommendedPosts from './recommended-posts';
 import CrossPost from './x-post';
 
 /**
@@ -80,12 +82,18 @@ class PostLifecycle extends Component {
 	};
 
 	render() {
-		const { post, postKey, isSelected, streamKey, siteId, isDiscoverStream } = this.props;
+		const { post, postKey, isSelected, recsStreamKey, streamKey, siteId, isDiscoverStream } =
+			this.props;
 
 		if ( postKey.isRecommendationBlock ) {
-			// We are temporarily disabling these from our feeds while investigating issues with
-			// irrelevant mature content. https://github.com/Automattic/wp-calypso/pull/85045
-			return null;
+			return (
+				<RecommendedPosts
+					recommendations={ postKey.recommendations }
+					index={ postKey.index }
+					streamKey={ recsStreamKey }
+					followSource={ IN_STREAM_RECOMMENDATION }
+				/>
+			);
 		} else if ( postKey.isPromptBlock ) {
 			return (
 				<div

--- a/client/reader/stream/style.scss
+++ b/client/reader/stream/style.scss
@@ -466,12 +466,12 @@
 
 .reader-stream__recommended-posts-list {
 	display: flex;
-	flex-direction: row;
+	flex-direction: column;
 	margin: 0;
 	padding: 0;
 
-	@include breakpoint-deprecated( "<480px" ) {
-		flex-direction: column;
+	@include break-small {
+		flex-direction: row;
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/pull/85045

## Proposed Changes

* Re-enables the recommended posts block we hid last month.
* un-hides the "dismiss" this recommendation button
* updates styles to prevent broken layouts that were happening, overflows, missing ellipsis, and other issues.


#### BEFORE
Here are a few style issues this PR has resolved:

The title being cut off by the length of the author name:
<img width="354" alt="Screenshot 2024-01-05 at 12 03 52 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/f1e2117a-e9b2-4ff0-be3e-00d4aecbd56a">

With a longer author name, more of the title was then shown in the same space.
The longer author name also broke layout by pushing the follow button off the card:
<img width="347" alt="Screenshot 2024-01-05 at 12 04 33 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/92ed5951-5ef9-46ca-a11c-0a3ecc8fb2b2">
<img width="392" alt="Screenshot 2024-01-05 at 12 04 49 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/22ea0f6d-cc74-43ae-8715-fa31163f739c">

We were waiting until too small of a breakpoint to convert to column view, causing a very cramped layout between 480-600px width:
<img width="481" alt="Screenshot 2024-01-05 at 12 05 55 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/9bbba83e-1a13-49f6-a496-725efdb607c9">

The dismiss button shifting off to the side on smaller breakpoints (as well as being hidden at times due to other layout breakages noted above):
<img width="638" alt="Screenshot 2024-01-04 at 1 54 02 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/10fa013b-4d8b-4880-904d-5478a2ac548f">


#### AFTER

Titles take up the space available to them regardless of the author name length, and both title and author overflows are hidden at the right cutoff with an ellipsis:
<img width="648" alt="Screenshot 2024-01-05 at 11 23 08 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/cf0defad-19c6-4b98-ac69-5d89898d2339">

The dismiss button no longer moves off to the side at smaller breakpoints.
<img width="564" alt="Screenshot 2024-01-05 at 11 23 20 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/ea42bfb1-7443-4aca-ad6a-7d7c40c25133">

Note - I did update since the above screenshots to make the ellipsis for the title the same color:
<img width="262" alt="Screenshot 2024-01-05 at 12 42 17 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/a0c9cdf9-dde9-4026-93ee-28eb882d1acb">

And we break to column view sooner to prevent the cramped layout shown above:
<img width="577" alt="Screenshot 2024-01-05 at 12 42 48 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/8f3c5794-5d49-4864-b952-c1332705b612">



more discussion - pe7F0s-1tw-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Go to your "Recent" feed and scroll down to find a recommended post block. For simplicity in development testing I altered[ this LOC locally](https://github.com/Automattic/wp-calypso/blob/54c371ed8d70c0f0dacd1452f8c50bfb4fd1d550/client/reader/stream/post-lifecycle.jsx#L89) to always run and return null, filling my recent feed with nothing but recommended posts.
* Test recommended posts with varying screen widths, title lengths, author lengths, etc. Verify this works as expected and no longer breaks layouts.
* Verify the dismiss button is clearly visible at the top-right of each recommendation, and works as expected.
* Smoke test related posts on the full post page. Some of these byline style improvements helped there as well, verify there are no regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?