### PR TITLE
Plugin Details: Open Reviews modal by clicking the number of reviews

### DIFF
--- a/client/my-sites/marketplace/components/reviews-cards/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-cards/index.tsx
@@ -1,7 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { forwardRef } from 'react';
 import { useSelector } from 'react-redux';
 import {
 	useMarketplaceReviewsQuery,
@@ -13,72 +12,70 @@ import './style.scss';
 
 type MarketplaceReviewsCardsProps = { showMarketplaceReviews?: () => void } & ProductProps;
 
-export const MarketplaceReviewsCards = forwardRef< HTMLDivElement, MarketplaceReviewsCardsProps >(
-	( props, ref ) => {
-		const translate = useTranslate();
-		const currentUserId = useSelector( getCurrentUserId );
-		const { data: userReviews = [] } = useMarketplaceReviewsQuery( {
-			...props,
-			perPage: 1,
-			author: currentUserId ?? undefined,
-			status: 'all',
-		} );
-		const { data: reviews, error } = useMarketplaceReviewsQuery( {
-			...props,
-			perPage: 2,
-			page: 1,
-		} );
+export const MarketplaceReviewsCards = ( props: MarketplaceReviewsCardsProps ) => {
+	const translate = useTranslate();
+	const currentUserId = useSelector( getCurrentUserId );
+	const { data: userReviews = [] } = useMarketplaceReviewsQuery( {
+		...props,
+		perPage: 1,
+		author: currentUserId ?? undefined,
+		status: 'all',
+	} );
+	const { data: reviews, error } = useMarketplaceReviewsQuery( {
+		...props,
+		perPage: 2,
+		page: 1,
+	} );
 
-		if ( ! isEnabled( 'marketplace-reviews-show' ) ) {
-			return null;
-		}
+	if ( ! isEnabled( 'marketplace-reviews-show' ) ) {
+		return null;
+	}
 
-		if ( ! Array.isArray( reviews ) || error ) {
-			return null;
-		}
+	if ( ! Array.isArray( reviews ) || error ) {
+		return null;
+	}
 
-		const hasReview = userReviews.length > 0;
-		const addLeaveAReviewCard = ! hasReview && reviews.length < 2;
+	const hasReview = userReviews.length > 0;
+	const addLeaveAReviewCard = ! hasReview && reviews.length < 2;
 
-		const addEmptyCard = reviews.length === 0;
+	const addEmptyCard = reviews.length === 0;
 
-		return (
-			<div ref={ ref } className="marketplace-reviews-cards__container">
-				<div className="marketplace-reviews-cards__reviews">
-					<h2 className="marketplace-reviews-cards__reviews-title">
-						{ translate( 'Customer reviews' ) }
-					</h2>
-					<h3 className="marketplace-reviews-cards__reviews-subtitle">
-						{ translate( 'What other users are saying' ) }
-					</h3>
+	return (
+		<div className="marketplace-reviews-cards__container">
+			<div className="marketplace-reviews-cards__reviews">
+				<h2 className="marketplace-reviews-cards__reviews-title">
+					{ translate( 'Customer reviews' ) }
+				</h2>
+				<h3 className="marketplace-reviews-cards__reviews-subtitle">
+					{ translate( 'What other users are saying' ) }
+				</h3>
 
-					<div className="marketplace-reviews-cards__read-all">
-						<Button
-							className="is-link"
-							borderless
-							primary
-							onClick={ () => props.showMarketplaceReviews && props.showMarketplaceReviews() }
-							href=""
-						>
-							{ translate( 'Read all reviews' ) }
-						</Button>
-					</div>
-				</div>
-
-				<div className="marketplace-reviews-cards__content">
-					{ reviews.map( ( review ) => (
-						<MarketplaceReviewCard review={ review } key={ review.id } />
-					) ) }
-					{ addEmptyCard && <MarketplaceReviewCard empty={ true } key="empty-card" /> }
-					{ addLeaveAReviewCard && (
-						<MarketplaceReviewCard
-							leaveAReview={ true }
-							key="leave-a-review-card"
-							showMarketplaceReviews={ props.showMarketplaceReviews }
-						/>
-					) }
+				<div className="marketplace-reviews-cards__read-all">
+					<Button
+						className="is-link"
+						borderless
+						primary
+						onClick={ () => props.showMarketplaceReviews && props.showMarketplaceReviews() }
+						href=""
+					>
+						{ translate( 'Read all reviews' ) }
+					</Button>
 				</div>
 			</div>
-		);
-	}
-);
+
+			<div className="marketplace-reviews-cards__content">
+				{ reviews.map( ( review ) => (
+					<MarketplaceReviewCard review={ review } key={ review.id } />
+				) ) }
+				{ addEmptyCard && <MarketplaceReviewCard empty={ true } key="empty-card" /> }
+				{ addLeaveAReviewCard && (
+					<MarketplaceReviewCard
+						leaveAReview={ true }
+						key="leave-a-review-card"
+						showMarketplaceReviews={ props.showMarketplaceReviews }
+					/>
+				) }
+			</div>
+		</div>
+	);
+};

--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -1,13 +1,11 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Badge, Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useMarketplaceReviewsQuery } from 'calypso/data/marketplace/use-marketplace-reviews';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
 import { preventWidows } from 'calypso/lib/formatting';
-import scrollTo from 'calypso/lib/scroll-to';
 import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
 import PluginRatings from 'calypso/my-sites/plugins/plugin-ratings/';
 import { useLocalizedPlugins } from 'calypso/my-sites/plugins/utils';
@@ -20,7 +18,7 @@ const PluginDetailsHeader = ( {
 	plugin,
 	isPlaceholder,
 	isJetpackCloud,
-	reviewsListRef = null,
+	onReviewsClick = () => {},
 } ) => {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
@@ -35,13 +33,6 @@ const PluginDetailsHeader = ( {
 		slug: plugin.slug,
 	} );
 	const numberOfReviews = marketplaceReviews?.length || 0;
-	const scrollToReviews = useCallback( () => {
-		scrollTo( {
-			x: 0,
-			y: reviewsListRef?.current?.offsetTop - 50,
-			duration: 1000,
-		} );
-	}, [ reviewsListRef ] );
 
 	if ( isPlaceholder ) {
 		return <PluginDetailsHeaderPlaceholder />;
@@ -93,7 +84,7 @@ const PluginDetailsHeader = ( {
 								<Button
 									borderless
 									className="plugin-details-header__number-reviews-link is-link"
-									onClick={ scrollToReviews }
+									onClick={ onReviewsClick }
 								>
 									{ translate( '%(numberOfReviews)d review', '%(numberOfReviews)d reviews', {
 										count: numberOfReviews,

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -4,7 +4,7 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
@@ -92,7 +92,6 @@ function PluginDetails( props ) {
 	const requestingPluginsForSites = useSelector( ( state ) => isRequestingForAllSites( state ) );
 	const analyticsPath = selectedSite ? '/plugins/:plugin/:site' : '/plugins/:plugin';
 	const isLoggedIn = useSelector( isUserLoggedIn );
-	const reviewsListRef = useRef();
 	const { localizePath } = useLocalizedPlugins();
 
 	// Plugin information.
@@ -388,7 +387,7 @@ function PluginDetails( props ) {
 						<PluginDetailsHeader
 							plugin={ fullPlugin }
 							isPlaceholder={ showPlaceholder }
-							reviewsListRef={ reviewsListRef }
+							onReviewsClick={ () => setIsReviewsModalVisible( true ) }
 						/>
 					</div>
 					<div className="plugin-details__content">
@@ -475,7 +474,6 @@ function PluginDetails( props ) {
 						slug={ fullPlugin.slug }
 						productType="plugin"
 						showMarketplaceReviews={ () => setIsReviewsModalVisible( true ) }
-						ref={ reviewsListRef }
 					/>
 				</div>
 			) }


### PR DESCRIPTION


## Proposed Changes

Update the reviews anchor to open the Reviews modal.
Before this change, the page was scrolling to the Reviews section.

## Testing Instructions

* with the feature flag enabled `marketplace-reviews-show`
* Open a plugin details page with reviews. Ex: `/plugins/woocommerce-subscriptions`
* Click on the reviews number below the review average
* The reviews modal should open

![CleanShot 2024-01-09 at 12 04 50](https://github.com/Automattic/wp-calypso/assets/5039531/18d33484-9f25-4bb6-999a-792eea45a775)
