### PR TITLE
Jetpack Backup: Refactor preflight check hook away from onSuccess

### DIFF
--- a/client/state/rewind/preflight/types.ts
+++ b/client/state/rewind/preflight/types.ts
@@ -14,8 +14,3 @@ export interface PreflightState {
 	overallStatus: PreflightTestStatus;
 	tests: PreflightTest[];
 }
-
-export interface APIPreflightStatusResponse {
-	ok: boolean;
-	status: PreflightTest[];
-}


### PR DESCRIPTION
## Proposed Changes

This PR migrates the `usePreflightStatusQuery` hook to use an effect instead of `onSuccess`. 

This is part of the work done to upgrade React Query to v5 - see https://github.com/Automattic/wp-calypso/pull/84413 and https://github.com/Automattic/wp-calypso/pull/84338.

The reason is that `onSuccess` and a few more callbacks have been removed from `useQuery` (see https://tanstack.com/query/v5/docs/react/guides/migrating-to-v5#callbacks-on-usequery-and-queryobserver-have-been-removed)

We're also removing the unused type `APIPreflightStatusResponse`. Let me know if you're planning to use it in another PR and I'm happy to revert its removal.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Not sure how to test, since the hook is not in use just yet. @Initsogar any way we could test it at this time?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?