### PR TITLE
Add title and description of the new, hidden Affiliate mailing list

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -96,6 +96,8 @@ class MainComponent extends Component {
 			return this.props.translate( 'Research' );
 		} else if ( 'community' === category ) {
 			return this.props.translate( 'Community' );
+		} else if ( 'affiliates' === category ) {
+			return this.props.translate( 'Affiliates' );
 		} else if ( 'digest' === category ) {
 			return this.props.translate( 'Digests' );
 		} else if ( 'news' === category ) {
@@ -136,6 +138,10 @@ class MainComponent extends Component {
 		} else if ( 'community' === category ) {
 			return this.props.translate(
 				'Information on WordPress.com courses and events (online and in-person).'
+			);
+		} else if ( 'affiliates' === category ) {
+			return this.props.translate(
+				'Communications regarding the refer.wordpress.com affiliate program.'
 			);
 		} else if ( 'digest' === category ) {
 			return this.props.translate( 'Popular content from the blogs you follow.' );


### PR DESCRIPTION
Related to D134026.

## Proposed Changes

This change aims to add a proper name and description to the recently implemented Affiliates mailing list, as requested by stakeholders. Provided labels:

Title: **Affiliates**
Description: **Communications regarding the refer.wordpress.com affiliate program**

## Testing Instructions

Visit [a previously-generated unsubscribe URL](http://calypso.localhost:3000/mailing-lists/unsubscribe?category=affiliates&email=fabiocchetti%40automattic.com&hmac=4a88d8cbf5922b839d32fd3986b7e93c). Confirm that the subscribe and resubscribe actions work, and that the title and description of the message are correctly displayed as follows.

<img width="1400" alt="Screenshot 2024-01-09 at 17 49 22" src="https://github.com/Automattic/wp-calypso/assets/24655386/799ce4fe-d8a6-49c6-829c-c138be8fbe4f">

Please note that this mailing list won't be displayed in the notifications page. This has already been discussed and agreed on the above mentioned P2, as the impacted audience size is relatively low.