### PR TITLE
Marketplace Reviews: Update the cache invalidation strategy

### DIFF
--- a/client/data/marketplace/use-marketplace-reviews.ts
+++ b/client/data/marketplace/use-marketplace-reviews.ts
@@ -34,6 +34,8 @@ export type PaginationProps = {
 	perPage?: number;
 };
 
+export type ProductDefinitionProps = Omit< ProductProps, 'author' >;
+
 export type MarketplaceReviewsQueryProps = ProductProps & FilteringProps & PaginationProps;
 
 export type MarketplaceReviewBody = {
@@ -270,13 +272,13 @@ export const useInfiniteMarketplaceReviewsQuery = (
 ) => {
 	const queryKey: QueryKey = [
 		queryKeyBase,
-		'infinite',
 		productType,
 		slug,
 		author,
 		author_exclude,
 		page,
 		perPage,
+		'infinite',
 	];
 	const queryFn = ( { pageParam = 1 } ) =>
 		fetchMarketplaceReviews( productType, slug, pageParam, perPage, author, author_exclude );
@@ -295,22 +297,32 @@ export const useInfiniteMarketplaceReviewsQuery = (
 	} );
 };
 
-export const useCreateMarketplaceReviewMutation = () => {
+export const useCreateMarketplaceReviewMutation = ( {
+	productType,
+	slug,
+}: ProductDefinitionProps ) => {
 	const queryClient = useQueryClient();
+	const queryKeyPrefix = [ queryKeyBase, productType, slug ];
+
 	return useMutation( {
 		mutationFn: createReview,
 		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: queryKeyBase } );
+			queryClient.invalidateQueries( { queryKey: queryKeyPrefix } );
 		},
 	} );
 };
 
-export const useUpdateMarketplaceReviewMutation = () => {
+export const useUpdateMarketplaceReviewMutation = ( {
+	productType,
+	slug,
+}: ProductDefinitionProps ) => {
 	const queryClient = useQueryClient();
+	const queryKeyPrefix = [ queryKeyBase, productType, slug ];
+
 	return useMutation( {
 		mutationFn: updateReview,
 		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey: queryKeyBase } );
+			queryClient.invalidateQueries( { queryKey: queryKeyPrefix } );
 		},
 	} );
 };
@@ -318,25 +330,14 @@ export const useUpdateMarketplaceReviewMutation = () => {
 export const useDeleteMarketplaceReviewMutation = ( {
 	productType,
 	slug,
-	page,
-	perPage,
-	author,
-	author_exclude,
-}: MarketplaceReviewsQueryProps ) => {
+}: ProductDefinitionProps ) => {
 	const queryClient = useQueryClient();
-	const queryKey: QueryKey = [
-		queryKeyBase,
-		productType,
-		slug,
-		author,
-		author_exclude,
-		page,
-		perPage,
-	];
+	const queryKeyPrefix = [ queryKeyBase, productType, slug ];
+
 	return useMutation< MarketplaceReviewResponse, ErrorResponse, DeleteMarketplaceReviewProps >( {
 		mutationFn: deleteReview,
 		onSuccess: () => {
-			queryClient.invalidateQueries( { queryKey } );
+			queryClient.invalidateQueries( { queryKey: queryKeyPrefix } );
 		},
 	} );
 };
@@ -349,7 +350,7 @@ export const useMarketplaceReviewsStatsQuery = (
 		refetchOnMount = true,
 	}: MarketplaceReviewsStatsQueryOptions = {}
 ) => {
-	const queryKey: QueryKey = [ queryKeyBase, productProps ];
+	const queryKey: QueryKey = [ queryKeyBase, productProps.productType, productProps.slug, 'stats' ];
 	const queryFn = () => fetchMarketplaceReviewsStats( productProps );
 	return useQuery( {
 		queryKey,
@@ -368,7 +369,13 @@ export const useIsUserAllowedToReview = (
 		refetchOnMount = true,
 	}: MarketplaceReviewsValidateQueryOptions = {}
 ) => {
-	const queryKey: QueryKey = [ ...queryKeyBase, 'validate', productProps ];
+	const queryKey: QueryKey = [
+		queryKeyBase,
+		productProps.productType,
+		productProps.slug,
+		'validate',
+	];
+
 	const queryFn = () => fetchIsUserAllowedToReview( productProps );
 	return useQuery( {
 		queryKey,

--- a/client/my-sites/marketplace/components/review-modal/index.tsx
+++ b/client/my-sites/marketplace/components/review-modal/index.tsx
@@ -24,7 +24,7 @@ export const ReviewModal = ( { isVisible, onClose, slug, productName, productTyp
 	const [ content, setContent ] = useState< string >( '' );
 	const [ rating, setRating ] = useState< number >( 5 );
 
-	const createReview = useCreateMarketplaceReviewMutation();
+	const createReview = useCreateMarketplaceReviewMutation( { productType, slug } );
 
 	if ( createReview.isSuccess ) {
 		return (

--- a/client/my-sites/marketplace/components/reviews-list/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-list/index.tsx
@@ -41,8 +41,6 @@ export const MarketplaceReviewsList = ( props: MarketplaceReviewsQueryProps ) =>
 
 	const deleteReviewMutation = useDeleteMarketplaceReviewMutation( {
 		...props,
-		perPage: 1,
-		author: currentUserId ?? undefined,
 	} );
 	const deleteReview = ( reviewId: number ) => {
 		setIsConfirmModalVisible( false );


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/4897

## Proposed Changes

Update the cache invalidation strategy by:
* Make all queries start with `queryKeyBase`, `productType`,  `slug` in this order
* After any mutation (delete, update, create), remove all query keys starting with `queryKeyBase`, `productType`,  `slug` for the given product
* This will make all queries for this product stale and refetch all of them, keeping the other products caches

## Testing Instructions

* Go to the plugin details page where you have reviews. Ex: `/plugins/woocommerce-bookings/`
* Scroll down and click on `Read all reviews`
* Delete your own review
* Check the average rating and the number of reviews is updated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
