### PR TITLE
Jetpack Manage: Add new payment methods page with heading & subheading

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page, { type Callback, type Context } from '@automattic/calypso-router';
 import IssueLicenseV2 from 'calypso/jetpack-cloud/sections/partner-portal/issue-license-v2';
 import {
@@ -35,7 +36,10 @@ import { ToSConsent } from 'calypso/state/partner-portal/types';
 import getSites from 'calypso/state/selectors/get-sites';
 import { setAllSitesSelected } from 'calypso/state/ui/actions/set-sites';
 import Header from './header';
+import PaymentMethodListV2 from './payment-methods-v2';
 import WPCOMAtomicHosting from './primary/wpcom-atomic-hosting';
+
+const isNewCardAdditionEnabled = isEnabled( 'jetpack/card-addition-improvements' );
 
 const setSidebar = ( context: Context, isLicenseContext: boolean = false ): void => {
 	context.secondary = isLicenseContext ? (
@@ -138,7 +142,7 @@ export const assignLicenseContext: Callback = ( context, next ) => {
 export const paymentMethodListContext: Callback = ( context, next ) => {
 	context.header = <Header />;
 	setSidebar( context );
-	context.primary = <PaymentMethodList />;
+	context.primary = isNewCardAdditionEnabled ? <PaymentMethodListV2 /> : <PaymentMethodList />;
 	next();
 };
 

--- a/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/index.tsx
@@ -1,0 +1,27 @@
+import { useTranslate } from 'i18n-calypso';
+import Layout from 'calypso/jetpack-cloud/components/layout';
+import LayoutHeader, {
+	LayoutHeaderSubtitle as Subtitle,
+	LayoutHeaderTitle as Title,
+} from 'calypso/jetpack-cloud/components/layout/header';
+import LayoutTop from 'calypso/jetpack-cloud/components/layout/top';
+
+export default function PaymentMethodListV2() {
+	const translate = useTranslate();
+
+	const title = translate( 'Payment Methods' );
+	const subtitle = translate(
+		"Add a payment method to issue licenses. It's auto-charged monthly."
+	);
+
+	return (
+		<Layout className="payment-method-list" title={ title } wide>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ title } </Title>
+					<Subtitle>{ subtitle }</Subtitle>
+				</LayoutHeader>
+			</LayoutTop>
+		</Layout>
+	);
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/174

## Proposed Changes

This PR adds a new payment methods page with a heading & subheading

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link
2. Visit /partner-portal/payment-methods?flags=jetpack/card-addition-improvements and verify a new page is displayed.

<img width="1457" alt="Screenshot 2024-01-10 at 1 11 51 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/4f25d19e-be31-40d9-ac87-991dbc109dc3">

3. The Old UI should show up without the feature flag enabled. 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?