### PR TITLE
Paid Stats: Release config flag to production

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -131,6 +131,7 @@
 		"stats/date-control": true,
 		"stats/new-video-summary": false,
 		"stats/paid-wpcom-stats": true,
+		"stats/paid-wpcom-v2": true,
 		"stats/plan-usage": true,
 		"stats/tier-upgrade-slider": true,
 		"stats/type-detection": true,

--- a/config/production.json
+++ b/config/production.json
@@ -161,6 +161,7 @@
 		"stats/date-control": true,
 		"stats/new-video-summary": false,
 		"stats/paid-wpcom-stats": true,
+		"stats/paid-wpcom-v2": true,
 		"stats/plan-usage": true,
 		"stats/tier-upgrade-slider": true,
 		"stats/type-detection": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -155,6 +155,7 @@
 		"stats/date-control": true,
 		"stats/new-video-summary": false,
 		"stats/paid-wpcom-stats": true,
+		"stats/paid-wpcom-v2": true,
 		"stats/plan-usage": true,
 		"stats/tier-upgrade-slider": true,
 		"stats/type-detection": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -164,6 +164,7 @@
 		"stats/date-control": true,
 		"stats/new-video-summary": false,
 		"stats/paid-wpcom-stats": true,
+		"stats/paid-wpcom-v2": true,
 		"stats/plan-usage": true,
 		"stats/tier-upgrade-slider": true,
 		"stats/type-detection": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5083

## Proposed Changes

* Release Paid Stats to Production

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?