### PR TITLE
Promote subscription: Update subscription modal setting copy

### DIFF
--- a/client/my-sites/site-settings/settings-newsletter/SubscribeModalOnCommentSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/SubscribeModalOnCommentSetting.tsx
@@ -1,6 +1,7 @@
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 export const SUBSCRIBE_MODAL_ON_COMMENT_OPTION = 'jetpack_verbum_subscription_modal';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 
 type SubscribeModalOnCommentSettingProps = {
 	value?: boolean;
@@ -21,8 +22,11 @@ export const SubscribeModalOnCommentSetting = ( {
 				checked={ !! value }
 				onChange={ handleToggle( SUBSCRIBE_MODAL_ON_COMMENT_OPTION ) }
 				disabled={ disabled }
-				label={ translate( 'Display subscription suggestion after comment' ) }
+				label={ translate( 'Enable comment subscriber pop-up' ) }
 			/>
+			<FormSettingExplanation>
+				{ translate( 'Ask your readers to subscribe after commenting.' ) }
+			</FormSettingExplanation>
 		</>
 	);
 };

--- a/client/my-sites/site-settings/settings-newsletter/SubscribeModalOnCommentSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/SubscribeModalOnCommentSetting.tsx
@@ -22,7 +22,7 @@ export const SubscribeModalOnCommentSetting = ( {
 				checked={ !! value }
 				onChange={ handleToggle( SUBSCRIBE_MODAL_ON_COMMENT_OPTION ) }
 				disabled={ disabled }
-				label={ translate( 'Enable comment subscriber pop-up' ) }
+				label={ translate( 'Enable subscription pop-up for commenters' ) }
 			/>
 			<FormSettingExplanation>
 				{ translate( 'Ask your readers to subscribe after commenting.' ) }

--- a/client/my-sites/site-settings/settings-newsletter/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/SubscribeModalSetting.tsx
@@ -46,11 +46,11 @@ export const SubscribeModalSetting = ( {
 				checked={ !! value }
 				onChange={ handleToggle( SUBSCRIBE_MODAL_OPTION ) }
 				disabled={ disabled }
-				label={ translate( 'Enable subscriber pop-up' ) }
+				label={ translate( 'Enable subscription pop-up' ) }
 			/>
 			<FormSettingExplanation>
 				{ translate(
-					'Grow your subscriber list by enabling a pop-up modal with a subscribe form. This will show as readers scroll.'
+					'Grow your subscriber list by enabling a pop-up modal with a subscription form. This will show as readers scroll.'
 				) }
 				{ subscribeModalEditorUrl && (
 					<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5122

## Proposed Changes

* Update the comment subscription modal setting copy (the second toggle in the screenshot) and add a description.

> Enable comment subscriber pop-up
> Ask your readers to subscribe after commenting.

Before | After
----- | -----
<img width="754" alt="Screen Shot 2024-01-10 at 11 24 35 AM" src="https://github.com/Automattic/wp-calypso/assets/1689238/868dea73-9c6f-49ee-bd23-14bffd14a437"> | <img width="768" alt="Screen Shot 2024-01-10 at 4 52 02 PM" src="https://github.com/Automattic/wp-calypso/assets/1689238/79635bf3-7417-46a8-a18d-4e9fbf75db1d">


Context for this pop-up: pdtkmj-2ey-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Settings > Newsletter

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?