### PR TITLE
GF Signup: Dropdown Interval: Cosmetic fixes v1

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -701,7 +701,7 @@ const PlansFeaturesMain = ( {
 	const isPlansGridReady = ! isLoadingGridPlans && ! resolvedSubdomainName.isLoading;
 
 	const enablePlanTypeSelectorStickyBehavior = isMobile() && showPlanTypeSelectorDropdown;
-	const stickyPlanTypeSelectorHeight = 48;
+	const stickyPlanTypeSelectorHeight = isMobile() ? 62 : 48;
 	const comparisonGridStickyRowOffset = enablePlanTypeSelectorStickyBehavior
 		? stickyPlanTypeSelectorHeight + masterbarHeight
 		: masterbarHeight;

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -390,10 +390,6 @@ body.is-section-signup.is-white-signup {
 }
 
 .plans-features-main__plan-type-selector-layout {
-	display: flex;
-	align-content: space-between;
-	justify-content: center;
-	margin: 0 20px 24px;
 	.segmented-control.price-toggle {
 		.is-section-signup &,
 		.is-section-stepper & {

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -1094,6 +1094,7 @@ const ComparisonGrid = ( {
 					disabled={ isBottomHeaderInView }
 					stickyClass="is-sticky-header-row"
 					stickyOffset={ stickyRowOffset }
+					zIndex={ 1 }
 				>
 					{ ( isStuck: boolean ) => (
 						<ComparisonGridHeader

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -70,6 +70,7 @@ class FeaturesGrid extends Component< FeaturesGridProps > {
 						stickyClass="is-sticky-top-buttons-row"
 						element="tr"
 						stickyOffset={ stickyRowOffset }
+						zIndex={ 2 }
 					>
 						{ ( isStuck: boolean ) =>
 							this.renderTopButtons( gridPlansWithoutSpotlight, { isTableCell: true, isStuck } )

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -10,13 +10,27 @@ const AddOnOption = styled.a`
 		color: var( --color-text );
 	}
 	.discount {
-		color: var( --studio-green-40 );
+		background-color: var( --studio-green-0 );
+		color: var( --studio-green-50 );
 		display: inline-block;
 		font-size: 0.7rem;
+		display: flex;
+		padding: 0px 10px;
+		line-height: 14px;
+		border-radius: 3px;
+		line-height: 20px;
 	}
 	.name {
 		font-size: 0.8rem;
 		margin-right: 4px;
+		line-height: 19px;
+	}
+	padding: 16px;
+	padding-right: 25px;
+	display: flex;
+	justify-content: space-between;
+	.is-highlighted & {
+		background-color: #f6f7f7;
 	}
 `;
 
@@ -31,7 +45,7 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 		name: (
 			<AddOnOption href={ option.url }>
 				<span className="name"> { option.name } </span>
-				<span className="discount"> { option.discountText } </span>
+				{ option.discountText ? <span className="discount"> { option.discountText } </span> : null }
 			</AddOnOption>
 		),
 	} ) );

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -25,12 +25,15 @@ const AddOnOption = styled.a`
 		margin-right: 4px;
 		line-height: 19px;
 	}
-	padding: 16px;
-	padding-right: 25px;
 	display: flex;
 	justify-content: space-between;
 	.is-highlighted & {
 		background-color: #f6f7f7;
+	}
+
+	padding: 13px 13px 16px;
+	button & {
+		padding-right: 32px;
 	}
 `;
 

--- a/client/my-sites/plans-grid/components/plan-type-selector/index.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/index.tsx
@@ -25,6 +25,7 @@ const PlanTypeSelector: React.FunctionComponent< PlanTypeSelectorProps > = ( {
 				stickyClass="is-sticky-plan-type-selector"
 				disabled={ ! enableStickyBehavior }
 				stickyOffset={ stickyPlanTypeSelectorOffset }
+				zIndex={ 2 }
 			>
 				{ () => (
 					<div className={ classNames( layoutClassName ) }>

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -77,6 +77,9 @@
 				height: auto;
 				padding: 0;
 			}
+			.components-input-control__backdrop {
+				border-color: var(--studio-gray-10);
+			}
 		}
 	}
 

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -1,7 +1,7 @@
 @import "calypso/my-sites/plans-grid/media-queries";
 
 .plan-type-selector {
-	max-width: fit-content;
+	width: 100%;
 }
 
 .plan-type-selector__title {
@@ -63,11 +63,7 @@
 
 .plan-type-selector .plan-type-selector__interval-type-dropdown {
 	width: 259px;
-	background-color: var(--studio-gray-0);
-
-	@include plan-type-selector-custom-mobile-breakpoint {
-		width: 100%;
-	}
+	margin: 0 auto;
 
 	&,
 	&:visited,
@@ -77,7 +73,7 @@
 	.components-flex {
 		overflow: hidden;
 		.components-input-control__container {
-			background-color: var(--studio-gray-0);
+			background-color: var(--studio-white);
 			.components-custom-select-control__button {
 				min-width: 225px;
 				height: auto;
@@ -85,6 +81,10 @@
 			}
 			.components-input-control__backdrop {
 				border-color: var(--studio-gray-10);
+			}
+
+			.components-input-control__suffix > div {
+				padding-right: 13px;
 			}
 		}
 	}
@@ -117,28 +117,24 @@
 	}
 }
 
-div.is-sticky-plan-type-selector {
+div.is-sticky-plan-type-selector .plan-type-selector__interval-type-dropdown {
+	width: 100%;
 	@include plan-type-selector-custom-mobile-breakpoint {
 		// Display above sticky feature and comparison grid plan headers
 		z-index: 3;
-
 		.components-flex {
 			width: 100vw;
-			height: 48px;
-			padding: 0 16px;
+			height: 64px;
+			padding: 0;
 			border-bottom: 1px solid #e0e0e0;
+			border-bottom-right-radius: 0;
+			border-bottom-left-radius: 0;
 		}
 
 		.components-custom-select-control__menu {
 			width: 100%;
-			margin: 0;
 			border: 1px solid #e0e0e0;
 		}
-
-		.components-custom-select-control__item {
-			padding-left: 22px;
-		}
-
 		.components-input-control__backdrop.components-input-control__backdrop {
 			border: none;
 		}

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -62,19 +62,47 @@
 }
 
 .plan-type-selector .plan-type-selector__interval-type-dropdown {
+	width: 259px;
 	&,
 	&:visited,
 	&:hover span.name {
 		color: var(--color-text);
 	}
-	.components-custom-select-control__button {
-		min-width: 225px;
+	.components-flex {
+		overflow: hidden;
+		.components-input-control__container{
+			background-color: var(--studio-gray-0);
+			.components-custom-select-control__button {
+				min-width: 225px;
+				height: auto;
+				padding: 0;
+			}
+		}
 	}
+
 	.components-custom-select-control__menu {
-		margin: 0;
+		margin: 0;			
+		border-radius: 0;
+		border-bottom-right-radius: 2px;
+		border-bottom-left-radius: 2px;
+		box-sizing: border-box;
+		border: 1px solid var(--studio-gray-10);
+		border-top: none;
+		margin-top: -2px;
 	}
 	.components-custom-select-control__item {
 		grid-template-columns: auto min-content;
+		padding:0;
+		.is-highlighted {
+			background-color: var(--studio-gray-0);
+		}
+		.a {
+			padding: 11.5px 16px;
+		}
+		
+		.components-custom-select-control__item-icon{
+			display: none;
+		}
 	}
 }
 
@@ -99,6 +127,8 @@ div.is-sticky-plan-type-selector {
 			margin: 0;
 
 			border: 1px solid #e0e0e0;
+
+
 		}
 
 		.components-custom-select-control__item {

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -121,7 +121,6 @@ div.is-sticky-plan-type-selector .plan-type-selector__interval-type-dropdown {
 	width: 100%;
 	@include plan-type-selector-custom-mobile-breakpoint {
 		// Display above sticky feature and comparison grid plan headers
-		z-index: 3;
 		.components-flex {
 			width: 100vw;
 			height: 64px;

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -63,6 +63,12 @@
 
 .plan-type-selector .plan-type-selector__interval-type-dropdown {
 	width: 259px;
+	background-color: var(--studio-gray-0);
+
+	@include plan-type-selector-custom-mobile-breakpoint {
+		width: 100%;
+	}
+
 	&,
 	&:visited,
 	&:hover span.name {
@@ -70,7 +76,7 @@
 	}
 	.components-flex {
 		overflow: hidden;
-		.components-input-control__container{
+		.components-input-control__container {
 			background-color: var(--studio-gray-0);
 			.components-custom-select-control__button {
 				min-width: 225px;
@@ -82,9 +88,8 @@
 			}
 		}
 	}
-
 	.components-custom-select-control__menu {
-		margin: 0;			
+		margin: 0;
 		border-radius: 0;
 		border-bottom-right-radius: 2px;
 		border-bottom-left-radius: 2px;
@@ -95,25 +100,24 @@
 	}
 	.components-custom-select-control__item {
 		grid-template-columns: auto min-content;
-		padding:0;
+		padding: 0;
 		.is-highlighted {
 			background-color: var(--studio-gray-0);
 		}
 		.a {
 			padding: 11.5px 16px;
 		}
-		
-		.components-custom-select-control__item-icon{
+
+		.components-custom-select-control__item-icon {
 			display: none;
 		}
+	}
+	.components-custom-select-control__label {
+		display: none;
 	}
 }
 
 div.is-sticky-plan-type-selector {
-	.components-custom-select-control__label {
-		display: inline;
-	}
-
 	@include plan-type-selector-custom-mobile-breakpoint {
 		// Display above sticky feature and comparison grid plan headers
 		z-index: 3;
@@ -128,10 +132,7 @@ div.is-sticky-plan-type-selector {
 		.components-custom-select-control__menu {
 			width: 100%;
 			margin: 0;
-
 			border: 1px solid #e0e0e0;
-
-
 		}
 
 		.components-custom-select-control__item {

--- a/client/my-sites/plans-grid/components/sticky-container.tsx
+++ b/client/my-sites/plans-grid/components/sticky-container.tsx
@@ -4,12 +4,38 @@ import classNames from 'classnames';
 import { useRef, type ElementType, useState, useLayoutEffect, ReactNode } from 'react';
 
 type Props = {
+	/**
+	 * Function that renders the content when the element is stuck
+	 * @param isStuck - Indicates if the element is stuck
+	 * @returns ReactNode
+	 */
 	children: ( isStuck: boolean ) => ReactNode;
-	stickyClass?: string; // class to apply when the element is "stuck"
-	element?: ElementType; // which element to render, defaults to div
-	stickyOffset?: number; // offset from the top of the scrolling container to control when the element should start sticking, default 0
-	disabled?: boolean; // force disabled sticky behaviour if set to true
-	zIndex?: number; // Set z index manually
+
+	/**
+	 * CSS class applied when the element is "stuck"
+	 */
+	stickyClass?: string;
+
+	/**
+	 * Element type to render (defaults to div)
+	 */
+	element?: ElementType;
+
+	/**
+	 * Offset from the top of the scrolling container to trigger stickiness (default 0)
+	 */
+	stickyOffset?: number;
+
+	/**
+	 * Set to true to disable sticky behavior
+	 */
+	disabled?: boolean;
+
+	/**
+	 * Manually set z-index. Useful for managing the stacking order of sticky elements when multiple components compete.
+	 * Higher z-index values will make the element appear on top of elements with lower z-index values.
+	 */
+	zIndex?: number;
 };
 
 const styles = ( {
@@ -85,7 +111,7 @@ export function StickyContainer( props: Props ) {
 		return () => {
 			observer.disconnect();
 		};
-	}, [ stickyOffset ] );
+	}, [ disabled, stickyOffset ] );
 
 	return (
 		<>

--- a/client/my-sites/plans-grid/components/sticky-container.tsx
+++ b/client/my-sites/plans-grid/components/sticky-container.tsx
@@ -9,15 +9,24 @@ type Props = {
 	element?: ElementType; // which element to render, defaults to div
 	stickyOffset?: number; // offset from the top of the scrolling container to control when the element should start sticking, default 0
 	disabled?: boolean; // force disabled sticky behaviour if set to true
+	zIndex?: number; // Set z index manually
 };
 
-const styles = ( { disabled, stickyOffset }: { disabled: boolean; stickyOffset: number } ) =>
+const styles = ( {
+	disabled,
+	stickyOffset,
+	zIndex,
+}: {
+	disabled: boolean;
+	stickyOffset: number;
+	zIndex: number;
+} ) =>
 	disabled
 		? ''
 		: css`
 				position: sticky;
 				top: ${ stickyOffset + 'px' };
-				z-index: 2;
+				z-index: ${ zIndex };
 		  `;
 
 const Container = styled.div`
@@ -25,7 +34,14 @@ const Container = styled.div`
 `;
 
 export function StickyContainer( props: Props ) {
-	const { stickyOffset = 0, stickyClass = '', element = 'div', disabled = false, children } = props;
+	const {
+		stickyOffset = 0,
+		zIndex = 2,
+		stickyClass = '',
+		element = 'div',
+		disabled = false,
+		children,
+	} = props;
 
 	const stickyRef = useRef( null );
 	const [ isStuck, setIsStuck ] = useState( false );
@@ -91,6 +107,7 @@ export function StickyContainer( props: Props ) {
 				stickyOffset={ stickyOffset }
 				disabled={ disabled }
 				className={ classNames( { [ stickyClass ]: isStuck } ) }
+				zIndex={ zIndex }
 			>
 				{ children( isStuck ) }
 			</Container>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related Automattic/growth-foundations#296

## Proposed Changes

Fixes cosmetic issues in comparison to the spec.

https://github.com/Automattic/wp-calypso/assets/3422709/63279f61-3b18-4053-89e8-59a355cb0e3f



## Testing Instructions

Make sure the dropdown matches the design spec.

- Issue: Automattic/growth-foundations#293

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?