### PR TITLE
Replace old Plan name in Creator Trial /plans page

### DIFF
--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -362,10 +362,10 @@ class FeaturesGrid extends Component< FeaturesGridProps > {
 				) {
 					buttonText = translate( 'Get Essential', { textOnly: true } );
 				} else if ( isBusinessTrial( currentSitePlanSlug || '' ) ) {
-					buttonText = translate( 'Get %(planTitle)s', {
+					buttonText = translate( 'Get %(plan)s', {
 						textOnly: true,
 						args: {
-							planTitle: getPlan( planSlug )?.getTitle() || '',
+							plan: getPlan( planSlug )?.getTitle() || '',
 						},
 					} );
 				}

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -1,5 +1,6 @@
 import {
 	FEATURE_CUSTOM_DOMAIN,
+	getPlan,
 	getPlanClass,
 	isBusinessTrial,
 	isWooExpressMediumPlan,
@@ -361,7 +362,12 @@ class FeaturesGrid extends Component< FeaturesGridProps > {
 				) {
 					buttonText = translate( 'Get Essential', { textOnly: true } );
 				} else if ( isBusinessTrial( currentSitePlanSlug || '' ) ) {
-					buttonText = translate( 'Get Business', { textOnly: true } );
+					buttonText = translate( 'Get %(planTitle)s', {
+						textOnly: true,
+						args: {
+							planTitle: getPlan( planSlug )?.getTitle() || '',
+						},
+					} );
 				}
 
 				return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This replaces the hardcoded, old `Business` plan with the actual plan name.
<img width="480" alt="Screenshot 2024-01-05 at 12 58 35" src="https://github.com/Automattic/wp-calypso/assets/2749938/1546c63b-dac6-4f0c-a858-170fba9febbf">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Go to /plans on Creator Trial plan
* You should see the `Get Creator` CTA button
<img width="280" alt="Screenshot 2024-01-05 at 13 09 01" src="https://github.com/Automattic/wp-calypso/assets/2749938/ca66fe97-b4e0-4922-a0fa-4130a6429b01">

* The button should be translated
<img width="280" alt="Screenshot 2024-01-05 at 13 08 43" src="https://github.com/Automattic/wp-calypso/assets/2749938/d4e31b7c-cc5e-4dac-adff-db2109cd7592">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
