### PR TITLE
Fix various E2E tests for recent Gutenberg changes

### DIFF
--- a/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-settings-sidebar-component.ts
@@ -7,9 +7,10 @@ const panel = '[aria-label="Editor settings"]';
 
 const selectors = {
 	// Tab
-	tabButton: ( tabName: EditorSidebarTab ) => `${ panel } button:has-text("${ tabName }")`,
+	tabButton: ( tabName: EditorSidebarTab ) =>
+		`${ panel } button[role="tab"]:has-text("${ tabName }")`,
 	activeTabButton: ( tabName: EditorSidebarTab ) =>
-		`${ panel } button[aria-selected="true"]:has-text("${ tabName }")`,
+		`${ panel } button[aria-selected="true"][role="tab"]:has-text("${ tabName }")`,
 
 	// General section-related
 	section: ( name: string ) =>

--- a/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
+++ b/packages/calypso-e2e/src/lib/components/editor-toolbar-component.ts
@@ -15,10 +15,10 @@ const selectors = {
 	switchToDraftButton: `${ panel } button.editor-post-switch-to-draft`,
 
 	// Preview
-	previewButton: `${ panel } :text("Preview"):visible, [aria-label="Preview"]:visible`,
+	previewButton: `${ panel } :text("Preview"):visible, [aria-label="View"]:visible`,
 	desktopPreviewMenuItem: ( target: EditorPreviewOptions ) =>
 		`button[role="menuitem"] span:text("${ target }")`,
-	previewPane: ( target: EditorPreviewOptions ) => `.is-${ target.toLowerCase() }-preview`,
+	previewPane: `.edit-post-visual-editor`,
 
 	// Publish
 	publishButton: ( state: 'disabled' | 'enabled' ) => {
@@ -199,7 +199,7 @@ export class EditorToolbarComponent {
 		await desktopPreviewMenuItemLocator.click();
 
 		// Verify the editor panel is resized and stable.
-		const desktopPreviewPaneLocator = editorParent.locator( selectors.previewPane( target ) );
+		const desktopPreviewPaneLocator = editorParent.locator( selectors.previewPane );
 		await desktopPreviewPaneLocator.waitFor();
 		const elementHandle = await desktopPreviewPaneLocator.elementHandle();
 		await elementHandle?.waitForElementState( 'stable' );
@@ -214,7 +214,7 @@ export class EditorToolbarComponent {
 	async openDesktopPreviewMenu(): Promise< void > {
 		const editorParent = await this.editor.parent();
 
-		const translatedButtonName = await this.translateFromPage( 'Preview' );
+		const translatedButtonName = await this.translateFromPage( 'View' );
 		const previewButton = editorParent.getByRole( 'button', {
 			name: translatedButtonName,
 			exact: true,
@@ -233,7 +233,7 @@ export class EditorToolbarComponent {
 	async closeDesktopPreviewMenu(): Promise< void > {
 		const editorParent = await this.editor.parent();
 
-		const translatedButtonName = await this.translateFromPage( 'Preview' );
+		const translatedButtonName = await this.translateFromPage( 'View' );
 		const previewButton = editorParent.getByRole( 'button', {
 			name: translatedButtonName,
 			exact: true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* wordpress/gutenberg#56921 changed the label of the preview button from "Preview" to "View".
* wordpress/gutenberg#56904 removed the setting of an `is-xxx-preview` class when using the in-page preview. Targeting the parent element (that has a static class) instead.
* #86033 attempted to fix a test for another Gutenberg change, but the selector used there matches multiple elements in one of our tests and so causes it to fail. Adding `[role="tab"]` into the selector fixes that.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run tests, see if they pass now.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?