### PR TITLE
Update @types/react to 18.2.47

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -225,7 +225,7 @@
 		"@testing-library/jest-dom": "^6.1.5",
 		"@testing-library/react": "^14.1.2",
 		"@testing-library/user-event": "^14.5.1",
-		"@types/react": "^18.2.14",
+		"@types/react": "^18.2.47",
 		"@types/redux-mock-store": "1.0.6",
 		"autoprefixer": "^10.2.5",
 		"component-event": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
 		"@types/node": "^20.8.6",
 		"@types/page": "^1.11.5",
 		"@types/qs": "^6.9.7",
-		"@types/react": "^18.2.6",
+		"@types/react": "^18.2.47",
 		"@types/react-modal": "^3.13.1",
 		"@types/react-router-dom": "^5.3.3",
 		"@types/react-transition-group": "^4.4.4",
@@ -304,7 +304,6 @@
 		"yargs": "^17.0.1"
 	},
 	"resolutions": {
-		"@types/react": "^18.2",
 		"@types/wordpress__block-editor": "npm:noop-package@1.0.0",
 		"@types/wordpress__editor": "npm:noop-package@1.0.0",
 		"keytar@npm:7.7.0/node-addon-api": "3.1.0",

--- a/packages/i18n-utils/package.json
+++ b/packages/i18n-utils/package.json
@@ -39,7 +39,7 @@
 		"@automattic/calypso-typescript-config": "workspace:^",
 		"@testing-library/jest-dom": "^6.1.5",
 		"@testing-library/react": "^14.1.2",
-		"@types/react": "^18.2.6",
+		"@types/react": "^18.2.47",
 		"react-dom": "^18.2.0",
 		"react-test-renderer": "^18.2.0",
 		"typescript": "^5.3.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -998,7 +998,7 @@ __metadata:
     "@automattic/languages": "workspace:^"
     "@testing-library/jest-dom": "npm:^6.1.5"
     "@testing-library/react": "npm:^14.1.2"
-    "@types/react": "npm:^18.2.6"
+    "@types/react": "npm:^18.2.47"
     "@wordpress/compose": "npm:^6.25.0"
     "@wordpress/i18n": "npm:^4.48.0"
     react: "npm:^18.2.0"
@@ -8137,14 +8137,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:^18.2":
-  version: 18.2.13
-  resolution: "@types/react@npm:18.2.13"
+"@types/react@npm:*, @types/react@npm:^18.0.21, @types/react@npm:^18.2.47":
+  version: 18.2.47
+  resolution: "@types/react@npm:18.2.47"
   dependencies:
     "@types/prop-types": "npm:*"
     "@types/scheduler": "npm:*"
     csstype: "npm:^3.0.2"
-  checksum: 59b434ab9f2cf4874c8715a3d848d7cfd257419af8c0e486e2af5b6760c99aab62a511cb3456a3044d8250c93539016ca84fbd23eaac988e74987e268df2eef2
+  checksum: e98ea1827fe60636d0f7ce206397159a29fc30613fae43e349e32c10ad3c0b7e0ed2ded2f3239e07bd5a3cba8736b6114ba196acccc39905ca4a06f56a8d2841
   languageName: node
   linkType: hard
 
@@ -12181,7 +12181,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:^6.1.5"
     "@testing-library/react": "npm:^14.1.2"
     "@testing-library/user-event": "npm:^14.5.1"
-    "@types/react": "npm:^18.2.14"
+    "@types/react": "npm:^18.2.47"
     "@types/redux-mock-store": "npm:1.0.6"
     "@wordpress/a11y": "npm:^3.48.0"
     "@wordpress/api-fetch": "npm:^6.45.0"
@@ -32138,7 +32138,7 @@ __metadata:
     "@types/node": "npm:^20.8.6"
     "@types/page": "npm:^1.11.5"
     "@types/qs": "npm:^6.9.7"
-    "@types/react": "npm:^18.2.6"
+    "@types/react": "npm:^18.2.47"
     "@types/react-modal": "npm:^3.13.1"
     "@types/react-router-dom": "npm:^5.3.3"
     "@types/react-transition-group": "npm:^4.4.4"


### PR DESCRIPTION
## Proposed Changes

Updating `@types/react` to the latest version in order to resolve issues with some other upcoming dependency updates.

## Testing Instructions

All should be green. 

