### PR TITLE
Replace old WPCOM plan names

### DIFF
--- a/client/me/help/help-courses/course-schedule-item.jsx
+++ b/client/me/help/help-courses/course-schedule-item.jsx
@@ -1,3 +1,4 @@
+import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
 import { Card, Button, Gridicon } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -36,7 +37,9 @@ export default localize( ( props ) => {
 					</Button>
 				) : (
 					<div className="help-courses__course-schedule-item-businessplan-button">
-						{ translate( 'Only on Business Plan' ) }
+						{ translate( 'Only on %(planName)s Plan', {
+							args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() },
+						} ) }
 					</div>
 				) }
 			</div>

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -108,7 +108,14 @@ class StepUpgrade extends Component {
 								<ProductIcon slug="business-bundle" />
 							</div>
 							<div className="migrate__plan-upsell-info">
-								<div className="migrate__plan-name">{ translate( 'WordPress.com Business' ) }</div>
+								<div className="migrate__plan-name">
+									{
+										// translators: %(planName)s is the name of the Creator/Business plan
+										translate( 'WordPress.com %(planName)s', {
+											args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() },
+										} )
+									}
+								</div>
 								<div className="migrate__plan-price">
 									<PlanPrice rawPrice={ planPrice } currencyCode={ currency } />
 								</div>

--- a/client/my-sites/plugins/plans/index.tsx
+++ b/client/my-sites/plugins/plans/index.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { PLAN_BUSINESS } from '@automattic/calypso-products';
+import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import ActionCard from 'calypso/components/action-card';
@@ -127,7 +127,11 @@ const Plans = ( { intervalType }: { intervalType: 'yearly' | 'monthly' } ) => {
 						},
 					}
 				) }
-				buttonText={ translate( 'Upgrade to Business' ) }
+				buttonText={
+					translate( 'Upgrade to %(planName)s', {
+						args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+					} ) as string
+				}
 				buttonPrimary={ true }
 				buttonOnClick={ () => {
 					alert( 'Connect code after merging PR 68087' );

--- a/packages/data-stores/src/contextual-help/admin-sections.ts
+++ b/packages/data-stores/src/contextual-help/admin-sections.ts
@@ -1,3 +1,4 @@
+import { PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
 import { __, sprintf } from '@wordpress/i18n';
 
 export function generateAdminSections(
@@ -139,11 +140,15 @@ export function generateAdminSections(
 		},
 		{
 			title: __( 'Earn money from my site', __i18n_text_domain__ ),
-			description: __(
-				"By upgrading to the Premium plan, you'll be able to monetize your site through the WordAds program."
+			description: sprintf(
+				// translators: %s is the name of the Explorer/Premium plan.
+				__(
+					"By upgrading to the %s plan, you'll be able to monetize your site through the WordAds program."
+				),
+				getPlan( PLAN_PREMIUM )?.getTitle()
 			),
 			link: `/earn/${ siteSlug }`,
-			synonyms: [ 'monetize', 'wordads', 'premium' ],
+			synonyms: [ 'monetize', 'wordads', 'premium', 'explorer' ],
 			icon: 'money',
 		},
 		{

--- a/packages/global-styles/src/components/global-styles-variations/index.tsx
+++ b/packages/global-styles/src/components/global-styles-variations/index.tsx
@@ -105,16 +105,10 @@ const GlobalStylesVariations = ( {
 }: GlobalStylesVariationsProps ) => {
 	const hasEnTranslation = useHasEnTranslation();
 	const isRegisteredCoreBlocks = useRegisterCoreBlocks();
-	const premiumStylesDescription = hasEnTranslation(
-		'Unlock style variations and tons of other features with the %(planName)s plan, or try them out now for free.'
-	)
-		? translate(
-				'Unlock style variations and tons of other features with the %(planName)s plan, or try them out now for free.',
-				{ args: { planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' } }
-		  )
-		: translate(
-				'Unlock premium styles and tons of other features with the Premium plan, or try them out now for free.'
-		  );
+	const premiumStylesDescription = translate(
+		'Unlock style variations and tons of other features with the %(planName)s plan, or try them out now for free.',
+		{ args: { planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' } }
+	);
 
 	const baseGlobalStyles = useMemo(
 		() =>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This replaces references to the old Personal and Premium plan names.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure translations are used correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
