### PR TITLE
Stats: Add feature flag for updated purchase flows

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -75,6 +75,7 @@ interface StatsPersonalPurchaseProps {
 }
 
 const COMPONENT_CLASS_NAME = 'stats-purchase-single';
+const FLAGS_CHECKOUT_FLOWS_V2 = 'stats/checkout-flows-v2';
 
 const StatsUpgradeInstructions = () => {
 	const translate = useTranslate();
@@ -149,9 +150,13 @@ Thanks\n\n`;
 		setPurchaseTierQuantity( value );
 	}, [] );
 
+	const pageTitle = config.isEnabled( FLAGS_CHECKOUT_FLOWS_V2 )
+		? translate( 'Welcome to Jetpack Stats' )
+		: translate( 'Jetpack Stats' );
+
 	return (
 		<>
-			<h1>{ translate( 'Jetpack Stats' ) }</h1>
+			<h1>{ pageTitle }</h1>
 			{ ! isCommercialOwned && (
 				<>
 					<p>{ translate( 'The most advanced stats Jetpack has to offer.' ) }</p>
@@ -306,9 +311,13 @@ const StatsPersonalPurchase = ( {
 		page( `/stats/purchase/${ siteSlug }?productType=commercial&flags=stats/type-detection` );
 	};
 
+	const pageTitle = config.isEnabled( FLAGS_CHECKOUT_FLOWS_V2 )
+		? translate( 'Name your price for Jetpack Stats' )
+		: translate( 'Jetpack Stats' );
+
 	return (
 		<>
-			<h1>{ translate( 'Jetpack Stats' ) }</h1>
+			<h1>{ pageTitle }</h1>
 			<p>{ translate( 'The most advanced stats Jetpack has to offer.' ) }</p>
 			<PersonalPurchase
 				subscriptionValue={ subscriptionValue }

--- a/config/development.json
+++ b/config/development.json
@@ -192,6 +192,7 @@
 		"site-indicator": true,
 		"site-profiler": true,
 		"ssr/prefetch-timebox": false,
+		"stats/checkout-flows-v2": true,
 		"stats/date-control": true,
 		"stats/new-video-summary": true,
 		"stats/paid-wpcom-stats": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -128,6 +128,7 @@
 		"site-indicator": true,
 		"site-profiler": true,
 		"ssr/prefetch-timebox": true,
+		"stats/checkout-flows-v2": false,
 		"stats/date-control": true,
 		"stats/new-video-summary": false,
 		"stats/paid-wpcom-stats": true,

--- a/config/production.json
+++ b/config/production.json
@@ -158,6 +158,7 @@
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
+		"stats/checkout-flows-v2": false,
 		"stats/date-control": true,
 		"stats/new-video-summary": false,
 		"stats/paid-wpcom-stats": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -152,6 +152,7 @@
 		"site-indicator": true,
 		"site-profiler": true,
 		"ssr/prefetch-timebox": true,
+		"stats/checkout-flows-v2": false,
 		"stats/date-control": true,
 		"stats/new-video-summary": false,
 		"stats/paid-wpcom-stats": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -161,6 +161,7 @@
 		"site-indicator": true,
 		"site-profiler": true,
 		"ssr/prefetch-timebox": true,
+		"stats/checkout-flows-v2": false,
 		"stats/date-control": true,
 		"stats/new-video-summary": false,
 		"stats/paid-wpcom-stats": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86128 

## Proposed Changes

- Adds the "stats/checkout-flows-v2" feature flag.
- Enabled in development for now.
- Updates the H1 on each of the flows to match the new designs.

Doesn't update any other copy or change the flow in any way. Just detects the flag and updates the visible page header when enabled.

<img width="591" alt="SCR-20240109-qaff" src="https://github.com/Automattic/wp-calypso/assets/40267301/dd93b5fe-e63f-4c85-a612-f9709020d1ff">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch the Calypso Live link.
* Visit the Stats page on a site without a plan.
* Click the button in the upgrade notice.
* Confirm the heading is still "Jetpack Stats".
* Add the `stats/checkout-flows-v2` flag to the URL.
* Confirm the heading matches the screenshot posted above.

If building locally, the flag will be enabled by default. Use `-stats/checkout-flows-v2` to disable it.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?