### PR TITLE
Fix: Ecommerce setup flow does not respect the `recur` query param

### DIFF
--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -50,7 +50,7 @@ function getPlanFromRecurType( recurType: string ) {
 		case ecommerceFlowRecurTypes[ '3Y' ]:
 			return PLAN_ECOMMERCE_3_YEARS;
 		default:
-			return PLAN_ECOMMERCE_MONTHLY;
+			return PLAN_ECOMMERCE;
 	}
 }
 

--- a/client/landing/stepper/hooks/use-save-query-params.ts
+++ b/client/landing/stepper/hooks/use-save-query-params.ts
@@ -1,3 +1,4 @@
+import { ecommerceFlowRecurTypes } from '@automattic/onboarding';
 import { useDispatch } from '@wordpress/data';
 import { ONBOARD_STORE } from '../stores';
 import { useQuery } from './use-query';
@@ -10,7 +11,8 @@ import { useQuery } from './use-query';
  */
 export function useSaveQueryParams() {
 	const urlQueryParams = useQuery();
-	const { setCouponCode, setStorageAddonSlug } = useDispatch( ONBOARD_STORE );
+	const { setCouponCode, setStorageAddonSlug, setEcommerceFlowRecurType } =
+		useDispatch( ONBOARD_STORE );
 	urlQueryParams.forEach( ( value, key ) => {
 		switch ( key ) {
 			case 'coupon':
@@ -25,6 +27,15 @@ export function useSaveQueryParams() {
 				// This stores a storage addon, supplied as a query param by landing pages when
 				// an addon is selected in the pricing grid.
 				value && setStorageAddonSlug( value );
+				break;
+
+			case 'recur':
+				{
+					const isValidRecurType =
+						value && Object.values( ecommerceFlowRecurTypes ).includes( value );
+					const recurType = isValidRecurType ? value : ecommerceFlowRecurTypes.YEARLY;
+					setEcommerceFlowRecurType( recurType );
+				}
 				break;
 		}
 	} );

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -29,6 +29,7 @@ import { AsyncHelpCenter } from './declarative-flow/internals/components';
 import 'calypso/components/environment-badge/style.scss';
 import 'calypso/assets/stylesheets/style.scss';
 import availableFlows from './declarative-flow/registered-flows';
+import { USER_STORE } from './stores';
 import { setupWpDataDebug } from './utils/devtools';
 import { WindowLocaleEffectManager } from './utils/window-locale-effect-manager';
 import type { Flow } from './declarative-flow/internals/types';

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -4,7 +4,6 @@ import { initializeAnalytics } from '@automattic/calypso-analytics';
 import { CurrentUser } from '@automattic/calypso-analytics/dist/types/utils/current-user';
 import config from '@automattic/calypso-config';
 import { User as UserStore } from '@automattic/data-stores';
-import { ECOMMERCE_FLOW, ecommerceFlowRecurTypes } from '@automattic/onboarding';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
 import defaultCalypsoI18n from 'i18n-calypso';
@@ -30,8 +29,6 @@ import { AsyncHelpCenter } from './declarative-flow/internals/components';
 import 'calypso/components/environment-badge/style.scss';
 import 'calypso/assets/stylesheets/style.scss';
 import availableFlows from './declarative-flow/registered-flows';
-import { useQuery } from './hooks/use-query';
-import { ONBOARD_STORE, USER_STORE } from './stores';
 import { setupWpDataDebug } from './utils/devtools';
 import { WindowLocaleEffectManager } from './utils/window-locale-effect-manager';
 import type { Flow } from './declarative-flow/internals/types';
@@ -57,20 +54,6 @@ const FlowSwitch: React.FC< { user: UserStore.CurrentUser | undefined; flow: Flo
 	flow,
 } ) => {
 	const { receiveCurrentUser } = useDispatch( USER_STORE );
-	const { setEcommerceFlowRecurType } = useDispatch( ONBOARD_STORE );
-
-	const recurType = useQuery().get( 'recur' );
-
-	if ( flow.name === ECOMMERCE_FLOW ) {
-		const isValidRecurType =
-			recurType && Object.values( ecommerceFlowRecurTypes ).includes( recurType );
-		if ( isValidRecurType ) {
-			setEcommerceFlowRecurType( recurType );
-		} else {
-			setEcommerceFlowRecurType( ecommerceFlowRecurTypes.YEARLY );
-		}
-	}
-
 	user && receiveCurrentUser( user as UserStore.CurrentUser );
 
 	return <FlowRenderer flow={ flow } />;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This fixes the issue that `/setup/ecommerce/?recur=monthly` adds the yearly ecommerce plan to cart instead of the monthly plan.
* To reproduce the issue, visit the LOHP and click on "Commerce" in the [tailored flow section](https://d.pr/i/NmaZno). Proceed through signup to checkout, and notice that the yearly commerce plan is in cart.
* Note that the parent PR is https://github.com/Automattic/wp-calypso/pull/85990. This PR builds on top of the `useSaveQueryParams()` hook introduced in #85990.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/setup/ecommerce/?recur=monthly` and go through the setup flow. At checkout, verify that you have the monthly ecommerce plan in cart.
* Visit `/setup/ecommerce/` and go through the setup flow. Verify that the checkout page has the annual ecommerce plan in cart. 
