### PR TITLE
Add a new header for woo sites when in jetpack 

### DIFF
--- a/apps/blaze-dashboard/src/app.scss
+++ b/apps/blaze-dashboard/src/app.scss
@@ -182,3 +182,41 @@ $break-medium-expanded-menu: $break-medium + 272px;
 		}
 	}
 }
+
+
+.woo-blaze-dashboard {
+
+	.promote-post-i2 {
+		// Header
+		.promote-post-i2__top-bar {
+			height: 40px;
+			display: flex;
+			align-items: center;
+			margin-bottom: 16px;
+
+			.promote-post-i2__top-bar-buttons {
+				height: 100%;
+
+				.inline-support-link {
+					font-size: rem(14px);
+					font-weight: 400;
+
+					height: 36px;
+					line-height: 22px;
+					min-width: auto;
+					padding: 6px 12px;
+				}
+
+				button {
+					font-size: rem(13px);
+					font-weight: 400;
+					height: 36px;
+					justify-content: center;
+					line-height: 22px;
+					min-width: auto;
+					padding: 6px 12px;
+				}
+			}
+		}
+	}
+}

--- a/apps/blaze-dashboard/src/components/generic-header/index.jsx
+++ b/apps/blaze-dashboard/src/components/generic-header/index.jsx
@@ -2,8 +2,8 @@ import config from '@automattic/calypso-config';
 import JetpackBlazeHeader from '../jetpack-blaze-header';
 import WooBlazeHeader from '../woo-blaze-header';
 
-const GenericHeader = () => {
+const GenericHeader = ( props ) => {
 	const isWooBlaze = config.isEnabled( 'is_running_in_woo_site' );
-	return isWooBlaze ? <WooBlazeHeader /> : <JetpackBlazeHeader />;
+	return isWooBlaze ? <WooBlazeHeader { ...props } /> : <JetpackBlazeHeader { ...props } />;
 };
 export default GenericHeader;

--- a/apps/blaze-dashboard/src/components/generic-header/index.jsx
+++ b/apps/blaze-dashboard/src/components/generic-header/index.jsx
@@ -1,0 +1,9 @@
+import config from '@automattic/calypso-config';
+import JetpackBlazeHeader from '../jetpack-blaze-header';
+import WooBlazeHeader from '../woo-blaze-header';
+
+const GenericHeader = () => {
+	const isWooBlaze = config.isEnabled( 'is_running_in_woo_site' );
+	return isWooBlaze ? <WooBlazeHeader /> : <JetpackBlazeHeader />;
+};
+export default GenericHeader;

--- a/apps/blaze-dashboard/src/components/woo-blaze-header/index.jsx
+++ b/apps/blaze-dashboard/src/components/woo-blaze-header/index.jsx
@@ -1,0 +1,11 @@
+import classNames from 'classnames';
+
+import './style.scss';
+
+const WooBlazeHeader = ( { className = '' } ) => (
+	<header className={ classNames( 'woo-blaze-header', className ) }>
+		<h2>Blaze for WooCommerce</h2>
+	</header>
+);
+
+export default WooBlazeHeader;

--- a/apps/blaze-dashboard/src/components/woo-blaze-header/index.jsx
+++ b/apps/blaze-dashboard/src/components/woo-blaze-header/index.jsx
@@ -1,11 +1,17 @@
 import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
 
 import './style.scss';
 
-const WooBlazeHeader = ( { className = '' } ) => (
-	<header className={ classNames( 'woo-blaze-header', className ) }>
-		<h2>Blaze for WooCommerce</h2>
-	</header>
-);
+const WooBlazeHeader = ( { className = '', children } ) => {
+	const translate = useTranslate();
+
+	return (
+		<header className={ classNames( 'woo-blaze-header', className ) }>
+			<h2>{ translate( 'Blaze for WooCommerce' ) }</h2>
+			{ children }
+		</header>
+	);
+};
 
 export default WooBlazeHeader;

--- a/apps/blaze-dashboard/src/components/woo-blaze-header/style.scss
+++ b/apps/blaze-dashboard/src/components/woo-blaze-header/style.scss
@@ -1,0 +1,8 @@
+.woo-blaze-header {
+	display: flex;
+
+	h2 {
+		font-size: rem(24px);
+		font-weight: 500;
+	}
+}

--- a/apps/blaze-dashboard/src/components/woo-blaze-header/style.scss
+++ b/apps/blaze-dashboard/src/components/woo-blaze-header/style.scss
@@ -1,8 +1,26 @@
+@import "@automattic/color-studio/dist/color-variables";
+@import "@automattic/components/src/styles/typography";
+
 .woo-blaze-header {
 	display: flex;
+	flex-direction: column;
 
 	h2 {
-		font-size: rem(24px);
+		color: $studio-gray-100;
+		font-family: $font-sf-pro-display;
+		font-size: 1.5rem;
+		font-style: normal;
 		font-weight: 500;
+		letter-spacing: 0.36px;
+		line-height: 1.33;
 	}
+
+	&.advertising__page-header_has-banner {
+		h2 {
+			font-size: 0.875rem;
+			letter-spacing: -0.15px;
+			line-height: 1.43;
+		}
+	}
+
 }

--- a/apps/blaze-dashboard/webpack.config.js
+++ b/apps/blaze-dashboard/webpack.config.js
@@ -187,7 +187,7 @@ module.exports = {
 		),
 		new webpack.NormalModuleReplacementPlugin(
 			/^calypso\/components\/formatted-header$/,
-			path.resolve( __dirname, 'src/components/jetpack-blaze-header' )
+			path.resolve( __dirname, 'src/components/generic-header' )
 		),
 		...excludedPackagePlugins,
 		shouldEmitStats &&


### PR DESCRIPTION
Override the jetpack default header when in woo config flag is true

We need a new header for the blaze app - for when the user initiates the page from Woo. 
This is a minor fix that will check the `is_running_in_woo_site ` flag and will return either the default Jetpack header or a woo header for the blaze page.

attached below are the 2 different header in screenshots

![Screenshot 2024-01-08 at 17 32 02](https://github.com/Automattic/wp-calypso/assets/1416426/17373666-21c5-44d2-a666-c0f89ba8dcaa)
![Screenshot 2024-01-08 at 17 34 23](https://github.com/Automattic/wp-calypso/assets/1416426/58d24958-ce65-4d54-b850-33b98782a90a)



<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

1- In wp-calypso, execute yarn install to install all dependencies
2- In a console, connect to your sandbox and pull the latest changes
3- In other console, go to /apps/blaze-dashboard  and execute yarn dev --sync
This will sync all the changes you make in Calypso/Blaze app to your sandbox
4- Redirect the traffic from [widgets.wp.com](http://widgets.wp.com/) to your sandbox
5- Open a jetpack site or our plugin site, it should start using your sandboxing verison

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
