### PR TITLE
Prevent Assembler CTA overflow container

### DIFF
--- a/packages/design-picker/src/components/pattern-assembler-cta/style.scss
+++ b/packages/design-picker/src/components/pattern-assembler-cta/style.scss
@@ -132,19 +132,16 @@
 	}
 
 	.pattern-assembler-cta__image-wrapper {
+		padding-left: 35px;
 		text-align: right;
-
-		@include break-wide {
-			padding-left: 35px;
-		}
 	}
 
 	.pattern-assembler-cta__image {
+		max-width: 405px;
 		width: 100%;
 
 		@include break-wide {
 			min-width: 380px;
-			max-width: 405px;
 		}
 	}
 }

--- a/packages/design-picker/src/components/pattern-assembler-cta/style.scss
+++ b/packages/design-picker/src/components/pattern-assembler-cta/style.scss
@@ -29,7 +29,6 @@
 		padding: 96px 64px;
 	}
 
-
 	@media ( min-width: 1600px ) {
 		flex-direction: column;
 	}
@@ -133,13 +132,19 @@
 	}
 
 	.pattern-assembler-cta__image-wrapper {
-		padding-left: 35px;
 		text-align: right;
+
+		@include break-wide {
+			padding-left: 35px;
+		}
 	}
 
 	.pattern-assembler-cta__image {
 		width: 100%;
-		min-width: 380px;
-		max-width: 405px;
+
+		@include break-wide {
+			min-width: 380px;
+			max-width: 405px;
+		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85817

## Proposed Changes

This PR fixes the issue where the Design Picker cards overflow the container due to the image width of the Assembler CTA.

| Before | After |
| --- | --- |
| ![Screenshot 2024-01-08 at 4 02 29 PM](https://github.com/Automattic/wp-calypso/assets/797888/d4e8703a-ad75-42eb-95c6-8fe91e7dd482) | ![Screenshot 2024-01-08 at 4 02 18 PM](https://github.com/Automattic/wp-calypso/assets/797888/dce2099e-623f-4ee9-9ed3-23b95fe15539) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Design Picker.
* Set the browser viewport to mobile.
* Ensure that the theme cards and the Assembler CTA are confined within their container.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?