### PR TITLE
Bug was reported where urlForDisplay was not an array

### DIFF
--- a/client/reader/stream/reader-list-followed-sites/item.jsx
+++ b/client/reader/stream/reader-list-followed-sites/item.jsx
@@ -99,7 +99,7 @@ const ReaderListFollowingItem = ( props ) => {
 					{ follow.description?.length > 0 && (
 						<span className="reader-sidebar-site_description">{ follow.description }</span>
 					) }
-					{ urlForDisplay.length > 0 && (
+					{ urlForDisplay?.length > 0 && (
 						<span className="reader-sidebar-site_url">{ urlForDisplay }</span>
 					) }
 				</span>


### PR DESCRIPTION
## Description

@wargcm reported seeing a bug in the feed that is potentially crashing his browser. This one character fix should allow the call to length to be ignored if urlForDisplay is not an array.

## Testing

Tested this locally. Will retest on staging.