### PR TITLE
Plan IntervalTypeDropdown: allow using onChange instead of href

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -138,11 +138,13 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		setDomain( freeDomainSuggestion );
 	};
 
-	const handleIntervalTypeChange = ( intervalType: SupportIntervalTypes ) => {
-		setIntervalType( intervalType );
-		const url = new URL( window.location.href );
-		url.searchParams.set( 'intervalType', intervalType );
-		window.history.pushState( null, '', url.toString() );
+	const handleIntervalTypeChange = ( nextIntervalType: SupportIntervalTypes ) => {
+		if ( nextIntervalType !== intervalType ) {
+			setIntervalType( nextIntervalType );
+			const url = new URL( window.location.href );
+			url.searchParams.set( 'intervalType', nextIntervalType );
+			window.history.pushState( null, '', url.toString() );
+		}
 	};
 
 	const plansFeaturesList = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -18,11 +18,11 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { getPlanCartItem } from 'calypso/lib/cart-values/cart-items';
-import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
+import PlansFeaturesMain, { SupportIntervalTypes } from 'calypso/my-sites/plans-features-main';
 import PlanFAQ from 'calypso/my-sites/plans-features-main/components/plan-faq';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { getIntervalType } from 'calypso/signup/steps/plans/util';
@@ -73,6 +73,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		};
 	}, [] );
 	const { flowName, selectedSiteId, setSelectedSiteId } = props;
+	const [ intervalType, setIntervalType ] = useState( getIntervalType() );
 
 	const { setPlanCartItem, setDomain, setDomainCartItem, setProductCartItems } =
 		useDispatch( ONBOARD_STORE );
@@ -137,6 +138,13 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		setDomain( freeDomainSuggestion );
 	};
 
+	const handleIntervalTypeChange = ( intervalType: SupportIntervalTypes ) => {
+		setIntervalType( intervalType );
+		const url = new URL( window.location );
+		url.searchParams.set( 'intervalType', intervalType );
+		window.history.pushState( null, '', url.toString() );
+	};
+
 	const plansFeaturesList = () => {
 		return (
 			<div>
@@ -147,7 +155,8 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 					hideFreePlan={ hideFreePlan }
 					isInSignup={ isInSignup }
 					isStepperUpgradeFlow={ true }
-					intervalType={ getIntervalType() }
+					intervalType={ intervalType }
+					onIntervalTypeChange={ handleIntervalTypeChange }
 					onUpgradeClick={ onUpgradeClick }
 					paidDomainName={ getPaidDomainName() }
 					customerType={ customerType }
@@ -222,7 +231,6 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		const fallbackHeaderText = headerText;
 		const subHeaderText = getSubHeaderText();
 		const fallbackSubHeaderText = subHeaderText;
-
 		return (
 			<>
 				<StepWrapper

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -140,7 +140,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 
 	const handleIntervalTypeChange = ( intervalType: SupportIntervalTypes ) => {
 		setIntervalType( intervalType );
-		const url = new URL( window.location );
+		const url = new URL( window.location.href );
 		url.searchParams.set( 'intervalType', intervalType );
 		window.history.pushState( null, '', url.toString() );
 	};

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -141,7 +141,7 @@ export interface PlansFeaturesMainProps {
 	removePaidDomain?: () => void;
 	setSiteUrlAsFreeDomainSuggestion?: ( freeDomainSuggestion: { domain_name: string } ) => void;
 	intervalType?: SupportIntervalTypes;
-	onIntervalTypeChange?( intervalType: SupportIntervalTypes );
+	onIntervalTypeChange?( intervalType: SupportIntervalTypes ): void;
 	planTypeSelector?: 'interval';
 	withDiscount?: string;
 	discountEndDate?: Date;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -115,6 +115,11 @@ const PlanComparisonHeader = styled.h1`
 	}
 `;
 
+export type SupportIntervalTypes = Extract<
+	UrlFriendlyTermType,
+	'monthly' | 'yearly' | '2yearly' | '3yearly'
+>;
+
 export interface PlansFeaturesMainProps {
 	siteId?: number | null;
 	intent?: PlansIntent | null;
@@ -135,7 +140,8 @@ export interface PlansFeaturesMainProps {
 	flowName?: string | null;
 	removePaidDomain?: () => void;
 	setSiteUrlAsFreeDomainSuggestion?: ( freeDomainSuggestion: { domain_name: string } ) => void;
-	intervalType?: Extract< UrlFriendlyTermType, 'monthly' | 'yearly' | '2yearly' | '3yearly' >;
+	intervalType?: SupportIntervalTypes;
+	onIntervalTypeChange?( intervalType: SupportIntervalTypes );
 	planTypeSelector?: 'interval';
 	withDiscount?: string;
 	discountEndDate?: Date;
@@ -229,6 +235,7 @@ const PlansFeaturesMain = ( {
 	customerType = 'personal',
 	planTypeSelector = 'interval',
 	intervalType = 'yearly',
+	onIntervalTypeChange,
 	hidePlansFeatureComparison = false,
 	hideUnavailableFeatures = false,
 	isInSignup = false,
@@ -784,6 +791,7 @@ const PlansFeaturesMain = ( {
 								layoutClassName="plans-features-main__plan-type-selector-layout"
 								enableStickyBehavior={ enablePlanTypeSelectorStickyBehavior }
 								stickyPlanTypeSelectorOffset={ masterbarHeight - 1 }
+								onIntervalTypeChange={ onIntervalTypeChange }
 							/>
 						) }
 						<div

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -33,6 +33,16 @@ const AddOnOption = styled.a`
 	}
 `;
 
+type Option = {
+	key: string;
+	name: JSX.Element;
+	value: string;
+};
+
+type OnChangeValue = {
+	selectedItem: Option;
+};
+
 export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
 	const { intervalType } = props;
 	const supportedIntervalType = (
@@ -40,7 +50,7 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 	) as SupportedUrlFriendlyTermType;
 	const optionsList = useIntervalOptions( props );
 
-	const selectOptionsList = Object.values( optionsList ).map( ( option ) => ( {
+	const selectOptionsList: Option[] = Object.values( optionsList ).map( ( option ) => ( {
 		key: option.key,
 		value: option.url,
 		name: (
@@ -58,7 +68,7 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 				label=""
 				options={ selectOptionsList }
 				value={ selectOptionsList.find( ( { key } ) => key === supportedIntervalType ) }
-				onChange={ ( { selectedItem } ) => {
+				onChange={ ( { selectedItem }: OnChangeValue ) => {
 					window.location.replace( selectedItem.value );
 				} }
 			/>

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -33,8 +33,18 @@ const AddOnOption = styled.a`
 	}
 `;
 
+type Option = {
+	key: string;
+	name: JSX.Element;
+	value: string;
+};
+
+type OnChangeValue = {
+	selectedItem: Option;
+};
+
 export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
-	const { intervalType } = props;
+	const { intervalType, onIntervalTypeChange } = props;
 	const supportedIntervalType = (
 		[ 'yearly', '2yearly', '3yearly', 'monthly' ].includes( intervalType ) ? intervalType : 'yearly'
 	) as SupportedUrlFriendlyTermType;
@@ -42,8 +52,9 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 
 	const selectOptionsList = Object.values( optionsList ).map( ( option ) => ( {
 		key: option.key,
+		value: option.url,
 		name: (
-			<AddOnOption href={ option.url }>
+			<AddOnOption href={ onIntervalTypeChange ? undefined : option.url }>
 				<span className="name"> { option.name } </span>
 				{ option.discountText ? <span className="discount"> { option.discountText } </span> : null }
 			</AddOnOption>
@@ -57,6 +68,11 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 				label=""
 				options={ selectOptionsList }
 				value={ selectOptionsList.find( ( { key } ) => key === supportedIntervalType ) }
+				onChange={ ( { selectedItem }: OnChangeValue ) => {
+					if ( onIntervalTypeChange ) {
+						onIntervalTypeChange( selectedItem.key );
+					}
+				} }
 			/>
 		</div>
 	);

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -33,16 +33,6 @@ const AddOnOption = styled.a`
 	}
 `;
 
-type Option = {
-	key: string;
-	name: JSX.Element;
-	value: string;
-};
-
-type OnChangeValue = {
-	selectedItem: Option;
-};
-
 export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
 	const { intervalType } = props;
 	const supportedIntervalType = (
@@ -50,11 +40,10 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 	) as SupportedUrlFriendlyTermType;
 	const optionsList = useIntervalOptions( props );
 
-	const selectOptionsList: Option[] = Object.values( optionsList ).map( ( option ) => ( {
+	const selectOptionsList = Object.values( optionsList ).map( ( option ) => ( {
 		key: option.key,
-		value: option.url,
 		name: (
-			<AddOnOption>
+			<AddOnOption href={ option.url }>
 				<span className="name"> { option.name } </span>
 				{ option.discountText ? <span className="discount"> { option.discountText } </span> : null }
 			</AddOnOption>
@@ -68,9 +57,6 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 				label=""
 				options={ selectOptionsList }
 				value={ selectOptionsList.find( ( { key } ) => key === supportedIntervalType ) }
-				onChange={ ( { selectedItem }: OnChangeValue ) => {
-					window.location.replace( selectedItem.value );
-				} }
 			/>
 		</div>
 	);

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -42,8 +42,9 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 
 	const selectOptionsList = Object.values( optionsList ).map( ( option ) => ( {
 		key: option.key,
+		value: option.url,
 		name: (
-			<AddOnOption href={ option.url }>
+			<AddOnOption>
 				<span className="name"> { option.name } </span>
 				{ option.discountText ? <span className="discount"> { option.discountText } </span> : null }
 			</AddOnOption>
@@ -57,6 +58,9 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 				label=""
 				options={ selectOptionsList }
 				value={ selectOptionsList.find( ( { key } ) => key === supportedIntervalType ) }
+				onChange={ ( { selectedItem } ) => {
+					window.location.replace( selectedItem.value );
+				} }
 			/>
 		</div>
 	);

--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { CustomSelectControl } from '@wordpress/components';
+import { SupportIntervalTypes } from 'calypso/my-sites/plans-features-main/index';
 import useIntervalOptions from '../hooks/use-interval-options';
 import { IntervalTypeProps, SupportedUrlFriendlyTermType } from '../types';
 
@@ -34,7 +35,7 @@ const AddOnOption = styled.a`
 `;
 
 type Option = {
-	key: string;
+	key: SupportIntervalTypes;
 	name: JSX.Element;
 	value: string;
 };

--- a/client/my-sites/plans-grid/components/plan-type-selector/types.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/types.ts
@@ -36,6 +36,7 @@ export type PlanTypeSelectorProps = {
 export type IntervalTypeProps = Pick<
 	PlanTypeSelectorProps,
 	| 'intervalType'
+	| 'onIntervalTypeChange'
 	| 'plans'
 	| 'isInSignup'
 	| 'eligibleForWpcomMonthlyPlans'

--- a/client/my-sites/plans-grid/components/plan-type-selector/types.ts
+++ b/client/my-sites/plans-grid/components/plan-type-selector/types.ts
@@ -1,11 +1,13 @@
 import { UrlFriendlyTermType, type PlanSlug } from '@automattic/calypso-products';
 import { type TranslateResult } from 'i18n-calypso';
+import { SupportIntervalTypes } from 'calypso/my-sites/plans-features-main/index';
 import { type UsePricingMetaForGridPlans } from '../../hooks/npm-ready/data-store/use-grid-plans';
 
 export type PlanTypeSelectorProps = {
 	kind: 'interval';
 	basePlansPath?: string | null;
 	intervalType: UrlFriendlyTermType;
+	onIntervalTypeChange?( intervalType: SupportIntervalTypes ): void;
 	customerType: string;
 	withDiscount?: string;
 	enableStickyBehavior?: boolean;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1704870751451319-slack-C0347E545HR

## Proposed Changes

* Allow using `onChange` in `IntervalTypeDropdown` instead of using `href` on the option. Older flows like `/start/plans` detect URL changes and silently update the page (it seems PageJS is handling this p1704879502963149-slack-C0347E545HR), but `/setup/new-hosted-site/plans` does a full refresh and is broken in prod where just clicking the dropdown triggers a page refresh. This PR fixes the issue shown in p1704870751451319-slack-C0347E545HR and makes the update silent to match the behaviour of `/start/plans`  and other flows. 

There could well be a simpler way to fix this bug. I am going offline soon and wanted to get something out. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test this PR anywhere we show plans with the interval picker and ensure it works
* Make sure grid prices update
* Make sure it works at `/setup/new-hosted-site/`  and doesn't refresh the page before the user can change the value

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?