### PR TITLE
Stats: allow switch to pwyw if site is personal or not identified yet

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -34,7 +34,7 @@ interface StatsCommercialPurchaseProps {
 	adminUrl: string;
 	redirectUri: string;
 	from: string;
-	showClassificationDispute?: boolean;
+	isCommercial?: boolean;
 }
 
 interface StatsSingleItemPagePurchaseProps {
@@ -102,7 +102,7 @@ const StatsCommercialPurchase = ( {
 	from,
 	adminUrl,
 	redirectUri,
-	showClassificationDispute = true,
+	isCommercial = true,
 }: StatsCommercialPurchaseProps ) => {
 	const translate = useTranslate();
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
@@ -121,7 +121,7 @@ const StatsCommercialPurchase = ( {
 
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
-	const handleClick = ( event: React.MouseEvent, isOdysseyStats: boolean ) => {
+	const handleRequestUpdateClick = ( event: React.MouseEvent, isOdysseyStats: boolean ) => {
 		event.preventDefault();
 
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
@@ -143,6 +143,13 @@ Thanks\n\n`;
 		) }&body=${ encodeURIComponent( emailBody ) }`;
 
 		setTimeout( () => ( window.location.href = emailHref ), 250 );
+	};
+
+	const handleSwitchToPersonalClick = ( event: React.MouseEvent, isOdysseyStats: boolean ) => {
+		event.preventDefault();
+		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
+		recordTracksEvent( `${ event_from }_stats_purchase_commercial_switch_to_personal_clicked` );
+		setTimeout( () => page( `/stats/purchase/${ siteSlug }?productType=personal` ), 250 );
 	};
 
 	const handleSliderChanged = useCallback( ( value: number ) => {
@@ -201,8 +208,8 @@ Thanks\n\n`;
 					</ButtonComponent>
 				</>
 			) }
-
-			{ showClassificationDispute && (
+			{ /** Hide the section for upgrades */ }
+			{ ! isCommercialOwned && (
 				<div className={ `${ COMPONENT_CLASS_NAME }__additional-card-panel` }>
 					<Panel className={ `${ COMPONENT_CLASS_NAME }__card-panel` }>
 						<PanelBody title={ translate( 'This is not a commercial site' ) } initialOpen={ false }>
@@ -254,20 +261,42 @@ Thanks\n\n`;
 										/>
 									</li>
 								</ul>
-								{ isAdsChecked && isSellingChecked && isBusinessChecked && isDonationChecked && (
-									<Button
-										variant="secondary"
-										disabled={
-											! isAdsChecked ||
-											! isSellingChecked ||
-											! isBusinessChecked ||
-											! isDonationChecked
-										}
-										onClick={ ( e: React.MouseEvent ) => handleClick( e, isOdysseyStats ) }
-									>
-										{ translate( 'Request update' ) }
-									</Button>
-								) }
+								{ isAdsChecked &&
+									isSellingChecked &&
+									isBusinessChecked &&
+									isDonationChecked &&
+									( isCommercial ? (
+										<Button
+											variant="secondary"
+											disabled={
+												! isAdsChecked ||
+												! isSellingChecked ||
+												! isBusinessChecked ||
+												! isDonationChecked
+											}
+											onClick={ ( e: React.MouseEvent ) =>
+												handleRequestUpdateClick( e, isOdysseyStats )
+											}
+										>
+											{ translate( 'Request update' ) }
+										</Button>
+									) : (
+										// Otherwise if the site is personal or not identified yet, we should allow products switch.
+										<Button
+											variant="secondary"
+											disabled={
+												! isAdsChecked ||
+												! isSellingChecked ||
+												! isBusinessChecked ||
+												! isDonationChecked
+											}
+											onClick={ ( e: React.MouseEvent ) =>
+												handleSwitchToPersonalClick( e, isOdysseyStats )
+											}
+										>
+											{ translate( 'Choose a non-commercial license' ) }
+										</Button>
+									) ) }
 							</div>
 						</PanelBody>
 					</Panel>
@@ -382,7 +411,7 @@ const StatsSingleItemPagePurchase = ( {
 				adminUrl={ adminUrl || '' }
 				redirectUri={ redirectUri }
 				from={ from }
-				showClassificationDispute={ !! isCommercial }
+				isCommercial={ !! isCommercial }
 			/>
 		</StatsSingleItemPagePurchaseFrame>
 	);

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -34,7 +34,7 @@ interface StatsCommercialPurchaseProps {
 	adminUrl: string;
 	redirectUri: string;
 	from: string;
-	isCommercial?: boolean;
+	isCommercial?: boolean | null;
 }
 
 interface StatsSingleItemPagePurchaseProps {
@@ -411,7 +411,7 @@ const StatsSingleItemPagePurchase = ( {
 				adminUrl={ adminUrl || '' }
 				redirectUri={ redirectUri }
 				from={ from }
-				isCommercial={ !! isCommercial }
+				isCommercial={ isCommercial }
 			/>
 		</StatsSingleItemPagePurchaseFrame>
 	);


### PR DESCRIPTION
Related to #

## Proposed Changes

We are going to default site to the commercial products for new sites that are not identified yet. For those sites, we should allow them to choose personal sites freely, if they satisfy all the requirements.

Site identified as commercial will still need to contact support to be able to be identified as personal.

The next step will be defaulting all unidentified sites to the commercial product, as they'll be able to switch to pwyw now.

## Testing Instructions

* Prepare a fresh JN site and connnect it
* Open `/stats/purchase/:siteSlug`
* Click 'This is not a commercial site'
* Check all the boxes
* Ensure you see button 'Choose a non-commercial license'
* Click the button
* Ensure you are taken to the PWYW page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?