### PR TITLE
Marketplace Reviews: Update color of Read all reviews link

### DIFF
--- a/client/my-sites/marketplace/components/reviews-cards/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-cards/index.tsx
@@ -53,8 +53,6 @@ export const MarketplaceReviewsCards = ( props: MarketplaceReviewsCardsProps ) =
 				<div className="marketplace-reviews-cards__read-all">
 					<Button
 						className="is-link"
-						borderless
-						primary
 						onClick={ () => props.showMarketplaceReviews && props.showMarketplaceReviews() }
 						href=""
 					>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* Update the style of the `Read all reviews` link to match the color of other links

|Before | After|
|-------|------|
|  ![CleanShot 2024-01-11 at 11 19 23@2x](https://github.com/Automattic/wp-calypso/assets/3519124/f59d6481-3575-43e0-88f6-a0148ede1253)   |     ![CleanShot 2024-01-11 at 11 18 43@2x](https://github.com/Automattic/wp-calypso/assets/3519124/dadc3c7c-5a16-4cab-9389-08e967606b1d)   |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to the plugin details page where you have reviews. Ex: /plugins/woocommerce-bookings/
* Scroll down and check the style of the `Read all reviews` link
* Make sure the color is the same as other links, for example the `See all` link above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
