### PR TITLE
Jetpack Manage: Improve User feedback form text area label.

### DIFF
--- a/client/jetpack-cloud/components/user-feedback-modal-form/index.tsx
+++ b/client/jetpack-cloud/components/user-feedback-modal-form/index.tsx
@@ -135,7 +135,7 @@ export default function UserFeedbackModalForm( { show, onClose }: Props ) {
 
 				<FormFieldset>
 					<FormLabel htmlFor="textarea">
-						{ translate( 'How satisfied with Jetpack Manage are you?' ) }
+						{ translate( 'How satisfied are you with Jetpack Manage?' ) }
 					</FormLabel>
 					<ReviewsRatingsStars rating={ rating } onSelectRating={ onRatingChange } />
 				</FormFieldset>


### PR DESCRIPTION
This PR updates the string "How satisfied with Jetpack Manage are you?" to "How satisfied are you with Jetpack Manage?"

**Before**
<img width="850" alt="Screen Shot 2024-01-09 at 5 56 36 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/a562789e-990f-4e07-ac9f-67c76283ac5b">

**After**
<img width="854" alt="Screen Shot 2024-01-09 at 5 56 03 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/3a915af5-5b2f-4065-b98a-75ba1481ce0c">


## Proposed Changes

* Update the translatable string in the User feedback form component.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Use the Jetpack cloud live link below and go to the Dashboard page (/dashboard)
* Click the 'Share product feedback' button in the sidebar.
* Confirm that the string is updated correctly.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?