### PR TITLE
Assembler: Handle renamed categories for page patterns ("Posts" to "Blog")

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { translate } from 'i18n-calypso';
 import { getPatternSourceSiteID } from './constants';
 import type { Pattern, Category } from './types';
 
@@ -35,5 +36,17 @@ export const isPriorityPattern = ( { tags: { assembler_priority } }: Pattern ) =
 export const isPagePattern = ( { categories, tags: { assembler_page } }: Pattern ) =>
 	Boolean( isEnabled( 'pattern-assembler/v2' ) ? categories.page : assembler_page );
 
-export const getPagePatternTitle = ( { categories }: Pattern ) =>
-	( Object.values( categories ) as Category[] ).find( ( { slug } ) => 'page' !== slug )?.title;
+export const getTitleForRenamedCategories = ( category: Category = {} ) => {
+	const { slug, title } = category;
+	if ( 'posts' === slug ) {
+		return translate( 'Blog' );
+	}
+	return title;
+};
+
+export const getPagePatternTitle = ( { categories }: Pattern ) => {
+	const category = ( Object.values( categories ) as Category[] ).find(
+		( { slug } ) => 'page' !== slug
+	);
+	return getTitleForRenamedCategories( category );
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/86039

## Proposed Changes

* Rename the category "Posts" to "Blog" for page patterns

|BEFORE|AFTER|
|-|-|
|<img width="1304" alt="Screenshot 2567-01-09 at 10 57 15" src="https://github.com/Automattic/wp-calypso/assets/1881481/305836d3-98c5-4ac0-a890-d82cb5780437">|<img width="1300" alt="Screenshot 2567-01-09 at 10 55 25" src="https://github.com/Automattic/wp-calypso/assets/1881481/3ba7dabb-e5a6-4522-88a2-52a7fd283860">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access assembler with the flag for v2 `/setup/with-theme-assembler/pattern-assembler?siteSlug={ SITE SLUG }&screen=pages&flags=pattern-assembler%2Fv2`
* Verify you see the page name "Blog" rather than "Posts"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?