### PR TITLE
usePlans: Protect against fatals caused by undefined coupon param

### DIFF
--- a/packages/data-stores/src/plans/queries/use-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-plans.ts
@@ -12,7 +12,7 @@ interface PlansIndex {
 /**
  * Plans from `/plans` endpoint, transformed into a map of planSlug => PlanNext
  */
-function usePlans( { coupon }: { coupon: string | undefined } ): UseQueryResult< PlansIndex > {
+function usePlans( { coupon }: { coupon?: string } = {} ): UseQueryResult< PlansIndex > {
 	const queryKeys = useQueryKeysFactory();
 	const params = new URLSearchParams();
 	coupon && params.append( 'coupon_code', coupon );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/86100 and https://github.com/Automattic/wp-calypso/pull/85480

## Proposed Changes

#86100 added a new optional `coupon` param to the `usePlans` hook, but #85480 regressed, removing the default empty object, which protected from fataling on undefined `coupon` param.

`usePlans` is used in countless locations across Calypso (and more!), apparently not all calls have been updated with the `coupon` parameter (`{ coupon: undefined }`) would work too), this PR restores the param's default value, again protecting against fatals.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Theme Showcase with the `themes/tiers` feature flag active.
* Ensure the page loads correctly without fatals in console.
* @Automattic/martech-decepticons please check for possible regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?