### PR TITLE
Remove flag unified-pages/virtual-home-page

### DIFF
--- a/client/my-sites/pages/page-list.jsx
+++ b/client/my-sites/pages/page-list.jsx
@@ -191,9 +191,8 @@ class Pages extends Component {
 		const { search, status } = this.props.query;
 
 		return (
-			( ! config.isEnabled( 'unified-pages/virtual-home-page' ) ||
-				/** Blog posts page is for themes that don't support FSE */
-				! isFSEActive ) &&
+			/** Blog posts page is for themes that don't support FSE */
+			! isFSEActive &&
 			site &&
 			( homepageType === 'posts' || ( homepageType === 'page' && ! homepageId ) ) &&
 			/** Under the "Published" tab */
@@ -212,7 +211,6 @@ class Pages extends Component {
 		const { search, status } = this.props.query;
 
 		return (
-			config.isEnabled( 'unified-pages/virtual-home-page' ) &&
 			/** Virtual homepage is for themes that support FSE */
 			isFSEActive &&
 			site &&

--- a/config/development.json
+++ b/config/development.json
@@ -220,7 +220,6 @@
 		"themes/assembler-first": true,
 		"themes/tiers": true,
 		"titan/iframe-control-panel": false,
-		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -154,7 +154,6 @@
 		"themes/text-search-lots": true,
 		"themes/assembler-first": true,
 		"themes/tiers": false,
-		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/production.json
+++ b/config/production.json
@@ -184,7 +184,6 @@
 		"themes/text-search-lots": true,
 		"themes/assembler-first": true,
 		"themes/tiers": false,
-		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -178,7 +178,6 @@
 		"themes/text-search-lots": true,
 		"themes/assembler-first": true,
 		"themes/tiers": false,
-		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -186,7 +186,6 @@
 		"themes/text-search-lots": true,
 		"themes/assembler-first": true,
 		"themes/tiers": false,
-		"unified-pages/virtual-home-page": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR removes the flag `unified-pages/virtual-home-page` and its references since it's been enabled in all environments for a while.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/pages`.
* Ensure that the Virtual Homepage is still displayed for block themes.
* Ensure that there are no JavaScript errors.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?