### PR TITLE
Reader: Fix SSR fetchQuery calls for v5

### DIFF
--- a/client/reader/controller.js
+++ b/client/reader/controller.js
@@ -151,11 +151,12 @@ export function feedDiscovery( context, next ) {
 	if ( ! context.params.feed_id.match( /^\d+$/ ) ) {
 		const url = context.params.feed_id;
 		context.queryClient
-			.fetchQuery(
-				[ 'feed-discovery', url ],
-				() => wpcom.req.get( '/read/feed', { url } ).then( ( res ) => res.feeds[ 0 ].feed_ID ),
-				{ meta: { persist: false } }
-			)
+			.fetchQuery( {
+				queryKey: [ 'feed-discovery', url ],
+				queryFn: () =>
+					wpcom.req.get( '/read/feed', { url } ).then( ( res ) => res.feeds[ 0 ].feed_ID ),
+				meta: { persist: false },
+			} )
 			.then( ( feedId ) => {
 				page.redirect( `/read/feeds/${ feedId }` );
 			} )
@@ -318,11 +319,11 @@ export async function blogDiscoveryByFeedId( context, next ) {
 	// Query the site by feed_id and inject to the context params so that calypso can get correct site
 	// after redirecting the user to log-in page
 	context.queryClient
-		.fetchQuery(
-			[ '/read/feed/', feed_id ],
-			() => wpcom.req.get( `/read/feed/${ feed_id }` ).then( ( res ) => res.blog_ID ),
-			{ meta: { persist: false } }
-		)
+		.fetchQuery( {
+			queryKey: [ '/read/feed/', feed_id ],
+			queryFn: () => wpcom.req.get( `/read/feed/${ feed_id }` ).then( ( res ) => res.blog_ID ),
+			meta: { persist: false },
+		} )
 		.then( ( blog_id ) => {
 			context.params.blog_id = blog_id;
 			next();

--- a/client/reader/tags/controller.tsx
+++ b/client/reader/tags/controller.tsx
@@ -67,17 +67,17 @@ export const fetchTrendingTags = ( context: PageJSContext, next: ( e?: Error ) =
 	const localeSlug = getCurrentUserLocale( context.store.getState() ) || context.lang;
 
 	context.queryClient
-		.fetchQuery(
-			[ 'trending-tags', localeSlug ?? '' ],
-			() => {
+		.fetchQuery( {
+			queryKey: [ 'trending-tags', localeSlug ],
+			queryFn: () => {
 				return wpcom.req.get( '/read/trending/tags', {
 					apiVersion: '1.2',
 					count: '6',
 					lang: localeSlug, // Note: undefined will be omitted by the query string builder.
 				} );
 			},
-			{ staleTime: 86400000 } // 24 hours
-		)
+			staleTime: 86400000, // 24 hours
+		} )
 		.then( ( trendingTags: { tags: TagResult[] } ) => {
 			context.params.trendingTags = trendingTags.tags;
 			next();
@@ -97,16 +97,16 @@ export const fetchAlphabeticTags = ( context: PageJSContext, next: ( e?: Error )
 	const currentUserLocale = getCurrentUserLocale( context.store.getState() );
 
 	context.queryClient
-		.fetchQuery(
-			[ 'alphabetic-tags', currentUserLocale ?? '' ],
-			() => {
+		.fetchQuery( {
+			queryKey: [ 'alphabetic-tags', currentUserLocale ],
+			queryFn: () => {
 				return wpcom.req.get( '/read/tags/alphabetic', {
 					apiVersion: '1.2',
 					lang: currentUserLocale, // Note: undefined will be omitted by the query string builder.
 				} );
 			},
-			{ staleTime: 86400000 } // 24 hours
-		)
+			staleTime: 86400000, // 24 hours
+		} )
 		.then( ( alphabeticTags: AlphabeticTagsResult ) => {
 			context.params.alphabeticTags = alphabeticTags;
 			next();


### PR DESCRIPTION
## Proposed Changes

Fixes SSR queries that we missed in https://github.com/Automattic/wp-calypso/pull/84413 to use the new React Query v5 format.

## Testing Instructions

* Go to `/tags`
* Verify alphabetical tags are loading properly.
* Note: trending tags section might still appear empty - the endpoint returns no trending tags in my testing, so that's expected.
