### PR TITLE
Jetpack Logo Generator: use contenteditable element instead of textarea

### DIFF
--- a/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.scss
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.scss
@@ -9,7 +9,8 @@
 	}
 
 	.components-modal__content {
-		padding: 32px;
+		padding: 32px 32px 0 32px;
+		margin-bottom: 32px;
 
 		> div:not(.components-modal__header) {
 			height: 100%;

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/history-carousel.scss
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/history-carousel.scss
@@ -2,6 +2,7 @@
 	display: flex;
 	gap: 8px;
 	overflow-x: auto;
+	flex-shrink: 0;
 
 	.components-button {
 		height: unset;

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.scss
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.scss
@@ -45,11 +45,27 @@
 		border: 0;
 		resize: none;
 		flex-grow: 1;
-		min-height: 60px; /* temporary while we figure out auto height */
+		padding: 6px 0;
+		vertical-align: baseline;
+		color: var(--studio-gray-100);
+		line-height: 1.6;
 
 		&:focus,
 		&:active {
 			outline: 0;
+		}
+
+		&[contentEditable="false"] {
+			color: var(--studio-gray-50, #646970);
+		}
+
+		&[placeholder]:empty::before {
+			content: attr(placeholder);
+			color: var(--studio-gray-50, #646970);
+		}
+
+		&[placeholder]:empty:focus::before {
+			content: "";
 		}
 	}
 }

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
@@ -7,7 +7,7 @@ import { useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
 import debugFactory from 'debug';
-import { SetStateAction, useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 /**
  * Internal dependencies
  */
@@ -93,8 +93,9 @@ export const Prompt: React.FC = () => {
 		increaseAiAssistantRequestsCount,
 	] );
 
-	const onChange = useCallback( ( event: { target: { value: SetStateAction< string > } } ) => {
-		setPrompt( event.target.value );
+	const onPromptInput = useCallback( ( event: React.ChangeEvent< HTMLInputElement > ) => {
+		// TODO: double check this, never used textContent before as a replacement to input.value
+		setPrompt( event.target.textContent || '' );
 	}, [] );
 
 	return (
@@ -115,17 +116,15 @@ export const Prompt: React.FC = () => {
 				</div>
 			</div>
 			<div className="jetpack-ai-logo-generator__prompt-query">
-				{ /* TODO: textarea doesn't resize, either import from block-editor or use custom contentEditable */ }
-				<textarea
+				<div
+					contentEditable={ ! isBusy && ! requireUpgrade }
 					className="prompt-query__input"
+					onInput={ onPromptInput }
 					placeholder={ __(
 						'Describe your site or simply ask for a logo specifying some details about it',
 						'jetpack'
 					) }
-					onChange={ onChange }
-					value={ prompt }
-					disabled={ isBusy || requireUpgrade }
-				></textarea>
+				></div>
 				<Button
 					variant="primary"
 					className="jetpack-ai-logo-generator__prompt-submit"

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
@@ -7,7 +7,7 @@ import { useDispatch } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
 import debugFactory from 'debug';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, useRef } from 'react';
 /**
  * Internal dependencies
  */
@@ -41,6 +41,8 @@ export const Prompt: React.FC = () => {
 	const enhanceLabel = __( 'Enhance prompt', 'jetpack' );
 	const enhanceButtonLabel = isEnhancingPrompt ? enhancingLabel : enhanceLabel;
 
+	const inputRef = useRef< HTMLDivElement | null >( null );
+
 	const onEnhance = useCallback( async () => {
 		debug( 'enhancing prompt', prompt );
 		setIsEnhancingPrompt( true );
@@ -66,6 +68,13 @@ export const Prompt: React.FC = () => {
 	useEffect( () => {
 		setRequestsRemaining( currentLimit - currentUsage );
 	}, [ currentLimit, currentUsage ] );
+
+	useEffect( () => {
+		// Update prompt after enhancement
+		if ( inputRef.current && inputRef.current.textContent !== prompt ) {
+			inputRef.current.textContent = prompt;
+		}
+	}, [ prompt ] );
 
 	const onGenerate = useCallback( async () => {
 		debug( 'getting image for prompt', prompt );
@@ -94,7 +103,6 @@ export const Prompt: React.FC = () => {
 	] );
 
 	const onPromptInput = useCallback( ( event: React.ChangeEvent< HTMLInputElement > ) => {
-		// TODO: double check this, never used textContent before as a replacement to input.value
 		setPrompt( event.target.textContent || '' );
 	}, [] );
 
@@ -117,7 +125,10 @@ export const Prompt: React.FC = () => {
 			</div>
 			<div className="jetpack-ai-logo-generator__prompt-query">
 				<div
+					ref={ inputRef }
 					contentEditable={ ! isBusy && ! requireUpgrade }
+					// The content editable div is expected to be updated by the enhance prompt, so warnings are suppressed
+					suppressContentEditableWarning={ true }
 					className="prompt-query__input"
 					onInput={ onPromptInput }
 					placeholder={ __(


### PR DESCRIPTION
Textarea element doesn't handle autosize very well, this is an attempt to use a div[contentEditable]

Related to #85557 

## Proposed Changes

* replace textarea with div[contentEditable]
* adapt styles
* adapt handlers
* implement placeholder effect
* mock disabled property

## Testing Instructions

Open the modal from the quick links. TBH you should not notice anything different.

- prompt input should be, initially, a single line height
- adding enough text should wrap and resize the input
- resized input should align to bottom (look at "Generate" button)
- disabled states (use the dispatcher trick seen on #86050  to toggle `requireUpgrade`) should work seamlessly on the contentEditable element
- placeholder should resemble the native input placeholder's behavior

Notes:
- test in main browsers, styling might need tweaking
- unaware of security concerns, but the value is taken from `textContent` property, should we cleanse it in any way?