### PR TITLE
Paid Stats: Don't show upgrade banner when site already has stats-paid feature

### DIFF
--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -1,3 +1,4 @@
+import { FEATURE_STATS_PAID } from '@automattic/calypso-products';
 import { useState, useEffect } from 'react';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import version_compare from 'calypso/lib/version-compare';
@@ -9,10 +10,10 @@ import {
 import { useSelector, useDispatch } from 'calypso/state';
 import { resetSiteState } from 'calypso/state/purchases/actions';
 import { hasLoadedSitePurchasesFromServer } from 'calypso/state/purchases/selectors';
-import isSiteOnPaidPlan from 'calypso/state/selectors/is-site-on-paid-plan';
 import isSiteWpcom from 'calypso/state/selectors/is-site-wpcom';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { hasLoadedSitePlansFromServer } from 'calypso/state/sites/plans/selectors';
 import getJetpackStatsAdminVersion from 'calypso/state/sites/selectors/get-jetpack-stats-admin-version';
 import getSiteOption from 'calypso/state/sites/selectors/get-site-option';
@@ -23,6 +24,7 @@ import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import useStatsPurchases from '../hooks/use-stats-purchases';
 import ALL_STATS_NOTICES from './all-notice-definitions';
 import { StatsNoticeProps, StatsNoticesProps } from './types';
+
 import './style.scss';
 
 const TEAM51_OWNER_ID = 70055110;
@@ -78,14 +80,13 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 		( state ) => getSelectedSite( state )?.site_owner === TEAM51_OWNER_ID
 	);
 
-	// Check whether sites have paid plans of WPCOM.
-	const siteHasPaidPlan = useSelector( ( state ) => isSiteOnPaidPlan( state, siteId || 0 ) );
-	// TODO: Consolidate the proper way of checking WPCOM plans for supporting Stats to `hasSiteProductJetpackStatsPaid`.
-	const wpcomSiteHasPaidPlan = isWpcom && siteHasPaidPlan;
+	const wpcomSiteHasPaidStatsFeature = useSelector(
+		( state ) => isWpcom && siteHasFeature( state, siteId, FEATURE_STATS_PAID )
+	);
 
 	const hasPaidStats =
 		useSelector( ( state ) => hasSiteProductJetpackStatsPaid( state, siteId ) ) ||
-		wpcomSiteHasPaidPlan;
+		wpcomSiteHasPaidStatsFeature;
 	const hasFreeStats = useSelector( ( state ) => hasSiteProductJetpackStatsFree( state, siteId ) );
 
 	const { isRequestingSitePurchases, isCommercialOwned } = useStatsPurchases( siteId );


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5100

## Proposed Changes

* Update the logic for showing the upgrade banner to feature checking instead of site plan check
* Should not show banner for free sites that have access to paid stats

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/376c394a-29de-4924-ae5c-37a581cf5d68">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/57fb981b-ab21-4491-ad0a-309e7ea5010b">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /stats with a free site that has access to Paid Stats (currently the criteria are sites created before Dec. 19
* The upgrade banner should not render
* Double-check sites on other plans (starter, explorer, creator, creator on atomic, Jetpack)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?