### PR TITLE
Live Preview: add `theme_style` prop to `calypso_block_theme_live_preview_click`

### DIFF
--- a/client/state/themes/actions/live-preview.ts
+++ b/client/state/themes/actions/live-preview.ts
@@ -1,3 +1,4 @@
+import { isDefaultGlobalStylesVariationSlug } from '@automattic/design-picker';
 import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
 import { getGlobalStylesId, updateGlobalStyles } from 'calypso/state/global-styles/actions';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -29,6 +30,11 @@ export function livePreview(
 			source,
 			theme_type: getThemeType( getState(), themeId ),
 			theme: themeId,
+			theme_style:
+				themeId +
+				( isDefaultGlobalStylesVariationSlug( styleVariation?.slug )
+					? ''
+					: `-${ styleVariation?.slug }` ),
 		} );
 		dispatch( withAnalytics( analysis, { type: LIVE_PREVIEW_START, themeId } ) );
 		if ( isJetpackSite( getState(), siteId ) && ! getTheme( getState(), siteId, themeId ) ) {

--- a/client/state/themes/test/actions.js
+++ b/client/state/themes/test/actions.js
@@ -1432,6 +1432,7 @@ describe( 'actions', () => {
 								site_id: 2211667,
 								source: 'detail',
 								theme: 'pendant',
+								theme_style: 'pendant',
 								theme_type: 'free',
 							},
 							service: 'tracks',

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -453,6 +453,7 @@ interface PaletteColor {
 }
 
 export interface GlobalStyles {
+	slug?: string;
 	title?: string;
 	settings: {
 		color: {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/85945#discussion_r1445945997

## Proposed Changes

Track the preselected style variation when live-previewing, by adding a prop `theme_style` to the `calypso_block_theme_live_preview_click` event.

I initially wanted to add the same prop to the other BTP-related events. However, once the user lands in the Site Editor, they can basically change the style variation there, so I think the prop is not relevant after the initial click. Unless we want to query / get the current styles before tracking every event, which I think is too much.

## Testing Instructions

Try to do live-preview using the following scenarios and make sure that the prop is sent correctly:

|Theme without variations|Theme with default variation|Theme with custom variation|
|-|-|-|
|<img width="463" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/02121f45-6fed-4c18-9c94-e3f51b15eaa8">|<img width="407" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/5abdef2c-1a18-4a51-870d-e4c8e05d949e">|<img width="519" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/75d65fe5-8bd9-45eb-a309-9323b40f8cbf">|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?