### PR TITLE
Revert "Plans 2023: Add pricing to Plans data-store and use in plans-grid (take 4)"

### DIFF
--- a/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
+++ b/client/my-sites/plans-features-main/hooks/test/use-pricing-meta-for-grid-plans.ts
@@ -10,6 +10,12 @@ jest.mock( 'react-redux', () => ( {
 	useSelector: ( selector ) => selector(),
 } ) );
 jest.mock( '@wordpress/data' );
+jest.mock( 'calypso/state/plans/selectors', () => ( {
+	getPlanPrices: jest.fn(),
+} ) );
+jest.mock( 'calypso/state/sites/plans/selectors', () => ( {
+	getSitePlanRawPrice: jest.fn(),
+} ) );
 jest.mock( 'calypso/state/ui/selectors/get-selected-site-id', () => jest.fn() );
 jest.mock( '@automattic/data-stores', () => ( {
 	Plans: {
@@ -26,6 +32,8 @@ jest.mock( '../use-check-plan-availability-for-purchase', () => jest.fn() );
 
 import { PLAN_PERSONAL, PLAN_PREMIUM } from '@automattic/calypso-products';
 import { Plans, Purchases } from '@automattic/data-stores';
+import { getPlanPrices } from 'calypso/state/plans/selectors';
+import { getSitePlanRawPrice } from 'calypso/state/sites/plans/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import usePricingMetaForGridPlans from '../data-store/use-pricing-meta-for-grid-plans';
 import useCheckPlanAvailabilityForPurchase from '../use-check-plan-availability-for-purchase';
@@ -33,47 +41,21 @@ import useCheckPlanAvailabilityForPurchase from '../use-check-plan-availability-
 describe( 'usePricingMetaForGridPlans', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
-		getSelectedSiteId.mockImplementation( () => 100 );
-		Purchases.useSitePurchaseById.mockImplementation( () => undefined );
-		Plans.useIntroOffers.mockImplementation( () => ( {
-			[ PLAN_PREMIUM ]: null,
+		Plans.useSitePlans.mockImplementation( () => ( {
+			isLoading: false,
+			data: null,
 		} ) );
+		Purchases.useSitePurchaseById.mockImplementation( () => undefined );
 		Plans.usePlans.mockImplementation( () => ( {
 			isLoading: false,
 			data: {
 				[ PLAN_PREMIUM ]: {
-					pricing: {
-						billPeriod: 365,
-						currencyCode: 'USD',
-						originalPrice: {
-							full: 500,
-							monthly: 500,
-						},
-						discountedPrice: {
-							full: 400,
-							monthly: 400,
-						},
-					},
+					billPeriod: 365,
+					currencyCode: 'USD',
 				},
-			},
-		} ) );
-		Plans.useSitePlans.mockImplementation( () => ( {
-			isLoading: false,
-			data: {
-				[ PLAN_PREMIUM ]: {
-					expiry: null,
-					pricing: {
-						billPeriod: 365,
-						currencyCode: 'USD',
-						originalPrice: {
-							full: 500,
-							monthly: 500,
-						},
-						discountedPrice: {
-							full: 250,
-							monthly: 250,
-						},
-					},
+				[ PLAN_PERSONAL ]: {
+					billPeriod: 365,
+					currencyCode: 'USD',
 				},
 			},
 		} ) );
@@ -85,6 +67,9 @@ describe( 'usePricingMetaForGridPlans', () => {
 			productSlug: PLAN_PREMIUM,
 			planSlug: PLAN_PREMIUM,
 		} ) );
+		getSelectedSiteId.mockImplementation( () => 100 );
+		getPlanPrices.mockImplementation( () => null );
+		getSitePlanRawPrice.mockImplementation( () => 300 );
 		useCheckPlanAvailabilityForPurchase.mockImplementation( () => {
 			return {
 				[ PLAN_PREMIUM ]: true,
@@ -100,8 +85,8 @@ describe( 'usePricingMetaForGridPlans', () => {
 		const expectedPricingMeta = {
 			[ PLAN_PREMIUM ]: {
 				originalPrice: {
-					full: 500,
-					monthly: 500,
+					full: 300,
+					monthly: 300,
 				},
 				discountedPrice: {
 					full: null,
@@ -109,8 +94,6 @@ describe( 'usePricingMetaForGridPlans', () => {
 				},
 				billingPeriod: 365,
 				currencyCode: 'USD',
-				expiry: null,
-				introOffer: null,
 			},
 		};
 
@@ -122,23 +105,30 @@ describe( 'usePricingMetaForGridPlans', () => {
 			productSlug: PLAN_PREMIUM,
 			planSlug: PLAN_PREMIUM,
 		} ) );
+		getSelectedSiteId.mockImplementation( () => 100 );
+		getPlanPrices.mockImplementation( () => ( {
+			rawPrice: 300,
+			discountedRawPrice: 200,
+			planDiscountedRawPrice: 100,
+		} ) );
+		getSitePlanRawPrice.mockImplementation( () => null );
 		useCheckPlanAvailabilityForPurchase.mockImplementation( () => {
 			return {
 				[ PLAN_PREMIUM ]: false,
+				[ PLAN_PERSONAL ]: false,
 			};
 		} );
 
 		const pricingMeta = usePricingMetaForGridPlans( {
-			planSlugs: [ PLAN_PREMIUM ],
+			planSlugs: [ PLAN_PERSONAL ],
 			withoutProRatedCredits: false,
-			storageAddOns: null,
 		} );
 
 		const expectedPricingMeta = {
-			[ PLAN_PREMIUM ]: {
+			[ PLAN_PERSONAL ]: {
 				originalPrice: {
-					full: 500,
-					monthly: 500,
+					full: 300,
+					monthly: 300,
 				},
 				discountedPrice: {
 					full: null,
@@ -146,57 +136,24 @@ describe( 'usePricingMetaForGridPlans', () => {
 				},
 				billingPeriod: 365,
 				currencyCode: 'USD',
-				expiry: null,
-				introOffer: null,
 			},
 		};
 
 		expect( pricingMeta ).toEqual( expectedPricingMeta );
 	} );
 
-	it( 'should return the original price and discounted price (prorated) when withoutProRatedCredits is false', () => {
+	it( 'should return the original price and discounted price without pro-rated credits when withoutProRatedCredits is true', () => {
 		Plans.useCurrentPlan.mockImplementation( () => ( {
-			productSlug: PLAN_PERSONAL,
-			planSlug: PLAN_PERSONAL,
+			productSlug: PLAN_PREMIUM,
+			planSlug: PLAN_PREMIUM,
 		} ) );
-		useCheckPlanAvailabilityForPurchase.mockImplementation( () => {
-			return {
-				[ PLAN_PERSONAL ]: true,
-				[ PLAN_PREMIUM ]: true,
-			};
-		} );
-
-		const pricingMeta = usePricingMetaForGridPlans( {
-			planSlugs: [ PLAN_PREMIUM ],
-			withoutProRatedCredits: false,
-			storageAddOns: null,
-		} );
-
-		const expectedPricingMeta = {
-			[ PLAN_PREMIUM ]: {
-				originalPrice: {
-					full: 500,
-					monthly: 500,
-				},
-				discountedPrice: {
-					full: 250,
-					monthly: 250,
-				},
-				billingPeriod: 365,
-				currencyCode: 'USD',
-				expiry: null,
-				introOffer: null,
-			},
-		};
-
-		expect( pricingMeta ).toEqual( expectedPricingMeta );
-	} );
-
-	it( 'should return the original price and discounted price (not prorated) when withoutProRatedCredits is true', () => {
-		Plans.useCurrentPlan.mockImplementation( () => ( {
-			productSlug: PLAN_PERSONAL,
-			planSlug: PLAN_PERSONAL,
+		getSelectedSiteId.mockImplementation( () => 100 );
+		getPlanPrices.mockImplementation( () => ( {
+			rawPrice: 300,
+			discountedRawPrice: 200,
+			planDiscountedRawPrice: 100,
 		} ) );
+		getSitePlanRawPrice.mockImplementation( () => null );
 		useCheckPlanAvailabilityForPurchase.mockImplementation( () => {
 			return {
 				[ PLAN_PREMIUM ]: true,
@@ -205,25 +162,66 @@ describe( 'usePricingMetaForGridPlans', () => {
 		} );
 
 		const pricingMeta = usePricingMetaForGridPlans( {
-			planSlugs: [ PLAN_PREMIUM ],
+			planSlugs: [ PLAN_PERSONAL ],
 			withoutProRatedCredits: true,
 			storageAddOns: null,
 		} );
 
 		const expectedPricingMeta = {
-			[ PLAN_PREMIUM ]: {
+			[ PLAN_PERSONAL ]: {
 				originalPrice: {
-					full: 500,
-					monthly: 500,
+					full: 300,
+					monthly: 300,
 				},
 				discountedPrice: {
-					full: 400,
-					monthly: 400,
+					full: 200,
+					monthly: 200,
 				},
 				billingPeriod: 365,
 				currencyCode: 'USD',
-				expiry: null,
-				introOffer: null,
+			},
+		};
+
+		expect( pricingMeta ).toEqual( expectedPricingMeta );
+	} );
+
+	it( 'should return the original price and discounted price with pro-rated credits when withoutProRatedCredits is false', () => {
+		Plans.useCurrentPlan.mockImplementation( () => ( {
+			productSlug: PLAN_PREMIUM,
+			planSlug: PLAN_PREMIUM,
+		} ) );
+		getSelectedSiteId.mockImplementation( () => 100 );
+		getPlanPrices.mockImplementation( () => ( {
+			rawPrice: 300,
+			discountedRawPrice: 200,
+			planDiscountedRawPrice: 100,
+		} ) );
+		getSitePlanRawPrice.mockImplementation( () => null );
+		useCheckPlanAvailabilityForPurchase.mockImplementation( () => {
+			return {
+				[ PLAN_PREMIUM ]: true,
+				[ PLAN_PERSONAL ]: true,
+			};
+		} );
+
+		const pricingMeta = usePricingMetaForGridPlans( {
+			planSlugs: [ PLAN_PERSONAL ],
+			withoutProRatedCredits: false,
+			storageAddOns: null,
+		} );
+
+		const expectedPricingMeta = {
+			[ PLAN_PERSONAL ]: {
+				originalPrice: {
+					full: 300,
+					monthly: 300,
+				},
+				discountedPrice: {
+					full: 100,
+					monthly: 100,
+				},
+				billingPeriod: 365,
+				currencyCode: 'USD',
 			},
 		};
 

--- a/packages/data-stores/src/plans/hooks/test/use-intro-offers.ts
+++ b/packages/data-stores/src/plans/hooks/test/use-intro-offers.ts
@@ -32,7 +32,7 @@ describe( 'useIntroOffers selector', () => {
 
 		expect( introOffers ).toEqual( {
 			[ MockData.NEXT_STORE_SITE_PLAN_BUSINESS.planSlug ]:
-				MockData.NEXT_STORE_SITE_PLAN_BUSINESS.pricing.introOffer,
+				MockData.NEXT_STORE_SITE_PLAN_BUSINESS.introOffer,
 		} );
 	} );
 
@@ -68,8 +68,7 @@ describe( 'useIntroOffers selector', () => {
 		const introOffers = useIntroOffers( { siteId: 1 } );
 
 		expect( introOffers ).toEqual( {
-			[ MockData.NEXT_STORE_PLAN_BUSINESS.planSlug ]:
-				MockData.NEXT_STORE_PLAN_BUSINESS.pricing.introOffer,
+			[ MockData.NEXT_STORE_PLAN_BUSINESS.planSlug ]: MockData.NEXT_STORE_PLAN_BUSINESS.introOffer,
 		} );
 	} );
 
@@ -91,7 +90,7 @@ describe( 'useIntroOffers selector', () => {
 		expect( introOffers ).toEqual( {
 			[ MockData.NEXT_STORE_PLAN_PERSONAL.planSlug ]: null,
 			[ MockData.NEXT_STORE_SITE_PLAN_BUSINESS.planSlug ]:
-				MockData.NEXT_STORE_SITE_PLAN_BUSINESS.pricing.introOffer,
+				MockData.NEXT_STORE_SITE_PLAN_BUSINESS.introOffer,
 		} );
 	} );
 } );

--- a/packages/data-stores/src/plans/hooks/use-intro-offers.ts
+++ b/packages/data-stores/src/plans/hooks/use-intro-offers.ts
@@ -33,7 +33,7 @@ const useIntroOffers = ( { siteId }: Props ): IntroOffersIndex | undefined => {
 
 				return {
 					...acc,
-					[ planSlug ]: plan?.pricing?.introOffer ?? null,
+					[ planSlug ]: plan?.introOffer ?? null,
 				};
 			},
 			{}

--- a/packages/data-stores/src/plans/index.ts
+++ b/packages/data-stores/src/plans/index.ts
@@ -17,7 +17,6 @@ export type {
 	PlanPath,
 	PlanBillingPeriod,
 	PlanSimplifiedFeature,
-	PlanPricing,
 } from './types';
 
 /** Queries */

--- a/packages/data-stores/src/plans/mock/next/store/plans.ts
+++ b/packages/data-stores/src/plans/mock/next/store/plans.ts
@@ -8,41 +8,18 @@ export const NEXT_STORE_SITE_PLAN_PERSONAL: SitePlan = {
 	planSlug: 'personal-bundle',
 	productSlug: 'personal-bundle',
 	productId: 1,
-	pricing: {
-		currencyCode: 'USD',
-		introOffer: null,
-		originalPrice: {
-			monthly: 400,
-			full: 4800,
-		},
-		discountedPrice: {
-			monthly: null,
-			full: null,
-		},
-	},
 };
 
 export const NEXT_STORE_SITE_PLAN_BUSINESS: SitePlan = {
 	planSlug: 'business-bundle',
 	productSlug: 'business-bundle',
 	productId: 2,
-	pricing: {
-		introOffer: {
-			formattedPrice: '$15.00',
-			rawPrice: 15,
-			intervalUnit: 'month',
-			intervalCount: 1,
-			isOfferComplete: false,
-		},
-		originalPrice: {
-			monthly: 2500,
-			full: 30000,
-		},
-		discountedPrice: {
-			monthly: null,
-			full: null,
-		},
-		currencyCode: 'USD',
+	introOffer: {
+		formattedPrice: '$15.00',
+		rawPrice: 15,
+		intervalUnit: 'month',
+		intervalCount: 1,
+		isOfferComplete: false,
 	},
 };
 
@@ -60,43 +37,22 @@ export const NEXT_STORE_PLAN_PERSONAL: PlanNext = {
 	productSlug: 'personal-bundle',
 	productId: 1,
 	productNameShort: 'Personal',
-	pricing: {
-		billPeriod: 365,
-		currencyCode: 'USD',
-		introOffer: null,
-		originalPrice: {
-			monthly: 400,
-			full: 4800,
-		},
-		discountedPrice: {
-			monthly: null,
-			full: null,
-		},
-	},
+	billPeriod: -1,
+	currencyCode: 'USD',
 };
 
 export const NEXT_STORE_PLAN_BUSINESS: PlanNext = {
 	planSlug: 'business-bundle',
 	productSlug: 'business-bundle',
 	productId: 2,
-	productNameShort: 'Business',
-	pricing: {
-		billPeriod: 365,
-		currencyCode: 'USD',
-		introOffer: {
-			formattedPrice: '$25.00',
-			rawPrice: 25,
-			intervalUnit: 'month',
-			intervalCount: 1,
-			isOfferComplete: false,
-		},
-		originalPrice: {
-			monthly: 2500,
-			full: 30000,
-		},
-		discountedPrice: {
-			monthly: null,
-			full: null,
-		},
+	introOffer: {
+		formattedPrice: '$25.00',
+		rawPrice: 25,
+		intervalUnit: 'month',
+		intervalCount: 1,
+		isOfferComplete: false,
 	},
+	productNameShort: 'Business',
+	billPeriod: 365,
+	currencyCode: 'USD',
 };

--- a/packages/data-stores/src/plans/queries/use-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-plans.ts
@@ -1,4 +1,3 @@
-import { calculateMonthlyPriceForPlan } from '@automattic/calypso-products';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import unpackIntroOffer from './lib/unpack-intro-offer';
@@ -17,46 +16,25 @@ function usePlans(): UseQueryResult< PlansIndex > {
 
 	return useQuery( {
 		queryKey: queryKeys.plans(),
-		queryFn: async (): Promise< PlansIndex > => {
+		queryFn: async () => {
 			const data: PricedAPIPlan[] = await wpcomRequest( {
 				path: `/plans`,
 				apiVersion: '1.5',
 			} );
 
 			return Object.fromEntries(
-				data.map( ( plan ) => {
-					const discountedPriceFull =
-						plan.orig_cost_integer !== plan.raw_price_integer ? plan.raw_price_integer : null;
-
-					return [
-						plan.product_slug,
-						{
-							planSlug: plan.product_slug,
-							productSlug: plan.product_slug,
-							productId: plan.product_id,
-							productNameShort: plan.product_name_short,
-							pricing: {
-								billPeriod: plan.bill_period,
-								currencyCode: plan.currency_code,
-								introOffer: unpackIntroOffer( plan ),
-								originalPrice: {
-									monthly:
-										typeof plan.orig_cost_integer === 'number'
-											? calculateMonthlyPriceForPlan( plan.product_slug, plan.orig_cost_integer )
-											: null,
-									full: plan.orig_cost_integer,
-								},
-								discountedPrice: {
-									monthly:
-										typeof discountedPriceFull === 'number'
-											? calculateMonthlyPriceForPlan( plan.product_slug, discountedPriceFull )
-											: null,
-									full: discountedPriceFull,
-								},
-							},
-						},
-					];
-				} )
+				data.map( ( plan ) => [
+					plan.product_slug,
+					{
+						planSlug: plan.product_slug,
+						productSlug: plan.product_slug,
+						productId: plan.product_id,
+						introOffer: unpackIntroOffer( plan ),
+						productNameShort: plan.product_name_short,
+						billPeriod: plan.bill_period,
+						currencyCode: plan.currency_code,
+					},
+				] )
 			);
 		},
 	} );

--- a/packages/data-stores/src/plans/queries/use-site-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-site-plans.ts
@@ -1,4 +1,3 @@
-import { calculateMonthlyPriceForPlan } from '@automattic/calypso-products';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import unpackIntroOffer from './lib/unpack-intro-offer';
@@ -26,7 +25,7 @@ function useSitePlans( { siteId }: Props ): UseQueryResult< SitePlansIndex > {
 
 	return useQuery( {
 		queryKey: queryKeys.sitePlans( siteId ),
-		queryFn: async (): Promise< SitePlansIndex > => {
+		queryFn: async () => {
 			const data: PricedAPISitePlansIndex = await wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteId as string ) }/plans`,
 				apiVersion: '1.3',
@@ -35,10 +34,6 @@ function useSitePlans( { siteId }: Props ): UseQueryResult< SitePlansIndex > {
 			return Object.fromEntries(
 				Object.keys( data ).map( ( productId ) => {
 					const plan = data[ Number( productId ) ];
-					const originalPriceFull = plan.raw_discount_integer
-						? plan.raw_price_integer + plan.raw_discount_integer
-						: plan.raw_price_integer;
-					const discountedPriceFull = plan.raw_discount_integer ? plan.raw_price_integer : null;
 
 					return [
 						plan.product_slug,
@@ -46,27 +41,10 @@ function useSitePlans( { siteId }: Props ): UseQueryResult< SitePlansIndex > {
 							planSlug: plan.product_slug,
 							productSlug: plan.product_slug,
 							productId: Number( productId ),
+							introOffer: unpackIntroOffer( plan ),
 							expiry: plan.expiry,
 							currentPlan: plan.current_plan,
 							purchaseId: plan.id ? Number( plan.id ) : undefined,
-							pricing: {
-								currencyCode: plan.currency_code,
-								introOffer: unpackIntroOffer( plan ),
-								originalPrice: {
-									monthly:
-										typeof originalPriceFull === 'number'
-											? calculateMonthlyPriceForPlan( plan.product_slug, originalPriceFull )
-											: null,
-									full: originalPriceFull,
-								},
-								discountedPrice: {
-									monthly:
-										typeof discountedPriceFull === 'number'
-											? calculateMonthlyPriceForPlan( plan.product_slug, discountedPriceFull )
-											: null,
-									full: discountedPriceFull,
-								},
-							},
 						},
 					];
 				} )

--- a/packages/data-stores/src/plans/types.ts
+++ b/packages/data-stores/src/plans/types.ts
@@ -68,45 +68,21 @@ export interface PlanIntroductoryOffer {
 	isOfferComplete: boolean;
 }
 
-export interface PlanPricing {
-	billPeriod: -1 | ( typeof PERIOD_LIST )[ number ];
-	currencyCode: string;
-	introOffer?: PlanIntroductoryOffer | null;
-	/**
-	 * This is the original cost as defined for the associated billing plan.
-	 */
-	originalPrice: {
-		monthly: number | null;
-		full: number | null;
-	};
-	/**
-	 * This is the original cost as defined for the associated billing plan, minus any discounts
-	 * stemming from either currency conversion and/or prorated credits (in the case of Site Plans).
-	 *   1. If a concrete value exists for `Plan` (derived from `usePlans`),
-	 * then it refers to a technical discount due to currency conversion.
-	 *   2. If a concrete value exists for `SitePlan` (derived from `useSitePlans`),
-	 * then it refers to a credit-based discount on the plan price (e.g. from proration).
-	 */
-	discountedPrice: {
-		monthly: number | null;
-		full: number | null;
-	};
-}
-
-export interface SitePlanPricing extends Omit< PlanPricing, 'billPeriod' > {}
-
 export interface SitePlan {
 	/* START: Same SitePlan/PlanNext props */
 	planSlug: PlanSlugFromProducts;
 	productSlug: PlanSlugFromProducts;
 	productId: number;
-	pricing: SitePlanPricing;
+	introOffer?: PlanIntroductoryOffer | null;
 	/* END: Same SitePlan/PlanNext props */
+
 	currentPlan?: boolean;
+
 	/**
 	 * This value is only returned for the current plan on the site.
 	 */
 	expiry?: string;
+
 	/**
 	 * This is only set when `currentPlan` is true (so for the current plan on the site).
 	 * It is sent through as `id` from the endpoint and remapped here to avoid confusion e.g. with `productId`.
@@ -123,9 +99,12 @@ export interface PlanNext {
 	planSlug: PlanSlugFromProducts;
 	productSlug: PlanSlugFromProducts;
 	productId: number;
-	pricing: PlanPricing;
+	introOffer?: PlanIntroductoryOffer | null;
 	/* END: Same SitePlan/PlanNext props */
+
 	productNameShort: string;
+	billPeriod: -1 | ( typeof PERIOD_LIST )[ number ];
+	currencyCode: string;
 }
 
 export interface PricedAPIPlanIntroductoryOffer {
@@ -136,7 +115,17 @@ export interface PricedAPIPlanIntroductoryOffer {
 	introductory_offer_end_date?: string;
 }
 
-export interface PricedAPIPlanPricing {
+/**
+ * Item returned from https://public-api.wordpress.com/rest/v1.5/plans response
+ * Only the properties that are actually used in the store are typed
+ */
+export interface PricedAPIPlan extends PricedAPIPlanIntroductoryOffer {
+	product_id: number;
+	product_name: string;
+	path_slug?: PlanPath;
+	product_slug: StorePlanSlug;
+	product_name_short: string;
+	product_type?: string;
 	bill_period: -1 | ( typeof PERIOD_LIST )[ number ];
 	product_display_price: string;
 	formatted_price: string;
@@ -147,43 +136,24 @@ export interface PricedAPIPlanPricing {
 	raw_price_integer: number;
 
 	/**
-	 * The orig cost in the currency's smallest unit. Note that orig_cost_integer is never null.
-	 * If the cost of a store product is overridden by a promotion or a coupon, orig_cost_integer
-	 * will return a price identical to raw_price_integer instead.
-	 */
-	orig_cost_integer: number;
-
-	currency_code: string;
-}
-
-export interface PricedAPISitePlanPricing
-	extends Omit< PricedAPIPlanPricing, 'orig_cost_integer' | 'bill_period' > {
-	raw_discount_integer: number;
-}
-
-/**
- * Item returned from https://public-api.wordpress.com/rest/v1.5/plans response
- * Only the properties that are actually used in the store are typed
- */
-export interface PricedAPIPlan extends PricedAPIPlanPricing, PricedAPIPlanIntroductoryOffer {
-	product_id: number;
-	product_name: string;
-	path_slug?: PlanPath;
-	product_slug: StorePlanSlug;
-	product_name_short: string;
-	product_type?: string;
-
-	/**
 	 * The product price as a float.
 	 * @deprecated use raw_price_integer as using floats for currency is not safe.
 	 */
 	raw_price: number;
 
 	/**
+	 * The orig cost in the currency's smallest unit. Note that origCostInteger is never null. Although orig_cost
+	 * is undefined if the cost of a store product is overridden by a promotion or a coupon, orig_cost_integer
+	 * is not. origCostInteger will return a price identical to raw_price_integer instead.
+	 */
+	orig_cost_integer: number;
+
+	/**
 	 * The orig cost as a float.
 	 * @deprecated use orig_cost_integer as using floats for currency is not safe.
 	 */
 	orig_cost?: number | null;
+	currency_code: string;
 }
 
 /**
@@ -191,9 +161,7 @@ export interface PricedAPIPlan extends PricedAPIPlanPricing, PricedAPIPlanIntrod
  * Only the properties that are actually used in the store are typed
  * Note: These, unlike the PricedAPIPlan, are returned indexed by product_id (and do not inlcude that in the plan's payload)
  */
-export interface PricedAPISitePlan
-	extends PricedAPISitePlanPricing,
-		PricedAPIPlanIntroductoryOffer {
+export interface PricedAPISitePlan extends PricedAPIPlanIntroductoryOffer {
 	/* product_id: number; // not included in the plan's payload */
 	product_slug: StorePlanSlug;
 	current_plan?: boolean;


### PR DESCRIPTION
Reverts Automattic/wp-calypso#86227