### PR TITLE
Jetpack Manage: Fix bundle pricing info

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/pricing.ts
+++ b/client/jetpack-cloud/sections/partner-portal/issue-license-v2/lib/pricing.ts
@@ -40,7 +40,7 @@ export const getProductPricingInfo = (
 			);
 		// If a monthly product is found, calculate the actual cost and discount percentage
 		if ( monthlyProduct ) {
-			const monthlyProductBundleCost = parseFloat( product.amount );
+			const monthlyProductBundleCost = parseFloat( product.amount ) * quantity;
 			const actualCost = isDailyPricing ? monthlyProductBundleCost / 365 : monthlyProductBundleCost;
 			const discountedCost = actualCost - productBundleCost;
 			discountInfo.discountPercentage = productBundleCost


### PR DESCRIPTION
## Proposed Changes

This PR fixes the issue caused by https://github.com/Automattic/wp-calypso/pull/85621 that wasn't showing the discount info

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Once you are directed to the Dashboard > Click the `Issue License` page.
2. Verify that the discount percentage is shown as displayed below

<img width="1416" alt="Screenshot 2024-01-08 at 3 42 04 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8ea0e508-b45b-4ca2-b2ad-68eeb5996bda">

3. Click the Review X Licenses button and verify that the pricing info is shown accurately. 

<img width="440" alt="Screenshot 2024-01-08 at 3 42 35 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/b2347414-9686-440e-aeb6-6a235a0166e8">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?