### PR TITLE
Add Tracks events e2e tests

### DIFF
--- a/packages/calypso-e2e/src/lib/utils/index.ts
+++ b/packages/calypso-e2e/src/lib/utils/index.ts
@@ -6,5 +6,8 @@ export * from './translate';
 // Other items are exported for unit testing, we only care about the manager class.
 export { EditorTracksEventManager } from './editor-tracks-event-manager';
 
+// Generic functions for testing Tracks events
+export { TracksEventManager } from './tracks-event-manager';
+
 /* Types */
 export * from './types';

--- a/packages/calypso-e2e/src/lib/utils/tracks-event-manager.ts
+++ b/packages/calypso-e2e/src/lib/utils/tracks-event-manager.ts
@@ -99,7 +99,7 @@ export class TracksEventManager {
 	 */
 	blockUnnecessaryRequests() {
 		// Only allow specific requests needed for tests
-		// We're specific not allowing the t.gif requests. We only need the request URL.
+		// We're explicitly not allowing t.gif requests. We only need the request URL.
 		const urlContainsAllowList = [
 			'https://wordpress.com',
 			'public-api.wordpress.com',

--- a/packages/calypso-e2e/src/lib/utils/tracks-event-manager.ts
+++ b/packages/calypso-e2e/src/lib/utils/tracks-event-manager.ts
@@ -1,0 +1,108 @@
+import { Page, Request } from 'playwright';
+
+/**
+ * A class to help monitor Tracks events in the browser
+ */
+export class TracksEventManager {
+	private page: Page;
+	private timeout: number;
+
+	/**
+	 * Construct an instance of the Tracks event class
+	 * @param page
+	 * @param timeout
+	 */
+	constructor( page: Page, timeout: number = 10000 ) {
+		this.page = page;
+		this.timeout = timeout;
+		this.blockUnnecessaryRequests();
+	}
+
+	/**
+	 * Navigate to a URL
+	 * @param url
+	 */
+	async navigateToUrl( url: string ) {
+		try {
+			await this.page.goto( url, { timeout: this.timeout } );
+		} catch ( error ) {
+			console.error( error );
+		}
+	}
+
+	/**
+	 * Check if a Tracks event fired
+	 * @param eventName
+	 * @returns
+	 */
+	async didEventFire( eventName: string ) {
+		return !! ( await this.getRequestUrlForEvent( eventName ) );
+	}
+
+	/**
+	 * Get the request URL of a Tracks event
+	 * @param eventName
+	 * @returns
+	 */
+	async getRequestUrlForEvent( eventName: string ): Promise< string > {
+		const pixelUrl: string = 'https://pixel.wp.com/t.gif';
+		return new Promise( ( resolve ) => {
+			const timeoutId = setTimeout( () => {
+				resolve( '' );
+			}, this.timeout );
+
+			const handler = ( request: Request ) => {
+				if (
+					request.url().startsWith( pixelUrl ) &&
+					this.getParamFromUrl( '_en', request.url() ) === eventName
+				) {
+					this.page.removeListener( 'request', handler );
+					clearTimeout( timeoutId );
+					resolve( request.url() );
+				}
+			};
+
+			this.page.on( 'request', handler );
+		} );
+	}
+
+	/**
+	 * Get a parameter value from a URL
+	 * @param param
+	 * @param url
+	 * @returns
+	 */
+	getParamFromUrl( param: string, url: string ): string {
+		const urlObj = new URL( url );
+		return urlObj.searchParams.get( param ) as string;
+	}
+
+	/**
+	 * Block unnecessary network requests
+	 */
+	blockUnnecessaryRequests() {
+		// Only allow specific requests needed for tests
+		// We're specific not allowing the t.gif requests. We only need the request URL.
+		const urlContainsAllowList = [
+			'https://wordpress.com',
+			'public-api.wordpress.com',
+			's0.wp.com',
+			's1.wp.com',
+			's2.wp.com',
+			'a8c-analytics.js',
+			'/w.js',
+			'fonts.googleapis.com',
+			'.min.css',
+		];
+
+		this.page.route( '**/*', ( route, request ) => {
+			if (
+				urlContainsAllowList.some( ( allowedString ) => request.url().includes( allowedString ) )
+			) {
+				route.continue();
+			} else {
+				route.abort();
+			}
+		} );
+	}
+}

--- a/packages/calypso-e2e/src/lib/utils/tracks-event-manager.ts
+++ b/packages/calypso-e2e/src/lib/utils/tracks-event-manager.ts
@@ -1,5 +1,12 @@
 import { Page, Request } from 'playwright';
 
+// Modify global Window interface to include _tkAllowE2ETests
+declare global {
+	interface Window {
+		_tkAllowE2ETests: boolean;
+	}
+}
+
 /**
  * A class to help monitor Tracks events in the browser
  */
@@ -8,7 +15,7 @@ export class TracksEventManager {
 	private timeout: number;
 
 	/**
-	 * Construct an instance of the Tracks event class
+	 * Construct an instance of the Tracks event manager class
 	 * @param page
 	 * @param timeout
 	 */
@@ -16,6 +23,16 @@ export class TracksEventManager {
 		this.page = page;
 		this.timeout = timeout;
 		this.blockUnnecessaryRequests();
+	}
+
+	/**
+	 * Tell Tracks to allow these tests to fire events
+	 * We later abort any requests to t.gif
+	 */
+	async allowTestsToFireEvents() {
+		await this.page.addInitScript( () => {
+			window._tkAllowE2ETests = true;
+		} );
 	}
 
 	/**

--- a/test/e2e/specs/tracks/tracks__lohp-to-signup-events.ts
+++ b/test/e2e/specs/tracks/tracks__lohp-to-signup-events.ts
@@ -15,7 +15,7 @@ describe( DataHelper.createSuiteTitle( 'Verify Tracks events starting at LOHP' )
 	beforeEach( async () => {
 		page = await browser.newPage();
 		tracksEventManager = new TracksEventManager( page );
-		tracksEventManager.allowTestsToFireEvents();
+		tracksEventManager.init();
 	} );
 
 	afterEach( async () => {

--- a/test/e2e/specs/tracks/tracks__lohp-to-signup-events.ts
+++ b/test/e2e/specs/tracks/tracks__lohp-to-signup-events.ts
@@ -1,0 +1,89 @@
+/**
+ * TODO: decide on group - maybe once a day rather than per PR or release?
+ * @group calypso-release
+ */
+
+import { DataHelper, TracksEventManager } from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Verify Tracks events starting at LOHP' ), function () {
+	let page: Page;
+	let tracksEventManager: TracksEventManager;
+	const lohpUrl: string = 'https://wordpress.com/?flags=a8c-analytics.on';
+
+	beforeEach( async () => {
+		page = await browser.newPage();
+		tracksEventManager = new TracksEventManager( page );
+	} );
+
+	afterEach( async () => {
+		await page.close();
+	} );
+
+	it( 'Loading LOHP fires wpcom_page_view event', async function () {
+		// Set up listener for wpcom_page_view event
+		const didEventFirePromise = tracksEventManager.didEventFire( 'wpcom_page_view' );
+
+		// Navigate to LOHP
+		await tracksEventManager.navigateToUrl( lohpUrl );
+
+		// Expect the event to fire
+		expect( await didEventFirePromise ).toBe( true );
+	} );
+
+	it( 'Clicking link on LOHP fires wpcom_link_click', async function () {
+		// Navigate to LOHP
+		await tracksEventManager.navigateToUrl( lohpUrl );
+
+		// Set up listener for wpcom_link_click event
+		const didEventFirePromise = tracksEventManager.didEventFire( 'wpcom_link_click' );
+
+		// Click first signup link to go to signup page
+		await page.click( 'a[href*="https://wordpress.com/start"]' );
+
+		// Expect the event to fire
+		expect( await didEventFirePromise ).toBe( true );
+	} );
+
+	it( 'Anon ids in page view events match when navigating from LOHP to Calypso signup', async function () {
+		// Set up listener for wpcom_page_view event
+		let requestUrlPromise = tracksEventManager.getRequestUrlForEvent( 'wpcom_page_view' );
+
+		// Navigate to LOHP
+		await tracksEventManager.navigateToUrl( lohpUrl );
+
+		// Get anon id from wpcom_page_view event
+		let requestUrl = await requestUrlPromise;
+		const anonIdFromWpcomPageView = tracksEventManager.getParamFromUrl( '_ui', requestUrl );
+
+		// Set up listener for calypso_page_view event
+		requestUrlPromise = tracksEventManager.getRequestUrlForEvent( 'calypso_page_view' );
+
+		// Click first signup link to go to signup page
+		await page.click( 'a[href*="https://wordpress.com/start"]' );
+		requestUrl = await requestUrlPromise;
+
+		const anonIdFromCalypsoPageView = tracksEventManager.getParamFromUrl( '_ui', requestUrl );
+
+		// Expect anon ids in wpcom and calypso page view events to match
+		expect( anonIdFromCalypsoPageView ).toBe( anonIdFromWpcomPageView );
+	} );
+
+	/**
+	 * Used to test the timeout
+	 * Leaving commented out for now to not slow down tests
+	 */
+	// eslint-disable-next-line jest/no-commented-out-tests
+	// it( 'Bad event does not fire when loading LOHP', async function () {
+	// 	// Set up listener for wpcom_page_view event
+	// 	const didEventFirePromise = tracksEventManager.didEventFire( 'bad_event_name_abcde12345' );
+
+	// 	// Navigate to LOHP
+	// 	await tracksEventManager.navigateToUrl( lohpUrl );
+
+	// 	// Expect the event to fire
+	// 	expect( await didEventFirePromise ).toBe( false );
+	// } );
+} );

--- a/test/e2e/specs/tracks/tracks__lohp-to-signup-events.ts
+++ b/test/e2e/specs/tracks/tracks__lohp-to-signup-events.ts
@@ -41,7 +41,7 @@ describe( DataHelper.createSuiteTitle( 'Verify Tracks events starting at LOHP' )
 		const didEventFirePromise = tracksEventManager.didEventFire( 'wpcom_link_click' );
 
 		// Click first signup link to go to signup page
-		await page.click( 'a[href*="https://wordpress.com/start"]' );
+		await page.locator( 'a[href^="https://wordpress.com/start"]' ).first().click();
 
 		// Expect the event to fire
 		expect( await didEventFirePromise ).toBe( true );
@@ -62,7 +62,7 @@ describe( DataHelper.createSuiteTitle( 'Verify Tracks events starting at LOHP' )
 		requestUrlPromise = tracksEventManager.getRequestUrlForEvent( 'calypso_page_view' );
 
 		// Click first signup link to go to signup page
-		await page.click( 'a[href*="https://wordpress.com/start"]' );
+		await page.locator( 'a[href^="https://wordpress.com/start"]' ).first().click();
 		requestUrl = await requestUrlPromise;
 
 		// Expect anon ids in wpcom and calypso page view events to match
@@ -71,20 +71,4 @@ describe( DataHelper.createSuiteTitle( 'Verify Tracks events starting at LOHP' )
 			anonIdFromWpcomPageView
 		);
 	} );
-
-	/**
-	 * Used to test the timeout
-	 * Leaving commented out for now to not slow down tests
-	 */
-	// eslint-disable-next-line jest/no-commented-out-tests
-	// it( 'Bad event does not fire when loading LOHP', async function () {
-	// 	// Set up listener for wpcom_page_view event
-	// 	const didEventFirePromise = tracksEventManager.didEventFire( 'bad_event_name_abcde12345' );
-
-	// 	// Navigate to LOHP
-	// 	await tracksEventManager.navigateToUrl( lohpUrl );
-
-	// 	// Expect the event to fire
-	// 	expect( await didEventFirePromise ).toBe( false );
-	// } );
 } );

--- a/test/e2e/specs/tracks/tracks__lohp-to-signup-events.ts
+++ b/test/e2e/specs/tracks/tracks__lohp-to-signup-events.ts
@@ -1,5 +1,4 @@
 /**
- * TODO: decide on group - maybe once a day rather than per PR or release?
  * @group calypso-release
  */
 

--- a/test/e2e/specs/tracks/tracks__lohp-to-signup-events.ts
+++ b/test/e2e/specs/tracks/tracks__lohp-to-signup-events.ts
@@ -16,6 +16,7 @@ describe( DataHelper.createSuiteTitle( 'Verify Tracks events starting at LOHP' )
 	beforeEach( async () => {
 		page = await browser.newPage();
 		tracksEventManager = new TracksEventManager( page );
+		tracksEventManager.allowTestsToFireEvents();
 	} );
 
 	afterEach( async () => {

--- a/test/e2e/specs/tracks/tracks__lohp-to-signup-events.ts
+++ b/test/e2e/specs/tracks/tracks__lohp-to-signup-events.ts
@@ -66,10 +66,11 @@ describe( DataHelper.createSuiteTitle( 'Verify Tracks events starting at LOHP' )
 		await page.click( 'a[href*="https://wordpress.com/start"]' );
 		requestUrl = await requestUrlPromise;
 
-		const anonIdFromCalypsoPageView = tracksEventManager.getParamFromUrl( '_ui', requestUrl );
-
 		// Expect anon ids in wpcom and calypso page view events to match
-		expect( anonIdFromCalypsoPageView ).toBe( anonIdFromWpcomPageView );
+		expect( tracksEventManager.getParamFromUrl( '_en', requestUrl ) ).toBe( 'calypso_page_view' );
+		expect( tracksEventManager.getParamFromUrl( '_ui', requestUrl ) ).toBe(
+			anonIdFromWpcomPageView
+		);
 	} );
 
 	/**


### PR DESCRIPTION
This adds a few end-to-end tests to test that specific Tracks events are fired at specific times, and with specific properties. It's a start that we can continue to expand on.

The need came up when uncovering an issue where the anon user id event property (`_ui`) was different between events where it should have matched. This caused sessions to get reset resulting in bad analytics data (details: p4qSXL-6TT-p2#comment-20998). Hopefully with tests like these we can more quickly catch issues like this in the future.

For this to work, a small change to the Tracks library is needed (Automattic/analytics#73).

Note: I did investigate refactoring [editor-tracks-event-manager.ts](https://github.com/Automattic/wp-calypso/blob/trunk/packages/calypso-e2e/src/lib/utils/editor-tracks-event-manager.ts) to be more generic, but the general approach used there won't work in this case. It inspects a `window._e2eEventsStack` variable to check for events, which won't include the properties added by Tracks itself, such as `_ui`.

## Proposed Changes

* Add a few e2e tests to check that appropriate Tracks events fire at certain times.
* Add a generic class and methods for inspecting Tracks event requests.

## Testing Instructions


#### ~~Setup~~
* ~~Sandbox `stats.wp.com`~~
* ~~If not done already, ssh into your wpcom sandbox to ensure nginx is running.~~

#### ~~Get changes to Tracks library~~ (updates to w.js have been shipped)
* ~~If you don't have it already, clone the Automattic analytics repo.~~
* ~~Checkout the branch needed to test this: Automattic/analytics#73~~
* ~~From that branch in the analytics repo, sync the changes from `tracks.js` to `w.js` on your wpcom sandbox.~~
  * ~~_note: you need an older version of Node. `v16.20.2` works for me._~~
  * ~~_change `wpcomsandbox` to whatever host you have defined in your hosts file pointing to your sandbox_~~
```
    npm run build && scp dist/w.js wpcomsandbox:/home/wpcom/public_html/stats.dir/
```


#### Test this branch
* If not done already, set up the Calypso e2e testing environment (see the [quick start](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e#quick-start)). More docs in [/docs](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e/docs).
* Run tests (from wp-calypso repo root)
```
yarn workspace wp-e2e-tests test -- test/e2e/specs/tracks/tracks__lohp-to-signup-events.ts
```
* Make sure all 3 tests pass
  <img width="934" alt="Screenshot 2024-01-05 at 1 11 06 PM" src="https://github.com/Automattic/wp-calypso/assets/690843/17f2a317-c287-478d-ae06-89a08ab57261">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?