### PR TITLE
Paid-stats: Remove Jetpack Stats add-on card

### DIFF
--- a/client/my-sites/add-ons/components/add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/add-ons-card.tsx
@@ -1,26 +1,16 @@
-import {
-	PRODUCT_JETPACK_STATS_PWYW_YEARLY,
-	PRODUCT_JETPACK_STATS_YEARLY,
-	PRODUCT_1GB_SPACE,
-} from '@automattic/calypso-products';
-import page from '@automattic/calypso-router';
+import { PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
 import { Badge, Button, Gridicon, Spinner } from '@automattic/components';
 import styled from '@emotion/styled';
 import { Card, CardBody, CardFooter, CardHeader } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { getStatsPurchaseURL } from 'calypso/my-sites/stats/stats-purchase/stats-purchase-notice';
-import { useSelector } from 'calypso/state';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { AddOnMeta } from '@automattic/data-stores';
 
-type ActionPrimary = {
-	text: string;
-	handler: ( productSlug: string, quantity?: number ) => void;
-};
-
 export interface Props {
-	actionPrimary?: ActionPrimary;
+	actionPrimary?: {
+		text: string;
+		handler: ( productSlug: string, quantity?: number ) => void;
+	};
 	actionSecondary?: {
 		text: string;
 		handler: ( productSlug: string ) => void;
@@ -98,61 +88,15 @@ const Container = styled.div`
 	}
 `;
 
-const useAddonName = ( addOnMeta: AddOnMeta ) => {
-	const translate = useTranslate();
-
-	// Add special handling for Jetpack Stats, which actually encompasses three different products:
-	// - Jetpack Stats (free)
-	// - Jetpack Stats Personal (pay-what-you-want, yearly)
-	// - Jetpack Stats Commercial (fixed monthly price for now, monthly)
-	if ( addOnMeta.productSlug === PRODUCT_JETPACK_STATS_PWYW_YEARLY ) {
-		return translate( 'Jetpack Stats' );
-	}
-
-	return addOnMeta.name;
-};
-
-const useModifiedActionPrimary = (
-	actionPrimary: ActionPrimary | undefined,
-	addOnMeta: AddOnMeta
-) => {
-	const translate = useTranslate();
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-
-	// Add special handling for Jetpack Stats, which uses its own special purchase page.
-	if (
-		[ PRODUCT_JETPACK_STATS_PWYW_YEARLY, PRODUCT_JETPACK_STATS_YEARLY ].includes(
-			addOnMeta.productSlug
-		)
-	) {
-		return {
-			text: translate( 'Upgrade Stats' ),
-			handler: () => {
-				// Navigate to the stats purchase page, scrolled to the top.
-				const purchaseUrl = getStatsPurchaseURL(
-					siteId,
-					addOnMeta.productSlug === PRODUCT_JETPACK_STATS_YEARLY ? 'commercial' : 'personal'
-				);
-				// TODO: Remove the feature flag once we enable Paid Stats for WPCOM sites.
-				page.show( purchaseUrl + ',stats/paid-wpcom-stats' );
-				window.scrollTo( 0, 0 );
-			},
-		};
-	}
-	return actionPrimary;
-};
-
 const AddOnCard = ( {
 	addOnMeta,
-	actionPrimary: actionPrimaryFromProps,
+	actionPrimary,
 	actionSecondary,
 	useAddOnAvailabilityStatus,
 	highlightFeatured,
 }: Props ) => {
 	const translate = useTranslate();
 	const availabilityStatus = useAddOnAvailabilityStatus?.( addOnMeta );
-	const name = useAddonName( addOnMeta );
-	const actionPrimary = useModifiedActionPrimary( actionPrimaryFromProps, addOnMeta );
 
 	const onActionPrimary = () => {
 		actionPrimary?.handler( addOnMeta.productSlug, addOnMeta.quantity );
@@ -184,7 +128,7 @@ const AddOnCard = ( {
 					</div>
 					<div className="add-ons-card__name-and-billing">
 						<div className="add-ons-card__name-tag">
-							<div className="add-ons-card__name">{ name }</div>
+							<div className="add-ons-card__name">{ addOnMeta.name }</div>
 							{ highlightFeatured && addOnMeta.featured && (
 								<Badge key="popular" type="info-green" className="add-ons-card__featured-badge">
 									{ translate( 'Popular' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4916

> [!CAUTION]
> These updates are not behind a feature flag, so let's wait to merge this until a day or two before paid-stats launches.

## Proposed Changes

* This PR removes the Pay What You Want (PWYW) and Commercial Jetpack Stats add-on cards.
* These cards are being removed because this feature will no longer be an add-on, but instead built in to Explorer and higher plans.

<img width="1442" alt="Screenshot 2024-01-04 at 2 28 57 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/d45b330b-0f1a-461a-ae03-60895e5b4c74">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://wordpress.com/add-ons/ in production to confirm the add-on is available on your free test site
* Now go to http://calypso.localhost:3000/add-ons/ (or use calypso.live) to confirm it was removed from your test site
* Force your free test site to be a "commercial" site and repeat the first two steps to confirm the Commercial Jetpack Stats add-on card is removed. p1704403622106019/1704400818.269099-slack-C068X5XJT3J
* Ensure the removal did not introduce any new console errors or regressions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?