### PR TITLE
Added tests for `email/paths.js`

### DIFF
--- a/client/my-sites/email/test/paths.ts
+++ b/client/my-sites/email/test/paths.ts
@@ -1,0 +1,167 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+	emailManagementAddEmailForwards,
+	emailManagementAddGSuiteUsers,
+	emailManagementManageTitanAccount,
+	emailManagementManageTitanMailboxes,
+	emailManagementNewTitanAccount,
+	emailManagementTitanSetUpMailbox,
+	emailManagementTitanSetUpThankYou,
+	emailManagementTitanControlPanelRedirect,
+	emailManagement,
+	emailManagementForwarding,
+	emailManagementPurchaseNewEmailAccount,
+	emailManagementInDepthComparison,
+	emailManagementMailboxes,
+	isUnderEmailManagementAll,
+} from '../paths';
+
+const siteName = 'hello.wordpress.com';
+const domainName = 'hello.com';
+
+describe( 'path helper functions', () => {
+	it( 'emailManagementAddEmailForwards', () => {
+		expect( emailManagementAddEmailForwards( siteName, domainName ) ).toEqual(
+			`/email/${ domainName }/forwarding/add/${ siteName }`
+		);
+		expect( emailManagementAddEmailForwards( siteName, '' ) ).toEqual(
+			`/email//forwarding/add/${ siteName }`
+		);
+		expect( emailManagementAddEmailForwards( '', '' ) ).toEqual( `/email//forwarding/add/` );
+	} );
+
+	it( 'emailManagementAddGSuiteUsers', () => {
+		expect( emailManagementAddGSuiteUsers( siteName, domainName, 'google-workspace' ) ).toEqual(
+			`/email/${ domainName }/google-workspace/add-users/${ siteName }`
+		);
+		expect( emailManagementAddGSuiteUsers( siteName, null, 'google-workspace' ) ).toEqual(
+			`/email/google-workspace/add-users/${ siteName }`
+		);
+		expect( emailManagementAddGSuiteUsers( null, null, 'google-workspace' ) ).toEqual(
+			`/email/google-workspace/add-users/null`
+		);
+	} );
+
+	it( 'emailManagementManageTitanAccount', () => {
+		expect( emailManagementManageTitanAccount( siteName, domainName ) ).toEqual(
+			`/email/${ domainName }/titan/manage/${ siteName }`
+		);
+		expect( emailManagementManageTitanAccount( siteName, '' ) ).toEqual(
+			`/email//titan/manage/${ siteName }`
+		);
+		expect( emailManagementManageTitanAccount( null, '' ) ).toEqual( '/email//titan/manage/null' );
+	} );
+
+	it( 'emailManagementManageTitanMailboxes', () => {
+		expect( emailManagementManageTitanMailboxes( siteName, domainName ) ).toEqual(
+			`/email/${ domainName }/titan/manage-mailboxes/${ siteName }`
+		);
+		expect( emailManagementManageTitanMailboxes( siteName, '' ) ).toEqual(
+			`/email//titan/manage-mailboxes/${ siteName }`
+		);
+		expect( emailManagementManageTitanMailboxes( null, '' ) ).toEqual(
+			'/email//titan/manage-mailboxes/null'
+		);
+	} );
+
+	it( 'emailManagementNewTitanAccount', () => {
+		expect( emailManagementNewTitanAccount( siteName, domainName ) ).toEqual(
+			`/email/${ domainName }/titan/new/${ siteName }`
+		);
+		expect( emailManagementNewTitanAccount( siteName, '' ) ).toEqual(
+			`/email//titan/new/${ siteName }`
+		);
+		expect( emailManagementNewTitanAccount( null, '' ) ).toEqual( '/email//titan/new/null' );
+	} );
+
+	it( 'emailManagementTitanSetUpMailbox', () => {
+		expect( emailManagementTitanSetUpMailbox( siteName, domainName ) ).toEqual(
+			`/email/${ domainName }/titan/set-up-mailbox/${ siteName }`
+		);
+		expect( emailManagementTitanSetUpMailbox( siteName, '' ) ).toEqual(
+			`/email//titan/set-up-mailbox/${ siteName }`
+		);
+		expect( emailManagementTitanSetUpMailbox( null, '' ) ).toEqual(
+			`/email//titan/set-up-mailbox/null`
+		);
+	} );
+
+	it( 'emailManagementTitanSetUpThankYou', () => {
+		expect( emailManagementTitanSetUpThankYou( siteName, domainName ) ).toEqual(
+			`/email/${ domainName }/titan/set-up-mailbox/thank-you/${ siteName }`
+		);
+		expect( emailManagementTitanSetUpThankYou( siteName, '' ) ).toEqual(
+			`/email//titan/set-up-mailbox/thank-you/${ siteName }`
+		);
+		expect( emailManagementTitanSetUpThankYou( null, '' ) ).toEqual(
+			`/email//titan/set-up-mailbox/thank-you/null`
+		);
+	} );
+
+	it( 'emailManagementTitanControlPanelRedirect', () => {
+		expect( emailManagementTitanControlPanelRedirect( siteName, domainName ) ).toEqual(
+			`/email/${ domainName }/titan/control-panel/${ siteName }`
+		);
+		expect( emailManagementTitanControlPanelRedirect( siteName, '' ) ).toEqual(
+			`/email//titan/control-panel/${ siteName }`
+		);
+		expect( emailManagementTitanControlPanelRedirect( null, '' ) ).toEqual(
+			`/email//titan/control-panel/null`
+		);
+	} );
+
+	it( 'emailManagement', () => {
+		expect( emailManagement( siteName, domainName ) ).toEqual(
+			`/email/${ domainName }/manage/${ siteName }`
+		);
+		expect( emailManagement( siteName, null ) ).toEqual( `/email/${ siteName }` );
+		expect( emailManagement( null, null ) ).toEqual( `/email` );
+	} );
+
+	it( 'emailManagementForwarding', () => {
+		expect( emailManagementForwarding( siteName, domainName ) ).toEqual(
+			`/email/${ domainName }/forwarding/${ siteName }`
+		);
+		expect( emailManagementForwarding( siteName, '' ) ).toEqual(
+			`/email//forwarding/${ siteName }`
+		);
+		expect( emailManagementForwarding( null, '' ) ).toEqual( `/email//forwarding/null` );
+	} );
+
+	it( 'emailManagementPurchaseNewEmailAccount', () => {
+		expect( emailManagementPurchaseNewEmailAccount( siteName, domainName ) ).toEqual(
+			`/email/${ domainName }/purchase/${ siteName }`
+		);
+		expect( emailManagementPurchaseNewEmailAccount( siteName, '' ) ).toEqual(
+			`/email//purchase/${ siteName }`
+		);
+		expect( emailManagementPurchaseNewEmailAccount( null, '' ) ).toEqual( `/email//purchase/null` );
+	} );
+
+	it( 'emailManagementInDepthComparison', () => {
+		expect( emailManagementInDepthComparison( siteName, domainName ) ).toEqual(
+			`/email/${ domainName }/compare/${ siteName }`
+		);
+		expect( emailManagementInDepthComparison( siteName, '' ) ).toEqual(
+			`/email//compare/${ siteName }`
+		);
+		expect( emailManagementInDepthComparison( null, '' ) ).toEqual( `/email//compare/null` );
+	} );
+
+	it( 'emailManagementMailboxes', () => {
+		expect( emailManagementMailboxes( siteName ) ).toEqual( `/mailboxes/${ siteName }` );
+		expect( emailManagementMailboxes() ).toEqual( '/mailboxes' );
+	} );
+
+	it.each( [
+		[ '/domains', false ],
+		[ '/email', false ],
+		[ '/email/all', false ],
+		[ '/email/all/', true ],
+	] )( 'isUnderEmailManagement %s', ( path, expectedResult ) => {
+		expect( isUnderEmailManagementAll( path ) ).toEqual( expectedResult );
+	} );
+} );

--- a/client/my-sites/email/test/paths.ts
+++ b/client/my-sites/email/test/paths.ts
@@ -2,7 +2,9 @@
  * @jest-environment jsdom
  */
 
+import { GOOGLE_WORKSPACE_PRODUCT_TYPE, GSUITE_PRODUCT_TYPE } from 'calypso/lib/gsuite/constants';
 import {
+	emailManagementAllSitesPrefix,
 	emailManagementAddEmailForwards,
 	emailManagementAddGSuiteUsers,
 	emailManagementManageTitanAccount,
@@ -27,6 +29,12 @@ describe( 'path helper functions', () => {
 		expect( emailManagementAddEmailForwards( siteName, domainName ) ).toEqual(
 			`/email/${ domainName }/forwarding/add/${ siteName }`
 		);
+		expect(
+			emailManagementAddEmailForwards( ':site', ':domain', emailManagementAllSitesPrefix )
+		).toEqual( '/email/all/:domain/forwarding/add/:site' );
+		expect( emailManagementAddEmailForwards( ':site', ':domain' ) ).toEqual(
+			'/email/:domain/forwarding/add/:site'
+		);
 		expect( emailManagementAddEmailForwards( siteName, '' ) ).toEqual(
 			`/email//forwarding/add/${ siteName }`
 		);
@@ -34,8 +42,16 @@ describe( 'path helper functions', () => {
 	} );
 
 	it( 'emailManagementAddGSuiteUsers', () => {
+		const productTypePlaceholder = `:productType(${ GOOGLE_WORKSPACE_PRODUCT_TYPE }|${ GSUITE_PRODUCT_TYPE })`;
+
 		expect( emailManagementAddGSuiteUsers( siteName, domainName, 'google-workspace' ) ).toEqual(
 			`/email/${ domainName }/google-workspace/add-users/${ siteName }`
+		);
+		expect( emailManagementAddGSuiteUsers( ':site', ':domain', productTypePlaceholder ) ).toEqual(
+			`/email/:domain/${ productTypePlaceholder }/add-users/:site`
+		);
+		expect( emailManagementAddGSuiteUsers( ':site', ':domain', 'google-workspace' ) ).toEqual(
+			'/email/:domain/google-workspace/add-users/:site'
 		);
 		expect( emailManagementAddGSuiteUsers( siteName, null, 'google-workspace' ) ).toEqual(
 			`/email/google-workspace/add-users/${ siteName }`
@@ -49,6 +65,12 @@ describe( 'path helper functions', () => {
 		expect( emailManagementManageTitanAccount( siteName, domainName ) ).toEqual(
 			`/email/${ domainName }/titan/manage/${ siteName }`
 		);
+		expect(
+			emailManagementManageTitanAccount( ':site', ':domain', emailManagementAllSitesPrefix )
+		).toEqual( '/email/all/:domain/titan/manage/:site' );
+		expect( emailManagementManageTitanAccount( ':site', ':domain' ) ).toEqual(
+			'/email/:domain/titan/manage/:site'
+		);
 		expect( emailManagementManageTitanAccount( siteName, '' ) ).toEqual(
 			`/email//titan/manage/${ siteName }`
 		);
@@ -58,6 +80,12 @@ describe( 'path helper functions', () => {
 	it( 'emailManagementManageTitanMailboxes', () => {
 		expect( emailManagementManageTitanMailboxes( siteName, domainName ) ).toEqual(
 			`/email/${ domainName }/titan/manage-mailboxes/${ siteName }`
+		);
+		expect(
+			emailManagementManageTitanMailboxes( ':site', ':domain', emailManagementAllSitesPrefix )
+		).toEqual( '/email/all/:domain/titan/manage-mailboxes/:site' );
+		expect( emailManagementManageTitanMailboxes( ':site', ':domain' ) ).toEqual(
+			'/email/:domain/titan/manage-mailboxes/:site'
 		);
 		expect( emailManagementManageTitanMailboxes( siteName, '' ) ).toEqual(
 			`/email//titan/manage-mailboxes/${ siteName }`
@@ -71,6 +99,12 @@ describe( 'path helper functions', () => {
 		expect( emailManagementNewTitanAccount( siteName, domainName ) ).toEqual(
 			`/email/${ domainName }/titan/new/${ siteName }`
 		);
+		expect(
+			emailManagementNewTitanAccount( ':site', ':domain', emailManagementAllSitesPrefix )
+		).toEqual( '/email/all/:domain/titan/new/:site' );
+		expect( emailManagementNewTitanAccount( ':site', ':domain' ) ).toEqual(
+			'/email/:domain/titan/new/:site'
+		);
 		expect( emailManagementNewTitanAccount( siteName, '' ) ).toEqual(
 			`/email//titan/new/${ siteName }`
 		);
@@ -80,6 +114,12 @@ describe( 'path helper functions', () => {
 	it( 'emailManagementTitanSetUpMailbox', () => {
 		expect( emailManagementTitanSetUpMailbox( siteName, domainName ) ).toEqual(
 			`/email/${ domainName }/titan/set-up-mailbox/${ siteName }`
+		);
+		expect(
+			emailManagementTitanSetUpMailbox( ':site', ':domain', emailManagementAllSitesPrefix )
+		).toEqual( '/email/all/:domain/titan/set-up-mailbox/:site' );
+		expect( emailManagementTitanSetUpMailbox( ':site', ':domain' ) ).toEqual(
+			'/email/:domain/titan/set-up-mailbox/:site'
 		);
 		expect( emailManagementTitanSetUpMailbox( siteName, '' ) ).toEqual(
 			`/email//titan/set-up-mailbox/${ siteName }`
@@ -93,6 +133,9 @@ describe( 'path helper functions', () => {
 		expect( emailManagementTitanSetUpThankYou( siteName, domainName ) ).toEqual(
 			`/email/${ domainName }/titan/set-up-mailbox/thank-you/${ siteName }`
 		);
+		expect(
+			emailManagementTitanSetUpThankYou( ':site', ':domain', null, emailManagementAllSitesPrefix )
+		).toEqual( '/email/all/:domain/titan/set-up-mailbox/thank-you/:site' );
 		expect( emailManagementTitanSetUpThankYou( siteName, '' ) ).toEqual(
 			`/email//titan/set-up-mailbox/thank-you/${ siteName }`
 		);
@@ -104,6 +147,12 @@ describe( 'path helper functions', () => {
 	it( 'emailManagementTitanControlPanelRedirect', () => {
 		expect( emailManagementTitanControlPanelRedirect( siteName, domainName ) ).toEqual(
 			`/email/${ domainName }/titan/control-panel/${ siteName }`
+		);
+		expect(
+			emailManagementTitanControlPanelRedirect( ':site', ':domain', emailManagementAllSitesPrefix )
+		).toEqual( '/email/all/:domain/titan/control-panel/:site' );
+		expect( emailManagementTitanControlPanelRedirect( ':site', ':domain' ) ).toEqual(
+			'/email/:domain/titan/control-panel/:site'
 		);
 		expect( emailManagementTitanControlPanelRedirect( siteName, '' ) ).toEqual(
 			`/email//titan/control-panel/${ siteName }`
@@ -117,6 +166,11 @@ describe( 'path helper functions', () => {
 		expect( emailManagement( siteName, domainName ) ).toEqual(
 			`/email/${ domainName }/manage/${ siteName }`
 		);
+		expect( emailManagement( ':site', ':domain', emailManagementAllSitesPrefix ) ).toEqual(
+			'/email/all/:domain/manage/:site'
+		);
+		expect( emailManagement( ':site', ':domain' ) ).toEqual( '/email/:domain/manage/:site' );
+		expect( emailManagement( ':site' ) ).toEqual( '/email/:site' );
 		expect( emailManagement( siteName, null ) ).toEqual( `/email/${ siteName }` );
 		expect( emailManagement( null, null ) ).toEqual( `/email` );
 	} );
@@ -124,6 +178,12 @@ describe( 'path helper functions', () => {
 	it( 'emailManagementForwarding', () => {
 		expect( emailManagementForwarding( siteName, domainName ) ).toEqual(
 			`/email/${ domainName }/forwarding/${ siteName }`
+		);
+		expect(
+			emailManagementForwarding( ':site', ':domain', emailManagementAllSitesPrefix )
+		).toEqual( '/email/all/:domain/forwarding/:site' );
+		expect( emailManagementForwarding( ':site', ':domain' ) ).toEqual(
+			'/email/:domain/forwarding/:site'
 		);
 		expect( emailManagementForwarding( siteName, '' ) ).toEqual(
 			`/email//forwarding/${ siteName }`
@@ -135,6 +195,12 @@ describe( 'path helper functions', () => {
 		expect( emailManagementPurchaseNewEmailAccount( siteName, domainName ) ).toEqual(
 			`/email/${ domainName }/purchase/${ siteName }`
 		);
+		expect(
+			emailManagementPurchaseNewEmailAccount( ':site', ':domain', emailManagementAllSitesPrefix )
+		).toEqual( '/email/all/:domain/purchase/:site' );
+		expect( emailManagementPurchaseNewEmailAccount( ':site', ':domain' ) ).toEqual(
+			'/email/:domain/purchase/:site'
+		);
 		expect( emailManagementPurchaseNewEmailAccount( siteName, '' ) ).toEqual(
 			`/email//purchase/${ siteName }`
 		);
@@ -145,6 +211,9 @@ describe( 'path helper functions', () => {
 		expect( emailManagementInDepthComparison( siteName, domainName ) ).toEqual(
 			`/email/${ domainName }/compare/${ siteName }`
 		);
+		expect( emailManagementInDepthComparison( ':site', ':domain' ) ).toEqual(
+			'/email/:domain/compare/:site'
+		);
 		expect( emailManagementInDepthComparison( siteName, '' ) ).toEqual(
 			`/email//compare/${ siteName }`
 		);
@@ -153,6 +222,7 @@ describe( 'path helper functions', () => {
 
 	it( 'emailManagementMailboxes', () => {
 		expect( emailManagementMailboxes( siteName ) ).toEqual( `/mailboxes/${ siteName }` );
+		expect( emailManagementMailboxes( ':site' ) ).toEqual( '/mailboxes/:site' );
 		expect( emailManagementMailboxes() ).toEqual( '/mailboxes' );
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR adds unit tests for `client/my-sites/email/paths.js`. The purpose of this is to illustrate how the refactorings in #86096 will change the code.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

See #86096

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?