### PR TITLE
Add coupon to query hook

### DIFF
--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -23,6 +23,7 @@ interface Props {
 	planSlugs: PlanSlug[];
 	withoutProRatedCredits?: boolean;
 	storageAddOns?: ( AddOnMeta | null )[] | null;
+	coupon?: string | null;
 }
 
 function getTotalPrices( planPrices: PlanPrices, addOnPrice = 0 ): PlanPrices {
@@ -50,6 +51,7 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 	planSlugs,
 	withoutProRatedCredits = false,
 	storageAddOns,
+	coupon = null,
 }: Props ) => {
 	// TODO: pass this in as a prop to uncouple the dependency
 	const selectedSiteId = useSelector( getSelectedSiteId ) ?? undefined;
@@ -57,7 +59,7 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 	const planAvailabilityForPurchase = useCheckPlanAvailabilityForPurchase( { planSlugs } );
 
 	// pricedAPIPlans - should have a definition for all plans, being the main source of API data
-	const pricedAPIPlans = Plans.usePlans();
+	const pricedAPIPlans = Plans.usePlans( { coupon } );
 	// pricedAPISitePlans - unclear if all plans are included
 	const pricedAPISitePlans = Plans.useSitePlans( { siteId: selectedSiteId } );
 	const currentPlan = Plans.useCurrentPlan( { siteId: selectedSiteId } );

--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -23,7 +23,7 @@ interface Props {
 	planSlugs: PlanSlug[];
 	withoutProRatedCredits?: boolean;
 	storageAddOns?: ( AddOnMeta | null )[] | null;
-	coupon?: string | null;
+	coupon?: string;
 }
 
 function getTotalPrices( planPrices: PlanPrices, addOnPrice = 0 ): PlanPrices {
@@ -51,7 +51,7 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 	planSlugs,
 	withoutProRatedCredits = false,
 	storageAddOns,
-	coupon = null,
+	coupon,
 }: Props ) => {
 	// TODO: pass this in as a prop to uncouple the dependency
 	const selectedSiteId = useSelector( getSelectedSiteId ) ?? undefined;

--- a/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -122,6 +122,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 		const pricingMeta = usePricingMetaForGridPlans( {
 			planSlugs: [ PLAN_PERSONAL ],
 			withoutProRatedCredits: false,
+			storageAddOns: null,
 		} );
 
 		const expectedPricingMeta = {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -424,6 +424,7 @@ const PlansFeaturesMain = ( {
 		showLegacyStorageFeature,
 		isSubdomainNotGenerated: ! resolvedSubdomainName.result,
 		storageAddOns,
+		coupon,
 	} );
 
 	const planFeaturesForFeaturesGrid = usePlanFeaturesForGridPlans( {

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -77,10 +77,12 @@ export type UsePricingMetaForGridPlans = ( {
 	planSlugs,
 	withoutProRatedCredits,
 	storageAddOns,
+	coupon,
 }: {
 	planSlugs: PlanSlug[];
 	withoutProRatedCredits?: boolean;
 	storageAddOns: ( AddOnMeta | null )[] | null;
+	coupon: string | null;
 } ) => { [ planSlug: string ]: PricingMetaForGridPlan } | null;
 
 export type UseFreeTrialPlanSlugs = ( {
@@ -160,6 +162,7 @@ interface Props {
 	 */
 	isSubdomainNotGenerated?: boolean;
 	storageAddOns: ( AddOnMeta | null )[] | null;
+	coupon?: string | null;
 }
 
 const usePlanTypesWithIntent = ( {
@@ -280,6 +283,7 @@ const useGridPlans = ( {
 	eligibleForFreeHostingTrial,
 	isSubdomainNotGenerated,
 	storageAddOns,
+	coupon = null,
 }: Props ): Omit< GridPlan, 'features' >[] | null => {
 	const freeTrialPlanSlugs = useFreeTrialPlanSlugs( {
 		intent: intent ?? 'default',
@@ -321,7 +325,7 @@ const useGridPlans = ( {
 	} );
 
 	// TODO: pricedAPIPlans to be queried from data-store package
-	const pricedAPIPlans = Plans.usePlans();
+	const pricedAPIPlans = Plans.usePlans( { coupon } );
 	const pricingMeta = usePricingMetaForGridPlans( {
 		planSlugs: availablePlanSlugs,
 		storageAddOns,

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -82,7 +82,7 @@ export type UsePricingMetaForGridPlans = ( {
 	planSlugs: PlanSlug[];
 	withoutProRatedCredits?: boolean;
 	storageAddOns: ( AddOnMeta | null )[] | null;
-	coupon: string | null;
+	coupon?: string;
 } ) => { [ planSlug: string ]: PricingMetaForGridPlan } | null;
 
 export type UseFreeTrialPlanSlugs = ( {
@@ -162,7 +162,7 @@ interface Props {
 	 */
 	isSubdomainNotGenerated?: boolean;
 	storageAddOns: ( AddOnMeta | null )[] | null;
-	coupon?: string | null;
+	coupon?: string;
 }
 
 const usePlanTypesWithIntent = ( {
@@ -283,7 +283,7 @@ const useGridPlans = ( {
 	eligibleForFreeHostingTrial,
 	isSubdomainNotGenerated,
 	storageAddOns,
-	coupon = null,
+	coupon,
 }: Props ): Omit< GridPlan, 'features' >[] | null => {
 	const freeTrialPlanSlugs = useFreeTrialPlanSlugs( {
 		intent: intent ?? 'default',
@@ -329,6 +329,7 @@ const useGridPlans = ( {
 	const pricingMeta = usePricingMetaForGridPlans( {
 		planSlugs: availablePlanSlugs,
 		storageAddOns,
+		coupon,
 	} );
 
 	// Null return would indicate that we are still loading the data. No grid without grid plans.

--- a/packages/data-stores/src/plans/queries/use-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-plans.ts
@@ -11,8 +11,10 @@ interface PlansIndex {
 /**
  * Plans from `/plans` endpoint, transformed into a map of planSlug => PlanNext
  */
-function usePlans(): UseQueryResult< PlansIndex > {
+function usePlans( { coupon }: { coupon: string | null } ): UseQueryResult< PlansIndex > {
 	const queryKeys = useQueryKeysFactory();
+	const params = new URLSearchParams();
+	coupon && params.append( 'coupon_code', coupon );
 
 	return useQuery( {
 		queryKey: queryKeys.plans(),
@@ -20,6 +22,7 @@ function usePlans(): UseQueryResult< PlansIndex > {
 			const data: PricedAPIPlan[] = await wpcomRequest( {
 				path: `/plans`,
 				apiVersion: '1.5',
+				query: params.toString(),
 			} );
 
 			return Object.fromEntries(

--- a/packages/data-stores/src/plans/queries/use-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-plans.ts
@@ -11,7 +11,7 @@ interface PlansIndex {
 /**
  * Plans from `/plans` endpoint, transformed into a map of planSlug => PlanNext
  */
-function usePlans( { coupon }: { coupon: string | null } ): UseQueryResult< PlansIndex > {
+function usePlans( { coupon }: { coupon?: string } = {} ): UseQueryResult< PlansIndex > {
 	const queryKeys = useQueryKeysFactory();
 	const params = new URLSearchParams();
 	coupon && params.append( 'coupon_code', coupon );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This is a follow-up to https://github.com/Automattic/wp-calypso/pull/85660 which sends `coupon` as a query parameter to the `/plans` endpoint. @chriskmnds pointed out that `<QueryPlans />` will soon be deprecated, so this PR includes `coupon` as a query param in the respective query hook. 
* In the upcoming changes in the PR https://github.com/Automattic/wp-calypso/pull/85486, the `usePlans()` query hook will return the original and discounted prices for plans.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get a valid coupon code from `33094-pb`.
* Visit `/start/coupon=A_VALID_COUPON` using the coupon code you got in the previous step. At the plans step of the signup flow, verify network requests to confirm that `coupon_code` query param is sent. 
