### PR TITLE
Checkout ToS: Move TermsCollapseContent styled component declaration outside of calling component

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-terms.tsx
+++ b/client/my-sites/checkout/src/components/checkout-terms.tsx
@@ -30,6 +30,20 @@ import ThirdPartyPluginsTermsOfService from './third-party-plugins-terms-of-serv
 import TitanTermsOfService from './titan-terms-of-service';
 import type { ResponseCart } from '@automattic/shopping-cart';
 
+const TermsCollapsedContent = styled.div`
+	& .foldable-card__main {
+		position: relative;
+		left: 20px;
+	}
+
+	& .foldable-card__expand {
+		position: absolute;
+		left: -24px;
+		top: -3px;
+		width: 20px;
+	}
+`;
+
 export default function CheckoutTerms( { cart }: { cart: ResponseCart } ) {
 	const isGiftPurchase = cart.is_gift_purchase;
 	const translate = useTranslate();
@@ -45,20 +59,6 @@ export default function CheckoutTerms( { cart }: { cart: ResponseCart } ) {
 	// subscription behind the scenes so we need to show the full TOS including
 	// renewal text.
 	const hasDomainTransfer = cart.products.some( ( product ) => isDomainTransfer( product ) );
-
-	const TermsCollapsedContent = styled.div`
-		& .foldable-card__main {
-			position: relative;
-			left: 20px;
-		}
-
-		& .foldable-card__expand {
-			position: absolute;
-			left: -24px;
-			top: -3px;
-			width: 20px;
-		}
-	`;
 
 	const showToSFoldableCard = useToSFoldableCard();
 

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -105,15 +105,9 @@ export default function BeforeSubmitCheckoutHeader() {
 
 	return (
 		<>
-			{ ! showToSFoldableCard ? (
-				<CheckoutTermsWrapper showToSFoldableCard={ showToSFoldableCard }>
-					<CheckoutTerms cart={ responseCart } />
-				</CheckoutTermsWrapper>
-			) : (
-				<CheckoutTermsWrapper showToSFoldableCard={ showToSFoldableCard }>
-					<CheckoutTerms cart={ responseCart } />
-				</CheckoutTermsWrapper>
-			) }
+			<CheckoutTermsWrapper showToSFoldableCard={ showToSFoldableCard }>
+				<CheckoutTerms cart={ responseCart } />
+			</CheckoutTermsWrapper>
 
 			{ ! hasCheckoutVersion( '2' ) && (
 				<WPOrderReviewSection>


### PR DESCRIPTION
This fixes a bug reported in #86074 that was introduced in #84031.

Fixes #86074

## Proposed Changes

* Move the styled component `TermsCollapseContent` to outside of its calling component `CheckoutTerms`

## Testing Instructions

* Add a product to your cart and go to checkout
* Scroll down and click on 'Read more' header found in the ToS section above the payment button
* Ensure that the header remains open and doesn't collapse until you click on the header again
