### PR TITLE
Live preview: Apply the selected variation when previewing a theme from the menu

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -281,7 +281,7 @@ export class Theme extends Component {
 	};
 
 	renderMoreButton = () => {
-		const { active, buttonContents, index, theme } = this.props;
+		const { active, buttonContents, index, theme, siteId } = this.props;
 
 		let moreOptions = buttonContents;
 		if ( isEnabled( 'themes/tiers' ) ) {
@@ -301,8 +301,10 @@ export class Theme extends Component {
 		return (
 			<ThemeMoreButton
 				index={ index }
+				siteId={ siteId }
 				themeId={ theme.id }
 				themeName={ theme.name }
+				hasStyleVariations={ !! theme?.style_variations?.length }
 				active={ active }
 				onMoreButtonClick={ this.props.onMoreButtonClick }
 				onMoreButtonItemClick={ this.props.onMoreButtonItemClick }

--- a/client/components/theme/more-button.jsx
+++ b/client/components/theme/more-button.jsx
@@ -1,8 +1,8 @@
 import { Gridicon } from '@automattic/components';
 import classNames from 'classnames';
-import { map } from 'lodash';
 import PropTypes from 'prop-types';
 import { createRef, Component } from 'react';
+import QueryCanonicalTheme from 'calypso/components/data/query-canonical-theme';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import PopoverMenuSeparator from 'calypso/components/popover-menu/separator';
@@ -20,14 +20,20 @@ function isOutsideCalypso( url ) {
 }
 
 class ThemeMoreButton extends Component {
-	state = { showPopover: false };
+	state = { showPopover: false, hasPopoverOpened: false };
 
 	moreButtonRef = createRef();
 
 	togglePopover = () => {
-		this.setState( { showPopover: ! this.state.showPopover } );
-		! this.state.showPopover &&
+		const shouldOpen = ! this.state.showPopover;
+		this.setState( { showPopover: shouldOpen } );
+
+		if ( shouldOpen ) {
 			this.props.onMoreButtonClick( this.props.themeId, this.props.index, 'popup_open' );
+			if ( ! this.state.hasPopoverOpened ) {
+				this.setState( { hasPopoverOpened: true } );
+			}
+		}
 	};
 
 	closePopover = ( action ) => {
@@ -46,38 +52,42 @@ class ThemeMoreButton extends Component {
 	}
 
 	render() {
+		const { siteId, themeId, themeName, hasStyleVariations, options, active } = this.props;
+		const { showPopover, hasPopoverOpened } = this.state;
 		const classes = classNames(
 			'theme__more-button',
-			{ 'is-active': this.props.active },
-			{ 'is-open': this.state.showPopover }
+			{ 'is-active': active },
+			{ 'is-open': showPopover }
 		);
 
 		return (
 			<span className={ classes }>
 				<button
-					aria-label={ `More options for theme ${ this.props.themeName }` }
+					aria-label={ `More options for theme ${ themeName }` }
 					ref={ this.moreButtonRef }
 					onClick={ this.togglePopover }
 				>
 					<Gridicon icon="ellipsis" size={ 24 } />
 				</button>
-
-				{ this.state.showPopover && (
+				{ hasPopoverOpened && hasStyleVariations && (
+					<QueryCanonicalTheme themeId={ themeId } siteId={ siteId } />
+				) }
+				{ showPopover && (
 					<PopoverMenu
 						context={ this.moreButtonRef.current }
 						isVisible
 						onClose={ this.closePopover }
 						position="top left"
 					>
-						{ map( this.props.options, ( option, key ) => {
+						{ Object.entries( options ).map( ( [ key, option ] ) => {
 							if ( option.separator ) {
 								return <PopoverMenuSeparator key={ key } />;
 							}
 							if ( option.getUrl ) {
-								const url = option.getUrl( this.props.themeId );
+								const url = option.getUrl( themeId );
 								return (
 									<PopoverMenuItem
-										key={ `${ option.label }-geturl` }
+										key={ `${ key }-geturl` }
 										action={ this.popoverAction( option.action, option.label, option.key ) }
 										href={ url }
 										target={ isOutsideCalypso( url ) ? '_blank' : null }
@@ -89,7 +99,7 @@ class ThemeMoreButton extends Component {
 							if ( option.action ) {
 								return (
 									<PopoverMenuItem
-										key={ `${ option.label }-action` }
+										key={ `${ key }-action` }
 										action={ this.popoverAction( option.action, option.label, option.key ) }
 									>
 										{ option.label }
@@ -107,9 +117,11 @@ class ThemeMoreButton extends Component {
 }
 
 ThemeMoreButton.propTypes = {
+	siteId: PropTypes.number,
 	// Name of theme to give image context.
 	themeName: PropTypes.string,
 	themeId: PropTypes.string,
+	hasStyleVariations: PropTypes.bool,
 	// Index of theme in results list
 	index: PropTypes.number,
 	// More elaborate onClick action, used for tracking.

--- a/client/my-sites/theme/live-preview-button/index.tsx
+++ b/client/my-sites/theme/live-preview-button/index.tsx
@@ -5,25 +5,18 @@ import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { useDispatch, useSelector } from 'calypso/state';
 import { livePreview } from 'calypso/state/themes/actions';
 import { getIsLivePreviewSupported } from 'calypso/state/themes/selectors';
-import type { GlobalStyles } from '@automattic/data-stores';
 
 interface Props {
 	siteId: number;
 	themeId: string;
-	hasStyleVariations: boolean;
-	styleVariation?: GlobalStyles;
+	onBeforeLivePreview?: () => void;
 }
 
 /**
  * Live Preview leveraging Gutenberg's Block Theme Previews
  * @see pbxlJb-3Uv-p2
  */
-export const LivePreviewButton: FC< Props > = ( {
-	siteId,
-	themeId,
-	hasStyleVariations,
-	styleVariation,
-} ) => {
+export const LivePreviewButton: FC< Props > = ( { siteId, themeId, onBeforeLivePreview } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -38,7 +31,8 @@ export const LivePreviewButton: FC< Props > = ( {
 
 	const handleClick = () => {
 		setIsLoading( true );
-		dispatch( livePreview( siteId, themeId, hasStyleVariations, styleVariation, 'detail' ) );
+		onBeforeLivePreview?.();
+		dispatch( livePreview( siteId, themeId, 'detail' ) );
 	};
 
 	return (

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -351,16 +351,18 @@ class ThemeSheet extends Component {
 	isRemoved = () =>
 		!! this.props.taxonomies?.theme_status?.find( ( status ) => status.slug === 'removed' );
 
-	onButtonClick = () => {
-		const { defaultOption, secondaryOption, themeId } = this.props;
-		const selectedStyleVariation = this.getSelectedStyleVariation();
-		if ( selectedStyleVariation ) {
-			this.props.setThemePreviewOptions( themeId, defaultOption, secondaryOption, {
-				styleVariation: selectedStyleVariation,
-			} );
-		}
+	onBeforeOptionAction = () => {
+		this.props.setThemePreviewOptions(
+			this.props.themeId,
+			this.props.defaultOption,
+			this.props.secondaryOption,
+			{ styleVariation: this.getSelectedStyleVariation() }
+		);
+	};
 
-		defaultOption.action && defaultOption.action( themeId );
+	onButtonClick = () => {
+		this.onBeforeOptionAction();
+		this.props.defaultOption.action?.( this.props.themeId );
 	};
 
 	onUnlockStyleButtonClick = () => {
@@ -495,12 +497,7 @@ class ThemeSheet extends Component {
 		// The embed live demo works only for WP.com themes
 		if ( isWpcomTheme && ! isExternallyManagedTheme ) {
 			const { preview } = this.props.options;
-			this.props.setThemePreviewOptions(
-				this.props.themeId,
-				this.props.defaultOption,
-				this.props.secondaryOption,
-				{ styleVariation: this.getSelectedStyleVariation() }
-			);
+			this.onBeforeOptionAction();
 			return preview.action( this.props.themeId );
 		}
 
@@ -727,7 +724,6 @@ class ThemeSheet extends Component {
 			softLaunched,
 			themeId,
 			translate,
-			styleVariations,
 		} = this.props;
 		const placeholder = <span className="theme__sheet-placeholder">loading.....</span>;
 		const title = name || placeholder;
@@ -758,8 +754,7 @@ class ThemeSheet extends Component {
 						<LivePreviewButton
 							siteId={ siteId }
 							themeId={ themeId }
-							hasStyleVariations={ styleVariations.length > 0 }
-							styleVariation={ this.getSelectedStyleVariation() }
+							onBeforeLivePreview={ this.onBeforeOptionAction }
 						/>
 						{ this.shouldRenderPreviewButton() && ! isLivePreviewSupported && (
 							<Button

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -262,7 +262,7 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 			comment: 'label for previewing a block theme',
 		} ),
 		action: ( themeId, siteId ) => {
-			return livePreviewAction( siteId, themeId, false, undefined, 'list' );
+			return livePreviewAction( siteId, themeId, 'list' );
 		},
 		hideForTheme: ( state, themeId, siteId ) =>
 			! getIsLivePreviewSupported( state, themeId, siteId ),

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -138,7 +138,7 @@ class ThemesSelection extends Component {
 		let options = this.props.getOptions( themeId, styleVariation );
 
 		const { tabFilter, tier } = this.props;
-		const wrappedActivateAction = ( action ) => {
+		const wrappedActivateOrLivePreviewAction = ( action ) => {
 			return ( t ) => {
 				this.props.setThemePreviewOptions( themeId, null, null, {
 					styleVariation,
@@ -192,7 +192,13 @@ class ThemesSelection extends Component {
 				styleVariationSlug: styleVariation?.slug,
 			} );
 			if ( options.activate ) {
-				options.activate.action = wrappedActivateAction( options.activate.action );
+				options.activate.action = wrappedActivateOrLivePreviewAction( options.activate.action );
+			}
+
+			if ( options.livePreview ) {
+				options.livePreview.action = wrappedActivateOrLivePreviewAction(
+					options.livePreview.action
+				);
 			}
 
 			if ( options.preview ) {

--- a/client/state/global-styles/actions.ts
+++ b/client/state/global-styles/actions.ts
@@ -5,14 +5,14 @@ import type { ActiveTheme, GlobalStyles } from '@automattic/data-stores';
 import type { CalypsoDispatch } from 'calypso/state/types';
 import type { AppState } from 'calypso/types';
 
-export function getGlobalStylesId( siteIdOrSlug: number | string, stylesheet: string ) {
+export function getGlobalStylesId( siteId: number, stylesheet: string ) {
 	return async ( dispatch: CalypsoDispatch, getState: () => AppState ) => {
 		const state = getState();
-		const themeId = isJetpackSite( state, siteIdOrSlug )
+		const themeId = isJetpackSite( state, siteId )
 			? getThemeIdFromStylesheet( stylesheet )
 			: stylesheet;
 		const themes: ActiveTheme[] = await wpcom.req.get( {
-			path: `/sites/${ encodeURIComponent( siteIdOrSlug ) }/themes?${ new URLSearchParams( {
+			path: `/sites/${ encodeURIComponent( siteId ) }/themes?${ new URLSearchParams( {
 				status: 'active',
 				wp_theme_preview: themeId,
 			} ).toString() }`,

--- a/client/state/global-styles/actions.ts
+++ b/client/state/global-styles/actions.ts
@@ -1,12 +1,20 @@
+import { getThemeIdFromStylesheet } from '@automattic/data-stores';
 import wpcom from 'calypso/lib/wp';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import type { ActiveTheme, GlobalStyles } from '@automattic/data-stores';
+import type { CalypsoDispatch } from 'calypso/state/types';
+import type { AppState } from 'calypso/types';
 
 export function getGlobalStylesId( siteIdOrSlug: number | string, stylesheet: string ) {
-	return async () => {
+	return async ( dispatch: CalypsoDispatch, getState: () => AppState ) => {
+		const state = getState();
+		const themeId = isJetpackSite( state, siteIdOrSlug )
+			? getThemeIdFromStylesheet( stylesheet )
+			: stylesheet;
 		const themes: ActiveTheme[] = await wpcom.req.get( {
 			path: `/sites/${ encodeURIComponent( siteIdOrSlug ) }/themes?${ new URLSearchParams( {
 				status: 'active',
-				wp_theme_preview: stylesheet,
+				wp_theme_preview: themeId,
 			} ).toString() }`,
 			apiNamespace: 'wp/v2',
 		} );
@@ -20,20 +28,6 @@ export function getGlobalStylesId( siteIdOrSlug: number | string, stylesheet: st
 			}
 		}
 		return 0;
-	};
-}
-
-export function getGlobalStylesVariations( siteIdOrSlug: number | string, stylesheet: string ) {
-	return async () => {
-		const params = new URLSearchParams( { wp_theme_preview: stylesheet } );
-		const variations: GlobalStyles[] = await wpcom.req.get( {
-			path: `/sites/${ encodeURIComponent(
-				siteIdOrSlug
-			) }/global-styles/themes/${ stylesheet }/variations?${ params }`,
-			apiNamespace: 'wp/v2',
-		} );
-
-		return variations;
 	};
 }
 

--- a/client/state/global-styles/actions.ts
+++ b/client/state/global-styles/actions.ts
@@ -1,20 +1,20 @@
-import { getThemeIdFromStylesheet } from '@automattic/data-stores';
 import wpcom from 'calypso/lib/wp';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getCanonicalTheme } from 'calypso/state/themes/selectors';
 import type { ActiveTheme, GlobalStyles } from '@automattic/data-stores';
 import type { CalypsoDispatch } from 'calypso/state/types';
 import type { AppState } from 'calypso/types';
 
-export function getGlobalStylesId( siteId: number, stylesheet: string ) {
+export function getGlobalStylesId( siteId: number, themeId: string ) {
 	return async ( dispatch: CalypsoDispatch, getState: () => AppState ) => {
 		const state = getState();
-		const themeId = isJetpackSite( state, siteId )
-			? getThemeIdFromStylesheet( stylesheet )
-			: stylesheet;
+		const theme = getCanonicalTheme( state, siteId, themeId );
+		const stylesheet = theme?.stylesheet || themeId;
+		const wpThemePreview = isJetpackSite( state, siteId ) ? themeId : stylesheet;
 		const themes: ActiveTheme[] = await wpcom.req.get( {
 			path: `/sites/${ encodeURIComponent( siteId ) }/themes?${ new URLSearchParams( {
 				status: 'active',
-				wp_theme_preview: themeId,
+				wp_theme_preview: wpThemePreview,
 			} ).toString() }`,
 			apiNamespace: 'wp/v2',
 		} );

--- a/client/state/global-styles/actions.ts
+++ b/client/state/global-styles/actions.ts
@@ -25,10 +25,11 @@ export function getGlobalStylesId( siteIdOrSlug: number | string, stylesheet: st
 
 export function getGlobalStylesVariations( siteIdOrSlug: number | string, stylesheet: string ) {
 	return async () => {
+		const params = new URLSearchParams( { wp_theme_preview: stylesheet } );
 		const variations: GlobalStyles[] = await wpcom.req.get( {
 			path: `/sites/${ encodeURIComponent(
 				siteIdOrSlug
-			) }/global-styles/themes/${ stylesheet }/variations`,
+			) }/global-styles/themes/${ stylesheet }/variations?${ params }`,
 			apiNamespace: 'wp/v2',
 		} );
 

--- a/client/state/themes/actions/activate-style-variation.ts
+++ b/client/state/themes/actions/activate-style-variation.ts
@@ -22,8 +22,6 @@ export function activateStyleVariation(
 		const themeStylesheet = theme?.stylesheet || themeId;
 		const globalStylesId = await dispatch( getGlobalStylesId( siteId, themeStylesheet ) );
 
-		// Don't wait for the response to speed up the next action.
-		// We can do that until the race condition happens.
-		dispatch( updateGlobalStyles( siteId, globalStylesId, globalStyles ) );
+		await dispatch( updateGlobalStyles( siteId, globalStylesId, globalStyles ) );
 	};
 }

--- a/client/state/themes/actions/activate-style-variation.ts
+++ b/client/state/themes/actions/activate-style-variation.ts
@@ -1,8 +1,6 @@
 import { getGlobalStylesId, updateGlobalStyles } from 'calypso/state/global-styles/actions';
-import { getCanonicalTheme } from 'calypso/state/themes/selectors';
 import type { GlobalStyles } from '@automattic/data-stores';
 import type { CalypsoDispatch } from 'calypso/state/types';
-import type { AppState } from 'calypso/types';
 
 /**
  * Triggers a network request to activate a specific style variation on a given site.
@@ -16,11 +14,8 @@ export function activateStyleVariation(
 	siteId: number,
 	globalStyles: GlobalStyles
 ) {
-	return async ( dispatch: CalypsoDispatch, getState: AppState ) => {
-		const state = getState();
-		const theme = getCanonicalTheme( state, siteId, themeId );
-		const themeStylesheet = theme?.stylesheet || themeId;
-		const globalStylesId = await dispatch( getGlobalStylesId( siteId, themeStylesheet ) );
+	return async ( dispatch: CalypsoDispatch ) => {
+		const globalStylesId = await dispatch( getGlobalStylesId( siteId, themeId ) );
 
 		await dispatch( updateGlobalStyles( siteId, globalStylesId, globalStyles ) );
 	};

--- a/client/state/themes/actions/activate-style-variation.ts
+++ b/client/state/themes/actions/activate-style-variation.ts
@@ -1,9 +1,4 @@
-import { isDefaultGlobalStylesVariationSlug } from '@automattic/design-picker';
-import {
-	getGlobalStylesId,
-	getGlobalStylesVariations,
-	updateGlobalStyles,
-} from 'calypso/state/global-styles/actions';
+import { getGlobalStylesId, updateGlobalStyles } from 'calypso/state/global-styles/actions';
 import { getCanonicalTheme } from 'calypso/state/themes/selectors';
 import type { GlobalStyles } from '@automattic/data-stores';
 import type { CalypsoDispatch } from 'calypso/state/types';
@@ -11,40 +6,21 @@ import type { AppState } from 'calypso/types';
 
 /**
  * Triggers a network request to activate a specific style variation on a given site.
- * @param {string}  themeId            Theme ID
- * @param {number}  siteId             Site ID
- * @param {string}  styleVariationSlug The slug of the style variation
- * @returns {Function}                 Action thunk
+ * @param {string}  themeId      Theme ID
+ * @param {number}  siteId       Site ID
+ * @param {Object}  globalStyles The global styles to be activated
+ * @returns {Function}           Action thunk
  */
 export function activateStyleVariation(
 	themeId: string,
 	siteId: number,
-	styleVariationSlug: string
+	globalStyles: GlobalStyles
 ) {
 	return async ( dispatch: CalypsoDispatch, getState: AppState ) => {
 		const state = getState();
 		const theme = getCanonicalTheme( state, siteId, themeId );
 		const themeStylesheet = theme?.stylesheet || themeId;
-
-		if ( styleVariationSlug ) {
-			let currentVariation;
-
-			// Clear the global styles if the default style variation is selected.
-			if ( isDefaultGlobalStylesVariationSlug( styleVariationSlug ) ) {
-				currentVariation = {} as GlobalStyles;
-			} else {
-				const variations = await dispatch( getGlobalStylesVariations( siteId, themeStylesheet ) );
-				currentVariation = variations.find(
-					( variation ) =>
-						variation.title &&
-						variation.title.split( ' ' ).join( '-' ).toLowerCase() === styleVariationSlug
-				);
-			}
-
-			if ( currentVariation ) {
-				const globalStylesId = await dispatch( getGlobalStylesId( siteId, themeStylesheet ) );
-				await dispatch( updateGlobalStyles( siteId, globalStylesId, currentVariation ) );
-			}
-		}
+		const globalStylesId = await dispatch( getGlobalStylesId( siteId, themeStylesheet ) );
+		await dispatch( updateGlobalStyles( siteId, globalStylesId, globalStyles ) );
 	};
 }

--- a/client/state/themes/actions/activate-style-variation.ts
+++ b/client/state/themes/actions/activate-style-variation.ts
@@ -1,0 +1,50 @@
+import { isDefaultGlobalStylesVariationSlug } from '@automattic/design-picker';
+import {
+	getGlobalStylesId,
+	getGlobalStylesVariations,
+	updateGlobalStyles,
+} from 'calypso/state/global-styles/actions';
+import { getCanonicalTheme } from 'calypso/state/themes/selectors';
+import type { GlobalStyles } from '@automattic/data-stores';
+import type { CalypsoDispatch } from 'calypso/state/types';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Triggers a network request to activate a specific style variation on a given site.
+ * @param {string}  themeId            Theme ID
+ * @param {number}  siteId             Site ID
+ * @param {string}  styleVariationSlug The slug of the style variation
+ * @returns {Function}                 Action thunk
+ */
+export function activateStyleVariation(
+	themeId: string,
+	siteId: number,
+	styleVariationSlug: string
+) {
+	return async ( dispatch: CalypsoDispatch, getState: AppState ) => {
+		const state = getState();
+		const theme = getCanonicalTheme( state, siteId, themeId );
+		const themeStylesheet = theme?.stylesheet || themeId;
+
+		if ( styleVariationSlug ) {
+			let currentVariation;
+
+			// Clear the global styles if the default style variation is selected.
+			if ( isDefaultGlobalStylesVariationSlug( styleVariationSlug ) ) {
+				currentVariation = {} as GlobalStyles;
+			} else {
+				const variations = await dispatch( getGlobalStylesVariations( siteId, themeStylesheet ) );
+				currentVariation = variations.find(
+					( variation ) =>
+						variation.title &&
+						variation.title.split( ' ' ).join( '-' ).toLowerCase() === styleVariationSlug
+				);
+			}
+
+			if ( currentVariation ) {
+				const globalStylesId = await dispatch( getGlobalStylesId( siteId, themeStylesheet ) );
+				await dispatch( updateGlobalStyles( siteId, globalStylesId, currentVariation ) );
+			}
+		}
+	};
+}

--- a/client/state/themes/actions/activate-style-variation.ts
+++ b/client/state/themes/actions/activate-style-variation.ts
@@ -21,6 +21,9 @@ export function activateStyleVariation(
 		const theme = getCanonicalTheme( state, siteId, themeId );
 		const themeStylesheet = theme?.stylesheet || themeId;
 		const globalStylesId = await dispatch( getGlobalStylesId( siteId, themeStylesheet ) );
-		await dispatch( updateGlobalStyles( siteId, globalStylesId, globalStyles ) );
+
+		// Don't wait for the response to speed up the next action.
+		// We can do that until the race condition happens.
+		dispatch( updateGlobalStyles( siteId, globalStylesId, globalStyles ) );
 	};
 }

--- a/client/state/themes/actions/activate-theme.js
+++ b/client/state/themes/actions/activate-theme.js
@@ -44,7 +44,7 @@ export function activateTheme( themeId, siteId, source = 'unknown', purchased = 
 			} )
 			.then( async ( theme ) => {
 				if ( styleVariationSlug ) {
-					await dispatch( activateStyleVariation( themeId, siteId, styleVariationSlug ) );
+					await dispatch( activateStyleVariation( themeId, siteId, themeOptions.styleVariation ) );
 				}
 
 				return theme;

--- a/client/state/themes/actions/activate-theme.js
+++ b/client/state/themes/actions/activate-theme.js
@@ -2,11 +2,6 @@ import { translate } from 'i18n-calypso';
 import { CALYPSO_CONTACT } from 'calypso/lib/url/support';
 import wpcom from 'calypso/lib/wp';
 import {
-	getGlobalStylesId,
-	getGlobalStylesVariations,
-	updateGlobalStyles,
-} from 'calypso/state/global-styles/actions';
-import {
 	productsReinstall,
 	productsReinstallNotStarted,
 } from 'calypso/state/marketplace/products-reinstall/actions';
@@ -18,8 +13,8 @@ import {
 	getThemePreviewThemeOptions,
 	isMarketplaceThemeSubscribed,
 } from 'calypso/state/themes/selectors';
-
 import 'calypso/state/themes/init';
+import { activateStyleVariation } from './activate-style-variation';
 
 /**
  * Triggers a network request to activate a specific theme on a given site.
@@ -49,18 +44,7 @@ export function activateTheme( themeId, siteId, source = 'unknown', purchased = 
 			} )
 			.then( async ( theme ) => {
 				if ( styleVariationSlug ) {
-					const themeStylesheet = theme.stylesheet || themeId;
-					const variations = await dispatch( getGlobalStylesVariations( siteId, themeStylesheet ) );
-					const currentVariation = variations.find(
-						( variation ) =>
-							variation.title &&
-							variation.title.split( ' ' ).join( '-' ).toLowerCase() === styleVariationSlug
-					);
-
-					if ( currentVariation ) {
-						const globalStylesId = await dispatch( getGlobalStylesId( siteId, themeStylesheet ) );
-						await dispatch( updateGlobalStyles( siteId, globalStylesId, currentVariation ) );
-					}
+					await dispatch( activateStyleVariation( themeId, siteId, styleVariationSlug ) );
 				}
 
 				return theme;

--- a/client/state/themes/actions/live-preview.ts
+++ b/client/state/themes/actions/live-preview.ts
@@ -1,7 +1,4 @@
-import {
-	isDefaultGlobalStylesVariationSlug,
-	DEFAULT_GLOBAL_STYLES_VARIATION_SLUG,
-} from '@automattic/design-picker';
+import { isDefaultGlobalStylesVariationSlug } from '@automattic/design-picker';
 import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { LIVE_PREVIEW_START } from 'calypso/state/themes/action-types';
@@ -48,11 +45,7 @@ export function livePreview( siteId: number, themeId: string, source?: 'list' | 
 
 		if ( hasStyleVariations ) {
 			await dispatch(
-				activateStyleVariation(
-					themeId,
-					siteId,
-					styleVariationSlug ?? DEFAULT_GLOBAL_STYLES_VARIATION_SLUG
-				)
+				activateStyleVariation( themeId, siteId, themeOptions?.styleVariation ?? {} )
 			);
 		}
 

--- a/client/state/themes/actions/live-preview.ts
+++ b/client/state/themes/actions/live-preview.ts
@@ -1,4 +1,7 @@
-import { isDefaultGlobalStylesVariationSlug, DEFAULT_GLOBAL_STYLES_VARIATION_SLUG } from '@automattic/design-picker';
+import {
+	isDefaultGlobalStylesVariationSlug,
+	DEFAULT_GLOBAL_STYLES_VARIATION_SLUG,
+} from '@automattic/design-picker';
 import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { LIVE_PREVIEW_START } from 'calypso/state/themes/action-types';
@@ -22,7 +25,7 @@ export function livePreview( siteId: number, themeId: string, source?: 'list' | 
 		const theme = getCanonicalTheme( state, siteId, themeId );
 		const themeOptions = getThemePreviewThemeOptions( state );
 		const hasStyleVariations = theme?.style_variations && theme?.style_variations.length > 0;
-		const styleVariationSlug = themeOptions.styleVariation?.slug;
+		const styleVariationSlug = themeOptions?.styleVariation?.slug;
 		const analysis = recordTracksEvent( 'calypso_block_theme_live_preview_click', {
 			active_theme: getActiveTheme( state, siteId ),
 			site_id: siteId,

--- a/client/state/themes/actions/live-preview.ts
+++ b/client/state/themes/actions/live-preview.ts
@@ -1,6 +1,5 @@
-import { isDefaultGlobalStylesVariationSlug } from '@automattic/design-picker';
+import { isDefaultGlobalStylesVariationSlug, DEFAULT_GLOBAL_STYLES_VARIATION_SLUG } from '@automattic/design-picker';
 import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
-import { getGlobalStylesId, updateGlobalStyles } from 'calypso/state/global-styles/actions';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { LIVE_PREVIEW_START } from 'calypso/state/themes/action-types';
 import {
@@ -8,53 +7,50 @@ import {
 	getCanonicalTheme,
 	getTheme,
 	getThemeType,
+	getThemePreviewThemeOptions,
 } from 'calypso/state/themes/selectors';
 import { CalypsoDispatch } from 'calypso/state/types';
 import { AppState } from 'calypso/types';
+import { activateStyleVariation } from './activate-style-variation';
 import { installTheme } from './install-theme';
 import { redirectToLivePreview } from './redirect-to-live-preview';
 import { suffixThemeIdForInstall } from './suffix-theme-id-for-install';
-import type { GlobalStyles } from '@automattic/data-stores';
 
-export function livePreview(
-	siteId: number,
-	themeId: string,
-	hasStyleVariations: boolean,
-	styleVariation?: GlobalStyles,
-	source?: 'list' | 'detail'
-) {
+export function livePreview( siteId: number, themeId: string, source?: 'list' | 'detail' ) {
 	return async ( dispatch: CalypsoDispatch, getState: () => AppState ) => {
+		const state = getState();
+		const theme = getCanonicalTheme( state, siteId, themeId );
+		const themeOptions = getThemePreviewThemeOptions( state );
+		const hasStyleVariations = theme?.style_variations && theme?.style_variations.length > 0;
+		const styleVariationSlug = themeOptions.styleVariation?.slug;
 		const analysis = recordTracksEvent( 'calypso_block_theme_live_preview_click', {
-			active_theme: getActiveTheme( getState(), siteId ),
+			active_theme: getActiveTheme( state, siteId ),
 			site_id: siteId,
 			source,
-			theme_type: getThemeType( getState(), themeId ),
+			theme_type: getThemeType( state, themeId ),
 			theme: themeId,
 			theme_style:
 				themeId +
-				( isDefaultGlobalStylesVariationSlug( styleVariation?.slug )
+				( isDefaultGlobalStylesVariationSlug( styleVariationSlug )
 					? ''
-					: `-${ styleVariation?.slug }` ),
+					: `-${ styleVariationSlug }` ),
 		} );
 		dispatch( withAnalytics( analysis, { type: LIVE_PREVIEW_START, themeId } ) );
-		if ( isJetpackSite( getState(), siteId ) && ! getTheme( getState(), siteId, themeId ) ) {
-			const installId = suffixThemeIdForInstall( getState(), siteId, themeId );
+		if ( isJetpackSite( state, siteId ) && ! getTheme( state, siteId, themeId ) ) {
+			const installId = suffixThemeIdForInstall( state, siteId, themeId );
 			// If theme is already installed, installation will silently fail, and we just switch to the Live Preview.
 			// FIXME: Handle the case where the installation fails and the theme is not installed.
 			await dispatch( installTheme( installId, siteId ) );
 		}
 
 		if ( hasStyleVariations ) {
-			const theme = getCanonicalTheme( getState(), siteId, themeId );
-			const stylesheet = theme?.stylesheet ?? themeId;
-
-			const styleVariationToUpdate =
-				styleVariation ??
-				// Clear the global styles if the default style variation is selected.
-				( {} as GlobalStyles );
-
-			const globalStylesId = await dispatch( getGlobalStylesId( siteId, stylesheet ) );
-			dispatch( updateGlobalStyles( siteId, globalStylesId, styleVariationToUpdate ) );
+			await dispatch(
+				activateStyleVariation(
+					themeId,
+					siteId,
+					styleVariationSlug ?? DEFAULT_GLOBAL_STYLES_VARIATION_SLUG
+				)
+			);
 		}
 
 		return dispatch( redirectToLivePreview( themeId, siteId ) );

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -1467,8 +1467,6 @@ describe( 'actions', () => {
 					livePreview(
 						2211667,
 						'pendant',
-						false,
-						undefined,
 						'detail'
 					)( dispatch, state ).then( () => {
 						expect( dispatch ).toHaveBeenCalledWith( livePreviewStartAction );
@@ -1513,8 +1511,6 @@ describe( 'actions', () => {
 						livePreview(
 							2211667,
 							'pendant',
-							false,
-							undefined,
 							'detail'
 						)( dispatch, state ).then( () => {
 							expect( dispatch ).toHaveBeenCalledWith( livePreviewStartAction );
@@ -1540,8 +1536,6 @@ describe( 'actions', () => {
 						livePreview(
 							2211667,
 							'pendant',
-							false,
-							undefined,
 							'detail'
 						)( dispatch, state ).then( () => {
 							expect( dispatch ).toHaveBeenCalledWith( livePreviewStartAction );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/85945

## Proposed Changes

* Apply the selected variation to the preview when you preview the theme from the three-dot menu of the Theme Showcase.
* Introduce the `activateStyleVariation` action to centralize the logic of applying the style variation so we can use it for the live preview or theme activation.
* Use the `setThemePreviewOptions` to set the selected style variation before previewing a theme, and then the `livePreview` action can get the selected variation from the redux store. It's just the same as how the theme activation does.
* Add the `wp_theme_preview` query parameter to the `/variations` endpoint so that we can get variations from a theme that is not active.

https://github.com/Automattic/wp-calypso/assets/13596067/c49e990a-61b3-43c8-9029-511d5a9b2132

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Theme Showcase
* Pick a variation from any theme
* Click a three-dot menu of that theme
* Select “Preview & Customize”
* Make sure the selected variation is applied when you land on the Site Editor to preview that theme

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?