### PR TITLE
Reader: Ensure we have a urlForDisplay before checking length

### DIFF
--- a/client/reader/stream/reader-list-followed-sites/item.jsx
+++ b/client/reader/stream/reader-list-followed-sites/item.jsx
@@ -99,7 +99,7 @@ const ReaderListFollowingItem = ( props ) => {
 					{ follow.description?.length > 0 && (
 						<span className="reader-sidebar-site_description">{ follow.description }</span>
 					) }
-					{ urlForDisplay.length > 0 && (
+					{ urlForDisplay?.length > 0 && (
 						<span className="reader-sidebar-site_url">{ urlForDisplay }</span>
 					) }
 				</span>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1704918483756629-slack-C0Q664T29 

## Proposed Changes

* Make sure we have a `urlForDisplay` before checking its `length`, otherwise we might get a white screen of death if `follow.URL` is undefined/empty.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/read`
* Ensure you don't see a white screen of death

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?