### PR TITLE
Reblogging: track site selector

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -444,6 +444,7 @@ function createSitesComponent( context ) {
 			getSiteSelectionHeaderText={ context.getSiteSelectionHeaderText }
 			fromSite={ context.query.site }
 			clearPageTitle={ context.clearPageTitle }
+			isPostShare={ context.query?.is_post_share }
 		/>
 	);
 }

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -29,10 +29,16 @@ class Sites extends Component {
 	static propTypes = {
 		siteBasePath: PropTypes.string.isRequired,
 		clearPageTitle: PropTypes.bool,
+		isPostShare: PropTypes.bool,
 	};
 
 	componentDidMount() {
 		const path = this.getPath();
+		recordTracksEvent( 'calypso_site_selector_view', {
+			path,
+			is_post_share: this.props.isPostShare,
+		} );
+
 		if ( this.props.fromSite && path ) {
 			recordTracksEvent( 'calypso_site_selector_site_missing', {
 				path,


### PR DESCRIPTION
While trying to see data from the Reblogging experience, we noticed a limitation in the track events that we could use.

This PR fires a `calypso_site_selector_view` event, with parameter `is_post_share`, when the user visits the Site Selector.
It will be helpful to see the behavior of users after they click on Reblog.

## Testing

1. Visit a post.
2. Click on reblog
3. Land in the Site Selector, and use Live link instead of wordpress.com
4.  Remember to PCYsg-cae-p2
5. Check events fired, you should see `calypso_site_selector_view` with the `is_post_share` parameter.
6. Visit the site selector without the parameter in the URL. The event should fire without the parameter
7. Click on a site, you should see `calypso_switch_site_click_item` 