### PR TITLE
E2E: Update editor-settings-sidebar-component selectors

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -7,9 +7,9 @@ const panel = '[aria-label="Editor settings"]';
 
 const selectors = {
 	// Tab
-	tabButton: ( tabName: EditorSidebarTab ) => `${ panel } button[data-label="${ tabName }"]`,
+	tabButton: ( tabName: EditorSidebarTab ) => `${ panel } button:has-text("${ tabName }")`,
 	activeTabButton: ( tabName: EditorSidebarTab ) =>
-		`${ panel } button.is-active:has-text("${ tabName }")`,
+		`${ panel } button[aria-selected="true"]:has-text("${ tabName }")`,
 
 	// General section-related
 	section: ( name: string ) =>
@@ -115,9 +115,7 @@ export class EditorSettingsSidebarComponent {
 		const locator = editorParent.locator( selectors.tabButton( tabName ) );
 		await locator.click();
 
-		const activeTabLocator = editorParent.locator(
-			`${ selectors.tabButton( tabName ) }.is-active`
-		);
+		const activeTabLocator = editorParent.locator( selectors.activeTabButton( tabName ) );
 		await activeTabLocator.waitFor();
 	}
 


### PR DESCRIPTION
## Proposed Changes

This PR updates the CSS selector for the E2E component `EditorSettingsSidebarComponent` to reflect the latest DOM updates in the Site Editor. There were two changes:

1. The previous selector looked for the attribute `data-label` which is no longer present in the element, so we replace it with `:has-text` instead.

2. The previous selector looked for the class name `.is-active` to locate the active tab which is no longer the case, so we replace it with `[aria-selected="true"]`. Alternatively, we could use `[data-active-item]`.

For reference, this is what the element looks like now:
![Screenshot 2024-01-05 at 3 21 16 PM](https://github.com/Automattic/wp-calypso/assets/797888/b0888469-8444-40ae-bc83-34f58737ef31)

While in 17.3.0:
![Screenshot 2024-01-05 at 3 34 42 PM](https://github.com/Automattic/wp-calypso/assets/797888/0313dcc4-8cad-4ce2-b635-bdd24d2a933a)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Ensure that the E2E tests pass.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?