### PR TITLE
i18n-calypso: Adding additional information about translating emoji within strings

### DIFF
--- a/packages/i18n-calypso/README.md
+++ b/packages/i18n-calypso/README.md
@@ -45,6 +45,8 @@ const translation = i18n.translate( 'Some content to translate' );
 
 Translation strings are extracted from our codebase through a process of [static analysis](http://en.wikipedia.org/wiki/Static_program_analysis) and imported into GlotPress where they are translated ([more on that process here](./cli)). So you must avoid passing a variable, ternary expression, function call, or other form of logic in place of a string value to the `translate` method. The _one_ exception is that you can split a long string into multiple substrings concatenated with the `+` operator.
 
+GlotPress also support emoji being part of the translatable string, as it allows flexibility with positioning when being translated.
+
 ```js
 /*----------------- Bad Examples -----------------*/
 
@@ -69,6 +71,8 @@ const translation4 = i18n.translate(
 		'I know the kings of England, and I quote the fights historical ' +
 		'from Marathon to Waterloo, in order categorical.'
 );
+
+const emoji = 18n.translate( 'Let us celebrate 🎉');
 ```
 
 ### String Substitution

--- a/packages/i18n-calypso/README.md
+++ b/packages/i18n-calypso/README.md
@@ -72,7 +72,7 @@ const translation4 = i18n.translate(
 		'from Marathon to Waterloo, in order categorical.'
 );
 
-const emoji = 18n.translate( 'Let us celebrate 🎉');
+const emoji = i18n.translate( 'Let us celebrate 🎉');
 ```
 
 ### String Substitution


### PR DESCRIPTION
## Proposed Changes

* This PR adds an additional line of text in the readme for the i18n-calypso package as well as an example, clarifying that emoji usage can be added within strings in terms of being supported by GlotPress.

References:
- p1703229258258059/1703212440.075029-slack-C02AED43D
- p1704442235053829-slack-C02AED43D

## Testing Instructions

* Proof-read

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?