### PR TITLE
Marketplace Test: Pass a proper object to reviews mutation

### DIFF
--- a/client/my-sites/marketplace/pages/marketplace-test/index.jsx
+++ b/client/my-sites/marketplace/pages/marketplace-test/index.jsx
@@ -26,7 +26,6 @@ import {
 	requestEligibility,
 } from 'calypso/state/automated-transfer/actions';
 import { getAutomatedTransfer, getEligibility } from 'calypso/state/automated-transfer/selectors';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import shouldUpgradeCheck from 'calypso/state/marketplace/selectors';
 import {
 	getPluginOnSite,
@@ -55,7 +54,6 @@ export default function MarketplaceTest() {
 	const translate = useTranslate();
 
 	const selectedSite = useSelector( getSelectedSite );
-	const currentUserId = useSelector( getCurrentUserId );
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const isAtomicSite = useSelector( ( state ) => isSiteWpcomAtomic( state, selectedSiteId ?? 0 ) );
@@ -97,13 +95,9 @@ export default function MarketplaceTest() {
 		slug: 'woocommerce-bookings',
 	} );
 
-	const createReview = useCreateMarketplaceReviewMutation();
-	const updateReview = useUpdateMarketplaceReviewMutation();
-	const deleteReview = useDeleteMarketplaceReviewMutation( {
-		productType: 'plugin',
-		perPage: 1,
-		author: currentUserId ?? undefined,
-	} );
+	const createReview = useCreateMarketplaceReviewMutation( {} );
+	const updateReview = useUpdateMarketplaceReviewMutation( {} );
+	const deleteReview = useDeleteMarketplaceReviewMutation( {} );
 
 	const dispatch = useDispatch();
 	const transferDetails = useSelector( ( state ) => getAutomatedTransfer( state, selectedSiteId ) );


### PR DESCRIPTION


## Proposed Changes
Pass an object instead of nothing when creating mutations as all the mutations now expect an object.
The actual properties doesn't need to be passed as it is only used to invalidate cache.

## Testing Instructions

Check if `/marketplace/test/:site` is loading and working.
On the current version, the page is not loading.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
