### PR TITLE
GF Signup: Fix plan type selector dropdown width and text alignment

### DIFF
--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -16,7 +16,6 @@ const AddOnOption = styled.a`
 	display: flex;
 	.discount {
 		color: var( --studio-green-50 );
-		display: inline-block;
 		display: flex;
 		line-height: 14px;
 		border-radius: 3px;
@@ -24,7 +23,7 @@ const AddOnOption = styled.a`
 	}
 	.name {
 		margin-right: 4px;
-		line-height: 19px;
+		line-height: 20px;
 	}
 	.is-highlighted & {
 		background-color: #f6f7f7;

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -71,7 +71,7 @@
 }
 
 .plan-type-selector .plan-type-selector__interval-type-dropdown-container {
-	width: 259px;
+	width: 275px;
 	margin: 0 auto;
 	.is-sticky-plan-type-selector & {
 		width: 100%;
@@ -85,6 +85,7 @@
 		}
 		.components-flex {
 			overflow: hidden;
+			width: 100%;
 			.components-input-control__container {
 				background-color: var(--studio-white);
 				.components-custom-select-control__button {

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -81,6 +81,8 @@
 		&,
 		&:visited,
 		&:hover span.name {
+			display: flex;
+			align-items: center;
 			color: var(--color-text);
 		}
 		.components-flex {

--- a/client/my-sites/plans-grid/components/plan-type-selector/style.scss
+++ b/client/my-sites/plans-grid/components/plan-type-selector/style.scss
@@ -81,8 +81,6 @@
 		&,
 		&:visited,
 		&:hover span.name {
-			display: flex;
-			align-items: center;
 			color: var(--color-text);
 		}
 		.components-flex {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the issue.
-->

Related to p1704829372322639/1704736051.206559-slack-C059R8S4ALT

## Proposed Changes

* Widens the plan type selector dropdown to accommodate longer text strings
* Fixes slight mismatch in vertical alignment between plan type name and discount

## Screenshots
### Before
![Screenshot 2024-01-09 at 2 41 34 PM](https://github.com/Automattic/wp-calypso/assets/5414230/e9dd1bd4-4ec4-4ba4-9a31-3079d453ff3f)

### After
<img width="303" alt="Screenshot 2024-01-09 at 1 34 35 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/5817d613-f58a-4eac-a55a-cc99ca7251a6">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /start?flags=onboarding%2Finterval-dropdown
* Make sure the dropdown with term interval appears
* Verify that the 1px vertical misalignment between plan type name and discount has been fixed
* Verify that the width of the plan type dropdown selector when not in mobile view is 275px

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?