### PR TITLE
Enable the "Preview & Customize" button for Premium and WooCommerce themes (on production)

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -178,7 +178,7 @@
 		"subscription-management/comments-list-controls": true,
 		"subscription-management/migrate-subscribers": true,
 		"subscription-management-redirect-following": true,
-		"themes/block-theme-previews-premium-and-woo": false,
+		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-bundle": true,
 		"themes/premium": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -172,7 +172,7 @@
 		"subscription-management/comments-list-controls": true,
 		"subscription-management/migrate-subscribers": true,
 		"subscription-management-redirect-following": true,
-		"themes/block-theme-previews-premium-and-woo": false,
+		"themes/block-theme-previews-premium-and-woo": true,
 		"themes/discovery": true,
 		"themes/display-thank-you-page-for-bundle": true,
 		"themes/premium": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79223, https://github.com/Automattic/wp-calypso/pull/85182

## Proposed Changes

This PR enables the "Preview & Customize" button for Premium and WooCommerce themes on the staging and production environment.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the Clypso Live 
* Follow the testing instructions in https://github.com/Automattic/wp-calypso/issues/79223

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?