### PR TITLE
Marketplace Reviews: Add new review from modal

### DIFF
--- a/client/data/marketplace/use-marketplace-reviews.ts
+++ b/client/data/marketplace/use-marketplace-reviews.ts
@@ -311,7 +311,7 @@ export const useCreateMarketplaceReviewMutation = ( {
 	const queryClient = useQueryClient();
 	const queryKeyPrefix = [ queryKeyBase, productType, slug ];
 
-	return useMutation( {
+	return useMutation< MarketplaceReviewResponse, ErrorResponse, MarketplaceReviewBody >( {
 		mutationFn: createReview,
 		onSuccess: () => {
 			queryClient.invalidateQueries( { queryKey: queryKeyPrefix } );

--- a/client/my-sites/marketplace/components/review-item/index.tsx
+++ b/client/my-sites/marketplace/components/review-item/index.tsx
@@ -25,7 +25,7 @@ import { getCurrentUser, getCurrentUserId } from 'calypso/state/current-user/sel
 import './style.scss';
 
 type MarketplaceReviewItemProps = {
-	review?: MarketplaceReviewResponse;
+	review: MarketplaceReviewResponse;
 } & MarketplaceReviewsQueryProps;
 
 export const MarketplaceReviewItem = ( props: MarketplaceReviewItemProps ) => {
@@ -90,10 +90,6 @@ export const MarketplaceReviewItem = ( props: MarketplaceReviewItemProps ) => {
 		);
 		clearEditing();
 	};
-
-	if ( ! review ) {
-		return null;
-	}
 
 	return (
 		<div className="marketplace-review-item__review-container" key={ `review-${ review.id }` }>
@@ -226,8 +222,6 @@ export const MarketplaceReviewItem = ( props: MarketplaceReviewItemProps ) => {
 	);
 };
 
-const THANK_YOU_ANIMATION_DURATION = 5000; // in ms
-
 export function MarketplaceCreateReviewItem( props: ProductDefinitionProps ) {
 	const { productType, slug } = props;
 	const translate = useTranslate();
@@ -238,7 +232,7 @@ export function MarketplaceCreateReviewItem( props: ProductDefinitionProps ) {
 	const [ showThankYouSection, setShowThankYouSection ] = useState( false );
 	const [ showContentArea, setShowContentArea ] = useState( false );
 
-	const { data: userReviews } = useMarketplaceReviewsQuery( {
+	const { data: userReviews, isFetching: isFetchingUserReviews } = useMarketplaceReviewsQuery( {
 		productType,
 		slug,
 		perPage: 1,
@@ -264,10 +258,6 @@ export function MarketplaceCreateReviewItem( props: ProductDefinitionProps ) {
 				onSuccess: () => {
 					resetFields();
 					setShowThankYouSection( true );
-
-					setTimeout( () => {
-						setShowThankYouSection( false );
-					}, THANK_YOU_ANIMATION_DURATION );
 				},
 			}
 		);
@@ -277,6 +267,11 @@ export function MarketplaceCreateReviewItem( props: ProductDefinitionProps ) {
 		setRating( value );
 		setShowContentArea( true );
 	};
+
+	// Hide the Thank You section if user removed their review
+	if ( ! userReviews?.length && ! isFetchingUserReviews && showThankYouSection ) {
+		setShowThankYouSection( false );
+	}
 
 	if ( !! userReviews?.length && ! showThankYouSection ) {
 		return null;
@@ -352,7 +347,7 @@ export function MarketplaceCreateReviewItem( props: ProductDefinitionProps ) {
 						<h2>{ translate( 'Thank you for your feedback!' ) }</h2>
 						<div className="marketplace-create-review-item__thank-you-subtitle">
 							{ translate(
-								'Your review is currently under moderation and will notify you once your feedback is published.'
+								'We appreciate you sharing your experience with this plugin! Your review will help to guide other users.'
 							) }
 						</div>
 					</div>

--- a/client/my-sites/marketplace/components/review-item/style.scss
+++ b/client/my-sites/marketplace/components/review-item/style.scss
@@ -2,7 +2,8 @@ $profile-picture-size: 36px;
 $border-color: #eee;
 
 
-.marketplace-review-item__review-container {
+.marketplace-review-item__review-container,
+.marketplace-create-review-item__container {
 	border-top: 1px solid $border-color;
 	padding: 32px 0;
 
@@ -22,6 +23,7 @@ $border-color: #eee;
 		.marketplace-review-item__rating-data {
 			display: flex;
 			flex-direction: column;
+			justify-content: center;
 
 			.rating {
 				margin-left: -1px;
@@ -152,4 +154,11 @@ $border-color: #eee;
 		font-size: $font-body-small;
 		line-height: 20px;
 	}
+}
+
+.marketplace-create-review-item__container {
+	margin-top: 32px;
+	padding: 40px;
+	border: 1px solid $border-color;
+	border-radius: 9px; /* stylelint-disable-line scales/radii */
 }

--- a/client/my-sites/marketplace/components/review-item/style.scss
+++ b/client/my-sites/marketplace/components/review-item/style.scss
@@ -162,3 +162,26 @@ $border-color: #eee;
 	border: 1px solid $border-color;
 	border-radius: 9px; /* stylelint-disable-line scales/radii */
 }
+
+.marketplace-create-review-item__thank-you {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	gap: 8px;
+	text-align: center;
+
+	h2 {
+		font-family: Recoleta, sans-serif;
+		font-size: $font-title-large;
+		line-height: 40px;
+		color: var(--studio-gray-100);
+	}
+
+	.marketplace-create-review-item__thank-you-subtitle {
+		font-family: "SF Pro Text", $sans;
+		font-size: $font-body-small;
+		line-height: 20px;
+		color: var(--studio-gray-60);
+	}
+}

--- a/client/my-sites/marketplace/components/reviews-list/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-list/index.tsx
@@ -61,7 +61,7 @@ export const MarketplaceReviewsList = ( props: MarketplaceReviewsQueryProps ) =>
 			<div className="marketplace-reviews-list__customer-reviews">
 				<div className="marketplace-reviews-list__items">
 					{ allReviews.map( ( review: MarketplaceReviewResponse ) => (
-						<MarketplaceReviewItem review={ review } { ...props } />
+						<MarketplaceReviewItem key={ review.id } review={ review } { ...props } />
 					) ) }
 				</div>
 				<InfiniteScroll nextPageMethod={ fetchNextPage } />

--- a/client/my-sites/marketplace/components/reviews-modal/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-modal/index.tsx
@@ -57,7 +57,6 @@ export const ReviewsModal = ( props: Props ) => {
 	const hasActiveSubscription = useSelector( ( state: AppState ) =>
 		hasActivePluginSubscription( state, variations )
 	);
-	const askForReview = canPublishReview && ! userHasReviewed;
 
 	const { ratings_average: averageRating, ratings_count: numberOfReviews } = reviewsStats || {};
 	const normalizedRating = ( ( averageRating ?? 0 ) * 100 ) / 5; // Normalize to 100
@@ -103,15 +102,10 @@ export const ReviewsModal = ( props: Props ) => {
 								</div>
 							</div>
 						</div>
-						{ askForReview && (
-							<div className="marketplace-reviews-modal__summary-button">
-								<Button primary onClick={ () => alert( 'Not implemented yet' ) }>
-									{ translate( 'Leave my review' ) }
-								</Button>
-							</div>
-						) }
+
 						{ /* TODO: Add theme purchase */ }
-						{ ! askForReview &&
+						{ ! canPublishReview &&
+							! userHasReviewed &&
 							! hasActiveSubscription &&
 							isMarketplacePlugin &&
 							selectedSite?.slug && (

--- a/client/my-sites/marketplace/components/reviews-modal/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-modal/index.tsx
@@ -131,9 +131,8 @@ export const ReviewsModal = ( props: Props ) => {
 					</div>
 				) }
 
-				{ ! userHasReviewed && (
-					<MarketplaceCreateReviewItem productType={ productType } slug={ slug } />
-				) }
+				<MarketplaceCreateReviewItem productType={ productType } slug={ slug } />
+
 				<div className="marketplace-reviews-modal__reviews-list">
 					<MarketplaceReviewsList productType={ productType } slug={ slug } />
 				</div>

--- a/client/my-sites/marketplace/components/reviews-modal/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-modal/index.tsx
@@ -20,6 +20,7 @@ import {
 import { getProductsList, isMarketplaceProduct } from 'calypso/state/products-list/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
+import { MarketplaceCreateReviewItem } from '../review-item';
 
 type Props = {
 	isVisible: boolean;
@@ -130,7 +131,9 @@ export const ReviewsModal = ( props: Props ) => {
 					</div>
 				) }
 
-				{ /* TODO: Add the review creation section */ }
+				{ ! userHasReviewed && (
+					<MarketplaceCreateReviewItem productType={ productType } slug={ slug } />
+				) }
 				<div className="marketplace-reviews-modal__reviews-list">
 					<MarketplaceReviewsList productType={ productType } slug={ slug } />
 				</div>

--- a/packages/components/src/confetti/index.ts
+++ b/packages/components/src/confetti/index.ts
@@ -29,7 +29,7 @@ function fireConfetti( colors: string[] ) {
 				spread: scale * opts.spread,
 				scalar: opts.scalar ? scale * opts.scalar : scale,
 				// counter react-modal very high z index, always render the confetti on top
-				zIndex: 100000,
+				zIndex: 1000000,
 			} )
 		);
 	}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5023

## Proposed Changes

* Create the `MarketplaceCreateReviewItem` to add reviews from the modal
  * Its based and its on the same file as  `MarketplaceReviewItem` to reuse common components
* Remove the `Leave my review` CTA
* Increase confetti z-index to be shown on top of the modal


![CleanShot 2024-01-09 at 11 40 40](https://github.com/Automattic/wp-calypso/assets/5039531/912ddf89-6c97-4bef-b6e9-a529f02f86b5)


## Testing Instructions

* Go to the plugin details page where you don't have reviews. Ex: `/plugins/woocommerce-subscriptions/`
* Scroll down and click on `Read all reviews`
* You should see the section to add a new review
* Click on the stars and fill your comment
* Click on `Leave my review`
* You should see the Thank You section, confetti on the page and your review on the list (possibly as pending)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
