### PR TITLE
Creator trial: Allow the user to upgrade to Entrepreneur

### DIFF
--- a/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-grid-plans.tsx
@@ -146,10 +146,7 @@ const usePlanTypesWithIntent = ( {
 			];
 			break;
 		case 'plans-business-trial':
-			planTypes = [
-				TYPE_BUSINESS,
-				...( isEnterpriseAvailable ? [ TYPE_ENTERPRISE_GRID_WPCOM ] : [] ),
-			];
+			planTypes = [ TYPE_BUSINESS, TYPE_ECOMMERCE ];
 			break;
 		case 'plans-videopress':
 			planTypes = [ TYPE_PREMIUM, TYPE_BUSINESS ];


### PR DESCRIPTION
Related to p1704451568187099/1704450832.255149-slack-CFFF01Q4V.

## Proposed Changes

We currently display Creator and Enterprise as upgrading options, but Enterprise doesn't make sense. At the same time, Entrepreneur is very well possible if they want to host an online store after trying Creator on the same site.

<img width="916" alt="image" src="https://github.com/Automattic/wp-calypso/assets/26530524/a12e0b49-0850-4bb7-af42-ff9efdf8507a">

## Testing Instructions

1. Apply D133760-code to your sandbox and proxy the API
2. Create a Creator trial site at `/setup/new-hosted-site`
3. Visit `/plans/%s` and check that you see Entrepreneur as a valid upgradable plan
4. Click the CTA and upgrade to Entrepreneur