### PR TITLE
calypso-babel-config: Remove `@emotion/react` as a default import source

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -6,4 +6,5 @@ const babelConfig = require( '@automattic/calypso-babel-config' );
 module.exports = babelConfig( {
 	isBrowser: process.env.BROWSERSLIST_ENV !== 'server',
 	outputPOT: path.join( __dirname, 'build/i18n-calypso/' ),
+	importSource: '@emotion/react',
 } );

--- a/packages/calypso-babel-config/CHANGELOG.md
+++ b/packages/calypso-babel-config/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Remove `@emotion/react` import source configuration for `@babel/preset-react` from the default preset
+- Introduce `importSource` preset option and `IMPORT_SOURCE` env variable to allow configuring import source for `@babel/preset-react`
+
 ### Added
 
 - Initial release

--- a/packages/calypso-babel-config/config.js
+++ b/packages/calypso-babel-config/config.js
@@ -1,5 +1,5 @@
-module.exports = ( { isBrowser = true, outputPOT = 'build' } = {} ) => ( {
-	presets: [ [ require.resolve( './presets/default' ), { bugfixes: true } ] ],
+module.exports = ( { isBrowser = true, outputPOT = 'build', importSource } = {} ) => ( {
+	presets: [ [ require.resolve( './presets/default' ), { bugfixes: true, importSource } ] ],
 	plugins: [ [ '@automattic/babel-plugin-transform-wpcalypso-async', { ignore: ! isBrowser } ] ],
 	env: {
 		production: {

--- a/packages/calypso-babel-config/presets/default.js
+++ b/packages/calypso-babel-config/presets/default.js
@@ -11,6 +11,18 @@ function modulesOption( opts ) {
 	return false; // Default
 }
 
+function importSourceOption( opts ) {
+	if ( opts && opts.importSource !== undefined ) {
+		return opts.importSource;
+	}
+
+	if ( typeof process.env.IMPORT_SOURCE !== 'undefined' ) {
+		return process.env.IMPORT_SOURCE;
+	}
+
+	return undefined; // Default
+}
+
 module.exports = ( api, opts ) => ( {
 	presets: [
 		[
@@ -27,7 +39,10 @@ module.exports = ( api, opts ) => ( {
 		],
 		[
 			require.resolve( '@babel/preset-react' ),
-			{ runtime: 'automatic', importSource: '@emotion/react' },
+			{
+				runtime: 'automatic',
+				importSource: importSourceOption( opts ),
+			},
 		],
 		[ require.resolve( '@babel/preset-typescript' ), { allowDeclareFields: true } ],
 	],

--- a/packages/calypso-babel-config/presets/default.js
+++ b/packages/calypso-babel-config/presets/default.js
@@ -11,18 +11,6 @@ function modulesOption( opts ) {
 	return false; // Default
 }
 
-function importSourceOption( opts ) {
-	if ( opts && opts.importSource !== undefined ) {
-		return opts.importSource;
-	}
-
-	if ( typeof process.env.IMPORT_SOURCE !== 'undefined' ) {
-		return process.env.IMPORT_SOURCE;
-	}
-
-	return undefined; // Default
-}
-
 module.exports = ( api, opts ) => ( {
 	presets: [
 		[
@@ -41,7 +29,7 @@ module.exports = ( api, opts ) => ( {
 			require.resolve( '@babel/preset-react' ),
 			{
 				runtime: 'automatic',
-				importSource: importSourceOption( opts ),
+				importSource: opts.importSource ?? process.env.IMPORT_SOURCE,
 			},
 		],
 		[ require.resolve( '@babel/preset-typescript' ), { allowDeclareFields: true } ],


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/85991

According to [Emotion documentation](https://emotion.sh/docs/css-prop), using `@emotion/react` as an import source is required when using the `css` prop.

On inspecting the codebase, I found that the `css` prop is [only used in a few places in `/client/*`](https://github.com/search?q=repo%3AAutomattic%2Fwp-calypso%20%22css%3D%22&type=code).

However, we've been using `@emotion/react` as a default import source in `@automattic/calypso-babel-config"`. The preset itself is used in some places, such as building some of the `/packages/*`, which results in introducing unnecessary dependency to the `@emotion/react` JSX runtime wrapper (see https://github.com/Automattic/wp-calypso/pull/85991 as an example).

## Proposed Changes

- Remove `@emotion/react` import source configuration for `@babel/preset-react` from the default preset
- Introduce `importSource` preset option and `IMPORT_SOURCE` env variable to allow configuring import source for `@babel/preset-react`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* Test some of the affected components to confirm the `css` prop is still being handled properly, for example: 
    *  Navigate to `/domains/manage/[SITE]`, for a site that has multiple domains.
    * Inspect the `Manage all the domains you own on WordPress.com` paragraph.
    * Confirm the `css` prop is transformed into a class name that applies the specified styles.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
