### PR TITLE
Domains: Fix auto-renewal toggle not shown on `Domain Settings` page in certain cases

### DIFF
--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -727,9 +727,12 @@ const Settings = ( {
 	return (
 		// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 		<Main wideLayout className="domain-settings-page">
-			{ selectedSite?.ID && ! purchase && <QuerySitePurchases siteId={ selectedSite?.ID } /> }
+			{ selectedSite?.ID && <QuerySitePurchases siteId={ selectedSite?.ID } /> }
+
 			<BodySectionCssClass bodyClass={ [ 'edit__body-white' ] } />
+
 			{ renderHeader() }
+
 			<TwoColumnsLayout content={ renderMainContent() } sidebar={ renderSettingsCards() } />
 		</Main>
 	);


### PR DESCRIPTION
This pull request seeks to address https://github.com/Automattic/nomado-issues/issues/606, and more specifically fix a placeholder that would be displayed forever instead of the auto-renewal toggle on the `Domain Settings` page, when coming from the `Domains` page. The `Renew now` button would also stay disabled:

![image](https://github.com/Automattic/wp-calypso/assets/594356/9eca0bd9-91ab-4be5-b6a8-b0a64f81aa2b)

The underlying issue is that the `Domain Settings` page expects a list of _site_ purchases, and will fetch it if no purchase for the domain could be found in the global state tree. However, if a user loads the `Domains` page first, the latter will fetch _user_ purchases and will store them in this tree. Before that pull request, navigating to the `Domain Settings` page would not reload the list of _site_ purchases because a purchase would be available in the tree. However, several components from that page check that _site_ purchases (and not _user_ purchases) have been loaded to show/hide placeholders and enable/disable buttons.

The fix here is quite simple - we will no longer check if a purchase is available from the global state tree to fetch _site_ purchases. The downside is that this will trigger a request even if that purchase has already been loaded.

I tried to consider a different approach in order to avoid that but this would require additional discussions to better understand certain choices: e.g. why do we load _user_ purchases instead of _site_ purchases on the `Domains` page? I suspect it's to be able to support the `All sites` view but then in that case we should update the `Domain Settings` page to support that use case. Finally, is it better (in term of user experience) to show a placeholder/disable buttons instead of showing data/enabling buttons when some data is being refetched, i.e. even if we have already loaded that data?

#### Testing instructions

1. Run `git checkout fix/auto-renew-status-on-domain-settings-page` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/86180#issuecomment-1883405200)
2. Log into a WordPress.com account with a domain
3. Open the [`Domains` page](http://calypso.localhost:3000/domains/manage) of a site
4. Click a domain to access the `Domain Settings` page
5. Assert that the auto-renewal toggle is shown
6. Assert that the `Renew now` button is enabled
7. Reload the page, and repeat the two last steps