### PR TITLE
Marketing: Update Service Tips for Publicise Connections

### DIFF
--- a/client/my-sites/marketing/connections/service-tip.jsx
+++ b/client/my-sites/marketing/connections/service-tip.jsx
@@ -19,12 +19,12 @@ import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
  * a method with the tip's content.
  * @type {string[]}
  */
-const SERVICES_WITH_TIPS = [ 'instagram', 'google_plus' ];
+const SERVICES_WITH_TIPS = [ 'instagram' ];
 /**
  * List of services we provide tips for, only if the site is connected to Jetpack.
  * @type {string[]}
  */
-const JETPACK_SERVICES_WITH_TIPS = SERVICES_WITH_TIPS.concat( [ 'facebook', 'twitter' ] );
+const JETPACK_SERVICES_WITH_TIPS = SERVICES_WITH_TIPS.concat( [ 'facebook' ] );
 
 class SharingServiceTip extends Component {
 	static propTypes = {
@@ -46,13 +46,13 @@ class SharingServiceTip extends Component {
 
 	facebook() {
 		return this.props.translate(
-			'You can also add a {{likeBoxLink}}Like Box{{/likeBoxLink}}, a {{shareButtonLink}}share button{{/shareButtonLink}}, or {{embedLink}}embed{{/embedLink}} your page or profile on your site.',
+			'You can also add a {{pagePluginLink}}Page Plugin{{/pagePluginLink}}, a {{shareButtonLink}}share button{{/shareButtonLink}}, or {{embedLink}}embed{{/embedLink}} your page or profile on your site.',
 			{
 				components: {
-					likeBoxLink: (
+					pagePluginLink: (
 						<a
 							href={ localizeUrl(
-								'https://wordpress.com/support/facebook-integration/#facebook-like-box'
+								'https://wordpress.com/support/facebook-embeds/#facebook-page-plugin-widget'
 							) }
 						/>
 					),
@@ -61,24 +61,6 @@ class SharingServiceTip extends Component {
 						<a
 							href={ localizeUrl(
 								'https://wordpress.com/support/facebook-integration/facebook-embeds/'
-							) }
-						/>
-					),
-				},
-				context: 'Sharing: Tip in settings',
-			}
-		);
-	}
-
-	twitter() {
-		return this.props.translate(
-			'You can also add a {{widgetLink}}Twitter Timeline Widget{{/widgetLink}} to display any public timeline on your site.',
-			{
-				components: {
-					widgetLink: (
-						<a
-							href={ localizeUrl(
-								'https://wordpress.com/support/widgets/twitter-timeline-widget/'
 							) }
 						/>
 					),
@@ -104,18 +86,13 @@ class SharingServiceTip extends Component {
 		);
 	}
 
-	google_plus() {
-		return null;
-	}
-
 	render() {
 		const { service } = this.props;
 		if (
 			! includes(
 				this.props.hasJetpack ? JETPACK_SERVICES_WITH_TIPS : SERVICES_WITH_TIPS,
 				service.ID
-			) ||
-			'google_plus' === service.ID
+			)
 		) {
 			return <div className="connections__sharing-service-tip" />;
 		}

--- a/client/my-sites/marketing/connections/service-tip.jsx
+++ b/client/my-sites/marketing/connections/service-tip.jsx
@@ -75,7 +75,7 @@ class SharingServiceTip extends Component {
 			'You can also add the {{blockLink}}Latest Instagram Posts block{{/blockLink}} to display your latest Instagram photos on your site.',
 			{
 				components: {
-					widgetLink: (
+					blockLink: (
 						<a
 							href={ localizeUrl( 'https://wordpress.com/support/instagram/' ) }
 						/>

--- a/client/my-sites/marketing/connections/service-tip.jsx
+++ b/client/my-sites/marketing/connections/service-tip.jsx
@@ -72,12 +72,12 @@ class SharingServiceTip extends Component {
 
 	instagram() {
 		return this.props.translate(
-			'You can also add an {{widgetLink}}Instagram Widget{{/widgetLink}} to display your latest Instagram photos on your site.',
+			'You can also add the {{blockLink}}Latest Instagram Posts block{{/blockLink}} to display your latest Instagram photos on your site.',
 			{
 				components: {
 					widgetLink: (
 						<a
-							href={ localizeUrl( 'https://wordpress.com/support/instagram/instagram-widget/' ) }
+							href={ localizeUrl( 'https://wordpress.com/support/instagram/' ) }
 						/>
 					),
 				},


### PR DESCRIPTION
Fixes #83032
Fixes #66730

## Proposed Changes

Updates the service tips for Publicise services: 

- Replaces reference to the Facebook Like Box with Page Plugin, and corrects the current incorrect documentation. 
- Removes Twitter, since that's no longer supported. 
- Also removes Google Plus, which seems to still be lingering from years ago.
- Updates the legacy Instagram widget to reference the new Latest Instagram Posts block. 

## Testing Instructions

Go to `/marketing/connections/site` - confirm that the legacy Twitter and Google Plus descriptions were never visible, but that the Facebook one still is. 

<img width="1079" alt="Screenshot 2024-01-04 at 22 39 11" src="https://github.com/Automattic/wp-calypso/assets/43215253/69bf7b90-2b63-4db6-b721-34d9d88fcfbb">

You can unhide it with CSS if you don't have a Facebook connection.

```css
.connections__sharing-service-tip {
    display: block !important;
}
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

cc @pablinos 