### PR TITLE
Jetpack Manage: Small code tweak, remove an unused code

### DIFF
--- a/client/jetpack-cloud/sections/overview/primary/overview-products/jetpack-products.ts
+++ b/client/jetpack-cloud/sections/overview/primary/overview-products/jetpack-products.ts
@@ -2,7 +2,6 @@ import { translate } from 'i18n-calypso';
 
 export interface ProductData {
 	description: string;
-	url: string;
 	data?: any;
 	name?: string;
 	slug?: string;
@@ -15,34 +14,26 @@ export interface JetpackProducts {
 export const jetpackProductsToShow: JetpackProducts = {
 	'jetpack-backup-t1': {
 		description: translate( 'Cloud backups and one-click restores.' ),
-		url: 'https://jetpack.com/upgrade/backup/',
 	},
 	'jetpack-ai': {
 		description: translate( 'Create content with ease.' ),
-		url: 'https://jetpack.com/ai/',
 	},
 	'jetpack-monitor': {
 		description: translate( '1-minute alerts & SMS notifications.' ),
-		url: 'https://jetpack.com/features/security/downtime-monitoring/',
 	},
 	'jetpack-boost': {
 		description: translate( 'Speed up your site.' ),
-		url: 'https://jetpack.com/boost/',
 	},
 	'jetpack-social-basic': {
 		description: translate( 'Write once, post everywhere.' ),
-		url: 'https://jetpack.com/social/',
 	},
 	'jetpack-scan': {
 		description: translate( 'Automatic malware scanning.' ),
-		url: 'https://jetpack.com/upgrade/scan/',
 	},
 	'jetpack-security-t1': {
 		description: translate( 'VaultPress Backup, Scan, Anti-spam.' ),
-		url: 'https://jetpack.com/features/security/',
 	},
 	'jetpack-complete': {
 		description: translate( 'The full Jetpack suite.' ),
-		url: 'https://jetpack.com/complete/',
 	},
 };

--- a/client/jetpack-cloud/sections/overview/primary/product-grid/product-item.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/product-grid/product-item.tsx
@@ -24,7 +24,7 @@ const ProductItem: React.FC< Props > = ( { productData, onMoreAboutClick } ) => 
 		<>
 			{ productData.description } <br />
 			<Button
-				className="more-info-link license-lightbox-link"
+				className="more-info-link"
 				onClick={ () => onMoreAboutClick( productData.data.slug ) }
 				plain
 			>


### PR DESCRIPTION
## Proposed Changes

This is a small tweak to remove an unused class style. The `More about ...` link, just removing `license-lightbox-link` class style.

<img width="325" alt="image" src="https://github.com/Automattic/wp-calypso/assets/9832440/1ac5e86e-2a40-49ae-a258-82a6451e877c">

Also, it removes the `url` field from `ProductData` and `jetpackProductsToShow` because now we are showing a product Lightbox, so the external link to jetpack.com product page is no longer necessary.


## Testing Instructions

- Just check the code
- Everything remains the same, the `More about ...` link style will be the same.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
