### PR TITLE
Stats: Update copy on purchase pages

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -107,7 +107,7 @@ const PersonalPurchase = ( {
 		<div>
 			<div className={ `${ COMPONENT_CLASS_NAME }__notice` }>
 				{ translate(
-					'This plan is for personal sites only. If your site is used for a commercial activity, {{Button}}you will need to choose a commercial plan{{/Button}}.',
+					'This plan is for non-commercial sites only. Sites with any commercial activity {{Button}}require a commercial license{{/Button}}.',
 					{
 						components: {
 							Button: <Button variant="link" href="#" onClick={ handleClick } />,

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -103,6 +103,13 @@ const PersonalPurchase = ( {
 	const showOldSlider = ! isTierUpgradeSliderEnabled;
 	// const showOldSlider = true;
 
+	let continueButtonText = isStandalone
+		? translate( 'Get Stats' )
+		: translate( 'Get Jetpack Stats' );
+	if ( config.isEnabled( 'stats/checkout-flows-v2' ) ) {
+		continueButtonText = translate( 'Contribute and continue' );
+	}
+
 	return (
 		<div>
 			<div className={ `${ COMPONENT_CLASS_NAME }__notice` }>
@@ -252,7 +259,7 @@ const PersonalPurchase = ( {
 						} )
 					}
 				>
-					{ isStandalone ? translate( 'Get Stats' ) : translate( 'Get Jetpack Stats' ) }
+					{ continueButtonText }
 				</ButtonComponent>
 			) }
 		</div>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -161,6 +161,10 @@ Thanks\n\n`;
 		? translate( 'Welcome to Jetpack Stats' )
 		: translate( 'Jetpack Stats' );
 
+	const continueButtonText = config.isEnabled( FLAGS_CHECKOUT_FLOWS_V2 )
+		? translate( 'Upgrade and continue' )
+		: translate( 'Purchase' );
+
 	return (
 		<>
 			<h1>{ pageTitle }</h1>
@@ -209,7 +213,7 @@ Thanks\n\n`;
 							} )
 						}
 					>
-						{ translate( 'Purchase' ) }
+						{ continueButtonText }
 					</ButtonComponent>
 				</>
 			) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86128.

## Proposed Changes

* Updates the commercial license callout text.
* Updates the button text on the commercial page.
* Updates the button text on the PWYW page.

### Commercial page (just the heading)

<img width="550" alt="SCR-20240110-qilp" src="https://github.com/Automattic/wp-calypso/assets/40267301/b7f9539e-9a76-4818-a938-57843c914254">

### PWYW page (heading & notice)

<img width="603" alt="SCR-20240110-qijf" src="https://github.com/Automattic/wp-calypso/assets/40267301/05c46077-5138-4959-914f-14b841606391">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch the Calypso Live site.
* Visit the Stats page for a self-hosted site.
* Click the upgrade notice.
* Confirm the PWYW flow has updated header, notice, and button text.
* Confirm the Commercial flow has updated header and button text.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?