### PR TITLE
Replace old WPCOM plan names 2

### DIFF
--- a/client/lib/discounts/active-discounts.ts
+++ b/client/lib/discounts/active-discounts.ts
@@ -8,7 +8,7 @@ import {
 } from '@automattic/calypso-products';
 
 const simplePaymentsNoticeTextWPCOM =
-	'Upgrade to a Premium or Business plan today and start collecting payments with the Pay with PayPal button!';
+	'Upgrade to a Explorer or Creator plan today and start collecting payments with the Pay with PayPal button!';
 
 const simplePaymentsNoticeTextJetpack =
 	'Upgrade to a Premium or Professional plan today and start collecting payments with the Pay with PayPal button!';

--- a/client/me/help/help-courses/constants.js
+++ b/client/me/help/help-courses/constants.js
@@ -1,3 +1,4 @@
+import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
 import i18n from 'i18n-calypso';
 
 export const helpCourses = [
@@ -15,11 +16,17 @@ export const helpCourses = [
 	},
 	{
 		title: i18n.translate( 'How to Make a Business Site on WordPress.com' ),
+		// translators: %(planName)s is the name of the Creator/Business plan.
 		description: i18n.translate(
 			'A 60-minute overview course with two of our Happiness Engineers. In this live group session, ' +
-				'we provide an overview of WordPress.com, discuss features of the WordPress.com Business ' +
+				'we provide an overview of WordPress.com, discuss features of the WordPress.com %(planName)s ' +
 				'plan, provide a basic setup overview to help you get started with your site, and show you ' +
-				'where to find additional resources and help in the future.'
+				'where to find additional resources and help in the future.',
+			{
+				args: {
+					planName: getPlan( PLAN_BUSINESS )?.getTitle(),
+				},
+			}
 		),
 		video: {
 			youtubeId: 'S2h_mV0OAcU',

--- a/client/me/help/help-courses/course-schedule-item.jsx
+++ b/client/me/help/help-courses/course-schedule-item.jsx
@@ -37,7 +37,7 @@ export default localize( ( props ) => {
 					</Button>
 				) : (
 					<div className="help-courses__course-schedule-item-businessplan-button">
-						{ translate( 'Only on %(planName)s Plan', {
+						{ translate( 'Only on %(planName)s plan', {
 							args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() },
 						} ) }
 					</div>

--- a/client/me/help/help-courses/course.jsx
+++ b/client/me/help/help-courses/course.jsx
@@ -1,3 +1,4 @@
+import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
@@ -30,7 +31,10 @@ class Course extends Component {
 					{ ! isBusinessPlanUser && (
 						<HelpTeaserButton
 							href={ `/plans/${ this.props.primarySiteSlug }` }
-							title={ translate( 'Join this course with the Business Plan.' ) }
+							// translators: %(planName)s is the name of the Creator/Business plan.
+							title={ translate( 'Join this course with the %(planName)s Plan.', {
+								args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() },
+							} ) }
 							description={ translate(
 								'Upgrade to access webinars and courses to learn how to make the most of your site'
 							) }

--- a/client/me/help/help-courses/course.jsx
+++ b/client/me/help/help-courses/course.jsx
@@ -32,7 +32,7 @@ class Course extends Component {
 						<HelpTeaserButton
 							href={ `/plans/${ this.props.primarySiteSlug }` }
 							// translators: %(planName)s is the name of the Creator/Business plan.
-							title={ translate( 'Join this course with the %(planName)s Plan.', {
+							title={ translate( 'Join this course with the %(planName)s plan.', {
 								args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() },
 							} ) }
 							description={ translate(

--- a/client/signup/steps/store-features/intents.tsx
+++ b/client/signup/steps/store-features/intents.tsx
@@ -1,3 +1,4 @@
+import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { SelectItem } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
@@ -81,7 +82,8 @@ export function useIntents(
 					<span className="store-features__requirements">
 						{ hasWooFeature
 							? translate( 'Included in your plan' )
-							: translate( 'Requires a {{a}}Business plan{{/a}}', {
+							: // translators: %(planName)s is the name of the Creator/Business plan
+							  translate( 'Requires a {{a}}%(planName)s plan{{/a}}', {
 									components: {
 										a: (
 											<a
@@ -90,6 +92,9 @@ export function useIntents(
 												rel="noopener noreferrer"
 											/>
 										),
+									},
+									args: {
+										planName: getPlan( PLAN_BUSINESS )?.getTitle() || '',
 									},
 							  } ) }
 					</span>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86278

## Proposed Changes

This is a continuation of the effort in #86278 to replace the old plan names.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure translations are used correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
