### PR TITLE
Stats: Grammar fixes in benefits listing

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -63,9 +63,9 @@ const StatsBenefitsCommercial = () => {
 		<div className={ `${ COMPONENT_CLASS_NAME }__benefits` }>
 			<ul className={ `${ COMPONENT_CLASS_NAME }__benefits--included` }>
 				<li>{ translate( 'Real-time data on visitors' ) }</li>
-				<li>{ translate( 'Traffic stats and trends for post and pages' ) }</li>
+				<li>{ translate( 'Traffic stats and trends for posts and pages' ) }</li>
 				<li>{ translate( 'Detailed statistics about links leading to your site' ) }</li>
-				<li>{ translate( 'GDPR compliant' ) }</li>
+				<li>{ translate( 'GDPR compliance' ) }</li>
 				<li>{ translate( 'Access to upcoming advanced features' ) }</li>
 				<li>{ translate( 'Priority support' ) }</li>
 				<li>{ translate( 'Commercial use' ) }</li>
@@ -123,9 +123,9 @@ const StatsBenefitsPersonal = () => {
 		<div className={ `${ COMPONENT_CLASS_NAME }__benefits` }>
 			<ul className={ `${ COMPONENT_CLASS_NAME }__benefits--included` }>
 				<li>{ translate( 'Real-time data on visitors' ) }</li>
-				<li>{ translate( 'Traffic stats and trends for post and pages' ) }</li>
+				<li>{ translate( 'Traffic stats and trends for posts and pages' ) }</li>
 				<li>{ translate( 'Detailed statistics about links leading to your site' ) }</li>
-				<li>{ translate( 'GDPR compliant' ) }</li>
+				<li>{ translate( 'GDPR compliance' ) }</li>
 				<li>{ translate( 'Access to upcoming advanced features' ) }</li>
 				{ /** TODO: check sub price for validation -  will need support added to use-stats-purchases hook */ }
 				<li>{ translate( 'Priority support' ) }</li>
@@ -144,9 +144,9 @@ const StatsBenefitsFree = () => {
 		<div className={ `${ COMPONENT_CLASS_NAME }__benefits` }>
 			<ul className={ `${ COMPONENT_CLASS_NAME }__benefits--included` }>
 				<li>{ translate( 'Real-time data on visitors' ) }</li>
-				<li>{ translate( 'Traffic stats and trends for post and pages' ) }</li>
+				<li>{ translate( 'Traffic stats and trends for posts and pages' ) }</li>
 				<li>{ translate( 'Detailed statistics about links leading to your site' ) }</li>
-				<li>{ translate( 'GDPR compliant' ) }</li>
+				<li>{ translate( 'GDPR compliance' ) }</li>
 			</ul>
 			<ul className={ `${ COMPONENT_CLASS_NAME }__benefits--not-included` }>
 				<li>{ translate( 'No access to upcoming features' ) }</li>

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1223,9 +1223,9 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 	];
 	const statsCommercialIncludesInfo = [
 		translate( 'Real-time data on visitors' ),
-		translate( 'Traffic stats and trends for post and pages' ),
+		translate( 'Traffic stats and trends for posts and pages' ),
 		translate( 'Detailed statistics about links leading to your site' ),
-		translate( 'GDPR compliant' ),
+		translate( 'GDPR compliance' ),
 		translate( 'Access to upcoming advanced features' ),
 		translate( 'Priority support' ),
 		translate( 'Commercial use' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Update two grammar issues in the benefits listing.

* posts and pages
* GDPR compliance

<img width="584" alt="SCR-20240105-mrql" src="https://github.com/Automattic/wp-calypso/assets/40267301/b9c43749-4383-40f7-8e31-5586545b2684">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Visit the commercial upgrade page and confirm the grammar updates are present. URL for testing is:

```
https://wordpress.com/stats/purchase/SITA_SLUG?productType=commercial&flags=stats/type-detection
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?