### PR TITLE
JP Manage: 220 - update no purchases upsell link

### DIFF
--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -103,6 +103,7 @@ export default function SubscriptionsContentWrapper() {
 
 function NoPurchasesMessage() {
 	const selectedSite = useSelector( getSelectedSite );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 	const translate = useTranslate();
 	return isJetpackCloud() ? (
 		<JetpackRnaActionCard
@@ -111,7 +112,11 @@ function NoPurchasesMessage() {
 				'Check out how Jetpack’s security, performance, and growth tools can improve your site.'
 			) }
 			ctaButtonLabel={ translate( 'Compare plans' ) }
-			ctaButtonURL={ selectedSite ? `/pricing/${ selectedSite.slug }` : '/pricing' }
+			ctaButtonURL={
+				selectedSiteId
+					? `/partner-portal/issue-license?site_id=${ selectedSiteId }`
+					: '/partner-portal/issue-license'
+			}
 		/>
 	) : (
 		<CompactCard className="subscriptions__list">

--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -111,7 +111,7 @@ function NoPurchasesMessage() {
 			subHeaderText={ translate(
 				'Check out how Jetpack’s security, performance, and growth tools can improve your site.'
 			) }
-			ctaButtonLabel={ translate( 'Compare plans' ) }
+			ctaButtonLabel={ translate( 'View products' ) }
 			ctaButtonURL={
 				selectedSiteId
 					? `/partner-portal/issue-license?site_id=${ selectedSiteId }`

--- a/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
+++ b/client/my-sites/purchases/subscriptions/subscriptions-content.tsx
@@ -10,6 +10,7 @@ import PurchasesListHeader from 'calypso/me/purchases/purchases-list/purchases-l
 import PurchasesSite from 'calypso/me/purchases/purchases-site';
 import { useStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import { useSelector } from 'calypso/state';
+import { hasJetpackPartnerAccess as hasJetpackPartnerAccessSelector } from 'calypso/state/partner-portal/partner/selectors';
 import {
 	getSitePurchases,
 	hasLoadedSitePurchasesFromServer,
@@ -105,6 +106,19 @@ function NoPurchasesMessage() {
 	const selectedSite = useSelector( getSelectedSite );
 	const selectedSiteId = useSelector( getSelectedSiteId );
 	const translate = useTranslate();
+	const hasJetpackPartnerAccess = useSelector( hasJetpackPartnerAccessSelector );
+
+	let url;
+	if ( hasJetpackPartnerAccess ) {
+		url = selectedSiteId
+			? `/partner-portal/issue-license?site_id=${ selectedSiteId }`
+			: '/partner-portal/issue-license';
+	} else if ( isJetpackCloud() ) {
+		url = selectedSite ? `/pricing/${ selectedSite.slug }` : '/pricing';
+	} else {
+		url = selectedSite ? `/plans/${ selectedSite.slug }` : '/plans';
+	}
+
 	return isJetpackCloud() ? (
 		<JetpackRnaActionCard
 			headerText={ translate( 'You don’t have any active subscriptions for this site.' ) }
@@ -112,11 +126,7 @@ function NoPurchasesMessage() {
 				'Check out how Jetpack’s security, performance, and growth tools can improve your site.'
 			) }
 			ctaButtonLabel={ translate( 'View products' ) }
-			ctaButtonURL={
-				selectedSiteId
-					? `/partner-portal/issue-license?site_id=${ selectedSiteId }`
-					: '/partner-portal/issue-license'
-			}
+			ctaButtonURL={ url }
 		/>
 	) : (
 		<CompactCard className="subscriptions__list">
@@ -124,7 +134,7 @@ function NoPurchasesMessage() {
 				title={ translate( 'Looking to upgrade?' ) }
 				line={ translate( 'You have made no purchases for this site.' ) }
 				action={ translate( 'Upgrade now' ) }
-				actionURL={ selectedSite ? `/plans/${ selectedSite.slug }` : '/plans' }
+				actionURL={ url }
 				illustration={ noSitesIllustration }
 			/>
 		</CompactCard>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves Automattic/jetpack-manage#220 - update no purchases upsell link

## Proposed Changes

If one doesn't have any upgrades on a site, and they go to `/purchases/subscriptions/somesite.example`, they see an upsell:

![image](https://github.com/Automattic/wp-calypso/assets/32492176/88446904-08dc-42b9-a8ee-3921b38dbba0)


Previously the link would go to `/pricing/${ selectedSite.slug }`.

It now goes to `/partner-portal/issue-license?site_id=${ siteId }`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Verify the link continues to work.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
