### PR TITLE
Jetpack Manage: Implement the new 'Add Payment method' page.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/credit-card-fields/credit-card-submit-button.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/credit-card-fields/credit-card-submit-button.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button, FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { useElements, CardElement } from '@stripe/react-stripe-js';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -43,15 +44,19 @@ export default function CreditCardSubmitButton( {
 	const cardElement = elements?.getElement( CardElement ) ?? undefined;
 	const formSubmitting = FormStatus.SUBMITTING === formStatus;
 
+	const isNewCardAdditionEnabled = isEnabled( 'jetpack/card-addition-improvements' );
+
 	const buttonContents = useMemo( () => {
 		if ( formStatus === FormStatus.SUBMITTING ) {
 			return __( 'Processing…' );
 		}
 		if ( formStatus === FormStatus.READY ) {
-			return activeButtonText || __( 'Save payment method' );
+			return activeButtonText || isNewCardAdditionEnabled
+				? __( 'Add card' )
+				: __( 'Save payment method' );
 		}
 		return __( 'Please wait…' );
-	}, [ formStatus, activeButtonText, __ ] );
+	}, [ formStatus, __, activeButtonText, isNewCardAdditionEnabled ] );
 
 	const { setCardDataError, setFieldValue, setFieldError } = useDispatch( creditCardStore );
 

--- a/client/jetpack-cloud/sections/partner-portal/credit-card-fields/credit-card-submit-button.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/credit-card-fields/credit-card-submit-button.tsx
@@ -51,9 +51,10 @@ export default function CreditCardSubmitButton( {
 			return __( 'Processing…' );
 		}
 		if ( formStatus === FormStatus.READY ) {
-			return activeButtonText || isNewCardAdditionEnabled
-				? __( 'Add card' )
-				: __( 'Save payment method' );
+			return (
+				activeButtonText ||
+				( isNewCardAdditionEnabled ? __( 'Add card' ) : __( 'Save payment method' ) )
+			);
 		}
 		return __( 'Please wait…' );
 	}, [ formStatus, __, activeButtonText, isNewCardAdditionEnabled ] );

--- a/client/jetpack-cloud/sections/partner-portal/credit-card-fields/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/credit-card-fields/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { Field } from '@automattic/wpcom-checkout';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -13,6 +14,7 @@ import CreditCardLoading from './credit-card-loading';
 import SetAsPrimaryPaymentMethod from './set-as-primary-payment-method';
 import type { StoreState } from '@automattic/wpcom-checkout';
 import type { StripeElementChangeEvent, StripeElementStyle } from '@stripe/stripe-js';
+
 import './style.scss';
 
 export default function CreditCardFields() {
@@ -73,6 +75,8 @@ export default function CreditCardFields() {
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 
+	const isNewCardAdditionEnabled = isEnabled( 'jetpack/card-addition-improvements' );
+
 	return (
 		<>
 			{ ! isStripeFullyLoaded && <CreditCardLoading /> }
@@ -87,7 +91,7 @@ export default function CreditCardFields() {
 					className="credit-card-fields__input-field"
 					type="Text"
 					autoComplete="cc-name"
-					label={ __( 'Name' ) }
+					label={ isNewCardAdditionEnabled ? __( 'Name on card' ) : __( 'Name' ) }
 					value={ cardholderName?.value ?? '' }
 					onChange={ ( value ) => setFieldValue( 'cardholderName', value ) }
 					isError={ !! cardholderNameErrorMessage }

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-form/index.tsx
@@ -11,6 +11,7 @@ import { CheckoutProvider, CheckoutFormSubmit } from '@automattic/composite-chec
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { CardElement, useElements } from '@stripe/react-stripe-js';
 import { useSelect } from '@wordpress/data';
+import { Icon, info } from '@wordpress/icons';
 import { getQueryArg } from '@wordpress/url';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo, useEffect } from 'react';
@@ -287,11 +288,11 @@ function PaymentMethodForm() {
 
 					{ 0 < paymentMethods.length && useAsPrimaryPaymentMethod && (
 						<p className="payment-method-form__notice">
-							<small>
-								{ translate(
-									'By adding your primary payment method, you authorize automatic monthly charges for your active licenses.'
-								) }
-							</small>
+							<Icon className="payment-method-form__notice-icon" size={ 20 } icon={ info } />
+
+							{ translate(
+								'By adding your primary payment method, you authorize automatic monthly charges for your active licenses.'
+							) }
 						</p>
 					) }
 				</div>

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-form/index.tsx
@@ -339,12 +339,14 @@ function PaymentMethodFormFooter( {
 
 	const { formStatus } = useFormStatus();
 
+	const shouldDisableBackButton = formStatus !== FormStatus.READY || disableBackButton;
+
 	return (
 		<div className="payment-method-form__footer">
 			<Button
 				className="payment-method-form__back-button"
-				href={ backButtonHref }
-				disabled={ formStatus !== FormStatus.READY || disableBackButton }
+				href={ shouldDisableBackButton ? undefined : backButtonHref }
+				disabled={ shouldDisableBackButton }
 				onClick={ onGoToPaymentMethods }
 			>
 				{ translate( 'Go back' ) }

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-form/index.tsx
@@ -1,0 +1,329 @@
+import page from '@automattic/calypso-router';
+import {
+	ReloadSetupIntentId,
+	StripeHookProvider,
+	StripeSetupIntentIdProvider,
+	useStripe,
+	useStripeSetupIntentId,
+} from '@automattic/calypso-stripe';
+import { Button } from '@automattic/components';
+import { CheckoutProvider, CheckoutFormSubmit } from '@automattic/composite-checkout';
+import { isValueTruthy } from '@automattic/wpcom-checkout';
+import { CardElement, useElements } from '@stripe/react-stripe-js';
+import { useSelect } from '@wordpress/data';
+import { getQueryArg } from '@wordpress/url';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { useCallback, useMemo, useEffect } from 'react';
+import {
+	useReturnUrl,
+	useIssueAndAssignLicenses,
+} from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
+import { assignNewCardProcessor } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods/assignment-processor-functions';
+import { getStripeConfiguration } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods/get-stripe-configuration';
+import { useCreateStoredCreditCardMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods/hooks/use-create-stored-credit-card';
+import { partnerPortalBasePath } from 'calypso/lib/jetpack/paths';
+import { addQueryArgs } from 'calypso/lib/url';
+import { useSelector, useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
+import { creditCardStore } from 'calypso/state/partner-portal/credit-card-form';
+import { doesPartnerRequireAPaymentMethod } from 'calypso/state/partner-portal/partner/selectors';
+import { fetchStoredCards } from 'calypso/state/partner-portal/stored-cards/actions';
+import { APIError } from 'calypso/state/partner-portal/types';
+import getSites from 'calypso/state/selectors/get-sites';
+import CreditCardLoading from '../credit-card-fields/credit-card-loading';
+import useIssueLicenses from '../hooks/use-issue-licenses';
+import { parseQueryStringProducts } from '../lib/querystring-products';
+
+import './style.scss';
+
+function onPaymentSelectComplete( {
+	successCallback,
+	translate,
+	showSuccessMessage,
+	reloadSetupIntentId,
+}: {
+	successCallback: () => void;
+	translate: ReturnType< typeof useTranslate >;
+	showSuccessMessage: ( message: string | TranslateResult ) => void;
+	reloadSetupIntentId: ReloadSetupIntentId;
+} ) {
+	showSuccessMessage( translate( 'Your payment method has been added successfully.' ) );
+	// We need to regenerate the setup intent if the form was submitted.
+	reloadSetupIntentId();
+	successCallback();
+}
+
+function PaymentMethodForm() {
+	const translate = useTranslate();
+	const reduxDispatch = useDispatch();
+	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
+	const { isStripeLoading, stripeLoadingError, stripeConfiguration, stripe } = useStripe();
+	const {
+		reload: reloadSetupIntentId,
+		setupIntentId: stripeSetupIntentId,
+		error: setupIntentError,
+	} = useStripeSetupIntentId();
+	const stripeMethod = useCreateStoredCreditCardMethod( {
+		isStripeLoading,
+		stripeLoadingError,
+		stripeConfiguration,
+		stripe,
+	} );
+	const paymentMethods = useMemo(
+		() => [ stripeMethod ].filter( isValueTruthy ),
+		[ stripeMethod ]
+	);
+	const useAsPrimaryPaymentMethod: boolean = useSelect(
+		( select ) => select( creditCardStore ).useAsPrimaryPaymentMethod(),
+		[]
+	);
+
+	const sites = useSelector( getSites );
+
+	const returnQueryArg = ( getQueryArg( window.location.href, 'return' ) ?? '' ).toString();
+	const products = ( getQueryArg( window.location.href, 'products' ) ?? '' ).toString();
+	const product = ( getQueryArg( window.location.href, 'product' ) ?? '' ).toString();
+	const siteId = ( getQueryArg( window.location.href, 'site_id' ) ?? '' ).toString();
+
+	const source = useMemo(
+		() => ( getQueryArg( window.location.href, 'source' ) || '' ).toString(),
+		[]
+	);
+
+	const isSiteCreationFlow = source === 'create-site' && !! product;
+
+	const dispatch = useDispatch();
+	const { issueAndAssignLicenses, isReady: isIssueAndAssignLicensesReady } =
+		useIssueAndAssignLicenses(
+			siteId ? sites.find( ( site ) => site?.ID === parseInt( siteId ) ) : null,
+			{
+				onIssueError: ( error: APIError ) => {
+					if ( error.code === 'missing_valid_payment_method' ) {
+						dispatch(
+							errorNotice(
+								translate(
+									'A primary payment method is required.{{br/}} {{a}}Try adding a new payment method{{/a}} or contact support.',
+									{
+										components: {
+											a: (
+												<a href="/partner-portal/payment-methods/add?return=/partner-portal/issue-license" />
+											),
+											br: <br />,
+										},
+									}
+								)
+							)
+						);
+
+						return;
+					}
+
+					dispatch( errorNotice( error.message ) );
+				},
+				onAssignError: ( error: Error ) =>
+					dispatch( errorNotice( error.message, { isPersistent: true } ) ),
+			}
+		);
+
+	const { issueLicenses } = useIssueLicenses();
+
+	useReturnUrl( ! paymentMethodRequired );
+
+	const onGoToPaymentMethods = () => {
+		reduxDispatch(
+			recordTracksEvent( 'calypso_partner_portal_payment_method_card_go_back_click' )
+		);
+	};
+
+	const handleChangeError = useCallback(
+		( { transactionError }: { transactionError: string | null } ) => {
+			reduxDispatch(
+				errorNotice(
+					transactionError ||
+						translate( 'There was a problem assigning that payment method. Please try again.' ),
+					{ id: 'payment-method-failure' }
+				)
+			);
+			// We need to regenerate the setup intent if the form was submitted.
+			reloadSetupIntentId();
+		},
+		[ reduxDispatch, translate, reloadSetupIntentId ]
+	);
+
+	const showSuccessMessage = useCallback(
+		( message: TranslateResult ) => {
+			// We do not want to show overlapping notice with site creation notice.
+			if ( ! isSiteCreationFlow ) {
+				reduxDispatch(
+					successNotice( message, { isPersistent: true, displayOnNextPage: true, duration: 5000 } )
+				);
+			}
+		},
+		[ isSiteCreationFlow, reduxDispatch ]
+	);
+
+	const successCallback = useCallback( () => {
+		// returnQueryArg - will make sure the license issuing flow will be resumed
+		// when the user already has a license issued but not assigned, and will
+		// assign the license after adding a payment method.
+		//
+		// product - will make sure there will be a license issuing for that product
+		//
+		// isSiteCreationFlow - will make sure there will be site creation
+		if ( returnQueryArg || products || isSiteCreationFlow ) {
+			reduxDispatch(
+				fetchStoredCards( {
+					startingAfter: '',
+					endingBefore: '',
+				} )
+			);
+		} else {
+			page( partnerPortalBasePath( '/payment-methods' ) );
+		}
+	}, [ returnQueryArg, products, isSiteCreationFlow, reduxDispatch ] );
+
+	useEffect( () => {
+		if ( paymentMethodRequired ) {
+			return;
+		}
+
+		// If this is a site creation flow, we will need to resume on the creation of site.
+		if ( isSiteCreationFlow ) {
+			issueLicenses( [ { slug: product, quantity: 1 } ] );
+			page( `/dashboard?provisioning=true` );
+			return;
+		}
+
+		if ( ! products ) {
+			return;
+		}
+
+		dispatch(
+			recordTracksEvent( 'calypso_partner_portal_issue_multiple_licenses_submit', {
+				products,
+			} )
+		);
+
+		const itemsToIssue = parseQueryStringProducts( products );
+		issueAndAssignLicenses( itemsToIssue );
+		// Do not update the dependency array with products since
+		// it gets changed on every product change, which triggers this `useEffect` to run infinitely.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ dispatch, issueAndAssignLicenses, paymentMethodRequired ] );
+
+	useEffect( () => {
+		if ( stripeLoadingError ) {
+			reduxDispatch( errorNotice( stripeLoadingError.message ) );
+		}
+	}, [ stripeLoadingError, reduxDispatch ] );
+
+	useEffect( () => {
+		if ( setupIntentError ) {
+			reduxDispatch( errorNotice( setupIntentError.message ) );
+		}
+	}, [ setupIntentError, reduxDispatch ] );
+
+	const elements = useElements();
+
+	const getPreviousPageLink = () => {
+		if ( isSiteCreationFlow ) {
+			return partnerPortalBasePath( '/create-site' );
+		}
+
+		if ( products ) {
+			return addQueryArgs(
+				{
+					products,
+					...( siteId && { site_id: siteId } ),
+					...( source && { source } ),
+				},
+				partnerPortalBasePath( '/issue-license' )
+			);
+		}
+		return partnerPortalBasePath( '/payment-methods/' );
+	};
+
+	return (
+		<CheckoutProvider
+			onPaymentComplete={ () => {
+				onPaymentSelectComplete( {
+					successCallback,
+					translate,
+					showSuccessMessage,
+					reloadSetupIntentId,
+				} );
+			} }
+			onPaymentError={ handleChangeError }
+			paymentMethods={ paymentMethods }
+			paymentProcessors={ {
+				card: ( data: unknown ) => {
+					reduxDispatch( removeNotice( 'payment-method-failure' ) );
+					return assignNewCardProcessor(
+						{
+							useAsPrimaryPaymentMethod,
+							translate,
+							stripe,
+							stripeConfiguration,
+							stripeSetupIntentId,
+							cardElement: elements?.getElement( CardElement ) ?? undefined,
+							reduxDispatch,
+						},
+						data
+					);
+				},
+			} }
+			initiallySelectedPaymentMethodId="card"
+			isLoading={ isStripeLoading }
+		>
+			<div className="payment-method-form">
+				<h1 className="payment-method-form__title">{ translate( 'Credit card details' ) } </h1>
+
+				<div className="payment-method-form__main">
+					{ 0 === paymentMethods.length && <CreditCardLoading /> }
+
+					{ paymentMethods && paymentMethods[ 0 ] && paymentMethods[ 0 ].activeContent }
+
+					{ 0 < paymentMethods.length && useAsPrimaryPaymentMethod && (
+						<p className="payment-method-form__notice">
+							<small>
+								{ translate(
+									'By adding your primary payment method, you authorize automatic monthly charges for your active licenses.'
+								) }
+							</small>
+						</p>
+					) }
+				</div>
+
+				<div className="payment-method-form__footer">
+					<Button
+						className="payment-method-form__back-button"
+						href={ getPreviousPageLink() }
+						disabled={ isStripeLoading || ! isIssueAndAssignLicensesReady }
+						onClick={ onGoToPaymentMethods }
+					>
+						{ translate( 'Go back' ) }
+					</Button>
+					<span className="payment-method-form__submit-button">
+						<CheckoutFormSubmit />
+					</span>
+				</div>
+			</div>
+		</CheckoutProvider>
+	);
+}
+
+export default function PaymentMethodFormWrapper() {
+	const locale = useSelector( getCurrentUserLocale );
+
+	return (
+		<StripeHookProvider locale={ locale } fetchStripeConfiguration={ getStripeConfiguration }>
+			<StripeSetupIntentIdProvider
+				fetchStripeSetupIntentId={ () => getStripeConfiguration( { needs_intent: true } ) }
+			>
+				<PaymentMethodForm />
+			</StripeSetupIntentIdProvider>
+		</StripeHookProvider>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-form/style.scss
@@ -16,11 +16,15 @@
 }
 
 .payment-method-form__submit-button {
-	flex-grow: 1;
-
 	.checkout-steps__submit-button-wrapper {
 		padding: 0;
 	}
+}
+
+.payment-method-form__back-button {
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .payment-method-form__notice,

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-form/style.scss
@@ -1,0 +1,24 @@
+.payment-method-form {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+}
+
+.payment-method-form__title {
+	font-size: rem(20px);
+	line-height: 1.2;
+	font-weight: 500;
+}
+
+.payment-method-form__footer {
+	display: flex;
+	gap: 16px;
+}
+
+.payment-method-form__submit-button {
+	flex-grow: 1;
+
+	.checkout-steps__submit-button-wrapper {
+		padding: 0;
+	}
+}

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-form/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-form/style.scss
@@ -22,3 +22,23 @@
 		padding: 0;
 	}
 }
+
+.payment-method-form__notice,
+.payment-method-form .credit-card-fields__input-field :is(label, .credit-card-fields__label-text) {
+	font-size: rem(14px);
+	line-height: 1.4;
+	font-weight: 500;
+}
+
+.payment-method-form__notice {
+	color: var(--studio-gray-50);
+	font-weight: 400;
+	margin-block-start: 24px;
+	display: flex;
+	gap: 8px;
+}
+
+.payment-method-form__notice-icon {
+	fill: var(--studio-gray-30);
+	flex-shrink: 0;
+}

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/index.tsx
@@ -1,11 +1,16 @@
+import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import Layout from 'calypso/jetpack-cloud/components/layout';
+import LayoutBody from 'calypso/jetpack-cloud/components/layout/body';
 import LayoutHeader, {
 	LayoutHeaderSubtitle as Subtitle,
 	LayoutHeaderTitle as Title,
 	LayoutHeaderBreadcrumb as Breadcrumb,
 } from 'calypso/jetpack-cloud/components/layout/header';
 import LayoutTop from 'calypso/jetpack-cloud/components/layout/top';
+import PaymentMethodForm from '../../payment-method-form';
+
+import './style.scss';
 
 export default function PaymentMethodListV2() {
 	const translate = useTranslate();
@@ -27,6 +32,14 @@ export default function PaymentMethodListV2() {
 					<Subtitle>{ subtitle }</Subtitle>
 				</LayoutHeader>
 			</LayoutTop>
+
+			<LayoutBody>
+				<div className="payment-method-add__content">
+					<Card className="payment-method-add__card">
+						<PaymentMethodForm />
+					</Card>
+				</div>
+			</LayoutBody>
 		</Layout>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/style.scss
@@ -1,0 +1,13 @@
+.card.payment-method-add__card {
+	background-color: var(--studio-white);
+	border: none;
+	outline: none;
+	box-shadow: none;
+	padding: 24px;
+	margin: 0;
+	width: 100%;
+}
+
+.payment-method-add__content {
+	padding-block: 47px;
+}


### PR DESCRIPTION
This pull request implements the new **'Add Payment Method'** form. 

<img width="1636" alt="Screen Shot 2024-01-11 at 4 52 20 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/778f33fd-79db-426f-b108-cadea28a1bd5">


Closes https://github.com/Automattic/jetpack-genesis/issues/180

## Proposed Changes

* This pull request introduces a new component called `PaymentMethodForm` that handles the addition of payment methods. We made it a reusable component to make it easier to use in a modal later on. Please note that we copied most of the implementation from the old component.
* Update components dependent on `PaymentMethodForm` to load new strings based on the feature flag.
* Update the new page to include the new form.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Use the Jetpack cloud live link below and go to the new Add Payment Method page (`/partner-portal/payment-methods/add?flags=jetpack/card-addition-improvements`)
* Confirm that the form works as expected and follows the new design.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?