### PR TITLE
Editor "Add a page" Modal: Allow testing v2 page patterns on sites using pub/assembler or assembler theme

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -210,6 +210,19 @@ class Starter_Page_Templates {
 			}
 		}
 
+		// Hide non-user-facing categories (Pages & Virtual Theme) in modal
+		$hidden_categories = array( 'page', 'virtual-theme' );
+		foreach ( $page_templates as &$page_template ) {
+			if ( ! isset( $page_template['categories'] ) ) {
+				continue;
+			}
+			foreach ( $page_template['categories'] as $category ) {
+				if ( in_array( $category['slug'], $hidden_categories, true ) ) {
+					unset( $page_template['categories'][ $category['slug'] ] );
+				}
+			}
+		}
+
 		if ( empty( $page_templates ) ) {
 			$this->pass_error_to_frontend( __( 'No data received from the vertical API. Skipped showing modal window with template selection.', 'full-site-editing' ) );
 			return;
@@ -277,17 +290,27 @@ class Starter_Page_Templates {
 	public function get_page_templates( string $locale ) {
 		$page_template_data   = get_transient( $this->get_templates_cache_key( $locale ) );
 		$override_source_site = apply_filters( 'a8c_override_patterns_source_site', false );
+		$is_assembler_v2_site = 'pub/assembler' === get_stylesheet();
 
 		// Load fresh data if we don't have any or vertical_id doesn't match.
-		if ( false === $page_template_data || ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || false !== $override_source_site ) {
+		if ( $is_assembler_v2_site || false === $page_template_data || ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || false !== $override_source_site ) {
+			$request_params = array(
+				'site'         => $override_source_site,
+				'tags'         => 'layout',
+				'pattern_meta' => 'is_web',
+			);
+
+			if ( $is_assembler_v2_site ) {
+				$request_params = array(
+					'site'       => 'assemblerv2patterns.wordpress.com',
+					'categories' => 'page',
+					'post_type'  => 'wp_block',
+				);
+			}
 
 			$request_url = esc_url_raw(
 				add_query_arg(
-					array(
-						'site'         => $override_source_site,
-						'tags'         => 'layout',
-						'pattern_meta' => 'is_web',
-					),
+					$request_params,
 					'https://public-api.wordpress.com/rest/v1/ptk/patterns/' . $locale
 				)
 			);
@@ -307,7 +330,7 @@ class Starter_Page_Templates {
 			$page_template_data = json_decode( wp_remote_retrieve_body( $response ), true );
 
 			// Only save to cache if we have not overridden the source site.
-			if ( false === $override_source_site ) {
+			if ( ! $is_assembler_v2_site && false === $override_source_site ) {
 				set_transient( $this->get_templates_cache_key( $locale ), $page_template_data, DAY_IN_SECONDS );
 			}
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -290,7 +290,7 @@ class Starter_Page_Templates {
 	public function get_page_templates( string $locale ) {
 		$page_template_data   = get_transient( $this->get_templates_cache_key( $locale ) );
 		$override_source_site = apply_filters( 'a8c_override_patterns_source_site', false );
-		$is_assembler_v2_site = 'pub/assembler' === get_stylesheet();
+		$is_assembler_v2_site = in_array( get_stylesheet(), array( 'pub/assembler', 'assembler' ), true );
 
 		// Load fresh data if we don't have any or vertical_id doesn't match.
 		if ( $is_assembler_v2_site || false === $page_template_data || ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || false !== $override_source_site ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* Only on sites using `pub/assembler` or `assembler` theme, show the v2 page patterns on the editor's "Add a page" modal
* Hide the categories "Pages" and "Virtual Themes" from the UI

|BEFORE|AFTER|
|-|-|
|<img width="1593" alt="Screenshot 2567-01-11 at 18 42 51" src="https://github.com/Automattic/wp-calypso/assets/1881481/b3253394-2b25-4e5a-86ea-75842ffc5517">|<img width="1259" alt="Screenshot 2567-01-12 at 13 17 55" src="https://github.com/Automattic/wp-calypso/assets/1881481/b4845f8a-a188-4347-ba44-8259fcbdac0a">|

### Follow-up Tasks
- Release: Update the code to show these patterns on the modal for all sites

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox any site
* Apply this patch to your sandbox with `install-plugin.sh etk chore/add-feature-flag-for-testing-v2-pages-modal`
* Visit `{ SITE }/wp-admin/post-new.php?post_type=page`
* Verify you see only the patterns from the category "Pages" of assemblerv2patterns.wordpress.com
* Verify you don't see the categories "Pages" and "Virtual Themes" on the UI




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?