### PR TITLE
Themes Cleanup: delete unused dont_change_homepage logic in theme activation

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -605,7 +605,6 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 									themeId ?? '',
 									site?.ID ?? 0,
 									'assembler',
-									false,
 									false
 								) as ThunkAction< PromiseLike< string >, any, any, AnyAction >
 							)

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -377,13 +377,12 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 			Promise.resolve()
 				.then( () =>
 					reduxDispatch(
-						activateOrInstallThenActivate(
-							themeId,
-							site?.ID,
-							'assembler',
-							false,
-							false
-						) as ThunkAction< PromiseLike< string >, any, any, AnyAction >
+						activateOrInstallThenActivate( themeId, site?.ID, 'assembler', false ) as ThunkAction<
+							PromiseLike< string >,
+							any,
+							any,
+							AnyAction
+						>
 					)
 				)
 				.then( ( activeThemeStylesheet: string ) =>

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -164,8 +164,7 @@ export interface CheckoutThankYouConnectedProps {
 		themeId: string,
 		siteId: number,
 		source?: string,
-		purchased?: boolean,
-		keepCurrentHomepage?: boolean
+		purchased?: boolean
 	) => void;
 	requestSite: ( siteId: number ) => void;
 }

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -160,9 +160,7 @@ export const ThankYouThemeSection = ( {
 			return;
 		}
 		sendTrackEvent( 'calypso_theme_thank_you_activate_theme_click' );
-		dispatch(
-			activate( theme.id, siteId, 'marketplace-thank-you', false, false, isOnboardingFlow )
-		);
+		dispatch( activate( theme.id, siteId, 'marketplace-thank-you', false, isOnboardingFlow ) );
 	}, [ theme.id, siteId, isOnboardingFlow, dispatch, isActive, sendTrackEvent ] );
 
 	useEffect( () => {

--- a/client/my-sites/themes/activation-modal.jsx
+++ b/client/my-sites/themes/activation-modal.jsx
@@ -48,18 +48,10 @@ export class ActivationModal extends Component {
 			if ( 'activeTheme' === action ) {
 				this.props.acceptActivationModal( newThemeId );
 
-				/**
-				 * We don't want to keep the current homepage since it's "broken" for now.
-				 * Update this when we find a way to improve the theme switch experience as a whole.
-				 * @see pbxlJb-3Uv-p2
-				 */
-				const keepCurrentHomepage = false;
-
 				recordTracksEvent( 'calypso_theme_autoloading_homepage_modal_activate_click', {
 					theme: newThemeId,
-					keep_current_homepage: keepCurrentHomepage,
 				} );
-				return this.props.activateTheme( newThemeId, siteId, source, false, keepCurrentHomepage );
+				return this.props.activateTheme( newThemeId, siteId, source, false );
 			} else if ( 'dismiss' === action ) {
 				recordTracksEvent( 'calypso_theme_autoloading_homepage_modal_dismiss', {
 					action: 'escape',

--- a/client/state/themes/actions/activate-theme.js
+++ b/client/state/themes/actions/activate-theme.js
@@ -27,16 +27,9 @@ import 'calypso/state/themes/init';
  * @param {number}  siteId             Site ID
  * @param {string}  source             The source that is requesting theme activation, e.g. 'showcase'
  * @param {boolean} purchased          Whether the theme has been purchased prior to activation
- * @param {boolean} dontChangeHomepage Prevent theme from switching homepage content if this is what it'd normally do when activated
  * @returns {Function}                 Action thunk
  */
-export function activateTheme(
-	themeId,
-	siteId,
-	source = 'unknown',
-	purchased = false,
-	dontChangeHomepage = false
-) {
+export function activateTheme( themeId, siteId, source = 'unknown', purchased = false ) {
 	return ( dispatch, getState ) => {
 		const themeOptions = getThemePreviewThemeOptions( getState() );
 		const styleVariationSlug =
@@ -53,7 +46,6 @@ export function activateTheme(
 		return wpcom.req
 			.post( `/sites/${ siteId }/themes/mine?_locale=user`, {
 				theme: themeId,
-				...( dontChangeHomepage && { dont_change_homepage: true } ),
 			} )
 			.then( async ( theme ) => {
 				if ( styleVariationSlug ) {

--- a/client/state/themes/actions/install-and-activate-theme.js
+++ b/client/state/themes/actions/install-and-activate-theme.js
@@ -11,21 +11,14 @@ import 'calypso/state/themes/init';
  * @param {number} siteId    Site ID
  * @param {string} source    The source that is requesting theme activation, e.g. 'showcase'
  * @param {boolean} purchased Whether the theme has been purchased prior to activation
- * @param {boolean} keepCurrentHomepage Prevent theme from switching homepage content if this is what it'd normally do when activated
  * @returns {Function}           Action thunk
  */
-export function installAndActivateTheme(
-	themeId,
-	siteId,
-	source = 'unknown',
-	purchased = false,
-	keepCurrentHomepage = false
-) {
+export function installAndActivateTheme( themeId, siteId, source = 'unknown', purchased = false ) {
 	return ( dispatch ) => {
 		return dispatch( installTheme( themeId, siteId ) ).then( () =>
 			// This will be called even if `installTheme` silently fails. We rely on
 			// `activateTheme`'s own error handling here.
-			dispatch( activateTheme( themeId, siteId, source, purchased, keepCurrentHomepage ) )
+			dispatch( activateTheme( themeId, siteId, source, purchased ) )
 		);
 	};
 }

--- a/client/state/themes/actions/request-then-activate.js
+++ b/client/state/themes/actions/request-then-activate.js
@@ -16,17 +16,10 @@ import { requestTheme, activate } from 'calypso/state/themes/actions';
  * @param  {number}   siteId    Site ID
  * @param  {string}   source    The source that is requesting theme activation, e.g. 'showcase'
  * @param  {boolean}  purchased Whether the theme has been purchased prior to activation
- * @param  {boolean}  keepCurrentHomepage Prevent theme from switching homepage content if this is what it'd normally do when activated
  * @returns {Function}          Action thunk
  */
 
-export function requestThenActivate(
-	themeId,
-	siteId,
-	source = 'unknown',
-	purchased = false,
-	keepCurrentHomepage = false
-) {
+export function requestThenActivate( themeId, siteId, source = 'unknown', purchased = false ) {
 	return ( dispatch, getState ) => {
 		// Request the theme, then when that's done, activate it.
 
@@ -52,7 +45,7 @@ export function requestThenActivate(
 			requests.push( dispatch( requestTheme( themeId, siteId ) ) );
 		}
 		return Promise.all( requests ).then( () => {
-			dispatch( activate( themeId, siteId, source, purchased, keepCurrentHomepage ) );
+			dispatch( activate( themeId, siteId, source, purchased ) );
 		} );
 	};
 }

--- a/client/state/themes/selectors/theme-has-auto-loading-homepage.js
+++ b/client/state/themes/selectors/theme-has-auto-loading-homepage.js
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { includes } from 'lodash';
 import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getTheme } from 'calypso/state/themes/selectors/get-theme';
@@ -14,17 +13,15 @@ import 'calypso/state/themes/init';
  * @returns {boolean} True if the theme has auto loading homepage. Otherwise, False.
  */
 export function themeHasAutoLoadingHomepage( state, themeId, siteId ) {
-	if ( isEnabled( 'themes/atomic-homepage-replace' ) ) {
-		const atomic = isSiteAtomic( state, siteId );
-		const atomicAutoLoading = includes(
-			getThemeTaxonomySlugs( getTheme( state, siteId, themeId ), 'theme_feature' ),
-			'auto-loading-homepage'
-		);
+	const atomic = isSiteAtomic( state, siteId );
+	const atomicAutoLoading = includes(
+		getThemeTaxonomySlugs( getTheme( state, siteId, themeId ), 'theme_feature' ),
+		'auto-loading-homepage'
+	);
 
-		// If the Atomic site has the theme in its library, use that value.
-		if ( atomic && atomicAutoLoading ) {
-			return atomicAutoLoading;
-		}
+	// If the Atomic site has the theme in its library, use that value.
+	if ( atomic && atomicAutoLoading ) {
+		return atomicAutoLoading;
 	}
 
 	// Fall back to the full `wpcom` library.

--- a/config/development.json
+++ b/config/development.json
@@ -210,7 +210,6 @@
 		"subscription-management/comments-list-controls": true,
 		"subscription-management/migrate-subscribers": true,
 		"subscription-management-redirect-following": true,
-		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-bundle": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -145,7 +145,6 @@
 		"subscription-management/comments-list-controls": true,
 		"subscription-management/migrate-subscribers": true,
 		"subscription-management-redirect-following": true,
-		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-bundle": true,

--- a/config/production.json
+++ b/config/production.json
@@ -175,7 +175,6 @@
 		"subscription-management/comments-list-controls": true,
 		"subscription-management/migrate-subscribers": true,
 		"subscription-management-redirect-following": true,
-		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews-premium-and-woo": false,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-bundle": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -169,7 +169,6 @@
 		"subscription-management/comments-list-controls": true,
 		"subscription-management/migrate-subscribers": true,
 		"subscription-management-redirect-following": true,
-		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews-premium-and-woo": false,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-bundle": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -177,7 +177,6 @@
 		"subscription-management-pending-view": true,
 		"subscription-management/comments-list-controls": true,
 		"subscription-management-redirect-following": true,
-		"themes/atomic-homepage-replace": true,
 		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-bundle": true,


### PR DESCRIPTION
## Proposed Changes

We have removed the theme switch modal via https://github.com/Automattic/wp-calypso/pull/77881. This PR cleans up the leftover "`dont_change_homepage`" logic.

## Testing Instructions

1. Patch D133693-code.
1. Try activating themes from Simple, Atomic (non-installed and already-installed), and Jetpack-connected self-hosted sites,  including Partner and WooCommerce themes, and verify that they still work.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?