### PR TITLE
Data stores: Use object for `invalidateQueries`

### DIFF
--- a/packages/data-stores/src/reader/helpers/optimistic-update.ts
+++ b/packages/data-stores/src/reader/helpers/optimistic-update.ts
@@ -67,15 +67,19 @@ const invalidateSiteSubscriptionDetails = (
 	{ blogId, subscriptionId, isLoggedIn, id }: SiteSubScriptionDetailsParameters
 ) => {
 	queryClient.invalidateQueries( { queryKey: [ 'read', 'site-subscriptions' ] } );
-	queryClient.invalidateQueries(
-		buildQueryKey( [ 'read', 'site-subscription-details', blogId ], isLoggedIn, id )
-	);
-	queryClient.invalidateQueries(
-		buildQueryKey( [ 'read', 'site-subscription-details', blogId, '' ], isLoggedIn, id )
-	);
-	queryClient.invalidateQueries(
-		buildQueryKey( [ 'read', 'site-subscription-details', '', subscriptionId ], isLoggedIn, id )
-	);
+	queryClient.invalidateQueries( {
+		queryKey: buildQueryKey( [ 'read', 'site-subscription-details', blogId ], isLoggedIn, id ),
+	} );
+	queryClient.invalidateQueries( {
+		queryKey: buildQueryKey( [ 'read', 'site-subscription-details', blogId, '' ], isLoggedIn, id ),
+	} );
+	queryClient.invalidateQueries( {
+		queryKey: buildQueryKey(
+			[ 'read', 'site-subscription-details', '', subscriptionId ],
+			isLoggedIn,
+			id
+		),
+	} );
 };
 
 export { alterSiteSubscriptionDetails, invalidateSiteSubscriptionDetails };

--- a/packages/data-stores/src/reader/mutations/use-post-notify-me-of-new-comments-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-post-notify-me-of-new-comments-mutation.ts
@@ -81,7 +81,7 @@ const usePostNotifyMeOfNewCommentsMutation = () => {
 			}
 		},
 		onSettled: () => {
-			queryClient.invalidateQueries( postSubscriptionsQueryKeyPrefix );
+			queryClient.invalidateQueries( { queryKey: postSubscriptionsQueryKeyPrefix } );
 		},
 	} );
 };

--- a/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
+++ b/packages/data-stores/src/reader/mutations/use-site-unsubscribe-mutation.ts
@@ -209,7 +209,8 @@ const useSiteUnsubscribeMutation = () => {
 			if ( isValidId( params.blog_id ) ) {
 				const siteSubscriptionDetailsByBlogIdQueryKey =
 					buildSiteSubscriptionDetailsByBlogIdQueryKey( params.blog_id, isLoggedIn, userId );
-				queryClient.invalidateQueries( siteSubscriptionDetailsByBlogIdQueryKey, {
+				queryClient.invalidateQueries( {
+					queryKey: siteSubscriptionDetailsByBlogIdQueryKey,
 					refetchType: 'none',
 				} );
 				queryClient.invalidateQueries( {
@@ -221,9 +222,9 @@ const useSiteUnsubscribeMutation = () => {
 			queryClient.invalidateQueries( {
 				queryKey: [ 'read', 'feed', 'search' ],
 			} );
-			queryClient.invalidateQueries(
-				buildSiteSubscriptionDetailsQueryKey( params.subscriptionId, isLoggedIn, userId )
-			);
+			queryClient.invalidateQueries( {
+				queryKey: buildSiteSubscriptionDetailsQueryKey( params.subscriptionId, isLoggedIn, userId ),
+			} );
 		},
 	} );
 };


### PR DESCRIPTION
## Proposed Changes

This PR updates `invalidateQueries` to use a single object instead of separate arguments. 

Part of the prep work for the v5 update.

See https://tanstack.com/query/v5/docs/react/guides/migrating-to-v5#supports-a-single-signature-one-object and https://github.com/Automattic/wp-calypso/pull/84338 for more info.

## Testing Instructions

* Go to `/read/subscriptions`
* Pick a site and play with all of its subscription settings.
* Verify they still load and save correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?