### PR TITLE
Login Page: don't try to parse site IDs from URL for Akismet renewal links

### DIFF
--- a/client/lib/route/path.ts
+++ b/client/lib/route/path.ts
@@ -23,7 +23,9 @@ export function getSiteFragment( path: URLString ): SiteSlug | SiteId | false {
 		// Avoid confusing the receipt ID for the site ID in domain-only checkouts.
 		0 === basePath.indexOf( '/checkout/thank-you/no-site/' ) ||
 		// Avoid confusing the subscription ID for the site ID in gifting checkouts.
-		( basePath.includes( '/gift/' ) && basePath.startsWith( '/checkout/' ) )
+		( basePath.includes( '/gift/' ) && basePath.startsWith( '/checkout/' ) ) ||
+		// Avoid confusing the subscription ID for the site ID in Akismet checkouts.
+		( basePath.includes( '/akismet/' ) && basePath.startsWith( '/checkout/' ) )
 	) {
 		return false;
 	}


### PR DESCRIPTION
All Akismet Checkouts (new purchase and renewal) are site-less and as such should never have a site fragment (slug or ID) in the URL. If a user is logged-out and clicks on an Akismet Renewal CTA in one of their billing emails, they'll be directed to the login page before being redirected to Checkout. That login page will attempt to parse a site ID from the initial Checkout link to present an option to: "or visit [1049562]". Since Akismet renewal URLs don't have a site fragment, but do have a subscription ID, this subscription ID can be misinterpreted as a site link (if a site with the same ID exists) and presented to the user.

This diff returns early for Akismet Checkouts in the function that attempts to parse the site url, causing the visit option to not be shown.

| Before      | After |
| ----------- | ----------- |
| ![Screenshot 2024-01-09 at 9 46 14 AM](https://github.com/Automattic/wp-calypso/assets/942359/c90d0bb4-5337-4065-a8a6-824cc2465b11) | <img width="1552" alt="Screenshot 2024-01-09 at 9 57 11 AM" src="https://github.com/Automattic/wp-calypso/assets/942359/46bb70ea-3705-4fb7-be3b-91ac6b6e347c"> |

Fixes: https://github.com/Automattic/payments-shilling/issues/2292

**To test:**
- make an Akismet purchase (Store Sandbox works best because the subscription IDs are low) by visiting: https://wordpress.com/checkout/akismet/ak_plus_yearly_1
- get the subscription ID for the new purchase from SA or PA
- in an incognito browser, visit: `http://calypso.localhost/checkout/ak_plus_yearly_1/renew/{subscriptionID}`
- verify that you're taken to a login page _without_ an option to visit a site matching the subscription ID
- verify that if you log in to your account, you're redirected to Checkout with the subscription renewal in your cart
- verify that you can complete checkout for the renewal