### PR TITLE
Live Preview: Make sure the routerPrivateApis is available

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-location.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-location.ts
@@ -4,7 +4,7 @@ import { getUnlock } from '../utils';
 const unlock = getUnlock();
 
 let useLocation = () => null;
-if ( unlock && unlock( routerPrivateApis ) ) {
+if ( unlock && routerPrivateApis && unlock( routerPrivateApis ) ) {
 	useLocation = unlock( routerPrivateApis ).useLocation;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1704706676004469-slack-CRWCHQGUB

## Proposed Changes

* Check whether the `routerPrivateApis` is available or not to resolve the following error

```
Uncaught TypeError: can't access property "privateApis", T is undefined
wpcom.editor.min.js:9921:9
```

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox `widgets.wp.com`
* Apply changes to your sandbox
* Go to p2
* Make sure you won't see the above error

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?