### PR TITLE
Hide Google Analytics banner on /stats for Jetpack sites (rebased)

### DIFF
--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -79,6 +79,7 @@ const MiniCarousel = ( { slug, isSitePrivate } ) => {
 
 	const showGoogleAnalyticsPromo =
 		! useSelector( isBlockDismissed( EVENT_GOOGLE_ANALYTICS_BANNER_DISMISS ) ) &&
+		! jetpackNonAtomic &&
 		( isFreePlan( currentPlanSlug ) || isPersonalPlan( currentPlanSlug ) );
 
 	const viewEvents = useMemo( () => {


### PR DESCRIPTION
New version of the reverted one: https://github.com/Automattic/wp-calypso/pull/86164

Slack: p1704807316862129-slack-C82FZ5T4G

## Proposed Changes

Hide Google Analytics banner on /stats for Jetpack sites.

![image](https://github.com/Automattic/wp-calypso/assets/402286/0b8adb31-3297-4748-8886-d56e80146083)

## Testing Instructions

* Using a Jetpack site
* Go to /stats
* You should not see the banner
