### PR TITLE
Unhardcode plan name in .blog domain transfer notice

### DIFF
--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -1,4 +1,4 @@
-import { PLAN_PERSONAL, isPlan } from '@automattic/calypso-products';
+import { PLAN_PERSONAL, getPlan, isPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -409,10 +409,23 @@ class TransferDomainStep extends Component {
 				<div>
 					<UpsellNudge
 						description={ translate(
-							'Only .blog domains are included with your plan, to use a different tld upgrade to a Personal plan.'
+							// translators: %s is the Starter/Personal plan name
+							'Only .blog domains are included with your plan, to use a different tld upgrade to a %(planName)s plan.',
+							{
+								args: {
+									planName: getPlan( PLAN_PERSONAL )?.getTitle(),
+								},
+							}
 						) }
 						plan={ PLAN_PERSONAL }
-						title={ translate( 'Personal plan required' ) }
+						title={
+							// translators: %s is the Starter/Personal plan name
+							translate( '%(planName)s plan required', {
+								args: {
+									planName: getPlan( PLAN_PERSONAL )?.getTitle(),
+								},
+							} )
+						}
 						showIcon={ true }
 					/>
 					{ content }

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -11,7 +11,16 @@ export type PlanSlug = ( typeof plansSlugs )[ number ];
 export type PlanPath = PlanSlug;
 
 export type PlanBillingPeriod = 'MONTHLY' | 'ANNUALLY';
-export type PlanNonlocalizedShortName = 'Free' | 'Personal' | 'Premium' | 'Business' | 'eCommerce';
+export type PlanNonlocalizedShortName =
+	| 'Free'
+	| 'Personal'
+	| 'Premium'
+	| 'Business'
+	| 'eCommerce'
+	| 'Starter'
+	| 'Explorer'
+	| 'Creator'
+	| 'Entrepreneur';
 
 export type PlanAction = {
 	type: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This replaces the old, harcoded Personal plan name in .blog transfer notice with reference to the current plan name.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure translation code is correct.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
