### PR TITLE
Live Preview: Load feature only in the Site Editor

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
@@ -1,93 +1,30 @@
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import domReady from '@wordpress/dom-ready';
-import { __, sprintf } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
-import { FC, useEffect } from 'react';
-import { NOTICE_ID } from './constants';
-import { useCanPreviewButNeedUpgrade } from './hooks/use-can-preview-but-need-upgrade';
-import { useHideTemplatePartHint } from './hooks/use-hide-template-part-hint';
-import { usePreviewingTheme } from './hooks/use-previewing-theme';
-import { LivePreviewUpgradeModal } from './upgrade-modal';
-import { LivePreviewUpgradeNotice } from './upgrade-notice';
-import { getUnlock } from './utils';
+import { Suspense, lazy } from 'react';
 
-const unlock = getUnlock();
+const LivePreviewNoticePlugin = lazy(
+	() => import( /* webpackChunkName: "wpcom-live-preview-notice" */ './live-preview-notice-plugin' )
+);
 
-/**
- * This is an interim solution to clarify to users that they are currently live previewing a theme.
- * And this should be moved to jetpack-mu-wpcom.
- * @see https://github.com/Automattic/wp-calypso/issues/82218
- */
-const LivePreviewNotice: FC< {
-	dashboardLink?: string;
-	previewingThemeName?: string;
-} > = ( { dashboardLink, previewingThemeName } ) => {
-	const { createInfoNotice, removeNotice } = useDispatch( 'core/notices' );
-
-	useHideTemplatePartHint();
-
-	useEffect( () => {
-		createInfoNotice(
-			sprintf(
-				// translators: %s: theme name
-				__(
-					'You are previewing the %s theme. You can try out your own style customizations, which will only be saved if you activate this theme.',
-					'wpcom-live-preview'
-				),
-				previewingThemeName
-			),
-			{
-				id: NOTICE_ID,
-				isDismissible: false,
-				actions: dashboardLink && [
-					{
-						label: __( 'Back to themes', 'wpcom-live-preview' ),
-						url: dashboardLink,
-						variant: 'secondary',
-					},
-				],
-			}
-		);
-		return () => removeNotice( NOTICE_ID );
-	}, [ dashboardLink, createInfoNotice, removeNotice, previewingThemeName ] );
-	return null;
-};
-
-const LivePreviewNoticePlugin = () => {
+const LivePreviewPlugin = () => {
 	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
-	const previewingTheme = usePreviewingTheme();
-	const { canPreviewButNeedUpgrade, upgradePlan } = useCanPreviewButNeedUpgrade( previewingTheme );
-	const dashboardLink = useSelect(
-		( select ) =>
-			unlock &&
-			select( 'core/edit-site' ) &&
-			unlock( siteEditorStore ).getSettings().__experimentalDashboardLink,
-		[ siteEditorStore ]
-	);
 
-	// Do nothing in the Post Editor context.
+	// Do nothing outside the Site Editor context.
 	if ( ! siteEditorStore ) {
 		return null;
 	}
-	// Do nothing if the user is NOT previewing a theme.
-	if ( ! previewingTheme.name ) {
-		return null;
-	}
 
-	if ( canPreviewButNeedUpgrade ) {
-		return (
-			<>
-				<LivePreviewUpgradeModal { ...{ previewingTheme, upgradePlan } } />
-				<LivePreviewUpgradeNotice { ...{ previewingTheme, dashboardLink } } />
-			</>
-		);
-	}
-	return <LivePreviewNotice { ...{ dashboardLink, previewingThemeName: previewingTheme.name } } />;
+	return (
+		<Suspense fallback={ null }>
+			<LivePreviewNoticePlugin />
+		</Suspense>
+	);
 };
 
 const registerLivePreviewPlugin = () => {
 	registerPlugin( 'wpcom-live-preview', {
-		render: () => <LivePreviewNoticePlugin />,
+		render: () => <LivePreviewPlugin />,
 	} );
 };
 

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/live-preview-notice-plugin.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/live-preview-notice-plugin.tsx
@@ -1,0 +1,86 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { FC, useEffect } from 'react';
+import { NOTICE_ID } from './constants';
+import { useCanPreviewButNeedUpgrade } from './hooks/use-can-preview-but-need-upgrade';
+import { useHideTemplatePartHint } from './hooks/use-hide-template-part-hint';
+import { usePreviewingTheme } from './hooks/use-previewing-theme';
+import { LivePreviewUpgradeModal } from './upgrade-modal';
+import { LivePreviewUpgradeNotice } from './upgrade-notice';
+import { getUnlock } from './utils';
+
+const unlock = getUnlock();
+
+/**
+ * This is an interim solution to clarify to users that they are currently live previewing a theme.
+ * And this should be moved to jetpack-mu-wpcom.
+ * @see https://github.com/Automattic/wp-calypso/issues/82218
+ */
+const LivePreviewNotice: FC< {
+	dashboardLink?: string;
+	previewingThemeName?: string;
+} > = ( { dashboardLink, previewingThemeName } ) => {
+	const { createInfoNotice, removeNotice } = useDispatch( 'core/notices' );
+
+	useHideTemplatePartHint();
+
+	useEffect( () => {
+		createInfoNotice(
+			sprintf(
+				// translators: %s: theme name
+				__(
+					'You are previewing the %s theme. You can try out your own style customizations, which will only be saved if you activate this theme.',
+					'wpcom-live-preview'
+				),
+				previewingThemeName
+			),
+			{
+				id: NOTICE_ID,
+				isDismissible: false,
+				actions: dashboardLink && [
+					{
+						label: __( 'Back to themes', 'wpcom-live-preview' ),
+						url: dashboardLink,
+						variant: 'secondary',
+					},
+				],
+			}
+		);
+		return () => removeNotice( NOTICE_ID );
+	}, [ dashboardLink, createInfoNotice, removeNotice, previewingThemeName ] );
+	return null;
+};
+
+const LivePreviewNoticePlugin = () => {
+	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
+	const previewingTheme = usePreviewingTheme();
+	const { canPreviewButNeedUpgrade, upgradePlan } = useCanPreviewButNeedUpgrade( previewingTheme );
+	const dashboardLink = useSelect(
+		( select ) =>
+			unlock &&
+			select( 'core/edit-site' ) &&
+			unlock( siteEditorStore ).getSettings().__experimentalDashboardLink,
+		[ siteEditorStore ]
+	);
+
+	// Do nothing in the Post Editor context.
+	if ( ! siteEditorStore ) {
+		return null;
+	}
+	// Do nothing if the user is NOT previewing a theme.
+	if ( ! previewingTheme.name ) {
+		return null;
+	}
+
+	if ( canPreviewButNeedUpgrade ) {
+		return (
+			<>
+				<LivePreviewUpgradeModal { ...{ previewingTheme, upgradePlan } } />
+				<LivePreviewUpgradeNotice { ...{ previewingTheme, dashboardLink } } />
+			</>
+		);
+	}
+	return <LivePreviewNotice { ...{ dashboardLink, previewingThemeName: previewingTheme.name } } />;
+};
+
+export default LivePreviewNoticePlugin;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* The live preview feature is used in the Site Editor, so this PR proposes to load the feature only in the Site Editor

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox `widgets.wp.com`
* Apply changes to your site
* Go to Theme Showcase
* Pick a theme
* Click the “Preview & Customize” button
* Click the preview on the Site Editor to enter the edit mode
* Make sure you can see the live preview notice
* Activate the theme
* Make sure the live preview notice is gone

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?