### PR TITLE
Open links from post details page in new tab

### DIFF
--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -25,6 +25,7 @@ const embedsToLookFor = {
 	'.wp-embedded-content': embedWordPressPost,
 	'a[data-pin-do="embedPin"]': embedPinterest,
 	'div.embed-issuu': embedIssuu,
+	a: embedLink,
 };
 
 const cacheBustQuery = `?v=${ Math.floor( new Date().getTime() / ( 1000 * 60 * 60 * 24 * 10 ) ) }`; // A new query every 10 days
@@ -110,7 +111,13 @@ function embedTwitter( domNode ) {
 
 	loadAndRun( 'https://platform.twitter.com/widgets.js', embedTwitter.bind( null, domNode ) );
 }
-
+function embedLink( domNode ) {
+	debug( 'processing link for', domNode );
+	if ( ! domNode ) {
+		return;
+	}
+	domNode.setAttribute( 'target', '_blank' );
+}
 function embedFacebook( domNode ) {
 	debug( 'processing facebook for', domNode );
 	if ( typeof fb !== 'undefined' ) {

--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -25,7 +25,7 @@ const embedsToLookFor = {
 	'.wp-embedded-content': embedWordPressPost,
 	'a[data-pin-do="embedPin"]': embedPinterest,
 	'div.embed-issuu': embedIssuu,
-	a: embedLink,
+	a: embedLink, // process plain links last
 };
 
 const cacheBustQuery = `?v=${ Math.floor( new Date().getTime() / ( 1000 * 60 * 60 * 24 * 10 ) ) }`; // A new query every 10 days
@@ -113,9 +113,6 @@ function embedTwitter( domNode ) {
 }
 function embedLink( domNode ) {
 	debug( 'processing link for', domNode );
-	if ( ! domNode ) {
-		return;
-	}
 	domNode.setAttribute( 'target', '_blank' );
 }
 function embedFacebook( domNode ) {


### PR DESCRIPTION
Currently links on the post details page of reader are not opening properly.

p1704926570921019-slack-C03NLNTPZ2T

Notice the URL changing when the link is clicked.

https://github.com/Automattic/wp-calypso/assets/22446385/322d3a1d-6a23-4e0b-8750-2dfc213a9608

I'm not sure if this has broken recently, but I think the ideal behaviour is that these links would open in a new tab, which is what this change does.


## Testing Instructions

Go to post details for a post with an inline link, e.g. https://wordpress.com/read/feeds/25823/posts/5066143898
Click the link
It should open in a new tab
