### PR TITLE
Stats: default unidentified sites to commercial product

### DIFF
--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -226,25 +226,9 @@ const StatsPurchasePage = ( {
 					! isLoading && isTypeDetectionEnabled && showPurchasePage && (
 						<>
 							{
-								// blog doesn't have any plan but is not categorised as either personal or commectial - show old purchase wizard
-								! isForceProductRedirect && isCommercial === null && (
-									<StatsPurchaseWizard
-										siteSlug={ siteSlug }
-										commercialProduct={ commercialProduct }
-										maxSliderPrice={ maxSliderPrice ?? 10 }
-										pwywProduct={ pwywProduct }
-										siteId={ siteId }
-										redirectUri={ query.redirect_uri ?? '' }
-										from={ query.from ?? '' }
-										disableFreeProduct={ ! noPlanOwned }
-										initialStep={ initialStep }
-										initialSiteType={ initialSiteType }
-									/>
-								)
-							}
-							{
-								// blog is commercial or we are forcing a product - show the commercial purchase page
-								( ( ! isForceProductRedirect && isCommercial ) || redirectToCommercial ) && (
+								// blog is commercial, we are forcing a product or the site is not identified yet - show the commercial purchase page
+								( ( ! isForceProductRedirect && ( isCommercial || isCommercial === null ) ) ||
+									redirectToCommercial ) && (
 									<div className="stats-purchase-page__notice">
 										<StatsSingleItemPagePurchase
 											siteSlug={ siteSlug ?? '' }

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -227,6 +227,7 @@ const StatsPurchasePage = ( {
 						<>
 							{
 								// blog is commercial, we are forcing a product or the site is not identified yet - show the commercial purchase page
+								// TODO: remove StatsPurchaseWizard component as it's not in use anymore.
 								( ( ! isForceProductRedirect && ( isCommercial || isCommercial === null ) ) ||
 									redirectToCommercial ) && (
 									<div className="stats-purchase-page__notice">


### PR DESCRIPTION
## Proposed Changes

If a site is not identified yet - meaning isCommercial is null, we default the purchase page to the commercial product. Users will be able to switch to personal, and the support is underway #86205.

## Testing Instructions

- Prepare a fresh JN site and connect it (maybe just override the value `isCommercial=null` somewhere for easier testing)
- Open /stats/purchase/:siteSlug
-  Ensure you are taken to the commercial product purchase page


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?