### PR TITLE
Fix Emoji images in Reader post content

### DIFF
--- a/client/lib/post-normalizer/rule-add-image-wrapper-element.js
+++ b/client/lib/post-normalizer/rule-add-image-wrapper-element.js
@@ -80,6 +80,11 @@ export default function addImageWrapperElement( post, dom ) {
 
 	const images = dom.querySelectorAll( 'img[src]' );
 	forEach( images, ( image ) => {
+		if ( image.classList.contains( 'wp-smiley' ) ) {
+			// filter images that have the class wp-smiley
+			// these are emoji images and should not be wrapped
+			return;
+		}
 		// Add container wrapper for img elements
 		const parent = image.parentNode;
 		const imageWrapper = document.createElement( 'div' );


### PR DESCRIPTION
This PR fixes an issue with emoji images in the post content.

In the post normaliser, there is a rule that adds an image wrapper to each image in the post to allow it to be styled properly on Reader.

In this case, the image wrapper isn't helpful as the emoji images are small and inline, we can bypass wrapping these images.

**Before**
<img width="1054" alt="Screenshot 2024-01-05 at 13 44 13" src="https://github.com/Automattic/wp-calypso/assets/5560595/315541ef-9b66-4189-b328-9b7e8beb5947">
**After**
<img width="1039" alt="Screenshot 2024-01-05 at 13 44 22" src="https://github.com/Automattic/wp-calypso/assets/5560595/47873004-36fc-4a94-bc6b-21e760f993cf">

### Test
* Go to `read/feeds/67372852/posts/5059629799` and confirm emojis render as you'd expect
