### PR TITLE
Jetpack Logo Generator: Add require upgrade flag

### DIFF
--- a/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
@@ -33,6 +33,7 @@ export const Prompt: React.FC = () => {
 		isEnhancingPrompt,
 		site,
 		getAiAssistantFeature,
+		requireUpgrade,
 	} = useLogoGenerator();
 
 	const enhancingLabel = __( 'Enhancing…', 'jetpack' );
@@ -57,7 +58,6 @@ export const Prompt: React.FC = () => {
 
 	const featureData = getAiAssistantFeature( String( site?.id || '' ) );
 
-	const isFreeTier = featureData?.currentTier?.value === 0;
 	const currentLimit = featureData?.currentTier?.value || 0;
 	const currentUsage = featureData?.usagePeriod?.requestsCount || 0;
 	const isUnlimited = currentLimit === 1;
@@ -96,17 +96,6 @@ export const Prompt: React.FC = () => {
 		setPrompt( event.target.value );
 	}, [] );
 
-	const freeUsage = sprintf(
-		// translators: %u is the number of requests
-		__( '%u free requests remaining.', 'jetpack' ),
-		requestsRemaining
-	);
-	const tieredUsage = sprintf(
-		// translators: %u is the number of requests
-		__( '%u requests remaining.', 'jetpack' ),
-		requestsRemaining
-	);
-
 	return (
 		<div className="jetpack-ai-logo-generator__prompt">
 			<div className="jetpack-ai-logo-generator__prompt-header">
@@ -114,7 +103,7 @@ export const Prompt: React.FC = () => {
 					{ __( 'Describe your site:', 'jetpack' ) }
 				</div>
 				<div className="jetpack-ai-logo-generator__prompt-actions">
-					<Button variant="link" disabled={ isBusy } onClick={ onEnhance }>
+					<Button variant="link" disabled={ isBusy || requireUpgrade } onClick={ onEnhance }>
 						<AiIcon />
 						<span>{ enhanceButtonLabel }</span>
 					</Button>
@@ -130,13 +119,13 @@ export const Prompt: React.FC = () => {
 					) }
 					onChange={ onChange }
 					value={ prompt }
-					disabled={ isBusy }
+					disabled={ isBusy || requireUpgrade }
 				></textarea>
 				<Button
 					variant="primary"
 					className="jetpack-ai-logo-generator__prompt-submit"
 					onClick={ onGenerate }
-					disabled={ isBusy }
+					disabled={ isBusy || requireUpgrade }
 				>
 					{ __( 'Generate', 'jetpack' ) }
 				</Button>
@@ -144,7 +133,13 @@ export const Prompt: React.FC = () => {
 			<div className="jetpack-ai-logo-generator__prompt-footer">
 				{ ! isUnlimited && (
 					<>
-						<div>{ isFreeTier ? freeUsage : tieredUsage }</div>
+						<div>
+							{ sprintf(
+								// translators: %u is the number of requests
+								__( '%u requests remaining.', 'jetpack' ),
+								requestsRemaining
+							) }
+						</div>
 						&nbsp;
 						<Button variant="link" href="https://automattic.com/ai-guidelines" target="_blank">
 							{ __( 'Upgrade', 'jetpack' ) }

--- a/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
@@ -37,6 +37,7 @@ const useLogoGenerator = () => {
 		isBusy,
 		isRequestingImage,
 		getAiAssistantFeature,
+		requireUpgrade,
 	} = useSelect( ( select ) => {
 		const selectors: Selectors = select( STORE_NAME );
 		return {
@@ -49,6 +50,7 @@ const useLogoGenerator = () => {
 			isEnhancingPrompt: selectors.getIsEnhancingPrompt(),
 			isBusy: selectors.getIsBusy(),
 			getAiAssistantFeature: selectors.getAiAssistantFeature,
+			requireUpgrade: selectors.getRequireUpgrade(),
 		};
 	}, [] );
 
@@ -224,6 +226,7 @@ For example: user's prompt: A logo for an ice cream shop. Returned prompt: A log
 		isApplyingLogo,
 		isBusy,
 		getAiAssistantFeature,
+		requireUpgrade,
 	};
 };
 

--- a/packages/jetpack-ai-calypso/src/logo-generator/store/reducer.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/store/reducer.ts
@@ -103,7 +103,8 @@ export default function reducer( state = INITIAL_STATE, action: any ) {
 			const isOverLimit = currentCount >= requestsLimit;
 
 			// highest tier holds a soft limit so requireUpgrade is false on that case (nextTier null means highest tier)
-			const requireUpgrade = isOverLimit && state?.features?.aiAssistantFeature?.nextTier !== null;
+			const requireUpgrade =
+				isFreeTierPlan || ( isOverLimit && state?.features?.aiAssistantFeature?.nextTier !== null );
 
 			return {
 				...state,

--- a/packages/jetpack-ai-calypso/src/logo-generator/store/selectors.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/store/selectors.ts
@@ -103,6 +103,15 @@ const selectors = {
 			selectors.getIsEnhancingPrompt( state )
 		);
 	},
+
+	/**
+	 * Get the requireUpgrade value from aiAssistantFeature
+	 * @param {LogoGeneratorStateProp} state - The app state tree.
+	 * @returns {boolean}                      The requireUpgrade flag.
+	 */
+	getRequireUpgrade( state: LogoGeneratorStateProp ): boolean {
+		return state.features.aiAssistantFeature?.requireUpgrade ?? true;
+	},
 };
 
 export default selectors;

--- a/packages/jetpack-ai-calypso/src/logo-generator/store/types.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/store/types.ts
@@ -156,6 +156,7 @@ export type Selectors = {
 	getIsRequestingImage(): boolean;
 	getIsEnhancingPrompt(): boolean;
 	getIsBusy(): boolean;
+	getRequireUpgrade(): boolean;
 };
 
 /*


### PR DESCRIPTION
UI needs to invalidate when the site requires an upgrade to use the generator

Related to #85557 

## Proposed Changes

* change how requireUpgrade works on the store, free tiers now mean requireUpgrade is `true`
* expose requireUpgrade on the logo generator hook
* disable prompt features when requireUpgrade is `true`

## Testing Instructions

This one is not easy to test, the changes impact the store and are closed with no access from outside the app.

You can expose the dispatcher by adding these lines on `packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx`, around line 42:

```js
// @ts-expect-error -- TSCONVERSION
window.__dispatcher = useDispatch( STORE_NAME );
```

Once that's done, run `yarn start` on a terminal and `yarn workspace @automattic/jetpack-ai-calypso run watch` on another, wait for both to be ready, then visit the local calypso. Head to `/home/some-site`, find the "Create a logo with Jetpack AI" and open the modal.
- If you're on a free tier, prompt, submit and enhance links should be disabled. No "upgrade" link yet.
- If you are on unlimited you should see no change and no usage counter.
- If you are on any tier, you should see your remaining requests (below the prompt).

Now use the dispatcher from the devtools console:

```js
// increase request count by 1 (remaining requests will decrease)
__dispatcher.increaseAiAssistantRequestsCount();

// exceed the remaining requests by increasing as many as you need
__dispatcher.increaseAiAssistantRequestsCount( 45 );

// simply toggle requireUpgrade
__dispatcher.setAiAssistantFeatureRequireUpgrade(true)
```

Toggling requireUpgrade to `true` should disable all prompt elements.
Going over your tier limit should toggle requireUpgrade to `true` (hence, disable all prompt elements)

NOTE: this is all optimistic, no impact on the backend. My intention is we fetch all AI feature data every time the modal opens, at that point the actual data is synced.