### PR TITLE
AI Logo Generator: First logo process

### DIFF
--- a/packages/jetpack-ai-calypso/global.d.ts
+++ b/packages/jetpack-ai-calypso/global.d.ts
@@ -1,0 +1,5 @@
+interface Window {
+	JP_CONNECTION_INITIAL_STATE: {
+		siteSuffix: string;
+	};
+}

--- a/packages/jetpack-ai-calypso/src/constants.ts
+++ b/packages/jetpack-ai-calypso/src/constants.ts
@@ -7,7 +7,3 @@ export const EVENT_PROMPT_ENHANCE = 'calypso_jp_ai_logo_generator_prompt_enhance
 
 // Feature constants
 export const MINIMUM_PROMPT_LENGTH = 10;
-export const DEFAULT_LOGO = {
-	url: 'https://s.w.org/style/images/about/WordPress-logotype-wmark.png',
-	description: 'A publishing company in the form of a greek statue.',
-};

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/first-load-screen.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/first-load-screen.tsx
@@ -9,12 +9,20 @@ import React from 'react';
 import { ImageLoader } from './image-loader';
 import './first-load-screen.scss';
 
-export const FirstLoadScreen: React.FC = () => {
+export const FirstLoadScreen: React.FC< {
+	state?: 'loadingFeature' | 'analyzing' | 'generating';
+} > = ( { state = 'loadingFeature' } ) => {
+	const loadingLabel = __( 'Loading…', 'jetpack' );
+	const analyzingLabel = __( 'Analyzing your site to create the perfect logo…', 'jetpack' );
+	const generatingLabel = __( 'Generating logo…', 'jetpack' );
+
 	return (
 		<div className="jetpack-ai-logo-generator-modal__loading-wrapper">
 			<ImageLoader />
 			<span className="jetpack-ai-logo-generator-modal__loading-message">
-				{ __( 'Analyzing your site to create the perfect logo…', 'jetpack' ) }
+				{ state === 'loadingFeature' && loadingLabel }
+				{ state === 'analyzing' && analyzingLabel }
+				{ state === 'generating' && generatingLabel }
 			</span>
 		</div>
 	);

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
@@ -11,6 +11,7 @@ import { useState, useEffect, useCallback } from 'react';
  * Internal dependencies
  */
 import useLogoGenerator from '../hooks/use-logo-generator';
+import { isLogoHistoryEmpty } from '../lib/logo-storage';
 import { STORE_NAME } from '../store';
 import { FirstLoadScreen } from './first-load-screen';
 import { HistoryCarousel } from './history-carousel';
@@ -37,7 +38,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	>( null );
 	const [ initialPrompt, setInitialPrompt ] = useState< string | undefined >();
 	const [ isFirstCallOnOpen, setIsFirstCallOnOpen ] = useState( true );
-	const { selectedLogo, getAiAssistantFeature, generateFirstPrompt, generateLogo, logos } =
+	const { selectedLogo, getAiAssistantFeature, generateFirstPrompt, generateLogo } =
 		useLogoGenerator();
 	const siteId = siteDetails?.ID;
 
@@ -79,7 +80,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 			const feature = await getFeature();
 
 			// If there is any logo we do not need to generate a first logo again.
-			if ( logos.length > 0 ) {
+			if ( ! isLogoHistoryEmpty( String( siteId ) ) ) {
 				setLoadingState( null );
 				return;
 			}
@@ -95,7 +96,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 			debug( 'Error fetching feature', error );
 			setLoadingState( null );
 		}
-	}, [ loadLogoHistory, siteId, getFeature, logos.length, generateFirstLogo ] );
+	}, [ loadLogoHistory, siteId, getFeature, generateFirstLogo ] );
 
 	const handleApplyLogo = () => {
 		onClose();

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
@@ -6,7 +6,7 @@ import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { external } from '@wordpress/icons';
 import debugFactory from 'debug';
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 /**
  * Internal dependencies
  */
@@ -21,6 +21,8 @@ import './generator-modal.scss';
  * Types
  */
 import type { GeneratorModalProps } from '../../types';
+import type { AiFeatureProps } from '../store/types';
+import type React from 'react';
 
 const debug = debugFactory( 'jetpack-ai-calypso:generator-modal' );
 
@@ -29,33 +31,71 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	onClose,
 	siteDetails,
 } ) => {
-	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	const { setSiteDetails, fetchAiAssistantFeature, loadLogoHistory } = useDispatch( STORE_NAME );
-	const [ isLoading, setIsLoading ] = useState( true );
-	const { selectedLogo } = useLogoGenerator();
+	const [ loadingState, setLoadingState ] = useState<
+		'loadingFeature' | 'analyzing' | 'generating' | null
+	>( null );
+	const [ initialPrompt, setInitialPrompt ] = useState< string | undefined >();
+	const [ isFirstCallOnOpen, setIsFirstCallOnOpen ] = useState( true );
+	const { selectedLogo, getAiAssistantFeature, generateFirstPrompt, generateLogo, logos } =
+		useLogoGenerator();
 	const siteId = siteDetails?.ID;
 
-	useEffect( () => {
-		if ( siteId ) {
-			setSiteDetails( siteDetails );
-		}
-	}, [ siteId, siteDetails, setSiteDetails ] );
+	const getFeature = useCallback( async () => {
+		setLoadingState( 'loadingFeature' );
+		debug( 'Fetching AI assistant feature for site', siteId );
+		await fetchAiAssistantFeature( String( siteId ) );
 
-	useEffect( () => {
-		if ( isOpen ) {
-			if ( siteId ) {
-				debug( 'fetching ai assistant feature for site', siteId );
-				fetchAiAssistantFeature( String( siteId ) );
-				loadLogoHistory( siteId );
+		// Wait for store to update.
+		return new Promise< Partial< AiFeatureProps > >( ( resolve ) => {
+			setTimeout( () => {
+				resolve( getAiAssistantFeature( String( siteId ) ) );
+			}, 100 );
+		} );
+	}, [ fetchAiAssistantFeature, getAiAssistantFeature, siteId ] );
+
+	const generateFirstLogo = useCallback( async () => {
+		try {
+			// First generate the prompt based on the site's data.
+			setLoadingState( 'analyzing' );
+			const prompt = await generateFirstPrompt();
+			setInitialPrompt( prompt );
+
+			// Then generate the logo based on the prompt.
+			setLoadingState( 'generating' );
+			await generateLogo( { prompt } );
+			setLoadingState( null );
+		} catch ( error ) {
+			debug( 'Error generating first logo', error );
+			setLoadingState( null );
+		}
+	}, [ generateFirstPrompt, generateLogo ] );
+
+	const handleModalOpen = useCallback( async () => {
+		loadLogoHistory( siteId );
+
+		// First fetch the feature data so we have the most up-to-date info from the backend.
+		try {
+			const feature = await getFeature();
+
+			// If there is any logo we do not need to generate a first logo again.
+			if ( logos.length > 0 ) {
+				setLoadingState( null );
+				return;
 			}
 
-			setTimeout( () => {
-				setIsLoading( false );
-			}, 1000 );
-		} else {
-			setIsLoading( true );
+			if ( feature?.requireUpgrade ) {
+				// TODO: Show upgrade screen.
+				setLoadingState( null );
+			} else {
+				// If the site does not require an upgrade, generate the first prompt based on the site's data.
+				generateFirstLogo();
+			}
+		} catch ( error ) {
+			debug( 'Error fetching feature', error );
+			setLoadingState( null );
 		}
-	}, [ isOpen, fetchAiAssistantFeature, siteId, loadLogoHistory ] );
+	}, [ loadLogoHistory, siteId, getFeature, logos.length, generateFirstLogo ] );
 
 	const handleApplyLogo = () => {
 		onClose();
@@ -65,6 +105,33 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 			window.location.reload();
 		}, 1000 );
 	};
+
+	// Set site details when siteId changes
+	useEffect( () => {
+		if ( siteId ) {
+			setSiteDetails( siteDetails );
+		}
+	}, [ siteId, siteDetails, setSiteDetails ] );
+
+	// Handles modal opening logic
+	useEffect( () => {
+		if ( ! isOpen || ! siteId ) {
+			return;
+		}
+
+		// Prevent multiple async calls
+		if ( isFirstCallOnOpen ) {
+			setIsFirstCallOnOpen( false );
+			handleModalOpen();
+		}
+	}, [ isOpen, siteId, isFirstCallOnOpen, setIsFirstCallOnOpen, handleModalOpen ] );
+
+	// Reset the modal first call flag
+	useEffect( () => {
+		if ( ! isOpen ) {
+			setIsFirstCallOnOpen( true );
+		}
+	}, [ isOpen ] );
 
 	return (
 		<>
@@ -77,11 +144,11 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 					title={ __( 'Jetpack AI Logo Generator', 'jetpack' ) }
 				>
 					<div className="jetpack-ai-logo-generator-modal__body">
-						{ isLoading ? (
-							<FirstLoadScreen />
+						{ loadingState ? (
+							<FirstLoadScreen state={ loadingState } />
 						) : (
 							<>
-								<Prompt />
+								<Prompt initialPrompt={ initialPrompt } />
 								<LogoPresenter logo={ selectedLogo } onApplyLogo={ handleApplyLogo } />
 								<HistoryCarousel />
 								<div className="jetpack-ai-logo-generator__footer">

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/logo-presenter.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/logo-presenter.tsx
@@ -79,11 +79,16 @@ const UseOnSiteButton: React.FC< { onApplyLogo: () => void } > = ( { onApplyLogo
 };
 
 export const LogoPresenter: React.FC< LogoPresenterProps > = ( {
-	logo,
+	logo = null,
 	loading = false,
 	onApplyLogo,
 } ) => {
 	const { isRequestingImage } = useLogoGenerator();
+
+	if ( ! logo ) {
+		return null;
+	}
+
 	return (
 		<div className="jetpack-ai-logo-generator-modal-presenter">
 			<div className="jetpack-ai-logo-generator-modal-presenter__container">

--- a/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
@@ -6,15 +6,15 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
 import { useCallback } from 'react';
-import wpcomProxyRequest from 'wpcom-proxy-request';
 /**
  * Internal dependencies
  */
-import { stashLogo } from '../lib/logo-storage';
 import { EVENT_PROMPT_SUBMIT } from '../../constants';
+import { stashLogo } from '../lib/logo-storage';
 import { requestJwt } from '../lib/request-token';
 import { saveToMediaLibrary } from '../lib/save-to-media-library';
 import { setSiteLogo } from '../lib/set-site-logo';
+import wpcomLimitedRequest from '../lib/wpcom-limited-request';
 import { STORE_NAME } from '../store';
 /**
  * Types
@@ -88,15 +88,15 @@ Site description: ${ description }`;
 			stream: false,
 		};
 
-		const data = await wpcomProxyRequest< { choices: Array< { message: { content: string } } > } >(
-			{
-				apiNamespace: 'wpcom/v2',
-				path: '/jetpack-ai-query',
-				method: 'POST',
-				token: tokenData.token,
-				body,
-			}
-		);
+		const data = await wpcomLimitedRequest< {
+			choices: Array< { message: { content: string } } >;
+		} >( {
+			apiNamespace: 'wpcom/v2',
+			path: '/jetpack-ai-query',
+			method: 'POST',
+			token: tokenData.token,
+			body,
+		} );
 
 		return data?.choices?.[ 0 ]?.message?.content;
 	};
@@ -199,7 +199,7 @@ User request: ${ prompt }
 			// 	query: `prompt=${ prompt }&token=${ tokenData.token }&response_format=url`,
 			// } );
 		} else {
-			data = await wpcomProxyRequest( {
+			data = await wpcomLimitedRequest( {
 				apiNamespace: 'wpcom/v2',
 				path: '/jetpack-ai-image',
 				method: 'POST',
@@ -242,15 +242,15 @@ For example: user's prompt: A logo for an ice cream shop. Returned prompt: A log
 			stream: false,
 		};
 
-		const data = await wpcomProxyRequest< { choices: Array< { message: { content: string } } > } >(
-			{
-				apiNamespace: 'wpcom/v2',
-				path: '/jetpack-ai-query',
-				method: 'POST',
-				token: tokenData.token,
-				body,
-			}
-		);
+		const data = await wpcomLimitedRequest< {
+			choices: Array< { message: { content: string } } >;
+		} >( {
+			apiNamespace: 'wpcom/v2',
+			path: '/jetpack-ai-query',
+			method: 'POST',
+			token: tokenData.token,
+			body,
+		} );
 
 		return data?.choices?.[ 0 ]?.message?.content;
 	};

--- a/packages/jetpack-ai-calypso/src/logo-generator/lib/logo-storage.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/lib/logo-storage.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_LOGO } from '../../constants';
 /**
  * Types
  */
@@ -21,7 +20,13 @@ export function stashLogo( { siteId, url, description }: SaveToStorageProps ) {
 
 export function getSiteLogoHistory( siteId: string ) {
 	const storedString = localStorage.getItem( `logo-history-${ siteId }` );
-	const storedContent = storedString ? JSON.parse( storedString ) : [ DEFAULT_LOGO ];
+	const storedContent = storedString ? JSON.parse( storedString ) : [];
 
 	return storedContent;
+}
+
+export function isLogoHistoryEmpty( siteId: string ) {
+	const storedContent = getSiteLogoHistory( siteId );
+
+	return storedContent.length === 0;
 }

--- a/packages/jetpack-ai-calypso/src/logo-generator/lib/request-token.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/lib/request-token.ts
@@ -15,8 +15,7 @@ export async function requestJwt( {
 	expirationTime,
 }: RequestTokenOptions = {} ): Promise< TokenDataProps > {
 	// Default values
-	// @ts-expect-error meh
-	const siteId = siteDetails?.ID || window.JP_CONNECTION_INITIAL_STATE.siteSuffix;
+	const siteId = String( siteDetails?.ID || window.JP_CONNECTION_INITIAL_STATE.siteSuffix );
 	expirationTime = expirationTime || JWT_TOKEN_EXPIRATION_TIME;
 
 	const isSimple = ! siteDetails?.is_wpcom_atomic;

--- a/packages/jetpack-ai-calypso/src/logo-generator/lib/request-token.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/lib/request-token.ts
@@ -1,7 +1,13 @@
+/**
+ * External dependencies
+ */
 import debugFactory from 'debug';
-import wpcomProxyRequest from 'wpcom-proxy-request';
+/**
+ * Internal dependencies
+ */
 import { JWT_TOKEN_EXPIRATION_TIME, JWT_TOKEN_ID } from '../../constants';
 import { RequestTokenOptions, TokenDataProps, TokenDataEndpointResponseProps } from '../../types';
+import wpcomLimitedRequest from './wpcom-limited-request';
 
 const debug = debugFactory( 'jetpack-ai-calypso:request-token' );
 
@@ -40,12 +46,12 @@ export async function requestJwt( {
 	let data: TokenDataEndpointResponseProps;
 
 	if ( ! isSimple ) {
-		data = await wpcomProxyRequest( {
+		data = await wpcomLimitedRequest( {
 			path: '/jetpack/v4/jetpack-ai-jwt?_cacheBuster=' + Date.now(),
 			method: 'POST',
 		} );
 	} else {
-		data = await wpcomProxyRequest( {
+		data = await wpcomLimitedRequest( {
 			apiNamespace: 'wpcom/v2',
 			path: '/sites/' + siteId + '/jetpack-openai-query/jwt',
 			method: 'POST',

--- a/packages/jetpack-ai-calypso/src/logo-generator/lib/save-to-media-library.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/lib/save-to-media-library.ts
@@ -1,11 +1,11 @@
 /**
  * External dependencies
  */
-import wpcomProxyRequest from 'wpcom-proxy-request';
+import wpcomLimitedRequest from './wpcom-limited-request';
 /**
  * Types
  */
-import { SaveToMediaLibraryProps, SaveToMediaLibraryResponseProps } from '../../types';
+import type { SaveToMediaLibraryProps, SaveToMediaLibraryResponseProps } from '../../types';
 
 export async function saveToMediaLibrary( { siteId, url, attrs = {} }: SaveToMediaLibraryProps ) {
 	const body = {
@@ -13,7 +13,7 @@ export async function saveToMediaLibrary( { siteId, url, attrs = {} }: SaveToMed
 		attrs: [ attrs ],
 	};
 
-	const response = await wpcomProxyRequest< SaveToMediaLibraryResponseProps >( {
+	const response = await wpcomLimitedRequest< SaveToMediaLibraryResponseProps >( {
 		path: `/sites/${ String( siteId ) }/media/new`,
 		apiVersion: '1.1',
 		body,

--- a/packages/jetpack-ai-calypso/src/logo-generator/lib/set-site-logo.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/lib/set-site-logo.ts
@@ -1,11 +1,11 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import wpcomProxyRequest from 'wpcom-proxy-request';
+import wpcomLimitedRequest from './wpcom-limited-request';
 /**
  * Types
  */
-import { SetSiteLogoProps, SetSiteLogoResponseProps } from '../../types';
+import type { SetSiteLogoProps, SetSiteLogoResponseProps } from '../../types';
 
 export async function setSiteLogo( { siteId, imageId }: SetSiteLogoProps ) {
 	const body = {
@@ -13,7 +13,7 @@ export async function setSiteLogo( { siteId, imageId }: SetSiteLogoProps ) {
 		site_icon: imageId,
 	};
 
-	return wpcomProxyRequest< SetSiteLogoResponseProps >( {
+	return wpcomLimitedRequest< SetSiteLogoResponseProps >( {
 		path: `/sites/${ String( siteId ) }/settings`,
 		apiVersion: 'v2',
 		apiNamespace: 'wp/v2',

--- a/packages/jetpack-ai-calypso/src/logo-generator/lib/wpcom-limited-request.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/lib/wpcom-limited-request.ts
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import wpcomProxyRequest from 'wpcom-proxy-request';
+/**
+ * Types
+ */
+import type { WpcomRequestParams } from 'wpcom-proxy-request';
+
+const MAX_CONCURRENT_REQUESTS = 5;
+
+let concurrentCounter = 0;
+let lastCallTimestamp: number | null = null;
+
+/**
+ * Concurrency-limited request to wpcom-proxy-request.
+ * @param { WpcomRequestParams } params - The request params.
+ * @returns { Promise }                   The response.
+ * @throws { Error }                      If there are too many concurrent requests.
+ */
+export default async function wpcomLimitedRequest< T >( params: WpcomRequestParams ): Promise< T > {
+	concurrentCounter += 1;
+
+	if ( concurrentCounter > MAX_CONCURRENT_REQUESTS ) {
+		concurrentCounter -= 1;
+		throw new Error( 'Too many requests' );
+	}
+
+	const now = Date.now();
+
+	// Check if the last call was made less than 100 milliseconds ago
+	if ( lastCallTimestamp && now - lastCallTimestamp < 100 ) {
+		concurrentCounter -= 1;
+		throw new Error( 'Too many requests' );
+	}
+
+	lastCallTimestamp = now; // Update the timestamp
+
+	return wpcomProxyRequest< T >( params ).finally( () => {
+		concurrentCounter -= 1;
+	} );
+}

--- a/packages/jetpack-ai-calypso/src/logo-generator/store/actions.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/store/actions.ts
@@ -1,11 +1,11 @@
 /**
- * External dependencies
+ * Internal dependencies
  */
-import proxy from 'wpcom-proxy-request';
+import { getSiteLogoHistory } from '../lib/logo-storage';
+import wpcomLimitedRequest from '../lib/wpcom-limited-request';
 /**
  * Types & Constants
  */
-import { getSiteLogoHistory } from '../lib/logo-storage';
 import {
 	ACTION_INCREASE_AI_ASSISTANT_REQUESTS_COUNT,
 	ACTION_REQUEST_AI_ASSISTANT_FEATURE,
@@ -24,6 +24,7 @@ import {
 } from './constants';
 import type { AiFeatureProps, AiAssistantFeatureEndpointResponseProps, Logo } from './types';
 import type { SiteDetails } from '@automattic/data-stores';
+
 /**
  * Map the response from the `sites/$site/ai-assistant-feature`
  * endpoint to the AI Assistant feature props.
@@ -71,7 +72,7 @@ const actions = {
 			dispatch( { type: ACTION_REQUEST_AI_ASSISTANT_FEATURE } );
 
 			try {
-				const response: AiAssistantFeatureEndpointResponseProps = await proxy( {
+				const response: AiAssistantFeatureEndpointResponseProps = await wpcomLimitedRequest( {
 					apiNamespace: 'wpcom/v2',
 					path:
 						'/sites/' + encodeURIComponent( String( siteId ) ) + '/jetpack-ai/ai-assistant-feature',

--- a/packages/jetpack-ai-calypso/src/types.ts
+++ b/packages/jetpack-ai-calypso/src/types.ts
@@ -11,7 +11,7 @@ export interface GeneratorModalProps {
 }
 
 export interface LogoPresenterProps {
-	logo: Logo;
+	logo?: Logo;
 	loading?: boolean;
 	onApplyLogo: () => void;
 }

--- a/packages/jetpack-ai-calypso/test/index.js
+++ b/packages/jetpack-ai-calypso/test/index.js
@@ -13,10 +13,8 @@ import { render, screen } from '@testing-library/react';
 import { GeneratorModal } from '../src';
 
 describe( 'Base', () => {
-	it( 'should render initial message', async () => {
+	it( 'should render modal header', async () => {
 		render( <GeneratorModal isOpen={ true } /> );
-		expect(
-			await screen.findByText( 'Analyzing your site to create the perfect logo…' )
-		).toBeInTheDocument();
+		expect( await screen.findByText( 'Jetpack AI Logo Generator' ) ).toBeInTheDocument();
 	} );
 } );

--- a/packages/jetpack-ai-calypso/tsconfig.json
+++ b/packages/jetpack-ai-calypso/tsconfig.json
@@ -6,5 +6,6 @@
 		"declarationDir": "dist/types",
 		"rootDir": "src"
 	},
+	"files": [ "./global.d.ts" ],
 	"references": [ { "path": "../data-stores" } ]
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/85981

## Proposed Changes

* Adds loading states for the first loader
* Moves the generation function from the prompt component to the hook
* Adds function to generate the first rough prompt based on a website's name and description
* Starts the first generation on modal open when there is no other logo
* Removes the placeholder logo

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set a title and description to your testing site
* Go to the generator modal
* It should generate and set the initial prompt and the first logo
* Close the modal
* Open the modal again
* The ai-feature endpoint should be called once more, without generating another logo

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?