### PR TITLE
Paid Stats: Fix lock icon overlap in date picker

### DIFF
--- a/client/components/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/components/stats-date-control/stats-date-control-picker-date.tsx
@@ -25,9 +25,9 @@ const DateControlPickerDate = ( {
 			} ) }
 		>
 			<h2 className={ `${ BASE_CLASS_NAME }__heading` }>
-				{ translate( 'Date Range' ) }
 				{ overlay && <Icon icon={ lock } /> }
-				<span> &#8212;</span>
+				{ translate( 'Date Range' ) }
+				<span>&#8212;</span>
 				<input id="date-example" type="date" disabled />
 			</h2>
 			<div className={ `${ BASE_CLASS_NAME }s__inputs` }>

--- a/client/components/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/components/stats-date-control/stats-date-control-picker-date.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@wordpress/components';
+import { Icon, lock } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import DateInput from './stats-date-control-date-input';
@@ -25,6 +26,7 @@ const DateControlPickerDate = ( {
 		>
 			<h2 className={ `${ BASE_CLASS_NAME }__heading` }>
 				{ translate( 'Date Range' ) }
+				{ overlay && <Icon icon={ lock } /> }
 				<span> &#8212;</span>
 				<input id="date-example" type="date" disabled />
 			</h2>

--- a/client/components/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/components/stats-date-control/stats-date-control-picker-date.tsx
@@ -26,9 +26,11 @@ const DateControlPickerDate = ( {
 		>
 			<h2 className={ `${ BASE_CLASS_NAME }__heading` }>
 				{ overlay && <Icon icon={ lock } /> }
-				{ translate( 'Date Range' ) }
-				<span>&#8212;</span>
-				<input id="date-example" type="date" disabled />
+				<div className={ `${ BASE_CLASS_NAME }s__heading-text` }>
+					{ translate( 'Date Range' ) }
+					<span> &#8212;</span>
+					<input id="date-example" type="date" disabled />
+				</div>
 			</h2>
 			<div className={ `${ BASE_CLASS_NAME }s__inputs` }>
 				<div className={ `${ BASE_CLASS_NAME }s__inputs-input-group` }>

--- a/client/components/stats-date-control/style.scss
+++ b/client/components/stats-date-control/style.scss
@@ -19,6 +19,10 @@ $date-control-shortcut-min-width: 140px;
 		.stats-date-control-picker-date__overlay {
 			grid-column: 1;
 			grid-row: 1;
+
+			.stats-card-upsell__lock {
+				visibility: hidden;
+			}
 		}
 
 		.stats-date-control-picker-dates__inputs,

--- a/client/components/stats-date-control/style.scss
+++ b/client/components/stats-date-control/style.scss
@@ -150,6 +150,8 @@ $date-control-shortcut-min-width: 140px;
 }
 
 .stats-date-control-picker__popover-content .stats-date-control-picker-date .stats-date-control-picker-date__heading {
+	display: flex;
+	align-items: center;
 	color: var(--gray-gray-80, #2c3338);
 	font-family: $font-sf-pro-text;
 	font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
@@ -160,11 +162,15 @@ $date-control-shortcut-min-width: 140px;
 	text-align: left;
 	padding: 8px 0;
 
+	svg {
+		fill: var(--gray-gray-80, #2c3338);
+	}
 	span {
 		color: var(--gray-gray-50, #646970);
 		font-size: 12px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		line-height: 18px;
 		letter-spacing: -0.24px;
+		margin-left: 2px;
 	}
 	#date-example {
 		border: none;

--- a/client/components/stats-date-control/style.scss
+++ b/client/components/stats-date-control/style.scss
@@ -170,7 +170,6 @@ $date-control-shortcut-min-width: 140px;
 		font-size: 12px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 		line-height: 18px;
 		letter-spacing: -0.24px;
-		margin-left: 2px;
 	}
 	#date-example {
 		border: none;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Move the lock icon to the date picker header.

Before | After
----- | -----
<img width="526" alt="Screen Shot 2024-01-05 at 4 37 18 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/56c2bbb0-1d05-4f5e-93cc-986e934d577b"> | <img width="549" alt="Screen Shot 2024-01-05 at 4 40 55 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/77680d7c-08c1-4cb8-af4d-8791b4e0643d">

To do:
- [x] Move lock icon in front of header.
- [x] Fix lock icon alignment and fill color.
- [x] Test in Safari
- [x] Test in Edge
- [x] Test Odyssey Stats

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With `?flags=stats/paid-wpcom-v2` applied, visit /stats for a free site created after Dec 19.
* Click the "Last 30 Days" datepicker and check that the lock icon doesn't overlap with the heading.
* The icon should be the same gray as "Date Range" and the heading component should be horizontally aligned.
* Go to /stats for a site that does have full Stats access.
* Click the "Last 30 Days" datepicker and check that the heading is the same as without these changes applied.

<img width="539" alt="Screen Shot 2024-01-05 at 4 40 42 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/b19244c6-ad6d-44fa-beb1-93028df80b56">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?