### PR TITLE
[Woo Express $1 offer] Update Checkout screen copy

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -183,8 +183,8 @@ function CheckoutSummaryWooOfferDetails( props: {
 				priceTextArgs
 			);
 			detailsText = translate(
-				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d year.",
-				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d years.",
+				"After the initial offer period, you'll be billed %(cost)s annually. You can cancel your plan at any point during the first %(intervalCount)d year.",
+				"After the initial offer period, you'll be billed %(cost)s annually. You can cancel your plan at any point during the first %(intervalCount)d years.",
 				detailsTextArgs
 			);
 			break;
@@ -195,8 +195,8 @@ function CheckoutSummaryWooOfferDetails( props: {
 				priceTextArgs
 			);
 			detailsText = translate(
-				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d month.",
-				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d months.",
+				"After the initial offer period, you'll be billed %(cost)s annually. You can cancel your plan at any point during the first %(intervalCount)d month.",
+				"After the initial offer period, you'll be billed %(cost)s annually. You can cancel your plan at any point during the first %(intervalCount)d months.",
 				detailsTextArgs
 			);
 			break;
@@ -207,8 +207,8 @@ function CheckoutSummaryWooOfferDetails( props: {
 				priceTextArgs
 			);
 			detailsText = translate(
-				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d week.",
-				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d weeks.",
+				"After the initial offer period, you'll be billed %(cost)s annually. You can cancel your plan at any point during the first %(intervalCount)d week.",
+				"After the initial offer period, you'll be billed %(cost)s annually. You can cancel your plan at any point during the first %(intervalCount)d weeks.",
 				detailsTextArgs
 			);
 			break;
@@ -219,8 +219,8 @@ function CheckoutSummaryWooOfferDetails( props: {
 				priceTextArgs
 			);
 			detailsText = translate(
-				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d day.",
-				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d days.",
+				"After the initial offer period, you'll be billed %(cost)s annually. You can cancel your plan at any point during the first %(intervalCount)d day.",
+				"After the initial offer period, you'll be billed %(cost)s annually. You can cancel your plan at any point during the first %(intervalCount)d days.",
 				detailsTextArgs
 			);
 			break;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -148,7 +148,9 @@ function CheckoutSummaryWooOfferDetails( props: {
 		return null;
 	}
 
-	const cost = plan.product_cost_display;
+	const cost = formatCurrency( plan.item_original_cost_integer, plan.currency, {
+		isSmallestUnit: true,
+	} );
 	const productName = plan.product_name;
 	const intervalPrice = wooExpressIntroOffer.formattedPrice;
 	const intervalCount = wooExpressIntroOffer.intervalCount;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -119,12 +119,12 @@ export default function WPCheckoutOrderSummary( {
 				<CheckoutSummaryPriceListTitle>{ translate( 'Your order' ) }</CheckoutSummaryPriceListTitle>
 			) }
 			<CheckoutSummaryPriceList />
-			<CheckoutSummaryAdditionalDetails plan={ plan } siteId={ siteId } />
+			<CheckoutSummaryWooOfferDetails plan={ plan } siteId={ siteId } />
 		</CheckoutSummaryCard>
 	);
 }
 
-function CheckoutSummaryAdditionalDetails( props: {
+function CheckoutSummaryWooOfferDetails( props: {
 	plan: ResponseCartProduct | undefined;
 	siteId: number | undefined;
 } ) {

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -22,6 +22,7 @@ import {
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
+import { Plans } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
 import { isNewsletterOrLinkInBioFlow, isAnyHostingFlow } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
@@ -122,20 +123,34 @@ export default function WPCheckoutOrderSummary( {
 				<CheckoutSummaryPriceListTitle>{ translate( 'Your order' ) }</CheckoutSummaryPriceListTitle>
 			) }
 			<CheckoutSummaryPriceList />
-			<CheckoutSummaryAdditionalDetails plan={ plan } />
+			<CheckoutSummaryAdditionalDetails plan={ plan } siteId={ siteId } />
 		</CheckoutSummaryCard>
 	);
 }
 
-function CheckoutSummaryAdditionalDetails( props: { plan: ResponseCartProduct | undefined } ) {
-	const { plan } = props;
+function CheckoutSummaryAdditionalDetails( props: {
+	plan: ResponseCartProduct | undefined;
+	siteId: number | undefined;
+} ) {
+	const { plan, siteId } = props;
+	const wooExpressIntroOffers = Plans.useIntroOffersForWooExpress( {
+		siteId,
+	} );
+	const wooExpressIntroOffer =
+		wooExpressIntroOffers && plan ? wooExpressIntroOffers[ plan.product_slug ] : undefined;
+
+	// console.log( 'wooExpressIntroOffer: ', wooExpressIntroOffer );
+
 	const cost = plan?.product_cost_display;
 	const productName = plan?.product_name;
-	const subtotal = plan?.item_subtotal_display;
+	const intervalPrice = wooExpressIntroOffer?.formattedPrice;
+	const intervalCount = wooExpressIntroOffer?.intervalCount;
+	const intervalUnit = wooExpressIntroOffer?.intervalUnit;
+
 	return (
 		plan && (
 			<div>
-				<p>{ `You'll be charged ${ subtotal } for the first 3 months of your ${ productName } plan.` }</p>
+				<p>{ `You'll be charged ${ intervalPrice } for the first ${ intervalCount } ${ intervalUnit } of your ${ productName } plan.` }</p>
 				<p>
 					{ `Once the offer period has expired, you'll be charged ${ cost } on an annual basis. You can cancel
 				your plan at any point in the first 3 months.` }

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -128,6 +128,7 @@ function CheckoutSummaryAdditionalDetails( props: {
 	plan: ResponseCartProduct | undefined;
 	siteId: number | undefined;
 } ) {
+	const translate = useTranslate();
 	const { plan, siteId } = props;
 	const productSlug = plan?.product_slug;
 	const wooExpressIntroOffers = Plans.useIntroOffersForWooExpress( {
@@ -135,6 +136,10 @@ function CheckoutSummaryAdditionalDetails( props: {
 	} );
 	const wooExpressIntroOffer =
 		wooExpressIntroOffers && plan ? wooExpressIntroOffers[ plan.product_slug ] : undefined;
+	// Appeasing the typescript checker
+	if ( ! wooExpressIntroOffer || ! plan ) {
+		return null;
+	}
 	const shouldShowAdditionalDetails = Boolean(
 		productSlug && isWooExpressPlan( productSlug ) && !! wooExpressIntroOffer
 	);
@@ -143,20 +148,39 @@ function CheckoutSummaryAdditionalDetails( props: {
 		return null;
 	}
 
-	const cost = plan?.product_cost_display;
-	const productName = plan?.product_name;
-	const intervalPrice = wooExpressIntroOffer?.formattedPrice;
-	const intervalCount = wooExpressIntroOffer?.intervalCount;
-	const intervalUnit = wooExpressIntroOffer?.intervalUnit;
+	const cost = plan.product_cost_display;
+	const productName = plan.product_name;
+	const intervalPrice = wooExpressIntroOffer.formattedPrice;
+	const intervalCount = wooExpressIntroOffer.intervalCount;
+	const intervalUnit = wooExpressIntroOffer.intervalUnit;
+
+	const priceText = translate(
+		"You'll be charged %(intervalPrice)s for the first %(intervalCount)d %(intervalUnit)s of your %(productName)s plan.",
+		{
+			args: {
+				intervalPrice,
+				intervalCount,
+				intervalUnit,
+				productName,
+			},
+		}
+	);
+	const detailsText = translate(
+		"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d %(intervalUnit)s.",
+		{
+			args: {
+				cost,
+				intervalCount,
+				intervalUnit,
+			},
+		}
+	);
 
 	return (
 		plan && (
 			<div>
-				<p>{ `You'll be charged ${ intervalPrice } for the first ${ intervalCount } ${ intervalUnit } of your ${ productName } plan.` }</p>
-				<p>
-					{ `Once the offer period has expired, you'll be charged ${ cost } on an annual basis. You can cancel
-				your plan at any point in the first 3 months.` }
-				</p>
+				<p>{ priceText }</p>
+				<p>{ detailsText }</p>
 			</div>
 		)
 	);

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -86,9 +86,9 @@ export default function WPCheckoutOrderSummary( {
 	const plan = responseCart.products.find( ( product ) => isPlan( product ) );
 	const hasMonthlyPlanInCart = Boolean( plan && isMonthly( plan?.product_slug ) );
 
-	const productSlug = plan?.product_slug;
-	console.log( 'isWooExpressPlan: ', isWooExpressPlan( productSlug ) );
-	console.log( plan );
+	// const productSlug = plan?.product_slug;
+	// console.log( 'isWooExpressPlan: ', isWooExpressPlan( productSlug ) );
+	// console.log( plan );
 
 	const shouldHideCheckoutIncludedPurchases = useHideCheckoutIncludedPurchases() === 'treatment';
 

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -154,27 +154,70 @@ function CheckoutSummaryAdditionalDetails( props: {
 	const intervalCount = wooExpressIntroOffer.intervalCount;
 	const intervalUnit = wooExpressIntroOffer.intervalUnit;
 
-	const priceText = translate(
-		"You'll be charged %(intervalPrice)s for the first %(intervalCount)d %(intervalUnit)s of your %(productName)s plan.",
-		{
-			args: {
-				intervalPrice,
-				intervalCount,
-				intervalUnit,
-				productName,
-			},
-		}
-	);
-	const detailsText = translate(
-		"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d %(intervalUnit)s.",
-		{
-			args: {
-				cost,
-				intervalCount,
-				intervalUnit,
-			},
-		}
-	);
+	let priceTextStringSingular = '';
+	let priceTextStringPlural = '';
+	let detailsTextStringSingular = '';
+	let detailsTextStringPlural = '';
+	switch ( intervalUnit ) {
+		case 'year':
+			priceTextStringSingular =
+				"You'll be charged %(intervalPrice)s for the first year of your %(productName)s plan.";
+			priceTextStringPlural =
+				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d years of your %(productName)s plan.";
+			detailsTextStringSingular =
+				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first year.";
+			detailsTextStringPlural =
+				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d years.";
+			break;
+		case 'month':
+			priceTextStringSingular =
+				"You'll be charged %(intervalPrice)s for the first month of your %(productName)s plan.";
+			priceTextStringPlural =
+				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d months of your %(productName)s plan.";
+			detailsTextStringSingular =
+				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first month.";
+			detailsTextStringPlural =
+				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d months.";
+			break;
+		case 'week':
+			priceTextStringSingular =
+				"You'll be charged %(intervalPrice)s for the first week of your %(productName)s plan.";
+			priceTextStringPlural =
+				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d weeks of your %(productName)s plan.";
+			detailsTextStringSingular =
+				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first week.";
+			detailsTextStringPlural =
+				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d weeks.";
+			break;
+		case 'day':
+			priceTextStringSingular =
+				"You'll be charged %(intervalPrice)s for the first day of your %(productName)s plan.";
+			priceTextStringPlural =
+				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d days of your %(productName)s plan.";
+			detailsTextStringSingular =
+				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first day.";
+			detailsTextStringPlural =
+				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d days.";
+			break;
+	}
+
+	const priceText = translate( priceTextStringSingular, priceTextStringPlural, {
+		count: intervalCount,
+		args: {
+			intervalPrice,
+			intervalCount,
+			intervalUnit,
+			productName,
+		},
+	} );
+	const detailsText = translate( detailsTextStringSingular, detailsTextStringPlural, {
+		count: intervalCount,
+		args: {
+			cost,
+			intervalCount,
+			intervalUnit,
+		},
+	} );
 
 	return (
 		plan && (

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -130,7 +130,6 @@ function CheckoutSummaryAdditionalDetails( props: {
 } ) {
 	const translate = useTranslate();
 	const { plan, siteId } = props;
-	const productSlug = plan?.product_slug;
 	const wooExpressIntroOffers = Plans.useIntroOffersForWooExpress( {
 		siteId,
 	} );
@@ -140,6 +139,7 @@ function CheckoutSummaryAdditionalDetails( props: {
 	if ( ! wooExpressIntroOffer || ! plan ) {
 		return null;
 	}
+	const productSlug = plan.product_slug;
 	const shouldShowAdditionalDetails = Boolean(
 		productSlug && isWooExpressPlan( productSlug ) && !! wooExpressIntroOffer
 	);

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -227,8 +227,8 @@ function CheckoutSummaryWooOfferDetails( props: {
 	return (
 		plan && (
 			<div>
-				<p>{ priceText }</p>
-				<p>{ detailsText }</p>
+				<CheckoutSummaryWooOfferDetailsText>{ priceText }</CheckoutSummaryWooOfferDetailsText>
+				<CheckoutSummaryWooOfferDetailsText>{ detailsText }</CheckoutSummaryWooOfferDetailsText>
 			</div>
 		)
 	);
@@ -1058,4 +1058,10 @@ const SwitchToAnnualPlanButton = styled.button`
 	&:hover {
 		text-decoration: none;
 	}
+`;
+
+const CheckoutSummaryWooOfferDetailsText = styled.p`
+	font-size: 12px;
+	font-weight: 400;
+	line-height: 19px;
 `;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -156,113 +156,70 @@ function CheckoutSummaryAdditionalDetails( props: {
 
 	let priceText;
 	let detailsText;
+	const priceTextArgs = {
+		count: intervalCount,
+		args: {
+			intervalPrice,
+			intervalCount,
+			intervalUnit,
+			productName,
+		},
+	};
+	const detailsTextArgs = {
+		count: intervalCount,
+		args: {
+			cost,
+			intervalCount,
+			intervalUnit,
+		},
+	};
 	switch ( intervalUnit ) {
 		case 'year':
 			priceText = translate(
 				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d year of your %(productName)s plan.",
 				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d years of your %(productName)s plan.",
-				{
-					count: intervalCount,
-					args: {
-						intervalPrice,
-						intervalCount,
-						intervalUnit,
-						productName,
-					},
-				}
+				priceTextArgs
 			);
 			detailsText = translate(
 				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d year.",
 				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d years.",
-				{
-					count: intervalCount,
-					args: {
-						cost,
-						intervalCount,
-						intervalUnit,
-					},
-				}
+				detailsTextArgs
 			);
 			break;
 		case 'month':
 			priceText = translate(
 				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d month of your %(productName)s plan.",
 				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d months of your %(productName)s plan.",
-				{
-					count: intervalCount,
-					args: {
-						intervalPrice,
-						intervalCount,
-						intervalUnit,
-						productName,
-					},
-				}
+				priceTextArgs
 			);
 			detailsText = translate(
 				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d month.",
 				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d months.",
-				{
-					count: intervalCount,
-					args: {
-						cost,
-						intervalCount,
-						intervalUnit,
-					},
-				}
+				detailsTextArgs
 			);
 			break;
 		case 'week':
 			priceText = translate(
 				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d week of your %(productName)s plan.",
 				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d weeks of your %(productName)s plan.",
-				{
-					count: intervalCount,
-					args: {
-						intervalPrice,
-						intervalCount,
-						intervalUnit,
-						productName,
-					},
-				}
+				priceTextArgs
 			);
 			detailsText = translate(
 				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d week.",
 				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d weeks.",
-				{
-					count: intervalCount,
-					args: {
-						cost,
-						intervalCount,
-						intervalUnit,
-					},
-				}
+				detailsTextArgs
 			);
 			break;
 		case 'day':
 			priceText = translate(
 				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d day of your %(productName)s plan.",
 				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d days of your %(productName)s plan.",
-				{
-					count: intervalCount,
-					args: {
-						intervalPrice,
-						intervalCount,
-						intervalUnit,
-						productName,
-					},
-				}
+				priceTextArgs
 			);
 			detailsText = translate(
 				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d day.",
 				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d days.",
-				{
-					count: intervalCount,
-					args: {
-						cost,
-						intervalCount,
-						intervalUnit,
-					},
-				}
+				detailsTextArgs
 			);
 			break;
 	}

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -154,70 +154,118 @@ function CheckoutSummaryAdditionalDetails( props: {
 	const intervalCount = wooExpressIntroOffer.intervalCount;
 	const intervalUnit = wooExpressIntroOffer.intervalUnit;
 
-	let priceTextStringSingular = '';
-	let priceTextStringPlural = '';
-	let detailsTextStringSingular = '';
-	let detailsTextStringPlural = '';
+	let priceText;
+	let detailsText;
 	switch ( intervalUnit ) {
 		case 'year':
-			priceTextStringSingular =
-				"You'll be charged %(intervalPrice)s for the first year of your %(productName)s plan.";
-			priceTextStringPlural =
-				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d years of your %(productName)s plan.";
-			detailsTextStringSingular =
-				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first year.";
-			detailsTextStringPlural =
-				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d years.";
+			priceText = translate(
+				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d year of your %(productName)s plan.",
+				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d years of your %(productName)s plan.",
+				{
+					count: intervalCount,
+					args: {
+						intervalPrice,
+						intervalCount,
+						intervalUnit,
+						productName,
+					},
+				}
+			);
+			detailsText = translate(
+				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d year.",
+				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d years.",
+				{
+					count: intervalCount,
+					args: {
+						cost,
+						intervalCount,
+						intervalUnit,
+					},
+				}
+			);
 			break;
 		case 'month':
-			priceTextStringSingular =
-				"You'll be charged %(intervalPrice)s for the first month of your %(productName)s plan.";
-			priceTextStringPlural =
-				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d months of your %(productName)s plan.";
-			detailsTextStringSingular =
-				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first month.";
-			detailsTextStringPlural =
-				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d months.";
+			priceText = translate(
+				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d month of your %(productName)s plan.",
+				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d months of your %(productName)s plan.",
+				{
+					count: intervalCount,
+					args: {
+						intervalPrice,
+						intervalCount,
+						intervalUnit,
+						productName,
+					},
+				}
+			);
+			detailsText = translate(
+				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d month.",
+				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d months.",
+				{
+					count: intervalCount,
+					args: {
+						cost,
+						intervalCount,
+						intervalUnit,
+					},
+				}
+			);
 			break;
 		case 'week':
-			priceTextStringSingular =
-				"You'll be charged %(intervalPrice)s for the first week of your %(productName)s plan.";
-			priceTextStringPlural =
-				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d weeks of your %(productName)s plan.";
-			detailsTextStringSingular =
-				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first week.";
-			detailsTextStringPlural =
-				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d weeks.";
+			priceText = translate(
+				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d week of your %(productName)s plan.",
+				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d weeks of your %(productName)s plan.",
+				{
+					count: intervalCount,
+					args: {
+						intervalPrice,
+						intervalCount,
+						intervalUnit,
+						productName,
+					},
+				}
+			);
+			detailsText = translate(
+				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d week.",
+				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d weeks.",
+				{
+					count: intervalCount,
+					args: {
+						cost,
+						intervalCount,
+						intervalUnit,
+					},
+				}
+			);
 			break;
 		case 'day':
-			priceTextStringSingular =
-				"You'll be charged %(intervalPrice)s for the first day of your %(productName)s plan.";
-			priceTextStringPlural =
-				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d days of your %(productName)s plan.";
-			detailsTextStringSingular =
-				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first day.";
-			detailsTextStringPlural =
-				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d days.";
+			priceText = translate(
+				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d day of your %(productName)s plan.",
+				"You'll be charged %(intervalPrice)s for the first %(intervalCount)d days of your %(productName)s plan.",
+				{
+					count: intervalCount,
+					args: {
+						intervalPrice,
+						intervalCount,
+						intervalUnit,
+						productName,
+					},
+				}
+			);
+			detailsText = translate(
+				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d day.",
+				"Once the offer period has expired, you'll be charged %(cost)s on an annual basis. You can cancel your plan at any point in the first %(intervalCount)d days.",
+				{
+					count: intervalCount,
+					args: {
+						cost,
+						intervalCount,
+						intervalUnit,
+					},
+				}
+			);
 			break;
 	}
-
-	const priceText = translate( priceTextStringSingular, priceTextStringPlural, {
-		count: intervalCount,
-		args: {
-			intervalPrice,
-			intervalCount,
-			intervalUnit,
-			productName,
-		},
-	} );
-	const detailsText = translate( detailsTextStringSingular, detailsTextStringPlural, {
-		count: intervalCount,
-		args: {
-			cost,
-			intervalCount,
-			intervalUnit,
-		},
-	} );
 
 	return (
 		plan && (

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -87,10 +87,6 @@ export default function WPCheckoutOrderSummary( {
 	const plan = responseCart.products.find( ( product ) => isPlan( product ) );
 	const hasMonthlyPlanInCart = Boolean( plan && isMonthly( plan?.product_slug ) );
 
-	// const productSlug = plan?.product_slug;
-	// console.log( 'isWooExpressPlan: ', isWooExpressPlan( productSlug ) );
-	// console.log( plan );
-
 	const shouldHideCheckoutIncludedPurchases = useHideCheckoutIncludedPurchases() === 'treatment';
 
 	return (
@@ -133,13 +129,19 @@ function CheckoutSummaryAdditionalDetails( props: {
 	siteId: number | undefined;
 } ) {
 	const { plan, siteId } = props;
+	const productSlug = plan?.product_slug;
 	const wooExpressIntroOffers = Plans.useIntroOffersForWooExpress( {
 		siteId,
 	} );
 	const wooExpressIntroOffer =
 		wooExpressIntroOffers && plan ? wooExpressIntroOffers[ plan.product_slug ] : undefined;
+	const shouldShowAdditionalDetails = Boolean(
+		productSlug && isWooExpressPlan( productSlug ) && !! wooExpressIntroOffer
+	);
 
-	// console.log( 'wooExpressIntroOffer: ', wooExpressIntroOffer );
+	if ( ! shouldShowAdditionalDetails ) {
+		return null;
+	}
 
 	const cost = plan?.product_cost_display;
 	const productName = plan?.product_name;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -86,6 +86,10 @@ export default function WPCheckoutOrderSummary( {
 	const plan = responseCart.products.find( ( product ) => isPlan( product ) );
 	const hasMonthlyPlanInCart = Boolean( plan && isMonthly( plan?.product_slug ) );
 
+	const productSlug = plan?.product_slug;
+	console.log( 'isWooExpressPlan: ', isWooExpressPlan( productSlug ) );
+	console.log( plan );
+
 	const shouldHideCheckoutIncludedPurchases = useHideCheckoutIncludedPurchases() === 'treatment';
 
 	return (
@@ -118,7 +122,26 @@ export default function WPCheckoutOrderSummary( {
 				<CheckoutSummaryPriceListTitle>{ translate( 'Your order' ) }</CheckoutSummaryPriceListTitle>
 			) }
 			<CheckoutSummaryPriceList />
+			<CheckoutSummaryAdditionalDetails plan={ plan } />
 		</CheckoutSummaryCard>
+	);
+}
+
+function CheckoutSummaryAdditionalDetails( props: { plan: ResponseCartProduct | undefined } ) {
+	const { plan } = props;
+	const cost = plan?.product_cost_display;
+	const productName = plan?.product_name;
+	const subtotal = plan?.item_subtotal_display;
+	return (
+		plan && (
+			<div>
+				<p>{ `You'll be charged ${ subtotal } for the first 3 months of your ${ productName } plan.` }</p>
+				<p>
+					{ `Once the offer period has expired, you'll be charged ${ cost } on an annual basis. You can cancel
+				your plan at any point in the first 3 months.` }
+				</p>
+			</div>
+		)
 	);
 }
 

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -525,9 +525,6 @@ export interface ResponseCartProduct {
 	is_included_for_100yearplan: boolean;
 
 	product_variants: ResponseCartProductVariant[];
-
-	product_cost_display: string;
-	item_subtotal_display: string;
 }
 
 export interface ResponseCartProductVariant {

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -525,6 +525,9 @@ export interface ResponseCartProduct {
 	is_included_for_100yearplan: boolean;
 
 	product_variants: ResponseCartProductVariant[];
+
+	product_cost_display: string;
+	item_subtotal_display: string;
 }
 
 export interface ResponseCartProductVariant {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/86054

## Proposed Changes

* Add additional text to the Checkout Summary when merchants are about to purchase a Woo Express site via the $1 offer

<img width="368" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1922453/63d87cec-0252-45a6-837c-b129f3c5dba5">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Setup a new Woo Express site via intructions found in peapX7-1D4-p2 using Calypso with this branch built, ie `http://calypso.localhost:3000/setup/free`. Pause on the Checkout screen.
2. Note the additional text under "Total" and confirm the text is correct according to jFG3dxNDOdMkw8AC1aGWBL-fi-458:1884#624583779
3. Now create a new site and/or place items in your cart. Proceed to checkout and confirm the text does not appear for other items.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
