### PR TITLE
Add title and description of the WordPress.com Learn mailing list category

### DIFF
--- a/client/mailing-lists/main.jsx
+++ b/client/mailing-lists/main.jsx
@@ -106,6 +106,8 @@ class MainComponent extends Component {
 			return this.props.translate( 'Promotions' );
 		} else if ( 'reports' === category ) {
 			return this.props.translate( 'Reports' );
+		} else if ( 'learn' === category ) {
+			return this.props.translate( 'Learn Faster to Grow Faster' );
 		} else if ( 'jetpack_marketing' === category ) {
 			return this.props.translate( 'Jetpack Suggestions' );
 		} else if ( 'jetpack_research' === category ) {
@@ -154,6 +156,10 @@ class MainComponent extends Component {
 		} else if ( 'reports' === category ) {
 			return this.props.translate(
 				'Complimentary reports and updates regarding site performance and traffic.'
+			);
+		} else if ( 'learn' === category ) {
+			return this.props.translate(
+				'Take your WordPress.com site to new heights with expert webinars, courses, and community forums.'
 			);
 		} else if ( 'jetpack_marketing' === category ) {
 			return this.props.translate( 'Tips for getting the most out of Jetpack.' );


### PR DESCRIPTION
Related to D122828.

# Proposed Changes
This change adds a proper title and description to the WordPress.com Learn mailing list category. 

Title: Learn Faster to Grow Faster
Description: Take your WordPress.com site to new heights with expert webinars, courses, and community forums.

# Testing Instructions
- Visit [this generated unsubscribe URL](http://calypso.localhost:3000/mailing-lists/unsubscribe?category=learn&email=codefourcomics%40gmail.com&hmac=a8c38788c74b990058fb5033e5527088). 
- Confirm that the subscribe and resubscribe actions work, and that the title and description of the message are correctly displayed as follows.

![CleanShot 2024-01-09 at 17 20 37@2x](https://github.com/Automattic/wp-calypso/assets/135139690/6dabbccb-5d0e-4189-ba56-80b181446b9d)

*Please note that this mailing list won't be displayed on the notifications page. This is a new opt-in mailing list category and the impacted audience size is relatively low.
