### PR TITLE
Eliminate dependency on wpcom-checkout and isValueTruthy

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/index.tsx
@@ -8,7 +8,6 @@ import {
 } from '@automattic/calypso-stripe';
 import { Card, Button } from '@automattic/components';
 import { CheckoutProvider, CheckoutFormSubmit } from '@automattic/composite-checkout';
-import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { CardElement, useElements } from '@stripe/react-stripe-js';
 import { useSelect } from '@wordpress/data';
 import { getQueryArg } from '@wordpress/url';
@@ -61,7 +60,7 @@ function PaymentMethodAdd( { selectedSite }: { selectedSite?: SiteDetails | null
 		stripe,
 	} );
 	const paymentMethods = useMemo(
-		() => [ stripeMethod ].filter( isValueTruthy ),
+		() => ( stripeMethod ? [ stripeMethod ] : [] ),
 		[ stripeMethod ]
 	);
 	const useAsPrimaryPaymentMethod: boolean = useSelect(
@@ -280,9 +279,11 @@ function PaymentMethodAdd( { selectedSite }: { selectedSite?: SiteDetails | null
 
 					<div className="payment-method-add__content">
 						<div className="payment-method-add__form">
-							{ 0 === paymentMethods.length && <CreditCardLoading /> }
-
-							{ paymentMethods && paymentMethods[ 0 ] && paymentMethods[ 0 ].activeContent }
+							{ 0 === paymentMethods.length ? (
+								<CreditCardLoading />
+							) : (
+								paymentMethods[ 0 ].activeContent
+							) }
 
 							{ useAsPrimaryPaymentMethod && (
 								<p className="payment-method-add__notice">

--- a/client/me/purchases/add-new-payment-method/index.tsx
+++ b/client/me/purchases/add-new-payment-method/index.tsx
@@ -1,6 +1,5 @@
 import page from '@automattic/calypso-router';
 import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
-import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -40,7 +39,7 @@ function AddNewPaymentMethod() {
 		initialUseForAllSubscriptions: true,
 	} );
 	const paymentMethodList = useMemo(
-		() => [ stripeMethod ].filter( isValueTruthy ),
+		() => ( stripeMethod ? [ stripeMethod ] : [] ),
 		[ stripeMethod ]
 	);
 	const reduxDispatch = useDispatch();

--- a/client/me/purchases/billing-history/filter-transactions.ts
+++ b/client/me/purchases/billing-history/filter-transactions.ts
@@ -1,4 +1,3 @@
-import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { getLocaleSlug } from 'i18n-calypso';
 import moment from 'moment';
 import {
@@ -26,7 +25,9 @@ function getSearchableStrings( transaction: BillingTransaction ): string[] {
 	const dateString: string | null = transaction.date ? formatDate( transaction.date ) : null;
 	const itemStrings: string[] = transaction.items.flatMap( ( item ) => Object.values( item ) );
 
-	return [ ...rootStrings, dateString, ...itemStrings ].filter( isValueTruthy );
+	return [ ...rootStrings, dateString, ...itemStrings ].filter(
+		( item: string | null ): item is string => !! item
+	);
 }
 
 /**

--- a/client/my-sites/checkout/src/lib/translate-cart.ts
+++ b/client/my-sites/checkout/src/lib/translate-cart.ts
@@ -2,7 +2,6 @@ import {
 	isGoogleWorkspaceExtraLicence,
 	isGSuiteOrGoogleWorkspaceProductSlug,
 } from '@automattic/calypso-products';
-import { isValueTruthy } from '@automattic/wpcom-checkout';
 import cookie from 'cookie';
 import getToSAcceptancePayload from 'calypso/lib/tos-acceptance-tracking';
 import {

--- a/client/my-sites/checkout/src/payment-methods/paypal.tsx
+++ b/client/my-sites/checkout/src/payment-methods/paypal.tsx
@@ -5,7 +5,6 @@ import {
 	useFormStatus,
 	Button,
 } from '@automattic/composite-checkout';
-import { isValueTruthy } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useSelect, useDispatch, registerStore } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -261,7 +260,7 @@ function TaxLabel() {
 		( select ) => ( select( storeKey ) as PaypalSelectors ).getCountryCode(),
 		[]
 	);
-	const taxString = [ countryCode.value, postalCode.value ].filter( isValueTruthy ).join( ', ' );
+	const taxString = [ countryCode.value, postalCode.value ].filter( Boolean ).join( ', ' );
 	if ( taxString.length < 1 ) {
 		return null;
 	}

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
-import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -108,7 +107,7 @@ function SiteLevelAddNewPaymentMethodForm( { siteSlug }: { siteSlug: string } ) 
 		initialUseForAllSubscriptions: true,
 	} );
 	const paymentMethodList = useMemo(
-		() => [ stripeMethod ].filter( isValueTruthy ),
+		() => ( stripeMethod ? [ stripeMethod ] : [] ),
 		[ stripeMethod ]
 	);
 	const reduxDispatch = useDispatch();

--- a/client/my-sites/stats/hooks/use-subscribers-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-query.tsx
@@ -1,4 +1,3 @@
-import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useQuery, useQueries, UseQueryResult } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
@@ -78,6 +77,8 @@ export default function useSubscribersQuery(
 	} );
 }
 
+const isTruthy = < T, >( value: T | undefined ): value is T => !! value;
+
 export function useSubscribersQueries(
 	siteId: number | null,
 	period: string,
@@ -98,7 +99,7 @@ export function useSubscribersQueries(
 
 	const isLoading = results.some( ( result ) => result.isLoading );
 	const isError = results.some( ( result ) => result.isError );
-	const subscribersData = results.map( ( result ) => result.data ).filter( isValueTruthy );
+	const subscribersData = results.map( ( result ) => result.data ).filter( isTruthy );
 
 	return { isLoading, isError, subscribersData };
 }

--- a/client/state/sites/selectors/get-customizer-url.ts
+++ b/client/state/sites/selectors/get-customizer-url.ts
@@ -1,4 +1,3 @@
-import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { addQueryArgs } from 'calypso/lib/url';
 import { getCustomizerFocus } from 'calypso/my-sites/customize/panels';
 import { AppState } from 'calypso/types';
@@ -25,9 +24,14 @@ export default function getCustomizerUrl(
 ): string | null {
 	if ( ! isJetpackSite( state, siteId ) ) {
 		const siteSlug = getSiteSlug( state, siteId );
-		const url = [ '' ]
-			.concat( [ 'customize', panel, siteSlug ].filter( isValueTruthy ) )
-			.join( '/' );
+		let url = '/customize';
+		if ( panel ) {
+			url += '/' + panel;
+		}
+		if ( siteSlug ) {
+			url += '/' + siteSlug;
+		}
+
 		return addQueryArgs(
 			{
 				return: returnUrl,


### PR DESCRIPTION
The `isValueTruthy` function from `wpcom-checkout` has the potential to drag a large dependency into a chunk that uses just this one tiny helper. Try to remove it from most places and see if that affects bundle size.

In any case, the helper belongs to some library of TS helpers rather than to a specialized feature package.