### PR TITLE
Marketplace Reviews: Fix success review styles

### DIFF
--- a/client/my-sites/marketplace/components/review-modal/styles.scss
+++ b/client/my-sites/marketplace/components/review-modal/styles.scss
@@ -5,7 +5,7 @@
 	box-shadow: none;
 }
 
-.marketplace-review-modal__card-successs {
+.marketplace-review-modal__card-success {
 	box-shadow: none;
 	padding: 26px 40px;
 	display: flex;
@@ -13,7 +13,7 @@
 	align-items: center;
 	margin-bottom: 0;
 
-	& .marketplace-review-modal__card-successs-title {
+	& .marketplace-review-modal__card-success-title {
 		font-family: $brand-serif;
 		font-size: $font-title-large;
 		font-weight: 400;
@@ -21,7 +21,7 @@
 		margin: 0;
 	}
 
-	& .marketplace-review-modal__card-successs-body {
+	& .marketplace-review-modal__card-success-body {
 		max-width: 400px;
 		font-size: $font-body-small;
 		text-align: center;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Fix typo in class names that prevented styles from being applied to the Success message when adding a review

|Before | After|
|-------|------|
| ![CleanShot 2024-01-09 at 15 38 34@2x](https://github.com/Automattic/wp-calypso/assets/3519124/9b250250-23fb-4550-92bd-ec8aab2ee58d)     |     ![CleanShot 2024-01-09 at 15 41 00@2x](https://github.com/Automattic/wp-calypso/assets/3519124/1b4515db-ee21-4adf-a786-1d569469699c)     |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In an environment with the `marketplace-reviews-show` and `marketplace-add-review` flags enabled, eg. `wpcalypso.wordpress.com/themes`
* Add a review to a theme
* Make sure the styles are applied as per the screenshot above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?