### PR TITLE
Use 'WooCommerce' for plugins search e2e tests

### DIFF
--- a/test/e2e/specs/plugins/plugins__search.ts
+++ b/test/e2e/specs/plugins/plugins__search.ts
@@ -13,8 +13,7 @@ import { Page, Browser } from 'playwright';
 
 declare const browser: Browser;
 
-// skip these tests while we work on the fix in https://github.com/Automattic/dotcom-forge/issues/5139
-describe.skip( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
+describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 	let page: Page;
 	let pluginsPage: PluginsPage;
 	let siteUrl: string;
@@ -42,13 +41,14 @@ describe.skip( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 
 	it( 'Search for "jetpack"', async function () {
 		pluginsPage = new PluginsPage( page );
-		await pluginsPage.search( 'jetpack' );
-		await pluginsPage.validateExpectedSearchResultFound( 'Jetpack Protect' );
+		await pluginsPage.search( 'woocommerce' );
+		// for this assumption we need to use a plugin whose name isn't changed often
+		await pluginsPage.validateExpectedSearchResultFound( 'WooCommerce' );
 	} );
 
 	it( 'Click on a search result', async function () {
-		await pluginsPage.clickSearchResult( 'Jetpack Protect' );
-		await pluginsPage.validatePluginDetailsHasHeaderTitle( 'Jetpack Protect' );
+		await pluginsPage.clickSearchResult( 'WooCommerce' );
+		await pluginsPage.validatePluginDetailsHasHeaderTitle( 'WooCommerce' );
 	} );
 
 	it( 'Click on breadcrumbs "Search Results"', async function () {
@@ -57,17 +57,17 @@ describe.skip( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 		} else {
 			await pluginsPage.clickBackBreadcrumb();
 		}
-		await pluginsPage.validateExpectedSearchResultFound( 'Jetpack Protect' );
+		await pluginsPage.validateExpectedSearchResultFound( 'WooCommerce' );
 	} );
 
 	it( 'Click on breadcrumbs "Plugins"', async function () {
-		await pluginsPage.clickSearchResult( 'Jetpack Protect' );
+		await pluginsPage.clickSearchResult( 'WooCommerce' );
 		if ( envVariables.VIEWPORT_NAME !== 'mobile' ) {
 			await pluginsPage.clickPluginsBreadcrumb();
 			await pluginsPage.validateHasSection( PluginsPage.paidSection );
 		} else {
 			await pluginsPage.clickBackBreadcrumb();
-			await pluginsPage.validateExpectedSearchResultFound( 'Jetpack Protect' );
+			await pluginsPage.validateExpectedSearchResultFound( 'WooCommerce' );
 		}
 	} );
 
@@ -76,9 +76,9 @@ describe.skip( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 			'Search Engine Optimization',
 			envVariables.VIEWPORT_NAME !== 'mobile'
 		);
-		await pluginsPage.search( 'jetpack' );
+		await pluginsPage.search( 'woocommerce' );
 
 		// Check if its redirecting to the default plugins page
-		await page.waitForURL( new RegExp( `/plugins/${ siteUrl }\\?s=jetpack`, 'g' ) );
+		await page.waitForURL( new RegExp( `/plugins/${ siteUrl }\\?s=woocommerce`, 'g' ) );
 	} );
 } );

--- a/test/e2e/specs/plugins/plugins__search.ts
+++ b/test/e2e/specs/plugins/plugins__search.ts
@@ -39,7 +39,7 @@ describe( DataHelper.createSuiteTitle( 'Plugins search' ), function () {
 		await sidebarCompoonent.navigate( 'Plugins' );
 	} );
 
-	it( 'Search for "jetpack"', async function () {
+	it( 'Search for "woocommerce"', async function () {
 		pluginsPage = new PluginsPage( page );
 		await pluginsPage.search( 'woocommerce' );
 		// for this assumption we need to use a plugin whose name isn't changed often


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/dotcom-forge/issues/5139

## Proposed Changes

Update the search term and test plugins used for assumptions from 'Jetpack Protect' to 'WooCommerce'.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* E2E test suite should pass

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?