### PR TITLE
Marketplace Reviews: Create a review item component to isolate logic from the list

### DIFF
--- a/client/my-sites/marketplace/components/review-item/index.tsx
+++ b/client/my-sites/marketplace/components/review-item/index.tsx
@@ -1,0 +1,208 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { Gridicon, Button } from '@automattic/components';
+import Card from '@automattic/components/src/card';
+import { CheckboxControl, TextareaControl } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import moment from 'moment';
+import { useState } from 'react';
+import { useSelector } from 'react-redux';
+import ConfirmModal from 'calypso/components/confirm-modal';
+import Rating from 'calypso/components/rating';
+import ReviewsRatingsStars from 'calypso/components/reviews-rating-stars/reviews-ratings-stars';
+import {
+	MarketplaceReviewResponse,
+	MarketplaceReviewsQueryProps,
+	useDeleteMarketplaceReviewMutation,
+	useUpdateMarketplaceReviewMutation,
+} from 'calypso/data/marketplace/use-marketplace-reviews';
+import { getAvatarURL } from 'calypso/data/marketplace/utils';
+import { sanitizeSectionContent } from 'calypso/lib/plugins/sanitize-section-content';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import './style.scss';
+
+export const MarketplaceReviewItem = (
+	props: { review: MarketplaceReviewResponse } & MarketplaceReviewsQueryProps
+) => {
+	const { review } = props;
+	const translate = useTranslate();
+	const [ isConfirmModalVisible, setIsConfirmModalVisible ] = useState( false );
+	const currentUserId = useSelector( getCurrentUserId );
+	const [ errorMessage, setErrorMessage ] = useState( '' );
+	const deleteReviewMutation = useDeleteMarketplaceReviewMutation( {
+		...props,
+	} );
+	const deleteReview = ( reviewId: number ) => {
+		setIsConfirmModalVisible( false );
+		deleteReviewMutation.mutate(
+			{ reviewId: reviewId },
+			{
+				onError: ( error ) => {
+					setErrorMessage( error.message );
+				},
+				onSuccess: () => {
+					setErrorMessage( '' );
+				},
+			}
+		);
+	};
+
+	const updateReviewMutation = useUpdateMarketplaceReviewMutation( { ...props } );
+
+	const [ isEditing, setIsEditing ] = useState< boolean >( false );
+	const [ editorContent, setEditorContent ] = useState< string >( '' );
+	const [ editorRating, setEditorRating ] = useState< number >( 0 );
+
+	const setEditing = ( review: MarketplaceReviewResponse ) => {
+		setIsEditing( true );
+		setEditorContent( review.content.rendered );
+		setEditorRating( review.meta.wpcom_marketplace_rating );
+	};
+
+	const clearEditing = () => {
+		setIsEditing( false );
+		setEditorContent( '' );
+		setEditorRating( 0 );
+	};
+
+	return (
+		<div className="marketplace-review-item__review-container" key={ `review-${ review.id }` }>
+			{ review.author === currentUserId && errorMessage && (
+				<Card className="marketplace-review-item__error-message" highlight="error">
+					{ errorMessage }
+				</Card>
+			) }
+			{ review.author === currentUserId && review.status === 'hold' && (
+				<Card className="marketplace-review-item__pending-review" highlight="warning">
+					<Gridicon className="marketplace-review-item__card-icon" icon="info" size={ 18 } />
+					<div className="marketplace-review-item__card-text">
+						<span>{ translate( 'Your review is pending approval.' ) }</span>
+						{ isEnabled( 'marketplace-reviews-notification' ) && (
+							<span>{ translate( ' You will be notified once it is published.' ) }</span>
+						) }
+					</div>
+				</Card>
+			) }
+			<div className="marketplace-review-item__review-container-header">
+				<div className="marketplace-review-item__profile-picture">
+					{ getAvatarURL( review ) ? (
+						<img
+							className="marketplace-review-item__profile-picture-img"
+							src={ getAvatarURL( review ) }
+							alt={ translate( "%(reviewer)s's profile picture", {
+								comment: 'Alt description for the profile picture of a reviewer',
+								args: { reviewer: review.author_name },
+							} ).toString() }
+						/>
+					) : (
+						<div className="marketplace-review-item__profile-picture-placeholder" />
+					) }
+				</div>
+
+				<div className="marketplace-review-item__rating-data">
+					<div className="marketplace-review-item__author">{ review.author_name }</div>
+
+					<Rating rating={ review.meta.wpcom_marketplace_rating * 20 } />
+				</div>
+				<div className="marketplace-review-item__date">
+					{ moment( review.date ).format( 'll' ) }
+				</div>
+			</div>
+			{ isEditing && review.author === currentUserId ? (
+				<>
+					<div className="marketplace-review-item__review-rating">
+						<h2>{ translate( 'Let us know how your experience has changed' ) }</h2>
+						<ReviewsRatingsStars
+							size="medium-large"
+							rating={ editorRating }
+							onSelectRating={ setEditorRating }
+						/>
+					</div>
+					<TextareaControl
+						rows={ 4 }
+						cols={ 40 }
+						name="content"
+						value={ editorContent }
+						onChange={ setEditorContent }
+					/>
+				</>
+			) : (
+				<div
+					// sanitized with sanitizeSectionContent
+					// eslint-disable-next-line react/no-danger
+					dangerouslySetInnerHTML={ {
+						__html: sanitizeSectionContent( review.content.rendered ),
+					} }
+					className="marketplace-review-item__content"
+				></div>
+			) }
+			<div className="marketplace-review-item__review-actions">
+				{ isEditing && review.author === currentUserId && (
+					<>
+						<div>
+							{ isEnabled( 'marketplace-reviews-notification' ) && (
+								<CheckboxControl
+									className="marketplace-review-item__checkbox"
+									label={ translate( 'Notify me when my review is approved and published.' ) }
+									checked={ false }
+									onChange={ () => alert( 'Not implemented yet' ) }
+								/>
+							) }
+						</div>
+						<div className="marketplace-review-item__review-actions-editable">
+							<Button className="is-link" onClick={ clearEditing }>
+								{ translate( 'Cancel' ) }
+							</Button>
+							<Button
+								className="marketplace-review-item__review-submit"
+								primary
+								onClick={ () => {
+									updateReviewMutation.mutate(
+										{
+											reviewId: review.id,
+											productType: props.productType,
+											slug: props.slug,
+											content: editorContent,
+											rating: editorRating,
+										},
+										{ onError: ( error ) => alert( error.message ) }
+									);
+									clearEditing();
+								} }
+							>
+								{ translate( 'Save my review' ) }
+							</Button>
+						</div>
+					</>
+				) }
+				{ ! isEditing && review.author === currentUserId && (
+					<div className="marketplace-review-item__review-actions-editable">
+						<button
+							className="marketplace-review-item__review-actions-editable-button"
+							onClick={ () => setEditing( review ) }
+						>
+							<Gridicon icon="pencil" size={ 18 } />
+							{ translate( 'Edit my review' ) }
+						</button>
+						<button
+							className="marketplace-review-item__review-actions-editable-button"
+							onClick={ () => setIsConfirmModalVisible( true ) }
+						>
+							<Gridicon icon="trash" size={ 18 } />
+							{ translate( 'Delete my review' ) }
+						</button>
+						<div className="marketplace-review-item__review-actions-editable-confirm-modal">
+							<ConfirmModal
+								isVisible={ isConfirmModalVisible }
+								confirmButtonLabel={ translate( 'Yes' ) }
+								text={ translate( 'Do you really want to delete your review?' ) }
+								title={ translate( 'Delete my review' ) }
+								onCancel={ () => setIsConfirmModalVisible( false ) }
+								onConfirm={ () => deleteReview( review.id ) }
+							/>
+						</div>
+					</div>
+				) }
+			</div>
+		</div>
+	);
+};

--- a/client/my-sites/marketplace/components/review-item/style.scss
+++ b/client/my-sites/marketplace/components/review-item/style.scss
@@ -1,0 +1,155 @@
+$profile-picture-size: 36px;
+$border-color: #eee;
+
+
+.marketplace-review-item__review-container {
+	border-top: 1px solid $border-color;
+	padding: 32px 0;
+
+	&:first-of-type {
+		border-top: none;
+		padding-top: 0;
+	}
+
+	&:last-of-type {
+		padding-bottom: 0;
+	}
+
+	.marketplace-review-item__review-container-header {
+		display: grid;
+		grid-template-columns: calc($profile-picture-size + 8px) 1fr 100px;
+
+		.marketplace-review-item__rating-data {
+			display: flex;
+			flex-direction: column;
+
+			.rating {
+				margin-left: -1px;
+			}
+		}
+
+		.marketplace-review-item__profile-picture {
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+
+			.marketplace-review-item__profile-picture-img,
+			.marketplace-review-item__profile-picture-placeholder {
+				height: $profile-picture-size;
+				width: $profile-picture-size;
+				border-radius: 50%;
+			}
+
+			.marketplace-review-item__profile-picture-placeholder {
+				background-color: var(--studio-gray-20);
+			}
+		}
+
+		.marketplace-review-item__date {
+			color: var(--studio-gray-60);
+			font-size: $font-body-small;
+			text-align: right;
+			align-self: center;
+		}
+
+		.marketplace-review-item__author {
+			color: var(--studio-gray-100);
+			font-size: $font-body-small;
+		}
+	}
+
+	.marketplace-review-item__review-rating {
+		margin-top: 16px;
+		margin-bottom: 16px;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+
+		h2 {
+			font-family: "SF Pro Text", $sans;
+			font-size: $font-title-small;
+			font-weight: 500;
+			line-height: 26px;
+			overflow-wrap: anywhere;
+			color: var(--studio-gray-100);
+		}
+	}
+
+	.marketplace-review-item__content {
+		color: var(--studio-gray-100);
+		font-size: $font-body-small;
+		margin-top: 16px;
+
+		p {
+			margin-bottom: 0;
+		}
+
+		&.edting {
+			background-color: var(--studio-gray-0);
+			padding: 16px;
+		}
+	}
+
+	.marketplace-review-item__editor {
+		color: var(--studio-gray-100);
+		background-color: var(--studio-gray-0);
+		border-radius: 4px;
+		font-size: $font-body-small;
+		margin-top: 16px;
+		padding: 16px;
+
+		p {
+			margin-bottom: 0;
+		}
+	}
+}
+
+
+.marketplace-review-item__review-actions {
+	display: flex;
+	align-items: baseline;
+	flex-wrap: wrap;
+	justify-content: space-between;
+	margin-top: 15px;
+	font-size: $font-body-small;
+
+	.marketplace-review-item__review-actions-editable {
+		display: flex;
+		align-items: center;
+
+		.marketplace-review-item__review-submit {
+			margin-left: 16px;
+		}
+
+		.marketplace-review-item__review-actions-editable-button {
+			color: var(--studio-blue-50);
+			margin-right: 15px;
+			cursor: pointer;
+			display: flex;
+			align-items: center;
+		}
+
+		.gridicon {
+			margin-right: 5px;
+			color: var(--studio-gray-10);
+		}
+	}
+}
+
+.marketplace-review-item__pending-review,
+.marketplace-review-item__error-message {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+	align-self: stretch;
+
+	.marketplace-review-item__card-icon {
+		color: var(--studio-gray-10);
+	}
+
+	.marketplace-review-item__card-text {
+		font-family: "SF Pro Text", $sans;
+		font-size: $font-body-small;
+		line-height: 20px;
+	}
+}

--- a/client/my-sites/marketplace/components/reviews-list/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-list/index.tsx
@@ -1,34 +1,20 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Gridicon, Button } from '@automattic/components';
-import Card from '@automattic/components/src/card';
-import { CheckboxControl, TextareaControl } from '@wordpress/components';
-import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import moment from 'moment';
-import { useState } from 'react';
 import { useSelector } from 'react-redux';
-import ConfirmModal from 'calypso/components/confirm-modal';
 import InfiniteScroll from 'calypso/components/infinite-scroll';
-import Rating from 'calypso/components/rating';
-import ReviewsRatingsStars from 'calypso/components/reviews-rating-stars/reviews-ratings-stars';
 import {
 	useMarketplaceReviewsQuery,
 	MarketplaceReviewResponse,
 	MarketplaceReviewsQueryProps,
-	useDeleteMarketplaceReviewMutation,
-	useUpdateMarketplaceReviewMutation,
 	useInfiniteMarketplaceReviewsQuery,
 } from 'calypso/data/marketplace/use-marketplace-reviews';
-import './style.scss';
-import { getAvatarURL } from 'calypso/data/marketplace/utils';
-import { sanitizeSectionContent } from 'calypso/lib/plugins/sanitize-section-content';
+import { MarketplaceReviewItem } from 'calypso/my-sites/marketplace/components/review-item';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import './style.scss';
 
 export const MarketplaceReviewsList = ( props: MarketplaceReviewsQueryProps ) => {
 	const translate = useTranslate();
-	const [ isConfirmModalVisible, setIsConfirmModalVisible ] = useState( false );
 	const currentUserId = useSelector( getCurrentUserId );
-	const [ errorMessage, setErrorMessage ] = useState( '' );
 	const { data, fetchNextPage, error } = useInfiniteMarketplaceReviewsQuery( {
 		...props,
 		author_exclude: currentUserId ?? undefined,
@@ -41,42 +27,6 @@ export const MarketplaceReviewsList = ( props: MarketplaceReviewsQueryProps ) =>
 		author: currentUserId ?? undefined,
 		status: 'all',
 	} );
-
-	const deleteReviewMutation = useDeleteMarketplaceReviewMutation( {
-		...props,
-	} );
-	const deleteReview = ( reviewId: number ) => {
-		setIsConfirmModalVisible( false );
-		deleteReviewMutation.mutate(
-			{ reviewId: reviewId },
-			{
-				onError: ( error ) => {
-					setErrorMessage( error.message );
-				},
-				onSuccess: () => {
-					setErrorMessage( '' );
-				},
-			}
-		);
-	};
-
-	const updateReviewMutation = useUpdateMarketplaceReviewMutation( { ...props } );
-
-	const [ isEditing, setIsEditing ] = useState< boolean >( false );
-	const [ editorContent, setEditorContent ] = useState< string >( '' );
-	const [ editorRating, setEditorRating ] = useState< number >( 0 );
-
-	const setEditing = ( review: MarketplaceReviewResponse ) => {
-		setIsEditing( true );
-		setEditorContent( review.content.rendered );
-		setEditorRating( review.meta.wpcom_marketplace_rating );
-	};
-
-	const clearEditing = () => {
-		setIsEditing( false );
-		setEditorContent( '' );
-		setEditorRating( 0 );
-	};
 
 	if ( ! isEnabled( 'marketplace-reviews-show' ) ) {
 		return null;
@@ -109,152 +59,11 @@ export const MarketplaceReviewsList = ( props: MarketplaceReviewsQueryProps ) =>
 	return (
 		<div className="marketplace-reviews-list__container">
 			<div className="marketplace-reviews-list__customer-reviews">
-				{ allReviews.map( ( review: MarketplaceReviewResponse, i ) => (
-					<div
-						className={ classnames( 'marketplace-reviews-list__review-container', {
-							last: i === allReviews.length - 1,
-						} ) }
-						key={ `review-${ review.id }` }
-					>
-						{ review.author === currentUserId && errorMessage && (
-							<Card className="marketplace-reviews-list__error-message" highlight="error">
-								{ errorMessage }
-							</Card>
-						) }
-						{ review.author === currentUserId && review.status === 'hold' && (
-							<Card className="marketplace-reviews-list__pending-review" highlight="warning">
-								<Gridicon className="marketplace-reviews-list__card-icon" icon="info" size={ 18 } />
-								<div className="marketplace-reviews-list__card-text">
-									<span>{ translate( 'Your review is pending approval.' ) }</span>
-									{ isEnabled( 'marketplace-reviews-notification' ) && (
-										<span>{ translate( ' You will be notified once it is published.' ) }</span>
-									) }
-								</div>
-							</Card>
-						) }
-						<div className="marketplace-reviews-list__review-container-header">
-							<div className="marketplace-reviews-list__profile-picture">
-								{ getAvatarURL( review ) ? (
-									<img
-										className="marketplace-reviews-list__profile-picture-img"
-										src={ getAvatarURL( review ) }
-										alt={ translate( "%(reviewer)s's profile picture", {
-											comment: 'Alt description for the profile picture of a reviewer',
-											args: { reviewer: review.author_name },
-										} ).toString() }
-									/>
-								) : (
-									<div className="marketplace-reviews-list__profile-picture-placeholder" />
-								) }
-							</div>
-
-							<div className="marketplace-reviews-list__rating-data">
-								<div className="marketplace-reviews-list__author">{ review.author_name }</div>
-
-								<Rating rating={ review.meta.wpcom_marketplace_rating * 20 } />
-							</div>
-							<div className="marketplace-reviews-list__date">
-								{ moment( review.date ).format( 'll' ) }
-							</div>
-						</div>
-						{ isEditing && review.author === currentUserId ? (
-							<>
-								<div className="marketplace-reviews-list__review-rating">
-									<h2>{ translate( 'Let us know how your experience has changed' ) }</h2>
-									<ReviewsRatingsStars
-										size="medium-large"
-										rating={ editorRating }
-										onSelectRating={ setEditorRating }
-									/>
-								</div>
-								<TextareaControl
-									rows={ 4 }
-									cols={ 40 }
-									name="content"
-									value={ editorContent }
-									onChange={ setEditorContent }
-								/>
-							</>
-						) : (
-							<div
-								// sanitized with sanitizeSectionContent
-								// eslint-disable-next-line react/no-danger
-								dangerouslySetInnerHTML={ {
-									__html: sanitizeSectionContent( review.content.rendered ),
-								} }
-								className="marketplace-reviews-list__content"
-							></div>
-						) }
-						<div className="marketplace-reviews-list__review-actions">
-							{ isEditing && review.author === currentUserId && (
-								<>
-									<div>
-										{ isEnabled( 'marketplace-reviews-notification' ) && (
-											<CheckboxControl
-												className="marketplace-reviews-list__checkbox"
-												label={ translate( 'Notify me when my review is approved and published.' ) }
-												checked={ false }
-												onChange={ () => alert( 'Not implemented yet' ) }
-											/>
-										) }
-									</div>
-									<div className="marketplace-reviews-list__review-actions-editable">
-										<Button className="is-link" onClick={ clearEditing }>
-											{ translate( 'Cancel' ) }
-										</Button>
-										<Button
-											className="marketplace-reviews-list__review-submit"
-											primary
-											onClick={ () => {
-												updateReviewMutation.mutate(
-													{
-														reviewId: review.id,
-														productType: props.productType,
-														slug: props.slug,
-														content: editorContent,
-														rating: editorRating,
-													},
-													{ onError: ( error ) => alert( error.message ) }
-												);
-												clearEditing();
-											} }
-										>
-											{ translate( 'Save my review' ) }
-										</Button>
-									</div>
-								</>
-							) }
-							{ ! isEditing && review.author === currentUserId && (
-								<div className="marketplace-reviews-list__review-actions-editable">
-									<button
-										className="marketplace-reviews-list__review-actions-editable-button"
-										onClick={ () => setEditing( review ) }
-									>
-										<Gridicon icon="pencil" size={ 18 } />
-										{ translate( 'Edit my review' ) }
-									</button>
-									<button
-										className="marketplace-reviews-list__review-actions-editable-button"
-										onClick={ () => setIsConfirmModalVisible( true ) }
-									>
-										<Gridicon icon="trash" size={ 18 } />
-										{ translate( 'Delete my review' ) }
-									</button>
-									<div className="marketplace-reviews-list__review-actions-editable-confirm-modal">
-										<ConfirmModal
-											isVisible={ isConfirmModalVisible }
-											confirmButtonLabel={ translate( 'Yes' ) }
-											text={ translate( 'Do you really want to delete your review?' ) }
-											title={ translate( 'Delete my review' ) }
-											onCancel={ () => setIsConfirmModalVisible( false ) }
-											onConfirm={ () => deleteReview( review.id ) }
-										/>
-									</div>
-								</div>
-							) }
-						</div>
-					</div>
-				) ) }
+				<div className="marketplace-reviews-list__items">
+					{ allReviews.map( ( review: MarketplaceReviewResponse ) => (
+						<MarketplaceReviewItem review={ review } { ...props } />
+					) ) }
+				</div>
 				<InfiniteScroll nextPageMethod={ fetchNextPage } />
 			</div>
 		</div>

--- a/client/my-sites/marketplace/components/reviews-list/style.scss
+++ b/client/my-sites/marketplace/components/reviews-list/style.scss
@@ -1,4 +1,3 @@
-$profile-picture-size: 36px;
 $border-color: #eee;
 
 .marketplace-reviews-list__container {
@@ -9,109 +8,6 @@ $border-color: #eee;
 		color: var(--studio-gray-100);
 	}
 
-	.marketplace-reviews-list__customer-reviews {
-		.marketplace-reviews-list__review-container {
-			border-top: 1px solid $border-color;
-			padding: 32px 0;
-
-			&:first-of-type {
-				border-top: none;
-				padding-top: 0;
-			}
-
-			&.last {
-				padding-bottom: 0;
-			}
-
-			.marketplace-reviews-list__review-container-header {
-				display: grid;
-				grid-template-columns: calc($profile-picture-size + 8px) 1fr 100px;
-
-				.marketplace-reviews-list__rating-data {
-					display: flex;
-					flex-direction: column;
-
-					.rating {
-						margin-left: -1px;
-					}
-				}
-
-				.marketplace-reviews-list__profile-picture {
-					display: flex;
-					flex-direction: column;
-					justify-content: center;
-
-					.marketplace-reviews-list__profile-picture-img,
-					.marketplace-reviews-list__profile-picture-placeholder {
-						height: $profile-picture-size;
-						width: $profile-picture-size;
-						border-radius: 50%;
-					}
-
-					.marketplace-reviews-list__profile-picture-placeholder {
-						background-color: var(--studio-gray-20);
-					}
-				}
-
-				.marketplace-reviews-list__date {
-					color: var(--studio-gray-60);
-					font-size: $font-body-small;
-					text-align: right;
-					align-self: center;
-				}
-
-				.marketplace-reviews-list__author {
-					color: var(--studio-gray-100);
-					font-size: $font-body-small;
-				}
-			}
-
-			.marketplace-reviews-list__review-rating {
-				margin-top: 16px;
-				margin-bottom: 16px;
-				display: flex;
-				align-items: center;
-				justify-content: space-between;
-
-				h2 {
-					font-family: "SF Pro Text", $sans;
-					font-size: $font-title-small;
-					font-weight: 500;
-					line-height: 26px;
-					overflow-wrap: anywhere;
-					color: var(--studio-gray-100);
-				}
-			}
-
-			.marketplace-reviews-list__content {
-				color: var(--studio-gray-100);
-				font-size: $font-body-small;
-				margin-top: 16px;
-
-				p {
-					margin-bottom: 0;
-				}
-
-				&.edting {
-					background-color: var(--studio-gray-0);
-					padding: 16px;
-				}
-			}
-
-			.marketplace-reviews-list__editor {
-				color: var(--studio-gray-100);
-				background-color: var(--studio-gray-0);
-				border-radius: 4px;
-				font-size: $font-body-small;
-				margin-top: 16px;
-				padding: 16px;
-
-				p {
-					margin-bottom: 0;
-				}
-			}
-		}
-	}
 	.rating .rating__overlay .is-empty,
 	.rating .rating__star-outline .is-empty {
 		fill: var(--studio-yellow-20);
@@ -123,36 +19,6 @@ $border-color: #eee;
 	}
 }
 
-.marketplace-reviews-list__review-actions {
-	display: flex;
-	align-items: baseline;
-	flex-wrap: wrap;
-	justify-content: space-between;
-	margin-top: 15px;
-	font-size: $font-body-small;
-
-	.marketplace-reviews-list__review-actions-editable {
-		display: flex;
-		align-items: center;
-
-		.marketplace-reviews-list__review-submit {
-			margin-left: 16px;
-		}
-
-		.marketplace-reviews-list__review-actions-editable-button {
-			color: var(--studio-blue-50);
-			margin-right: 15px;
-			cursor: pointer;
-			display: flex;
-			align-items: center;
-		}
-
-		.gridicon {
-			margin-right: 5px;
-			color: var(--studio-gray-10);
-		}
-	}
-}
 
 .marketplace-reviews-list__no-reviews,
 .marketplace-reviews-list__customer-reviews {
@@ -182,23 +48,6 @@ $border-color: #eee;
 	}
 }
 
-.marketplace-reviews-list__pending-review,
-.marketplace-reviews-list__error-message {
-	display: flex;
-	align-items: flex-start;
-	gap: 8px;
-	align-self: stretch;
-
-	.marketplace-reviews-list__card-icon {
-		color: var(--studio-gray-10);
-	}
-
-	.marketplace-reviews-list__card-text {
-		font-family: "SF Pro Text", $sans;
-		font-size: $font-body-small;
-		line-height: 20px;
-	}
-}
 
 .confirm-modal {
 	z-index: z-index(".dialog__backdrop", ".confirm-modal");


### PR DESCRIPTION
First part of https://github.com/Automattic/dotcom-forge/issues/5023

## Proposed Changes

Create a review item component to isolate logic from the list.
The item component with part of this logic should be reused on https://github.com/Automattic/dotcom-forge/issues/5023

## Testing Instructions

The reviews modal should still be working as previously with list, updating and deletion of review.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
