### PR TITLE
GF Signup: Dropdown Interval: Clean up binnenial toggle flag and introduce interval array

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -143,7 +143,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 				<PlansFeaturesMain
 					isPlansInsideStepper={ true }
 					siteId={ site?.ID }
-					showBiennialToggle={ false }
+					displayedIntervals={ [ 'yearly', '2yearly', '3yearly', 'monthly' ] }
 					hideFreePlan={ hideFreePlan }
 					isInSignup={ isInSignup }
 					isStepperUpgradeFlow={ true }

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -34,9 +34,9 @@ const AddOnOption = styled.a`
 `;
 
 export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
-	const { intervalType } = props;
+	const { intervalType, displayedIntervals } = props;
 	const supportedIntervalType = (
-		[ 'yearly', '2yearly', '3yearly', 'monthly' ].includes( intervalType ) ? intervalType : 'yearly'
+		displayedIntervals.includes( intervalType ) ? intervalType : 'yearly'
 	) as SupportedUrlFriendlyTermType;
 	const optionsList = useIntervalOptions( props );
 

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-toggle.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-toggle.tsx
@@ -16,13 +16,14 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		isInSignup,
 		eligibleForWpcomMonthlyPlans,
 		hideDiscountLabel,
-		showBiennialToggle,
 		currentSitePlanSlug,
 		usePricingMetaForGridPlans,
+		displayedIntervals,
 		title,
 		coupon,
 		selectedSiteId,
 	} = props;
+	const showBiennialToggle = displayedIntervals.includes( '2yearly' );
 	const [ spanRef, setSpanRef ] = useState< HTMLSpanElement >();
 	const segmentClasses = classNames( 'price-toggle', {
 		'is-signup': isInSignup,

--- a/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-interval-options.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-interval-options.tsx
@@ -25,10 +25,11 @@ type IntervalSelectOptionsMap = Record<
 >;
 export default function useIntervalOptions( props: IntervalTypeProps ): IntervalSelectOptionsMap {
 	const translate = useTranslate();
-	let optionList: Record<
+	const { displayedIntervals } = props;
+	const optionList: Record<
 		SupportedUrlFriendlyTermType,
 		{
-			key: string;
+			key: SupportedUrlFriendlyTermType;
 			name: TranslateResult;
 			discountText: TranslateResult;
 			url: string;
@@ -64,9 +65,16 @@ export default function useIntervalOptions( props: IntervalTypeProps ): Interval
 			termInMonths: 1,
 		},
 	};
+
+	let displayedOptionList = Object.fromEntries(
+		Object.entries( optionList ).filter( ( [ , value ] ) =>
+			displayedIntervals.includes( value.key )
+		)
+	) as IntervalSelectOptionsMap;
+
 	const termWiseMaxDiscount = useMaxDiscountsForPlanTerms(
 		props.plans,
-		Object.keys( optionList ) as Array< SupportedUrlFriendlyTermType >,
+		Object.keys( displayedOptionList ) as Array< SupportedUrlFriendlyTermType >,
 		props.usePricingMetaForGridPlans,
 		props.selectedSiteId
 	);
@@ -86,11 +94,11 @@ export default function useIntervalOptions( props: IntervalTypeProps ): Interval
 		isJetpackAppFlow = new URLSearchParams( window.location.search ).get( 'jetpackAppPlans' );
 	}
 
-	optionList = Object.fromEntries(
-		Object.keys( optionList ).map( ( key ) => [
-			key,
+	displayedOptionList = Object.fromEntries(
+		Object.keys( displayedOptionList ).map( ( key ) => [
+			key as SupportedUrlFriendlyTermType,
 			{
-				...optionList[ key as SupportedUrlFriendlyTermType ],
+				...displayedOptionList[ key as SupportedUrlFriendlyTermType ],
 				url: generatePath( props, {
 					intervalType: key,
 					domain: isDomainUpsellFlow,
@@ -106,5 +114,5 @@ export default function useIntervalOptions( props: IntervalTypeProps ): Interval
 		] )
 	) as IntervalSelectOptionsMap;
 
-	return optionList;
+	return displayedOptionList;
 }

--- a/client/my-sites/plans-grid/components/plan-type-selector/types.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/types.ts
@@ -15,7 +15,6 @@ export type PlanTypeSelectorProps = {
 	siteSlug?: string | null;
 	selectedPlan?: string;
 	selectedFeature?: string;
-	showBiennialToggle?: boolean;
 	showPlanTypeSelectorDropdown?: boolean; // feature flag used for the plan selector dropdown
 	isInSignup: boolean;
 	plans: PlanSlug[];
@@ -35,18 +34,19 @@ export type PlanTypeSelectorProps = {
 	 * Coupon code for use in pricing hook usage.
 	 */
 	coupon?: string;
+	displayedIntervals: UrlFriendlyTermType[];
 };
 export type IntervalTypeProps = Pick<
 	PlanTypeSelectorProps,
 	| 'intervalType'
 	| 'selectedSiteId'
+	| 'displayedIntervals'
 	| 'plans'
 	| 'isInSignup'
 	| 'eligibleForWpcomMonthlyPlans'
 	| 'isPlansInsideStepper'
 	| 'hideDiscountLabel'
 	| 'redirectTo'
-	| 'showBiennialToggle'
 	| 'showPlanTypeSelectorDropdown'
 	| 'selectedPlan'
 	| 'selectedFeature'

--- a/client/my-sites/plans-grid/components/test/plan-type-selector.jsx
+++ b/client/my-sites/plans-grid/components/test/plan-type-selector.jsx
@@ -8,6 +8,7 @@ describe( '<PlanTypeSelector />', () => {
 		selectedPlan: PLAN_FREE,
 		hideFreePlan: true,
 		withWPPlanTabs: true,
+		displayedIntervals: [ 'monthly', 'yearly' ],
 		usePricingMetaForGridPlans: () => null,
 	};
 

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -186,7 +186,7 @@ export function generateFlows( {
 			optionalDependenciesInQuery: [ 'coupon' ],
 			props: {
 				plans: {
-					showBiennialToggle: true,
+					displayedIntervals: [ 'yearly', '2yearly', '3yearly' ],
 					/**
 					 * This intent is geared towards customizations related to the paid media flow
 					 * Current customizations are as follows

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -145,6 +145,7 @@ export class PlansStep extends Component {
 					isInSignup={ true }
 					isLaunchPage={ isLaunchPage }
 					intervalType={ intervalType }
+					displayedIntervals={ this.props.displayedIntervals }
 					onUpgradeClick={ ( cartItems ) => this.onSelectPlan( cartItems ) }
 					customerType={ this.getCustomerType() }
 					disableBloggerPlanWithNonBlogDomain={ disableBloggerPlanWithNonBlogDomain } // TODO clk investigate
@@ -156,7 +157,6 @@ export class PlansStep extends Component {
 					hidePremiumPlan={ this.props.hidePremiumPlan }
 					hideEcommercePlan={ this.shouldHideEcommercePlan() }
 					hideEnterprisePlan={ this.props.hideEnterprisePlan }
-					showBiennialToggle={ this.props.showBiennialToggle }
 					removePaidDomain={ this.removePaidDomain }
 					setSiteUrlAsFreeDomainSuggestion={ this.setSiteUrlAsFreeDomainSuggestion }
 					coupon={ coupon }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Injects the plan duration terms to be shown from outside in
* The terms to be shown in `onboarding-pm` flow should not include the monthly term
* Define The default term list shown when not injected
* Remove the shoBinneialToggle

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/onboarding-pm` and make sure 3 terms are shown except the monthly plan ( The discounts are not visible which is a known issue)
* Go to `/start/onboarding` and make sure 4 terms along with three respective discounts are visible

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
