### PR TITLE
Plugin Details: Replace first-child by first-of-type property

### DIFF
--- a/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
+++ b/client/my-sites/marketplace/components/billing-interval-switcher/index.tsx
@@ -31,7 +31,7 @@ const RadioButton = styled( FormRadio )`
 const RadioButtonLabel = styled( FormLabel )`
 	color: var( --studio-gray-60 );
 
-	&:first-child {
+	&:first-of-type {
 		margin-right: 15px;
 	}
 `;


### PR DESCRIPTION


## Proposed Changes

Replace `first-child` by `first-of-type` property to avoid an SSR error.


![CleanShot 2024-01-05 at 16 14 22@2x](https://github.com/Automattic/wp-calypso/assets/5039531/852d14f2-18bf-4a49-8cdf-e5f015439ec3)

## Testing Instructions

* Go to a plugin page you don't a have a subscription. Ex: `/plugins/sensei-pro/:site`
* On the console, check the error above is not shown
* In the trunk version, this error should be shown


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
