### PR TITLE
Plans 2023: Add coupon query param to `usePlans()` hook

### DIFF
--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -47,7 +47,7 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 	// sitePlans - unclear if all plans are included
 	const sitePlans = Plans.useSitePlans( { siteId: selectedSiteId } );
 	const currentPlan = Plans.useCurrentPlan( { siteId: selectedSiteId } );
-	const introOffers = Plans.useIntroOffers( { siteId: selectedSiteId } );
+	const introOffers = Plans.useIntroOffers( { siteId: selectedSiteId, coupon } );
 	const purchasedPlan = Purchases.useSitePurchaseById( {
 		siteId: selectedSiteId,
 		purchaseId: currentPlan?.purchaseId,

--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -19,6 +19,7 @@ interface Props {
 	planSlugs: PlanSlug[];
 	withoutProRatedCredits?: boolean;
 	storageAddOns?: ( AddOnMeta | null )[] | null;
+	coupon?: string;
 }
 
 function getTotalPrice( planPrice: number | null | undefined, addOnPrice = 0 ): number | null {
@@ -34,6 +35,7 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 	planSlugs,
 	withoutProRatedCredits = false,
 	storageAddOns,
+	coupon,
 }: Props ) => {
 	// TODO: pass this in as a prop to uncouple the dependency
 	const selectedSiteId = useSelector( getSelectedSiteId ) ?? undefined;
@@ -41,7 +43,7 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 	const planAvailabilityForPurchase = useCheckPlanAvailabilityForPurchase( { planSlugs } );
 
 	// plans - should have a definition for all plans, being the main source of API data
-	const plans = Plans.usePlans();
+	const plans = Plans.usePlans( { coupon } );
 	// sitePlans - unclear if all plans are included
 	const sitePlans = Plans.useSitePlans( { siteId: selectedSiteId } );
 	const currentPlan = Plans.useCurrentPlan( { siteId: selectedSiteId } );

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -715,7 +715,7 @@ const PlansFeaturesMain = ( {
 					'is-pricing-grid-2023-plans-features-main'
 				) }
 			>
-				<QueryPlans coupon={ coupon } />
+				<QueryPlans />
 				<QuerySites siteId={ siteId } />
 				<QuerySitePlans siteId={ siteId } />
 				<QueryActivePromotions />
@@ -822,6 +822,7 @@ const PlansFeaturesMain = ( {
 									allFeaturesList={ FEATURES_LIST }
 									onStorageAddOnClick={ handleStorageAddOnClick }
 									showRefundPeriod={ isAnyHostingFlow( flowName ) }
+									coupon={ coupon }
 								/>
 								{ showEscapeHatch && hidePlansFeatureComparison && (
 									<div className="plans-features-main__escape-hatch">
@@ -883,6 +884,7 @@ const PlansFeaturesMain = ( {
 												planTypeSelectorProps={
 													! hidePlanSelector ? planTypeSelectorProps : undefined
 												}
+												coupon={ coupon }
 											/>
 											<ComparisonGridToggle
 												onClick={ toggleShowPlansComparisonGrid }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -527,6 +527,7 @@ const PlansFeaturesMain = ( {
 			currentSitePlanSlug: sitePlanSlug,
 			usePricingMetaForGridPlans,
 			recordTracksEvent,
+			coupon,
 		};
 	}, [
 		_customerType,
@@ -544,6 +545,7 @@ const PlansFeaturesMain = ( {
 		showBiennialToggle,
 		showPlanTypeSelectorDropdown,
 		eligibleForWpcomMonthlyPlans,
+		coupon,
 	] );
 
 	/**

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -424,6 +424,7 @@ const PlansFeaturesMain = ( {
 		showLegacyStorageFeature,
 		isSubdomainNotGenerated: ! resolvedSubdomainName.result,
 		storageAddOns,
+		coupon,
 	} );
 
 	const planFeaturesForFeaturesGrid = usePlanFeaturesForGridPlans( {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -787,6 +787,7 @@ const PlansFeaturesMain = ( {
 								layoutClassName="plans-features-main__plan-type-selector-layout"
 								enableStickyBehavior={ enablePlanTypeSelectorStickyBehavior }
 								stickyPlanTypeSelectorOffset={ masterbarHeight - 1 }
+								coupon={ coupon }
 							/>
 						) }
 						<div
@@ -862,6 +863,7 @@ const PlansFeaturesMain = ( {
 												<PlanTypeSelector
 													{ ...planTypeSelectorProps }
 													layoutClassName="plans-features-main__plan-type-selector-layout"
+													coupon={ coupon }
 												/>
 											) }
 											<ComparisonGrid

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -715,7 +715,7 @@ const PlansFeaturesMain = ( {
 					'is-pricing-grid-2023-plans-features-main'
 				) }
 			>
-				<QueryPlans />
+				<QueryPlans coupon={ coupon } />
 				<QuerySites siteId={ siteId } />
 				<QuerySitePlans siteId={ siteId } />
 				<QueryActivePromotions />

--- a/client/my-sites/plans-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plans-grid/components/billing-timeframe.tsx
@@ -19,7 +19,7 @@ import { GridPlan } from '../hooks/npm-ready/data-store/use-grid-plans';
 
 function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 	const translate = useTranslate();
-	const { helpers, gridPlansIndex } = usePlansGridContext();
+	const { helpers, gridPlansIndex, coupon } = usePlansGridContext();
 	const {
 		isMonthlyPlan,
 		pricing: { currencyCode, originalPrice, discountedPrice, billingPeriod, introOffer },
@@ -45,6 +45,7 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 			planSlugs: [ yearlyVariantPlanSlug ],
 			withoutProRatedCredits: true,
 			storageAddOns: storageAddOnsForPlan,
+			coupon,
 		} )?.[ yearlyVariantPlanSlug ];
 
 	if (

--- a/client/my-sites/plans-grid/components/comparison-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/comparison-grid/index.tsx
@@ -496,6 +496,7 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 		const { prices, currencyCode } = usePlanPricingInfoFromGridPlans( {
 			gridPlans: visibleGridPlans,
 		} );
+		const { coupon } = usePlansGridContext();
 
 		const isLargeCurrency = useIsLargeCurrency( {
 			prices,
@@ -518,6 +519,7 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 								{ ...planTypeSelectorProps }
 								title={ translate( 'Billing Cycle' ) }
 								hideDiscountLabel={ true }
+								coupon={ coupon }
 							/>
 						</PlanTypeSelectorWrapper>
 					) }

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-toggle.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-toggle.tsx
@@ -20,6 +20,7 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		currentSitePlanSlug,
 		usePricingMetaForGridPlans,
 		title,
+		coupon,
 	} = props;
 	const [ spanRef, setSpanRef ] = useState< HTMLSpanElement >();
 	const segmentClasses = classNames( 'price-toggle', {
@@ -31,6 +32,7 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		planSlugs: currentSitePlanSlug ? [ currentSitePlanSlug ] : [],
 		withoutProRatedCredits: true,
 		storageAddOns: null,
+		coupon,
 	} );
 	const currentPlanBillingPeriod = currentSitePlanSlug
 		? pricingMeta?.[ currentSitePlanSlug ]?.billingPeriod

--- a/client/my-sites/plans-grid/components/plan-type-selector/types.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/types.ts
@@ -30,6 +30,10 @@ export type PlanTypeSelectorProps = {
 	 * Whether to render the selector along with a title if passed.
 	 */
 	title?: TranslateResult;
+	/**
+	 * Coupon code for use in pricing hook usage.
+	 */
+	coupon?: string;
 };
 export type IntervalTypeProps = Pick<
 	PlanTypeSelectorProps,
@@ -46,7 +50,7 @@ export type IntervalTypeProps = Pick<
 	| 'selectedFeature'
 	| 'currentSitePlanSlug'
 	| 'usePricingMetaForGridPlans'
-	| 'title'
+	| 'coupon'
 >;
 
 export type SupportedUrlFriendlyTermType = Extract<

--- a/client/my-sites/plans-grid/components/plan-type-selector/types.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/types.ts
@@ -50,6 +50,7 @@ export type IntervalTypeProps = Pick<
 	| 'selectedFeature'
 	| 'currentSitePlanSlug'
 	| 'usePricingMetaForGridPlans'
+	| 'title'
 	| 'coupon'
 >;
 

--- a/client/my-sites/plans-grid/grid-context.tsx
+++ b/client/my-sites/plans-grid/grid-context.tsx
@@ -13,6 +13,7 @@ interface PlansGridContext {
 	gridPlansIndex: { [ key: string ]: GridPlan };
 	allFeaturesList: FeatureList;
 	helpers?: Record< 'usePricingMetaForGridPlans', UsePricingMetaForGridPlans >;
+	coupon?: string;
 }
 
 const PlansGridContext = createContext< PlansGridContext >( {} as PlansGridContext );
@@ -23,6 +24,7 @@ const PlansGridContextProvider = ( {
 	usePricingMetaForGridPlans,
 	allFeaturesList,
 	children,
+	coupon,
 }: GridContextProps ) => {
 	const gridPlansIndex = gridPlans.reduce(
 		( acc, gridPlan ) => ( {
@@ -40,6 +42,7 @@ const PlansGridContextProvider = ( {
 				gridPlansIndex,
 				allFeaturesList,
 				helpers: { usePricingMetaForGridPlans },
+				coupon,
 			} }
 		>
 			{ children }

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -77,10 +77,12 @@ export type UsePricingMetaForGridPlans = ( {
 	planSlugs,
 	withoutProRatedCredits,
 	storageAddOns,
+	coupon,
 }: {
 	planSlugs: PlanSlug[];
 	withoutProRatedCredits?: boolean;
 	storageAddOns: ( AddOnMeta | null )[] | null;
+	coupon?: string;
 } ) => { [ planSlug: string ]: PricingMetaForGridPlan } | null;
 
 export type UseFreeTrialPlanSlugs = ( {
@@ -160,6 +162,7 @@ interface Props {
 	 */
 	isSubdomainNotGenerated?: boolean;
 	storageAddOns: ( AddOnMeta | null )[] | null;
+	coupon?: string;
 }
 
 const usePlanTypesWithIntent = ( {
@@ -280,6 +283,7 @@ const useGridPlans = ( {
 	eligibleForFreeHostingTrial,
 	isSubdomainNotGenerated,
 	storageAddOns,
+	coupon,
 }: Props ): Omit< GridPlan, 'features' >[] | null => {
 	const freeTrialPlanSlugs = useFreeTrialPlanSlugs( {
 		intent: intent ?? 'default',
@@ -321,10 +325,11 @@ const useGridPlans = ( {
 	} );
 
 	// TODO: pricedAPIPlans to be queried from data-store package
-	const pricedAPIPlans = Plans.usePlans();
+	const pricedAPIPlans = Plans.usePlans( { coupon } );
 	const pricingMeta = usePricingMetaForGridPlans( {
 		planSlugs: availablePlanSlugs,
 		storageAddOns,
+		coupon,
 	} );
 
 	// Null return would indicate that we are still loading the data. No grid without grid plans.

--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -26,6 +26,7 @@ const WrappedComparisonGrid = ( {
 	showUpgradeableStorage,
 	onStorageAddOnClick,
 	stickyRowOffset,
+	coupon,
 	...otherProps
 }: ComparisonGridExternalProps ) => {
 	const handleUpgradeClick = useUpgradeClickHandler( {
@@ -39,6 +40,7 @@ const WrappedComparisonGrid = ( {
 			gridPlans={ gridPlans }
 			usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 			allFeaturesList={ allFeaturesList }
+			coupon={ coupon }
 		>
 			<ComparisonGrid
 				intervalType={ intervalType }
@@ -59,8 +61,15 @@ const WrappedComparisonGrid = ( {
 };
 
 const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
-	const { siteId, intent, gridPlans, usePricingMetaForGridPlans, allFeaturesList, onUpgradeClick } =
-		props;
+	const {
+		siteId,
+		intent,
+		gridPlans,
+		usePricingMetaForGridPlans,
+		allFeaturesList,
+		onUpgradeClick,
+		coupon,
+	} = props;
 	const translate = useTranslate();
 	const isPlanUpgradeCreditEligible = useIsPlanUpgradeCreditVisible(
 		siteId,
@@ -84,6 +93,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 			intent={ intent }
 			gridPlans={ gridPlans }
 			usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
+			coupon={ coupon }
 			allFeaturesList={ allFeaturesList }
 		>
 			<FeaturesGrid

--- a/client/my-sites/plans-grid/types.ts
+++ b/client/my-sites/plans-grid/types.ts
@@ -83,6 +83,7 @@ export type GridContextProps = {
 	intent?: PlansIntent;
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
 	children: React.ReactNode;
+	coupon?: string;
 };
 
 export type ComparisonGridExternalProps = Omit< GridContextProps, 'children' > &

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -277,10 +277,12 @@ export class PlansStep extends Component {
 			'is-wide-layout': false,
 			'is-extra-wide-layout': true,
 		} );
+		const { signupDependencies } = this.props;
+		const { coupon } = signupDependencies;
 
 		return (
 			<>
-				<QueryPlans />
+				<QueryPlans coupon={ coupon } />
 				<MarketingMessage path="signup/plans" />
 				<div className={ classes }>{ this.plansFeaturesSelection() }</div>
 			</>

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -272,13 +272,13 @@ export class PlansStep extends Component {
 	}
 
 	render() {
+		const { signupDependencies } = this.props;
+		const { coupon } = signupDependencies;
 		const classes = classNames( 'plans plans-step', {
 			'has-no-sidebar': true,
 			'is-wide-layout': false,
 			'is-extra-wide-layout': true,
 		} );
-		const { signupDependencies } = this.props;
-		const { coupon } = signupDependencies;
 
 		return (
 			<>

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -272,8 +272,6 @@ export class PlansStep extends Component {
 	}
 
 	render() {
-		const { signupDependencies } = this.props;
-		const { coupon } = signupDependencies;
 		const classes = classNames( 'plans plans-step', {
 			'has-no-sidebar': true,
 			'is-wide-layout': false,
@@ -282,7 +280,7 @@ export class PlansStep extends Component {
 
 		return (
 			<>
-				<QueryPlans coupon={ coupon } />
+				<QueryPlans />
 				<MarketingMessage path="signup/plans" />
 				<div className={ classes }>{ this.plansFeaturesSelection() }</div>
 			</>

--- a/packages/data-stores/src/plans/hooks/use-intro-offers.ts
+++ b/packages/data-stores/src/plans/hooks/use-intro-offers.ts
@@ -9,6 +9,7 @@ interface IntroOffersIndex {
 
 interface Props {
 	siteId?: string | number | null;
+	coupon?: string;
 }
 
 /**
@@ -18,9 +19,9 @@ interface Props {
  * @returns {IntroOffersIndex | undefined} - an object `{ [ planSlug: string ]: PlanIntroductoryOffer | null }`,
  * or `undefined` if we haven't observed any metadata yet
  */
-const useIntroOffers = ( { siteId }: Props ): IntroOffersIndex | undefined => {
+const useIntroOffers = ( { siteId, coupon }: Props ): IntroOffersIndex | undefined => {
 	const sitePlans = useSitePlans( { siteId } );
-	const plans = usePlans();
+	const plans = usePlans( { coupon } );
 
 	return useMemo( () => {
 		if ( ! sitePlans.data && ! plans.data ) {

--- a/packages/data-stores/src/plans/queries/lib/use-query-keys-factory.ts
+++ b/packages/data-stores/src/plans/queries/lib/use-query-keys-factory.ts
@@ -1,6 +1,6 @@
 const useQueryKeysFactory = () => ( {
 	sitePlans: ( siteId?: string | number | null ) => [ 'site-plans', siteId ],
-	plans: () => [ 'plans' ],
+	plans: ( coupon?: string ) => [ 'plans', coupon ],
 } );
 
 export default useQueryKeysFactory;

--- a/packages/data-stores/src/plans/queries/use-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-plans.ts
@@ -18,7 +18,7 @@ function usePlans( { coupon }: { coupon?: string } = {} ): UseQueryResult< Plans
 	coupon && params.append( 'coupon_code', coupon );
 
 	return useQuery( {
-		queryKey: queryKeys.plans(),
+		queryKey: queryKeys.plans( coupon ),
 		queryFn: async (): Promise< PlansIndex > => {
 			const data: PricedAPIPlan[] = await wpcomRequest( {
 				path: `/plans`,

--- a/packages/data-stores/src/plans/queries/use-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-plans.ts
@@ -12,8 +12,10 @@ interface PlansIndex {
 /**
  * Plans from `/plans` endpoint, transformed into a map of planSlug => PlanNext
  */
-function usePlans(): UseQueryResult< PlansIndex > {
+function usePlans( { coupon }: { coupon?: string } = {} ): UseQueryResult< PlansIndex > {
 	const queryKeys = useQueryKeysFactory();
+	const params = new URLSearchParams();
+	coupon && params.append( 'coupon_code', coupon );
 
 	return useQuery( {
 		queryKey: queryKeys.plans(),
@@ -21,6 +23,7 @@ function usePlans(): UseQueryResult< PlansIndex > {
 			const data: PricedAPIPlan[] = await wpcomRequest( {
 				path: `/plans`,
 				apiVersion: '1.5',
+				query: params.toString(),
 			} );
 
 			return Object.fromEntries(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This is a follow-up to https://github.com/Automattic/wp-calypso/pull/85660 which sends `coupon` as a query parameter to the `/plans` endpoint. @chriskmnds pointed out that `<QueryPlans />` will soon be deprecated, so this PR includes `coupon` as a query param in the respective query hook. 
* In the upcoming changes in the PR https://github.com/Automattic/wp-calypso/pull/85486, the `usePlans()` query hook will return the original and discounted prices for plans.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Get a valid coupon code from `33094-pb`.
* Visit `/start/coupon=A_VALID_COUPON` using the coupon code you got in the previous step. At the plans step of the signup flow, verify network requests to confirm that `coupon_code` query param is sent. 
