### PR TITLE
Shopping Cart: Remove unused coupon_discounts from cart types

### DIFF
--- a/client/my-sites/checkout/src/test/translate-cart.js
+++ b/client/my-sites/checkout/src/test/translate-cart.js
@@ -66,7 +66,6 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 				'WPCOM_Billing_Web_Payment',
 			],
 			coupon: 'fakecoupon',
-			coupon_discounts_integer: [],
 		};
 
 		const clientCart = translateResponseCartToWPCOMCart( serverResponse );
@@ -181,7 +180,6 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 				'WPCOM_Billing_Ebanx',
 				'WPCOM_Billing_Web_Payment',
 			],
-			coupon_discounts_integer: [],
 		};
 
 		const clientCart = translateResponseCartToWPCOMCart( serverResponse );
@@ -338,7 +336,6 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 				'WPCOM_Billing_Ebanx',
 				'WPCOM_Billing_Web_Payment',
 			],
-			coupon_discounts_integer: [],
 		};
 
 		const clientCart = translateResponseCartToWPCOMCart( serverResponse );
@@ -421,7 +418,6 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 				'WPCOM_Billing_Web_Payment',
 			],
 			coupon: 'fakecoupon',
-			coupon_discounts_integer: { 1009: 1700 },
 			is_coupon_applied: true,
 		};
 

--- a/client/my-sites/checkout/src/test/util/index.ts
+++ b/client/my-sites/checkout/src/test/util/index.ts
@@ -468,7 +468,6 @@ export function mockSetCartEndpointWith( { currency, locale } ): SetCart {
 			cart_generated_at_timestamp: 12345,
 			cart_key: 1234,
 			coupon: requestCoupon,
-			coupon_discounts_integer: [],
 			coupon_savings_total_integer: requestCoupon ? 1000 : 0,
 			credits_integer: 0,
 			currency,
@@ -1348,7 +1347,6 @@ export function getBasicCart(): ResponseCart {
 		total_tax_integer: 700,
 		total_cost_integer: 15600,
 		sub_total_integer: 15600,
-		coupon_discounts_integer: [],
 	};
 }
 

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -263,8 +263,6 @@ export interface Cart {
 	blog_id: number;
 	cart_key: number;
 	coupon: string;
-	coupon_discounts: unknown[];
-	coupon_discounts_integer: unknown[];
 	is_coupon_applied: boolean;
 	next_domain_is_free: boolean;
 	next_domain_condition: string;

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -19,7 +19,6 @@ export function getEmptyResponseCart(): ResponseCart {
 		allowed_payment_methods: [],
 		coupon: '',
 		is_coupon_applied: false,
-		coupon_discounts_integer: [],
 		locale: 'en-us',
 		tax: { location: {}, display_taxes: false },
 		is_signup: false,

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -298,7 +298,6 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	allowed_payment_methods: string[];
 	coupon: string;
 	is_coupon_applied: boolean;
-	coupon_discounts_integer: number[];
 	locale: string;
 	is_signup: boolean;
 	messages?: ResponseCartMessages;

--- a/packages/shopping-cart/test/shopping-cart-endpoint.js
+++ b/packages/shopping-cart/test/shopping-cart-endpoint.js
@@ -22,7 +22,6 @@ const cart = {
 	allowed_payment_methods: [],
 	coupon: '',
 	is_coupon_applied: false,
-	coupon_discounts_integer: [],
 	locale: 'en-us',
 	tax: {
 		location: {},


### PR DESCRIPTION
## Proposed Changes

This removes the `coupon_discounts` and associated properties from the shopping cart types. They are unused and are expensive to calculate so we are removing them from the endpoint in D133673-code.

## Testing Instructions

Verify automated tests pass.