### PR TITLE
GF Signup: Fix plan type selector unescaped percentage sign translation

### DIFF
--- a/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-interval-options.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/hooks/use-interval-options.tsx
@@ -7,7 +7,7 @@ const getDiscountText = ( discountPercentage: number, translate: LocalizeProps[ 
 	if ( ! discountPercentage ) {
 		return '';
 	}
-	return translate( 'up to %(discount)d% off', {
+	return translate( 'up to %(discount)d%% off', {
 		args: { discount: discountPercentage },
 		comment: 'Discount percentage',
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/i18n-issues/issues/718

## Proposed Changes

* Escape percentage sign in discount text translation

## Screenshots
### Before
<img width="309" alt="Screenshot 2024-01-10 at 11 45 29 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/4404624e-c31a-48f2-a4c0-62cb51d8af54">

### After
<img width="317" alt="Screenshot 2024-01-10 at 11 44 30 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/89cc4d51-0b95-4252-a73b-70e359e28f6c">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Set language to Spanish (or one of affected languages)
* Visit `calypso.localhost:3000/start`
* Skip domains to access plans grid
* Verify that the percentage sign renders as expected in the plan type selector dropdown discount text

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?