### PR TITLE
AI Logo Generator: Enforce minimum prompt

### DIFF
--- a/packages/jetpack-ai-calypso/src/constants.ts
+++ b/packages/jetpack-ai-calypso/src/constants.ts
@@ -4,3 +4,6 @@ export const JWT_TOKEN_EXPIRATION_TIME = 2 * 60 * 1000; // 2 minutes
 // Tracks event names
 export const EVENT_PROMPT_SUBMIT = 'calypso_jp_ai_logo_generator_prompt_submit';
 export const EVENT_PROMPT_ENHANCE = 'calypso_jp_ai_logo_generator_prompt_enhance';
+
+// Feature constants
+export const MINIMUM_PROMPT_LENGTH = 10;

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
@@ -11,7 +11,7 @@ import { SetStateAction, useCallback, useEffect, useState } from 'react';
 /**
  * Internal dependencies
  */
-import { EVENT_PROMPT_SUBMIT, EVENT_PROMPT_ENHANCE } from '../../constants';
+import { EVENT_PROMPT_SUBMIT, EVENT_PROMPT_ENHANCE, MINIMUM_PROMPT_LENGTH } from '../../constants';
 import AiIcon from '../assets/icons/ai';
 import useLogoGenerator from '../hooks/use-logo-generator';
 import { STORE_NAME } from '../store';
@@ -23,6 +23,7 @@ export const Prompt: React.FC = () => {
 	const { addLogoToHistory, increaseAiAssistantRequestsCount } = useDispatch( STORE_NAME );
 	const [ prompt, setPrompt ] = useState( '' );
 	const [ requestsRemaining, setRequestsRemaining ] = useState( 0 );
+	const hasPrompt = prompt?.length >= MINIMUM_PROMPT_LENGTH;
 
 	const {
 		generateImage,
@@ -103,7 +104,11 @@ export const Prompt: React.FC = () => {
 					{ __( 'Describe your site:', 'jetpack' ) }
 				</div>
 				<div className="jetpack-ai-logo-generator__prompt-actions">
-					<Button variant="link" disabled={ isBusy || requireUpgrade } onClick={ onEnhance }>
+					<Button
+						variant="link"
+						disabled={ isBusy || requireUpgrade || ! hasPrompt }
+						onClick={ onEnhance }
+					>
 						<AiIcon />
 						<span>{ enhanceButtonLabel }</span>
 					</Button>
@@ -125,7 +130,7 @@ export const Prompt: React.FC = () => {
 					variant="primary"
 					className="jetpack-ai-logo-generator__prompt-submit"
 					onClick={ onGenerate }
-					disabled={ isBusy || requireUpgrade }
+					disabled={ isBusy || requireUpgrade || ! hasPrompt }
 				>
 					{ __( 'Generate', 'jetpack' ) }
 				</Button>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/issues/34378

## Proposed Changes

* Adds a minimum prompt length check before sending AI requests

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the feature modal
* Check that the Generate and Enhance buttons are disabled if there is less than 10 characters in the textarea

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?