### PR TITLE
Use separate selectors in TrialBanner to avoid unnecessary updates

### DIFF
--- a/client/my-sites/plans/trials/trial-banner/index.tsx
+++ b/client/my-sites/plans/trials/trial-banner/index.tsx
@@ -22,14 +22,12 @@ const TrialBanner = ( props: TrialBannerProps ) => {
 	const { callToAction, isEcommerceTrial } = props;
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) ) || -1;
 
-	const { currentPlan, trialDaysLeft, trialExpired, trialExpiration } = useSelector(
-		( state ) => ( {
-			currentPlan: getCurrentPlan( state, selectedSiteId ),
-			trialExpired: isTrialExpired( state, selectedSiteId ),
-			trialDaysLeft: Math.floor( getTrialDaysLeft( state, selectedSiteId ) || 0 ),
-			trialExpiration: getTrialExpiration( state, selectedSiteId ),
-		} )
+	const currentPlan = useSelector( ( state ) => getCurrentPlan( state, selectedSiteId ) );
+	const trialDaysLeft = useSelector( ( state ) =>
+		Math.floor( getTrialDaysLeft( state, selectedSiteId ) || 0 )
 	);
+	const trialExpiration = useSelector( ( state ) => getTrialExpiration( state, selectedSiteId ) );
+	const trialExpired = useSelector( ( state ) => isTrialExpired( state, selectedSiteId ) );
 
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* https://github.com/Automattic/wp-calypso/pull/84556
* https://github.com/Automattic/wp-calypso/pull/84608
* https://github.com/Automattic/wp-calypso/pull/84612

## Proposed Changes

* This PR updates the `TrialBanner` component to use individual `useSelector()` calls for some local properties, as we could trigger unnecessary updates because we're returning a new object every time we call `useSelector()`. The linked PRs above all include similar fixes.

## Testing Instructions

* I think inspection should be sufficient, but testing the banner for a Woo Express, migration, or hosting trial site would also work

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
