### PR TITLE
Plans 2024: Refactor `useCheckPlanAvailabilityForPurchase` dependency in the pricing hook

### DIFF
--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -8,6 +8,7 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import PlanPrice from 'calypso/my-sites/plan-price';
 import usePricingMetaForGridPlans from 'calypso/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans';
+import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { useSelector } from 'calypso/state';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -36,12 +37,16 @@ export default function PremiumGlobalStylesUpgradeModal( {
 	const premiumPlanProduct = useSelector( ( state ) => getProductBySlug( state, PLAN_PREMIUM ) );
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const translations = useGlobalStylesUpgradeTranslations( { numOfSelectedGlobalStyles } );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 	const isPremiumPlanProductLoaded = !! premiumPlanProduct;
 	const pricingMeta = usePricingMetaForGridPlans( {
 		coupon: undefined,
 		planSlugs: [ PLAN_PREMIUM ],
 		selectedSiteId,
 		storageAddOns: null,
+		useCheckPlanAvailabilityForPurchase,
+		selectedSiteId,
+		coupon: undefined,
 	} );
 
 	const pricing = pricingMeta?.[ PLAN_PREMIUM ];

--- a/client/components/premium-global-styles-upgrade-modal/index.tsx
+++ b/client/components/premium-global-styles-upgrade-modal/index.tsx
@@ -37,7 +37,6 @@ export default function PremiumGlobalStylesUpgradeModal( {
 	const premiumPlanProduct = useSelector( ( state ) => getProductBySlug( state, PLAN_PREMIUM ) );
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const translations = useGlobalStylesUpgradeTranslations( { numOfSelectedGlobalStyles } );
-	const selectedSiteId = useSelector( getSelectedSiteId );
 	const isPremiumPlanProductLoaded = !! premiumPlanProduct;
 	const pricingMeta = usePricingMetaForGridPlans( {
 		coupon: undefined,
@@ -45,8 +44,6 @@ export default function PremiumGlobalStylesUpgradeModal( {
 		selectedSiteId,
 		storageAddOns: null,
 		useCheckPlanAvailabilityForPurchase,
-		selectedSiteId,
-		coupon: undefined,
 	} );
 
 	const pricing = pricingMeta?.[ PLAN_PREMIUM ];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
@@ -32,6 +32,7 @@ const ScreenUpsell = ( { numOfSelectedGlobalStyles = 1, onCheckout, onTryStyle }
 		selectedSiteId,
 		coupon: undefined,
 		useCheckPlanAvailabilityForPurchase,
+		storageAddOns: null,
 	} );
 
 	const pricing = pricingMeta?.[ PLAN_PREMIUM ];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-upsell.tsx
@@ -8,6 +8,7 @@ import QueryPlans from 'calypso/components/data/query-plans';
 import useGlobalStylesUpgradeTranslations from 'calypso/components/premium-global-styles-upgrade-modal/use-global-styles-upgrade-translations';
 import PlanPrice from 'calypso/my-sites/plan-price';
 import usePricingMetaForGridPlans from 'calypso/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans';
+import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useScreen } from './hooks';
 import NavigatorTitle from './navigator-title';
@@ -28,9 +29,9 @@ const ScreenUpsell = ( { numOfSelectedGlobalStyles = 1, onCheckout, onTryStyle }
 	// TODO clk pricing
 	const pricingMeta = usePricingMetaForGridPlans( {
 		planSlugs: [ PLAN_PREMIUM ],
-		storageAddOns: null,
 		selectedSiteId,
 		coupon: undefined,
+		useCheckPlanAvailabilityForPurchase,
 	} );
 
 	const pricing = pricingMeta?.[ PLAN_PREMIUM ];

--- a/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans.ts
@@ -6,7 +6,6 @@ import {
 } from '@automattic/calypso-products';
 import { Plans, WpcomPlansUI, Purchases } from '@automattic/data-stores';
 import { useSelect } from '@wordpress/data';
-import useCheckPlanAvailabilityForPurchase from '../use-check-plan-availability-for-purchase';
 import type {
 	UsePricingMetaForGridPlans,
 	PricingMetaForGridPlan,
@@ -16,20 +15,23 @@ function getTotalPrice( planPrice: number | null | undefined, addOnPrice = 0 ): 
 	return null !== planPrice && undefined !== planPrice ? planPrice + addOnPrice : null;
 }
 
+export type UseCheckPlanAvailabilityForPurchase = ( { planSlugs }: { planSlugs: PlanSlug[] } ) => {
+	[ planSlug in PlanSlug ]?: boolean;
+};
+
 /*
  * Returns the pricing metadata needed for the plans-ui components.
  * - see `PricingMetaForGridPlan` type for details
  */
 const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 	planSlugs,
+	useCheckPlanAvailabilityForPurchase,
 	withoutProRatedCredits = false,
 	storageAddOns,
 	selectedSiteId,
 	coupon,
 } ) => {
-	// TODO: pass this in as a prop to uncouple the dependency
 	const planAvailabilityForPurchase = useCheckPlanAvailabilityForPurchase( { planSlugs } );
-
 	// plans - should have a definition for all plans, being the main source of API data
 	const plans = Plans.usePlans( { coupon } );
 	// sitePlans - unclear if all plans are included
@@ -40,7 +42,6 @@ const usePricingMetaForGridPlans: UsePricingMetaForGridPlans = ( {
 		siteId: selectedSiteId,
 		purchaseId: currentPlan?.purchaseId,
 	} );
-
 	const selectedStorageOptions = useSelect(
 		( select ) => select( WpcomPlansUI.store ).getSelectedStorageOptions(),
 		[]

--- a/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -22,12 +22,10 @@ jest.mock( '@automattic/data-stores', () => ( {
 		useSitePurchaseById: jest.fn(),
 	},
 } ) );
-jest.mock( '../use-check-plan-availability-for-purchase', () => jest.fn() );
 
 import { PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
 import { Plans, Purchases } from '@automattic/data-stores';
 import usePricingMetaForGridPlans from '../data-store/use-pricing-meta-for-grid-plans';
-import useCheckPlanAvailabilityForPurchase from '../use-check-plan-availability-for-purchase';
 
 describe( 'usePricingMetaForGridPlans', () => {
 	beforeEach( () => {
@@ -83,11 +81,12 @@ describe( 'usePricingMetaForGridPlans', () => {
 			productSlug: PLAN_PREMIUM,
 			planSlug: PLAN_PREMIUM,
 		} ) );
-		useCheckPlanAvailabilityForPurchase.mockImplementation( () => {
+
+		const useCheckPlanAvailabilityForPurchase = () => {
 			return {
 				[ PLAN_PREMIUM ]: true,
 			};
-		} );
+		};
 
 		const pricingMeta = usePricingMetaForGridPlans( {
 			planSlugs: [ PLAN_PREMIUM ],
@@ -95,6 +94,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 			storageAddOns: null,
 			selectedSiteId: 100,
 			coupon: undefined,
+			useCheckPlanAvailabilityForPurchase,
 		} );
 
 		const expectedPricingMeta = {
@@ -122,11 +122,12 @@ describe( 'usePricingMetaForGridPlans', () => {
 			productSlug: PLAN_PREMIUM,
 			planSlug: PLAN_PREMIUM,
 		} ) );
-		useCheckPlanAvailabilityForPurchase.mockImplementation( () => {
+
+		const useCheckPlanAvailabilityForPurchase = () => {
 			return {
 				[ PLAN_PREMIUM ]: false,
 			};
-		} );
+		};
 
 		const pricingMeta = usePricingMetaForGridPlans( {
 			planSlugs: [ PLAN_PREMIUM ],
@@ -134,6 +135,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 			storageAddOns: null,
 			selectedSiteId: 100,
 			coupon: undefined,
+			useCheckPlanAvailabilityForPurchase,
 		} );
 
 		const expectedPricingMeta = {
@@ -161,12 +163,13 @@ describe( 'usePricingMetaForGridPlans', () => {
 			productSlug: PLAN_PERSONAL,
 			planSlug: PLAN_PERSONAL,
 		} ) );
-		useCheckPlanAvailabilityForPurchase.mockImplementation( () => {
+
+		const useCheckPlanAvailabilityForPurchase = () => {
 			return {
 				[ PLAN_PERSONAL ]: true,
 				[ PLAN_PREMIUM ]: true,
 			};
-		} );
+		};
 
 		const pricingMeta = usePricingMetaForGridPlans( {
 			planSlugs: [ PLAN_PREMIUM ],
@@ -174,6 +177,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 			storageAddOns: null,
 			selectedSiteId: 100,
 			coupon: undefined,
+			useCheckPlanAvailabilityForPurchase,
 		} );
 
 		const expectedPricingMeta = {
@@ -201,12 +205,13 @@ describe( 'usePricingMetaForGridPlans', () => {
 			productSlug: PLAN_PERSONAL,
 			planSlug: PLAN_PERSONAL,
 		} ) );
-		useCheckPlanAvailabilityForPurchase.mockImplementation( () => {
+
+		const useCheckPlanAvailabilityForPurchase = () => {
 			return {
 				[ PLAN_PREMIUM ]: true,
 				[ PLAN_PERSONAL ]: true,
 			};
-		} );
+		};
 
 		const pricingMeta = usePricingMetaForGridPlans( {
 			planSlugs: [ PLAN_PREMIUM ],
@@ -214,6 +219,7 @@ describe( 'usePricingMetaForGridPlans', () => {
 			storageAddOns: null,
 			selectedSiteId: 100,
 			coupon: undefined,
+			useCheckPlanAvailabilityForPurchase,
 		} );
 
 		const expectedPricingMeta = {

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -552,6 +552,7 @@ const PlansFeaturesMain = ( {
 			plans: gridPlansForFeaturesGrid.map( ( gridPlan ) => gridPlan.planSlug ),
 			currentSitePlanSlug: sitePlanSlug,
 			usePricingMetaForGridPlans,
+			useCheckPlanAvailabilityForPurchase,
 			recordTracksEvent,
 			coupon,
 			selectedSiteId: siteId,
@@ -850,6 +851,7 @@ const PlansFeaturesMain = ( {
 									showUpgradeableStorage={ showUpgradeableStorage }
 									stickyRowOffset={ masterbarHeight }
 									usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
+									useCheckPlanAvailabilityForPurchase={ useCheckPlanAvailabilityForPurchase }
 									allFeaturesList={ FEATURES_LIST }
 									onStorageAddOnClick={ handleStorageAddOnClick }
 									showRefundPeriod={ isAnyHostingFlow( flowName ) }
@@ -910,6 +912,7 @@ const PlansFeaturesMain = ( {
 												showUpgradeableStorage={ showUpgradeableStorage }
 												stickyRowOffset={ comparisonGridStickyRowOffset }
 												usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
+												useCheckPlanAvailabilityForPurchase={ useCheckPlanAvailabilityForPurchase }
 												allFeaturesList={ FEATURES_LIST }
 												onStorageAddOnClick={ handleStorageAddOnClick }
 												showRefundPeriod={ isAnyHostingFlow( flowName ) }

--- a/client/my-sites/plans-grid/components/billing-timeframe.tsx
+++ b/client/my-sites/plans-grid/components/billing-timeframe.tsx
@@ -48,6 +48,7 @@ function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 			storageAddOns: storageAddOnsForPlan,
 			coupon,
 			selectedSiteId,
+			useCheckPlanAvailabilityForPurchase: helpers?.useCheckPlanAvailabilityForPurchase,
 		} )?.[ yearlyVariantPlanSlug ];
 
 	if (

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-toggle.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-toggle.tsx
@@ -38,6 +38,7 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		coupon,
 		selectedSiteId,
 		useCheckPlanAvailabilityForPurchase,
+		storageAddOns: null,
 	} );
 	const currentPlanBillingPeriod = currentSitePlanSlug
 		? pricingMeta?.[ currentSitePlanSlug ]?.billingPeriod

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-toggle.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-toggle.tsx
@@ -30,7 +30,12 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		'is-signup': isInSignup,
 	} );
 	const popupIsVisible = Boolean( intervalType === 'monthly' && props.plans.length );
-	const maxDiscount = useMaxDiscount( props.plans, usePricingMetaForGridPlans, useCheckPlanAvailabilityForPurchase, selectedSiteId );
+	const maxDiscount = useMaxDiscount(
+		props.plans,
+		usePricingMetaForGridPlans,
+		useCheckPlanAvailabilityForPurchase,
+		selectedSiteId
+	);
 	// TODO clk pricing
 	const pricingMeta = usePricingMetaForGridPlans( {
 		planSlugs: currentSitePlanSlug ? [ currentSitePlanSlug ] : [],

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-toggle.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-toggle.tsx
@@ -19,6 +19,7 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		currentSitePlanSlug,
 		usePricingMetaForGridPlans,
 		displayedIntervals,
+		useCheckPlanAvailabilityForPurchase,
 		title,
 		coupon,
 		selectedSiteId,
@@ -29,14 +30,14 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		'is-signup': isInSignup,
 	} );
 	const popupIsVisible = Boolean( intervalType === 'monthly' && props.plans.length );
-	const maxDiscount = useMaxDiscount( props.plans, usePricingMetaForGridPlans, selectedSiteId );
+	const maxDiscount = useMaxDiscount( props.plans, usePricingMetaForGridPlans, useCheckPlanAvailabilityForPurchase, selectedSiteId );
 	// TODO clk pricing
 	const pricingMeta = usePricingMetaForGridPlans( {
 		planSlugs: currentSitePlanSlug ? [ currentSitePlanSlug ] : [],
 		withoutProRatedCredits: true,
-		storageAddOns: null,
 		coupon,
 		selectedSiteId,
+		useCheckPlanAvailabilityForPurchase,
 	} );
 	const currentPlanBillingPeriod = currentSitePlanSlug
 		? pricingMeta?.[ currentSitePlanSlug ]?.billingPeriod

--- a/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-interval-options.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-interval-options.tsx
@@ -76,6 +76,7 @@ export default function useIntervalOptions( props: IntervalTypeProps ): Interval
 		props.plans,
 		Object.keys( displayedOptionList ) as Array< SupportedUrlFriendlyTermType >,
 		props.usePricingMetaForGridPlans,
+		props.useCheckPlanAvailabilityForPurchase,
 		props.selectedSiteId
 	);
 

--- a/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-max-discount.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-max-discount.ts
@@ -28,6 +28,7 @@ export default function useMaxDiscount(
 		selectedSiteId,
 		coupon: undefined,
 		useCheckPlanAvailabilityForPurchase,
+		storageAddOns: null,
 	} );
 	// TODO clk pricing
 	const yearlyPlansPricing = usePricingMetaForGridPlans( {
@@ -36,6 +37,7 @@ export default function useMaxDiscount(
 		selectedSiteId,
 		coupon: undefined,
 		useCheckPlanAvailabilityForPurchase,
+		storageAddOns: null,
 	} );
 
 	const discounts = wpcomMonthlyPlans.map( ( planSlug ) => {

--- a/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-max-discount.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-max-discount.ts
@@ -6,11 +6,13 @@ import {
 	isWpComPlan,
 } from '@automattic/calypso-products';
 import { useState } from '@wordpress/element';
+import { UseCheckPlanAvailabilityForPurchase } from 'calypso/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans';
 import { UsePricingMetaForGridPlans } from 'calypso/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans';
 
 export default function useMaxDiscount(
 	plans: PlanSlug[],
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans,
+	useCheckPlanAvailabilityForPurchase: UseCheckPlanAvailabilityForPurchase,
 	selectedSiteId?: number | null
 ): number {
 	const [ maxDiscount, setMaxDiscount ] = useState( 0 );
@@ -23,17 +25,17 @@ export default function useMaxDiscount(
 	const monthlyPlansPricing = usePricingMetaForGridPlans( {
 		planSlugs: wpcomMonthlyPlans,
 		withoutProRatedCredits: true,
-		storageAddOns: null,
 		selectedSiteId,
 		coupon: undefined,
+		useCheckPlanAvailabilityForPurchase,
 	} );
 	// TODO clk pricing
 	const yearlyPlansPricing = usePricingMetaForGridPlans( {
 		planSlugs: yearlyVariantPlanSlugs,
 		withoutProRatedCredits: true,
-		storageAddOns: null,
 		selectedSiteId,
 		coupon: undefined,
+		useCheckPlanAvailabilityForPurchase,
 	} );
 
 	const discounts = wpcomMonthlyPlans.map( ( planSlug ) => {

--- a/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-max-discounts-for-plan-terms.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-max-discounts-for-plan-terms.ts
@@ -9,6 +9,7 @@ import {
 	isWpComPlan,
 	isWpcomEnterpriseGridPlan,
 } from '@automattic/calypso-products';
+import { UseCheckPlanAvailabilityForPurchase } from 'calypso/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans';
 import { UsePricingMetaForGridPlans } from 'calypso/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans';
 
 /**
@@ -22,6 +23,7 @@ export default function useMaxDiscountsForPlanTerms(
 	plans: PlanSlug[],
 	urlFriendlyTerms: UrlFriendlyTermType[] = [],
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans,
+	useCheckPlanAvailabilityForPurchase: UseCheckPlanAvailabilityForPurchase,
 	selectedSiteId?: number | null
 ): Record< UrlFriendlyTermType, number > {
 	const termDefinitionsMapping = urlFriendlyTerms.map( ( urlFriendlyTerm ) => ( {
@@ -52,9 +54,9 @@ export default function useMaxDiscountsForPlanTerms(
 	const plansPricing = usePricingMetaForGridPlans( {
 		planSlugs: allRelatedPlanSlugs,
 		withoutProRatedCredits: true,
-		storageAddOns: null,
 		selectedSiteId,
 		coupon: undefined,
+		useCheckPlanAvailabilityForPurchase,
 	} );
 
 	const termWiseMaxDiscount: Record< UrlFriendlyTermType, number > = {} as Record<

--- a/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-max-discounts-for-plan-terms.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-max-discounts-for-plan-terms.ts
@@ -57,6 +57,7 @@ export default function useMaxDiscountsForPlanTerms(
 		selectedSiteId,
 		coupon: undefined,
 		useCheckPlanAvailabilityForPurchase,
+		storageAddOns: null,
 	} );
 
 	const termWiseMaxDiscount: Record< UrlFriendlyTermType, number > = {} as Record<

--- a/client/my-sites/plans-grid/components/plan-type-selector/types.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/types.ts
@@ -1,5 +1,6 @@
 import { UrlFriendlyTermType, type PlanSlug } from '@automattic/calypso-products';
 import { type TranslateResult } from 'i18n-calypso';
+import { UseCheckPlanAvailabilityForPurchase } from 'calypso/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans';
 import { type UsePricingMetaForGridPlans } from '../../hooks/npm-ready/data-store/use-grid-plans';
 
 export type PlanTypeSelectorProps = {
@@ -25,6 +26,7 @@ export type PlanTypeSelectorProps = {
 	isStepperUpgradeFlow: boolean;
 	currentSitePlanSlug?: PlanSlug | null;
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
+	useCheckPlanAvailabilityForPurchase: UseCheckPlanAvailabilityForPurchase;
 	recordTracksEvent?: ( eventName: string, eventProperties: Record< string, unknown > ) => void;
 	/**
 	 * Whether to render the selector along with a title if passed.
@@ -52,6 +54,7 @@ export type IntervalTypeProps = Pick<
 	| 'selectedFeature'
 	| 'currentSitePlanSlug'
 	| 'usePricingMetaForGridPlans'
+	| 'useCheckPlanAvailabilityForPurchase'
 	| 'title'
 	| 'coupon'
 >;

--- a/client/my-sites/plans-grid/grid-context.tsx
+++ b/client/my-sites/plans-grid/grid-context.tsx
@@ -1,10 +1,10 @@
 import { createContext, useContext } from '@wordpress/element';
-import { GridContextProps } from './types';
 import type {
 	GridPlan,
 	PlansIntent,
 	UsePricingMetaForGridPlans,
 } from './hooks/npm-ready/data-store/use-grid-plans';
+import type { GridContextProps, UseCheckPlanAvailabilityForPurchase } from './types';
 import type { FeatureList } from '@automattic/calypso-products';
 
 interface PlansGridContext {
@@ -13,7 +13,10 @@ interface PlansGridContext {
 	gridPlans: GridPlan[];
 	gridPlansIndex: { [ key: string ]: GridPlan };
 	allFeaturesList: FeatureList;
-	helpers?: Record< 'usePricingMetaForGridPlans', UsePricingMetaForGridPlans >;
+	helpers?: {
+		usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
+		useCheckPlanAvailabilityForPurchase: UseCheckPlanAvailabilityForPurchase;
+	};
 	coupon?: string;
 }
 
@@ -23,6 +26,7 @@ const PlansGridContextProvider = ( {
 	intent,
 	gridPlans,
 	usePricingMetaForGridPlans,
+	useCheckPlanAvailabilityForPurchase,
 	allFeaturesList,
 	selectedSiteId,
 	children,
@@ -44,7 +48,7 @@ const PlansGridContextProvider = ( {
 				gridPlans,
 				gridPlansIndex,
 				allFeaturesList,
-				helpers: { usePricingMetaForGridPlans },
+				helpers: { usePricingMetaForGridPlans, useCheckPlanAvailabilityForPurchase },
 				coupon,
 			} }
 		>

--- a/client/my-sites/plans-grid/grid-context.tsx
+++ b/client/my-sites/plans-grid/grid-context.tsx
@@ -4,7 +4,8 @@ import type {
 	PlansIntent,
 	UsePricingMetaForGridPlans,
 } from './hooks/npm-ready/data-store/use-grid-plans';
-import type { GridContextProps, UseCheckPlanAvailabilityForPurchase } from './types';
+import type { GridContextProps } from './types';
+import type { UseCheckPlanAvailabilityForPurchase } from '../plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans';
 import type { FeatureList } from '@automattic/calypso-products';
 
 interface PlansGridContext {

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -89,7 +89,7 @@ export type UsePricingMetaForGridPlans = ( {
 	 */
 	coupon: string | undefined;
 	/**
-	 * `useCheckPlanAvailabilityForPurchase` "required" on purpose to avoid inconsistent data across Calypso.
+	 * `useCheckPlanAvailabilityForPurchase` required on purpose to avoid inconsistent data across Calypso.
 	 * It's a function that is not available in the data store, but can be easily mocked in other contexts.
 	 */
 	useCheckPlanAvailabilityForPurchase: UseCheckPlanAvailabilityForPurchase;

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -25,11 +25,11 @@ import {
 	isEcommercePlan,
 	TYPE_P2_PLUS,
 } from '@automattic/calypso-products';
-import { Plans } from '@automattic/data-stores';
+import { Plans, type AddOnMeta, type PricedAPIPlan } from '@automattic/data-stores';
 import { isSamePlan } from '../../../lib/is-same-plan';
 import useHighlightLabels from './use-highlight-labels';
 import usePlansFromTypes from './use-plans-from-types';
-import type { AddOnMeta, PricedAPIPlan } from '@automattic/data-stores';
+import type { UseCheckPlanAvailabilityForPurchase } from 'calypso/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans';
 import type { TranslateResult } from 'i18n-calypso';
 
 // TODO clk: move to plans data store
@@ -75,6 +75,7 @@ export type UsePricingMetaForGridPlans = ( {
 	planSlugs,
 	selectedSiteId,
 	coupon,
+	useCheckPlanAvailabilityForPurchase,
 	storageAddOns,
 	withoutProRatedCredits,
 }: {
@@ -87,7 +88,12 @@ export type UsePricingMetaForGridPlans = ( {
 	 * `coupon` required on purpose to mitigate risk with not passing somethiing through when we should
 	 */
 	coupon: string | undefined;
-	storageAddOns: ( AddOnMeta | null )[] | null;
+	/**
+	 * `useCheckPlanAvailabilityForPurchase` "required" on purpose to avoid inconsistent data across Calypso.
+	 * It's a function that is not available in the data store, but can be easily mocked in other contexts.
+	 */
+	useCheckPlanAvailabilityForPurchase: UseCheckPlanAvailabilityForPurchase;
+	storageAddOns?: ( AddOnMeta | null )[] | null;
 	withoutProRatedCredits?: boolean;
 } ) => { [ planSlug: string ]: PricingMetaForGridPlan } | null;
 
@@ -113,9 +119,10 @@ export type GridPlan = {
 		conditionalFeatures?: FeatureObject[];
 	};
 	tagline: TranslateResult;
-	availableForPurchase: boolean;
-	productNameShort?: string | null;
 	planTitle: TranslateResult;
+	availableForPurchase: boolean;
+	pricing: PricingMetaForGridPlan;
+	productNameShort?: string | null;
 	billingTimeframe?: TranslateResult | null;
 	current?: boolean;
 	isMonthlyPlan?: boolean;
@@ -123,8 +130,7 @@ export type GridPlan = {
 		product_slug: string;
 	} | null;
 	highlightLabel?: React.ReactNode | null;
-	pricing: PricingMetaForGridPlan;
-	storageAddOnsForPlan: ( AddOnMeta | null )[] | null;
+	storageAddOnsForPlan?: ( AddOnMeta | null )[] | null;
 };
 
 // TODO clk: move to plans data store
@@ -149,6 +155,7 @@ interface Props {
 	// allFeaturesList temporary until feature definitions are ported to calypso-products package
 	allFeaturesList: FeatureList;
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
+	useCheckPlanAvailabilityForPurchase: UseCheckPlanAvailabilityForPurchase;
 	useFreeTrialPlanSlugs: UseFreeTrialPlanSlugs;
 	eligibleForFreeHostingTrial: boolean;
 	selectedFeature?: string | null;
@@ -158,16 +165,13 @@ interface Props {
 	sitePlanSlug?: PlanSlug | null;
 	hideEnterprisePlan?: boolean;
 	isInSignup?: boolean;
-	useCheckPlanAvailabilityForPurchase?: ( { planSlugs }: { planSlugs: PlanSlug[] } ) => {
-		[ planSlug in PlanSlug ]?: boolean;
-	};
 	showLegacyStorageFeature?: boolean;
 
 	/**
 	 * If the subdomain generation is unsuccessful we do not show the free plan
 	 */
 	isSubdomainNotGenerated?: boolean;
-	storageAddOns: ( AddOnMeta | null )[] | null;
+	storageAddOns?: ( AddOnMeta | null )[] | null;
 	coupon?: string;
 	selectedSiteId?: number | null;
 }
@@ -279,6 +283,7 @@ const usePlanTypesWithIntent = ( {
 // TODO clk: move to plans data store
 const useGridPlans = ( {
 	usePricingMetaForGridPlans,
+	useCheckPlanAvailabilityForPurchase,
 	useFreeTrialPlanSlugs,
 	term = TERM_MONTHLY,
 	intent,
@@ -286,7 +291,6 @@ const useGridPlans = ( {
 	sitePlanSlug,
 	hideEnterprisePlan,
 	isInSignup,
-	useCheckPlanAvailabilityForPurchase,
 	eligibleForFreeHostingTrial,
 	isSubdomainNotGenerated,
 	storageAddOns,
@@ -319,7 +323,7 @@ const useGridPlans = ( {
 		term,
 		intent,
 	} );
-	const plansAvailabilityForPurchase = useCheckPlanAvailabilityForPurchase?.( {
+	const plansAvailabilityForPurchase = useCheckPlanAvailabilityForPurchase( {
 		planSlugs: availablePlanSlugs,
 	} );
 
@@ -339,6 +343,7 @@ const useGridPlans = ( {
 		storageAddOns,
 		coupon,
 		selectedSiteId,
+		useCheckPlanAvailabilityForPurchase,
 	} );
 
 	// Null return would indicate that we are still loading the data. No grid without grid plans.

--- a/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
+++ b/client/my-sites/plans-grid/hooks/npm-ready/data-store/use-grid-plans.tsx
@@ -93,7 +93,7 @@ export type UsePricingMetaForGridPlans = ( {
 	 * It's a function that is not available in the data store, but can be easily mocked in other contexts.
 	 */
 	useCheckPlanAvailabilityForPurchase: UseCheckPlanAvailabilityForPurchase;
-	storageAddOns?: ( AddOnMeta | null )[] | null;
+	storageAddOns: ( AddOnMeta | null )[] | null;
 	withoutProRatedCredits?: boolean;
 } ) => { [ planSlug: string ]: PricingMetaForGridPlan } | null;
 
@@ -122,6 +122,7 @@ export type GridPlan = {
 	planTitle: TranslateResult;
 	availableForPurchase: boolean;
 	pricing: PricingMetaForGridPlan;
+	storageAddOnsForPlan: ( AddOnMeta | null )[] | null;
 	productNameShort?: string | null;
 	billingTimeframe?: TranslateResult | null;
 	current?: boolean;
@@ -130,7 +131,6 @@ export type GridPlan = {
 		product_slug: string;
 	} | null;
 	highlightLabel?: React.ReactNode | null;
-	storageAddOnsForPlan?: ( AddOnMeta | null )[] | null;
 };
 
 // TODO clk: move to plans data store
@@ -158,6 +158,7 @@ interface Props {
 	useCheckPlanAvailabilityForPurchase: UseCheckPlanAvailabilityForPurchase;
 	useFreeTrialPlanSlugs: UseFreeTrialPlanSlugs;
 	eligibleForFreeHostingTrial: boolean;
+	storageAddOns: ( AddOnMeta | null )[] | null;
 	selectedFeature?: string | null;
 	term?: ( typeof TERMS_LIST )[ number ]; // defaults to monthly
 	intent?: PlansIntent;
@@ -171,7 +172,6 @@ interface Props {
 	 * If the subdomain generation is unsuccessful we do not show the free plan
 	 */
 	isSubdomainNotGenerated?: boolean;
-	storageAddOns?: ( AddOnMeta | null )[] | null;
 	coupon?: string;
 	selectedSiteId?: number | null;
 }

--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -15,6 +15,7 @@ const WrappedComparisonGrid = ( {
 	intent,
 	gridPlans,
 	usePricingMetaForGridPlans,
+	useCheckPlanAvailabilityForPurchase,
 	allFeaturesList,
 	onUpgradeClick,
 	intervalType,
@@ -40,6 +41,7 @@ const WrappedComparisonGrid = ( {
 			selectedSiteId={ selectedSiteId }
 			gridPlans={ gridPlans }
 			usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
+			useCheckPlanAvailabilityForPurchase={ useCheckPlanAvailabilityForPurchase }
 			allFeaturesList={ allFeaturesList }
 			coupon={ coupon }
 		>
@@ -67,6 +69,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		intent,
 		gridPlans,
 		usePricingMetaForGridPlans,
+		useCheckPlanAvailabilityForPurchase,
 		allFeaturesList,
 		onUpgradeClick,
 		coupon,
@@ -96,6 +99,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 			gridPlans={ gridPlans }
 			usePricingMetaForGridPlans={ usePricingMetaForGridPlans }
 			coupon={ coupon }
+			useCheckPlanAvailabilityForPurchase={ useCheckPlanAvailabilityForPurchase }
 			allFeaturesList={ allFeaturesList }
 		>
 			<FeaturesGrid

--- a/client/my-sites/plans-grid/types.ts
+++ b/client/my-sites/plans-grid/types.ts
@@ -77,12 +77,17 @@ export interface ComparisonGridProps extends CommonGridProps {
 	selectedPlan?: string;
 }
 
+export type UseCheckPlanAvailabilityForPurchase = ( { planSlugs }: { planSlugs: PlanSlug[] } ) => {
+	[ planSlug in PlanSlug ]?: boolean;
+};
+
 export type GridContextProps = {
 	gridPlans: GridPlan[];
 	allFeaturesList: FeatureList;
 	intent?: PlansIntent;
 	selectedSiteId?: number | null;
 	usePricingMetaForGridPlans: UsePricingMetaForGridPlans;
+	useCheckPlanAvailabilityForPurchase: UseCheckPlanAvailabilityForPurchase;
 	children: React.ReactNode;
 	coupon?: string;
 };

--- a/client/my-sites/plans-grid/types.ts
+++ b/client/my-sites/plans-grid/types.ts
@@ -5,6 +5,7 @@ import type {
 	PlansIntent,
 	UsePricingMetaForGridPlans,
 } from './hooks/npm-ready/data-store/use-grid-plans';
+import type { UseCheckPlanAvailabilityForPurchase } from '../plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans';
 import type { FeatureList, PlanSlug, WPComStorageAddOnSlug } from '@automattic/calypso-products';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { LocalizeProps, TranslateResult } from 'i18n-calypso';
@@ -76,10 +77,6 @@ export interface ComparisonGridProps extends CommonGridProps {
 	// Value of the `?plan=` query param, so we can highlight a given plan.
 	selectedPlan?: string;
 }
-
-export type UseCheckPlanAvailabilityForPurchase = ( { planSlugs }: { planSlugs: PlanSlug[] } ) => {
-	[ planSlug in PlanSlug ]?: boolean;
-};
 
 export type GridContextProps = {
 	gridPlans: GridPlan[];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/85359 (reverted), https://github.com/Automattic/wp-calypso/pull/85486 (take 2)
Branched from https://github.com/Automattic/wp-calypso/pull/85480

## Proposed Changes

Similarly to https://github.com/Automattic/wp-calypso/pull/85480, we uncouple the `calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase` dependency from `usePricingMetaForGridPlans` so it can migrate to the Plans data-store next.

An important design consideration is `useCheckPlanAvailabilityForPurchase` being a required property on the pricing hook. This should force all usages within Calypso to pass the same callback through (as they can just import and pass along), and it wouldn't be any hassle to mock an "always true" function in some other context (tests & outside of Calypso). The alternative, making it optional, seems more risky.

As with most everything in pricing, this touches several files and might be easy for something to go amiss.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure pricing works correctly across `/plans` and `/start/plans`
* Go to `/plans/[site]` with a site that you don't own (like the `fieldguide`). It should show non-prorated prices for higher-tier plans.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?