### PR TITLE
Stats: change support doc links

### DIFF
--- a/client/my-sites/stats/const.js
+++ b/client/my-sites/stats/const.js
@@ -3,3 +3,6 @@
 export const SUPPORT_URL = 'https://wordpress.com/support/stats/understand-your-sites-traffic/';
 // eslint-disable-next-line wpcalypso/i18n-unlocalized-url
 export const SUBSCRIBERS_SUPPORT_URL = 'https://wordpress.com/support/subscribers/';
+export const INSIGHTS_SUPPORT_URL =
+	// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
+	'https://wordpress.com/support/stats/learn-insights-about-your-website/';

--- a/client/my-sites/stats/const.js
+++ b/client/my-sites/stats/const.js
@@ -1,6 +1,5 @@
 // No need to localize this URL, since it's used as the prefix for other localized URLs.
 // eslint-disable-next-line wpcalypso/i18n-unlocalized-url
-export const SUPPORT_URL = 'https://wordpress.com/support/stats/';
-export const UNDERSTAND_YOUR_TRAFFIC_SUPPORT_URL =
-	// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
-	'https://wordpress.com/support/stats/understand-your-sites-traffic/';
+export const SUPPORT_URL = 'https://wordpress.com/support/stats/understand-your-sites-traffic/';
+// eslint-disable-next-line wpcalypso/i18n-unlocalized-url
+export const SUBSCRIBERS_SUPPORT_URL = 'https://wordpress.com/support/subscribers/';

--- a/client/my-sites/stats/stats-comments/index.jsx
+++ b/client/my-sites/stats/stats-comments/index.jsx
@@ -14,7 +14,7 @@ import {
 	isRequestingSiteStatsForQuery,
 } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { SUPPORT_URL } from '../const';
+import { INSIGHTS_SUPPORT_URL } from '../const';
 import StatsErrorPanel from '../stats-error';
 import StatsListCard from '../stats-list/stats-list-card';
 import StatsModuleContent from '../stats-module/content-text';
@@ -139,7 +139,7 @@ class StatsComments extends Component {
 						{
 							comment: '{{link}} links to support documentation.',
 							components: {
-								link: <a href={ localizeUrl( `${ SUPPORT_URL }#:~:text=Comments:` ) } />,
+								link: <a href={ localizeUrl( `${ INSIGHTS_SUPPORT_URL }#:~:text=Comments:` ) } />,
 							},
 							context: 'Stats: Info box label when the Comments module is empty',
 						}

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -14,7 +14,7 @@ import {
 	hasSiteStatsQueryFailed,
 } from 'calypso/state/stats/lists/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { SUPPORT_URL } from '../const';
+import { SUBSCRIBERS_SUPPORT_URL } from '../const';
 import ErrorPanel from '../stats-error';
 import StatsListCard from '../stats-list/stats-list-card';
 import StatsModulePlaceholder from '../stats-module/placeholder';
@@ -155,7 +155,7 @@ class StatModuleFollowers extends Component {
 						{
 							comment: '{{link}} links to support documentation.',
 							components: {
-								link: <a href={ localizeUrl( `${ SUPPORT_URL }#subscribers` ) } />,
+								link: <a href={ localizeUrl( `${ SUBSCRIBERS_SUPPORT_URL }#subscriber-stats` ) } />,
 							},
 							context: 'Stats: Info box label when the Subscribers module is empty',
 						}

--- a/client/my-sites/stats/stats-strings.js
+++ b/client/my-sites/stats/stats-strings.js
@@ -1,6 +1,6 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
-import { SUPPORT_URL } from './const';
+import { SUPPORT_URL, INSIGHTS_SUPPORT_URL } from './const';
 
 export default function () {
 	const statsStrings = {};
@@ -142,6 +142,11 @@ export default function () {
 		} ),
 		empty: translate( 'Most viewed {{link}}tags & categories{{/link}} will be listed here.', {
 			comment: '{{link}} links to support documentation.',
+			components: {
+				link: (
+					<a href={ localizeUrl( `${ INSIGHTS_SUPPORT_URL }#:~:text=Tags%20,%20Categories` ) } />
+				),
+			},
 			context: 'Stats: Info box label when the Tags module is empty',
 		} ),
 	};

--- a/client/my-sites/stats/stats-strings.js
+++ b/client/my-sites/stats/stats-strings.js
@@ -1,6 +1,6 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
-import { SUPPORT_URL, UNDERSTAND_YOUR_TRAFFIC_SUPPORT_URL } from './const';
+import { SUPPORT_URL } from './const';
 
 export default function () {
 	const statsStrings = {};
@@ -48,7 +48,7 @@ export default function () {
 		empty: translate( 'Your most {{link}}clicked external links{{/link}} will display here.', {
 			comment: '{{link}} links to support documentation.',
 			components: {
-				link: <a href={ localizeUrl( `${ UNDERSTAND_YOUR_TRAFFIC_SUPPORT_URL }#clicks` ) } />,
+				link: <a href={ localizeUrl( `${ SUPPORT_URL }#clicks` ) } />,
 			},
 			context: 'Stats: Info box label when the Clicks module is empty',
 		} ),
@@ -83,7 +83,7 @@ export default function () {
 		empty: translate( 'See {{link}}terms that visitors search{{/link}} to find your site, here. ', {
 			comment: '{{link}} links to support documentation.',
 			components: {
-				link: <a href={ localizeUrl( `${ UNDERSTAND_YOUR_TRAFFIC_SUPPORT_URL }#search-terms` ) } />,
+				link: <a href={ localizeUrl( `${ SUPPORT_URL }#search-terms` ) } />,
 			},
 			context: 'Stats: Info box label when the Search Terms module is empty',
 		} ),
@@ -113,7 +113,7 @@ export default function () {
 		empty: translate( 'Your most viewed {{link}}video stats{{/link}} will show up here.', {
 			comment: '{{link}} links to support documentation.',
 			components: {
-				link: <a href={ localizeUrl( `${ UNDERSTAND_YOUR_TRAFFIC_SUPPORT_URL }#videos` ) } />,
+				link: <a href={ localizeUrl( `${ SUPPORT_URL }#videos` ) } />,
 			},
 			context: 'Stats: Info box label when the Videos module is empty',
 		} ),
@@ -142,9 +142,6 @@ export default function () {
 		} ),
 		empty: translate( 'Most viewed {{link}}tags & categories{{/link}} will be listed here.', {
 			comment: '{{link}} links to support documentation.',
-			components: {
-				link: <a href={ localizeUrl( `${ SUPPORT_URL }#:~:text=Tags%20,%20Categories` ) } />,
-			},
 			context: 'Stats: Info box label when the Tags module is empty',
 		} ),
 	};


### PR DESCRIPTION
Related to #85328

## Proposed Changes

* Replaced support links per request: https://github.com/Automattic/wp-calypso/issues/81632#issuecomment-1855787883

## Testing Instructions

* Open Calypso Live -> Stats -> Traffic
* Ensure support links to,
  * https://wordpress.com/support/stats/understand-your-sites-traffic/
  * https://wordpress.com/support/subscribers/
  * https://wordpress.com/support/stats/learn-insights-about-your-website/

<img width="1310" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/dc7dc575-f37c-48f9-9bcd-b7ebb0c29846">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?


cc @donalirl 