### PR TITLE
Jetpack Manage: Complete 'add new site' tour after first step 

### DIFF
--- a/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
@@ -47,7 +47,7 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 		},
 		{
 			calypso_path: '/dashboard?tour=add-new-site',
-			completed: checkTourCompletion( 'addSiteStep2' ),
+			completed: checkTourCompletion( 'addSiteStep1' ),
 			disabled: false,
 			actionDispatch: () => {
 				dispatch(


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/214

## Proposed Changes

* This PR changes the step that the Next Steps component looks for to determine whether the 'Add sites' tour should be completed. It changes it to the first step, as there are many instances where a user will not follow through with connecting a site to Jetpack following the onboarding prompts.

More conversation on this here: pf36In-xI-p2#comment-880

## Testing Instructions

* To test, apply this change. Making sure all preferences are cleared, then begin the 'Add Sites' tour from the Overview page:  `http://jetpack.cloud.localhost:3000/overview`.
* When the first prompt comes up to click the arrow button, click this button and no more. Navigate back to the Overview page and the tour should be marked as complete.


To clear preferences, click the X next to the add site tour preferences after hovering over 'jetpack-cloud-dev', then 'preferences':

<img width="1090" alt="Screenshot 2024-01-05 at 15 52 55" src="https://github.com/Automattic/wp-calypso/assets/16754605/a1b542d0-4a87-4866-9520-df7217281664">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?