### PR TITLE
blogging prompts modal - fix missing SVGs

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/blogging-prompts-modal/icons.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/blogging-prompts-modal/icons.js
@@ -1,0 +1,13 @@
+import { Path, SVG } from '@wordpress/components';
+
+export const ArrowRightIcon = () => (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24">
+		<Path d="M12 4l-1.41 1.41L16.17 11H4v2h12.17l-5.58 5.59L12 20l8-8-8-8z" />
+	</SVG>
+);
+
+export const ArrowLeftIcon = () => (
+	<SVG xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24">
+		<Path d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z" />
+	</SVG>
+);

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/blogging-prompts-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/blogging-prompts-modal/index.js
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Gridicon } from '@automattic/components';
 import apiFetch from '@wordpress/api-fetch';
 import { createBlock } from '@wordpress/blocks';
 import { Button, Modal } from '@wordpress/components';
@@ -8,6 +7,7 @@ import { addQueryArgs, getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { useEffect, useState } from 'react';
+import { ArrowLeftIcon, ArrowRightIcon } from './icons';
 
 import './style.scss';
 
@@ -73,7 +73,7 @@ export const BloggingPromptsModalInner = () => {
 						variant="secondary"
 						className="blogging-prompts-modal__prompt-navigation-button"
 					>
-						<Gridicon icon="arrow-left" size={ 18 } />
+						<ArrowLeftIcon />
 					</Button>
 					<h2 className="blogging-prompts-modal__prompt-text">{ prompts[ promptIndex ]?.text }</h2>
 					<Button
@@ -82,7 +82,7 @@ export const BloggingPromptsModalInner = () => {
 						variant="secondary"
 						className="blogging-prompts-modal__prompt-navigation-button"
 					>
-						<Gridicon icon="arrow-right" size={ 18 } />
+						<ArrowRightIcon />
 					</Button>
 				</div>
 				<Button onClick={ selectPrompt } variant="secondary">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/pull/84254

## Proposed Changes

* Adds SVGs directly to ETK so they can work in produtcion.

We just shipped https://github.com/Automattic/wp-calypso/pull/84254. The Icons worked in testing with sandboxing, but as soon as it hit production the icons are gone.  This is because while sandboxing the site URL, the request for the icon goes to the site which has this. When not sandboxing the site URL, the request goes to s0.wp.com which does not return the icon. Looking in ETK, it seems we are defining SVGs locally to supply them to our components. I have instead added these SVGs locally and removed the gridicon components.

BEFORE:
<img width="686" alt="Screenshot 2024-01-09 at 10 26 48 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/38f15081-f065-42ca-bbec-7f6ab139bea1">

AFTER:
<img width="650" alt="Screenshot 2024-01-09 at 10 26 09 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/faaae0e4-32f3-4240-a7c1-0fe070e4cb8e">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sync these changes of ETK to your sandbox
* sandbox the site URL and public-api
* open the post editor with added param `new_prompt=true`
* verify the modal that appears has arrows
* inspect the arrow SVG and verify that the path is from a local source and not requested from an external URL:
<img width="345" alt="Screenshot 2024-01-09 at 10 26 23 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/d7a6bf06-e261-4d7d-ac9c-91319f819e62">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
