### PR TITLE
Hosting Configuration: Redirect user to the same page after upgrading through the upsell banner

### DIFF
--- a/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
+++ b/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
@@ -6,6 +6,7 @@ import {
 	WPCOM_PLANS,
 	getPlan,
 } from '@automattic/calypso-products';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import useAddHostingTrialMutation from 'calypso/data/hosting/use-add-hosting-trial-mutation';
@@ -54,7 +55,9 @@ export function HostingUpsellNudge( { siteId, targetPlan }: HostingUpsellNudgePr
 	);
 	const callToAction = targetPlan ? targetPlan.callToAction : callToActionText;
 	const feature = targetPlan ? targetPlan.feature : FEATURE_SFTP;
-	const href = targetPlan ? targetPlan.href : `/checkout/${ siteId }/business`;
+	const href = targetPlan
+		? targetPlan.href
+		: addQueryArgs( `/checkout/${ siteId }/business`, { redirect_to: location.pathname } );
 	const plan = targetPlan ? targetPlan.plan : PLAN_BUSINESS;
 	const title = targetPlan ? targetPlan.title : titleText;
 	const isEligibleForTrial = useSelector( isUserEligibleForFreeHostingTrial );

--- a/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
+++ b/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
@@ -57,7 +57,9 @@ export function HostingUpsellNudge( { siteId, targetPlan }: HostingUpsellNudgePr
 	const feature = targetPlan ? targetPlan.feature : FEATURE_SFTP;
 	const href = targetPlan
 		? targetPlan.href
-		: addQueryArgs( `/checkout/${ siteId }/business`, { redirect_to: location.pathname } );
+		: addQueryArgs( `/checkout/${ siteId }/business`, {
+				redirect_to: `/hosting-config/${ siteId }`,
+		  } );
 	const plan = targetPlan ? targetPlan.plan : PLAN_BUSINESS;
 	const title = targetPlan ? targetPlan.title : titleText;
 	const isEligibleForTrial = useSelector( isUserEligibleForFreeHostingTrial );


### PR DESCRIPTION
## Proposed Changes

After clicking the upgrade button in the `/hosting-config/%s` upsell banner and purchasing our plan, the user gets redirected to `/home/%s`, breaking continuity.

This PR redirects the user back to hosting config after upgrading. A follow up PR, after https://github.com/Automattic/wp-calypso/pull/85937, could kick off the transfer right away.

https://github.com/Automattic/wp-calypso/assets/26530524/cc2670d8-25a8-447b-81d1-e042aabe5868

@daledupreez what do you think of consolidating the same behavior for the Entrepreneur trial?

## Testing Instructions

On `trunk`, verify that upgrading from `/hosting-config/%s` redirects you to `/home/%s`.

In this PR, verify that upgrading from `/hosting-config/%s` redirects you back to `/hosting-config/%s`. 