### PR TITLE
GF Signup: Fix plan type selector on change handling

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -101,7 +101,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		? reduxHideFreePlan && 'plans-blog-onboarding' === plansIntent
 		: reduxHideFreePlan;
 
-	const onPlanTypeSelectorChange = ( path: string ) => {
+	const onPlanIntervalChange = ( path: string ) => {
 		navigate( path );
 	};
 
@@ -172,7 +172,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 						 */
 						config.isEnabled( 'onboarding/interval-dropdown' ) && false
 					}
-					onPlanTypeSelectorChange={ onPlanTypeSelectorChange }
+					onPlanIntervalChange={ onPlanIntervalChange }
 				/>
 			</div>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
+import { useNavigate } from 'react-router';
 import {
 	START_WRITING_FLOW,
 	isLinkInBioFlow,
@@ -90,6 +91,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	const { __ } = useI18n();
 	const translate = useTranslate();
 	const isDesktop = useDesktopBreakpoint();
+	const navigate = useNavigate();
 	const stepName = 'plans';
 	const customerType = 'personal';
 	const headerText = __( 'Choose a plan' );
@@ -98,6 +100,10 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	const hideFreePlan = plansIntent
 		? reduxHideFreePlan && 'plans-blog-onboarding' === plansIntent
 		: reduxHideFreePlan;
+
+	const onPlanTypeSelectorChange = ( selectedItem: { url: string } ) => {
+		navigate( selectedItem.url );
+	};
 
 	const onUpgradeClick = ( cartItems?: MinimalRequestCartProduct[] | null ) => {
 		const planCartItem = getPlanCartItem( cartItems );
@@ -164,8 +170,9 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 						 *	Override the default feature flag to prevent this feature from rendering in untested locations
 						 *  The hardcoded 'false' short curicuit should be removed once the feature is fully tested in the given context
 						 */
-						config.isEnabled( 'onboarding/interval-dropdown' ) && false
+						config.isEnabled( 'onboarding/interval-dropdown' )
 					}
+					onPlanTypeSelectorChange={ onPlanTypeSelectorChange }
 				/>
 			</div>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
 import { PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
-import { useNavigate } from 'react-router';
 import {
 	START_WRITING_FLOW,
 	isLinkInBioFlow,
@@ -22,6 +21,7 @@ import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
+import { useNavigate } from 'react-router';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { getPlanCartItem } from 'calypso/lib/cart-values/cart-items';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
@@ -101,8 +101,8 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		? reduxHideFreePlan && 'plans-blog-onboarding' === plansIntent
 		: reduxHideFreePlan;
 
-	const onPlanTypeSelectorChange = ( selectedItem: { url: string } ) => {
-		navigate( selectedItem.url );
+	const onPlanTypeSelectorChange = ( path: string ) => {
+		navigate( path );
 	};
 
 	const onUpgradeClick = ( cartItems?: MinimalRequestCartProduct[] | null ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -170,7 +170,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 						 *	Override the default feature flag to prevent this feature from rendering in untested locations
 						 *  The hardcoded 'false' short curicuit should be removed once the feature is fully tested in the given context
 						 */
-						config.isEnabled( 'onboarding/interval-dropdown' )
+						config.isEnabled( 'onboarding/interval-dropdown' ) && false
 					}
 					onPlanTypeSelectorChange={ onPlanTypeSelectorChange }
 				/>

--- a/client/my-sites/plans-features-main/hooks/use-plan-type-destination-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-type-destination-callback.ts
@@ -1,7 +1,6 @@
 import { plansLink } from '@automattic/calypso-products';
 import { useCallback } from '@wordpress/element';
 import { addQueryArgs } from '@wordpress/url';
-// TODO: Consider moving type reference
 import { PlanTypeSelectorProps } from 'calypso/my-sites/plans-grid/components/plan-type-selector/types';
 
 interface PathArgs {

--- a/client/my-sites/plans-features-main/hooks/use-plan-type-destination-callback.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-type-destination-callback.ts
@@ -1,0 +1,58 @@
+import { plansLink } from '@automattic/calypso-products';
+import { useCallback } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
+// TODO: Consider moving type reference
+import { PlanTypeSelectorProps } from 'calypso/my-sites/plans-grid/components/plan-type-selector/types';
+
+interface PathArgs {
+	[ key: string ]: string | null;
+}
+
+/**
+ * Returns a callback to retrieve a plan type destination path or query param depending on
+ * the environment ( Ex. ?intervalType=yearly or /plans/yearly/{SITE_SLUG} )
+ */
+const usePlanTypeDestinationCallback = () => {
+	return useCallback(
+		( props: Partial< PlanTypeSelectorProps >, additionalArgs: PathArgs = {} ) => {
+			const { intervalType = '' } = additionalArgs;
+			const defaultArgs = {
+				customerType: undefined,
+				discount: props.withDiscount,
+				feature: props.selectedFeature,
+				plan: props.selectedPlan,
+			};
+			// remove empty values from additionalArgs
+			const _additionalArgs = Object.keys( additionalArgs ).reduce( ( acc, key ) => {
+				return {
+					...acc,
+					...( additionalArgs[ key ] && { [ key ]: additionalArgs[ key ] } ),
+				};
+			}, {} );
+
+			if ( props.isInSignup || 'customerType' in additionalArgs || props.isStepperUpgradeFlow ) {
+				return addQueryArgs( document.location?.search, {
+					...defaultArgs,
+					..._additionalArgs,
+				} );
+			}
+
+			return addQueryArgs(
+				plansLink(
+					props.basePlansPath || '/plans',
+					props.siteSlug,
+					intervalType ? String( intervalType ) : '',
+					true
+				),
+				{
+					...defaultArgs,
+					..._additionalArgs,
+					intervalType: undefined,
+				}
+			);
+		},
+		[]
+	);
+};
+
+export default usePlanTypeDestinationCallback;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -193,7 +193,7 @@ export interface PlansFeaturesMainProps {
 	 * Shows the plan type selector dropdown instead of the default toggle
 	 */
 	showPlanTypeSelectorDropdown?: boolean;
-	onPlanTypeSelectorChange?: ( path: string ) => void;
+	onPlanIntervalChange?: ( path: string ) => void;
 }
 
 const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) => {
@@ -256,7 +256,7 @@ const PlansFeaturesMain = ( {
 	renderSiblingWhenLoaded,
 	showPlanTypeSelectorDropdown = false,
 	coupon,
-	onPlanTypeSelectorChange,
+	onPlanIntervalChange,
 }: PlansFeaturesMainProps ) => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ lastClickedPlan, setLastClickedPlan ] = useState< string | null >( null );
@@ -751,8 +751,8 @@ const PlansFeaturesMain = ( {
 				jetpackAppPlans: isJetpackAppFlow,
 			} );
 
-			if ( onPlanTypeSelectorChange ) {
-				return onPlanTypeSelectorChange( pathOrQueryParam );
+			if ( onPlanIntervalChange ) {
+				return onPlanIntervalChange( pathOrQueryParam );
 			}
 
 			if ( hasQueryArg( pathOrQueryParam, 'intervalType' ) ) {
@@ -859,7 +859,7 @@ const PlansFeaturesMain = ( {
 								enableStickyBehavior={ enablePlanTypeSelectorStickyBehavior }
 								stickyPlanTypeSelectorOffset={ masterbarHeight - 1 }
 								coupon={ coupon }
-								onPlanTypeSelectorChange={ handlePlanTypeSelectorChange }
+								onPlanIntervalChange={ handlePlanTypeSelectorChange }
 							/>
 						) }
 						<div

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -561,6 +561,7 @@ const PlansFeaturesMain = ( {
 			recordTracksEvent,
 			coupon,
 			selectedSiteId: siteId,
+			withDiscount,
 		};
 	}, [
 		_customerType,
@@ -580,6 +581,7 @@ const PlansFeaturesMain = ( {
 		eligibleForWpcomMonthlyPlans,
 		coupon,
 		siteId,
+		withDiscount,
 	] );
 
 	/**
@@ -730,12 +732,6 @@ const PlansFeaturesMain = ( {
 
 	const handlePlanTypeSelectorChange = useCallback(
 		( selectedItem: { key: SupportedUrlFriendlyTermType } ) => {
-			const additionalPathProps = {
-				...( planTypeSelectorProps.redirectTo
-					? { redirect_to: planTypeSelectorProps.redirectTo }
-					: {} ),
-			};
-
 			let isDomainUpsellFlow: string | null = '';
 			let isDomainAndPlanPackageFlow: string | null = '';
 			let isJetpackAppFlow: string | null = '';
@@ -753,7 +749,6 @@ const PlansFeaturesMain = ( {
 				domain: isDomainUpsellFlow,
 				domainAndPlanPackage: isDomainAndPlanPackageFlow,
 				jetpackAppPlans: isJetpackAppFlow,
-				...additionalPathProps,
 			} );
 
 			if ( onPlanTypeSelectorChange ) {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -57,6 +57,7 @@ import useStorageAddOns from 'calypso/my-sites/add-ons/hooks/use-storage-add-ons
 import PlanNotice from 'calypso/my-sites/plans-features-main/components/plan-notice';
 import usePlanTypeDestinationCallback from 'calypso/my-sites/plans-features-main/hooks/use-plan-type-destination-callback';
 import { FeaturesGrid, ComparisonGrid, PlanTypeSelector } from 'calypso/my-sites/plans-grid';
+import { SupportedUrlFriendlyTermType } from 'calypso/my-sites/plans-grid/components/plan-type-selector/types';
 import useGridPlans from 'calypso/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans';
 import usePlanFeaturesForGridPlans from 'calypso/my-sites/plans-grid/hooks/npm-ready/data-store/use-plan-features-for-grid-plans';
 import useRestructuredPlanFeaturesForComparisonGrid from 'calypso/my-sites/plans-grid/hooks/npm-ready/data-store/use-restructured-plan-features-for-comparison-grid';
@@ -727,44 +728,47 @@ const PlansFeaturesMain = ( {
 		[]
 	);
 
-	const handlePlanTypeSelectorChange = useCallback( ( selectedItem: { key: string } ) => {
-		const additionalPathProps = {
-			...( planTypeSelectorProps.redirectTo
-				? { redirect_to: planTypeSelectorProps.redirectTo }
-				: {} ),
-		};
+	const handlePlanTypeSelectorChange = useCallback(
+		( selectedItem: { key: SupportedUrlFriendlyTermType } ) => {
+			const additionalPathProps = {
+				...( planTypeSelectorProps.redirectTo
+					? { redirect_to: planTypeSelectorProps.redirectTo }
+					: {} ),
+			};
 
-		let isDomainUpsellFlow: string | null = '';
-		let isDomainAndPlanPackageFlow: string | null = '';
-		let isJetpackAppFlow: string | null = '';
+			let isDomainUpsellFlow: string | null = '';
+			let isDomainAndPlanPackageFlow: string | null = '';
+			let isJetpackAppFlow: string | null = '';
 
-		if ( typeof window !== 'undefined' ) {
-			isDomainUpsellFlow = new URLSearchParams( window.location.search ).get( 'domain' );
-			isDomainAndPlanPackageFlow = new URLSearchParams( window.location.search ).get(
-				'domainAndPlanPackage'
-			);
-			isJetpackAppFlow = new URLSearchParams( window.location.search ).get( 'jetpackAppPlans' );
-		}
+			if ( typeof window !== 'undefined' ) {
+				isDomainUpsellFlow = new URLSearchParams( window.location.search ).get( 'domain' );
+				isDomainAndPlanPackageFlow = new URLSearchParams( window.location.search ).get(
+					'domainAndPlanPackage'
+				);
+				isJetpackAppFlow = new URLSearchParams( window.location.search ).get( 'jetpackAppPlans' );
+			}
 
-		const pathOrQueryParam = getPlanTypeDestination( planTypeSelectorProps, {
-			intervalType: selectedItem.key,
-			domain: isDomainUpsellFlow,
-			domainAndPlanPackage: isDomainAndPlanPackageFlow,
-			jetpackAppPlans: isJetpackAppFlow,
-			...additionalPathProps,
-		} );
+			const pathOrQueryParam = getPlanTypeDestination( planTypeSelectorProps, {
+				intervalType: selectedItem.key,
+				domain: isDomainUpsellFlow,
+				domainAndPlanPackage: isDomainAndPlanPackageFlow,
+				jetpackAppPlans: isJetpackAppFlow,
+				...additionalPathProps,
+			} );
 
-		if ( onPlanTypeSelectorChange ) {
-			return onPlanTypeSelectorChange( pathOrQueryParam );
-		}
+			if ( onPlanTypeSelectorChange ) {
+				return onPlanTypeSelectorChange( pathOrQueryParam );
+			}
 
-		if ( hasQueryArg( pathOrQueryParam, 'intervalType' ) ) {
-			const currentPath = window.location.pathname;
-			return page( currentPath + pathOrQueryParam );
-		}
+			if ( hasQueryArg( pathOrQueryParam, 'intervalType' ) ) {
+				const currentPath = window.location.pathname;
+				return page( currentPath + pathOrQueryParam );
+			}
 
-		page( pathOrQueryParam );
-	}, [] );
+			page( pathOrQueryParam );
+		},
+		[]
+	);
 
 	const comparisonGridContainerClasses = classNames(
 		'plans-features-main__comparison-grid-container',

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -816,6 +816,10 @@ const PlansFeaturesMain = ( {
 								enableStickyBehavior={ enablePlanTypeSelectorStickyBehavior }
 								stickyPlanTypeSelectorOffset={ masterbarHeight - 1 }
 								coupon={ coupon }
+								onPlanTypeSelectorChange={ ( selectedItem ) => {
+									const currentPath = window.location.pathname;
+									page( currentPath + selectedItem.queryParams );
+								} }
 							/>
 						) }
 						<div

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -722,6 +722,11 @@ const PlansFeaturesMain = ( {
 		[]
 	);
 
+	const handlePlanTypeSelectorChange = useCallback( ( selectedItem: { queryParams: string } ) => {
+		const currentPath = window.location.pathname;
+		page( currentPath + selectedItem.queryParams );
+	}, [] );
+
 	const comparisonGridContainerClasses = classNames(
 		'plans-features-main__comparison-grid-container',
 		{
@@ -815,11 +820,7 @@ const PlansFeaturesMain = ( {
 								layoutClassName="plans-features-main__plan-type-selector-layout"
 								enableStickyBehavior={ enablePlanTypeSelectorStickyBehavior }
 								stickyPlanTypeSelectorOffset={ masterbarHeight - 1 }
-								coupon={ coupon }
-								onPlanTypeSelectorChange={ ( selectedItem ) => {
-									const currentPath = window.location.pathname;
-									page( currentPath + selectedItem.queryParams );
-								} }
+								onPlanTypeSelectorChange={ handlePlanTypeSelectorChange }
 							/>
 						) }
 						<div

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -863,6 +863,7 @@ const PlansFeaturesMain = ( {
 								layoutClassName="plans-features-main__plan-type-selector-layout"
 								enableStickyBehavior={ enablePlanTypeSelectorStickyBehavior }
 								stickyPlanTypeSelectorOffset={ masterbarHeight - 1 }
+								coupon={ coupon }
 								onPlanTypeSelectorChange={ handlePlanTypeSelectorChange }
 							/>
 						) }

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -191,6 +191,7 @@ export interface PlansFeaturesMainProps {
 	 * Shows the plan type selector dropdown instead of the default toggle
 	 */
 	showPlanTypeSelectorDropdown?: boolean;
+	onPlanTypeSelectorChange?: ( selectedItem: { url: string } ) => void;
 }
 
 const SecondaryFormattedHeader = ( { siteSlug }: { siteSlug?: string | null } ) => {
@@ -253,6 +254,7 @@ const PlansFeaturesMain = ( {
 	renderSiblingWhenLoaded,
 	showPlanTypeSelectorDropdown = false,
 	coupon,
+	onPlanTypeSelectorChange,
 }: PlansFeaturesMainProps ) => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ lastClickedPlan, setLastClickedPlan ] = useState< string | null >( null );
@@ -724,6 +726,10 @@ const PlansFeaturesMain = ( {
 	);
 
 	const handlePlanTypeSelectorChange = useCallback( ( selectedItem: { url: string } ) => {
+		if ( onPlanTypeSelectorChange ) {
+			return onPlanTypeSelectorChange( selectedItem );
+		}
+
 		if ( hasQueryArg( selectedItem.url, 'intervalType' ) ) {
 			const currentPath = window.location.pathname;
 			return page( currentPath + selectedItem.url );

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -33,6 +33,7 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
+import { hasQueryArg } from '@wordpress/url';
 import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
 import { ReactNode } from 'react';
@@ -722,9 +723,13 @@ const PlansFeaturesMain = ( {
 		[]
 	);
 
-	const handlePlanTypeSelectorChange = useCallback( ( selectedItem: { queryParams: string } ) => {
-		const currentPath = window.location.pathname;
-		page( currentPath + selectedItem.queryParams );
+	const handlePlanTypeSelectorChange = useCallback( ( selectedItem: { url: string } ) => {
+		if ( hasQueryArg( selectedItem.url, 'intervalType' ) ) {
+			const currentPath = window.location.pathname;
+			return page( currentPath + selectedItem.url );
+		}
+
+		page( selectedItem.url );
 	}, [] );
 
 	const comparisonGridContainerClasses = classNames(

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -34,7 +34,7 @@ const IntervalTypeOption = styled.div`
 `;
 
 export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
-	const { intervalType, displayedIntervals, onPlanTypeSelectorChange } = props;
+	const { intervalType, displayedIntervals, onPlanIntervalChange } = props;
 	const supportedIntervalType = (
 		displayedIntervals.includes( intervalType ) ? intervalType : 'yearly'
 	) as SupportedUrlFriendlyTermType;
@@ -58,7 +58,7 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 				options={ selectOptionsList }
 				value={ selectOptionsList.find( ( { key } ) => key === supportedIntervalType ) }
 				onChange={ ( { selectedItem }: { selectedItem: { key: SupportedUrlFriendlyTermType } } ) =>
-					onPlanTypeSelectorChange && onPlanTypeSelectorChange( selectedItem )
+					onPlanIntervalChange && onPlanIntervalChange( selectedItem )
 				}
 			/>
 		</div>

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -57,11 +57,9 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 				label=""
 				options={ selectOptionsList }
 				value={ selectOptionsList.find( ( { key } ) => key === supportedIntervalType ) }
-				onChange={ ( {
-					selectedItem,
-				}: {
-					selectedItem: { key: SupportedUrlFriendlyTermType; url: string };
-				} ) => onPlanTypeSelectorChange && onPlanTypeSelectorChange( selectedItem ) }
+				onChange={ ( { selectedItem }: { selectedItem: { key: SupportedUrlFriendlyTermType } } ) =>
+					onPlanTypeSelectorChange && onPlanTypeSelectorChange( selectedItem )
+				}
 			/>
 		</div>
 	);

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -5,9 +5,9 @@ import useIntervalOptions from '../hooks/use-interval-options';
 import { IntervalTypeProps, SupportedUrlFriendlyTermType } from '../types';
 
 const IntervalTypeOption = styled.div`
-	& div.name,
-	&:visited div.name,
-	&:hover div.name {
+	& span.name,
+	&:visited span.name,
+	&:hover span.name {
 		color: var( --color-text );
 	}
 

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -1,12 +1,13 @@
+import page from '@automattic/calypso-router';
 import styled from '@emotion/styled';
 import { CustomSelectControl } from '@wordpress/components';
 import useIntervalOptions from '../hooks/use-interval-options';
 import { IntervalTypeProps, SupportedUrlFriendlyTermType } from '../types';
 
-const AddOnOption = styled.a`
-	& span.name,
-	&:visited span.name,
-	&:hover span.name {
+const IntervalTypeOption = styled.div`
+	& div.name,
+	&:visited div.name,
+	&:hover div.name {
 		color: var( --color-text );
 	}
 
@@ -43,11 +44,12 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 	const selectOptionsList = Object.values( optionsList ).map( ( option ) => ( {
 		key: option.key,
 		name: (
-			<AddOnOption href={ option.url }>
+			<IntervalTypeOption>
 				<span className="name"> { option.name } </span>
 				{ option.discountText ? <span className="discount"> { option.discountText } </span> : null }
-			</AddOnOption>
+			</IntervalTypeOption>
 		),
+		url: option.url,
 	} ) );
 
 	return (
@@ -57,6 +59,13 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 				label=""
 				options={ selectOptionsList }
 				value={ selectOptionsList.find( ( { key } ) => key === supportedIntervalType ) }
+				onChange={ ( {
+					selectedItem,
+				}: {
+					selectedItem: { key: SupportedUrlFriendlyTermType; url: string };
+				} ) => {
+					page( `/start/plans${ selectedItem.url }` );
+				} }
 			/>
 		</div>
 	);

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -1,4 +1,3 @@
-import page from '@automattic/calypso-router';
 import styled from '@emotion/styled';
 import { CustomSelectControl } from '@wordpress/components';
 import useIntervalOptions from '../hooks/use-interval-options';
@@ -35,7 +34,7 @@ const IntervalTypeOption = styled.div`
 `;
 
 export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
-	const { intervalType, displayedIntervals } = props;
+	const { intervalType, displayedIntervals, onPlanTypeSelectorChange } = props;
 	const supportedIntervalType = (
 		displayedIntervals.includes( intervalType ) ? intervalType : 'yearly'
 	) as SupportedUrlFriendlyTermType;
@@ -49,7 +48,9 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 				{ option.discountText ? <span className="discount"> { option.discountText } </span> : null }
 			</IntervalTypeOption>
 		),
-		url: option.url,
+		// TODO: The "url" attribute is actually a string of query params. We should revisit this in the
+		// useIntervalOptions hook.
+		queryParams: option.url,
 	} ) );
 
 	return (
@@ -62,10 +63,8 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 				onChange={ ( {
 					selectedItem,
 				}: {
-					selectedItem: { key: SupportedUrlFriendlyTermType; url: string };
-				} ) => {
-					page( `/start/plans${ selectedItem.url }` );
-				} }
+					selectedItem: { key: SupportedUrlFriendlyTermType; queryParams: string };
+				} ) => onPlanTypeSelectorChange && onPlanTypeSelectorChange( selectedItem ) }
 			/>
 		</div>
 	);

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -48,9 +48,6 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 				{ option.discountText ? <span className="discount"> { option.discountText } </span> : null }
 			</IntervalTypeOption>
 		),
-		// TODO: The "url" attribute can be either a relative url or only query params. We should revisit this in the
-		// useIntervalOptions hook.
-		url: option.url,
 	} ) );
 
 	return (

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -48,9 +48,9 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 				{ option.discountText ? <span className="discount"> { option.discountText } </span> : null }
 			</IntervalTypeOption>
 		),
-		// TODO: The "url" attribute is actually a string of query params. We should revisit this in the
+		// TODO: The "url" attribute can be either a relative url or only query params. We should revisit this in the
 		// useIntervalOptions hook.
-		queryParams: option.url,
+		url: option.url,
 	} ) );
 
 	return (
@@ -63,7 +63,7 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 				onChange={ ( {
 					selectedItem,
 				}: {
-					selectedItem: { key: SupportedUrlFriendlyTermType; queryParams: string };
+					selectedItem: { key: SupportedUrlFriendlyTermType; url: string };
 				} ) => onPlanTypeSelectorChange && onPlanTypeSelectorChange( selectedItem ) }
 			/>
 		</div>

--- a/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-interval-options.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-interval-options.tsx
@@ -1,6 +1,5 @@
 import { LocalizeProps, TranslateResult, useTranslate } from 'i18n-calypso';
 import { IntervalTypeProps, SupportedUrlFriendlyTermType } from '../types';
-import generatePath from '../utils';
 import useMaxDiscountsForPlanTerms from './use-max-discounts-for-plan-terms';
 
 const getDiscountText = ( discountPercentage: number, translate: LocalizeProps[ 'translate' ] ) => {
@@ -19,7 +18,6 @@ type IntervalSelectOptionsMap = Record<
 		key: string;
 		name: TranslateResult;
 		discountText: TranslateResult;
-		url: string;
 		termInMonths: number;
 	}
 >;
@@ -32,7 +30,6 @@ export default function useIntervalOptions( props: IntervalTypeProps ): Interval
 			key: SupportedUrlFriendlyTermType;
 			name: TranslateResult;
 			discountText: TranslateResult;
-			url: string;
 			termInMonths: number;
 		}
 	> = {
@@ -40,28 +37,24 @@ export default function useIntervalOptions( props: IntervalTypeProps ): Interval
 			key: 'yearly',
 			name: translate( 'Pay yearly' ),
 			discountText: '',
-			url: '',
 			termInMonths: 12,
 		},
 		'2yearly': {
 			key: '2yearly',
 			name: translate( 'Pay every 2 years' ),
 			discountText: '',
-			url: '',
 			termInMonths: 24,
 		},
 		'3yearly': {
 			key: '3yearly',
 			name: translate( 'Pay every 3 years' ),
 			discountText: '',
-			url: '',
 			termInMonths: 36,
 		},
 		monthly: {
 			key: 'monthly',
 			name: translate( 'Pay monthly' ),
 			discountText: '',
-			url: '',
 			termInMonths: 1,
 		},
 	};
@@ -79,33 +72,11 @@ export default function useIntervalOptions( props: IntervalTypeProps ): Interval
 		props.selectedSiteId
 	);
 
-	const additionalPathProps = {
-		...( props.redirectTo ? { redirect_to: props.redirectTo } : {} ),
-	};
-
-	let isDomainUpsellFlow: string | null = '';
-	let isDomainAndPlanPackageFlow: string | null = '';
-	let isJetpackAppFlow: string | null = '';
-	if ( typeof window !== 'undefined' ) {
-		isDomainUpsellFlow = new URLSearchParams( window.location.search ).get( 'domain' );
-		isDomainAndPlanPackageFlow = new URLSearchParams( window.location.search ).get(
-			'domainAndPlanPackage'
-		);
-		isJetpackAppFlow = new URLSearchParams( window.location.search ).get( 'jetpackAppPlans' );
-	}
-
 	displayedOptionList = Object.fromEntries(
 		Object.keys( displayedOptionList ).map( ( key ) => [
 			key as SupportedUrlFriendlyTermType,
 			{
 				...displayedOptionList[ key as SupportedUrlFriendlyTermType ],
-				url: generatePath( props, {
-					intervalType: key,
-					domain: isDomainUpsellFlow,
-					domainAndPlanPackage: isDomainAndPlanPackageFlow,
-					jetpackAppPlans: isJetpackAppFlow,
-					...additionalPathProps,
-				} ),
 				discountText: getDiscountText(
 					termWiseMaxDiscount[ key as SupportedUrlFriendlyTermType ],
 					translate

--- a/client/my-sites/plans-grid/components/plan-type-selector/types.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/types.ts
@@ -11,7 +11,7 @@ export type PlanTypeSelectorProps = {
 	withDiscount?: string;
 	enableStickyBehavior?: boolean;
 	stickyPlanTypeSelectorOffset?: number;
-	onPlanTypeSelectorChange?: ( selectedItem: { key: SupportedUrlFriendlyTermType } ) => void;
+	onPlanIntervalChange?: ( selectedItem: { key: SupportedUrlFriendlyTermType } ) => void;
 	layoutClassName?: string;
 	siteSlug?: string | null;
 	selectedPlan?: string;
@@ -55,7 +55,7 @@ export type IntervalTypeProps = Pick<
 	| 'usePricingMetaForGridPlans'
 	| 'title'
 	| 'coupon'
-	| 'onPlanTypeSelectorChange'
+	| 'onPlanIntervalChange'
 >;
 
 export type SupportedUrlFriendlyTermType = Extract<

--- a/client/my-sites/plans-grid/components/plan-type-selector/types.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/types.ts
@@ -11,7 +11,7 @@ export type PlanTypeSelectorProps = {
 	withDiscount?: string;
 	enableStickyBehavior?: boolean;
 	stickyPlanTypeSelectorOffset?: number;
-	onPlanTypeSelectorChange?: ( selectedItem: { queryParams: string } ) => void;
+	onPlanTypeSelectorChange?: ( selectedItem: { url: string } ) => void;
 	layoutClassName?: string;
 	siteSlug?: string | null;
 	selectedPlan?: string;

--- a/client/my-sites/plans-grid/components/plan-type-selector/types.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/types.ts
@@ -11,6 +11,7 @@ export type PlanTypeSelectorProps = {
 	withDiscount?: string;
 	enableStickyBehavior?: boolean;
 	stickyPlanTypeSelectorOffset?: number;
+	onPlanTypeSelectorChange?: ( selectedItem: { queryParams: string } ) => void;
 	layoutClassName?: string;
 	siteSlug?: string | null;
 	selectedPlan?: string;
@@ -54,6 +55,7 @@ export type IntervalTypeProps = Pick<
 	| 'usePricingMetaForGridPlans'
 	| 'title'
 	| 'coupon'
+	| 'onPlanTypeSelectorChange'
 >;
 
 export type SupportedUrlFriendlyTermType = Extract<

--- a/client/my-sites/plans-grid/components/plan-type-selector/types.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/types.ts
@@ -11,7 +11,7 @@ export type PlanTypeSelectorProps = {
 	withDiscount?: string;
 	enableStickyBehavior?: boolean;
 	stickyPlanTypeSelectorOffset?: number;
-	onPlanTypeSelectorChange?: ( selectedItem: { url: string } ) => void;
+	onPlanTypeSelectorChange?: ( selectedItem: { key: string } ) => void;
 	layoutClassName?: string;
 	siteSlug?: string | null;
 	selectedPlan?: string;

--- a/client/my-sites/plans-grid/components/plan-type-selector/types.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/types.ts
@@ -11,7 +11,7 @@ export type PlanTypeSelectorProps = {
 	withDiscount?: string;
 	enableStickyBehavior?: boolean;
 	stickyPlanTypeSelectorOffset?: number;
-	onPlanTypeSelectorChange?: ( selectedItem: { key: string } ) => void;
+	onPlanTypeSelectorChange?: ( selectedItem: { key: SupportedUrlFriendlyTermType } ) => void;
 	layoutClassName?: string;
 	siteSlug?: string | null;
 	selectedPlan?: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/growth-foundations/issues/296 and https://github.com/Automattic/wp-calypso/pull/84895#issuecomment-1850860431

## Proposed Changes

Logic around plan type selector on change handling is currently suboptimal, and it is manifesting as several different bugs
  * The enter key isn't selecting a plan term in the dropdown. We fix the HTML structure and logic of dropdown items to address this issue
  * The plan type selector dropdown immediately redirects the user when clicked in stepper flows ( see p1704870751451319-slack-C0347E545HR )

## GIF

![2024-01-08 16 41 36](https://github.com/Automattic/wp-calypso/assets/5414230/671bd156-f9f4-4d0a-9d33-cb88cd26c665)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start?flags=onboarding%2Finterval-dropdown`
* Make sure the dropdown with term interval appears
* Click on the term selector dropdown and use the keyboard to select a new interval. Use the keyboard enter button to select the new interval. The UI should update accordingly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?