### PR TITLE
Assembler: Add simple survey banner

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -80,6 +80,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 	const [ sectionPosition, setSectionPosition ] = useState< number | null >( null );
 	const wrapperRef = useRef< HTMLDivElement | null >( null );
 	const [ activePosition, setActivePosition ] = useState( -1 );
+	const [ surveyDismissed, setSurveyDismissed ] = useState( false );
 	const { goBack, goNext, submit } = navigation;
 	const { assembleSite, saveSiteSettings } = useDispatch( SITE_STORE );
 	const reduxDispatch = useReduxDispatch();
@@ -682,6 +683,8 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 						isNewSite={ isNewSite }
 						siteId={ site?.ID }
 						selectedDesign={ selectedDesign }
+						surveyDismissed={ surveyDismissed }
+						setSurveyDismissed={ setSurveyDismissed }
 						onConfirm={ onConfirm }
 					/>
 				</NavigatorScreen>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-confirmation.tsx
@@ -11,6 +11,7 @@ import { useSelector } from 'react-redux';
 import { getActiveTheme } from 'calypso/state/themes/selectors';
 import { useScreen } from './hooks';
 import NavigatorTitle from './navigator-title';
+import Survey from './survey';
 import type { IAppState } from 'calypso/state/types';
 import './screen-confirmation.scss';
 
@@ -18,10 +19,19 @@ interface Props {
 	isNewSite: boolean;
 	siteId?: number;
 	selectedDesign?: Design;
+	surveyDismissed: boolean;
+	setSurveyDismissed: ( dismissed: boolean ) => void;
 	onConfirm: () => void;
 }
 
-const ScreenConfirmation = ( { isNewSite, siteId = 0, selectedDesign, onConfirm }: Props ) => {
+const ScreenConfirmation = ( {
+	isNewSite,
+	siteId = 0,
+	selectedDesign,
+	surveyDismissed,
+	setSurveyDismissed,
+	onConfirm,
+}: Props ) => {
 	const translate = useTranslate();
 	const { title, continueLabel } = useScreen( 'confirmation' );
 
@@ -79,6 +89,13 @@ const ScreenConfirmation = ( { isNewSite, siteId = 0, selectedDesign, onConfirm 
 						</HStack>
 					) ) }
 				</VStack>
+				{ ! surveyDismissed && (
+					<Survey
+						eventName="assembler-january-2024"
+						eventUrl="https://automattic.survey.fm/assembler-simple-survey"
+						setSurveyDismissed={ setSurveyDismissed }
+					/>
+				) }
 			</div>
 			<div className="screen-container__footer">
 				<Button className="pattern-assembler__button" primary onClick={ onConfirm }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/85922

## Proposed Changes

This PR adds a survey banner in the Confirmation screen of the Assembler.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler.
* Continue the flow until arriving to the Confirmation screen.
* Ensure that the survey banner is visible.
* Ensure that the survey banner is dismissible.
* Ensure that clicking the survey banner opens a new tab to https://automattic.survey.fm/assembler-simple-survey.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?