### PR TITLE
Purchase Modal: enable foldable ToS for more sections

### DIFF
--- a/client/my-sites/checkout/purchase-modal/style.scss
+++ b/client/my-sites/checkout/purchase-modal/style.scss
@@ -38,7 +38,10 @@ $left-margin: 36px;
 }
 
 .purchase-modal__wrapper {
-	display: flex;
+	display: block;
+	.has-feature-list & {
+		display: flex;
+	}
 	width: 100%;
 	flex-direction: column;
 	gap: 12px;

--- a/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
+++ b/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
@@ -3,7 +3,7 @@ import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
 import { useSelector } from 'calypso/state';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId, getSectionName } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export function useToSFoldableCard(): boolean {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
@@ -11,15 +11,7 @@ export function useToSFoldableCard(): boolean {
 		( state ) => isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId )
 	);
 
-	const section = useSelector( getSectionName );
-	const enabledSections = [ 'business-plan-upgrade-upsell', 'plugins', 'signup', 'checkout' ];
-
-	const isWPcomCheckout =
-		section &&
-		enabledSections.includes( section ) &&
-		! isJetpackCheckout() &&
-		! isAkismetCheckout() &&
-		! isJetpackNotAtomic;
+	const isWPcomCheckout = ! isJetpackCheckout() && ! isAkismetCheckout() && ! isJetpackNotAtomic;
 
 	/* Only show the foldable card on the checkout page for WPCOM,
 	 * further testing for Jetpack and Akismet is required before removing this hook

--- a/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
+++ b/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
@@ -12,7 +12,7 @@ export function useToSFoldableCard(): boolean {
 	);
 
 	const section = useSelector( getSectionName );
-	const enabledSections = [ 'business-plan-upgrade-upsell', 'checkout' ];
+	const enabledSections = [ 'business-plan-upgrade-upsell', 'plugins', 'signup', 'checkout' ];
 
 	const isWPcomCheckout =
 		section &&


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Enables foldable ToS in the purchase modal for these sections: 'plugins', 'signup'.

I'm not sure an allowlist of sections is required in the first place, though. Are there any scenarios where we want to show the full ToS? 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Make sure that you have a saved credit card.
* Go to `/plugins/<site slug>` for a site on a free plan.
* Confirm that you see the purchase modal with ToS collapsed.
<img width="1443" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/b5af1640-c1d1-4903-8c44-1448811f0c6c">

* Go to `/start/do-it-for-me`.
* Choose "Existing site" and go through the flow steps till you reach the page picker step.
* Confirm that clicking on the Checkout CTA opens the purchase modal with the ToS collapsed.

<img width="1503" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/f5c89736-914d-493a-a168-7ad978ff033b">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?