### PR TITLE
AI Logo Generator: Change/request ai feature on open

### DIFF
--- a/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
@@ -36,8 +36,10 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	const siteId = siteDetails?.ID;
 
 	useEffect( () => {
-		setSiteDetails( siteDetails );
-	}, [ siteDetails, setSiteDetails ] );
+		if ( siteId ) {
+			setSiteDetails( siteDetails );
+		}
+	}, [ siteId, siteDetails, setSiteDetails ] );
 
 	useEffect( () => {
 		if ( isOpen ) {

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
@@ -5,6 +5,7 @@ import { Icon, Modal, Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { external } from '@wordpress/icons';
+import debugFactory from 'debug';
 import React, { useState, useEffect } from 'react';
 /**
  * Internal dependencies
@@ -21,15 +22,17 @@ import './generator-modal.scss';
  */
 import type { GeneratorModalProps } from '../../types';
 
+const debug = debugFactory( 'jetpack-ai-calypso:generator-modal' );
+
 export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	isOpen,
 	onClose,
 	siteDetails,
 } ) => {
 	// eslint-disable-next-line @typescript-eslint/no-unused-vars
-	const { setSiteDetails } = useDispatch( STORE_NAME );
+	const { setSiteDetails, fetchAiAssistantFeature } = useDispatch( STORE_NAME );
 	const [ isLoading, setIsLoading ] = useState( true );
-	const { selectedLogo, getAiAssistantFeature } = useLogoGenerator();
+	const { selectedLogo } = useLogoGenerator();
 	const siteId = siteDetails?.ID;
 
 	useEffect( () => {
@@ -39,7 +42,8 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	useEffect( () => {
 		if ( isOpen ) {
 			if ( siteId ) {
-				getAiAssistantFeature( String( siteId ) );
+				debug( 'fetching ai assistant feature for site', siteId );
+				fetchAiAssistantFeature( String( siteId ) );
 			}
 
 			setTimeout( () => {
@@ -48,7 +52,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 		} else {
 			setIsLoading( true );
 		}
-	}, [ isOpen, getAiAssistantFeature, siteId ] );
+	}, [ isOpen, fetchAiAssistantFeature, siteId ] );
 
 	const handleApplyLogo = () => {
 		onClose();

--- a/packages/jetpack-ai-calypso/src/logo-generator/store/index.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/store/index.ts
@@ -20,15 +20,6 @@ const jetpackAiLogoGeneratorStore = createReduxStore( STORE_NAME, {
 	reducer,
 
 	selectors,
-
-	resolvers: {
-		getAiAssistantFeature: ( siteId: string ) => {
-			if ( ! siteId ) {
-				return;
-			}
-			return actions.fetchAiAssistantFeature( String( siteId ) );
-		},
-	},
 } );
 
 register( jetpackAiLogoGeneratorStore );

--- a/packages/jetpack-ai-calypso/src/logo-generator/store/reducer.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/store/reducer.ts
@@ -50,6 +50,10 @@ export default function reducer( state = INITIAL_STATE, action: any ) {
 					...state.features,
 					aiAssistantFeature: {
 						...action.feature,
+						// re evaluate requireUpgrade as the logo generator does not allow free usage
+						requireUpgrade: action.feature.currentTier
+							? action.feature.currentTier.value === 0
+							: action.feature.requireUpgrade,
 						_meta: {
 							...state?.features?.aiAssistantFeature?._meta,
 							isRequesting: false,


### PR DESCRIPTION
Need to fetch AI Assistant data on modal open so we keep in sync after all the optimistic updates

Related to #85557

## Proposed Changes

* remove resolver
* dispatch fetch action on modal open
* bonus: re evaluate requireUpgrade as sites within the free request limit were getting `requireUpgrade` false (as it should, normally, for ai assistant
* bonus: only store siteDetails if site ID makes sense

## Testing Instructions

Keep devtools open on the network tab. See that opening the modal triggers a fetch to the ai-assistant-feature endpoint every time.
Test with a site that still has remaining free requests, previous to this PR you'd see the site was allowed to generate images even on the free tier. Now `requireUpgrade` should be re-evaluated based upon the value of `currentTier.value` and disable all prompt capabilities.