### PR TITLE
Domains: Update DomainsMiniCart to use integer cart item properties

### DIFF
--- a/client/signup/steps/domains/domains-mini-cart.jsx
+++ b/client/signup/steps/domains/domains-mini-cart.jsx
@@ -60,8 +60,20 @@ export function BoldTLD( { domain } ) {
 class DomainsMiniCart extends Component {
 	domainNameAndCost = ( domain ) => {
 		const isRemoving = this.props.domainRemovalQueue.some( ( item ) => item.meta === domain.meta );
+		const formattedOriginalCost = formatCurrency(
+			domain.item_original_cost_integer,
+			domain.currency,
+			{
+				isSmallestUnit: true,
+				stripZeros: true,
+			}
+		);
+		const formattedCost = formatCurrency( domain.item_subtotal_integer, domain.currency, {
+			isSmallestUnit: true,
+			stripZeros: true,
+		} );
 		const priceText = translate( '%(cost)s/year', {
-			args: { cost: domain.item_original_cost_display },
+			args: { cost: formattedOriginalCost },
 		} );
 		const costDifference = domain.item_original_cost - domain.cost;
 		const hasPromotion = costDifference > 0;
@@ -74,11 +86,11 @@ class DomainsMiniCart extends Component {
 					</div>
 					<div className="domain-product-price__price">
 						{ hasPromotion && <del>{ priceText }</del> }
-						<span className="domains__price">{ domain.item_subtotal_display }</span>
+						<span className="domains__price">{ formattedCost }</span>
 					</div>
 				</div>
 				<div>
-					{ hasPromotion && domain.item_subtotal === 0 && (
+					{ hasPromotion && domain.item_subtotal_integer === 0 && (
 						<span className="savings-message">
 							{ translate( 'Free for the first year with annual paid plans.' ) }
 						</span>

--- a/client/signup/steps/domains/domains-mini-cart.jsx
+++ b/client/signup/steps/domains/domains-mini-cart.jsx
@@ -61,14 +61,14 @@ class DomainsMiniCart extends Component {
 	domainNameAndCost = ( domain ) => {
 		const isRemoving = this.props.domainRemovalQueue.some( ( item ) => item.meta === domain.meta );
 		const formattedOriginalCost = formatCurrency(
-			domain.item_original_cost_integer,
+			domain.item_original_cost_integer ?? 0,
 			domain.currency,
 			{
 				isSmallestUnit: true,
 				stripZeros: true,
 			}
 		);
-		const formattedCost = formatCurrency( domain.item_subtotal_integer, domain.currency, {
+		const formattedCost = formatCurrency( domain.item_subtotal_integer ?? 0, domain.currency, {
 			isSmallestUnit: true,
 			stripZeros: true,
 		} );

--- a/client/signup/steps/domains/domains-mini-cart.jsx
+++ b/client/signup/steps/domains/domains-mini-cart.jsx
@@ -60,18 +60,18 @@ export function BoldTLD( { domain } ) {
 class DomainsMiniCart extends Component {
 	domainNameAndCost = ( domain ) => {
 		const isRemoving = this.props.domainRemovalQueue.some( ( item ) => item.meta === domain.meta );
-		const formattedOriginalCost = formatCurrency(
-			domain.item_original_cost_integer ?? 0,
-			domain.currency,
-			{
-				isSmallestUnit: true,
-				stripZeros: true,
-			}
-		);
-		const formattedCost = formatCurrency( domain.item_subtotal_integer ?? 0, domain.currency, {
-			isSmallestUnit: true,
-			stripZeros: true,
-		} );
+		const formattedOriginalCost = domain.temporary
+			? '...'
+			: formatCurrency( domain.item_original_cost_integer ?? 0, domain.currency, {
+					isSmallestUnit: true,
+					stripZeros: true,
+			  } );
+		const formattedCost = domain.temporary
+			? '...'
+			: formatCurrency( domain.item_subtotal_integer ?? 0, domain.currency, {
+					isSmallestUnit: true,
+					stripZeros: true,
+			  } );
 		const priceText = translate( '%(cost)s/year', {
 			args: { cost: formattedOriginalCost },
 		} );

--- a/client/signup/steps/domains/domains-mini-cart.jsx
+++ b/client/signup/steps/domains/domains-mini-cart.jsx
@@ -75,8 +75,9 @@ class DomainsMiniCart extends Component {
 		const priceText = translate( '%(cost)s/year', {
 			args: { cost: formattedOriginalCost },
 		} );
-		const costDifference = domain.item_original_cost - domain.cost;
-		const hasPromotion = costDifference > 0;
+		const hasPromotion = domain.cost_overrides?.some(
+			( override ) => ! override.does_override_original_cost
+		);
 
 		return isRemoving ? null : (
 			<>

--- a/client/signup/steps/domains/domains-mini-cart.jsx
+++ b/client/signup/steps/domains/domains-mini-cart.jsx
@@ -87,7 +87,7 @@ class DomainsMiniCart extends Component {
 					</div>
 					<div className="domain-product-price__price">
 						{ hasPromotion && <del>{ priceText }</del> }
-						<span className="domains__price">{ formattedCost }</span>
+						<span className="domains__price">{ domain.temporary ? '...' : formattedCost }</span>
 					</div>
 				</div>
 				<div>

--- a/client/signup/steps/domains/domains-mini-cart.jsx
+++ b/client/signup/steps/domains/domains-mini-cart.jsx
@@ -198,8 +198,8 @@ class DomainsMiniCart extends Component {
 				<div className="domains__domain-side-content domains__domain-cart">
 					<div className="domains__domain-cart-rows">
 						{ this.props.wpcomSubdomainSelected && this.freeDomain() }
-						{ this.props.domainsInCart.map( ( domain, i ) => (
-							<div key={ `row${ i }` } className="domains__domain-cart-row">
+						{ this.props.domainsInCart.map( ( domain ) => (
+							<div key={ `row-${ domain.meta }` } className="domains__domain-cart-row">
 								{ this.domainNameAndCost( domain ) }
 							</div>
 						) ) }
@@ -226,8 +226,8 @@ class DomainsMiniCart extends Component {
 				<div className="domains__domain-cart-title">{ translate( 'Your domains' ) }</div>
 				<div className="domains__domain-cart-rows">
 					{ this.props.wpcomSubdomainSelected && this.freeDomain() }
-					{ this.props.domainsInCart.map( ( domain, i ) => (
-						<div key={ `row${ i }` } className="domains__domain-cart-row">
+					{ this.props.domainsInCart.map( ( domain ) => (
+						<div key={ `row-${ domain.meta }` } className="domains__domain-cart-row">
 							{ this.domainNameAndCost( domain ) }
 						</div>
 					) ) }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -625,7 +625,6 @@ export class RenderDomainsStep extends Component {
 						...( state.temporaryCart || [] ),
 						{
 							meta: suggestion.domain_name,
-							item_subtotal_display: '...',
 							temporary: true,
 						},
 					],


### PR DESCRIPTION
## Proposed Changes

The `DomainsMiniCart` component uses deprecated shopping cart properties for displaying prices. Those properties will soon be removed from the cart entirely in D134038-code. This was not yet noticed because this component is not using TypeScript.

In this diff we replace the deprecated properties with valid ones.

## Testing Instructions

See the test instructions for https://github.com/Automattic/wp-calypso/pull/85152 or https://github.com/Automattic/wp-calypso/pull/85091


https://github.com/Automattic/wp-calypso/assets/2036909/218d2056-06a6-4c07-9903-acbfb1316979

