### PR TITLE
Revert "Hide Google Analytics banner on /stats for Jetpack sites"

### DIFF
--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -79,7 +79,6 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 
 	const showGoogleAnalyticsPromo =
 		! useSelector( isBlockDismissed( EVENT_GOOGLE_ANALYTICS_BANNER_DISMISS ) ) &&
-		! jetpackNonAtomic &&
 		( isFreePlan( currentPlanSlug ) || isPersonalPlan( currentPlanSlug ) );
 
 	const viewEvents = useMemo( () => {


### PR DESCRIPTION
Reverts Automattic/wp-calypso#86164

Reason: Pre-release tests are failing