### PR TITLE
Wrap CheckoutMain in RazorpayHookProvider

### DIFF
--- a/client/blocks/editor-checkout-modal/index.tsx
+++ b/client/blocks/editor-checkout-modal/index.tsx
@@ -1,10 +1,11 @@
+import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { Modal } from '@wordpress/components';
 import { Icon, wordpress } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import * as React from 'react';
-import { getStripeConfiguration } from 'calypso/lib/store-transactions';
+import { getRazorpayConfiguration, getStripeConfiguration } from 'calypso/lib/store-transactions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import CheckoutMain from 'calypso/my-sites/checkout/src/components/checkout-main';
 import { useSelector } from 'calypso/state';
@@ -70,16 +71,18 @@ const EditorCheckoutModal: React.FunctionComponent< Props > = ( props ) => {
 					fetchStripeConfiguration={ getStripeConfiguration }
 					locale={ translate.localeSlug }
 				>
-					<CheckoutMain
-						redirectTo={ redirectTo } // custom thank-you URL for payments that are processed after a redirect (eg: Paypal)
-						isInModal
-						disabledThankYouPage={ isFocusedLaunch }
-						siteId={ selectedSiteId ?? undefined }
-						siteSlug={ site?.slug }
-						productAliasFromUrl={ commaSeparatedProductSlugs }
-						productSourceFromUrl="editor-checkout-modal"
-						onAfterPaymentComplete={ handleAfterPaymentComplete }
-					/>
+					<RazorpayHookProvider fetchRazorpayConfiguration={ getRazorpayConfiguration }>
+						<CheckoutMain
+							redirectTo={ redirectTo } // custom thank-you URL for payments that are processed after a redirect (eg: Paypal)
+							isInModal
+							disabledThankYouPage={ isFocusedLaunch }
+							siteId={ selectedSiteId ?? undefined }
+							siteSlug={ site?.slug }
+							productAliasFromUrl={ commaSeparatedProductSlugs }
+							productSourceFromUrl="editor-checkout-modal"
+							onAfterPaymentComplete={ handleAfterPaymentComplete }
+						/>
+					</RazorpayHookProvider>
 				</StripeHookProvider>
 			</CalypsoShoppingCartProvider>
 		</Modal>

--- a/client/blocks/upsell-nudge/purchase-modal-wrapper.tsx
+++ b/client/blocks/upsell-nudge/purchase-modal-wrapper.tsx
@@ -1,9 +1,10 @@
+import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { createRequestCartProduct } from '@automattic/shopping-cart';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import { useDispatch } from 'react-redux';
-import { getStripeConfiguration } from 'calypso/lib/store-transactions';
+import { getRazorpayConfiguration, getStripeConfiguration } from 'calypso/lib/store-transactions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import PurchaseModal from 'calypso/my-sites/checkout/purchase-modal';
 import { successNotice } from 'calypso/state/notices/actions';
@@ -30,23 +31,25 @@ export default function PurchaseModalWrapper( {
 				fetchStripeConfiguration={ getStripeConfiguration }
 				locale={ translate.localeSlug }
 			>
-				<PurchaseModal
-					productToAdd={ product }
-					onClose={ () => {
-						setShowPurchaseModal( false );
-					} }
-					onPurchaseSuccess={ () => {
-						setShowPurchaseModal( false );
-						dispatch(
-							successNotice( translate( 'Your purchase has been completed!' ), {
-								id: 'plugins-purchase-modal-success',
-							} )
-						);
-					} }
-					disabledThankYouPage={ true }
-					showFeatureList={ true }
-					siteSlug={ siteSlug }
-				/>
+				<RazorpayHookProvider fetchRazorpayConfiguration={ getRazorpayConfiguration }>
+					<PurchaseModal
+						productToAdd={ product }
+						onClose={ () => {
+							setShowPurchaseModal( false );
+						} }
+						onPurchaseSuccess={ () => {
+							setShowPurchaseModal( false );
+							dispatch(
+								successNotice( translate( 'Your purchase has been completed!' ), {
+									id: 'plugins-purchase-modal-success',
+								} )
+							);
+						} }
+						disabledThankYouPage={ true }
+						showFeatureList={ true }
+						siteSlug={ siteSlug }
+					/>
+				</RazorpayHookProvider>
 			</StripeHookProvider>
 		</CalypsoShoppingCartProvider>
 	) : null;

--- a/client/me/purchases/add-new-payment-method/index.tsx
+++ b/client/me/purchases/add-new-payment-method/index.tsx
@@ -1,3 +1,4 @@
+import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
 import page from '@automattic/calypso-router';
 import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
 import { isValueTruthy } from '@automattic/wpcom-checkout';
@@ -10,7 +11,7 @@ import Column from 'calypso/components/layout/column';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { getStripeConfiguration } from 'calypso/lib/store-transactions';
+import { getRazorpayConfiguration, getStripeConfiguration } from 'calypso/lib/store-transactions';
 import PaymentMethodLoader from 'calypso/me/purchases/components/payment-method-loader';
 import PaymentMethodSidebar from 'calypso/me/purchases/components/payment-method-sidebar';
 import PaymentMethodSelector from 'calypso/me/purchases/manage-purchase/payment-method-selector';
@@ -85,7 +86,9 @@ export default function AccountLevelAddNewPaymentMethodWrapper() {
 	const locale = useSelector( getCurrentUserLocale );
 	return (
 		<StripeHookProvider locale={ locale } fetchStripeConfiguration={ getStripeConfiguration }>
-			<AddNewPaymentMethod />
+			<RazorpayHookProvider fetchRazorpayConfiguration={ getRazorpayConfiguration }>
+				<AddNewPaymentMethod />
+			</RazorpayHookProvider>
 		</StripeHookProvider>
 	);
 }

--- a/client/me/purchases/manage-purchase/change-payment-method/index.tsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/index.tsx
@@ -1,3 +1,4 @@
+import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
 import page from '@automattic/calypso-router';
 import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
 import { Fragment, useEffect } from 'react';
@@ -6,7 +7,7 @@ import HeaderCake from 'calypso/components/header-cake';
 import Layout from 'calypso/components/layout';
 import Column from 'calypso/components/layout/column';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { getStripeConfiguration } from 'calypso/lib/store-transactions';
+import { getRazorpayConfiguration, getStripeConfiguration } from 'calypso/lib/store-transactions';
 import PaymentMethodLoader from 'calypso/me/purchases/components/payment-method-loader';
 import PaymentMethodSidebar from 'calypso/me/purchases/components/payment-method-sidebar';
 import titles from 'calypso/me/purchases/titles';
@@ -117,7 +118,9 @@ export default function ChangePaymentMethodWrapper( props: ChangePaymentMethodPr
 	const locale = useSelector( getCurrentUserLocale );
 	return (
 		<StripeHookProvider locale={ locale } fetchStripeConfiguration={ getStripeConfiguration }>
-			<ChangePaymentMethod { ...props } />
+			<RazorpayHookProvider fetchRazorpayConfiguration={ getRazorpayConfiguration }>
+				<ChangePaymentMethod { ...props } />
+			</RazorpayHookProvider>
 		</StripeHookProvider>
 	);
 }

--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
 import { captureException } from '@automattic/calypso-sentry';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import colorStudio from '@automattic/color-studio';
@@ -7,7 +8,7 @@ import { styled } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { logToLogstash } from 'calypso/lib/logstash';
-import { getStripeConfiguration } from 'calypso/lib/store-transactions';
+import { getStripeConfiguration, getRazorpayConfiguration } from 'calypso/lib/store-transactions';
 import Recaptcha from 'calypso/signup/recaptcha';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
@@ -124,29 +125,31 @@ export default function CheckoutMainWrapper( {
 			>
 				<CalypsoShoppingCartProvider shouldShowPersistentErrors>
 					<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration } locale={ locale }>
-						<CheckoutMain
-							siteSlug={ siteSlug }
-							siteId={ selectedSiteId }
-							productAliasFromUrl={ productAliasFromUrl }
-							productSourceFromUrl={ productSourceFromUrl }
-							purchaseId={ purchaseId }
-							couponCode={ couponCode }
-							redirectTo={ redirectTo }
-							feature={ selectedFeature }
-							plan={ plan }
-							isComingFromUpsell={ isComingFromUpsell }
-							infoMessage={ prepurchaseNotices }
-							sitelessCheckoutType={ sitelessCheckoutType }
-							isLoggedOutCart={ isLoggedOutCart }
-							isNoSiteCart={ isNoSiteCart }
-							isGiftPurchase={ isGiftPurchase }
-							jetpackSiteSlug={ jetpackSiteSlug }
-							jetpackPurchaseToken={ jetpackPurchaseToken }
-							isUserComingFromLoginForm={ isUserComingFromLoginForm }
-							connectAfterCheckout={ connectAfterCheckout }
-							fromSiteSlug={ fromSiteSlug }
-							adminUrl={ adminUrl }
-						/>
+						<RazorpayHookProvider fetchRazorpayConfiguration={ getRazorpayConfiguration }>
+							<CheckoutMain
+								siteSlug={ siteSlug }
+								siteId={ selectedSiteId }
+								productAliasFromUrl={ productAliasFromUrl }
+								productSourceFromUrl={ productSourceFromUrl }
+								purchaseId={ purchaseId }
+								couponCode={ couponCode }
+								redirectTo={ redirectTo }
+								feature={ selectedFeature }
+								plan={ plan }
+								isComingFromUpsell={ isComingFromUpsell }
+								infoMessage={ prepurchaseNotices }
+								sitelessCheckoutType={ sitelessCheckoutType }
+								isLoggedOutCart={ isLoggedOutCart }
+								isNoSiteCart={ isNoSiteCart }
+								isGiftPurchase={ isGiftPurchase }
+								jetpackSiteSlug={ jetpackSiteSlug }
+								jetpackPurchaseToken={ jetpackPurchaseToken }
+								isUserComingFromLoginForm={ isUserComingFromLoginForm }
+								connectAfterCheckout={ connectAfterCheckout }
+								fromSiteSlug={ fromSiteSlug }
+								adminUrl={ adminUrl }
+							/>
+						</RazorpayHookProvider>
 					</StripeHookProvider>
 				</CalypsoShoppingCartProvider>
 			</CheckoutErrorBoundary>

--- a/client/my-sites/checkout/modal/index.tsx
+++ b/client/my-sites/checkout/modal/index.tsx
@@ -1,3 +1,4 @@
+import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { Modal } from '@wordpress/components';
 import { getQueryArg, removeQueryArgs } from '@wordpress/url';
@@ -5,7 +6,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import CheckoutMasterbar from 'calypso/layout/masterbar/checkout';
 import { navigate } from 'calypso/lib/navigate';
-import { getStripeConfiguration } from 'calypso/lib/store-transactions';
+import { getRazorpayConfiguration, getStripeConfiguration } from 'calypso/lib/store-transactions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import CheckoutMain from 'calypso/my-sites/checkout/src/components/checkout-main';
 import { useSelector, useDispatch } from 'calypso/state';
@@ -102,17 +103,19 @@ const CheckoutModal: FunctionComponent< Props > = ( {
 					fetchStripeConfiguration={ getStripeConfiguration }
 					locale={ translate.localeSlug }
 				>
-					<CheckoutMain
-						siteId={ selectedSiteId ?? undefined }
-						siteSlug={ siteSlug }
-						productAliasFromUrl={ productAliasFromUrl }
-						// Custom thank-you URL for payments that are processed after a redirect (eg: Paypal)
-						redirectTo={ redirectTo }
-						customizedPreviousPath={ previousRoute }
-						isInModal
-						disabledThankYouPage
-						onAfterPaymentComplete={ handleAfterPaymentComplete }
-					/>
+					<RazorpayHookProvider fetchRazorpayConfiguration={ getRazorpayConfiguration }>
+						<CheckoutMain
+							siteId={ selectedSiteId ?? undefined }
+							siteSlug={ siteSlug }
+							productAliasFromUrl={ productAliasFromUrl }
+							// Custom thank-you URL for payments that are processed after a redirect (eg: Paypal)
+							redirectTo={ redirectTo }
+							customizedPreviousPath={ previousRoute }
+							isInModal
+							disabledThankYouPage
+							onAfterPaymentComplete={ handleAfterPaymentComplete }
+						/>
+					</RazorpayHookProvider>
 				</StripeHookProvider>
 			</CalypsoShoppingCartProvider>
 		</Modal>

--- a/client/my-sites/checkout/purchase-modal/index.tsx
+++ b/client/my-sites/checkout/purchase-modal/index.tsx
@@ -1,3 +1,4 @@
+import { useRazorpay } from '@automattic/calypso-razorpay';
 import { useStripe } from '@automattic/calypso-stripe';
 import { Dialog } from '@automattic/components';
 import {
@@ -127,6 +128,7 @@ function PurchaseModalWrapper( props: PurchaseModalProps ) {
 	};
 
 	const { stripe, stripeConfiguration } = useStripe();
+	const { razorpayConfiguration } = useRazorpay();
 	const reduxDispatch = useDispatch();
 	const cartKey = useCartKey();
 	const { responseCart, updateLocation, replaceProductsInCart, isPendingUpdate } =
@@ -154,6 +156,7 @@ function PurchaseModalWrapper( props: PurchaseModalProps ) {
 			siteId: selectedSite?.ID,
 			stripe,
 			stripeConfiguration,
+			razorpayConfiguration,
 			contactDetails: {
 				countryCode: wrapValueInManagedValue( storedCard?.tax_location?.country_code ),
 				postalCode: wrapValueInManagedValue( storedCard?.tax_location?.postal_code ),
@@ -165,6 +168,7 @@ function PurchaseModalWrapper( props: PurchaseModalProps ) {
 			includeGSuiteDetails,
 			stripe,
 			stripeConfiguration,
+			razorpayConfiguration,
 			reduxDispatch,
 			selectedSite,
 			responseCart,

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -1,4 +1,5 @@
 import { JETPACK_SEARCH_PRODUCTS } from '@automattic/calypso-products';
+import { useRazorpay } from '@automattic/calypso-razorpay';
 import { useStripe } from '@automattic/calypso-stripe';
 import colorStudio from '@automattic/color-studio';
 import { CheckoutProvider, checkoutTheme } from '@automattic/composite-checkout';
@@ -51,6 +52,7 @@ import genericRedirectProcessor from '../lib/generic-redirect-processor';
 import getContactDetailsType from '../lib/get-contact-details-type';
 import multiPartnerCardProcessor from '../lib/multi-partner-card-processor';
 import payPalProcessor from '../lib/paypal-express-processor';
+import razorpayProcessor from '../lib/razorpay-processor';
 import { translateResponseCartToWPCOMCart } from '../lib/translate-cart';
 import weChatProcessor from '../lib/we-chat-processor';
 import webPayProcessor from '../lib/web-pay-processor';
@@ -154,6 +156,7 @@ export default function CheckoutMain( {
 	const isPrivate = useSelector( ( state ) => siteId && isPrivateSite( state, siteId ) ) || false;
 	const isSiteless = sitelessCheckoutType === 'jetpack' || sitelessCheckoutType === 'akismet';
 	const { stripe, stripeConfiguration, isStripeLoading, stripeLoadingError } = useStripe();
+	const { razorpayConfiguration, isRazorpayLoading, razorpayLoadingError } = useRazorpay();
 	const createUserAndSiteBeforeTransaction =
 		Boolean( isLoggedOutCart || isNoSiteCart ) && ! isSiteless;
 	const reduxDispatch = useDispatch();
@@ -368,6 +371,9 @@ export default function CheckoutMain( {
 		stripeLoadingError,
 		stripeConfiguration,
 		stripe,
+		isRazorpayLoading,
+		razorpayLoadingError,
+		razorpayConfiguration,
 		storedCards,
 	} );
 	debug( 'created payment method objects', paymentMethodObjects );
@@ -456,6 +462,7 @@ export default function CheckoutMain( {
 			siteSlug: updatedSiteSlug,
 			stripeConfiguration,
 			stripe,
+			razorpayConfiguration,
 			recaptchaClientId,
 			fromSiteSlug,
 		} ),
@@ -470,6 +477,7 @@ export default function CheckoutMain( {
 			updatedSiteId,
 			stripe,
 			stripeConfiguration,
+			razorpayConfiguration,
 			updatedSiteSlug,
 			recaptchaClientId,
 			fromSiteSlug,
@@ -510,6 +518,8 @@ export default function CheckoutMain( {
 			'existing-card-ebanx': ( transactionData: unknown ) =>
 				existingCardProcessor( transactionData, dataForProcessor ),
 			paypal: () => payPalProcessor( dataForProcessor ),
+			razorpay: ( transactionData: unknown ) =>
+				razorpayProcessor( transactionData, dataForProcessor, translate ),
 		} ),
 		[ dataForProcessor, translate ]
 	);

--- a/client/my-sites/checkout/src/lib/razorpay-processor.ts
+++ b/client/my-sites/checkout/src/lib/razorpay-processor.ts
@@ -97,7 +97,7 @@ export default async function razorpayProcessor(
 					response as WPCOMTransactionEndpointResponseRedirect,
 					( result ) => resolve( { bd_order_id: response.order_id.toString(), ...result } )
 				);
-				debug( 'Opening Razorpay modal' );
+				debug( 'Opening Razorpay modal with options', razorpayOptions );
 				const razorpay = new window.Razorpay( razorpayOptions );
 				razorpay.open();
 			} );
@@ -171,6 +171,7 @@ function combineRazorpayOptions(
 
 	const options = razorpayConfiguration.options;
 	options.order_id = txnResponse.razorpay_order_id;
+	options.customer_id = txnResponse.razorpay_customer_id;
 	options.handler = handler;
 
 	const modal = options.modal ?? {};
@@ -182,7 +183,6 @@ function combineRazorpayOptions(
 	prefill.contact =
 		prefill.contact ?? ( contactDetails ? contactDetails.phone?.value.replace( '.', '' ) : '' );
 	prefill.email = prefill.email ?? ( contactDetails ? contactDetails.email?.value : '' );
-	debug( 'Razorpay prefill', prefill );
 	options.prefill = prefill;
 
 	return options;

--- a/client/my-sites/checkout/src/lib/razorpay-processor.ts
+++ b/client/my-sites/checkout/src/lib/razorpay-processor.ts
@@ -1,0 +1,189 @@
+import {
+	RazorpayConfigurationError,
+	type Razorpay,
+	type RazorpayConfiguration,
+	type RazorpayConfirmationRequestArgs,
+	RazorpayOptions,
+	RazorpayModalResponse,
+} from '@automattic/calypso-razorpay';
+import {
+	makeErrorResponse,
+	makeSuccessResponse,
+	isErrorResponse,
+} from '@automattic/composite-checkout';
+import {
+	ManagedContactDetails,
+	WPCOMTransactionEndpointResponseRedirect,
+} from '@automattic/wpcom-checkout';
+import debugFactory from 'debug';
+import { LocalizeProps } from 'i18n-calypso';
+import { confirmRazorpayOrder } from 'calypso/lib/store-transactions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { logStashEvent, recordTransactionBeginAnalytics } from '../lib/analytics';
+import getDomainDetails from './get-domain-details';
+import getPostalCode from './get-postal-code';
+import submitWpcomTransaction from './submit-wpcom-transaction';
+import {
+	createTransactionEndpointRequestPayload,
+	createTransactionEndpointCartFromResponseCart,
+} from './translate-cart';
+import type { PaymentProcessorOptions } from '../types/payment-processors';
+import type { PaymentProcessorResponse } from '@automattic/composite-checkout';
+
+const debug = debugFactory( 'calypso:razorpay-processor' );
+
+type RazorpayTransactionRequest = {
+	razorpay: Razorpay;
+	razorpayConfiguration: RazorpayConfiguration;
+	name: string | undefined;
+};
+
+export default async function razorpayProcessor(
+	submitData: unknown,
+	transactionOptions: PaymentProcessorOptions,
+	translate: LocalizeProps[ 'translate' ]
+): Promise< PaymentProcessorResponse > {
+	if ( ! isValidTransactionData( submitData ) ) {
+		throw new Error( 'Required purchase data is missing' );
+	}
+	if ( ! isValidTransactionOptions( transactionOptions ) ) {
+		throw new Error( 'Required processor options are missing' );
+	}
+
+	transactionOptions.reduxDispatch(
+		recordTransactionBeginAnalytics( { paymentMethodId: 'razorpay' } )
+	);
+
+	const { includeDomainDetails, includeGSuiteDetails, responseCart, siteId, contactDetails } =
+		transactionOptions;
+
+	const formattedTransactionData = createTransactionEndpointRequestPayload( {
+		...submitData,
+		name: submitData.name ?? '',
+		country: contactDetails?.countryCode?.value ?? '',
+		postalCode: getPostalCode( contactDetails ),
+		domainDetails: getDomainDetails( contactDetails, {
+			includeDomainDetails,
+			includeGSuiteDetails,
+		} ),
+		cart: createTransactionEndpointCartFromResponseCart( {
+			siteId,
+			contactDetails:
+				getDomainDetails( contactDetails, { includeDomainDetails, includeGSuiteDetails } ) ?? null,
+			responseCart: responseCart,
+		} ),
+		paymentMethodType: 'WPCOM_Billing_Razorpay',
+		paymentPartnerProcessorId: 'razorpay',
+	} );
+	debug( 'submitting razorpay transaction', formattedTransactionData );
+	// Initiate razorpay order between wpcom and razorpay
+	return submitWpcomTransaction( formattedTransactionData, transactionOptions )
+		.then( async ( response ) => {
+			// Initiate purchase flow between user and razorpay
+			debug( 'Razorpay Wpcom transaction response', response );
+			return new Promise( ( resolve ) => {
+				// Last minute check that the global Razorpay class exists.
+				if ( typeof window === 'undefined' || ! window.Razorpay ) {
+					debug( 'Razorpay object not defined!' );
+					throw new RazorpayConfigurationError(
+						'Razorpay submission error: Razorpay object not defined'
+					);
+				}
+				// We have to initialize Razorpay here because we need the order ID that
+				// comes from the transactions endpoint.
+				const razorpayOptions = combineRazorpayOptions(
+					transactionOptions.razorpayConfiguration,
+					transactionOptions.contactDetails,
+					response as WPCOMTransactionEndpointResponseRedirect,
+					( result ) => resolve( { bd_order_id: response.order_id.toString(), ...result } )
+				);
+				debug( 'Opening Razorpay modal' );
+				const razorpay = new window.Razorpay( razorpayOptions );
+				razorpay.open();
+			} );
+		} )
+		.then( ( purchaseResult ) => {
+			// Confirm purchase result between user and wpcom
+			debug( 'Razorpay purchase result', purchaseResult );
+			if (
+				purchaseResult &&
+				typeof purchaseResult === 'object' &&
+				'razorpay_payment_id' in purchaseResult &&
+				'razorpay_signature' in purchaseResult &&
+				'bd_order_id' in purchaseResult
+			) {
+				return confirmRazorpayOrder( purchaseResult as RazorpayConfirmationRequestArgs );
+			}
+
+			// If we get here, most likely the user either closed or back-buttoned out of the modal.
+			return makeErrorResponse( translate( 'Payment cancelled.' ) );
+		} )
+		.then( ( confirmationResult ) => {
+			debug( 'Razorpay confirmation result', confirmationResult );
+
+			// Short circuit if an earlier step returned an error response.
+			if ( isErrorResponse( confirmationResult ) ) {
+				return confirmationResult;
+			}
+
+			if ( confirmationResult.success === true ) {
+				return makeSuccessResponse( confirmationResult );
+			}
+			// This should not happen because the API will have returned an
+			// error response if there was a problem confirming the payment.
+			return makeErrorResponse( 'Unexpected confirmation result status' );
+		} )
+		.catch( ( error: Error ) => {
+			debug( 'transaction failed' );
+			transactionOptions.reduxDispatch(
+				recordTracksEvent( 'calypso_checkout_razorpay_transaction_failed', {
+					error: error.message,
+				} )
+			);
+			logStashEvent( 'calypso_checkout_razorpay_transaction_failed', {
+				error: error.message,
+			} );
+			return makeErrorResponse( error.message );
+		} );
+}
+
+function isValidTransactionData( submitData: unknown ): submitData is RazorpayTransactionRequest {
+	return true;
+}
+
+function isValidTransactionOptions( options: unknown ): options is RazorpayTransactionRequest {
+	const data = options as RazorpayTransactionRequest;
+	if ( ! data?.razorpayConfiguration ) {
+		throw new Error( 'Transaction requires razorpayConfiguration and none was provided' );
+	}
+	return true;
+}
+
+function combineRazorpayOptions(
+	razorpayConfiguration: RazorpayConfiguration,
+	contactDetails: ManagedContactDetails | undefined,
+	txnResponse: WPCOMTransactionEndpointResponseRedirect,
+	handler: ( response: RazorpayModalResponse ) => void
+): RazorpayOptions {
+	if ( ! txnResponse.razorpay_order_id ) {
+		throw new Error( 'Missing order_id for razorpay transaction' );
+	}
+
+	const options = razorpayConfiguration.options;
+	options.order_id = txnResponse.razorpay_order_id;
+	options.handler = handler;
+
+	const modal = options.modal ?? {};
+	modal.ondismiss = handler;
+	options.modal = modal;
+
+	debug( 'Constructing Razorpay prefill object using contact details', contactDetails );
+	const prefill = options.prefill ?? {};
+	prefill.contact =
+		prefill.contact ?? ( contactDetails ? contactDetails.phone?.value.replace( '.', '' ) : '' );
+	prefill.email = prefill.email ?? ( contactDetails ? contactDetails.email?.value : '' );
+	debug( 'Razorpay prefill', prefill );
+	options.prefill = prefill;
+
+	return options;
+}

--- a/client/my-sites/checkout/src/types/payment-processors.ts
+++ b/client/my-sites/checkout/src/types/payment-processors.ts
@@ -1,4 +1,5 @@
 import type { GetThankYouUrl } from '../hooks/use-get-thank-you-url';
+import type { RazorpayConfiguration } from '@automattic/calypso-razorpay';
 import type { StripeConfiguration } from '@automattic/calypso-stripe';
 import type { ResponseCart } from '@automattic/shopping-cart';
 import type { ManagedContactDetails } from '@automattic/wpcom-checkout';
@@ -11,6 +12,7 @@ export interface PaymentProcessorOptions {
 	createUserAndSiteBeforeTransaction: boolean;
 	stripe: Stripe | null;
 	stripeConfiguration: StripeConfiguration | null;
+	razorpayConfiguration: RazorpayConfiguration | null;
 	reduxDispatch: CalypsoDispatch;
 	responseCart: ResponseCart;
 	getThankYouUrl: GetThankYouUrl;

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -5,6 +5,7 @@ import {
 	Product,
 	isPlan,
 } from '@automattic/calypso-products';
+import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
 import page from '@automattic/calypso-router';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { CompactCard, Gridicon } from '@automattic/components';
@@ -20,7 +21,7 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySites from 'calypso/components/data/query-sites';
 import Main from 'calypso/components/main';
-import { getStripeConfiguration } from 'calypso/lib/store-transactions';
+import { getRazorpayConfiguration, getStripeConfiguration } from 'calypso/lib/store-transactions';
 import { TITAN_MAIL_MONTHLY_SLUG, TITAN_MAIL_YEARLY_SLUG } from 'calypso/lib/titan/constants';
 import getThankYouPageUrl from 'calypso/my-sites/checkout/get-thank-you-page-url';
 import ProfessionalEmailUpsell from 'calypso/my-sites/checkout/upsell-nudge/professional-email-upsell';
@@ -423,14 +424,18 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 
 		return (
 			<StripeHookProvider fetchStripeConfiguration={ getStripeConfiguration }>
-				<PurchaseModal
-					productToAdd={ productToAdd }
-					onClose={ onCloseModal }
-					siteSlug={ this.props.siteSlug }
-					showFeatureList={
-						!! ( this.props.product && isPlan( { productSlug: this.props.product?.product_slug } ) )
-					}
-				/>
+				<RazorpayHookProvider fetchRazorpayConfiguration={ getRazorpayConfiguration }>
+					<PurchaseModal
+						productToAdd={ productToAdd }
+						onClose={ onCloseModal }
+						siteSlug={ this.props.siteSlug }
+						showFeatureList={
+							!! (
+								this.props.product && isPlan( { productSlug: this.props.product?.product_slug } )
+							)
+						}
+					/>
+				</RazorpayHookProvider>
 			</StripeHookProvider>
 		);
 	};

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
 import page from '@automattic/calypso-router';
 import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
@@ -16,7 +17,7 @@ import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { logToLogstash } from 'calypso/lib/logstash';
-import { getStripeConfiguration } from 'calypso/lib/store-transactions';
+import { getRazorpayConfiguration, getStripeConfiguration } from 'calypso/lib/store-transactions';
 import PaymentMethodLoader from 'calypso/me/purchases/components/payment-method-loader';
 import PaymentMethodSidebar from 'calypso/me/purchases/components/payment-method-sidebar';
 import PaymentMethodSelector from 'calypso/me/purchases/manage-purchase/payment-method-selector';
@@ -159,7 +160,9 @@ export function SiteLevelAddNewPaymentMethod( props: { siteSlug: string } ) {
 	const locale = useSelector( getCurrentUserLocale );
 	return (
 		<StripeHookProvider locale={ locale } fetchStripeConfiguration={ getStripeConfiguration }>
-			<SiteLevelAddNewPaymentMethodForm { ...props } />
+			<RazorpayHookProvider fetchRazorpayConfiguration={ getRazorpayConfiguration }>
+				<SiteLevelAddNewPaymentMethodForm { ...props } />
+			</RazorpayHookProvider>
 		</StripeHookProvider>
 	);
 }

--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -1,4 +1,5 @@
 import { getDIFMTieredPriceDetails, WPCOM_DIFM_LITE } from '@automattic/calypso-products';
+import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { Button } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
@@ -8,7 +9,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import InfoPopover from 'calypso/components/info-popover';
-import { getStripeConfiguration } from 'calypso/lib/store-transactions';
+import { getRazorpayConfiguration, getStripeConfiguration } from 'calypso/lib/store-transactions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import PurchaseModal from 'calypso/my-sites/checkout/purchase-modal';
 import { useIsEligibleForOneClickCheckout } from 'calypso/my-sites/checkout/purchase-modal/use-is-eligible-for-one-click-checkout';
@@ -402,12 +403,14 @@ function OneClickPurchaseModal( {
 				fetchStripeConfiguration={ getStripeConfiguration }
 				locale={ translate.localeSlug }
 			>
-				<PurchaseModal
-					productToAdd={ product }
-					onClose={ onClose }
-					showFeatureList={ false }
-					siteSlug={ siteSlug }
-				/>
+				<RazorpayHookProvider fetchRazorpayConfiguration={ getRazorpayConfiguration }>
+					<PurchaseModal
+						productToAdd={ product }
+						onClose={ onClose }
+						showFeatureList={ false }
+						siteSlug={ siteSlug }
+					/>
+				</RazorpayHookProvider>
 			</StripeHookProvider>
 		</CalypsoShoppingCartProvider>
 	);


### PR DESCRIPTION
#85846 adds a new package, analogous to calypso-stripe, which defines a `RazorpayHookProvider` component to be used to fetch a razorpay object using a vendor library and make it available in checkout. This patch wraps the `CheckoutMain` component in that provider.

## Proposed Changes

* Add Razorpay payment method
* Wrap `CheckoutMain` in `RazorpayHookProvider`.

## Testing Instructions

We need to test several different kinds of both success and failure.

### Prepare
* (a12s) Enable store sandbox and billing sandbox and tail the logs.
* Enable debug messages by running the following command in the console:
```
localStorage.setItem('debug', 'calypso-razorpay,calypso:razorpay-processor,wpcom-checkout:razorpay-processor');
```
* Change your user's currency to INR
* In checkout, set your tax location to India. Use any 6 digit numeric postal code.

### What to expect from the payment flow
* After clicking to submit in checkout, a modal window will appear.
* If prompted to enter a phone number, use 7513200000.
* You will be presented with a list of payment methods. Docs about testing these is [here](https://razorpay.com/docs/payments/payment-gateway/ecommerce-plugins/wordpress/test-integration/).
    * Card: Use `4111 1111 1111 1111` with any future expiration date, any 3 digit cvv, and any 4 digit 2FA code to simulate a successful payment.
    * Wallet and netbanking: choose to accept or fail the payment.
    * UPI: use `razorpay@success` and `razorpay@failure` to simulate a payment.
 * After choosing a payment method the browser focus may move to a new tab. Follow the instructions there; focus will eventually revert back to the checkout tab. Verify that when focus moves to the new tab, the checkout tab is not interactable (modal window is still active).
 * Once focus is in checkout again:
     * If the payment succeeded you will see a success message from Razorpay with a countdown. Once the countdown ends you should be redirected to a thank you page. Verify that the checkout form does not become interactable before the redirect happens.
     * If the payment failed the checkout form should become ready again and you should see an error notification.
 * After completing a test, verify that there are no (relevant and unexpected) errors in the browser console or the server logs.

### Test cases
1. **New purchase with card, no errors:** Go through a normal new purchase. Verify that you see a thank you page. Verify that the product provisions as expected. Verify that the receipt and ownership are as expected.
2. **Renewal with card, no errors**: Go through a normal renewal. Verify the thank you page and receipt. Verify that the expiration date updates.
3. **Renewal with non-card method, no errors**: Verify the thank you page and receipt. Verify that the expiration date updates.
4. **Currency not INR**: Change your user's currency to something other than INR. Verify that Razorpay is not available in checkout.
5. **MFA failure**: Attempt to pay with a card, but enter a 3 digit 2FA code. Verify that you are taken back to checkout, that the Razorpay modal is still active, and you see an error message (in the modal). Verify that you can try again and complete a payment.
6. **Card failure**: Unfortunately it seems razorpay doesn't have test cards for simulating card failures. :sadclown: Leaving this here to show we tried. However we can test netbanking failures. Pay with netbanking and choose to fail the transaction; verify that you end up back in checkout with the Razorpay modal active, and you see an error message (in the modal). Verify that you can try again and complete the payment.
7. **Confirmation failure (signature error)**: Simulate a confirmation failure by returning a WP_Error from WPCOM_JSON_API_Checkout_Razorpay_Confirm_Payment_Endpoint. Verify that you end up back in checkout with a calypso error notification. These errors are bad (provided we don't have a fraudster) because the user paid but we didn't deliver the product; real error messages from this endpoint will have a code the user can take to support for help.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
