### PR TITLE
Assembler: framer-motion-reorder-list

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -587,6 +587,10 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 		moveDownSection( position );
 	};
 
+	const onReorderSections = ( orderedSections: Pattern[] ) => {
+		setSections( orderedSections );
+	};
+
 	const onDeleteHeader = () => onSelect( 'header', null );
 
 	const onDeleteFooter = () => onSelect( 'footer', null );
@@ -744,6 +748,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 					onDeleteSection={ onDeleteSection }
 					onMoveUpSection={ onMoveUpSection }
 					onMoveDownSection={ onMoveDownSection }
+					onReorderSections={ onReorderSections }
 					onDeleteHeader={ onDeleteHeader }
 					onDeleteFooter={ onDeleteFooter }
 					onShuffle={ onShuffle }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -82,6 +82,7 @@ const PatternLargePreview = ( {
 
 	const [ activeElement, setActiveElement ] = useState< HTMLElement | null >( null );
 	const [ shouldShowTooltip, setShouldShowTooltip ] = useState( false );
+	const [ isReordering, setIsReordering ] = useState( false );
 
 	const popoverAnchor = useMemo( () => {
 		if ( ! activeElement ) {
@@ -120,6 +121,7 @@ const PatternLargePreview = ( {
 		const isSection = type === 'section';
 		const clientId = isSection ? pattern.key : type;
 		const isActive = activeElement?.dataset?.clientId === clientId;
+		const shouldShowActionBar = isActive && ! isReordering;
 
 		const handleMouseDown = ( event: React.MouseEvent< HTMLElement > ) => {
 			const target = event.target as HTMLElement | null;
@@ -177,7 +179,7 @@ const PatternLargePreview = ( {
 						transformHtml={ transformPatternHtml }
 					/>
 				) }
-				{ isActive && (
+				{ shouldShowActionBar && (
 					<Popover
 						animate={ false }
 						focusOnMount={ false }
@@ -231,6 +233,15 @@ const PatternLargePreview = ( {
 			onReorderSections( orderedSections );
 		};
 
+		const handleReorderStart = () => {
+			setIsReordering( true );
+			setShouldShowTooltip( false );
+		};
+
+		const handleReorderEnd = () => {
+			setIsReordering( false );
+		};
+
 		return (
 			<AsyncLoad
 				require="@automattic/framer-motion-reorder-list"
@@ -238,6 +249,8 @@ const PatternLargePreview = ( {
 				forwardedRef={ listRef }
 				items={ listItems }
 				onReorder={ handleReorder }
+				onReorderStart={ handleReorderStart }
+				onReorderEnd={ handleReorderEnd }
 				{ ...listProps }
 			/>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -12,7 +12,7 @@ import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import { injectTitlesToPageListBlock } from './html-transformers';
 import PatternActionBar from './pattern-action-bar';
 import PatternTooltipDeadClick from './pattern-tooltip-dead-click';
-import { encodePatternId } from './utils';
+import { encodePatternId, sortSectionsByKey } from './utils';
 import type { Pattern } from './types';
 import './pattern-large-preview.scss';
 
@@ -25,6 +25,7 @@ interface Props {
 	onDeleteSection: ( position: number ) => void;
 	onMoveUpSection: ( position: number ) => void;
 	onMoveDownSection: ( position: number ) => void;
+	onReorderSections: ( orderedSections: Pattern[] ) => void;
 	onDeleteHeader: () => void;
 	onDeleteFooter: () => void;
 	onShuffle: ( type: string, pattern: Pattern, position?: number ) => void;
@@ -46,6 +47,7 @@ const PatternLargePreview = ( {
 	onDeleteSection,
 	onMoveUpSection,
 	onMoveDownSection,
+	onReorderSections,
 	onDeleteHeader,
 	onDeleteFooter,
 	onShuffle,
@@ -224,12 +226,18 @@ const PatternLargePreview = ( {
 			);
 		}
 
+		const handleReorder = ( newOrder: any[] ) => {
+			const orderedSections = sortSectionsByKey( [ ...sections ], newOrder );
+			onReorderSections( orderedSections );
+		};
+
 		return (
 			<AsyncLoad
 				require="@automattic/framer-motion-reorder-list"
 				placeholder={ null }
 				forwardedRef={ listRef }
 				items={ listItems }
+				onReorder={ handleReorder }
 				{ ...listProps }
 			/>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -50,3 +50,6 @@ export const getPagePatternTitle = ( { categories }: Pattern ) => {
 	);
 	return getTitleForRenamedCategories( category );
 };
+
+export const sortSectionsByKey = ( sections: Pattern[], sortOrder: any[] ) =>
+	sections.sort( ( a, b ) => sortOrder.indexOf( a.key ) - sortOrder.indexOf( b.key ) );

--- a/config/development.json
+++ b/config/development.json
@@ -148,6 +148,7 @@
 		"onboarding/interval-dropdown": true,
 		"p2/p2-plus": true,
 		"page/export": true,
+		"pattern-assembler/frame-motion-reorder": false,
 		"pattern-assembler/v2": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -90,6 +90,7 @@
 		"network-connection": true,
 		"onboarding/design-choices": true,
 		"p2/p2-plus": true,
+		"pattern-assembler/frame-motion-reorder": false,
 		"pattern-assembler/v2": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/production.json
+++ b/config/production.json
@@ -115,6 +115,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
 		"p2/p2-plus": true,
+		"pattern-assembler/frame-motion-reorder": false,
 		"pattern-assembler/v2": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -111,6 +111,7 @@
 		"onboarding/interval-dropdown": true,
 		"p2/p2-plus": true,
 		"page/export": true,
+		"pattern-assembler/frame-motion-reorder": false,
 		"pattern-assembler/v2": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -119,6 +119,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
 		"p2/p2-plus": true,
+		"pattern-assembler/frame-motion-reorder": false,
 		"pattern-assembler/v2": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/packages/framer-motion-reorder-list/README.md
+++ b/packages/framer-motion-reorder-list/README.md
@@ -1,0 +1,3 @@
+# Framer-Motion-Reorder-List
+
+A drag to reorder list powered by framer motion

--- a/packages/framer-motion-reorder-list/jest.config.js
+++ b/packages/framer-motion-reorder-list/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	preset: '../../test/packages/jest-preset.js',
+	testEnvironment: 'jsdom',
+	testMatch: [ '<rootDir>/**/__tests__/**/*.[jt]s?(x)', '!**/.eslintrc.*' ],
+	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
+};

--- a/packages/framer-motion-reorder-list/package.json
+++ b/packages/framer-motion-reorder-list/package.json
@@ -29,7 +29,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"framer-motion": "10.17.0",
+		"framer-motion": "10.13.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"tslib": "^2.3.0"

--- a/packages/framer-motion-reorder-list/package.json
+++ b/packages/framer-motion-reorder-list/package.json
@@ -36,7 +36,7 @@
 	},
 	"devDependencies": {
 		"@automattic/calypso-typescript-config": "workspace:^",
-		"typescript": "^4.7.4"
+		"typescript": "^5.3.3"
 	},
 	"private": true
 }

--- a/packages/framer-motion-reorder-list/package.json
+++ b/packages/framer-motion-reorder-list/package.json
@@ -1,0 +1,42 @@
+{
+	"name": "@automattic/framer-motion-reorder-list",
+	"version": "1.0.0",
+	"description": "A drag-to-reorder list powered by framer-motion",
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic Inc.",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"calypso:src": "src/index.tsx",
+	"sideEffects": [
+		"*.css",
+		"*.scss"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/framer-motion-reorder-list"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"bugs": "https://github.com/Automattic/wp-calypso/issues",
+	"types": "dist/types",
+	"scripts": {
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"prepack": "yarn run clean && yarn run build",
+		"watch": "tsc --build ./tsconfig.json --watch"
+	},
+	"dependencies": {
+		"framer-motion": "10.13.0",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"tslib": "^2.3.0"
+	},
+	"devDependencies": {
+		"@automattic/calypso-typescript-config": "workspace:^",
+		"typescript": "^4.7.4"
+	},
+	"private": true
+}

--- a/packages/framer-motion-reorder-list/package.json
+++ b/packages/framer-motion-reorder-list/package.json
@@ -29,7 +29,7 @@
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {
-		"framer-motion": "10.13.0",
+		"framer-motion": "10.17.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"tslib": "^2.3.0"

--- a/packages/framer-motion-reorder-list/src/index.tsx
+++ b/packages/framer-motion-reorder-list/src/index.tsx
@@ -1,6 +1,10 @@
 import { Reorder } from 'framer-motion';
 import { CSSProperties, Ref } from 'react';
 
+interface FramerMotionReorderListItemProps {
+	item: any;
+}
+
 interface FramerMotionReorderListProps {
 	forwardedRef?: Ref< HTMLDivElement >;
 	className?: string;
@@ -9,13 +13,9 @@ interface FramerMotionReorderListProps {
 	onReorder: ( newOrder: any[] ) => void;
 }
 
-interface FramerMotionReorderListItemProps {
-	item: any;
-}
-
 const FramerMotionReorderListItem = ( { item }: FramerMotionReorderListItemProps ) => {
 	return (
-		<Reorder.Item value={ item } style={ { originX: '0px', originY: '0px' } }>
+		<Reorder.Item value={ item.key } style={ { originX: '0px', originY: '0px' } }>
 			{ item }
 		</Reorder.Item>
 	);

--- a/packages/framer-motion-reorder-list/src/index.tsx
+++ b/packages/framer-motion-reorder-list/src/index.tsx
@@ -24,7 +24,7 @@ const FramerMotionReorderListItem = ( {
 }: FramerMotionReorderListItemProps ) => {
 	return (
 		<Reorder.Item
-			style={ { originX: '0px', originY: '0px' } }
+			style={ { originX: '0px', originY: '0px', position: 'relative' } }
 			value={ item.key }
 			layout="position"
 			onDragStart={ onReorderStart }

--- a/packages/framer-motion-reorder-list/src/index.tsx
+++ b/packages/framer-motion-reorder-list/src/index.tsx
@@ -3,6 +3,8 @@ import { CSSProperties, Ref } from 'react';
 
 interface FramerMotionReorderListItemProps {
 	item: any;
+	onReorderStart: () => void;
+	onReorderEnd: () => void;
 }
 
 interface FramerMotionReorderListProps {
@@ -11,11 +13,23 @@ interface FramerMotionReorderListProps {
 	style?: CSSProperties;
 	items: any[];
 	onReorder: ( newOrder: any[] ) => void;
+	onReorderStart: () => void;
+	onReorderEnd: () => void;
 }
 
-const FramerMotionReorderListItem = ( { item }: FramerMotionReorderListItemProps ) => {
+const FramerMotionReorderListItem = ( {
+	item,
+	onReorderStart,
+	onReorderEnd,
+}: FramerMotionReorderListItemProps ) => {
 	return (
-		<Reorder.Item value={ item.key } style={ { originX: '0px', originY: '0px' } }>
+		<Reorder.Item
+			style={ { originX: '0px', originY: '0px' } }
+			value={ item.key }
+			layout="position"
+			onDragStart={ onReorderStart }
+			onDragEnd={ onReorderEnd }
+		>
 			{ item }
 		</Reorder.Item>
 	);
@@ -27,6 +41,8 @@ const FramerMotionReorderList = ( {
 	style,
 	items,
 	onReorder,
+	onReorderStart,
+	onReorderEnd,
 }: FramerMotionReorderListProps ) => {
 	const itemValues = items.map( ( item ) => item.key );
 
@@ -41,7 +57,12 @@ const FramerMotionReorderList = ( {
 			onReorder={ onReorder }
 		>
 			{ items.map( ( item ) => (
-				<FramerMotionReorderListItem key={ item.key } item={ item } />
+				<FramerMotionReorderListItem
+					key={ item.key }
+					item={ item }
+					onReorderStart={ onReorderStart }
+					onReorderEnd={ onReorderEnd }
+				/>
 			) ) }
 		</Reorder.Group>
 	);

--- a/packages/framer-motion-reorder-list/src/index.tsx
+++ b/packages/framer-motion-reorder-list/src/index.tsx
@@ -1,0 +1,50 @@
+import { Reorder } from 'framer-motion';
+import { CSSProperties, Ref } from 'react';
+
+interface FramerMotionReorderListProps {
+	forwardedRef?: Ref< HTMLDivElement >;
+	className?: string;
+	style?: CSSProperties;
+	items: any[];
+	onReorder: ( newOrder: any[] ) => void;
+}
+
+interface FramerMotionReorderListItemProps {
+	item: any;
+}
+
+const FramerMotionReorderListItem = ( { item }: FramerMotionReorderListItemProps ) => {
+	return (
+		<Reorder.Item value={ item } style={ { originX: '0px', originY: '0px' } }>
+			{ item }
+		</Reorder.Item>
+	);
+};
+
+const FramerMotionReorderList = ( {
+	forwardedRef,
+	className,
+	style,
+	items,
+	onReorder,
+}: FramerMotionReorderListProps ) => {
+	const itemValues = items.map( ( item ) => item.key );
+
+	return (
+		<Reorder.Group
+			ref={ forwardedRef }
+			className={ className }
+			style={ style }
+			axis="y"
+			values={ itemValues }
+			layoutScroll
+			onReorder={ onReorder }
+		>
+			{ items.map( ( item ) => (
+				<FramerMotionReorderListItem key={ item.key } item={ item } />
+			) ) }
+		</Reorder.Group>
+	);
+};
+
+export default FramerMotionReorderList;

--- a/packages/framer-motion-reorder-list/tsconfig-cjs.json
+++ b/packages/framer-motion-reorder-list/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"outDir": "dist/cjs"
+	}
+}

--- a/packages/framer-motion-reorder-list/tsconfig.json
+++ b/packages/framer-motion-reorder-list/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "@automattic/calypso-typescript-config/ts-package.json",
+	"compilerOptions": {
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src",
+		"types": []
+	},
+	"include": [ "src", "src/*.json" ],
+	"exclude": [ "**/__tests__/*", "**/__mocks__/*" ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -909,6 +909,19 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/framer-motion-reorder-list@workspace:packages/framer-motion-reorder-list":
+  version: 0.0.0-use.local
+  resolution: "@automattic/framer-motion-reorder-list@workspace:packages/framer-motion-reorder-list"
+  dependencies:
+    "@automattic/calypso-typescript-config": "workspace:^"
+    framer-motion: "npm:10.13.0"
+    react: "npm:^18.2.0"
+    react-dom: "npm:^18.2.0"
+    tslib: "npm:^2.3.0"
+    typescript: "npm:^4.7.4"
+  languageName: unknown
+  linkType: soft
+
 "@automattic/generate-password@workspace:^, @automattic/generate-password@workspace:packages/generate-password":
   version: 0.0.0-use.local
   resolution: "@automattic/generate-password@workspace:packages/generate-password"
@@ -17431,6 +17444,27 @@ __metadata:
   dependencies:
     map-cache: "npm:^0.2.2"
   checksum: 5891d1c1d1d5e1a7fb3ccf28515c06731476fa88f7a50f4ede8a0d8d239a338448e7f7cc8b73db48da19c229fa30066104fe6489862065a4f1ed591c42fbeabf
+  languageName: node
+  linkType: hard
+
+"framer-motion@npm:10.13.0":
+  version: 10.13.0
+  resolution: "framer-motion@npm:10.13.0"
+  dependencies:
+    "@emotion/is-prop-valid": "npm:^0.8.2"
+    tslib: "npm:^2.4.0"
+  peerDependencies:
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  dependenciesMeta:
+    "@emotion/is-prop-valid":
+      optional: true
+  peerDependenciesMeta:
+    react:
+      optional: true
+    react-dom:
+      optional: true
+  checksum: 0d2584643d6cc888c4d66a08c7400fbfce0dd4378ca41f1913546a8cdfebf7a93a4c29f9f3cc7c255af6c4e3064714d72b31941fbc7a3df0440fb559844bfb3f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -918,7 +918,7 @@ __metadata:
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     tslib: "npm:^2.3.0"
-    typescript: "npm:^4.7.4"
+    typescript: "npm:^5.3.3"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -914,7 +914,7 @@ __metadata:
   resolution: "@automattic/framer-motion-reorder-list@workspace:packages/framer-motion-reorder-list"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    framer-motion: "npm:10.13.0"
+    framer-motion: "npm:10.17.0"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     tslib: "npm:^2.3.0"
@@ -17447,9 +17447,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"framer-motion@npm:10.13.0":
-  version: 10.13.0
-  resolution: "framer-motion@npm:10.13.0"
+"framer-motion@npm:10.17.0":
+  version: 10.17.0
+  resolution: "framer-motion@npm:10.17.0"
   dependencies:
     "@emotion/is-prop-valid": "npm:^0.8.2"
     tslib: "npm:^2.4.0"
@@ -17464,7 +17464,7 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 0d2584643d6cc888c4d66a08c7400fbfce0dd4378ca41f1913546a8cdfebf7a93a4c29f9f3cc7c255af6c4e3064714d72b31941fbc7a3df0440fb559844bfb3f
+  checksum: 6ffa7967251945c63dbd2c448ab7e0b47acfde7c6ba6980a84ab0493453929f2b7973acae0cb9b40523a0c7976b327b1765805d1f9a442bc97153a04550ed5f1
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -914,7 +914,7 @@ __metadata:
   resolution: "@automattic/framer-motion-reorder-list@workspace:packages/framer-motion-reorder-list"
   dependencies:
     "@automattic/calypso-typescript-config": "workspace:^"
-    framer-motion: "npm:10.17.0"
+    framer-motion: "npm:10.13.0"
     react: "npm:^18.2.0"
     react-dom: "npm:^18.2.0"
     tslib: "npm:^2.3.0"
@@ -17447,9 +17447,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"framer-motion@npm:10.17.0":
-  version: 10.17.0
-  resolution: "framer-motion@npm:10.17.0"
+"framer-motion@npm:10.13.0":
+  version: 10.13.0
+  resolution: "framer-motion@npm:10.13.0"
   dependencies:
     "@emotion/is-prop-valid": "npm:^0.8.2"
     tslib: "npm:^2.4.0"
@@ -17464,7 +17464,7 @@ __metadata:
       optional: true
     react-dom:
       optional: true
-  checksum: 6ffa7967251945c63dbd2c448ab7e0b47acfde7c6ba6980a84ab0493453929f2b7973acae0cb9b40523a0c7976b327b1765805d1f9a442bc97153a04550ed5f1
+  checksum: 0d2584643d6cc888c4d66a08c7400fbfce0dd4378ca41f1913546a8cdfebf7a93a4c29f9f3cc7c255af6c4e3064714d72b31941fbc7a3df0440fb559844bfb3f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
