### PR TITLE
WooExpress: Ensure plugins are active before we forward to dashboard

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/wait-for-plugin-install/index.tsx
@@ -73,11 +73,14 @@ const WaitForPluginInstall: Step = function WaitForAtomic( { navigation, data } 
 						apiVersion: '1.1',
 					} );
 
-					// Check that all plugins to verify have been installed.
-					// If they _have_ been installed, we can stop polling.
+					// Check that all plugins to verify have been installed and activated.
+					// If they _have_ been installed and activated, we can stop polling.
 					if ( response?.plugins && pluginsToVerify ) {
 						stopPollingPlugins = pluginsToVerify.every( ( slug ) => {
-							return response?.plugins.find( ( plugin: { slug: string } ) => plugin.slug === slug );
+							return response?.plugins.find(
+								( plugin: { slug: string; active: boolean } ) =>
+									plugin.slug === slug && plugin.active === true
+							);
 						} );
 					}
 				} catch ( err ) {

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -140,6 +140,7 @@ export type AssertConditionResult = {
 
 export interface Plugin {
 	slug: string;
+	active: boolean;
 }
 
 export interface PluginsResponse {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86108

## Proposed Changes

* Add a check for the plugin's `active` status before stopping polling and continuing with setup. This should prevent users from (sometimes) landing on a dashboard that looks like this after signup:

![image-14](https://github.com/Automattic/wp-calypso/assets/2124984/306c1ce2-2766-4f66-8d8f-53b00c2f605e)

I've noticed that occasionally I'll still land in this dashboard and not on the WooCommerce one; I don't *think* that's related to the plugins being active or not and would suggest we investigate it separately.

<img width="1512" alt="Screenshot 2024-01-10 at 10 28 05 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/35303cfa-c2ed-438a-8b7d-5c1fb4cdec36">


**Before**

![image-14](https://github.com/Automattic/wp-calypso/assets/2124984/306c1ce2-2766-4f66-8d8f-53b00c2f605e)

**After**

<img width="1512" alt="Screenshot 2024-01-10 at 10 41 07 AM" src="https://github.com/Automattic/wp-calypso/assets/2124984/8289beb4-ab5b-4a34-9311-b184c29e4bce">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/setup/wooexpress` and wait for the setup process to complete
* You should land on the WooCommerce dashboard with all plugins activated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?