### PR TITLE
Jetpack Manage: Add track events for the user feedback modal form.

### DIFF
--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -75,9 +75,10 @@ const JetpackCloudSidebar = ( {
 
 	const [ showUserFeedbackForm, setShowUserFeedbackForm ] = useState( shouldShowUserFeedbackForm );
 
-	const onShowUserFeedbackForm = useCallback( () => {
+	const onShareProductFeedback = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_sidebar_share_product_feedback_click' ) );
 		setShowUserFeedbackForm( true );
-	}, [] );
+	}, [ dispatch ] );
 
 	const onCloseUserFeedbackForm = useCallback( () => {
 		// Remove any hash from the URL.
@@ -153,7 +154,7 @@ const JetpackCloudSidebar = ( {
 							link={ USER_FEEDBACK_FORM_URL_HASH }
 							path=""
 							icon={ <Icon icon={ starEmpty } /> }
-							onClickMenuItem={ onShowUserFeedbackForm }
+							onClickMenuItem={ onShareProductFeedback }
 						/>
 					) }
 				</ul>

--- a/client/jetpack-cloud/components/user-feedback-modal-form/index.tsx
+++ b/client/jetpack-cloud/components/user-feedback-modal-form/index.tsx
@@ -7,6 +7,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextarea from 'calypso/components/forms/form-textarea';
 import ReviewsRatingsStars from 'calypso/components/reviews-rating-stars/reviews-ratings-stars';
 import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { successNotice } from 'calypso/state/notices/actions';
 import useSubmitProductFeedback from './use-submit-product-feedback';
 
@@ -34,7 +35,9 @@ export default function UserFeedbackModalForm( { show, onClose }: Props ) {
 		setFeedback( DEFAULT_FEEDBACK_VALUE );
 		setRating( DEFAULT_RATING_VALUE );
 		onClose?.();
-	}, [ onClose ] );
+
+		dispatch( recordTracksEvent( 'calypso_jetpack_user_feedback_form_close' ) );
+	}, [ dispatch, onClose ] );
 
 	useEffect( () => {
 		if ( isSubmissionSuccessful ) {
@@ -52,9 +55,13 @@ export default function UserFeedbackModalForm( { show, onClose }: Props ) {
 		setFeedback( event.currentTarget.value );
 	}, [] );
 
-	const onRatingChange = useCallback( ( rating: number ) => {
-		setRating( rating );
-	}, [] );
+	const onRatingChange = useCallback(
+		( rating: number ) => {
+			dispatch( recordTracksEvent( 'calypso_jetpack_user_feedback_form_rating_click' ) );
+			setRating( rating );
+		},
+		[ dispatch ]
+	);
 
 	const hasCompletedForm = !! feedback && !! rating;
 
@@ -62,9 +69,23 @@ export default function UserFeedbackModalForm( { show, onClose }: Props ) {
 		if ( ! hasCompletedForm ) {
 			return;
 		}
+
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_user_feedback_form_submit', {
+				rating,
+				feedback,
+			} )
+		);
+
 		const sourceUrl = `${ window.location.origin }${ window.location.pathname }`;
 		submitFeedback( { feedback, rating, source_url: sourceUrl } );
-	}, [ feedback, hasCompletedForm, rating, submitFeedback ] );
+	}, [ dispatch, feedback, hasCompletedForm, rating, submitFeedback ] );
+
+	useEffect( () => {
+		if ( show ) {
+			dispatch( recordTracksEvent( 'calypso_jetpack_user_feedback_form_open' ) );
+		}
+	}, [ dispatch, show ] );
 
 	if ( ! show ) {
 		return null;
@@ -106,6 +127,9 @@ export default function UserFeedbackModalForm( { show, onClose }: Props ) {
 						placeholder="Add your feedback here"
 						value={ feedback }
 						onChange={ onFeedbackChange }
+						onClick={ () =>
+							dispatch( recordTracksEvent( 'calypso_jetpack_user_feedback_form_textarea_click' ) )
+						}
 					/>
 				</FormFieldset>
 


### PR DESCRIPTION
This pull request includes the addition of tracking events to the recently introduced user feedback form.

Closes https://github.com/Automattic/jetpack-genesis/issues/159

## Proposed Changes

* Add track event when clicking the 'Share product feedback' button in the sidebar.
* Add track event when opening or closing the 'User feedback' form modal.
* Add track event when clicking the Textarea and Rating component in the form.
* Add track event when submitting User feedback.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

### How to check if tracking is triggered?

In your browser's developer tool, go to the network tab and filter all requests with .gif. Note that the image below uses a Chrome browser. Please look for the equivalent function with your browser.

<img src="https://private-user-images.githubusercontent.com/56598660/290441252-99f399f8-c5a3-42ef-adf5-921aee28d100.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDQ0MzM0ODEsIm5iZiI6MTcwNDQzMzE4MSwicGF0aCI6Ii81NjU5ODY2MC8yOTA0NDEyNTItOTlmMzk5ZjgtYzVhMy00MmVmLWFkZjUtOTIxYWVlMjhkMTAwLnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDAxMDUlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwMTA1VDA1Mzk0MVomWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPTkyZjEwYzAzNDJkYjY2NjRmOTFjOTRiNmQ5NTU2NzZlZTJmZDAxY2U0NWFmM2Y4YTg4YTY4NGViNzM4ZGJhMmQmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0JmFjdG9yX2lkPTAma2V5X2lkPTAmcmVwb19pZD0wIn0.NgbkYw9ufMBQmck61a96QIyw6SJIImyL8q873v_ESy8" />

### Test Areas
**Sidebar**
* Use the Jetpack cloud live link below and go to the Dashboard page (`/dashboard?flags=jetpack/user-feedback-form`)
* In the sidebar, click the 'Share product feedback' button and confirm **calypso_jetpack_sidebar_share_product_feedback_click** event is triggered.
<img width="279" alt="Screen Shot 2024-01-05 at 1 44 02 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/a63e7fd3-4d69-40d9-8b36-7b7e7f983eaa">

**Modal**
<img width="851" alt="Screen Shot 2024-01-05 at 1 46 50 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/365678ab-9563-45de-8d3b-623210af860e">

1. When opening the modal, confirm that the **calypso_jetpack_user_feedback_form_open** event is triggered.
2. When closing the modal, confirm that the **calypso_jetpack_user_feedback_form_close** event is triggered.
3. When clicking the textarea, confirm that the **calypso_jetpack_user_feedback_form_textarea_click** event is triggered.
4. When clicking the rating, confirm that the **calypso_jetpack_user_feedback_form_rating_click** event is triggered.
5. When submitting the form, confirm that **calypso_jetpack_user_feedback_form_submit** event is triggered with **rating** and **feedback** parameters.




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?