### PR TITLE
Checkout: Remove misleading Tracks events for purchases

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -622,7 +622,6 @@ export default function CheckoutMain( {
 		disabledThankYouPage,
 		siteSlug: updatedSiteSlug,
 		sitelessCheckoutType,
-		checkoutFlow,
 		connectAfterCheckout,
 		adminUrl,
 		fromSiteSlug,

--- a/packages/composite-checkout/src/components/form-and-transaction-event-handler.ts
+++ b/packages/composite-checkout/src/components/form-and-transaction-event-handler.ts
@@ -157,7 +157,7 @@ function useCallStatusChangeCallbacks( {
 			formStatus !== prevFormStatus.current
 		) {
 			debug( "form status changed to complete so I'm calling onPaymentComplete" );
-			paymentCompleteRef.current( { paymentMethodId, transactionLastResponse } );
+			paymentCompleteRef.current( { transactionLastResponse } );
 		}
 		prevFormStatus.current = formStatus;
 	}, [ formStatus, transactionLastResponse, paymentMethodId ] );
@@ -169,7 +169,7 @@ function useCallStatusChangeCallbacks( {
 			transactionStatus !== prevTransactionStatus.current
 		) {
 			debug( "transaction status changed to redirecting so I'm calling onPaymentRedirect" );
-			paymentRedirectRef.current( { paymentMethodId, transactionLastResponse } );
+			paymentRedirectRef.current( { transactionLastResponse } );
 		}
 		if (
 			paymentErrorRef.current &&

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -140,7 +140,6 @@ export type StepChangedEventArguments = {
 };
 
 export type PaymentEventCallbackArguments = {
-	paymentMethodId: string | null;
 	transactionLastResponse: PaymentProcessorResponseData;
 };
 


### PR DESCRIPTION
## Proposed Changes

In this diff we remove two Tracks events, `calypso_checkout_payment_success`, and `calypso_checkout_composite_payment_complete`, which were misleading. Their names suggest that they record completed payments, but they only record completed payments which run the function returned by `useCreatePaymentCompleteCallback()`. That function is only run when a purchase completes synchronously, and is not run for purchases that use redirects to external sites (eg: PayPal) as part of their flow.

Part of https://github.com/Automattic/payments-shilling/issues/2301

## Testing Instructions

None should be required. TS will guard against errors.