### PR TITLE
Manage: update more about links to licenses page

### DIFF
--- a/client/jetpack-cloud/sections/overview/primary/product-grid/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/product-grid/index.tsx
@@ -27,7 +27,7 @@ const ProductGrid: React.FC< Props > = ( { products } ) => {
 	return (
 		<ul className="overview-products__items">
 			{ products.map( ( productData: ProductData ) => {
-				if ( productData.data === undefined ) {
+				if ( ! productData.data ) {
 					return null;
 				}
 				return (

--- a/client/jetpack-cloud/sections/overview/primary/product-grid/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/product-grid/index.tsx
@@ -1,3 +1,4 @@
+import page from '@automattic/calypso-router';
 import { ProductData } from 'calypso/jetpack-cloud/sections/overview/primary/overview-products/jetpack-products';
 import ProductItem from 'calypso/jetpack-cloud/sections/overview/primary/product-grid/product-item';
 import { useDispatch } from 'calypso/state';
@@ -12,8 +13,10 @@ interface Props {
 const ProductGrid: React.FC< Props > = ( { products } ) => {
 	const dispatch = useDispatch();
 
-	// Track the More About click
+	// Open the product lightbox and track the More About click
 	const onMoreAboutClick = ( product_slug: string ) => {
+		page.show( '/partner-portal/issue-license?show_license_modal=' + product_slug );
+
 		dispatch(
 			recordTracksEvent( 'calypso_jetpack_manage_overview_products_more_about_click', {
 				product: product_slug,
@@ -24,6 +27,9 @@ const ProductGrid: React.FC< Props > = ( { products } ) => {
 	return (
 		<ul className="overview-products__items">
 			{ products.map( ( productData: ProductData ) => {
+				if ( productData.data === undefined ) {
+					return null;
+				}
 				return (
 					<li key={ productData.data.product_id }>
 						<ProductItem productData={ productData } onMoreAboutClick={ onMoreAboutClick } />

--- a/client/jetpack-cloud/sections/overview/primary/product-grid/product-item.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/product-grid/product-item.tsx
@@ -1,10 +1,10 @@
 import { TERM_MONTHLY } from '@automattic/calypso-products';
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
 import Paid from 'calypso/components/jetpack/card/jetpack-product-card/display-price/paid';
 import { ProductData } from 'calypso/jetpack-cloud/sections/overview/primary/overview-products/jetpack-products';
-import { MoreInfoLink } from 'calypso/my-sites/plans/jetpack-plans/product-store/more-info-link';
 import { SimpleItemCard } from 'calypso/my-sites/plans/jetpack-plans/product-store/simple-item-card';
 import getProductIcon from 'calypso/my-sites/plans/jetpack-plans/product-store/utils/get-product-icon';
-import { PartnerSelectorProduct } from 'calypso/my-sites/plans/jetpack-plans/types';
 
 interface Props {
 	productData: ProductData;
@@ -12,27 +12,26 @@ interface Props {
 }
 
 const ProductItem: React.FC< Props > = ( { productData, onMoreAboutClick } ) => {
+	const translate = useTranslate();
+
 	if ( productData.data === undefined ) {
 		return null;
 	}
 
 	const productSlug = productData.slug ?? '';
 
-	const itemData: PartnerSelectorProduct = {
-		moreAboutUrl: productData.url,
-		shortName: <>{ productData.name }</>,
-		productSlug: productSlug,
-	};
-
 	const displayDescription = (
 		<>
 			{ productData.description } <br />
-			<MoreInfoLink
+			<Button
+				className="more-info-link license-lightbox-link"
 				onClick={ () => onMoreAboutClick( productData.data.slug ) }
-				item={ itemData }
-				isLinkExternal={ true }
-				withIcon={ false }
-			/>
+				plain
+			>
+				{ translate( 'More about {{productName/}}', {
+					components: { productName: <>{ productData.name }</> },
+				} ) }
+			</Button>
 		</>
 	);
 

--- a/client/jetpack-cloud/sections/overview/primary/product-grid/product-item.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/product-grid/product-item.tsx
@@ -14,7 +14,7 @@ interface Props {
 const ProductItem: React.FC< Props > = ( { productData, onMoreAboutClick } ) => {
 	const translate = useTranslate();
 
-	if ( productData.data === undefined ) {
+	if ( ! productData.data ) {
 		return null;
 	}
 

--- a/client/jetpack-cloud/sections/overview/primary/product-grid/style.scss
+++ b/client/jetpack-cloud/sections/overview/primary/product-grid/style.scss
@@ -22,6 +22,9 @@
 
 	.more-info-link {
 		font-size: rem(13px);
+		text-decoration: underline;
+		cursor: pointer;
+		color: var(--color-neutral-100);
 	}
 
 	.simple-item-card__title {


### PR DESCRIPTION
Resolve https://github.com/Automattic/jetpack-manage/issues/197

## Proposed Changes

This PR updates the `More about...` product link on the Overview page. It opens the product lightbox in the`partner-portal/issue-license` page.

## Testing Instructions

- Review the code.
- Check that each product link opens the correct lightbox.
- The browser back button should work and return to the Overview page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
