### PR TITLE
Fix: Update the PWA manifest to prefer the jetpack app vs the WP app

### DIFF
--- a/client/server/pwa/manifest.js
+++ b/client/server/pwa/manifest.js
@@ -20,14 +20,15 @@ const getWordPressOptions = ( environmentUrlSuffix ) => ( {
 			type: 'image/png',
 		},
 	],
+	prefer_related_applications: true,
 	related_applications: [
 		{
 			platform: 'play',
-			url: 'https://play.google.com/store/apps/details?id=org.wordpress.android',
+			url: 'https://play.google.com/store/apps/details?id=com.jetpack.android',
 		},
 		{
 			platform: 'itunes',
-			url: 'https://itunes.apple.com/app/wordpress/id335703880',
+			url: 'https://apps.apple.com/app/jetpack-for-wordpress/id1565481562?ct=pwa-manifest&mt=8&pt=299112',
 		},
 	],
 } );


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-mobile-roadmap/issues/169

## Proposed Changes

*  Update the manifest file to point users to the jetpack app instead the WP app or the WordPress.com PWA. 

## Testing Instructions
Vistit the calypso live links. 

* Use an Android phone + Chrome does it to install the PWA or the Jetpack app? 
* Use an iPhone + Chrome does it ask you install the iOS Jetpack app or the PWA. 

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?