### PR TITLE
Jetpack Manage: Remove 'jetpack/user-feedback-form' feature flag.

### DIFF
--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Icon, starEmpty } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -67,11 +66,8 @@ const JetpackCloudSidebar = ( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const isUserFeedbackEnabled = isEnabled( 'jetpack/user-feedback-form' );
-
 	// Determine whether to initially show the user feedback form.
-	const shouldShowUserFeedbackForm =
-		isUserFeedbackEnabled && window.location.hash === USER_FEEDBACK_FORM_URL_HASH;
+	const shouldShowUserFeedbackForm = window.location.hash === USER_FEEDBACK_FORM_URL_HASH;
 
 	const [ showUserFeedbackForm, setShowUserFeedbackForm ] = useState( shouldShowUserFeedbackForm );
 
@@ -146,7 +142,7 @@ const JetpackCloudSidebar = ( {
 						} }
 					/>
 
-					{ isUserFeedbackEnabled && isAgency && (
+					{ isAgency && (
 						<SidebarNavigatorMenuItem
 							title={ translate( 'Share product feedback', {
 								comment: 'Jetpack Cloud sidebar navigation item',

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -59,7 +59,6 @@
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
-		"jetpack/user-feedback-form": true,
 		"jetpack/card-addition-improvements": false,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -52,7 +52,6 @@
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
-		"jetpack/user-feedback-form": true,
 		"jetpack/card-addition-improvements": false,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -54,7 +54,6 @@
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
-		"jetpack/user-feedback-form": true,
 		"jetpack/card-addition-improvements": false,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -55,7 +55,6 @@
 		"jetpack/server-credentials-advanced-flow": true,
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
-		"jetpack/user-feedback-form": true,
 		"jetpack/card-addition-improvements": false,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,


### PR DESCRIPTION
Closes https://github.com/Automattic/jetpack-genesis/issues/160

## Proposed Changes

* Remove 'jetpack/user-feedback-form' feature flag.
* Update all codes that depend on the feature flag.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Use the Jetpack cloud live link below and go to the Dashboard page (`/dashboard`)
* Confirm that the User feedback button is still visible and working in the sidebar.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?