### PR TITLE
`PremiumGlobalStylesUpgradeModal`: Add plan pricing

### DIFF
--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -3,6 +3,7 @@ import { Button, Gridicon, Dialog, ScreenReaderText } from '@automattic/componen
 import { formatCurrency } from '@automattic/format-currency';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import QueryPlans from 'calypso/components/data/query-plans';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import PlanPrice from 'calypso/my-sites/plan-price';
@@ -61,6 +62,7 @@ export default function PremiumGlobalStylesUpgradeModal( {
 
 	return (
 		<>
+			<QueryPlans />
 			<QueryProductsList />
 			<Dialog
 				className={ classNames( 'upgrade-modal', 'premium-global-styles-upgrade-modal', {

--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -39,7 +39,7 @@ export default function PremiumGlobalStylesUpgradeModal( {
 	const translate = useTranslate();
 	const premiumPlanProduct = useSelector( ( state ) => getProductBySlug( state, PLAN_PREMIUM ) );
 	const translations = useGlobalStylesUpgradeTranslations( { numOfSelectedGlobalStyles } );
-	const isLoading = ! premiumPlanProduct;
+	const isPremiumPlanProductLoading = ! premiumPlanProduct;
 	const pricingMeta = usePricingMetaForGridPlans( {
 		planSlugs: [ PLAN_PREMIUM ],
 		storageAddOns: null,
@@ -68,14 +68,15 @@ export default function PremiumGlobalStylesUpgradeModal( {
 			<QueryProductsList />
 			<Dialog
 				className={ classNames( 'upgrade-modal', 'premium-global-styles-upgrade-modal', {
-					loading: isLoading,
+					loading: isPremiumPlanProductLoading,
 				} ) }
 				isFullScreen
 				isVisible={ isOpen }
 				onClose={ () => closeModal() }
 			>
-				{ isLoading && <LoadingEllipsis /> }
-				{ ! isLoading && (
+				{ isPremiumPlanProductLoading ? (
+					<LoadingEllipsis />
+				) : (
 					<>
 						<div className="upgrade-modal__col">
 							<h1 className="upgrade-modal__heading">{ translate( 'Unlock premium styles' ) }</h1>

--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -39,7 +39,7 @@ export default function PremiumGlobalStylesUpgradeModal( {
 	const translate = useTranslate();
 	const premiumPlanProduct = useSelector( ( state ) => getProductBySlug( state, PLAN_PREMIUM ) );
 	const translations = useGlobalStylesUpgradeTranslations( { numOfSelectedGlobalStyles } );
-	const isPremiumPlanProductLoading = ! premiumPlanProduct;
+	const isPremiumPlanProductLoaded = !! premiumPlanProduct;
 	const pricingMeta = usePricingMetaForGridPlans( {
 		planSlugs: [ PLAN_PREMIUM ],
 		storageAddOns: null,
@@ -48,6 +48,8 @@ export default function PremiumGlobalStylesUpgradeModal( {
 	const pricing = pricingMeta?.[ PLAN_PREMIUM ];
 	const isPricingLoaded =
 		pricing?.currencyCode && pricing?.originalPrice.monthly && pricing?.originalPrice.full;
+
+	const isLoaded = isPremiumPlanProductLoaded && isPricingLoaded;
 
 	const featureList = (
 		<div className="upgrade-modal__included">
@@ -68,15 +70,13 @@ export default function PremiumGlobalStylesUpgradeModal( {
 			<QueryProductsList />
 			<Dialog
 				className={ classNames( 'upgrade-modal', 'premium-global-styles-upgrade-modal', {
-					loading: isPremiumPlanProductLoading,
+					loading: isPremiumPlanProductLoaded,
 				} ) }
 				isFullScreen
 				isVisible={ isOpen }
 				onClose={ () => closeModal() }
 			>
-				{ isPremiumPlanProductLoading ? (
-					<LoadingEllipsis />
-				) : (
+				{ isLoaded ? (
 					<>
 						<div className="upgrade-modal__col">
 							<h1 className="upgrade-modal__heading">{ translate( 'Unlock premium styles' ) }</h1>
@@ -154,6 +154,8 @@ export default function PremiumGlobalStylesUpgradeModal( {
 							<ScreenReaderText>{ translate( 'Close modal' ) }</ScreenReaderText>
 						</Button>
 					</>
+				) : (
+					<LoadingEllipsis />
 				) }
 			</Dialog>
 		</>

--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -1,11 +1,5 @@
 import { PLAN_PREMIUM } from '@automattic/calypso-products';
-import {
-	Button,
-	Gridicon,
-	LoadingPlaceholder,
-	Dialog,
-	ScreenReaderText,
-} from '@automattic/components';
+import { Button, Gridicon, Dialog, ScreenReaderText } from '@automattic/components';
 import { formatCurrency } from '@automattic/format-currency';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -70,7 +64,7 @@ export default function PremiumGlobalStylesUpgradeModal( {
 			<QueryProductsList />
 			<Dialog
 				className={ classNames( 'upgrade-modal', 'premium-global-styles-upgrade-modal', {
-					loading: isPremiumPlanProductLoaded,
+					loading: ! isLoaded,
 				} ) }
 				isFullScreen
 				isVisible={ isOpen }
@@ -107,41 +101,31 @@ export default function PremiumGlobalStylesUpgradeModal( {
 										args: { planTitle: translations.planTitle },
 									} ) }
 								</div>
-								{ isPricingLoaded ? (
-									<PlanPrice
-										className="upgrade-modal__plan-price"
-										currencyCode={ pricing?.currencyCode }
-										rawPrice={ pricing?.originalPrice?.monthly }
-										displayPerMonthNotation={ false }
-										isLargeCurrency
-										isSmallestUnit
-									/>
-								) : (
-									<LoadingPlaceholder style={ { height: '48px' } } />
-								) }
+								<PlanPrice
+									className="upgrade-modal__plan-price"
+									currencyCode={ pricing?.currencyCode }
+									rawPrice={ pricing?.originalPrice?.monthly }
+									displayPerMonthNotation={ false }
+									isLargeCurrency
+									isSmallestUnit
+								/>
 								<div className="upgrade-modal__plan-billing-time-frame">
 									{ translate(
 										'per month, {{span}}%(rawPrice)s{{/span}} billed annually, excl. taxes',
 										{
 											args: {
-												rawPrice: isPricingLoaded
-													? formatCurrency(
-															pricing?.originalPrice.full ?? 0,
-															pricing?.currencyCode ?? '',
-															{
-																stripZeros: true,
-																isSmallestUnit: true,
-															}
-													  )
-													: '',
+												rawPrice: formatCurrency(
+													pricing?.originalPrice.full ?? 0,
+													pricing?.currencyCode ?? '',
+													{
+														stripZeros: true,
+														isSmallestUnit: true,
+													}
+												),
 											},
 											comment: 'excl. taxes is short for excluding taxes',
 											components: {
-												span: isPricingLoaded ? (
-													<span />
-												) : (
-													<LoadingPlaceholder style={ { display: 'inline-block', width: '30%' } } />
-												),
+												span: <span />,
 											},
 										}
 									) }

--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -1,9 +1,18 @@
 import { PLAN_PREMIUM } from '@automattic/calypso-products';
-import { Button, Gridicon, Dialog, ScreenReaderText } from '@automattic/components';
+import {
+	Button,
+	Gridicon,
+	LoadingPlaceholder,
+	Dialog,
+	ScreenReaderText,
+} from '@automattic/components';
+import { formatCurrency } from '@automattic/format-currency';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import PlanPrice from 'calypso/my-sites/plan-price';
+import usePricingMetaForGridPlans from 'calypso/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans';
 import { useSelector } from 'calypso/state';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import useGlobalStylesUpgradeTranslations from './use-global-styles-upgrade-translations';
@@ -31,6 +40,14 @@ export default function PremiumGlobalStylesUpgradeModal( {
 	const premiumPlanProduct = useSelector( ( state ) => getProductBySlug( state, PLAN_PREMIUM ) );
 	const translations = useGlobalStylesUpgradeTranslations( { numOfSelectedGlobalStyles } );
 	const isLoading = ! premiumPlanProduct;
+	const pricingMeta = usePricingMetaForGridPlans( {
+		planSlugs: [ PLAN_PREMIUM ],
+		storageAddOns: null,
+	} );
+
+	const pricing = pricingMeta?.[ PLAN_PREMIUM ];
+	const isPricingLoaded =
+		pricing?.currencyCode && pricing?.originalPrice.monthly && pricing?.originalPrice.full;
 
 	const featureList = (
 		<div className="upgrade-modal__included">
@@ -82,7 +99,55 @@ export default function PremiumGlobalStylesUpgradeModal( {
 								</Button>
 							</div>
 						</div>
-						<div className="upgrade-modal__col">{ featureList }</div>
+						<div className="upgrade-modal__col">
+							<div className="upgrade-modal__plan">
+								<div className="upgrade-modal__plan-heading">
+									{ translate( '%(planTitle)s plan', {
+										args: { planTitle: translations.planTitle },
+									} ) }
+								</div>
+								{ isPricingLoaded ? (
+									<PlanPrice
+										className="upgrade-modal__plan-price"
+										currencyCode={ pricing?.currencyCode }
+										rawPrice={ pricing?.originalPrice?.monthly }
+										displayPerMonthNotation={ false }
+										isLargeCurrency
+										isSmallestUnit
+									/>
+								) : (
+									<LoadingPlaceholder style={ { height: '48px' } } />
+								) }
+								<div className="upgrade-modal__plan-billing-time-frame">
+									{ translate(
+										'per month, {{span}}%(rawPrice)s{{/span}} billed annually, excl. taxes',
+										{
+											args: {
+												rawPrice: isPricingLoaded
+													? formatCurrency(
+															pricing?.originalPrice.full ?? 0,
+															pricing?.currencyCode ?? '',
+															{
+																stripZeros: true,
+																isSmallestUnit: true,
+															}
+													  )
+													: '',
+											},
+											comment: 'excl. taxes is short for excluding taxes',
+											components: {
+												span: isPricingLoaded ? (
+													<span />
+												) : (
+													<LoadingPlaceholder style={ { display: 'inline-block', width: '30%' } } />
+												),
+											},
+										}
+									) }
+								</div>
+							</div>
+							{ featureList }
+						</div>
 						<Button className="upgrade-modal__close" borderless onClick={ () => closeModal() }>
 							<Gridicon icon="cross" size={ 12 } />
 							<ScreenReaderText>{ translate( 'Close modal' ) }</ScreenReaderText>

--- a/client/components/premium-global-styles-upgrade-modal/style.scss
+++ b/client/components/premium-global-styles-upgrade-modal/style.scss
@@ -68,6 +68,38 @@
 		}
 	}
 
+	.upgrade-modal__plan {
+		margin-bottom: 12px;
+
+		.upgrade-modal__plan-heading {
+			margin-bottom: 8px;
+			font-size: 20px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-weight: 500;
+			line-height: 26px;
+			color: var(--studio-gray-100, #101517);
+		}
+
+		.upgrade-modal__plan-price {
+			.plan-price__integer {
+				font-size: 32px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-weight: 500;
+				color: var(--studio-gray-100, #101517);
+			}
+
+			.plan-price__currency-symbol {
+				margin-top: 2px;
+				font-size: 16px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-weight: 500;
+				color: var(--studio-gray-100, #101517);
+			}
+		}
+
+		.upgrade-modal__plan-billing-time-frame {
+			font-size: $font-body-extra-small;
+			color: var(--studio-gray-70, #3c434a);
+		}
+	}
+
 	h1.upgrade-modal__heading {
 		@extend .wp-brand-font;
 		font-size: $font-title-large;

--- a/client/components/premium-global-styles-upgrade-modal/style.scss
+++ b/client/components/premium-global-styles-upgrade-modal/style.scss
@@ -73,7 +73,7 @@
 
 		.upgrade-modal__plan-heading {
 			margin-bottom: 8px;
-			font-size: 20px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: $font-title-small;
 			font-weight: 500;
 			line-height: 26px;
 			color: var(--studio-gray-100, #101517);
@@ -81,14 +81,14 @@
 
 		.upgrade-modal__plan-price {
 			.plan-price__integer {
-				font-size: 32px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-size: $font-title-large;
 				font-weight: 500;
 				color: var(--studio-gray-100, #101517);
 			}
 
 			.plan-price__currency-symbol {
 				margin-top: 2px;
-				font-size: 16px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-size: $font-body;
 				font-weight: 500;
 				color: var(--studio-gray-100, #101517);
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.scss
@@ -6,7 +6,7 @@
 
 		.screen-upsell__plan-heading {
 			margin-bottom: 8px;
-			font-size: 20px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: $font-title-small;
 			font-weight: 500;
 			line-height: 26px;
 			color: var(--studio-gray-100, #101517);
@@ -16,14 +16,14 @@
 			display: flex;
 
 			.plan-price__integer {
-				font-size: 32px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-size: $font-title-large;
 				font-weight: 500;
 				color: var(--studio-gray-100, #101517);
 			}
 
 			.plan-price__currency-symbol {
 				margin-top: 2px;
-				font-size: 16px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-size: $font-body;
 				font-weight: 500;
 				color: var(--studio-gray-100, #101517);
 			}


### PR DESCRIPTION
Fixes #85541

## Proposed Changes

Improve the modal shown when the user is looking at plans with style variations by showing the plan price on the right side.

|Before|After|
|---|---|
|![image](https://github.com/Automattic/wp-calypso/assets/8511199/616e4b13-2d9b-4504-b196-62cd987dbe33)|![image](https://github.com/Automattic/wp-calypso/assets/8511199/a208c74d-523b-4bf6-8a0f-51222a36049a)|

## Testing Instructions

### From start

1. Go to the live preview link, and then to `/start`
2. Go through the process using a free domain and the free plan
3. Click a theme with style variations (has circles underneath it)
4. Once the page loads, choose one of the style variation "microwaves", not the default one.
5. Press "Continue", check that the modal dialog contains the plan pricing on the right side.

### From the design picker

1. Open an incognito window to the live preview link so the previous steps' data is cleared
2. Go to `setup/site-setup/designSetup?siteSlug=SITE_SLUG`
3. 3. When you get to the theme selection page, click a theme with style variations (has circles underneath it)
4. Once the page loads, choose one of the style variation "microwaves", not the default one.
5. Press "Continue", check that the modal dialog contains the plan pricing on the right side.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?