### PR TITLE
Fix ToS screenshots timeout error for `he`

### DIFF
--- a/packages/calypso-e2e/src/data-helper.ts
+++ b/packages/calypso-e2e/src/data-helper.ts
@@ -340,7 +340,6 @@ export function getMag16Locales(): string[] {
 		'pt-br',
 		'de',
 		'fr',
-		'he',
 		'ja',
 		'it',
 		'nl',
@@ -350,8 +349,9 @@ export function getMag16Locales(): string[] {
 		'zh-cn',
 		'zh-tw',
 		'ko',
-		'ar',
 		'sv',
+		'ar',
+		'he',
 	];
 }
 

--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -107,7 +107,7 @@ export class CartCheckoutPage {
 	 */
 	async validatePaymentForm(): Promise< void > {
 		const cardholderNameLocator = this.page.locator( selectors.cardholderName );
-		await cardholderNameLocator.waitFor( { timeout: 20 * 1000 } );
+		await cardholderNameLocator.waitFor( { state: 'visible', timeout: 20 * 1000 } );
 	}
 	/**
 	 * Validates that an item is in the cart with the expected text. Throws if it isn't.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This attempts to fix the frequent timeout errors on the `he` locale for the checkout screenshots. Error reported in p1704326549172429-Slack-C0313NGSK8R.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Same as https://github.com/Automattic/wp-calypso/pull/85822.

