### PR TITLE
Fix "Complete domain setup" CTA link

### DIFF
--- a/client/my-sites/domains/components/domain-warnings/index.jsx
+++ b/client/my-sites/domains/components/domain-warnings/index.jsx
@@ -31,6 +31,7 @@ import {
 	domainManagementList,
 	domainManagementTransferIn,
 	domainManagementManageConsent,
+	domainMappingSetup,
 } from 'calypso/my-sites/domains/paths';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import PendingGSuiteTosNotice from './pending-gsuite-tos-notice';
@@ -219,7 +220,13 @@ export class DomainWarnings extends PureComponent {
 		if ( this.props.isCompact ) {
 			noticeProps.text = translate( 'Complete domain setup' );
 			children = (
-				<NoticeAction href={ domainManagementList( this.props.selectedSite.slug ) }>
+				<NoticeAction
+					href={
+						wrongMappedDomains.length === 1
+							? domainMappingSetup( this.props.selectedSite.slug, wrongMappedDomains[ 0 ].name )
+							: domainManagementList( this.props.selectedSite.slug )
+					}
+				>
 					{ translate( 'Go' ) }
 				</NoticeAction>
 			);


### PR DESCRIPTION
## Proposed Changes

The link in "Complete domain setup" nudge is misleading, since is takes to the site domains list page. This behaviour is ok in case there are multiple pending setup, but for a single domain the link should takes to the "Use a domain I own" flow.

Context: p1699451298057219-slack-C0761SX4K

## Testing Instructions

Apply this patch (or visit the Calypso link below), then connect an external domain to a site (without any pending mapping setup). Don't complete dns setup and verify that the "GO" link in the nudge takes to the "Use a domain I own" flow.

Add another mapping (without completing the setup as well). This time the link should takes to Domains management page.

![link-mapping-setup](https://github.com/Automattic/wp-calypso/assets/2797601/7754c358-c858-4c1a-96f0-442c5ef41bde)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?