### PR TITLE
Adds a new origin to Promote Post widget

### DIFF
--- a/apps/blaze-dashboard/src/load-config.js
+++ b/apps/blaze-dashboard/src/load-config.js
@@ -1,3 +1,11 @@
+// Fixes a typo in Jetpack config response
+if ( window.configData?.intial_state ) {
+	window.configData.initial_state = window.configData.intial_state;
+	delete window.configData.intial_state;
+}
+
+const isWooStore = window.configData?.is_woo_store || false;
+
 // The JSON is filtered by `apps/blaze-dashboard/filter-json-config-loader.js`.
 import productionConfig from '../../../config/production.json';
 
@@ -5,21 +13,18 @@ import productionConfig from '../../../config/production.json';
 productionConfig.features.is_running_in_jetpack_site =
 	window.configData.features.is_running_in_jetpack_site ?? true;
 
+// Set is is_running_in_woo_site to true if the dashboard is running on the Woo Blaze plugin
+productionConfig.features.is_running_in_woo_site = isWooStore;
+
 // The option enables loading of the whole translation file, and could be optimized by setting it to `true`, which needs the translation chunks in place.
 // @see https://github.com/Automattic/wp-calypso/blob/trunk/docs/translation-chunks.md
 productionConfig.features[ 'use-translation-chunks' ] = false;
 
 // Sets the advertising path prefix for this app
-productionConfig.advertising_dashboard_path_prefix = '/advertising';
+productionConfig.advertising_dashboard_path_prefix = isWooStore ? '/wc-blaze' : '/advertising';
 
 // Note: configData is hydrated in Jetpack: https://github.com/Automattic/jetpack/blob/60b0dac0dc5ad7edec2b86edb57b65a3a98ec42d/projects/packages/blaze/src/class-dashboard-config-data.php#L31
 window.configData = {
 	...window.configData,
 	...productionConfig,
 };
-
-// Fixes a typo in Jetpack config response
-if ( window.configData.intial_state ) {
-	window.configData.initial_state = window.configData.intial_state;
-	delete window.configData.intial_state;
-}

--- a/client/lib/promote-post/index.ts
+++ b/client/lib/promote-post/index.ts
@@ -58,6 +58,7 @@ declare global {
 				showGetStartedMessage?: boolean;
 				onGetStartedMessageClose?: ( dontShowAgain: boolean ) => void;
 				source?: string;
+				isRunningInWooBlaze?: boolean;
 				isRunningInJetpack?: boolean;
 				jetpackXhrParams?: {
 					apiRoot: string;
@@ -118,7 +119,10 @@ const getWidgetOptions = () => {
 };
 
 export const getDSPOrigin = () => {
-	if ( config.isEnabled( 'is_running_in_jetpack_site' ) ) {
+	// We need to check for Woo first, because Woo Blaze is also running in Jetpack (At least in this iteration)
+	if ( config.isEnabled( 'is_running_in_woo_site' ) ) {
+		return 'wc-blaze-plugin';
+	} else if ( config.isEnabled( 'is_running_in_jetpack_site' ) ) {
 		return 'jetpack';
 	} else if ( isWpMobileApp() ) {
 		return 'wp-mobile-app';
@@ -161,6 +165,7 @@ export async function showDSP(
 
 		try {
 			const isRunningInJetpack = config.isEnabled( 'is_running_in_jetpack_site' );
+			const isRunningInWooBlaze = config.isEnabled( 'is_running_in_woo_site' );
 			const isMobileApp = isWpMobileApp() || isWcMobileApp();
 
 			window.BlazePress.render( {
@@ -188,6 +193,7 @@ export async function showDSP(
 				uploadImageLabel: isMobileApp ? __( 'Tap to add image' ) : undefined,
 				showGetStartedMessage: ! isMobileApp, // Don't show the GetStartedMessage in the mobile app.
 				source: source,
+				isRunningInWooBlaze,
 				isRunningInJetpack,
 				jetpackXhrParams: isRunningInJetpack
 					? {


### PR DESCRIPTION
## Proposed Changes

We are incorporating a new origin to the Promote Post widget. This new origin will be triggered from a WooCommerce plugin that will use the Blaze Dashboard app as entry point.

## Testing Instructions

* Open the live preview and navigate to Tools->Advertising
* Open the Network inspector, and filter for all request matching the name `t.gif` (tracks request)
* Append to the URl the following parameter to activate the woo site flag: `?flags=is_running_in_woo_site`
* Refresh the page and validate that the tracks event for `calypso_page_view` is displaying the correct origin: `wc-blaze-plugin`
* Click on the Promote button and verify that the track event for `promoted_posts-header` also shows the new origin.

A code review will be enough for the changes in the Blaze  Dashboard App.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?