### PR TITLE
Stats: Adjust Tier Upgrade Slider styling

### DIFF
--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/index.tsx
@@ -103,8 +103,8 @@ function TierUpgradeSlider( {
 						<p ref={ infoReferenceElement }>
 							{ discountedPrice ? (
 								<>
-									<span>{ discountedPrice }</span>
 									<span className="full-price-label">{ originalPrice }</span>
+									<span>{ discountedPrice }</span>
 								</>
 							) : (
 								<span>{ originalPrice }</span>

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
@@ -29,7 +29,14 @@ $track-height: 4px;
 
 	border: 1px solid var(--gray-gray-5);
 	border-radius: 5px; // stylelint-disable-line scales/radii
-	padding: 12px;
+	padding: 16px;
+
+	// Remove the box shadow on the slider thumb when not holding.
+	.tier-upgrade-slider__slider:not(.jp-components-pricing-slider--is-holding) {
+		.jp-components-pricing-slider__thumb.tier-upgrade-slider__thumb {
+			box-shadow: none;
+		}
+	}
 
 	.jp-components-pricing-slider__thumb.tier-upgrade-slider__thumb {
 		width: $thumb-width;
@@ -97,8 +104,9 @@ $track-height: 4px;
 
 .tier-upgrade-slider__info-message {
 	color: var(--studio-gray-40);
-	margin: 12px 0;
+	margin: 12px 0 0;
 	text-align: center;
+	font-size: $font-body-small;
 }
 
 .tier-upgrade-slider__step-callouts {
@@ -106,12 +114,12 @@ $track-height: 4px;
 	justify-content: space-between;
 
 	h2 {
-		font-weight: 500;
+		font-size: $font-body-small;
+		font-weight: 600;
 	}
 	p {
-		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-		font-size: 2em;
-		font-weight: 500;
+		font-size: $font-headline-small;
+		font-weight: bold;
 		margin: 0;
 	}
 	.right-aligned {

--- a/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
+++ b/client/my-sites/stats/stats-purchase/tier-upgrade-slider/styles.scss
@@ -126,6 +126,7 @@ $track-height: 4px;
 		text-align: right;
 	}
 	.full-price-label {
+		font-size: $font-title-medium;
 		color: var(--studio-gray-40);
 		text-decoration: line-through;
 	}

--- a/packages/components/src/pricing-slider/style.scss
+++ b/packages/components/src/pricing-slider/style.scss
@@ -72,8 +72,4 @@ $thumb-horizontal-padding: 16px;
 		// On focus styling
 		outline: none;
 	}
-
-	&[aria-valuenow="0"] {
-		border-color: var(--jp-gray);
-	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1704905088004889-slack-C82FZ5T4G

## Proposed Changes

* Adjust font styling and layout of the Tier Upgrade Slider to align with the design.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live link.
* Navigate to the Stats purchase page for a Jetpack site: `/stats/purchase/{site-slug}?productType=personal`.
* Ensure the pricing slider works in line with the design.

|Before|After|
|-|-|
|<img width="576" alt="截圖 2024-01-11 下午4 03 19" src="https://github.com/Automattic/wp-calypso/assets/6869813/2e210e01-7598-47a6-99ad-162fc50e8307">|<img width="591" alt="截圖 2024-01-11 下午4 02 38" src="https://github.com/Automattic/wp-calypso/assets/6869813/96f883c0-5eb2-45d1-9588-8a6e91391506">|

* Change the URL param **productType** to `commercial`.
* Ensure the tier upgrade slider works in line with the design.

|Before|After|
|-|-|
|<img width="571" alt="截圖 2024-01-11 下午4 03 08" src="https://github.com/Automattic/wp-calypso/assets/6869813/6f8b22ef-8513-42dc-acbb-54ac82e9a00c">|<img width="574" alt="截圖 2024-01-11 下午4 02 53" src="https://github.com/Automattic/wp-calypso/assets/6869813/358ddbf4-b59a-416a-bc66-90ef8dcc0f01">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?