### PR TITLE
Update Woo CYS custom theme card copy

### DIFF
--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -339,15 +339,15 @@ export const getWooMyCustomThemeOptions = ( { translate, siteAdminUrl, siteSlug,
 	return {
 		assembler: {
 			key: 'assembler',
-			label: translate( 'Quick editing in the Assembler' ),
-			extendedLabel: translate( 'Quick editing in the Assembler' ),
+			label: translate( 'Quick editing in the Store Designer' ),
+			extendedLabel: translate( 'Quick editing in the Store Designer' ),
 			getUrl: () => {
 				return `${ siteAdminUrl }admin.php?page=wc-admin&path=%2Fcustomize-store%2Fassembler-hub&customizing=true`;
 			},
 		},
 		customize: {
 			...options.customize,
-			label: translate( 'Advance customization in the Editor' ),
+			label: translate( 'Advanced customization in the Editor' ),
 			extendedLabel: translate( 'Advance customization in the Editor' ),
 		},
 		preview: {

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -348,7 +348,7 @@ export const getWooMyCustomThemeOptions = ( { translate, siteAdminUrl, siteSlug,
 		customize: {
 			...options.customize,
 			label: translate( 'Advanced customization in the Editor' ),
-			extendedLabel: translate( 'Advance customization in the Editor' ),
+			extendedLabel: translate( 'Advanced customization in the Editor' ),
 		},
 		preview: {
 			label: translate( 'Store preview' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 8xp9lPmaAT47xVASe2wakS-fi-36:257#659745685

## Proposed Changes

* Change the copy from "Quick editing in the Assembler" to "Quick editing in the Store Designer"
* Fix typo Advance -> Advanced

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**Reviewing the changes should be sufficient.**

If you want to test:

* Set up a Woo Express site
* Go to Home
* Complete CYS task with AI designer
* Go to /themes/<site-slug>
* Click on the three-dot icon
* Observe that the custom theme card is displayed like below

![Screenshot 2024-01-09 at 16 36 52](https://github.com/Automattic/wp-calypso/assets/4344253/5d5e0c13-b0b0-4acd-835a-2e19a0ffbdcf)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?