### PR TITLE
Leave stats unlocked until site features have been queried

### DIFF
--- a/client/my-sites/stats/hooks/test/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/test/use-should-gate-stats.ts
@@ -28,9 +28,38 @@ describe( 'shouldGateStats in Calypso', () => {
 		jest.clearAllMocks();
 	} );
 
+	it( 'should not gate stats when site features are not loaded', () => {
+		const mockState = {
+			sites: {
+				features: {
+					[ siteId ]: {
+						data: null,
+					},
+				},
+				items: {
+					[ siteId ]: {
+						jetpack: false, // true for atomic sites
+						options: {
+							is_wpcom_atomic: false,
+						},
+					},
+				},
+			},
+		};
+		const isGatedStats = shouldGateStats( mockState, siteId, gatedStatType );
+		expect( isGatedStats ).toBe( false );
+	} );
+
 	it( 'should gate stats when site is atomic without site feature', () => {
 		const mockState = {
 			sites: {
+				features: {
+					[ siteId ]: {
+						data: {
+							active: [],
+						},
+					},
+				},
 				items: {
 					[ siteId ]: {
 						jetpack: true, // true for atomic sites

--- a/client/my-sites/stats/hooks/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/use-should-gate-stats.ts
@@ -76,8 +76,8 @@ export const shouldGateStats = ( state: object, siteId: number | null, statType:
 		return false;
 	}
 
-	// check if the site has paid stats feature
-	if ( siteHasPaidStats || ! siteFeatures ) {
+	// check if the site features have loaded and the site has paid stats feature
+	if ( ! siteFeatures || siteHasPaidStats ) {
 		return false;
 	}
 

--- a/client/my-sites/stats/hooks/use-should-gate-stats.ts
+++ b/client/my-sites/stats/hooks/use-should-gate-stats.ts
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_STATS_PAID } from '@automattic/calypso-products';
 import { useSelector } from 'calypso/state';
+import getSiteFeatures from 'calypso/state/selectors/get-site-features';
 import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -49,14 +50,25 @@ const granularControlForPaidStats = [
  * const isGatedStats = shouldGateStats( state, siteId, STAT_TYPE_SEARCH_TERMS );
  */
 export const shouldGateStats = ( state: object, siteId: number | null, statType: string ) => {
+	const isPaidStatsEnabled = isEnabled( 'stats/paid-wpcom-v2' );
+	const isOdysseyStats = isEnabled( 'is_running_in_jetpack_site' );
+
+	// check feature flags
+	if ( ! isPaidStatsEnabled ) {
+		return false;
+	}
+	if ( isOdysseyStats ) {
+		// don't gate stats if using Odyssey stats
+		return false;
+	}
+
 	if ( ! siteId ) {
 		return true;
 	}
 
-	const isPaidStatsEnabled = isEnabled( 'stats/paid-wpcom-v2' );
-	const isOdysseyStats = isEnabled( 'is_running_in_jetpack_site' );
 	const jetpackSite = isJetpackSite( state, siteId );
 	const atomicSite = isAtomicSite( state, siteId );
+	const siteFeatures = getSiteFeatures( state, siteId );
 	const siteHasPaidStats = siteHasFeature( state, siteId, FEATURE_STATS_PAID );
 
 	// check site type
@@ -65,16 +77,7 @@ export const shouldGateStats = ( state: object, siteId: number | null, statType:
 	}
 
 	// check if the site has paid stats feature
-	if ( siteHasPaidStats ) {
-		return false;
-	}
-
-	// check feature flags
-	if ( ! isPaidStatsEnabled ) {
-		return false;
-	}
-	if ( isOdysseyStats ) {
-		// don't gate stats if using Odyssey stats
+	if ( siteHasPaidStats || ! siteFeatures ) {
 		return false;
 	}
 


### PR DESCRIPTION
Related to #

## Proposed Changes

* shouldGateStats should return false until site features have been queried
* shouldGateStats should return false if the feature is disabled or we're in a jetpack odyssey context regardless of site id

## Testing Instructions

* [x] Check stats aren't shown to users before locking on free sites
* [x] Check Jetpack odyssey remains unlocked in all cases (including load states)
* [x] Check this flashing lock screen is no longer shown on atomic


https://github.com/Automattic/wp-calypso/assets/811776/0f5e9d0c-be3d-45a5-a0df-6c79bba1c9d8

