### PR TITLE
Hosting Trial: Remove `hasTranslation` checks which are no longer needed

### DIFF
--- a/client/my-sites/plans/trials/trial-banner/use-banner-subtitle.ts
+++ b/client/my-sites/plans/trials/trial-banner/use-banner-subtitle.ts
@@ -4,8 +4,7 @@ import {
 	PlanSlug,
 } from '@automattic/calypso-products';
 import { Plans } from '@automattic/data-stores';
-import { useIsEnglishLocale, useLocale } from '@automattic/i18n-utils';
-import { hasTranslation } from '@wordpress/i18n';
+import { useLocale } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
 import type { Moment } from 'moment/moment';
@@ -19,7 +18,6 @@ export default function useBannerSubtitle(
 	isEcommerceTrial?: boolean
 ): string {
 	const locale = useLocale();
-	const isEn = useIsEnglishLocale();
 	const translate = useTranslate();
 	const [ bannerSubtitle, setBannerSubtitle ] = useState( '' );
 	// moment.js doesn't have a format option to display the long form in a localized way without the year
@@ -39,14 +37,7 @@ export default function useBannerSubtitle(
 			anyWooExpressIntroOffer &&
 			'month' === anyWooExpressIntroOffer.intervalUnit
 		) {
-			if (
-				trialDaysLeftToDisplay < 1 &&
-				( isEn ||
-					hasTranslation(
-						'Your free trial ends today. Upgrade by %(expirationdate)s to start selling and take advantage of our limited time offer ' +
-							'— any Woo Express plan for just %(introOfferFormattedPrice)s a month for your first %(introOfferIntervalCount)d months.'
-					) )
-			) {
+			if ( trialDaysLeftToDisplay < 1 ) {
 				introOfferSubtitle = translate(
 					'Your free trial ends today. Upgrade by %(expirationdate)s to start selling and take advantage of our limited time offer ' +
 						'— any Woo Express plan for just %(introOfferFormattedPrice)s a month for your first %(introOfferIntervalCount)d months.',
@@ -86,13 +77,7 @@ export default function useBannerSubtitle(
 					);
 				} else if ( introOfferSubtitle ) {
 					subtitle = introOfferSubtitle;
-				} else if (
-					trialDaysLeftToDisplay < 1 &&
-					( isEn ||
-						hasTranslation(
-							'Your free trial ends today. Upgrade to a plan by %(expirationdate)s to unlock new features and launch your migrated website.'
-						) )
-				) {
+				} else if ( trialDaysLeftToDisplay < 1 ) {
 					subtitle = translate(
 						'Your free trial ends today. Upgrade to a plan by %(expirationdate)s to unlock new features and launch your migrated website.',
 						{
@@ -120,13 +105,7 @@ export default function useBannerSubtitle(
 					subtitle = translate(
 						'Your free trial has expired. Upgrade to a plan to continue using advanced features.'
 					);
-				} else if (
-					trialDaysLeftToDisplay < 1 &&
-					( isEn ||
-						hasTranslation(
-							'Your free trial ends today. Upgrade to a plan by %(expirationdate)s to continue using advanced features.'
-						) )
-				) {
+				} else if ( trialDaysLeftToDisplay < 1 ) {
 					subtitle = translate(
 						'Your free trial ends today. Upgrade to a plan by %(expirationdate)s to continue using advanced features.',
 						{
@@ -156,13 +135,7 @@ export default function useBannerSubtitle(
 					);
 				} else if ( introOfferSubtitle ) {
 					subtitle = introOfferSubtitle;
-				} else if (
-					trialDaysLeftToDisplay < 1 &&
-					( isEn ||
-						hasTranslation(
-							'Your free trial ends today. Upgrade to a plan by %(expirationdate)s to unlock new features and start selling.'
-						) )
-				) {
+				} else if ( trialDaysLeftToDisplay < 1 ) {
 					subtitle = translate(
 						'Your free trial ends today. Upgrade to a plan by %(expirationdate)s to unlock new features and start selling.',
 						{
@@ -196,7 +169,6 @@ export default function useBannerSubtitle(
 		anyWooExpressIntroOffer,
 		isEcommerceTrial,
 		translate,
-		isEn,
 	] );
 
 	return bannerSubtitle;


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

Removes `hasTranslation()` checks from hosting trial banner now that the strings which were added in #85454 have been translated into the mag16.

https://translate.wordpress.com/deliverables/overview/10673869/

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test a free trial site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?