### PR TITLE
Live Preview: Fix the preview notice stuck after the activation (2nd try)

### DIFF
--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -44,6 +44,7 @@
 		"@wordpress/plugins": "^6.16.0",
 		"@wordpress/private-apis": "^0.30.0",
 		"@wordpress/rich-text": "^6.25.0",
+		"@wordpress/router": "^0.17.0",
 		"@wordpress/url": "^3.49.0",
 		"debug": "^4.3.3",
 		"lodash": "^4.17.21",

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-location.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-location.ts
@@ -6,6 +6,8 @@ const unlock = getUnlock();
 const routerPrivateApis = router?.privateApis;
 
 let useLocation = () => null;
+
+// The routerPrivateApis may be unavailable.
 if ( unlock && routerPrivateApis && unlock( routerPrivateApis ) ) {
 	useLocation = unlock( routerPrivateApis ).useLocation;
 }

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-location.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-location.ts
@@ -1,10 +1,12 @@
-import { privateApis as routerPrivateApis } from '@wordpress/router';
+import * as router from '@wordpress/router';
 import { getUnlock } from '../utils';
 
 const unlock = getUnlock();
 
+const routerPrivateApis = router?.privateApis;
+
 let useLocation = () => null;
-if ( unlock && unlock( routerPrivateApis ) ) {
+if ( unlock && routerPrivateApis && unlock( routerPrivateApis ) ) {
 	useLocation = unlock( routerPrivateApis ).useLocation;
 }
 

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-location.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-location.ts
@@ -1,0 +1,11 @@
+import { privateApis as routerPrivateApis } from '@wordpress/router';
+import { getUnlock } from '../utils';
+
+const unlock = getUnlock();
+
+let useLocation = () => null;
+if ( unlock && unlock( routerPrivateApis ) ) {
+	useLocation = unlock( routerPrivateApis ).useLocation;
+}
+
+export default useLocation;

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
@@ -1,8 +1,9 @@
 import config from '@automattic/calypso-config';
 import { useSelect } from '@wordpress/data';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import wpcom from 'calypso/lib/wp';
 import { currentlyPreviewingTheme, PREMIUM_THEME, WOOCOMMERCE_THEME } from '../utils';
+import useLocation from './use-location';
 import type { Theme } from 'calypso/types';
 
 /**
@@ -42,20 +43,26 @@ const getThemeFeature = ( theme?: Theme ) => {
 	return undefined;
 };
 
+export const usePreviewingThemeSlug = () => {
+	const location = useLocation();
+	const previewingThemeSlug = useMemo( () => currentlyPreviewingTheme(), [ location?.search ] );
+	return previewingThemeSlug;
+};
+
 export const usePreviewingTheme = () => {
-	const { previewingThemeSlug, previewingThemeName } = useSelect( ( select ) => {
-		// This needs to be inside `useSelect`, so that we can recompute `previewingThemeSlug` when the active theme changes.
-		// This is a workaround because we're not listening to the changes to the `wp_theme_preview` param in the URL.
-		const previewingThemeSlug = currentlyPreviewingTheme();
+	const previewingThemeSlug = usePreviewingThemeSlug();
+	const { previewingThemeName } = useSelect(
+		( select ) => {
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+			const previewingTheme = ( select( 'core' ) as any ).getTheme( previewingThemeSlug );
 
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const previewingTheme = ( select( 'core' ) as any ).getTheme( previewingThemeSlug );
-
-		return {
-			previewingThemeSlug,
-			previewingThemeName: previewingTheme?.name?.rendered || previewingThemeSlug,
-		};
-	}, [] );
+			return {
+				previewingThemeSlug,
+				previewingThemeName: previewingTheme?.name?.rendered || previewingThemeSlug,
+			};
+		},
+		[ previewingThemeSlug ]
+	);
 
 	const previewingThemeId =
 		( previewingThemeSlug as string )?.split( '/' )?.[ 1 ] || previewingThemeSlug;

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
@@ -1,93 +1,30 @@
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import domReady from '@wordpress/dom-ready';
-import { __, sprintf } from '@wordpress/i18n';
 import { registerPlugin } from '@wordpress/plugins';
-import { FC, useEffect } from 'react';
-import { NOTICE_ID } from './constants';
-import { useCanPreviewButNeedUpgrade } from './hooks/use-can-preview-but-need-upgrade';
-import { useHideTemplatePartHint } from './hooks/use-hide-template-part-hint';
-import { usePreviewingTheme } from './hooks/use-previewing-theme';
-import { LivePreviewUpgradeModal } from './upgrade-modal';
-import { LivePreviewUpgradeNotice } from './upgrade-notice';
-import { getUnlock } from './utils';
+import { Suspense, lazy } from 'react';
 
-const unlock = getUnlock();
+const LivePreviewNoticePlugin = lazy(
+	() => import( /* webpackChunkName: "wpcom-live-preview-notice" */ './live-preview-notice-plugin' )
+);
 
-/**
- * This is an interim solution to clarify to users that they are currently live previewing a theme.
- * And this should be moved to jetpack-mu-wpcom.
- * @see https://github.com/Automattic/wp-calypso/issues/82218
- */
-const LivePreviewNotice: FC< {
-	dashboardLink?: string;
-	previewingThemeName?: string;
-} > = ( { dashboardLink, previewingThemeName } ) => {
-	const { createInfoNotice, removeNotice } = useDispatch( 'core/notices' );
-
-	useHideTemplatePartHint();
-
-	useEffect( () => {
-		createInfoNotice(
-			sprintf(
-				// translators: %s: theme name
-				__(
-					'You are previewing the %s theme. You can try out your own style customizations, which will only be saved if you activate this theme.',
-					'wpcom-live-preview'
-				),
-				previewingThemeName
-			),
-			{
-				id: NOTICE_ID,
-				isDismissible: false,
-				actions: dashboardLink && [
-					{
-						label: __( 'Back to themes', 'wpcom-live-preview' ),
-						url: dashboardLink,
-						variant: 'secondary',
-					},
-				],
-			}
-		);
-		return () => removeNotice( NOTICE_ID );
-	}, [ dashboardLink, createInfoNotice, removeNotice, previewingThemeName ] );
-	return null;
-};
-
-const LivePreviewNoticePlugin = () => {
+const LivePreviewPlugin = () => {
 	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
-	const previewingTheme = usePreviewingTheme();
-	const { canPreviewButNeedUpgrade, upgradePlan } = useCanPreviewButNeedUpgrade( previewingTheme );
-	const dashboardLink = useSelect(
-		( select ) =>
-			unlock &&
-			select( 'core/edit-site' ) &&
-			unlock( siteEditorStore ).getSettings().__experimentalDashboardLink,
-		[ siteEditorStore ]
-	);
 
-	// Do nothing in the Post Editor context.
+	// Do nothing outside the Site Editor context.
 	if ( ! siteEditorStore ) {
 		return null;
 	}
-	// Do nothing if the user is NOT previewing a theme.
-	if ( ! previewingTheme.name ) {
-		return null;
-	}
 
-	if ( canPreviewButNeedUpgrade ) {
-		return (
-			<>
-				<LivePreviewUpgradeModal { ...{ previewingTheme, upgradePlan } } />
-				<LivePreviewUpgradeNotice { ...{ previewingTheme, dashboardLink } } />
-			</>
-		);
-	}
-	return <LivePreviewNotice { ...{ dashboardLink, previewingThemeName: previewingTheme.name } } />;
+	return (
+		<Suspense fallback={ null }>
+			<LivePreviewNoticePlugin />
+		</Suspense>
+	);
 };
 
 const registerLivePreviewPlugin = () => {
 	registerPlugin( 'wpcom-live-preview', {
-		render: () => <LivePreviewNoticePlugin />,
+		render: () => <LivePreviewPlugin />,
 	} );
 };
 

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/live-preview-notice-plugin.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/live-preview-notice-plugin.tsx
@@ -1,0 +1,86 @@
+import { useDispatch, useSelect } from '@wordpress/data';
+import { __, sprintf } from '@wordpress/i18n';
+import { FC, useEffect } from 'react';
+import { NOTICE_ID } from './constants';
+import { useCanPreviewButNeedUpgrade } from './hooks/use-can-preview-but-need-upgrade';
+import { useHideTemplatePartHint } from './hooks/use-hide-template-part-hint';
+import { usePreviewingTheme } from './hooks/use-previewing-theme';
+import { LivePreviewUpgradeModal } from './upgrade-modal';
+import { LivePreviewUpgradeNotice } from './upgrade-notice';
+import { getUnlock } from './utils';
+
+const unlock = getUnlock();
+
+/**
+ * This is an interim solution to clarify to users that they are currently live previewing a theme.
+ * And this should be moved to jetpack-mu-wpcom.
+ * @see https://github.com/Automattic/wp-calypso/issues/82218
+ */
+const LivePreviewNotice: FC< {
+	dashboardLink?: string;
+	previewingThemeName?: string;
+} > = ( { dashboardLink, previewingThemeName } ) => {
+	const { createInfoNotice, removeNotice } = useDispatch( 'core/notices' );
+
+	useHideTemplatePartHint();
+
+	useEffect( () => {
+		createInfoNotice(
+			sprintf(
+				// translators: %s: theme name
+				__(
+					'You are previewing the %s theme. You can try out your own style customizations, which will only be saved if you activate this theme.',
+					'wpcom-live-preview'
+				),
+				previewingThemeName
+			),
+			{
+				id: NOTICE_ID,
+				isDismissible: false,
+				actions: dashboardLink && [
+					{
+						label: __( 'Back to themes', 'wpcom-live-preview' ),
+						url: dashboardLink,
+						variant: 'secondary',
+					},
+				],
+			}
+		);
+		return () => removeNotice( NOTICE_ID );
+	}, [ dashboardLink, createInfoNotice, removeNotice, previewingThemeName ] );
+	return null;
+};
+
+const LivePreviewNoticePlugin = () => {
+	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
+	const previewingTheme = usePreviewingTheme();
+	const { canPreviewButNeedUpgrade, upgradePlan } = useCanPreviewButNeedUpgrade( previewingTheme );
+	const dashboardLink = useSelect(
+		( select ) =>
+			unlock &&
+			select( 'core/edit-site' ) &&
+			unlock( siteEditorStore ).getSettings().__experimentalDashboardLink,
+		[ siteEditorStore ]
+	);
+
+	// Do nothing in the Post Editor context.
+	if ( ! siteEditorStore ) {
+		return null;
+	}
+	// Do nothing if the user is NOT previewing a theme.
+	if ( ! previewingTheme.name ) {
+		return null;
+	}
+
+	if ( canPreviewButNeedUpgrade ) {
+		return (
+			<>
+				<LivePreviewUpgradeModal { ...{ previewingTheme, upgradePlan } } />
+				<LivePreviewUpgradeNotice { ...{ previewingTheme, dashboardLink } } />
+			</>
+		);
+	}
+	return <LivePreviewNotice { ...{ dashboardLink, previewingThemeName: previewingTheme.name } } />;
+};
+
+export default LivePreviewNoticePlugin;

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/live-preview-notice-plugin.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/live-preview-notice-plugin.tsx
@@ -63,10 +63,6 @@ const LivePreviewNoticePlugin = () => {
 		[ siteEditorStore ]
 	);
 
-	// Do nothing in the Post Editor context.
-	if ( ! siteEditorStore ) {
-		return null;
-	}
 	// Do nothing if the user is NOT previewing a theme.
 	if ( ! previewingTheme.name ) {
 		return null;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1916,6 +1916,7 @@ __metadata:
     "@wordpress/plugins": "npm:^6.16.0"
     "@wordpress/private-apis": "npm:^0.30.0"
     "@wordpress/rich-text": "npm:^6.25.0"
+    "@wordpress/router": "npm:^0.17.0"
     "@wordpress/url": "npm:^3.49.0"
     debug: "npm:^4.3.3"
     lodash: "npm:^4.17.21"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdtkmj-2f1-p2#comment-4070

## Proposed Changes

* Referring to pdtkmj-2f1-p2#comment-4070, the live preview notice is stuck there after the activation. After the investigation, the URL remains the same when the callback of the `useSelect` hook is triggered so we still get the previously previewing theme. As a result, this PR introduces the `useLocation` hook to recompute the previewing theme while the location is changed to resolve this issue.
* Besides, the live preview feature is used only in the Site Editor. As a result, make changes to load the feature lazily to ensure the `useLocation` hook is available and avoid any side effects if the context is outside the Site Editor.

https://github.com/Automattic/wp-calypso/assets/13596067/d925a8ce-d13a-4bd5-8c75-ad3921b33c56

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Site Editor

* Sandbox `widgets.wp.com`
* Apply changes to your sandbox
* Go to the Theme Showcase
* Select a theme
* Click the `Preview & Customize` button to preview the theme
* Click the preview to enter the edit mode
* Make sure the live preview notice is there
* Activate the theme
* Make sure the live preview notice disappears

### P2

* Sandbox `widgets.wp.com`
* Apply changes to your sandbox
* Go to any p2
* Make sure you won't see the following error log on the console

```
Uncaught TypeError: can't access property "privateApis", T is undefined
wpcom.editor.min.js:9921:9
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?