### PR TITLE
GF Signup: Dropdown Interval: Switch on feature flag for dropdown interval

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -145,7 +145,7 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-light": false,
 		"onboarding/import-redirect-to-themes": true,
-		"onboarding/interval-dropdown": false,
+		"onboarding/interval-dropdown": true,
 		"p2/p2-plus": true,
 		"page/export": true,
 		"pattern-assembler/v2": false,

--- a/config/production.json
+++ b/config/production.json
@@ -112,7 +112,7 @@
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-redirect-to-themes": true,
-		"onboarding/interval-dropdown": false,
+		"onboarding/interval-dropdown": true,
 		"p2/p2-plus": true,
 		"pattern-assembler/v2": false,
 		"plans/hosting-trial": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -107,7 +107,7 @@
 		"onboarding/import-from-wix": true,
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-redirect-to-themes": true,
-		"onboarding/interval-dropdown": false,
+		"onboarding/interval-dropdown": true,
 		"p2/p2-plus": true,
 		"page/export": true,
 		"pattern-assembler/v2": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -117,7 +117,7 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-light": false,
 		"onboarding/import-redirect-to-themes": true,
-		"onboarding/interval-dropdown": false,
+		"onboarding/interval-dropdown": true,
 		"p2/p2-plus": true,
 		"pattern-assembler/v2": false,
 		"plans/hosting-trial": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Fixes Automattic/growth-foundations#296

## Proposed Changes

### Ships following changes which were behind a feature flag to production.

- https://github.com/Automattic/wp-calypso/pull/84988
- https://github.com/Automattic/wp-calypso/pull/84777
- https://github.com/Automattic/wp-calypso/pull/84895
- https://github.com/Automattic/wp-calypso/pull/85158
- https://github.com/Automattic/wp-calypso/pull/85520
- https://github.com/Automattic/wp-calypso/pull/84895
- https://github.com/Automattic/wp-calypso/pull/86071
- https://github.com/Automattic/wp-calypso/pull/86121
- (Iterated on later) https://github.com/Automattic/wp-calypso/pull/86127


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?