### PR TITLE
JP Manage: 219 - update activity log upsell link

### DIFF
--- a/client/components/jetpack/upsell/index.tsx
+++ b/client/components/jetpack/upsell/index.tsx
@@ -42,7 +42,7 @@ const JetpackCloudUpsell: FunctionComponent< Props > = ( {
 					href={ String( buttonLink ) }
 					onClick={ onClick }
 					primary
-					target={ openButtonLinkOnNewTab ? '_blank' : false }
+					target={ openButtonLinkOnNewTab ? '_blank' : undefined }
 				>
 					{ buttonText || translate( 'Upgrade now' ) }
 				</Button>

--- a/client/components/jetpack/upsell/index.tsx
+++ b/client/components/jetpack/upsell/index.tsx
@@ -42,7 +42,7 @@ const JetpackCloudUpsell: FunctionComponent< Props > = ( {
 					href={ String( buttonLink ) }
 					onClick={ onClick }
 					primary
-					target={ openButtonLinkOnNewTab ? '_blank' : '_self' }
+					target={ openButtonLinkOnNewTab ? '_blank' : false }
 				>
 					{ buttonText || translate( 'Upgrade now' ) }
 				</Button>

--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -19,6 +19,7 @@ import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { backupClonePath } from 'calypso/my-sites/backup/paths';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { hasJetpackPartnerAccess as hasJetpackPartnerAccessSelector } from 'calypso/state/partner-portal/partner/selectors';
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
 import getSettingsUrl from 'calypso/state/selectors/get-settings-url';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -35,11 +36,19 @@ const ActivityLogV2: FunctionComponent = () => {
 	const filter = useSelector( ( state ) => getActivityLogFilter( state, siteId ) );
 	const { data: logs } = useActivityLogQuery( siteId, filter );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const hasJetpackPartnerAccess = useSelector( hasJetpackPartnerAccessSelector );
 
 	const siteHasFullActivityLog = useSelector(
 		( state ) => siteId && siteHasFeature( state, siteId, WPCOM_FEATURES_FULL_ACTIVITY_LOG )
 	);
 	const settingsUrl = useSelector( ( state ) => getSettingsUrl( state, siteId, 'general' ) );
+
+	let upsellURL;
+	if ( hasJetpackPartnerAccess ) {
+		upsellURL = `/partner-portal/issue-license?site_id=${ siteId }`;
+	} else {
+		upsellURL = `/pricing/${ selectedSiteSlug }`;
+	}
 
 	const jetpackCloudHeader = siteHasFullActivityLog ? (
 		<div className="activity-log-v2__header">
@@ -80,7 +89,7 @@ const ActivityLogV2: FunctionComponent = () => {
 						'by type and date range to quickly find the information you need.'
 				)
 			) }
-			buttonLink={ `/partner-portal/issue-license?site_id=${ siteId }` }
+			buttonLink={ upsellURL }
 			buttonText={ translate( 'Upgrade now' ) }
 			onClick={ () =>
 				dispatch( recordTracksEvent( 'calypso_jetpack_activity_log_upgrade_click' ) )

--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -81,7 +81,7 @@ const ActivityLogV2: FunctionComponent = () => {
 				)
 			) }
 			buttonLink={ `https://cloud.jetpack.com/pricing/${ selectedSiteSlug }` }
-			buttonText={ translate( 'Upgrade Now' ) }
+			buttonText={ translate( 'Upgrade now' ) }
 			onClick={ () =>
 				dispatch( recordTracksEvent( 'calypso_jetpack_activity_log_upgrade_click' ) )
 			}

--- a/client/my-sites/activity/activity-log-v2/index.tsx
+++ b/client/my-sites/activity/activity-log-v2/index.tsx
@@ -80,7 +80,7 @@ const ActivityLogV2: FunctionComponent = () => {
 						'by type and date range to quickly find the information you need.'
 				)
 			) }
-			buttonLink={ `https://cloud.jetpack.com/pricing/${ selectedSiteSlug }` }
+			buttonLink={ `/partner-portal/issue-license?site_id=${ siteId }` }
 			buttonText={ translate( 'Upgrade now' ) }
 			onClick={ () =>
 				dispatch( recordTracksEvent( 'calypso_jetpack_activity_log_upgrade_click' ) )


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves Automattic/jetpack-manage#219 - update activity log upsell link

## Proposed Changes

If one doesn't have an Activity Log upgrade for a site, and they go to `/activity-log/somesite.example`, they see an upsell:

![image](https://github.com/Automattic/wp-calypso/assets/32492176/9517f133-109f-414d-ae25-1fbdc5445bf9)

Previously the link would go to `https://cloud.jetpack.com/pricing/${ selectedSiteSlug }`.

It now goes to `/partner-portal/issue-license?site_id=${ siteId }`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verify the link continues to work.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
