### PR TITLE
Balance button text horizontally

### DIFF
--- a/packages/privacy-toolset/CHANGELOG.md
+++ b/packages/privacy-toolset/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## next
 
+## 2.1.0
+
+- Fixed mobile cookie banner button's vertical positioning
+
 ## 2.0.0
 
 - Update the default bucket selection when the cookie banner expands, leaving "advertising unticked.

--- a/packages/privacy-toolset/src/cookie-banner/styles.scss
+++ b/packages/privacy-toolset/src/cookie-banner/styles.scss
@@ -186,6 +186,7 @@ $cookie-banner-font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Robo
 
 			.cookie-banner__button-container {
 				align-self: flex-end;
+				align-items: baseline;
 			}
 		}
 		.cookie-banner__simple-text-description {


### PR DESCRIPTION
Related to # https://github.com/Automattic/wp-calypso/issues/84695

Adds `align-items: baseline` to cookie-banner button container element

Before

![before](https://github.com/Automattic/wp-calypso/assets/25906001/c3195d02-d49c-49cb-8e78-9583dd67dbb6)

After 

![after](https://github.com/Automattic/wp-calypso/assets/25906001/06002216-ca82-4023-ba48-0093762faab3)

## Testing Instructions

Code review is sufficient

