### PR TITLE
Replace harcoded plan name in video upload notice

### DIFF
--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -1,3 +1,4 @@
+import { PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { withMobileBreakpoint } from '@automattic/viewport-react';
@@ -36,7 +37,6 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import MediaLibraryExternalHeader from './external-media-header';
 import MediaLibraryHeader from './header';
 import MediaLibraryList from './list';
-
 import './content.scss';
 
 const noop = () => {};
@@ -141,7 +141,10 @@ export class MediaLibraryContent extends Component {
 			let onDismiss;
 			const i18nOptions = {
 				count: occurrences.length,
-				args: occurrences.length,
+				args: {
+					occurrences: occurrences.length,
+					planName: getPlan( PLAN_PREMIUM )?.getTitle(),
+				},
 			};
 
 			if ( site ) {
@@ -162,8 +165,8 @@ export class MediaLibraryContent extends Component {
 					upgradeNudgeName = 'plan-media-storage-error-video';
 					upgradeNudgeFeature = 'video-upload';
 					message = translate(
-						'%d file could not be uploaded because your site does not support video files. Upgrade to a premium plan for video support.',
-						'%d files could not be uploaded because your site does not support video files. Upgrade to a premium plan for video support.',
+						'%(occurrences)d file could not be uploaded because your site does not support video files. Upgrade to a %(planName)s plan for video support.',
+						'%(occurrences)d files could not be uploaded because your site does not support video files. Upgrade to a %(planName)s plan for video support.',
 						i18nOptions
 					);
 					break;

--- a/client/my-sites/media-library/content.jsx
+++ b/client/my-sites/media-library/content.jsx
@@ -165,8 +165,8 @@ export class MediaLibraryContent extends Component {
 					upgradeNudgeName = 'plan-media-storage-error-video';
 					upgradeNudgeFeature = 'video-upload';
 					message = translate(
-						'%(occurrences)d file could not be uploaded because your site does not support video files. Upgrade to a %(planName)s plan for video support.',
-						'%(occurrences)d files could not be uploaded because your site does not support video files. Upgrade to a %(planName)s plan for video support.',
+						'%(occurrences)d file could not be uploaded because your site does not support video files. Upgrade to the %(planName)s plan for video support.',
+						'%(occurrences)d files could not be uploaded because your site does not support video files. Upgrade to the %(planName)s plan for video support.',
 						i18nOptions
 					);
 					break;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This replaces the hardcoded Premium plan mention with the Explorer plan name in the video upload notice.
<img width="480" alt="Screenshot 2024-01-05 at 18 21 10" src="https://github.com/Automattic/wp-calypso/assets/2749938/b223e363-07ee-450a-949d-6db1fc5ac374">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go /media on a Free plan
* Try to upload a video
* You should see the updated upsell
<img width="480" alt="Screenshot 2024-01-05 at 18 22 08" src="https://github.com/Automattic/wp-calypso/assets/2749938/4bb0e09f-6ad7-4524-9abd-46786017e9f8">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
