### PR TITLE
Migration flow: Fix migrate ready render twice issue

### DIFF
--- a/client/blocks/importer/hooks/use-site-credentials-info.ts
+++ b/client/blocks/importer/hooks/use-site-credentials-info.ts
@@ -1,6 +1,7 @@
 import { useSelector } from 'react-redux';
 import { FormState } from 'calypso/components/advanced-credentials/form';
 import getJetpackCredentials from 'calypso/state/selectors/get-jetpack-credentials';
+import getSiteCredentialsRequestStatus from 'calypso/state/selectors/get-site-credentials-request-status';
 import isRequestingSiteCredentials from 'calypso/state/selectors/is-requesting-site-credentials';
 import { SiteId } from 'calypso/types';
 
@@ -13,10 +14,15 @@ export function useSiteCredentialsInfo( siteId?: SiteId ) {
 	const isRequesting = useSelector( ( state ) =>
 		isRequestingSiteCredentials( state, siteId || 0 )
 	);
+	const siteStatus = useSelector( ( state ) =>
+		getSiteCredentialsRequestStatus( state, siteId || 0 )
+	);
+	const hasLoaded = siteStatus === 'success';
 
 	return {
 		credentials,
 		hasCredentials,
 		isRequesting,
+		hasLoaded,
 	};
 }

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -103,8 +103,11 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		},
 	} );
 
-	const { hasCredentials, isRequesting: isFetchingCredentials } =
-		useSiteCredentialsInfo( sourceSiteId );
+	const {
+		hasCredentials,
+		isRequesting: isFetchingCredentials,
+		hasLoaded: hasCredentialLoaded,
+	} = useSiteCredentialsInfo( sourceSiteId );
 
 	const onUpgradeAndMigrateClick = () => {
 		fetchMigrationEnabledStatus();
@@ -170,7 +173,7 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 			setRenderState( 'upgrade-plan' );
 		} else if ( showCredentials ) {
 			setRenderState( 'credentials' );
-		} else if ( isFetchingCredentials || isFetchingMigrationData ) {
+		} else if ( ! hasCredentialLoaded || isFetchingCredentials || isFetchingMigrationData ) {
 			setRenderState( 'loading' );
 		} else if ( ! sourceSiteId ) {
 			setRenderState( 'not-authorized' );

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/test/index.test.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/test/index.test.tsx
@@ -11,6 +11,7 @@ import { createReduxStore } from 'calypso/state';
 import { getInitialState, getStateFromCache } from 'calypso/state/initial-state';
 import initialReducer from 'calypso/state/reducer';
 import { setStore } from 'calypso/state/redux-store';
+import getSiteCredentialsRequestStatus from 'calypso/state/selectors/get-site-credentials-request-status';
 import getUserSetting from 'calypso/state/selectors/get-user-setting';
 import isRequestingSiteCredentials from 'calypso/state/selectors/is-requesting-site-credentials';
 import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
@@ -52,6 +53,7 @@ jest.mock( 'calypso/state/selectors/get-jetpack-credentials' );
 jest.mock( 'calypso/data/plans/use-check-eligibility-migration-trial-plan' );
 jest.mock( 'calypso/state/user-settings/selectors' );
 jest.mock( 'calypso/state/selectors/get-user-setting' );
+jest.mock( 'calypso/state/selectors/get-site-credentials-request-status' );
 
 function renderPreMigrationScreen( props?: any ) {
 	const initialState = getInitialState( initialReducer, user.ID );
@@ -192,6 +194,10 @@ describe( 'PreMigration', () => {
 			isInitFetchingDone: true,
 		} );
 
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		getSiteCredentialsRequestStatus.mockReturnValue( 'success' );
+
 		renderPreMigrationScreen( {
 			sourceSite: sourceSite,
 			targetSite: targetSite,
@@ -199,6 +205,7 @@ describe( 'PreMigration', () => {
 			isMigrateFromWp: true,
 			onContentOnlyClick,
 		} );
+
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		isRequestingSiteCredentials.mockReturnValue( false );
@@ -244,6 +251,10 @@ describe( 'PreMigration', () => {
 			siteCanMigrate: true,
 			isInitFetchingDone: true,
 		} );
+
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		getSiteCredentialsRequestStatus.mockReturnValue( 'success' );
 
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86026

## Proposed Changes

* Instead of checking `isFetchingCredentials` for loading state only, we also add a new variable to check if credential is loaded, so we won't have state changing between ready and fetching credentials.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open your browser developer tool and type `localStorage.setItem('debug', 'calypso:analytics');` in console.
* Make sure you see events outputting in the console.
* Navigate to http://calypso.localhost:3000/setup/import-focused/import?siteSlug=SITE_SLUG
* Go through migration flow with various conditions like using a simple site or atomic site
* Make sure the migration ready screen event don't gets triggered twice.
* Other behavior should stays the same.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?