### PR TITLE
Marketplace Reviews: show update review error inside the modal

### DIFF
--- a/client/my-sites/marketplace/components/review-item/index.tsx
+++ b/client/my-sites/marketplace/components/review-item/index.tsx
@@ -28,6 +28,23 @@ export const MarketplaceReviewItem = (
 	const [ isConfirmModalVisible, setIsConfirmModalVisible ] = useState( false );
 	const currentUserId = useSelector( getCurrentUserId );
 	const [ errorMessage, setErrorMessage ] = useState( '' );
+
+	const [ isEditing, setIsEditing ] = useState< boolean >( false );
+	const [ editorContent, setEditorContent ] = useState< string >( '' );
+	const [ editorRating, setEditorRating ] = useState< number >( 0 );
+
+	const setEditing = ( review: MarketplaceReviewResponse ) => {
+		setIsEditing( true );
+		setEditorContent( review.content.rendered );
+		setEditorRating( review.meta.wpcom_marketplace_rating );
+	};
+
+	const clearEditing = () => {
+		setIsEditing( false );
+		setEditorContent( '' );
+		setEditorRating( 0 );
+	};
+
 	const deleteReviewMutation = useDeleteMarketplaceReviewMutation( {
 		...props,
 	} );
@@ -47,21 +64,25 @@ export const MarketplaceReviewItem = (
 	};
 
 	const updateReviewMutation = useUpdateMarketplaceReviewMutation( { ...props } );
-
-	const [ isEditing, setIsEditing ] = useState< boolean >( false );
-	const [ editorContent, setEditorContent ] = useState< string >( '' );
-	const [ editorRating, setEditorRating ] = useState< number >( 0 );
-
-	const setEditing = ( review: MarketplaceReviewResponse ) => {
-		setIsEditing( true );
-		setEditorContent( review.content.rendered );
-		setEditorRating( review.meta.wpcom_marketplace_rating );
-	};
-
-	const clearEditing = () => {
-		setIsEditing( false );
-		setEditorContent( '' );
-		setEditorRating( 0 );
+	const updateReview = ( reviewId: number ) => {
+		updateReviewMutation.mutate(
+			{
+				reviewId: reviewId,
+				productType: props.productType,
+				slug: props.slug,
+				content: editorContent,
+				rating: editorRating,
+			},
+			{
+				onError: ( error ) => {
+					setErrorMessage( error.message );
+				},
+				onSuccess: () => {
+					setErrorMessage( '' );
+				},
+			}
+		);
+		clearEditing();
 	};
 
 	return (
@@ -155,19 +176,7 @@ export const MarketplaceReviewItem = (
 							<Button
 								className="marketplace-review-item__review-submit"
 								primary
-								onClick={ () => {
-									updateReviewMutation.mutate(
-										{
-											reviewId: review.id,
-											productType: props.productType,
-											slug: props.slug,
-											content: editorContent,
-											rating: editorRating,
-										},
-										{ onError: ( error ) => alert( error.message ) }
-									);
-									clearEditing();
-								} }
+								onClick={ () => updateReview( review.id ) }
 							>
 								{ translate( 'Save my review' ) }
 							</Button>


### PR DESCRIPTION
Similar to https://github.com/Automattic/wp-calypso/pull/86018

## Proposed Changes

Show the update error message in a card instead of an alert.

![CleanShot 2024-01-08 at 11 37 41](https://github.com/Automattic/wp-calypso/assets/5039531/d3606877-1532-4697-99fb-bed1c0126ae6)

## Testing Instructions

* Check this branch on your local environment
* On the `use-marketplace-reviews.ts` file, update the method `updateReview` changing the param `reviewId` part to make it fail. Ex:
```js
path: `${ reviewsApiBase }/${ reviewId }ERROR`,
```
* Go to the plugin details page where you have reviews. Ex: `/plugins/woocommerce-bookings/`
* Scroll down and click on `Read all reviews`
* Try to delete update your own review
* You should see the error displayed as above


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
