### PR TITLE
Plans 2023: Fix plan type selector dropdown in stepper flows

### DIFF
--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -1,5 +1,8 @@
 import styled from '@emotion/styled';
 import { CustomSelectControl } from '@wordpress/components';
+// TODO: Check if the ReactNode type exists in @wordpress/element
+import React from 'react';
+import { Link } from 'react-router-dom';
 import useIntervalOptions from '../hooks/use-interval-options';
 import { IntervalTypeProps, SupportedUrlFriendlyTermType } from '../types';
 
@@ -33,8 +36,26 @@ const AddOnOption = styled.a`
 	}
 `;
 
+const ConditionalIntervalTypeOption = ( {
+	isPlansInsideStepper,
+	href,
+	children,
+}: {
+	isPlansInsideStepper: boolean;
+	href: string;
+	// TODO: Verify children type
+	children: React.ReactNode[];
+} ) => {
+	// TODO: Consider using generatePath helper
+	return isPlansInsideStepper ? (
+		<Link to={ href }>{ children }</Link>
+	) : (
+		<AddOnOption href={ href }>{ children }</AddOnOption>
+	);
+};
+
 export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
-	const { intervalType, displayedIntervals } = props;
+	const { intervalType, displayedIntervals, isPlansInsideStepper } = props;
 	const supportedIntervalType = (
 		displayedIntervals.includes( intervalType ) ? intervalType : 'yearly'
 	) as SupportedUrlFriendlyTermType;
@@ -43,10 +64,13 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 	const selectOptionsList = Object.values( optionsList ).map( ( option ) => ( {
 		key: option.key,
 		name: (
-			<AddOnOption href={ option.url }>
+			<ConditionalIntervalTypeOption
+				href={ option.url }
+				isPlansInsideStepper={ isPlansInsideStepper }
+			>
 				<span className="name"> { option.name } </span>
 				{ option.discountText ? <span className="discount"> { option.discountText } </span> : null }
-			</AddOnOption>
+			</ConditionalIntervalTypeOption>
 		),
 	} ) );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1704870751451319-slack-C0347E545HR

## Proposed Changes

* The stepper flow handles client side routing with `react-router`. Updates to the URL should be handled with specific helpers or components from said library
* This PR matches logic for the `IntervalTypeDropdown` with the behavior of the `IntervalTypeToggle`, whereby we render a `react-router` `Link` component in a stepper flow. Otherwise, we render a traditional anchor tag ( see [this link ](https://github.com/Automattic/wp-calypso/blob/trunk/packages/components/src/segmented-control/item.jsx#L52-L53))

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out branch
* Remove hard coded `false` flag https://github.com/Automattic/wp-calypso/blob/trunk/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx#L167
* Make sure the dropdown with term interval appears
* Verify that dropdown behavior works as expected ( no instantaneous page redirect when the dropdown is clicked, etc. )

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?