### PR TITLE
Jetpack Manage: Adding props to optionally hide steps showing on guided tour popovers, plus add a Skip button

### DIFF
--- a/client/jetpack-cloud/components/guided-tour/index.tsx
+++ b/client/jetpack-cloud/components/guided-tour/index.tsx
@@ -26,7 +26,7 @@ export interface Tour {
 		| 'top left';
 	nextStepOnTargetClick?: string;
 	hideSteps?: boolean;
-	showOkayButton?: boolean;
+	showSkipButton?: boolean;
 }
 
 interface Props {
@@ -86,7 +86,7 @@ const GuidedTour = ( { className, tours, preferenceName, redirectAfterTourEnds }
 		popoverPosition,
 		nextStepOnTargetClick,
 		hideSteps = false,
-		showOkayButton = false,
+		showSkipButton = false,
 	} = tours[ currentStep ];
 
 	const targetElement = useAsyncElement( target, 3000 );
@@ -171,29 +171,20 @@ const GuidedTour = ( { className, tours, preferenceName, redirectAfterTourEnds }
 					}
 				</div>
 				<div className="guided-tour__popover-footer-right-content">
-					{ ! nextStepOnTargetClick && (
-						<>
-							{
-								// Show the skip button if there are multiple steps and we're not on the last step
-								tours.length > 1 && currentStep < tours.length - 1 && (
-									<Button borderless onClick={ endTour }>
-										{ translate( 'Skip' ) }
-									</Button>
-								)
-							}
+					<>
+						{ ( ( ! nextStepOnTargetClick && tours.length > 1 && currentStep < tours.length - 1 ) ||
+							showSkipButton ) && (
+							// Show the skip button if there are multiple steps and we're not on the last step, unless we explicitly choose to add them
+							<Button borderless onClick={ endTour }>
+								{ translate( 'Skip' ) }
+							</Button>
+						) }
+						{ ! nextStepOnTargetClick && (
 							<Button onClick={ nextStep }>
 								{ currentStep === tours.length - 1 ? lastTourLabel : translate( 'Next' ) }
 							</Button>
-						</>
-					) }
-					{
-						// Show an okay button on any particular step if specified
-						showOkayButton && (
-							<>
-								<Button onClick={ endTour }>{ translate( 'Okay' ) }</Button>
-							</>
-						)
-					}
+						) }
+					</>
 				</div>
 			</div>
 		</Popover>

--- a/client/jetpack-cloud/components/guided-tour/index.tsx
+++ b/client/jetpack-cloud/components/guided-tour/index.tsx
@@ -25,6 +25,7 @@ export interface Tour {
 		| 'left'
 		| 'top left';
 	nextStepOnTargetClick?: string;
+	hideSteps?: boolean;
 }
 
 interface Props {
@@ -77,8 +78,14 @@ const GuidedTour = ( { className, tours, preferenceName, redirectAfterTourEnds }
 
 	const isDismissed = preference?.dismiss;
 
-	const { title, description, target, popoverPosition, nextStepOnTargetClick } =
-		tours[ currentStep ];
+	const {
+		title,
+		description,
+		target,
+		popoverPosition,
+		nextStepOnTargetClick,
+		hideSteps = false,
+	} = tours[ currentStep ];
 
 	const targetElement = useAsyncElement( target, 3000 );
 
@@ -152,7 +159,7 @@ const GuidedTour = ( { className, tours, preferenceName, redirectAfterTourEnds }
 				<div>
 					{
 						// Show the step count if there are multiple steps and we're not on the last step
-						tours.length > 1 && (
+						tours.length > 1 && ! hideSteps && (
 							<span className="guided-tour__popover-step-count">
 								{ translate( 'Step %(currentStep)d of %(totalSteps)d', {
 									args: { currentStep: currentStep + 1, totalSteps: tours.length },

--- a/client/jetpack-cloud/components/guided-tour/index.tsx
+++ b/client/jetpack-cloud/components/guided-tour/index.tsx
@@ -25,7 +25,6 @@ export interface Tour {
 		| 'left'
 		| 'top left';
 	nextStepOnTargetClick?: string;
-	hideSteps?: boolean;
 	forceShowSkipButton?: boolean;
 }
 
@@ -34,6 +33,7 @@ interface Props {
 	tours: Tour[];
 	preferenceName: string;
 	redirectAfterTourEnds?: string;
+	hideSteps?: boolean;
 }
 
 // This hook will return the async element matching the target selector.
@@ -67,7 +67,13 @@ const useAsyncElement = ( target: string, timeoutDuration: number ): HTMLElement
 	return asyncElement;
 };
 
-const GuidedTour = ( { className, tours, preferenceName, redirectAfterTourEnds }: Props ) => {
+const GuidedTour = ( {
+	className,
+	tours,
+	preferenceName,
+	redirectAfterTourEnds,
+	hideSteps = false,
+}: Props ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -85,7 +91,6 @@ const GuidedTour = ( { className, tours, preferenceName, redirectAfterTourEnds }
 		target,
 		popoverPosition,
 		nextStepOnTargetClick,
-		hideSteps = false,
 		forceShowSkipButton = false,
 	} = tours[ currentStep ];
 
@@ -161,7 +166,7 @@ const GuidedTour = ( { className, tours, preferenceName, redirectAfterTourEnds }
 				<div>
 					{
 						// Show the step count if there are multiple steps and we're not on the last step, unless we explicitly choose to hide them
-						tours.length > 1 && ! hideSteps && (
+						tours.length > 1 && ! { hideSteps } && (
 							<span className="guided-tour__popover-step-count">
 								{ translate( 'Step %(currentStep)d of %(totalSteps)d', {
 									args: { currentStep: currentStep + 1, totalSteps: tours.length },

--- a/client/jetpack-cloud/components/guided-tour/index.tsx
+++ b/client/jetpack-cloud/components/guided-tour/index.tsx
@@ -166,7 +166,7 @@ const GuidedTour = ( {
 				<div>
 					{
 						// Show the step count if there are multiple steps and we're not on the last step, unless we explicitly choose to hide them
-						tours.length > 1 && ! { hideSteps } && (
+						tours.length > 1 && ! hideSteps && (
 							<span className="guided-tour__popover-step-count">
 								{ translate( 'Step %(currentStep)d of %(totalSteps)d', {
 									args: { currentStep: currentStep + 1, totalSteps: tours.length },

--- a/client/jetpack-cloud/components/guided-tour/index.tsx
+++ b/client/jetpack-cloud/components/guided-tour/index.tsx
@@ -26,7 +26,7 @@ export interface Tour {
 		| 'top left';
 	nextStepOnTargetClick?: string;
 	hideSteps?: boolean;
-	showSkipButton?: boolean;
+	forceShowSkipButton?: boolean;
 }
 
 interface Props {
@@ -86,7 +86,7 @@ const GuidedTour = ( { className, tours, preferenceName, redirectAfterTourEnds }
 		popoverPosition,
 		nextStepOnTargetClick,
 		hideSteps = false,
-		showSkipButton = false,
+		forceShowSkipButton = false,
 	} = tours[ currentStep ];
 
 	const targetElement = useAsyncElement( target, 3000 );
@@ -173,7 +173,7 @@ const GuidedTour = ( { className, tours, preferenceName, redirectAfterTourEnds }
 				<div className="guided-tour__popover-footer-right-content">
 					<>
 						{ ( ( ! nextStepOnTargetClick && tours.length > 1 && currentStep < tours.length - 1 ) ||
-							showSkipButton ) && (
+							forceShowSkipButton ) && (
 							// Show the skip button if there are multiple steps and we're not on the last step, unless we explicitly choose to add them
 							<Button borderless onClick={ endTour }>
 								{ translate( 'Skip' ) }

--- a/client/jetpack-cloud/components/guided-tour/index.tsx
+++ b/client/jetpack-cloud/components/guided-tour/index.tsx
@@ -158,7 +158,7 @@ const GuidedTour = ( { className, tours, preferenceName, redirectAfterTourEnds }
 			<div className="guided-tour__popover-footer">
 				<div>
 					{
-						// Show the step count if there are multiple steps and we're not on the last step
+						// Show the step count if there are multiple steps and we're not on the last step, unless we explicitly choose to hide them
 						tours.length > 1 && ! hideSteps && (
 							<span className="guided-tour__popover-step-count">
 								{ translate( 'Step %(currentStep)d of %(totalSteps)d', {

--- a/client/jetpack-cloud/components/guided-tour/index.tsx
+++ b/client/jetpack-cloud/components/guided-tour/index.tsx
@@ -26,6 +26,7 @@ export interface Tour {
 		| 'top left';
 	nextStepOnTargetClick?: string;
 	hideSteps?: boolean;
+	showOkayButton?: boolean;
 }
 
 interface Props {
@@ -85,6 +86,7 @@ const GuidedTour = ( { className, tours, preferenceName, redirectAfterTourEnds }
 		popoverPosition,
 		nextStepOnTargetClick,
 		hideSteps = false,
+		showOkayButton = false,
 	} = tours[ currentStep ];
 
 	const targetElement = useAsyncElement( target, 3000 );
@@ -184,6 +186,14 @@ const GuidedTour = ( { className, tours, preferenceName, redirectAfterTourEnds }
 							</Button>
 						</>
 					) }
+					{
+						// Show an okay button on any particular step if specified
+						showOkayButton && (
+							<>
+								<Button onClick={ endTour }>{ translate( 'Okay' ) }</Button>
+							</>
+						)
+					}
 				</div>
 			</div>
 		</Popover>

--- a/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-1/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-1/index.tsx
@@ -31,7 +31,7 @@ export default function AddNewSiteTourStep1() {
 						),
 
 						nextStepOnTargetClick: '#sites-overview-add-sites-button .split-button__toggle',
-						showSkipButton: true,
+						forceShowSkipButton: true,
 					},
 				] }
 			/>

--- a/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-1/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-1/index.tsx
@@ -31,6 +31,7 @@ export default function AddNewSiteTourStep1() {
 						),
 
 						nextStepOnTargetClick: '#sites-overview-add-sites-button .split-button__toggle',
+						showOkayButton: true,
 					},
 				] }
 			/>

--- a/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-1/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/add-new-site-tour-step-1/index.tsx
@@ -31,7 +31,7 @@ export default function AddNewSiteTourStep1() {
 						),
 
 						nextStepOnTargetClick: '#sites-overview-add-sites-button .split-button__toggle',
-						showOkayButton: true,
+						showSkipButton: true,
 					},
 				] }
 			/>

--- a/client/jetpack-cloud/sections/onboarding-tours/enable-monitor-tour-step-1/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/enable-monitor-tour-step-1/index.tsx
@@ -28,6 +28,7 @@ export default function EnableMonitorTourStep1() {
 						),
 
 						nextStepOnTargetClick: '.dashboard-bulk-actions__edit-button',
+						hideSteps: true,
 					},
 					{
 						target: '.dashboard-bulk-actions__custom_notification_button',
@@ -45,6 +46,7 @@ export default function EnableMonitorTourStep1() {
 						),
 
 						nextStepOnTargetClick: '.dashboard-bulk-actions__custom_notification_button',
+						hideSteps: true,
 					},
 				] }
 			/>

--- a/client/jetpack-cloud/sections/onboarding-tours/enable-monitor-tour-step-1/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/enable-monitor-tour-step-1/index.tsx
@@ -26,9 +26,7 @@ export default function EnableMonitorTourStep1() {
 								) }
 							</>
 						),
-
 						nextStepOnTargetClick: '.dashboard-bulk-actions__edit-button',
-						hideSteps: true,
 					},
 					{
 						target: '.dashboard-bulk-actions__custom_notification_button',
@@ -46,9 +44,9 @@ export default function EnableMonitorTourStep1() {
 						),
 
 						nextStepOnTargetClick: '.dashboard-bulk-actions__custom_notification_button',
-						hideSteps: true,
 					},
 				] }
+				hideSteps={ true }
 			/>
 		)
 	);

--- a/client/jetpack-cloud/sections/onboarding-tours/enable-monitor-tour-step-1/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/enable-monitor-tour-step-1/index.tsx
@@ -46,7 +46,7 @@ export default function EnableMonitorTourStep1() {
 						nextStepOnTargetClick: '.dashboard-bulk-actions__custom_notification_button',
 					},
 				] }
-				hideSteps={ true }
+				hideSteps
 			/>
 		)
 	);


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/215

## Proposed Changes

* This PR removes the step numbers from showing at the bottom of the 'bulk editing / monitor' in-app onboarding tour
* This PR also includes a 'Skip'  button to stop the add sites tour in particular, instead of needing to click the arrow (it isn't clear to the user that this would actually end the tour otherwise).

## Testing Instructions

* Check-out this PR, and on the Overview page begin the 'Bulk Editing' tour. If it is marked as complete already, preferences can be cleared by following the steps above the first screenshot below.
Removal of step numbers:
* Begin the tour, and you should immediately notice that there is no 'Step 1 of x' showing on the tour. This applies to the first two steps which originally had step numbers showing.
Okay button on add sites tour first step:
* Begin the add sites tour, and notice a 'Skip' button on the first step. Click it and return to the overview page - you should see the tour marked as complete.

To clear preferences, click the X next to the monitor preferences after hovering over 'jetpack-cloud-dev', then 'preferences':

<img width="1108" alt="Screenshot 2024-01-05 at 17 08 38" src="https://github.com/Automattic/wp-calypso/assets/16754605/f15d5f49-984c-4158-80eb-ee21f4a23083">

**Removal of step numbers**

How it looked before:

<img width="200" alt="Screenshot 2024-01-05 at 17 12 45" src="https://github.com/Automattic/wp-calypso/assets/16754605/4e6ba69c-3172-45a5-85a4-8f2bd9ee70e0">

<img width="200" alt="Screenshot 2024-01-05 at 17 12 49" src="https://github.com/Automattic/wp-calypso/assets/16754605/bf769a4b-d90c-4fde-b5d3-f2ea86e70f98">

After the changes in this PR:

<img width="200" alt="Screenshot 2024-01-05 at 17 09 33" src="https://github.com/Automattic/wp-calypso/assets/16754605/2e651c37-7013-486f-a685-890dcf292e25">


<img width="250" alt="Screenshot 2024-01-05 at 17 09 38" src="https://github.com/Automattic/wp-calypso/assets/16754605/31630e01-1961-4399-a182-4d064c63fe4a">


**Add new site tour skip button**

<img width="396" alt="Screenshot 2024-01-08 at 11 01 41" src="https://github.com/Automattic/wp-calypso/assets/16754605/a9d7c90f-b12f-4d94-b638-ee0974319de8">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?