### PR TITLE
Login Magic link: No domain if unknown provider

### DIFF
--- a/client/login/magic-login/magic-login-email/magic-login-email-wrapper.tsx
+++ b/client/login/magic-login/magic-login-email/magic-login-email-wrapper.tsx
@@ -23,34 +23,35 @@ const knownDomains: MagicEmailDomainInfo[] = [
 	{ domain: 'aol.com', name: 'AOL', url: 'https://mail.aol.com' },
 ];
 
+const getEmailDomain = ( email: string ): MagicEmailDomainInfo[] => {
+	const domainMatch = extractDomainWithExtension( email );
+	return knownDomains.filter( ( e ) => e.domain.toLowerCase() === domainMatch );
+};
+
 export function MagicLoginEmailWrapper( { emailAddress }: MagicLoginEmailWrapperProps ) {
-	const getEmailDomain = ( email: string ): MagicEmailDomainInfo[] => {
-		const domainMatch = extractDomainWithExtension( email );
-		const filteredDomains = knownDomains.filter( ( e ) => e.domain.toLowerCase() === domainMatch );
-
-		// If no matches, we return the known domains.
-		return filteredDomains.length > 0 ? filteredDomains : knownDomains;
-	};
-
 	const logEvent = ( domain: string ) => {
 		recordTracksEvent( 'calypso_magic_login_email_click', { domain } );
 	};
 
-	return (
-		<ul>
-			{ getEmailDomain( emailAddress ).map( ( item: MagicEmailDomainInfo, key: number ) => (
-				<li key={ key }>
-					<a
-						onClick={ () => logEvent( item.name ) }
-						target="_blank"
-						href={ item.url }
-						rel="noreferrer noopener"
-					>
-						<MagicLoginEmail.Icon icon={ item.name.toLocaleLowerCase() } />
-						<MagicLoginEmail.Content mailProviderName={ item.name } />
-					</a>
-				</li>
-			) ) }
-		</ul>
-	);
+	const filteredDomains = getEmailDomain( emailAddress );
+
+	if ( filteredDomains ) {
+		return (
+			<ul>
+				{ filteredDomains.map( ( item: MagicEmailDomainInfo, key: number ) => (
+					<li key={ key }>
+						<a
+							onClick={ () => logEvent( item.name ) }
+							target="_blank"
+							href={ item.url }
+							rel="noreferrer noopener"
+						>
+							<MagicLoginEmail.Icon icon={ item.name.toLocaleLowerCase() } />
+							<MagicLoginEmail.Content mailProviderName={ item.name } />
+						</a>
+					</li>
+				) ) }
+			</ul>
+		);
+	}
 }


### PR DESCRIPTION
Context: p1704713132869389-slack-C9EJ7KSGH

Currently, on the email login confirmation page, we display a link to the customer's webmail if we guess the provider and links to all supported providers if we can't guess the provider.

It can overwhelm users, so let's not display webmail links if we can't guess the provider.

| Before | After |
|--------|--------|
| <img width="466" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/d51ccfe4-5fbd-4013-9ff0-ce99f164da24"> | <img width="478" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/f6815cc6-a47b-485b-b0d6-aa775b56f49d"> |

## Testing

1. Live link
2. Visit `/log-in` and choose `Email me a login link`.
3. Use an email with a known domain and a mail unknown. In the second case you shouldn't see any button to open the mail in a provider

Fixes https://github.com/Automattic/dotcom-forge/issues/5107