### PR TITLE
Assembler: Use page pattern category as page title

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
@@ -97,7 +97,7 @@ const usePatternPages = (
 	pagesToShow = pageCategoriesInOrder
 		.map( ( category: Category ) => {
 			const { name } = category;
-			const firstPage = name && pagesMapByCategory[ name ][ 0 ];
+			const firstPage = name && pagesMapByCategory[ name ]?.[ 0 ];
 			if ( firstPage ) {
 				return {
 					name,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
@@ -1,6 +1,7 @@
 import { useSearchParams } from 'react-router-dom';
 import { INITIAL_PAGES, ORDERED_PATTERN_PAGES_CATEGORIES } from '../constants';
 import { useCategoriesOrder } from '../hooks';
+import { getPagePatternTitle } from '../utils';
 import type { Pattern, Category, CustomPageTitle } from '../types';
 
 const usePatternPages = (
@@ -82,18 +83,34 @@ const usePatternPages = (
 		pageSlugs = INITIAL_PAGES;
 	}
 
-	pages = pageSlugs.map( ( slug ) => pagesMapByCategory[ slug ]?.[ 0 ] ).filter( Boolean );
+	pages = pageSlugs
+		.map( ( slug ) => {
+			const firstPage = pagesMapByCategory[ slug ]?.[ 0 ];
+			if ( firstPage ) {
+				return {
+					...firstPage,
+					title: getPagePatternTitle( firstPage ),
+				};
+			}
+		} )
+		.filter( Boolean ) as Pattern[];
 
-	pagesToShow = pageCategoriesInOrder.map( ( category: Category ) => {
-		const { name } = category;
-		const hasPages = name && pagesMapByCategory[ name ]?.length;
-		return {
-			name,
-			hasPages,
-			title: hasPages ? pagesMapByCategory[ name ][ 0 ].title : '',
-			isSelected: name ? pageSlugs.includes( name ) : false,
-		};
-	} );
+	pagesToShow = pageCategoriesInOrder
+		.map( ( category: Category ) => {
+			const { name } = category;
+			const hasPages = name && pagesMapByCategory[ name ]?.length;
+			if ( hasPages ) {
+				const firstPage = pagesMapByCategory[ name ][ 0 ];
+				return {
+					name,
+					hasPages,
+					title: getPagePatternTitle( firstPage ),
+					isSelected: pageSlugs.includes( name ),
+				};
+			}
+		} )
+		.filter( Boolean );
+
 	const setPageSlugs = ( slugs: string[] ) => {
 		setSearchParams(
 			( currentSearchParams ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
@@ -52,7 +52,6 @@ const usePatternPages = (
 			}
 			pagesToShow.push( {
 				name: pattern?.name || '',
-				hasPages: true,
 				title: title,
 				isSelected: !! selected,
 			} );
@@ -98,12 +97,10 @@ const usePatternPages = (
 	pagesToShow = pageCategoriesInOrder
 		.map( ( category: Category ) => {
 			const { name } = category;
-			const hasPages = name && pagesMapByCategory[ name ]?.length;
-			if ( hasPages ) {
-				const firstPage = pagesMapByCategory[ name ][ 0 ];
+			const firstPage = name && pagesMapByCategory[ name ][ 0 ];
+			if ( firstPage ) {
 				return {
 					name,
-					hasPages,
 					title: getPagePatternTitle( firstPage ),
 					isSelected: pageSlugs.includes( name ),
 				};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-list.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-list.tsx
@@ -65,10 +65,6 @@ const PageList = ( { pagesToShow, onSelectPage }: PageListProps ) => {
 					<PageListItem label={ translate( 'Homepage' ) } isDisabled />
 				</CompositeItem>
 				{ pagesToShow.map( ( page ) => {
-					if ( ! page.hasPages ) {
-						return null;
-					}
-
 					return (
 						<CompositeItem
 							{ ...composite }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types.ts
@@ -20,6 +20,7 @@ export interface NavigatorLocation {
 
 export type Category = {
 	name?: string;
+	title?: string;
 	slug?: string;
 	label?: string;
 	description?: string;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -34,3 +34,6 @@ export const isPriorityPattern = ( { tags: { assembler_priority } }: Pattern ) =
 
 export const isPagePattern = ( { categories, tags: { assembler_page } }: Pattern ) =>
 	Boolean( isEnabled( 'pattern-assembler/v2' ) ? categories.page : assembler_page );
+
+export const getPagePatternTitle = ( { categories }: Pattern ) =>
+	( Object.values( categories ) as Category[] ).find( ( { slug } ) => 'page' !== slug )?.title;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85288

## Proposed Changes

* Use page pattern category as page title

> [!Warning]
> These changes affect production, Assembler v2, and Assembler AI. The pattern data structure is the same for all, so a feature flag seems unnecessary. Let me know what you think.

|BEFORE|AFTER Production|AFTER Assembler v2|Assembler AI|
|--|--|--|--|
|<img width="1245" alt="Screenshot 2567-01-05 at 16 41 12" src="https://github.com/Automattic/wp-calypso/assets/1881481/de21a86b-6f96-4d36-a5a7-26b1a84f8976">|<img width="1246" alt="Screenshot 2567-01-05 at 16 43 37" src="https://github.com/Automattic/wp-calypso/assets/1881481/420373f8-58db-4935-b9d3-f56848e53806">|<img width="1245" alt="Screenshot 2567-01-05 at 16 39 22" src="https://github.com/Automattic/wp-calypso/assets/1881481/91fe1d41-d2b3-435a-9faf-04326c0bb177">|<img width="1242" alt="Screenshot 2567-01-05 at 16 50 53" src="https://github.com/Automattic/wp-calypso/assets/1881481/d083ff4b-5130-432f-b0e2-d44d95205123">|

## Testing Instructions

**Test Assembler V2**

- Access assembler pages screen: `/setup/with-theme-assembler/pattern-assembler?siteSlug={ SITE }&screen=pages&flags=pattern-assembler/v2`
- Make sure you pass the param `flags=pattern-assembler/v2` in the URL
- Verify the page titles look as expected, **especially the page for "Services"**

**Test Production**
- Repeat the test after removing the flag and refreshing the browser
- Verify the page titles look as expected, **especially the page for "Blog"**

**Test Assembler AI**
- Access `/setup/ai-assembler` select a site, enter a prompt and when on Assembler go to pages
- Verify the page titles look as expected

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?