### PR TITLE
Checkout: Move checkout line items into CSS Grid containers

### DIFF
--- a/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
@@ -61,7 +61,7 @@ export const Option = styled.li< OptionProps >`
 export const Dropdown = styled.div`
 	position: relative;
 	width: 100%;
-	margin: ${ hasCheckoutVersion( '2' ) ? '6px 0' : '16px 0' };
+	margin: ${ hasCheckoutVersion( '2' ) ? null : '16px 0' };
 	> ${ Option } {
 		border-radius: 3px;
 	}

--- a/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
@@ -11,7 +11,7 @@ export const CurrentOption = styled.button< CurrentOptionProps >`
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
-	padding: ${ hasCheckoutVersion( '2' ) ? '4px 16px' : '14px 16px' };
+	${ hasCheckoutVersion( '2' ) ? `padding:4px 16px; height: 40px` : `padding:14px 16px` };
 	width: 100%;
 	cursor: pointer;
 
@@ -40,7 +40,7 @@ export const Option = styled.li< OptionProps >`
 	/* the calc aligns the price with the price in CurrentOption */
 	padding: 10px calc( 14px + 24px + 16px ) 10px 16px;
 	cursor: pointer;
-
+	${ hasCheckoutVersion( '2' ) ? `height: 40px` : null };
 	&:hover {
 		background: var( --studio-blue-0 );
 

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -351,6 +351,7 @@ function LineItemWrapper( {
 				onRemoveProductCancel={ onRemoveProductCancel }
 				isAkPro500Cart={ isAkPro500Cart }
 				areThereVariants={ areThereVariants }
+				shouldShowVariantSelector={ shouldShowVariantSelector }
 			>
 				{ areThereVariants && shouldShowVariantSelector && onChangeSelection && (
 					<ItemVariationPicker

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -350,6 +350,7 @@ function LineItemWrapper( {
 				onRemoveProductClick={ onRemoveProductClick }
 				onRemoveProductCancel={ onRemoveProductCancel }
 				isAkPro500Cart={ isAkPro500Cart }
+				areThereVariants={ areThereVariants }
 			>
 				{ areThereVariants && shouldShowVariantSelector && onChangeSelection && (
 					<ItemVariationPicker

--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -17,6 +17,7 @@ import {
 	isJetpackStatsPaidTieredProductSlug,
 } from '@automattic/calypso-products';
 import { translate, numberFormat } from 'i18n-calypso';
+import { hasCheckoutVersion } from './checkout-version-checker';
 import { isWpComProductRenewal as isRenewal } from './is-wpcom-product-renewal';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
@@ -73,11 +74,15 @@ export function DefaultLineItemSublabel( { product }: { product: ResponseCartPro
 	}
 
 	if ( isMonthlyProduct( product ) ) {
-		return translate( 'Billed monthly' );
+		return hasCheckoutVersion( '2' )
+			? translate( 'Billed every month' )
+			: translate( 'Billed monthly' );
 	}
 
 	if ( isYearly( product ) ) {
-		return translate( 'Billed annually' );
+		return hasCheckoutVersion( '2' )
+			? translate( 'Billed every year' )
+			: translate( 'Billed annually' );
 	}
 
 	if ( isBiennially( product ) ) {

--- a/packages/wpcom-checkout/src/checkout-labels.ts
+++ b/packages/wpcom-checkout/src/checkout-labels.ts
@@ -17,7 +17,6 @@ import {
 	isJetpackStatsPaidTieredProductSlug,
 } from '@automattic/calypso-products';
 import { translate, numberFormat } from 'i18n-calypso';
-import { hasCheckoutVersion } from './checkout-version-checker';
 import { isWpComProductRenewal as isRenewal } from './is-wpcom-product-renewal';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
@@ -74,15 +73,11 @@ export function DefaultLineItemSublabel( { product }: { product: ResponseCartPro
 	}
 
 	if ( isMonthlyProduct( product ) ) {
-		return hasCheckoutVersion( '2' )
-			? translate( 'Billed every month' )
-			: translate( 'Billed monthly' );
+		return translate( 'Billed monthly' );
 	}
 
 	if ( isYearly( product ) ) {
-		return hasCheckoutVersion( '2' )
-			? translate( 'Billed every year' )
-			: translate( 'Billed annually' );
+		return translate( 'Billed annually' );
 	}
 
 	if ( isBiennially( product ) ) {

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -85,12 +85,11 @@ export const LineItem = styled( CheckoutLineItem )< {
 } >`
 	${ hasCheckoutVersion2
 		? `display: grid;
-	grid-template-columns: 3fr 1fr;
+	grid-template-columns: minmax(0, 3fr) 1fr;
 	grid-template-rows: auto;
 	grid-template-areas:
 		'label price'
-		'meta .     '
-		'term remove';
+		'meta remove';
 	gap: 2px;
 	margin-bottom: 8px;
 	padding: 10px 0;`
@@ -129,6 +128,8 @@ const GiftBadge = styled.span`
 
 const LineItemMetaWrapper = styled.div< { theme?: Theme } >`
 	grid-area: meta;
+	display: flex;
+	flex-direction: column;
 `;
 
 const LineItemMeta = styled.div< { theme?: Theme } >`
@@ -143,7 +144,7 @@ const LineItemMeta = styled.div< { theme?: Theme } >`
 	overflow-wrap: anywhere;
 	gap: 2px 10px;
 
-	${ hasCheckoutVersion2 ? `grid-area: term` : null }
+	${ hasCheckoutVersion2 ? `grid-area: meta` : null }
 `;
 
 const UpgradeCreditInformationLineItem = styled( LineItemMeta )< { theme?: Theme } >`
@@ -209,7 +210,7 @@ const LineItemPriceWrapper = styled.span< { theme?: Theme; isSummary?: boolean }
 `;
 
 const DropdownWrapper = styled.span`
-	${ hasCheckoutVersion2 ? `grid-area: term; margin-top: 6px;` : null }
+	${ hasCheckoutVersion2 ? `grid-area: meta; margin-top: 6px;` : null }
 `;
 
 const DeleteButtonWrapper = styled.div`
@@ -691,14 +692,6 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 		stripZeros: true,
 	} );
 
-	if ( hasCheckoutVersion2 ) {
-		return (
-			<>
-				<DefaultLineItemSublabel product={ product } />
-			</>
-		);
-	}
-
 	if ( isP2Plus( product ) ) {
 		// This is the price for one item for products with a quantity (eg. seats in a license).
 		const itemPrice = formatCurrency(
@@ -820,7 +813,9 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 		return (
 			<>
 				{ premiumLabel } <DefaultLineItemSublabel product={ product } />
-				{ ! product.is_included_for_100yearplan && <>: { translate( 'billed annually' ) }</> }
+				{ ! hasCheckoutVersion2 && ! product.is_included_for_100yearplan && (
+					<>: { translate( 'billed annually' ) }</>
+				) }
 			</>
 		);
 	}
@@ -837,7 +832,8 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 	}
 
 	const shouldRenderBasicTermSublabel =
-		isPlan( product ) || isAddOn( product ) || isJetpackProductSlug( productSlug );
+		! hasCheckoutVersion2 &&
+		( isPlan( product ) || isAddOn( product ) || isJetpackProductSlug( productSlug ) );
 	if ( shouldRenderBasicTermSublabel && isMonthlyProduct( product ) ) {
 		return (
 			<>
@@ -1276,6 +1272,9 @@ function CheckoutLineItem( {
 							<LineItemMeta>
 								<LineItemSublabelAndPrice product={ product } />
 							</LineItemMeta>
+							{ isJetpackSearch( product ) && <JetpackSearchMeta product={ product } /> }
+							{ isEmail && <EmailMeta product={ product } isRenewal={ isRenewal } /> }
+							<DropdownWrapper>{ children }</DropdownWrapper>
 						</LineItemMetaWrapper>
 					) : (
 						<>
@@ -1299,15 +1298,13 @@ function CheckoutLineItem( {
 				</LineItemMeta>
 			) }
 
-			{ isJetpackSearch( product ) && <JetpackSearchMeta product={ product } /> }
+			{ ! hasCheckoutVersion2 && isJetpackSearch( product ) && (
+				<JetpackSearchMeta product={ product } />
+			) }
 
 			{ isEmail && <EmailMeta product={ product } isRenewal={ isRenewal } /> }
 
-			{ hasCheckoutVersion2 && ! isEmail ? (
-				<DropdownWrapper>{ children }</DropdownWrapper>
-			) : (
-				<>{ children }</>
-			) }
+			{ ! hasCheckoutVersion2 && ! isEmail && <>{ children }</> }
 			{ hasDeleteButton && removeProductFromCart && (
 				<>
 					<DeleteButtonWrapper>

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1461,7 +1461,7 @@ function CheckoutLineItem( {
 
 			{ product && containsPartnerCoupon && (
 				<LineItemMeta>
-					<LineItemSublabelAndPrice product={ product } />
+					<LineItemBillingInterval product={ product } />
 				</LineItemMeta>
 			) }
 

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -228,7 +228,7 @@ const DeleteButtonWrapper = styled.div`
 
 const DeleteButton = styled( Button )< { theme?: Theme } >`
 	width: auto;
-	${ hasCheckoutVersion2 ? `font-size:  14px; text-decoration: none;` : `font-size: 0.75rem` };
+	${ hasCheckoutVersion2 ? `font-size:  14px;` : `font-size: 0.75rem` };
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 `;
 

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -814,9 +814,7 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 		return (
 			<>
 				{ premiumLabel } <DefaultLineItemSublabel product={ product } />
-				{ ! hasCheckoutVersion2 && ! product.is_included_for_100yearplan && (
-					<>: { translate( 'billed annually' ) }</>
-				) }
+				{ ! product.is_included_for_100yearplan && <>: { translate( 'billed annually' ) }</> }
 			</>
 		);
 	}
@@ -833,8 +831,7 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 	}
 
 	const shouldRenderBasicTermSublabel =
-		! hasCheckoutVersion2 &&
-		( isPlan( product ) || isAddOn( product ) || isJetpackProductSlug( productSlug ) );
+		isPlan( product ) || isAddOn( product ) || isJetpackProductSlug( productSlug );
 	if ( shouldRenderBasicTermSublabel && isMonthlyProduct( product ) ) {
 		return (
 			<>
@@ -1412,7 +1409,11 @@ function CheckoutLineItem( {
 
 			{ product && containsPartnerCoupon && (
 				<LineItemMeta>
-					<LineItemBillingInterval product={ product } />
+					{ hasCheckoutVersion2 ? (
+						<LineItemBillingInterval product={ product } />
+					) : (
+						<LineItemSublabelAndPrice product={ product } />
+					) }
 				</LineItemMeta>
 			) }
 

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1395,20 +1395,20 @@ function CheckoutLineItem( {
 			{ product && ! containsPartnerCoupon && (
 				<>
 					{ hasCheckoutVersion2 ? (
-						<LineItemMeta>
-							{ areThereVariants ? (
-								<DropdownWrapper>{ children }</DropdownWrapper>
-							) : (
-								<LineItemBillingIntervalWrapper product={ product } />
-							) }
-							<LineItemMetaInfoWrapper product={ product } />
-
-							{ isJetpackSearch( product ) && <JetpackSearchMeta product={ product } /> }
-							{ isEmail && <EmailMeta product={ product } isRenewal={ isRenewal } /> }
-							<DomainDiscountCallout product={ product } />
-							<IntroductoryOfferCallout product={ product } />
-							<JetpackAkismetSaleCouponCallout product={ product } />
-						</LineItemMeta>
+						<>
+							<BillingInterval>
+								{ areThereVariants && shouldShowVariantSelector ? (
+									<DropdownWrapper>{ children }</DropdownWrapper>
+								) : (
+									<LineItemBillingIntervalWrapper product={ product } />
+								) }
+							</BillingInterval>
+							<LineItemMeta>
+								<LineItemMetaInfoWrapper product={ product } />
+								{ isJetpackSearch( product ) && <JetpackSearchMeta product={ product } /> }
+								{ isEmail && <EmailMeta product={ product } isRenewal={ isRenewal } /> }
+							</LineItemMeta>
+						</>
 					) : (
 						<>
 							<UpgradeCreditInformationLineItem>

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -220,7 +220,7 @@ const DeleteButtonWrapper = styled.div`
 		? `
 	grid-area: remove;
 	display: grid;
-	align-items: center;
+	align-items: flex-start;
 	justify-content: end;
 	`
 		: `display: inherit };

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1390,6 +1390,9 @@ function CheckoutLineItem( {
 
 							{ isJetpackSearch( product ) && <JetpackSearchMeta product={ product } /> }
 							{ isEmail && <EmailMeta product={ product } isRenewal={ isRenewal } /> }
+							<DomainDiscountCallout product={ product } />
+							<IntroductoryOfferCallout product={ product } />
+							<JetpackAkismetSaleCouponCallout product={ product } />
 						</LineItemMeta>
 					) : (
 						<>

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -49,6 +49,8 @@ import type {
 	TitanProductUser,
 } from '@automattic/shopping-cart';
 
+const hasCheckoutVersion2 = hasCheckoutVersion( '2' );
+
 export const NonProductLineItem = styled( WPNonProductLineItem )< {
 	theme?: Theme;
 	total?: boolean;
@@ -81,13 +83,25 @@ export const NonProductLineItem = styled( WPNonProductLineItem )< {
 export const LineItem = styled( CheckoutLineItem )< {
 	theme?: Theme;
 } >`
-	display: flex;
-	flex-wrap: wrap;
-	justify-content: space-between;
+	${ hasCheckoutVersion2
+		? `display: grid;
+	grid-template-columns: 3fr 1fr;
+	grid-template-rows: auto;
+	grid-template-areas:
+		'label price'
+		'meta .     '
+		'term remove';
+	gap: 8px;
+	margin-bottom: 32px;
+	padding: 10px 0;`
+		: `display: flex;
+			flex-wrap: wrap;
+			justify-content: space-between;
+			padding: 20px 0;` }
+
 	font-weight: ${ ( { theme } ) => theme.weights.normal };
 	color: ${ ( { theme } ) => theme.colors.textColorDark };
 	font-size: 1.1em;
-	padding: ${ hasCheckoutVersion( '2' ) ? '10px' : '20px' } 0;
 	position: relative;
 
 	.checkout-line-item__price {
@@ -113,6 +127,10 @@ const GiftBadge = styled.span`
 	font-size: small;
 `;
 
+const LineItemMetaWrapper = styled.div< { theme?: Theme } >`
+	grid-area: meta;
+`;
+
 const LineItemMeta = styled.div< { theme?: Theme } >`
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 	font-size: 14px;
@@ -124,6 +142,8 @@ const LineItemMeta = styled.div< { theme?: Theme } >`
 	flex-wrap: wrap;
 	overflow-wrap: anywhere;
 	gap: 2px 10px;
+
+	${ hasCheckoutVersion2 ? `grid-area: term` : null }
 `;
 
 const UpgradeCreditInformationLineItem = styled( LineItemMeta )< { theme?: Theme } >`
@@ -160,37 +180,55 @@ const NotApplicableCallout = styled.div< { theme?: Theme } >`
 `;
 
 const LineItemTitle = styled.div< { theme?: Theme; isSummary?: boolean } >`
-	flex: 1;
 	word-break: break-word;
-	display: flex;
-	gap: 0.5em;
 	font-weight: ${ ( { theme } ) => theme.weights.bold };
-	font-size: ${ hasCheckoutVersion( '2' ) ? '14px' : 'inherit' };
+
+	${ hasCheckoutVersion2
+		? `grid-area: label;
+		   font-size: 14px;
+		   align-self: center;`
+		: `flex: 1;
+		   display: flex;
+		   gap: 0.5em;
+		   font-size: inherit;` }
 `;
 
 const LineItemPriceWrapper = styled.span< { theme?: Theme; isSummary?: boolean } >`
-	margin-left: 12px;
-	font-size: ${ hasCheckoutVersion( '2' ) ? '14px' : 'inherit' };
+	${ hasCheckoutVersion2
+		? `margin-left: 0px;
+		   font-size: 14px;
+		   grid-area: price;
+		   justify-self: flex-end;`
+		: `
+		margin-left: 12px;
+		font-size: inherit;` }
 	.rtl & {
 		margin-right: 12px;
 		margin-left: 0;
 	}
 `;
-const BillingLine = styled.div`
-	width: 100%;
-	display: ${ hasCheckoutVersion( '2' ) ? 'flex' : 'block' };
-	justify-content: ${ hasCheckoutVersion( '2' ) ? 'space-between' : 'inherit' };
-	align-items: ${ hasCheckoutVersion( '2' ) ? 'center' : 'inherit' };
+
+const DropdownWrapper = styled.span`
+	${ hasCheckoutVersion2 ? `grid-area: term;` : null }
 `;
+
 const DeleteButtonWrapper = styled.div`
 	width: 100%;
-	display: ${ hasCheckoutVersion( '2' ) ? 'flex' : 'inherit' };
-	justify-content: ${ hasCheckoutVersion( '2' ) ? 'flex-end' : 'inherit' };
+
+	${ hasCheckoutVersion2
+		? `
+	grid-area: remove;
+	display: grid;
+	align-items: center;
+	justify-content: end;
+	`
+		: `display: inherit };
+	justify-content: 'inherit' }` };
 `;
 
 const DeleteButton = styled( Button )< { theme?: Theme } >`
 	width: auto;
-	font-size: ${ hasCheckoutVersion( '2' ) ? '14px' : '0.75rem' };
+	${ hasCheckoutVersion2 ? `font-size:  14px; text-decoration: none;` : `font-size: 0.75rem` };
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 `;
 
@@ -260,9 +298,17 @@ function WPNonProductLineItem( {
 			<LineItemTitle id={ itemSpanId } isSummary={ isSummary }>
 				{ label }
 			</LineItemTitle>
-			<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
-				<LineItemPrice actualAmount={ actualAmountDisplay } isSummary={ isSummary } />
-			</span>
+			{ hasCheckoutVersion2 ? (
+				<LineItemPrice
+					aria-labelledby={ itemSpanId }
+					actualAmount={ actualAmountDisplay }
+					isSummary={ isSummary }
+				/>
+			) : (
+				<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
+					<LineItemPrice actualAmount={ actualAmountDisplay } isSummary={ isSummary } />
+				</span>
+			) }
 			{ hasDeleteButton && removeProductFromCart && (
 				<>
 					<DeleteButtonWrapper>
@@ -279,9 +325,7 @@ function WPNonProductLineItem( {
 								setIsModalVisible( true );
 							} }
 						>
-							{ hasCheckoutVersion( '2' )
-								? translate( 'Remove' )
-								: translate( 'Remove from cart' ) }
+							{ hasCheckoutVersion2 ? translate( 'Remove' ) : translate( 'Remove from cart' ) }
 						</DeleteButton>
 					</DeleteButtonWrapper>
 
@@ -1198,36 +1242,46 @@ function CheckoutLineItem( {
 					</DesktopGiftWrapper>
 				) }
 			</LineItemTitle>
-			<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
-				{ hasCheckoutVersion( '2' ) ? (
-					<LineItemPrice
-						actualAmount={ formatCurrency( costBeforeDiscounts, product.currency, {
-							isSmallestUnit: true,
-							stripZeros: true,
-						} ) }
-						isSummary={ isSummary }
-					/>
-				) : (
+			{ hasCheckoutVersion2 ? (
+				<LineItemPrice
+					actualAmount={ formatCurrency( costBeforeDiscounts, product.currency, {
+						isSmallestUnit: true,
+						stripZeros: true,
+					} ) }
+					isSummary={ isSummary }
+				/>
+			) : (
+				<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
 					<LineItemPrice
 						isDiscounted={ isDiscounted }
 						actualAmount={ actualAmountDisplay }
 						originalAmount={ originalAmountDisplay }
 						isSummary={ isSummary }
 					/>
-				) }
-			</span>
+				</span>
+			) }
 
-			{ ! hasCheckoutVersion( '2' ) && product && ! containsPartnerCoupon && (
+			{ product && ! containsPartnerCoupon && (
 				<>
-					<UpgradeCreditInformationLineItem>
-						<UpgradeCreditInformation product={ product } />
-					</UpgradeCreditInformationLineItem>
-					<LineItemMeta>
-						<LineItemSublabelAndPrice product={ product } />
-						<DomainDiscountCallout product={ product } />
-						<IntroductoryOfferCallout product={ product } />
-						<JetpackAkismetSaleCouponCallout product={ product } />
-					</LineItemMeta>
+					{ hasCheckoutVersion2 ? (
+						<LineItemMetaWrapper>
+							<LineItemMeta>
+								<LineItemSublabelAndPrice product={ product } />
+							</LineItemMeta>
+						</LineItemMetaWrapper>
+					) : (
+						<>
+							<UpgradeCreditInformationLineItem>
+								<UpgradeCreditInformation product={ product } />
+							</UpgradeCreditInformationLineItem>
+							<LineItemMeta>
+								<LineItemSublabelAndPrice product={ product } />
+								<DomainDiscountCallout product={ product } />
+								<IntroductoryOfferCallout product={ product } />
+								<JetpackAkismetSaleCouponCallout product={ product } />
+							</LineItemMeta>
+						</>
+					) }
 				</>
 			) }
 
@@ -1241,69 +1295,69 @@ function CheckoutLineItem( {
 
 			{ isEmail && <EmailMeta product={ product } isRenewal={ isRenewal } /> }
 
-			<BillingLine>
-				{ children }
-				{ hasDeleteButton && removeProductFromCart && (
-					<>
-						<DeleteButtonWrapper>
-							<DeleteButton
-								className="checkout-line-item__remove-product"
-								buttonType="text-button"
-								aria-label={ String(
-									translate( 'Remove %s from cart', {
-										args: label,
-									} )
-								) }
-								disabled={ isDisabled }
-								onClick={ () => {
-									setIsModalVisible( true );
-									onRemoveProductClick?.( label );
-								} }
-							>
-								{ hasCheckoutVersion( '2' )
-									? translate( 'Remove' )
-									: translate( 'Remove from cart' ) }
-							</DeleteButton>
-						</DeleteButtonWrapper>
+			{ hasCheckoutVersion2 && ! isEmail ? (
+				<DropdownWrapper>{ children }</DropdownWrapper>
+			) : (
+				<>{ children }</>
+			) }
+			{ hasDeleteButton && removeProductFromCart && (
+				<>
+					<DeleteButtonWrapper>
+						<DeleteButton
+							className="checkout-line-item__remove-product"
+							buttonType="text-button"
+							aria-label={ String(
+								translate( 'Remove %s from cart', {
+									args: label,
+								} )
+							) }
+							disabled={ isDisabled }
+							onClick={ () => {
+								setIsModalVisible( true );
+								onRemoveProductClick?.( label );
+							} }
+						>
+							{ hasCheckoutVersion2 ? translate( 'Remove' ) : translate( 'Remove from cart' ) }
+						</DeleteButton>
+					</DeleteButtonWrapper>
 
-						<CheckoutModal
-							isVisible={ isModalVisible }
-							closeModal={ () => {
-								setIsModalVisible( false );
-							} }
-							primaryAction={ () => {
-								let product_uuids_to_remove = [ product.uuid ];
+					<CheckoutModal
+						isVisible={ isModalVisible }
+						closeModal={ () => {
+							setIsModalVisible( false );
+						} }
+						primaryAction={ () => {
+							let product_uuids_to_remove = [ product.uuid ];
 
-								// Gifts need to be all or nothing, to prevent leaving
-								// the site in a state where it requires other purchases
-								// in order to actually work correctly for the period of
-								// the gift (for example, gifting a plan renewal without
-								// a domain renewal would likely lead the site's domain
-								// to expire soon afterwards).
-								if ( product.is_gift_purchase ) {
-									product_uuids_to_remove = responseCart.products
-										.filter( ( cart_product ) => cart_product.is_gift_purchase )
-										.map( ( cart_product ) => cart_product.uuid );
-								}
+							// Gifts need to be all or nothing, to prevent leaving
+							// the site in a state where it requires other purchases
+							// in order to actually work correctly for the period of
+							// the gift (for example, gifting a plan renewal without
+							// a domain renewal would likely lead the site's domain
+							// to expire soon afterwards).
+							if ( product.is_gift_purchase ) {
+								product_uuids_to_remove = responseCart.products
+									.filter( ( cart_product ) => cart_product.is_gift_purchase )
+									.map( ( cart_product ) => cart_product.uuid );
+							}
 
-								Promise.all( product_uuids_to_remove.map( removeProductFromCart ) ).catch( () => {
-									// Nothing needs to be done here. CartMessages will display the error to the user.
-								} );
-								onRemoveProduct?.( label );
-							} }
-							cancelAction={ () => {
-								onRemoveProductCancel?.( label );
-							} }
-							secondaryAction={ () => {
-								onRemoveProductCancel?.( label );
-							} }
-							secondaryButtonCTA={ String( translate( 'Cancel' ) ) }
-							title={ modalCopy.title }
-							copy={ modalCopy.description }
-						/>
-					</>
-				) }
-			</BillingLine>
+							Promise.all( product_uuids_to_remove.map( removeProductFromCart ) ).catch( () => {
+								// Nothing needs to be done here. CartMessages will display the error to the user.
+							} );
+							onRemoveProduct?.( label );
+						} }
+						cancelAction={ () => {
+							onRemoveProductCancel?.( label );
+						} }
+						secondaryAction={ () => {
+							onRemoveProductCancel?.( label );
+						} }
+						secondaryButtonCTA={ String( translate( 'Cancel' ) ) }
+						title={ modalCopy.title }
+						copy={ modalCopy.description }
+					/>
+				</>
+			) }
 		</div>
 	);
 	/* eslint-enable wpcalypso/jsx-classname-namespace */

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -691,6 +691,14 @@ export function LineItemSublabelAndPrice( { product }: { product: ResponseCartPr
 		stripZeros: true,
 	} );
 
+	if ( hasCheckoutVersion2 ) {
+		return (
+			<>
+				<DefaultLineItemSublabel product={ product } />
+			</>
+		);
+	}
+
 	if ( isP2Plus( product ) ) {
 		// This is the price for one item for products with a quantity (eg. seats in a license).
 		const itemPrice = formatCurrency(

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -90,7 +90,7 @@ export const LineItem = styled( CheckoutLineItem )< {
 	grid-template-areas:
 		'label price'
 		'meta remove';
-	gap: 2px;
+	gap: 6px 2px;
 	margin-bottom: 8px;
 	padding: 10px 0;`
 		: `display: flex;
@@ -142,9 +142,8 @@ const LineItemMeta = styled.div< { theme?: Theme } >`
 	justify-content: space-between;
 	flex-wrap: wrap;
 	overflow-wrap: anywhere;
-	gap: 2px 10px;
 
-	${ hasCheckoutVersion2 ? `grid-area: meta` : null }
+	${ hasCheckoutVersion2 ? `grid-area: meta; row-gap: 6px` : `gap: 2px 10px;` }
 `;
 
 const UpgradeCreditInformationLineItem = styled( LineItemMeta )< { theme?: Theme } >`
@@ -210,7 +209,7 @@ const LineItemPriceWrapper = styled.span< { theme?: Theme; isSummary?: boolean }
 `;
 
 const DropdownWrapper = styled.span`
-	${ hasCheckoutVersion2 ? `grid-area: meta; margin-top: 6px;` : null }
+	${ hasCheckoutVersion2 ? `grid-area: meta; width: 100%;` : null }
 `;
 
 const DeleteButtonWrapper = styled.div`

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -91,8 +91,8 @@ export const LineItem = styled( CheckoutLineItem )< {
 		'label price'
 		'meta .     '
 		'term remove';
-	gap: 8px;
-	margin-bottom: 32px;
+	gap: 2px;
+	margin-bottom: 8px;
 	padding: 10px 0;`
 		: `display: flex;
 			flex-wrap: wrap;
@@ -209,7 +209,7 @@ const LineItemPriceWrapper = styled.span< { theme?: Theme; isSummary?: boolean }
 `;
 
 const DropdownWrapper = styled.span`
-	${ hasCheckoutVersion2 ? `grid-area: term;` : null }
+	${ hasCheckoutVersion2 ? `grid-area: term; margin-top: 6px;` : null }
 `;
 
 const DeleteButtonWrapper = styled.div`

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1302,7 +1302,9 @@ function CheckoutLineItem( {
 				<JetpackSearchMeta product={ product } />
 			) }
 
-			{ isEmail && <EmailMeta product={ product } isRenewal={ isRenewal } /> }
+			{ ! hasCheckoutVersion2 && isEmail && (
+				<EmailMeta product={ product } isRenewal={ isRenewal } />
+			) }
 
 			{ ! hasCheckoutVersion2 && ! isEmail && <>{ children }</> }
 			{ hasDeleteButton && removeProductFromCart && (

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -86,12 +86,13 @@ export const LineItem = styled( CheckoutLineItem )< {
 } >`
 	${ hasCheckoutVersion2
 		? `display: grid;
-	grid-template-columns: minmax(0, 3fr) 1fr;
+	grid-template-columns: 1fr min-content;
 	grid-template-rows: auto;
 	grid-template-areas:
 		'label price'
-		'meta remove';
-	gap: 6px 2px;
+		'term remove'
+		'meta   meta';
+	gap: 6px 4px;
 	margin-bottom: 8px;
 	padding: 10px 0;`
 		: `display: flex;
@@ -210,8 +211,20 @@ const LineItemPriceWrapper = styled.span< { theme?: Theme; isSummary?: boolean }
 	}
 `;
 
+const BillingInterval = styled.div< { theme?: Theme } >`
+	grid-area: term;
+	color: ${ ( props ) => props.theme.colors.textColorLight };
+	font-size: 14px;
+	width: 100%;
+	display: flex;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	overflow-wrap: anywhere;
+	flex-direction: column;
+	align-content: flex-start;
+`;
 const DropdownWrapper = styled.span`
-	${ hasCheckoutVersion2 ? `grid-area: meta; width: 100%; margin-bottom: 6px;` : null }
+	${ hasCheckoutVersion2 ? `width: 100%; max-width: 200px` : null }
 `;
 
 const DeleteButtonWrapper = styled.div`
@@ -221,7 +234,7 @@ const DeleteButtonWrapper = styled.div`
 		? `
 	grid-area: remove;
 	display: grid;
-	align-items: flex-start;
+	align-items: center;
 	justify-content: end;
 	`
 		: `display: inherit };
@@ -1258,6 +1271,7 @@ function CheckoutLineItem( {
 	onRemoveProductCancel,
 	isAkPro500Cart,
 	areThereVariants,
+	shouldShowVariantSelector,
 }: PropsWithChildren< {
 	product: ResponseCartProduct;
 	className?: string;
@@ -1272,6 +1286,7 @@ function CheckoutLineItem( {
 	onRemoveProductCancel?: ( label: string ) => void;
 	isAkPro500Cart?: boolean;
 	areThereVariants?: boolean;
+	shouldShowVariantSelector?: boolean;
 } > ) {
 	const id = product.uuid;
 	const translate = useTranslate();

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1147,6 +1147,7 @@ function CheckoutLineItem( {
 	onRemoveProductClick,
 	onRemoveProductCancel,
 	isAkPro500Cart,
+	areThereVariants,
 }: PropsWithChildren< {
 	product: ResponseCartProduct;
 	className?: string;
@@ -1160,6 +1161,7 @@ function CheckoutLineItem( {
 	onRemoveProductClick?: ( label: string ) => void;
 	onRemoveProductCancel?: ( label: string ) => void;
 	isAkPro500Cart?: boolean;
+	areThereVariants?: boolean;
 } > ) {
 	const id = product.uuid;
 	const translate = useTranslate();
@@ -1270,11 +1272,14 @@ function CheckoutLineItem( {
 					{ hasCheckoutVersion2 ? (
 						<LineItemMetaWrapper>
 							<LineItemMeta>
-								<LineItemSublabelAndPrice product={ product } />
+								{ areThereVariants ? (
+									<DropdownWrapper>{ children }</DropdownWrapper>
+								) : (
+									<LineItemBillingInterval product={ product } />
+								) }
 							</LineItemMeta>
 							{ isJetpackSearch( product ) && <JetpackSearchMeta product={ product } /> }
 							{ isEmail && <EmailMeta product={ product } isRenewal={ isRenewal } /> }
-							<DropdownWrapper>{ children }</DropdownWrapper>
 						</LineItemMetaWrapper>
 					) : (
 						<>

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -912,6 +912,15 @@ export function LineItemBillingInterval( { product }: { product: ResponseCartPro
 	}
 }
 
+/**
+ * This new component manages all of the 'additional' info we tend to tack onto line items.
+ * We can look at this as just a list of 'non billing interval' related things.
+ * Each condition should match a specific product, and all of its additional items stored within.
+ * @param { ResponseCartProduct } product
+ *
+ * return { string | null }
+ */
+
 function LineItemMetaInfo( { product }: { product: ResponseCartProduct } ) {
 	const translate = useTranslate();
 	const productSlug = product.product_slug;


### PR DESCRIPTION
This PR rearranges the checkout sidebar line items into CSS Grid containers to provide a more flexible layout.

This PR also refactors existing styled components and adds a few more in key locations.

Related to https://github.com/Automattic/payments-shilling/issues/1969

## Proposed Changes

* A number of changes to the `LineItem` et al styled components found in `packages/wpcom-checkout/src/checkout-line-items.tsx` to wrap them in a CSS Grid

## Testing Instructions

* Add a couple of different products to your cart, i.e plans, domains, email, etc
* Go to `http://calypso.localhost:3000/checkout/your-site-here?checkoutVersion=2` note the query parameter at the end
* Check that the items in the sidebar are spaced evenly
* Check on smaller device widths
* Try to find a product or use case that breaks the layout

Example products and use cases to test:
- [ ] Dotcom Plans
- [ ]  Jetpack Products
- [ ]  Domain registrations
- [ ]  Domain transfers
- [ ]  Domain connections
- [ ]  Woo Express plans
- [ ]  Email licenses `'%(numberOfMailboxes)d mailbox for %(domainName)s'`
- [ ]  DIFM contracts `'%(numberOfExtraPages)d Extra Page: %(costOfExtraPages)s one-time fee'`
- [ ]  P2Plus `'Monthly subscription: %(itemPrice)s x %(members)s member'`
- [ ]  Tiered volume space addons `'%(quantity)s GB extra space, %(price)s per year'`
- [ ]  Jetpack search `'Up to %(purchaseQuantityDividedByThousand)sk records and/or requests per month'`
- [ ]  Partner logos (not sure when these are shown but it states `Included in your IONOS plan`)
- [ ]  Gift purchases
- [ ]  Large prices
- [ ]  Different currencies
- [ ]  Different languages (big 16?)
- [ ]  What are partner coupons and how are they displayed
