### PR TITLE
Help center: Avoid duplicated results

### DIFF
--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -134,8 +134,13 @@ function HelpSearchResults( {
 		sectionName
 	);
 
-	const searchResults = searchData ?? [];
+	let searchResults: SearchResult[] = searchData ?? [];
 	const hasAPIResults = searchResults.length > 0;
+
+	// Remove duplicates from the API results.
+	searchResults = searchResults.filter(
+		( value, index ) => index === searchResults.findIndex( ( t ) => t.post_id === value.post_id )
+	);
 
 	useEffect( () => {
 		// Cancel all queued speak messages.


### PR DESCRIPTION
Context: p1704967412880669/1702579492.758129-slack-C02T4NVL4JJ

## What

On `/posts/` we have two instances of "Related Posts" linking to the same URL and "Create a Post" and "About Blog Posts" also lead to the same URL.
More examples can be found at `/settings/general/` and `/settings/writing/`

<img width="328" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/71911092-14df-4bd6-b0b7-abbe0ac238b5">

## Why

Duplicated results come from two different indexes: fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Syvo%2Suryc%2Spynff%2Quryc%2Qfrnepu.cuc%3Se%3Q1s9pn41s%2344%2Q51-og Further investigation is needed.

## Solution

Filter duplicate results on the frontend.

<img width="424" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/3ff9e17d-468c-4f95-92f2-73a99dc29396">

## Testing

1. Live link
2. Visit `/posts`
3. You shouldn't be seeing any duplicate results in `Recommended Resources`