### PR TITLE
Site Settings: Fix/remove border from toggles

### DIFF
--- a/client/assets/stylesheets/_wp-components-overrides.scss
+++ b/client/assets/stylesheets/_wp-components-overrides.scss
@@ -1,8 +1,3 @@
-/* @wordpress/components Form toggles use the color scheme's background color */
-.components-form-toggle.is-checked .components-form-toggle__track {
-	background-color: var(--color-primary);
-}
-
 .components-form-toggle {
 	input[type="checkbox"] {
 		cursor: pointer;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5033

Site toggles have the primary color applied as a border when they are in a checked state. This is not what it should be.

## Proposed Changes

* Remove style that adds the primary color as a border to the checked state of a toggle.

This change will affect all toggles in Calypso.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Settings -> Writing
* Ensure that one of the toggles is selected and check that it no longer has a border with the primary color

Before:
<img width="733" alt="CleanShot 2567-01-08 at 13 40 51@2x" src="https://github.com/Automattic/wp-calypso/assets/10244734/4c045889-6032-4a0f-83e6-ff4fb7a4a81c">

After:
<img width="739" alt="CleanShot 2567-01-08 at 13 39 44@2x" src="https://github.com/Automattic/wp-calypso/assets/10244734/abce7b45-80b9-4527-83b5-a796d49995fd">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?