### PR TITLE
My Home: Tweak styles on domain upsell

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
@@ -216,7 +216,6 @@ export function RenderDomainUpsell( { isFreePlan, isMonthlyPlan, searchTerm, sit
 			illustrationAlwaysShow={ true }
 			illustrationHeader={ domainSuggestionName ? domainNameSVG : null }
 			badgeText={ domainSuggestionName }
-			timing={ 2 }
 			taskId={ TASK_DOMAIN_UPSELL }
 		/>
 	);

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
@@ -213,7 +213,6 @@ export function RenderDomainUpsell( { isFreePlan, isMonthlyPlan, searchTerm, sit
 			secondaryActionText={ translate( 'Find other domains' ) }
 			secondaryActionUrl={ searchLink }
 			illustration={ domainUpsellMobileIllustration }
-			illustrationAlwaysShow={ true }
 			illustrationHeader={ domainSuggestionName ? domainNameSVG : null }
 			badgeText={ domainSuggestionName }
 			taskId={ TASK_DOMAIN_UPSELL }

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/style.scss
@@ -29,7 +29,7 @@
 
 				.task__description,
 				.task__title {
-					max-width: 80%;
+					max-width: 70%;
 				}
 			}
 

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/style.scss
@@ -25,11 +25,21 @@
 			min-width: 360px;
 
 			@media (min-width: ( $break-wide + 1 ) ) {
-				max-width: calc(100% - 450px);
+				max-width: calc(100% - 200px);
+
+				.task__description,
+				.task__title {
+					max-width: 70%;
+				}
 			}
 
 			@media (max-width: $break-wide) {
-				max-width: calc(115% - 450px);
+				max-width: calc(115% - 200px);
+
+				.task__description,
+				.task__title {
+					max-width: 70%;
+				}
 			}
 
 			@media ( max-width: $break-wide ) {

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/style.scss
@@ -29,17 +29,12 @@
 
 				.task__description,
 				.task__title {
-					max-width: 70%;
+					max-width: 80%;
 				}
 			}
 
 			@media (max-width: $break-wide) {
 				max-width: calc(115% - 200px);
-
-				.task__description,
-				.task__title {
-					max-width: 70%;
-				}
 			}
 
 			@media ( max-width: $break-wide ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/83465

## Proposed Changes

* Remove the estimated time to conserve vertical space (not sure it adds anything here)
* Adjust the max width for the action buttons so they don't wrap as easily
* Don't show the image on mobile/tiny screens
* Maybe more based on your feedback. :) 

**Before**

<img width="999" alt="Screenshot 2024-01-08 at 12 59 16 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/d94fe3b1-f181-48ce-8fcf-234eb87b4585">

<img width="224" alt="Screenshot 2024-01-08 at 3 09 25 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/e7b91a5f-c356-4bc1-868e-5b21c0f4ef1a">

<img width="1103" alt="Screenshot 2024-01-09 at 9 43 20 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/a0327a68-6ffa-48c3-9201-ded6082af5ec">

**After**

<img width="1096" alt="Screenshot 2024-01-09 at 9 45 52 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/11448595-acb9-43d7-b03e-da61113b8cfa">

<img width="226" alt="Screenshot 2024-01-08 at 3 08 54 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/8df8e841-6262-4eed-b2df-2bf147721309">

<img width="1093" alt="Screenshot 2024-01-09 at 9 44 53 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/65a6c40a-b7bc-4a75-8366-fb8994749b46">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Sandbox `public-api.wordpress.com`
* If you're a member of Serenity, update line 174 of `/wp-content/lib/home/cards.php` to return `false`.
* Navigate to My Home on a launched site that has a completed task list. It may have to be an older site, because I wasn't able to see the domain upsell on some of my sites, but that's unclear.
* Check the domain upsell task card and ensure it looks OK at full width.
* If you're a member of Serenity, revert your changes to `/wp-content/lib/home/cards.php`. Otherwise, enable the back-end changes by adding the following to your 0-sandbox.php:
```add_filter( 'wpcom_my_home_force_two_column_layout', '__return_false' );```
* Check the same card and ensure it looks OK at different screen sizes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?