### PR TITLE
Update hardcoded Business plan on Jetpack Scan page

### DIFF
--- a/client/my-sites/scan/wpcom-upsell.tsx
+++ b/client/my-sites/scan/wpcom-upsell.tsx
@@ -1,6 +1,8 @@
 import {
 	WPCOM_FEATURES_BACKUPS,
 	WPCOM_FEATURES_FULL_ACTIVITY_LOG,
+	PLAN_BUSINESS,
+	getPlan,
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
@@ -54,6 +56,7 @@ export default function WPCOMScanUpsellPage() {
 
 	// Only show promos for features the blog does not already have.
 	const filteredPromos: PromoSectionProps = { promos: promos.filter( ( p ) => p.isShown ) };
+	const businessPlanName = getPlan( PLAN_BUSINESS )?.getTitle() ?? '';
 
 	return (
 		<Main className="scan scan__wpcom-upsell">
@@ -75,7 +78,11 @@ export default function WPCOMScanUpsellPage() {
 				</p>
 				<PromoCardCTA
 					cta={ {
-						text: translate( 'Upgrade to Business Plan' ),
+						text: translate( 'Upgrade to %(planName)s Plan', {
+							args: {
+								planName: businessPlanName,
+							},
+						} ),
 						action: {
 							url: `/checkout/${ siteSlug }/pro`,
 							onClick: onUpgradeClick,
@@ -87,7 +94,13 @@ export default function WPCOMScanUpsellPage() {
 
 			{ filteredPromos.promos.length > 0 && (
 				<>
-					<h2 className="scan__subheader">{ translate( 'Also included in the Business Plan' ) }</h2>
+					<h2 className="scan__subheader">
+						{ translate( 'Also included in the %(planName)s Plan', {
+							args: {
+								planName: businessPlanName,
+							},
+						} ) }
+					</h2>
 					<PromoSection { ...filteredPromos } />
 				</>
 			) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Update hardcoded Business plan name on /scan/SITE

## Testing Instructions

* First, we need to get the wpcom-upsell to display for a simple site. `/scan/<site>` 404s on free simple sites. I used this patch:
```diff
diff --git a/client/my-sites/scan/index.js b/client/my-sites/scan/index.js
index abe11c02b3..98548be109 100644
--- a/client/my-sites/scan/index.js
+++ b/client/my-sites/scan/index.js
@@ -25,9 +25,11 @@ const notFoundIfNotEnabled = ( context, next ) => {
        const showJetpackSection = isJetpackSectionEnabledForSite( state, siteId );
        const isWPCOMSite = getIsSiteWPCOM( state, siteId );
 
+       /*
        if ( isWPCOMSite || ( ! isJetpackCloud() && ! showJetpackSection ) ) {
                return notFound( context, next );
        }
+       */
```
* go to /scan/SITE
* You should see Creator instead of Business


<img width="790" alt="Screenshot 2024-01-05 at 15 25 58" src="https://github.com/Automattic/wp-calypso/assets/82778/d4ec5996-9322-42cd-abc1-f3fc4e51f957">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
