### PR TITLE
Manage subscriptions: Replace en.blog with wordpress.com

### DIFF
--- a/client/blocks/reader-site-subscription/site-subscription-subheader.tsx
+++ b/client/blocks/reader-site-subscription/site-subscription-subheader.tsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { Button, __experimentalHStack as HStack } from '@wordpress/components';
 import { numberFormat, useTranslate } from 'i18n-calypso';
 import React from 'react';
@@ -15,7 +16,7 @@ type SiteSubscriptionSubheaderProps = {
 
 const getHostname = ( url: string ) => {
 	try {
-		return new URL( url ).hostname;
+		return new URL( localizeUrl( url ) ).hostname;
 	} catch ( e ) {
 		return '';
 	}

--- a/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
+++ b/client/landing/subscriptions/components/site-subscriptions-list/site-subscription-row.tsx
@@ -1,5 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { Reader, SubscriptionManager } from '@automattic/data-stores';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo, useRef } from 'react';
@@ -101,7 +102,7 @@ const SiteSubscriptionRow = ( {
 
 	const hostname = useMemo( () => {
 		try {
-			return new URL( url ).hostname;
+			return new URL( localizeUrl( url ) ).hostname;
 		} catch ( e ) {
 			return '';
 		}


### PR DESCRIPTION
Related to D134014-code

## Proposed Changes

This function runs the site's URL through the localizeUrl function. This function translates URL's, such as en.blog.wordpress.com to their correct counterpart (wordpress.com/blog).

| Before | After |
|-|-|
| ![CleanShot 2024-01-09 at 16 22 18@2x](https://github.com/Automattic/wp-calypso/assets/528287/90a77c15-29cc-4e55-962c-f735e99e0051) | ![CleanShot 2024-01-09 at 16 22 25@2x](https://github.com/Automattic/wp-calypso/assets/528287/ad35e1f2-5302-483a-9898-4fb321408b55) |
| ![CleanShot 2024-01-09 at 16 21 45@2x](https://github.com/Automattic/wp-calypso/assets/528287/5f956f7f-64c6-4835-9f55-01aca51f4a0e) | ![CleanShot 2024-01-09 at 16 21 52@2x](https://github.com/Automattic/wp-calypso/assets/528287/c163c190-cfe8-43ba-8829-6e54f5e6c5d2) |

## Testing Instructions

1. Make sure you're subscribed to en.blog
2. Visit `https://wordpress.com/read/subscriptions` and verify that the hostname displayed is `en.blog.wordpress.com`
3. Click the title to go to the detail. Confirm that the hostname displayed is `en.blog.wordpress.com`
4. Start Calypso
5. Visit `http://localhost:3000/read/subscriptions` and verify that the hostname displayed is `wordpress.com`
3. Click the title to go to the detail. Confirm that the hostname displayed is `wordpress.com`

Check other subscriptions for regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?