### PR TITLE
Marketplace Reviews: Show error message as card on uncessful deletions

### DIFF
--- a/client/data/marketplace/use-marketplace-reviews.ts
+++ b/client/data/marketplace/use-marketplace-reviews.ts
@@ -333,13 +333,10 @@ export const useDeleteMarketplaceReviewMutation = ( {
 		page,
 		perPage,
 	];
-	return useMutation( {
+	return useMutation< MarketplaceReviewResponse, ErrorResponse, DeleteMarketplaceReviewProps >( {
 		mutationFn: deleteReview,
 		onSuccess: () => {
 			queryClient.invalidateQueries( { queryKey } );
-		},
-		onError: ( error: Error ) => {
-			alert( error.message );
 		},
 	} );
 };

--- a/client/my-sites/marketplace/components/reviews-list/style.scss
+++ b/client/my-sites/marketplace/components/reviews-list/style.scss
@@ -141,19 +141,19 @@ $border-color: #eee;
 	}
 }
 
-.marketplace-reviews-list__pending-review {
+.marketplace-reviews-list__pending-review,
+.marketplace-reviews-list__error-message {
 	display: flex;
 	align-items: flex-start;
 	gap: 8px;
 	align-self: stretch;
 
-	.marketplace-reviews-list__icon {
+	.marketplace-reviews-list__card-icon {
 		color: var(--studio-gray-10);
 	}
 
-	.marketplace-reviews-list__pending-review-text {
+	.marketplace-reviews-list__card-text {
 		font-family: "SF Pro Text", $sans;
-		color: var(--studio-gray-100);
 		font-size: $font-body-small;
 		line-height: 20px;
 	}


### PR DESCRIPTION

## Proposed Changes

Show the deletion error message as a card instead of an alert.

![CleanShot 2024-01-04 at 17 00 15](https://github.com/Automattic/wp-calypso/assets/5039531/116861a3-70ef-429c-b758-66553ab4dc68)


## Testing Instructions
* Check this branch on your local environment
* On the `use-marketplace-reviews.ts` file, update the method `deleteReview` changing the param `reviewId` part to make it fail. Ex:
```js
path: `${ reviewsApiBase }/${ reviewId }ERROR`,
```
* Go to the plugin details page where you have reviews. Ex: `/plugins/woocommerce-bookings/`
* Scroll down and click on `Read all reviews`
* Try to delete your own review
* You should see the error displayed as above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
