### PR TITLE
Memberships: support multiple currencies in coupons

### DIFF
--- a/client/my-sites/earn/components/add-edit-coupon-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-coupon-modal/index.tsx
@@ -91,12 +91,6 @@ const RecurringPaymentsCouponAddEditModal = ( {
 		}
 		return 'USD';
 	}, [ coupon, connectedAccountDefaultCurrency, currencyList ] );
-	const [ currentDiscountCurrency, setCurrentDiscountCurrency ] =
-		useState( defaultDiscountCurrency );
-	const onDiscountCurrencyChange = ( event: ChangeEvent< HTMLSelectElement > ) => {
-		const { value: currency } = event.currentTarget;
-		setCurrentDiscountCurrency( currency );
-	};
 
 	/** Other datasets */
 	const products: Product[] = useSelector( ( state ) =>
@@ -114,13 +108,16 @@ const RecurringPaymentsCouponAddEditModal = ( {
 	const [ editedDiscountPercentage, setEditedDiscountPercentage ] = useState(
 		coupon?.discount_percentage ?? 0
 	);
+	const [ editedDiscountCurrency, setEditedDiscountCurrency ] = useState(
+		coupon?.discount_currency ?? defaultDiscountCurrency
+	);
 	const [ editedDiscountValue, setEditedDiscountValue ] = useState( () => {
 		if ( COUPON_DISCOUNT_TYPE_AMOUNT === editedDiscountType ) {
 			return (
 				coupon?.discount_value ??
 				minimumCurrencyTransactionAmount(
 					connectedAccountMinimumCurrency,
-					currentDiscountCurrency,
+					editedDiscountCurrency,
 					connectedAccountDefaultCurrency
 				)
 			);
@@ -200,6 +197,10 @@ const RecurringPaymentsCouponAddEditModal = ( {
 	};
 	const onSelectDiscountType = ( event: ChangeEvent< HTMLSelectElement > ) =>
 		setEditedDiscountType( event.target.value );
+	const onDiscountCurrencyChange = ( event: ChangeEvent< HTMLSelectElement > ) => {
+		const { value: currency } = event.currentTarget;
+		setEditedDiscountCurrency( currency );
+	};
 	const onDiscountValueChange = ( event: ChangeEvent< HTMLInputElement > ) =>
 		setEditedDiscountValue( parseFloat( event.target.value ) );
 	const onDiscountPercentageChange = ( event: ChangeEvent< HTMLInputElement > ) =>
@@ -368,7 +369,7 @@ const RecurringPaymentsCouponAddEditModal = ( {
 			discount_type: editedDiscountType,
 			discount_value: editedDiscountValue,
 			discount_percentage: editedDiscountPercentage,
-			discount_currency: currentDiscountCurrency,
+			discount_currency: editedDiscountCurrency,
 			start_date: editedStartDate,
 			end_date: editedEndDate,
 			plan_ids_allow_list: editedPlanIdsAllowList,
@@ -486,7 +487,7 @@ const RecurringPaymentsCouponAddEditModal = ( {
 								onChange={ onDiscountValueChange }
 								onFocus={ onDiscountAmountFocus }
 								onBlur={ onDiscountValueBlur }
-								currencySymbolPrefix={ currentDiscountCurrency }
+								currencySymbolPrefix={ editedDiscountCurrency }
 								onCurrencyChange={ onDiscountCurrencyChange }
 								currencyList={ currencyList.map( ( code ) => ( { code } ) ) }
 								placeholder="0.00"

--- a/client/my-sites/earn/memberships/coupons-list.tsx
+++ b/client/my-sites/earn/memberships/coupons-list.tsx
@@ -193,7 +193,7 @@ function CouponsList() {
 													currentCoupon?.duration || '',
 													currentCoupon?.discount_type,
 													currentCoupon?.discount_value || 0,
-													currentCoupon?.discount_currency
+													currentCoupon?.discount_currency || 'USD'
 												) }
 											</Badge>
 										</div>

--- a/client/state/data-layer/wpcom/sites/memberships/index.js
+++ b/client/state/data-layer/wpcom/sites/memberships/index.js
@@ -37,6 +37,7 @@ export const membershipCouponFromApi = ( coupon ) => ( {
 	discount_type: coupon.discount_type,
 	discount_value: parseFloat( coupon.discount_value ),
 	discount_percentage: parseFloat( coupon.discount_percentage ),
+	discount_currency: coupon.discount_currency,
 	start_date: coupon.start_date,
 	end_date: coupon.end_date,
 	plan_ids_allow_list: coupon.plan_ids_allow_list.map( ( productId ) => parseInt( productId ) ),

--- a/client/state/memberships/coupon-list/schema.js
+++ b/client/state/memberships/coupon-list/schema.js
@@ -6,6 +6,7 @@ export const metadataSchema = {
 	discount_type: { type: 'string', metaKey: 'scoup_discount_type' },
 	discount_value: { type: 'number', metaKey: 'scoup_discount_value' },
 	discount_percentage: { type: 'number', metaKey: 'scoup_discount_percentage' },
+	discount_currency: { type: 'string', metaKey: 'scoup_discount_currency' },
 	start_date: { type: 'string', metaKey: 'scoup_start_date' },
 	end_date: { type: 'string', metaKey: 'scoup_end_date' },
 	plan_ids_allow_list: { type: 'array', metaKey: 'scoup_plan_ids_allow_list' },


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # 277-gh-automattic/gold

## Proposed Changes

* Support multiple currencies for membership coupons.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow instructions on D133971-code

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?