### PR TITLE
Allow Paid Stats upsell modal to be dismissed with outside click

### DIFF
--- a/client/my-sites/stats/stats-upsell-modal/index.tsx
+++ b/client/my-sites/stats/stats-upsell-modal/index.tsx
@@ -46,7 +46,6 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 		<Modal
 			className="stats-upsell-modal"
 			onRequestClose={ closeModal }
-			shouldCloseOnClickOutside={ false }
 			__experimentalHideHeader={ true }
 		>
 			<TrackComponentView


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5068
Note: the modal already supports close with esc key

## Proposed Changes

* Allow modal to be dismissed with outside click

https://github.com/Automattic/wp-calypso/assets/6586048/41a2f617-062a-4ac6-a341-02feeb220fb9


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /stats with a new free website
* Click on a stat upgrade button
* Click outside and modal can close
* Test on mobile and desktop

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?