### PR TITLE
Site Monitoring: Add all 4xx and 5xx error classes to unsuccessful responses chart

### DIFF
--- a/client/my-sites/site-monitoring/components/site-monitoring-line-chart/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-line-chart/index.tsx
@@ -227,6 +227,17 @@ export const SiteMonitoringLineChart = ( {
 					}
 				},
 			},
+			hooks: {
+				init: [
+					( u ) => {
+						[ ...u.root.querySelectorAll( '.u-legend .u-series' ) ].forEach( ( el, i ) => {
+							if ( ! u.series[ i ].showInLegend ) {
+								el.style.display = 'none';
+							}
+						} );
+					},
+				],
+			},
 		};
 
 		return {

--- a/client/my-sites/site-monitoring/components/site-monitoring-line-chart/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-line-chart/index.tsx
@@ -35,6 +35,7 @@ interface SeriesProp {
 	stroke: string;
 	scale?: string;
 	unit?: string;
+	showInLegend?: boolean;
 }
 
 export function formatChartHour( date: Date ): string {
@@ -230,11 +231,14 @@ export const SiteMonitoringLineChart = ( {
 			hooks: {
 				init: [
 					( u ) => {
-						[ ...u.root.querySelectorAll( '.u-legend .u-series' ) ].forEach( ( el, i ) => {
-							if ( ! u.series[ i ].showInLegend ) {
-								el.style.display = 'none';
+						[ ...u.root.querySelectorAll< HTMLElement >( '.u-legend .u-series' ) ].forEach(
+							( el, i ) => {
+								const serie = u.series[ i ] as SeriesProp;
+								if ( ! serie.showInLegend ) {
+									el.style.display = 'none';
+								}
 							}
-						} );
+						);
 					},
 				],
 			},

--- a/client/my-sites/site-monitoring/components/site-monitoring-line-chart/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-line-chart/index.tsx
@@ -230,10 +230,10 @@ export const SiteMonitoringLineChart = ( {
 			},
 			hooks: {
 				init: [
-					( u ) => {
-						[ ...u.root.querySelectorAll< HTMLElement >( '.u-legend .u-series' ) ].forEach(
+					( uPlot ) => {
+						[ ...uPlot.root.querySelectorAll< HTMLElement >( '.u-legend .u-series' ) ].forEach(
 							( el, i ) => {
-								const serie = u.series[ i ] as SeriesProp;
+								const serie = uPlot.series[ i ] as SeriesProp;
 								if ( ! serie.showInLegend ) {
 									el.style.display = 'none';
 								}

--- a/client/my-sites/site-monitoring/components/site-monitoring-line-chart/line-chart-tooltip.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-line-chart/line-chart-tooltip.tsx
@@ -109,14 +109,20 @@ export function HttpChartTooltip( { data, idx, series = [], ...rest }: HttpChart
 			totalRequests,
 		},
 	} );
+	const filteredTooltipSeries = series
+		.map( ( serie, serieI ) => ( {
+			color: serie.stroke,
+			label: serie.label,
+			value: rountToTwoDecimals( data[ serieI + 1 ][ idx ] ),
+			showInLegend: serie.showInLegend,
+		} ) )
+		.filter( ( serie ) => {
+			return !! serie.showInLegend || serie.value > 0;
+		} );
 	return (
 		<LineChartTooltip
 			{ ...rest }
-			tooltipSeries={ series.map( ( serie, serieI ) => ( {
-				color: serie.stroke,
-				label: serie.label,
-				value: rountToTwoDecimals( data[ serieI + 1 ][ idx ] ),
-			} ) ) }
+			tooltipSeries={ filteredTooltipSeries }
 			footer={ `${ totalRequestsString } - ${ dateString }` }
 		/>
 	);

--- a/client/my-sites/site-monitoring/components/site-monitoring-line-chart/line-chart-tooltip.tsx
+++ b/client/my-sites/site-monitoring/components/site-monitoring-line-chart/line-chart-tooltip.tsx
@@ -114,10 +114,10 @@ export function HttpChartTooltip( { data, idx, series = [], ...rest }: HttpChart
 			color: serie.stroke,
 			label: serie.label,
 			value: rountToTwoDecimals( data[ serieI + 1 ][ idx ] ),
-			showInLegend: serie.showInLegend,
+			showInTooltip: serie.showInTooltip,
 		} ) )
 		.filter( ( serie ) => {
-			return !! serie.showInLegend || serie.value > 0;
+			return !! serie.showInTooltip || serie.value > 0;
 		} );
 	return (
 		<LineChartTooltip

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -213,11 +213,12 @@ function getFormattedDataForPieChart(
 	} );
 }
 export interface HTTPCodeSerie {
-	statusCode: number;
+	statusCode?: number;
 	fill: string;
 	label: string;
 	stroke: string;
 	showInLegend?: boolean;
+	showInTooltip?: boolean;
 }
 
 const seriesDefaultProps = {
@@ -234,6 +235,7 @@ const useSuccessHttpCodeSeries = () => {
 			label: __( '200: OK Response' ),
 			stroke: 'rgba(104, 179, 232, 1)',
 			showInLegend: true,
+			showInTooltip: true,
 		},
 		{
 			statusCode: 301,
@@ -241,6 +243,7 @@ const useSuccessHttpCodeSeries = () => {
 			label: __( '301: Moved Permanently' ),
 			stroke: 'rgba(235, 101, 148, 1)',
 			showInLegend: true,
+			showInTooltip: true,
 		},
 		{
 			statusCode: 302,
@@ -248,6 +251,7 @@ const useSuccessHttpCodeSeries = () => {
 			label: __( '302: Moved Temporarily' ),
 			stroke: 'rgba(9, 181, 133, 1)',
 			showInLegend: true,
+			showInTooltip: true,
 		},
 	];
 	const statusCodes = series.map( ( { statusCode } ) => statusCode );
@@ -264,6 +268,7 @@ const useClientErrorHttpCodeSeries = () => {
 			label: __( '400: Bad Request' ),
 			stroke: 'rgba(242, 215, 107, 1)',
 			showInLegend: true,
+			showInTooltip: true,
 		},
 		{
 			statusCode: 401,
@@ -271,6 +276,7 @@ const useClientErrorHttpCodeSeries = () => {
 			label: __( '401: Unauthorized' ),
 			stroke: 'rgba(235, 101, 148, 1)',
 			showInLegend: true,
+			showInTooltip: true,
 		},
 		{
 			statusCode: 403,
@@ -278,6 +284,7 @@ const useClientErrorHttpCodeSeries = () => {
 			label: __( '403: Forbidden' ),
 			stroke: 'rgba(104, 179, 232, 1)',
 			showInLegend: true,
+			showInTooltip: true,
 		},
 		{
 			statusCode: 404,
@@ -285,12 +292,12 @@ const useClientErrorHttpCodeSeries = () => {
 			label: __( '404: Not Found' ),
 			stroke: 'rgba(9, 181, 133, 1)',
 			showInLegend: true,
+			showInTooltip: true,
 		},
 		// remaining 4xx errors
 		{
 			...seriesDefaultProps,
-			statusCode: 400,
-			label: __( '4xx errors' ),
+			label: __( 'Other 4xx errors' ),
 			showInLegend: true,
 		},
 		{
@@ -428,6 +435,7 @@ const useServerErrorHttpCodeSeries = () => {
 			label: __( '500: Internal Server Error' ),
 			stroke: 'rgba(242, 215, 107, 1)',
 			showInLegend: true,
+			showInTooltip: true,
 		},
 		{
 			statusCode: 502,
@@ -435,6 +443,7 @@ const useServerErrorHttpCodeSeries = () => {
 			label: __( '502: Bad Gateway' ),
 			stroke: 'rgba(235, 101, 148, 1)',
 			showInLegend: true,
+			showInTooltip: true,
 		},
 		{
 			statusCode: 503,
@@ -442,6 +451,7 @@ const useServerErrorHttpCodeSeries = () => {
 			label: __( '503: Service Unavailable' ),
 			stroke: 'rgba(104, 179, 232, 1)',
 			showInLegend: true,
+			showInTooltip: true,
 		},
 		{
 			statusCode: 504,
@@ -449,12 +459,12 @@ const useServerErrorHttpCodeSeries = () => {
 			label: __( '504: Gateway Timeout' ),
 			stroke: 'rgba(9, 181, 133, 1)',
 			showInLegend: true,
+			showInTooltip: true,
 		},
 		// remaining 5xx errors
 		{
 			...seriesDefaultProps,
-			statusCode: 500,
-			label: __( '5xx errors' ),
+			label: __( 'Other 5xx errors' ),
 			showInLegend: true,
 		},
 		{

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -213,7 +213,7 @@ function getFormattedDataForPieChart(
 	} );
 }
 export interface HTTPCodeSerie {
-	statusCode?: number;
+	statusCode: number;
 	fill: string;
 	label: string;
 	stroke: string;
@@ -297,6 +297,7 @@ const useClientErrorHttpCodeSeries = () => {
 		// remaining 4xx errors
 		{
 			...seriesDefaultProps,
+			statusCode: 0,
 			label: __( 'Other 4xx errors' ),
 			showInLegend: true,
 		},
@@ -464,6 +465,7 @@ const useServerErrorHttpCodeSeries = () => {
 		// remaining 5xx errors
 		{
 			...seriesDefaultProps,
+			statusCode: 0,
 			label: __( 'Other 5xx errors' ),
 			showInLegend: true,
 		},

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -258,7 +258,7 @@ const useSuccessHttpCodeSeries = () => {
 	return { series, statusCodes };
 };
 
-const useClientErrorHttpCodeSeries = () => {
+const useErrorHttpCodeSeries = () => {
 	const { __ } = useI18n();
 	const series: HTTPCodeSerie[] = [
 		// most common 4xx errors
@@ -272,9 +272,9 @@ const useClientErrorHttpCodeSeries = () => {
 		},
 		{
 			statusCode: 401,
-			fill: 'rgba(235, 101, 148, 0.1)',
+			fill: 'rgba(140, 143, 148, 0.1)',
 			label: __( '401: Unauthorized' ),
-			stroke: 'rgba(235, 101, 148, 1)',
+			stroke: 'rgba(140, 143, 148, 1)',
 			showInLegend: true,
 			showInTooltip: true,
 		},
@@ -294,13 +294,23 @@ const useClientErrorHttpCodeSeries = () => {
 			showInLegend: true,
 			showInTooltip: true,
 		},
-		// remaining 4xx errors
+		// most common 5xx errors
+		{
+			statusCode: 500,
+			fill: 'rgba(235, 101, 148, 0.1)',
+			label: __( '500: Internal Server Error' ),
+			stroke: 'rgba(235, 101, 148, 1)',
+			showInLegend: true,
+			showInTooltip: true,
+		},
+		// label for other 4xx and 5xx errors
 		{
 			...seriesDefaultProps,
 			statusCode: 0,
-			label: __( 'Other 4xx errors' ),
+			label: __( 'Other 4xx and 5xx errors' ),
 			showInLegend: true,
 		},
+		// remaining 4xx errors
 		{
 			...seriesDefaultProps,
 			statusCode: 402,
@@ -421,58 +431,26 @@ const useClientErrorHttpCodeSeries = () => {
 			statusCode: 451,
 			label: __( '451: Unavailable For Legal Reasons' ),
 		},
-	];
-	const statusCodes = series.map( ( { statusCode } ) => statusCode );
-	return { series, statusCodes };
-};
-
-const useServerErrorHttpCodeSeries = () => {
-	const { __ } = useI18n();
-	const series: HTTPCodeSerie[] = [
-		// most common 5xx errors
-		{
-			statusCode: 500,
-			fill: 'rgba(242, 215, 107, 0.1)',
-			label: __( '500: Internal Server Error' ),
-			stroke: 'rgba(242, 215, 107, 1)',
-			showInLegend: true,
-			showInTooltip: true,
-		},
-		{
-			statusCode: 502,
-			fill: 'rgba(235, 101, 148, 0.1)',
-			label: __( '502: Bad Gateway' ),
-			stroke: 'rgba(235, 101, 148, 1)',
-			showInLegend: true,
-			showInTooltip: true,
-		},
-		{
-			statusCode: 503,
-			fill: 'rgba(104, 179, 232, 0.1)',
-			label: __( '503: Service Unavailable' ),
-			stroke: 'rgba(104, 179, 232, 1)',
-			showInLegend: true,
-			showInTooltip: true,
-		},
-		{
-			statusCode: 504,
-			fill: 'rgba(9, 181, 133, 0.1)',
-			label: __( '504: Gateway Timeout' ),
-			stroke: 'rgba(9, 181, 133, 1)',
-			showInLegend: true,
-			showInTooltip: true,
-		},
 		// remaining 5xx errors
-		{
-			...seriesDefaultProps,
-			statusCode: 0,
-			label: __( 'Other 5xx errors' ),
-			showInLegend: true,
-		},
 		{
 			...seriesDefaultProps,
 			statusCode: 501,
 			label: __( '501: Not Implemented' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 502,
+			label: __( '502: Bad Gateway' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 503,
+			label: __( '503: Service Unavailable' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 504,
+			label: __( '504: Gateway Timeout' ),
 		},
 		{
 			...seriesDefaultProps,
@@ -530,15 +508,10 @@ export const MetricsTab = () => {
 		timeRange,
 		successHttpCodes.statusCodes
 	);
-	const clientErrorHttpCodes = useClientErrorHttpCodeSeries();
-	const { data: dataForClientErrorCodesChart } = useSiteMetricsStatusCodesData(
+	const errorHttpCodes = useErrorHttpCodeSeries();
+	const { data: dataForErrorCodesChart } = useSiteMetricsStatusCodesData(
 		timeRange,
-		clientErrorHttpCodes.statusCodes
-	);
-	const serverErrorHttpCodes = useServerErrorHttpCodeSeries();
-	const { data: dataForServerErrorCodesChart } = useSiteMetricsStatusCodesData(
-		timeRange,
-		serverErrorHttpCodes.statusCodes
+		errorHttpCodes.statusCodes
 	);
 
 	const startDate = moment( timeRange.start * 1000 );
@@ -653,33 +626,14 @@ export const MetricsTab = () => {
 			></SiteMonitoringLineChart>
 			<SiteMonitoringLineChart
 				timeRange={ timeRange }
-				title={ __( 'Unsuccessful HTTP responses with client errors (4xx)' ) }
-				subtitle={ __(
-					'Requests per minute that encountered errors related to request bad syntax or requests that can not be fulfilled.'
-				) }
-				data={ dataForClientErrorCodesChart as uPlot.AlignedData }
-				series={ clientErrorHttpCodes.series }
+				title={ __( 'Unsuccessful HTTP responses' ) }
+				subtitle={ __( 'Requests per minute that encountered errors or issues during processing' ) }
+				data={ dataForErrorCodesChart as uPlot.AlignedData }
+				series={ errorHttpCodes.series }
 				options={ {
 					plugins: [
 						timeHighlightPlugin( 'auto' ),
-						tooltipsPlugin( withSeries( HttpChartTooltip, clientErrorHttpCodes.series ), {
-							position: 'followCursor',
-						} ),
-					],
-				} }
-			></SiteMonitoringLineChart>
-			<SiteMonitoringLineChart
-				timeRange={ timeRange }
-				title={ __( 'Unsuccessful HTTP responses with server errors (5xx)' ) }
-				subtitle={ __(
-					'Requests per minute that encountered errors related to server processing.'
-				) }
-				data={ dataForServerErrorCodesChart as uPlot.AlignedData }
-				series={ serverErrorHttpCodes.series }
-				options={ {
-					plugins: [
-						timeHighlightPlugin( 'auto' ),
-						tooltipsPlugin( withSeries( HttpChartTooltip, serverErrorHttpCodes.series ), {
+						tooltipsPlugin( withSeries( HttpChartTooltip, errorHttpCodes.series ), {
 							position: 'followCursor',
 						} ),
 					],

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -245,7 +245,7 @@ const useSuccessHttpCodeSeries = () => {
 	return { series, statusCodes };
 };
 
-const useErrorHttpCodeSeries = () => {
+const useClientErrorHttpCodeSeries = () => {
 	const { __ } = useI18n();
 	const series: HTTPCodeSerie[] = [
 		{
@@ -272,6 +272,14 @@ const useErrorHttpCodeSeries = () => {
 			label: __( '404: Not Found Request' ),
 			stroke: 'rgba(9, 181, 133, 1)',
 		},
+	];
+	const statusCodes = series.map( ( { statusCode } ) => statusCode );
+	return { series, statusCodes };
+};
+
+const useServerErrorHttpCodeSeries = () => {
+	const { __ } = useI18n();
+	const series: HTTPCodeSerie[] = [
 		{
 			statusCode: 500,
 			fill: 'rgba(235, 101, 148, 0.1)',
@@ -304,10 +312,15 @@ export const MetricsTab = () => {
 		timeRange,
 		successHttpCodes.statusCodes
 	);
-	const errorHttpCodes = useErrorHttpCodeSeries();
-	const { data: dataForErrorCodesChart } = useSiteMetricsStatusCodesData(
+	const clientErrorHttpCodes = useClientErrorHttpCodeSeries();
+	const { data: dataForClientErrorCodesChart } = useSiteMetricsStatusCodesData(
 		timeRange,
-		errorHttpCodes.statusCodes
+		clientErrorHttpCodes.statusCodes
+	);
+	const serverErrorHttpCodes = useServerErrorHttpCodeSeries();
+	const { data: dataForServerErrorCodesChart } = useSiteMetricsStatusCodesData(
+		timeRange,
+		serverErrorHttpCodes.statusCodes
 	);
 
 	const startDate = moment( timeRange.start * 1000 );
@@ -422,14 +435,33 @@ export const MetricsTab = () => {
 			></SiteMonitoringLineChart>
 			<SiteMonitoringLineChart
 				timeRange={ timeRange }
-				title={ __( 'Unsuccessful HTTP responses' ) }
-				subtitle={ __( 'Requests per minute that encountered errors or issues during processing' ) }
-				data={ dataForErrorCodesChart as uPlot.AlignedData }
-				series={ errorHttpCodes.series }
+				title={ __( 'Unsuccessful HTTP responses with client errors (4xx)' ) }
+				subtitle={ __(
+					'Requests per minute that encountered errors related to request bad syntax or requests that can not be fulfilled.'
+				) }
+				data={ dataForClientErrorCodesChart as uPlot.AlignedData }
+				series={ clientErrorHttpCodes.series }
 				options={ {
 					plugins: [
 						timeHighlightPlugin( 'auto' ),
-						tooltipsPlugin( withSeries( HttpChartTooltip, errorHttpCodes.series ), {
+						tooltipsPlugin( withSeries( HttpChartTooltip, clientErrorHttpCodes.series ), {
+							position: 'followCursor',
+						} ),
+					],
+				} }
+			></SiteMonitoringLineChart>
+			<SiteMonitoringLineChart
+				timeRange={ timeRange }
+				title={ __( 'Unsuccessful HTTP responses with server errors (5xx)' ) }
+				subtitle={ __(
+					'Requests per minute that encountered errors related to server processing.'
+				) }
+				data={ dataForServerErrorCodesChart as uPlot.AlignedData }
+				series={ serverErrorHttpCodes.series }
+				options={ {
+					plugins: [
+						timeHighlightPlugin( 'auto' ),
+						tooltipsPlugin( withSeries( HttpChartTooltip, serverErrorHttpCodes.series ), {
 							position: 'followCursor',
 						} ),
 					],

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -219,6 +219,11 @@ export interface HTTPCodeSerie {
 	stroke: string;
 }
 
+const seriesDefaultProps = {
+	fill: 'rgba(196, 196, 196, 0.1)',
+	stroke: 'rgba(196, 196, 196, 1)',
+};
+
 const useSuccessHttpCodeSeries = () => {
 	const { __ } = useI18n();
 	const series: HTTPCodeSerie[] = [
@@ -248,6 +253,7 @@ const useSuccessHttpCodeSeries = () => {
 const useClientErrorHttpCodeSeries = () => {
 	const { __ } = useI18n();
 	const series: HTTPCodeSerie[] = [
+		// most common 4xx errors
 		{
 			statusCode: 400,
 			fill: 'rgba(242, 215, 107, 0.1)',
@@ -256,21 +262,142 @@ const useClientErrorHttpCodeSeries = () => {
 		},
 		{
 			statusCode: 401,
-			fill: 'rgba(140, 143, 148, 0.1)',
-			label: __( '401: Unauthorized Request' ),
-			stroke: 'rgba(140, 143, 148, 1)',
+			fill: 'rgba(235, 101, 148, 0.1)',
+			label: __( '401: Unauthorized' ),
+			stroke: 'rgba(235, 101, 148, 1)',
 		},
 		{
 			statusCode: 403,
 			fill: 'rgba(104, 179, 232, 0.1)',
-			label: __( '403: Forbidden Request' ),
+			label: __( '403: Forbidden' ),
 			stroke: 'rgba(104, 179, 232, 1)',
 		},
 		{
 			statusCode: 404,
 			fill: 'rgba(9, 181, 133, 0.1)',
-			label: __( '404: Not Found Request' ),
+			label: __( '404: Not Found' ),
 			stroke: 'rgba(9, 181, 133, 1)',
+		},
+		// remaining 4xx errors
+		{
+			...seriesDefaultProps,
+			statusCode: 402,
+			label: __( '402 Payment Required' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 405,
+			label: __( '405: Method Not Allowed' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 406,
+			label: __( '406: Not Acceptable' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 407,
+			label: __( '407: Proxy Authentication Required' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 408,
+			label: __( 'Request Timeout' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 409,
+			label: __( '409: Conflict' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 410,
+			label: __( '410: Gone' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 411,
+			label: __( '411: Length Required' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 412,
+			label: __( '412: Precondition Failed' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 413,
+			label: __( '413: Content Too Large' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 414,
+			label: __( '414: URI Too Long' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 415,
+			label: __( '415: Unsupported Media Type' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 416,
+			label: __( '416: Range Not Satisfiable' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 417,
+			label: __( '417: Expectation Failed' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 421,
+			label: __( '421: Misdirected Request' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 422,
+			label: __( '422: Unprocessable Content' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 423,
+			label: __( '423: Locked' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 424,
+			label: __( '424: Failed Dependency' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 425,
+			label: __( '425: Too Early' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 426,
+			label: __( '426: Upgrade Required' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 428,
+			label: __( '428: Precondition Required' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 429,
+			label: __( '429: Too Many Requests' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 431,
+			label: __( '431: Request Header Fields Too Large' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 451,
+			label: __( '451: Unavailable For Legal Reasons' ),
 		},
 	];
 	const statusCodes = series.map( ( { statusCode } ) => statusCode );
@@ -280,11 +407,66 @@ const useClientErrorHttpCodeSeries = () => {
 const useServerErrorHttpCodeSeries = () => {
 	const { __ } = useI18n();
 	const series: HTTPCodeSerie[] = [
+		// most common 5xx errors
 		{
 			statusCode: 500,
+			fill: 'rgba(242, 215, 107, 0.1)',
+			label: __( '500: Internal Server Error' ),
+			stroke: 'rgba(242, 215, 107, 1)',
+		},
+		{
+			statusCode: 502,
 			fill: 'rgba(235, 101, 148, 0.1)',
-			label: __( '500: Internal server error' ),
+			label: __( '502: Bad Gateway' ),
 			stroke: 'rgba(235, 101, 148, 1)',
+		},
+		{
+			statusCode: 503,
+			fill: 'rgba(104, 179, 232, 0.1)',
+			label: __( '503: Service Unavailable' ),
+			stroke: 'rgba(104, 179, 232, 1)',
+		},
+		{
+			statusCode: 504,
+			fill: 'rgba(9, 181, 133, 0.1)',
+			label: __( '504: Gateway Timeout' ),
+			stroke: 'rgba(9, 181, 133, 1)',
+		},
+		// remaining 5xx errors
+		{
+			...seriesDefaultProps,
+			statusCode: 501,
+			label: __( '501: Not Implemented' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 505,
+			label: __( '505: HTTP Version Not Supported' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 506,
+			label: __( '506: Variant Also Negotiates' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 507,
+			label: __( '507: Insufficient Storage' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 508,
+			label: __( '508: Loop Detected ' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 510,
+			label: __( '510: Not Extended' ),
+		},
+		{
+			...seriesDefaultProps,
+			statusCode: 511,
+			label: __( '511: Network Authentication Required ' ),
 		},
 	];
 	const statusCodes = series.map( ( { statusCode } ) => statusCode );

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -217,6 +217,7 @@ export interface HTTPCodeSerie {
 	fill: string;
 	label: string;
 	stroke: string;
+	showInLegend?: boolean;
 }
 
 const seriesDefaultProps = {
@@ -232,18 +233,21 @@ const useSuccessHttpCodeSeries = () => {
 			fill: 'rgba(104, 179, 232, 0.1)',
 			label: __( '200: OK Response' ),
 			stroke: 'rgba(104, 179, 232, 1)',
+			showInLegend: true,
 		},
 		{
 			statusCode: 301,
 			fill: 'rgba(235, 101, 148, 0.2)',
 			label: __( '301: Moved Permanently' ),
 			stroke: 'rgba(235, 101, 148, 1)',
+			showInLegend: true,
 		},
 		{
 			statusCode: 302,
 			fill: 'rgba(9, 181, 133, 0.1)',
 			label: __( '302: Moved Temporarily' ),
 			stroke: 'rgba(9, 181, 133, 1)',
+			showInLegend: true,
 		},
 	];
 	const statusCodes = series.map( ( { statusCode } ) => statusCode );
@@ -259,26 +263,36 @@ const useClientErrorHttpCodeSeries = () => {
 			fill: 'rgba(242, 215, 107, 0.1)',
 			label: __( '400: Bad Request' ),
 			stroke: 'rgba(242, 215, 107, 1)',
+			showInLegend: true,
 		},
 		{
 			statusCode: 401,
 			fill: 'rgba(235, 101, 148, 0.1)',
 			label: __( '401: Unauthorized' ),
 			stroke: 'rgba(235, 101, 148, 1)',
+			showInLegend: true,
 		},
 		{
 			statusCode: 403,
 			fill: 'rgba(104, 179, 232, 0.1)',
 			label: __( '403: Forbidden' ),
 			stroke: 'rgba(104, 179, 232, 1)',
+			showInLegend: true,
 		},
 		{
 			statusCode: 404,
 			fill: 'rgba(9, 181, 133, 0.1)',
 			label: __( '404: Not Found' ),
 			stroke: 'rgba(9, 181, 133, 1)',
+			showInLegend: true,
 		},
 		// remaining 4xx errors
+		{
+			...seriesDefaultProps,
+			statusCode: 400,
+			label: __( '4xx errors' ),
+			showInLegend: true,
+		},
 		{
 			...seriesDefaultProps,
 			statusCode: 402,
@@ -413,26 +427,36 @@ const useServerErrorHttpCodeSeries = () => {
 			fill: 'rgba(242, 215, 107, 0.1)',
 			label: __( '500: Internal Server Error' ),
 			stroke: 'rgba(242, 215, 107, 1)',
+			showInLegend: true,
 		},
 		{
 			statusCode: 502,
 			fill: 'rgba(235, 101, 148, 0.1)',
 			label: __( '502: Bad Gateway' ),
 			stroke: 'rgba(235, 101, 148, 1)',
+			showInLegend: true,
 		},
 		{
 			statusCode: 503,
 			fill: 'rgba(104, 179, 232, 0.1)',
 			label: __( '503: Service Unavailable' ),
 			stroke: 'rgba(104, 179, 232, 1)',
+			showInLegend: true,
 		},
 		{
 			statusCode: 504,
 			fill: 'rgba(9, 181, 133, 0.1)',
 			label: __( '504: Gateway Timeout' ),
 			stroke: 'rgba(9, 181, 133, 1)',
+			showInLegend: true,
 		},
 		// remaining 5xx errors
+		{
+			...seriesDefaultProps,
+			statusCode: 500,
+			label: __( '5xx errors' ),
+			showInLegend: true,
+		},
 		{
 			...seriesDefaultProps,
 			statusCode: 501,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4448

## Proposed Changes

In this diff, I propose to add support for [all HTTP error codes defined by IANA](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml) to Unsuccessful HTTP responses chart in Tools -> Site Monitoring.

- five most common HTTP status codes are displayed on each chart legend (three on the success chart)
- there is a generic 4xx or 5xx legend item that marks other possible status codes
- when a user hovers over the series, we display the most common codes regardless of the value and other codes only if the value is higher than 0

<img width="1324" alt="Screenshot 2024-03-18 at 17 22 40" src="https://github.com/Automattic/wp-calypso/assets/727413/47db579c-d99a-4d8c-bc4a-0754d44f8116">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a Creator site and enable hosting features
2. Connect to the site via SSH and add lines to the `wp-config.php` to simulate different HTTP errors:
```
header( 'HTTP/1.1 429 Too Many Requests' );
die( 'Simulate 429 for metrics api work' );
```
3. Load the site's homepage and confirm that error with defined code is thrown
4. Wait a few minutes and confirm that errors are shown in the charts in Tools -> Site Monitoring

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?