### PR TITLE
Staging Site: Refactor `useGetLockQuery` away from RQ callbacks

### DIFF
--- a/client/my-sites/hosting/staging-site-card/index.js
+++ b/client/my-sites/hosting/staging-site-card/index.js
@@ -99,13 +99,20 @@ export const StagingSiteCard = ( {
 		return stagingSites?.length ? stagingSites[ 0 ] : {};
 	}, [ stagingSites ] );
 
-	const { data: lock, isLoading: isLoadingLockQuery } = useGetLockQuery( siteId, {
+	const {
+		data: lock,
+		isError: isErrorLockQuery,
+		isLoading: isLoadingLockQuery,
+	} = useGetLockQuery( siteId, {
 		enabled: ! disabled || !! stagingSite.id,
 		refetchInterval: 5000,
-		onError: () => {
-			setIsErrorValidQuota( true );
-		},
 	} );
+
+	useEffect( () => {
+		if ( isErrorLockQuery ) {
+			setIsErrorValidQuota( true );
+		}
+	}, [ isErrorLockQuery, siteId ] );
 
 	const hasCompletedInitialLoading =
 		! isLoadingStagingSites && ! isLoadingQuotaValidation && ! isLoadingLockQuery;

--- a/client/my-sites/hosting/staging-site-card/use-get-lock-query.ts
+++ b/client/my-sites/hosting/staging-site-card/use-get-lock-query.ts
@@ -15,11 +15,9 @@ export const useGetLockQuery = (
 			} ),
 		enabled: !! siteId && options?.enabled,
 		refetchInterval: options?.refetchInterval ?? false,
-		onSuccess: options?.onSuccess,
 		meta: {
 			persist: false,
 		},
 		staleTime: 10 * 1000,
-		onError: options?.onError,
 	} );
 };


### PR DESCRIPTION
## Proposed Changes

This PR migrates the `useGetLockQuery` hook away from `onSuccess` and `onError`. 

This is part of the work done to upgrade React Query to v5 - see https://github.com/Automattic/wp-calypso/pull/84413 and https://github.com/Automattic/wp-calypso/pull/84338.

The reason is that `onSuccess` and a few more callbacks have been removed from `useQuery` (see https://tanstack.com/query/v5/docs/react/guides/migrating-to-v5#callbacks-on-usequery-and-queryobserver-have-been-removed).

## Testing Instructions

Follow the test instructions of #83545 that introduced the `useGetLockQuery` hook.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?