### PR TITLE
Launchpad: Use new task definition and tracking on the setup free flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/get-deprecated-task-data.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/get-deprecated-task-data.tsx
@@ -35,7 +35,7 @@ export function getDeprecatedTaskDefinition(
 	completeMigrateContentTask: () => Promise< void >,
 	site: SiteDetails | null,
 	submit: NavigationControls[ 'submit' ] | undefined,
-	getLaunchSiteTaskTitle: ( task: Task ) => string | undefined,
+	getLaunchSiteTaskTitle: ( task: Task ) => ReactNode | string | undefined,
 	getIsLaunchSiteTaskDisabled: () => boolean,
 	completeLaunchSiteTask: ( task: Task ) => Promise< void >,
 	launchpadUploadVideoLink: string,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/get-deprecated-task-data.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/get-deprecated-task-data.tsx
@@ -1,5 +1,6 @@
 import { FEATURE_VIDEO_UPLOADS, FEATURE_STYLE_CUSTOMIZATION } from '@automattic/calypso-products';
 import { type SiteDetails, type OnboardActions, type SiteActions } from '@automattic/data-stores';
+import { Task } from '@automattic/launchpad';
 import { isBlogOnboardingFlow, isSiteAssemblerFlow } from '@automattic/onboarding';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -11,7 +12,6 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ADD_TIER_PLAN_HASH } from 'calypso/my-sites/earn/memberships/constants';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import { recordTaskClickTracksEvent } from './task-helper';
-import { Task } from './types';
 
 /**
  * @deprecated The method should not be updated, use the new task-definitions modules to add/update the task definitions

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/get-deprecated-task-data.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/get-deprecated-task-data.tsx
@@ -1,0 +1,390 @@
+import { FEATURE_VIDEO_UPLOADS, FEATURE_STYLE_CUSTOMIZATION } from '@automattic/calypso-products';
+import { type SiteDetails, type OnboardActions, type SiteActions } from '@automattic/data-stores';
+import { isBlogOnboardingFlow, isSiteAssemblerFlow } from '@automattic/onboarding';
+import { dispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+import { translate } from 'i18n-calypso';
+import { Dispatch, ReactNode, SetStateAction } from 'react';
+import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { ADD_TIER_PLAN_HASH } from 'calypso/my-sites/earn/memberships/constants';
+import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
+import { recordTaskClickTracksEvent } from './task-helper';
+import { Task } from './types';
+
+/**
+ * @deprecated The method should not be updated, use the new task-definitions modules to add/update the task definitions
+ */
+export function getDeprecatedTaskDefinition(
+	task: Task,
+	flow: string,
+	siteInfoQueryArgs:
+		| { siteId: number | undefined; siteSlug?: undefined }
+		| { siteSlug: string | null; siteId?: undefined },
+	siteSlug: string | null,
+	displayGlobalStylesWarning: boolean,
+	shouldDisplayWarning: boolean,
+	globalStylesMinimumPlan: string,
+	isVideoPressFlowWithUnsupportedPlan: boolean,
+	getPlanTaskSubtitle: ( task: Task ) => ReactNode | string | undefined,
+	translatedPlanName: ReactNode | string,
+	isCurrentPlanFree: boolean,
+	goToStep: ( ( step: string ) => void ) | undefined,
+	mustVerifyEmailBeforePosting: boolean,
+	completeMigrateContentTask: () => Promise< void >,
+	site: SiteDetails | null,
+	submit: NavigationControls[ 'submit' ] | undefined,
+	getLaunchSiteTaskTitle: ( task: Task ) => string | undefined,
+	getIsLaunchSiteTaskDisabled: () => boolean,
+	completeLaunchSiteTask: ( task: Task ) => Promise< void >,
+	launchpadUploadVideoLink: string,
+	videoPressUploadCompleted: boolean,
+	domainUpsellCompleted: boolean,
+	isEmailVerified: boolean,
+	stripeConnectUrl: string | undefined,
+	completePaidNewsletterTask: () => Promise< void >,
+	setShowPlansModal: Dispatch< SetStateAction< boolean > >
+) {
+	let taskData = {};
+	switch ( task.id ) {
+		case 'setup_free':
+			taskData = {
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.assign(
+						addQueryArgs( `/setup/${ flow }/freePostSetup`, siteInfoQueryArgs )
+					);
+				},
+			};
+			break;
+		case 'setup_blog':
+			taskData = {
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.assign(
+						addQueryArgs( `/setup/${ flow }/setup-blog`, siteInfoQueryArgs )
+					);
+				},
+				disabled: task.completed && ! isBlogOnboardingFlow( flow ),
+			};
+			break;
+		case 'setup_newsletter':
+			taskData = {
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.assign(
+						addQueryArgs( `/setup/newsletter-post-setup/newsletterPostSetup`, siteInfoQueryArgs )
+					);
+				},
+			};
+			break;
+		case 'design_edited':
+			taskData = {
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.assign(
+						addQueryArgs( `/site-editor/${ siteSlug }`, {
+							canvas: 'edit',
+						} )
+					);
+				},
+			};
+			break;
+		case 'plan_selected':
+			/* eslint-disable no-case-declarations */
+			const openPlansPage = () => {
+				recordTaskClickTracksEvent( flow, task.completed, task.id );
+				if ( displayGlobalStylesWarning ) {
+					recordTracksEvent( 'calypso_launchpad_global_styles_gating_plan_selected_task_clicked', {
+						flow,
+					} );
+				}
+				const plansUrl = addQueryArgs( `/plans/${ siteSlug }`, {
+					...( shouldDisplayWarning && {
+						plan: globalStylesMinimumPlan,
+						feature: isVideoPressFlowWithUnsupportedPlan
+							? FEATURE_VIDEO_UPLOADS
+							: FEATURE_STYLE_CUSTOMIZATION,
+					} ),
+				} );
+				window.location.assign( plansUrl );
+			};
+
+			const completed = task.completed && ! isVideoPressFlowWithUnsupportedPlan;
+
+			taskData = {
+				actionDispatch: openPlansPage,
+				completed,
+				subtitle: getPlanTaskSubtitle( task ),
+			};
+			/* eslint-enable no-case-declarations */
+			break;
+		case 'plan_completed':
+			taskData = {
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					const plansUrl = addQueryArgs( `/setup/${ flow }/plans`, siteInfoQueryArgs );
+
+					window.location.assign( plansUrl );
+				},
+				badge_text: task.completed ? translatedPlanName : task.badge_text,
+				subtitle: getPlanTaskSubtitle( task ),
+				disabled: task.completed && ! isCurrentPlanFree,
+			};
+			break;
+		case 'subscribers_added':
+			taskData = {
+				actionDispatch: () => {
+					if ( goToStep ) {
+						recordTaskClickTracksEvent( flow, task.completed, task.id );
+						goToStep( 'subscribers' );
+					}
+				},
+			};
+			break;
+		case 'migrate_content':
+			taskData = {
+				disabled: mustVerifyEmailBeforePosting || false,
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+
+					// Mark task done
+					completeMigrateContentTask();
+
+					// Go to importers
+					window.location.assign( `/import/${ siteSlug }` );
+				},
+			};
+			break;
+		case 'first_post_published':
+			taskData = {
+				disabled:
+					mustVerifyEmailBeforePosting ||
+					( task.completed && isBlogOnboardingFlow( flow || null ) ) ||
+					false,
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					const newPostUrl = ! isBlogOnboardingFlow( flow || null )
+						? `/post/${ siteSlug }`
+						: addQueryArgs( `https://${ siteSlug }/wp-admin/post-new.php`, {
+								origin: window.location.origin,
+						  } );
+					window.location.assign( newPostUrl );
+				},
+			};
+			break;
+		case 'first_post_published_newsletter':
+			taskData = {
+				isLaunchTask: true,
+				disabled: mustVerifyEmailBeforePosting || false,
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.assign( `/post/${ siteSlug }` );
+				},
+			};
+			break;
+		case 'design_selected':
+		case 'design_completed':
+			taskData = {
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.assign(
+						addQueryArgs( `/setup/update-design/designSetup`, {
+							...siteInfoQueryArgs,
+							flowToReturnTo: flow,
+						} )
+					);
+				},
+			};
+			break;
+		case 'setup_general':
+			taskData = {
+				disabled: false,
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.assign(
+						addQueryArgs( `/setup/update-options/options`, {
+							...siteInfoQueryArgs,
+							flowToReturnTo: flow,
+						} )
+					);
+				},
+			};
+			break;
+		case 'setup_link_in_bio':
+			taskData = {
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.assign(
+						addQueryArgs( `/setup/link-in-bio-post-setup/linkInBioPostSetup`, siteInfoQueryArgs )
+					);
+				},
+			};
+			break;
+		case 'links_added':
+			taskData = {
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.assign(
+						addQueryArgs( `/site-editor/${ siteSlug }`, {
+							canvas: 'edit',
+						} )
+					);
+				},
+			};
+			break;
+		case 'link_in_bio_launched':
+			taskData = {
+				isLaunchTask: true,
+				actionDispatch: () => {
+					if ( site?.ID ) {
+						const { setPendingAction, setProgressTitle } = dispatch(
+							ONBOARD_STORE
+						) as OnboardActions;
+						const { launchSite } = dispatch( SITE_STORE ) as SiteActions;
+
+						setPendingAction( async () => {
+							setProgressTitle( __( 'Launching Link in bio' ) );
+							await launchSite( site.ID );
+
+							// Waits for half a second so that the loading screen doesn't flash away too quickly
+							await new Promise( ( res ) => setTimeout( res, 500 ) );
+							recordTaskClickTracksEvent( flow, task.completed, task.id );
+							return { goToHome: true, siteSlug };
+						} );
+
+						submit?.();
+					}
+				},
+			};
+			break;
+		case 'site_launched':
+			taskData = {
+				isLaunchTask: true,
+				title: getLaunchSiteTaskTitle( task ),
+				disabled: getIsLaunchSiteTaskDisabled(),
+				actionDispatch: () => {
+					completeLaunchSiteTask( task );
+				},
+			};
+			break;
+		case 'blog_launched': {
+			taskData = {
+				isLaunchTask: true,
+				title: getLaunchSiteTaskTitle( task ),
+				disabled: getIsLaunchSiteTaskDisabled(),
+				actionDispatch: () => {
+					completeLaunchSiteTask( task );
+				},
+			};
+			break;
+		}
+		case 'videopress_upload':
+			taskData = {
+				actionUrl: launchpadUploadVideoLink,
+				disabled: isVideoPressFlowWithUnsupportedPlan || videoPressUploadCompleted,
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.replace( launchpadUploadVideoLink );
+				},
+			};
+			break;
+		case 'videopress_launched':
+			taskData = {
+				isLaunchTask: true,
+				actionDispatch: () => {
+					if ( site?.ID ) {
+						const { setPendingAction, setProgressTitle } = dispatch(
+							ONBOARD_STORE
+						) as OnboardActions;
+						const { launchSite } = dispatch( SITE_STORE ) as SiteActions;
+
+						setPendingAction( async () => {
+							setProgressTitle( __( 'Launching video site' ) );
+							await launchSite( site.ID );
+
+							// Waits for half a second so that the loading screen doesn't flash away too quickly
+							await new Promise( ( res ) => setTimeout( res, 500 ) );
+							window.location.replace(
+								addQueryArgs( `/home/${ siteSlug }`, {
+									forceLoadLaunchpadData: true,
+								} )
+							);
+						} );
+
+						submit?.();
+					}
+				},
+			};
+			break;
+		case 'domain_upsell':
+			taskData = {
+				completed: domainUpsellCompleted,
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, domainUpsellCompleted, task.id );
+
+					if ( isBlogOnboardingFlow( flow ) || isSiteAssemblerFlow( flow ) ) {
+						window.location.assign(
+							addQueryArgs( `/setup/${ flow }/domains`, {
+								...siteInfoQueryArgs,
+								flowToReturnTo: flow,
+								new: site?.name,
+								domainAndPlanPackage: true,
+							} )
+						);
+
+						return;
+					}
+
+					const destinationUrl = domainUpsellCompleted
+						? `/domains/manage/${ siteSlug }`
+						: addQueryArgs( `/setup/domain-upsell/domains`, {
+								...siteInfoQueryArgs,
+								flowToReturnTo: flow,
+								new: site?.name,
+						  } );
+					window.location.assign( destinationUrl );
+				},
+				badge_text:
+					domainUpsellCompleted || isBlogOnboardingFlow( flow ) || isSiteAssemblerFlow( flow )
+						? ''
+						: translate( 'Upgrade plan' ),
+			};
+			break;
+		case 'verify_email':
+			taskData = {
+				completed: isEmailVerified,
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.replace( task.calypso_path || '/me/account' );
+				},
+			};
+			break;
+		case 'set_up_payments':
+			taskData = {
+				badge_text: task.completed ? translate( 'Connected' ) : null,
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					stripeConnectUrl
+						? window.location.assign( stripeConnectUrl )
+						: window.location.assign( `/earn/payments/${ siteSlug }#launchpad` );
+				},
+			};
+			break;
+		case 'newsletter_plan_created':
+			taskData = {
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					completePaidNewsletterTask();
+					site?.ID
+						? setShowPlansModal( true )
+						: window.location.assign(
+								`/earn/payments/${ siteSlug }?launchpad=add-product${ ADD_TIER_PLAN_HASH }`
+						  );
+				},
+			};
+			break;
+	}
+	return { ...task, ...taskData };
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -5,7 +5,7 @@ import {
 	sortLaunchpadTasksByCompletionStatus,
 	useLaunchpad,
 } from '@automattic/data-stores';
-import { LaunchpadInternal } from '@automattic/launchpad';
+import { LaunchpadInternal, Task } from '@automattic/launchpad';
 import { isBlogOnboardingFlow } from '@automattic/onboarding';
 import { useQueryClient } from '@tanstack/react-query';
 import { useSelect } from '@wordpress/data';
@@ -27,7 +27,6 @@ import { getConnectUrlForSiteId } from 'calypso/state/memberships/settings/selec
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { getEnhancedTasks } from './task-helper';
 import { getLaunchpadTranslations } from './translations';
-import { type Task } from './types';
 
 type SidebarProps = {
 	sidebarDomain: ResponseDomain;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/design/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/design/index.tsx
@@ -1,8 +1,9 @@
+import { Task } from '@automattic/launchpad';
 import { addQueryArgs } from '@wordpress/url';
 import { recordTaskClickTracksEvent } from '../../tracking';
-import { TaskAction, TaskActionTable, EnhancedTask } from '../../types';
+import { TaskAction, TaskActionTable } from '../../types';
 
-const getPlanSelected: TaskAction = ( task, flow, context ): EnhancedTask => {
+const getPlanSelected: TaskAction = ( task, flow, context ): Task => {
 	const { siteInfoQueryArgs } = context;
 
 	return {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/design/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/design/index.tsx
@@ -1,5 +1,5 @@
 import { addQueryArgs } from '@wordpress/url';
-import { recordTaskClickTracksEvent } from '../../task-helper';
+import { recordTaskClickTracksEvent } from '../../tracking';
 import { TaskAction, TaskActionTable, EnhancedTask } from '../../types';
 
 const getPlanSelected: TaskAction = ( task, flow, context ): EnhancedTask => {
@@ -7,7 +7,7 @@ const getPlanSelected: TaskAction = ( task, flow, context ): EnhancedTask => {
 
 	return {
 		...task,
-		actionDispatch: () => recordTaskClickTracksEvent( flow, task.completed, task.id ),
+		actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
 		calypso_path: addQueryArgs( `/setup/update-design/designSetup`, {
 			...siteInfoQueryArgs,
 			flowToReturnTo: flow,
@@ -16,14 +16,18 @@ const getPlanSelected: TaskAction = ( task, flow, context ): EnhancedTask => {
 	};
 };
 
-const getDesignEdited: TaskAction = ( task, flow, { siteInfoQueryArgs } ) => ( {
-	...task,
-	actionDispatch: () => recordTaskClickTracksEvent( flow, task.completed, task.id ),
-	calypso_path: addQueryArgs( `/site-editor/${ siteInfoQueryArgs?.siteSlug }`, {
-		canvas: 'edit',
-	} ),
-	useCalypsoPath: true,
-} );
+const getDesignEdited: TaskAction = ( task, flow, context ) => {
+	const { siteInfoQueryArgs } = context;
+
+	return {
+		...task,
+		actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
+		calypso_path: addQueryArgs( `/site-editor/${ siteInfoQueryArgs?.siteSlug }`, {
+			canvas: 'edit',
+		} ),
+		useCalypsoPath: true,
+	};
+};
 
 export const actions: Partial< TaskActionTable > = {
 	design_selected: getPlanSelected,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/design/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/design/index.tsx
@@ -1,0 +1,31 @@
+import { addQueryArgs } from '@wordpress/url';
+import { recordTaskClickTracksEvent } from '../../task-helper';
+import { TaskAction, TaskActionTable, EnhancedTask } from '../../types';
+
+const getPlanSelected: TaskAction = ( task, flow, context ): EnhancedTask => {
+	const { siteInfoQueryArgs } = context;
+
+	return {
+		...task,
+		actionDispatch: () => recordTaskClickTracksEvent( flow, task.completed, task.id ),
+		calypso_path: addQueryArgs( `/setup/update-design/designSetup`, {
+			...siteInfoQueryArgs,
+			flowToReturnTo: flow,
+		} ),
+		useCalypsoPath: true,
+	};
+};
+
+const getDesignEdited: TaskAction = ( task, flow, { siteInfoQueryArgs } ) => ( {
+	...task,
+	actionDispatch: () => recordTaskClickTracksEvent( flow, task.completed, task.id ),
+	calypso_path: addQueryArgs( `/site-editor/${ siteInfoQueryArgs?.siteSlug }`, {
+		canvas: 'edit',
+	} ),
+	useCalypsoPath: true,
+} );
+
+export const actions: Partial< TaskActionTable > = {
+	design_selected: getPlanSelected,
+	design_edited: getDesignEdited,
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
@@ -1,10 +1,11 @@
+import { Task } from '@automattic/launchpad';
 import { isBlogOnboardingFlow, isSiteAssemblerFlow } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { recordTaskClickTracksEvent } from '../../tracking';
-import { TaskAction, TaskActionTable, EnhancedTask } from '../../types';
+import { TaskAction, TaskActionTable } from '../../types';
 
-const getDomainUpSell: TaskAction = ( task, flow, context ): EnhancedTask => {
+const getDomainUpSell: TaskAction = ( task, flow, context ): Task => {
 	const { siteInfoQueryArgs, domainUpsellCompleted, site } = context;
 
 	const getDestionationUrl = () => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
@@ -1,7 +1,7 @@
 import { isBlogOnboardingFlow, isSiteAssemblerFlow } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
-import { recordTaskClickTracksEvent } from '../../task-helper';
+import { recordTaskClickTracksEvent } from '../../tracking';
 import { TaskAction, TaskActionTable, EnhancedTask } from '../../types';
 
 const getDomainUpSell: TaskAction = ( task, flow, context ): EnhancedTask => {
@@ -29,7 +29,8 @@ const getDomainUpSell: TaskAction = ( task, flow, context ): EnhancedTask => {
 	return {
 		...task,
 		completed: domainUpsellCompleted,
-		actionDispatch: () => recordTaskClickTracksEvent( flow, domainUpsellCompleted, task.id ),
+		actionDispatch: () =>
+			recordTaskClickTracksEvent( { ...task, completed: domainUpsellCompleted }, flow, context ),
 		calypso_path: getDestionationUrl(),
 		badge_text:
 			domainUpsellCompleted || isBlogOnboardingFlow( flow ) || isSiteAssemblerFlow( flow )

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
@@ -1,0 +1,44 @@
+import { isBlogOnboardingFlow, isSiteAssemblerFlow } from '@automattic/onboarding';
+import { addQueryArgs } from '@wordpress/url';
+import { translate } from 'i18n-calypso';
+import { recordTaskClickTracksEvent } from '../../task-helper';
+import { TaskAction, TaskActionTable, EnhancedTask } from '../../types';
+
+const getDomainUpSell: TaskAction = ( task, flow, context ): EnhancedTask => {
+	const { siteInfoQueryArgs, domainUpsellCompleted, site } = context;
+
+	const getDestionationUrl = () => {
+		if ( isBlogOnboardingFlow( flow ) || isSiteAssemblerFlow( flow ) ) {
+			return addQueryArgs( `/setup/${ flow }/domains`, {
+				...siteInfoQueryArgs,
+				flowToReturnTo: flow,
+				new: site?.name,
+				domainAndPlanPackage: true,
+			} );
+		}
+
+		return domainUpsellCompleted
+			? `/domains/manage/${ siteInfoQueryArgs?.siteSlug }`
+			: addQueryArgs( `/setup/domain-upsell/domains`, {
+					...siteInfoQueryArgs,
+					flowToReturnTo: flow,
+					new: site?.name,
+			  } );
+	};
+
+	return {
+		...task,
+		completed: domainUpsellCompleted,
+		actionDispatch: () => recordTaskClickTracksEvent( flow, domainUpsellCompleted, task.id ),
+		calypso_path: getDestionationUrl(),
+		badge_text:
+			domainUpsellCompleted || isBlogOnboardingFlow( flow ) || isSiteAssemblerFlow( flow )
+				? ''
+				: translate( 'Upgrade plan' ),
+		useCalypsoPath: true,
+	};
+};
+
+export const actions: Partial< TaskActionTable > = {
+	domain_upsell: getDomainUpSell,
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/index.ts
@@ -1,0 +1,24 @@
+import { Task, TaskId, TaskContext } from '../types';
+import { actions as designActions } from './design';
+import { actions as domainActions } from './domain';
+import { actions as planActions } from './plan';
+import { actions as postActions } from './post';
+import { actions as setupActions } from './setup';
+import { actions as siteActions } from './site';
+
+const ALL_ACTIONS = new Map(
+	Object.entries( {
+		...planActions,
+		...setupActions,
+		...designActions,
+		...domainActions,
+		...postActions,
+		...siteActions,
+	} )
+);
+
+export const getTaskDefinition = ( flow: string, task: Task, context: TaskContext ) => {
+	return ALL_ACTIONS.has( task.id as TaskId )
+		? ALL_ACTIONS.get( task.id as TaskId )?.( task, flow, context )
+		: null;
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/plan/index.tsx
@@ -1,5 +1,6 @@
 import { FEATURE_VIDEO_UPLOADS, FEATURE_STYLE_CUSTOMIZATION } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { Task } from '@automattic/launchpad';
 import { ExternalLink } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
@@ -7,7 +8,7 @@ import {
 	recordGlobalStylesGattingPlanSelectedResetStylesEvent,
 	recordTaskClickTracksEvent,
 } from '../../tracking';
-import { EnhancedTask, Task, TaskAction, TaskActionTable, TaskContext } from '../../types';
+import { TaskAction, TaskActionTable, TaskContext } from '../../types';
 
 const getPlanTaskSubtitle = (
 	task: Task,
@@ -43,7 +44,7 @@ const getPlanTaskSubtitle = (
 	);
 };
 
-const getPlanSelected: TaskAction = ( task, flow, context ): EnhancedTask => {
+const getPlanSelected: TaskAction = ( task, flow, context ): Task => {
 	const {
 		siteInfoQueryArgs,
 		displayGlobalStylesWarning,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/plan/index.tsx
@@ -1,13 +1,45 @@
 import { FEATURE_VIDEO_UPLOADS, FEATURE_STYLE_CUSTOMIZATION } from '@automattic/calypso-products';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { ExternalLink } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
+import { translate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { recordTaskClickTracksEvent } from '../../task-helper';
-import { EnhancedTask, TaskAction, TaskActionTable } from '../../types';
+import { EnhancedTask, Task, TaskAction, TaskActionTable } from '../../types';
+
+const getPlanTaskSubtitle = ( task: Task, flow: string, displayGlobalStylesWarning: boolean ) => {
+	if ( ! displayGlobalStylesWarning ) {
+		return task.subtitle;
+	}
+
+	const removeCustomStyles = translate( 'Or, {{a}}remove your premium styles{{/a}}.', {
+		components: {
+			a: (
+				<ExternalLink
+					children={ null }
+					href={ localizeUrl( 'https://wordpress.com/support/using-styles/#reset-all-styles' ) }
+					onClick={ ( event ) => {
+						event.stopPropagation();
+						recordTracksEvent(
+							'calypso_launchpad_global_styles_gating_plan_selected_reset_styles',
+							{ flow }
+						);
+					} }
+				/>
+			),
+		},
+	} );
+
+	return (
+		<>
+			{ task.subtitle }&nbsp;{ removeCustomStyles }
+		</>
+	);
+};
 
 const getPlanSelected: TaskAction = ( task, flow, context ): EnhancedTask => {
 	const {
 		siteInfoQueryArgs,
-		getPlanTaskSubtitle,
 		displayGlobalStylesWarning,
 		shouldDisplayWarning,
 		globalStylesMinimumPlan,
@@ -33,7 +65,7 @@ const getPlanSelected: TaskAction = ( task, flow, context ): EnhancedTask => {
 			} ),
 		} ),
 		completed: task.completed && ! isVideoPressFlowWithUnsupportedPlan,
-		subtitle: getPlanTaskSubtitle( task ),
+		subtitle: getPlanTaskSubtitle( task, flow, displayGlobalStylesWarning ),
 		useCalypsoPath: true,
 	};
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/plan/index.tsx
@@ -3,11 +3,18 @@ import { localizeUrl } from '@automattic/i18n-utils';
 import { ExternalLink } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { recordTaskClickTracksEvent } from '../../task-helper';
-import { EnhancedTask, Task, TaskAction, TaskActionTable } from '../../types';
+import {
+	recordGlobalStylesGattingPlanSelectedResetStylesEvent,
+	recordTaskClickTracksEvent,
+} from '../../tracking';
+import { EnhancedTask, Task, TaskAction, TaskActionTable, TaskContext } from '../../types';
 
-const getPlanTaskSubtitle = ( task: Task, flow: string, displayGlobalStylesWarning: boolean ) => {
+const getPlanTaskSubtitle = (
+	task: Task,
+	flow: string,
+	context: TaskContext,
+	displayGlobalStylesWarning: boolean
+) => {
 	if ( ! displayGlobalStylesWarning ) {
 		return task.subtitle;
 	}
@@ -20,10 +27,9 @@ const getPlanTaskSubtitle = ( task: Task, flow: string, displayGlobalStylesWarni
 					href={ localizeUrl( 'https://wordpress.com/support/using-styles/#reset-all-styles' ) }
 					onClick={ ( event ) => {
 						event.stopPropagation();
-						recordTracksEvent(
-							'calypso_launchpad_global_styles_gating_plan_selected_reset_styles',
-							{ flow }
-						);
+						recordGlobalStylesGattingPlanSelectedResetStylesEvent( task, flow, context, {
+							displayGlobalStylesWarning,
+						} );
 					} }
 				/>
 			),
@@ -49,10 +55,10 @@ const getPlanSelected: TaskAction = ( task, flow, context ): EnhancedTask => {
 	return {
 		...task,
 		actionDispatch: () => {
-			recordTaskClickTracksEvent( flow, task.completed, task.id );
+			recordTaskClickTracksEvent( task, flow, context );
 			if ( displayGlobalStylesWarning ) {
-				recordTracksEvent( 'calypso_launchpad_global_styles_gating_plan_selected_task_clicked', {
-					flow,
+				recordGlobalStylesGattingPlanSelectedResetStylesEvent( task, flow, context, {
+					displayGlobalStylesWarning,
 				} );
 			}
 		},
@@ -65,7 +71,7 @@ const getPlanSelected: TaskAction = ( task, flow, context ): EnhancedTask => {
 			} ),
 		} ),
 		completed: task.completed && ! isVideoPressFlowWithUnsupportedPlan,
-		subtitle: getPlanTaskSubtitle( task, flow, displayGlobalStylesWarning ),
+		subtitle: getPlanTaskSubtitle( task, flow, context, displayGlobalStylesWarning ),
 		useCalypsoPath: true,
 	};
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/plan/index.tsx
@@ -1,0 +1,43 @@
+import { FEATURE_VIDEO_UPLOADS, FEATURE_STYLE_CUSTOMIZATION } from '@automattic/calypso-products';
+import { addQueryArgs } from '@wordpress/url';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { recordTaskClickTracksEvent } from '../../task-helper';
+import { EnhancedTask, TaskAction, TaskActionTable } from '../../types';
+
+const getPlanSelected: TaskAction = ( task, flow, context ): EnhancedTask => {
+	const {
+		siteInfoQueryArgs,
+		getPlanTaskSubtitle,
+		displayGlobalStylesWarning,
+		shouldDisplayWarning,
+		globalStylesMinimumPlan,
+		isVideoPressFlowWithUnsupportedPlan,
+	} = context;
+
+	return {
+		...task,
+		actionDispatch: () => {
+			recordTaskClickTracksEvent( flow, task.completed, task.id );
+			if ( displayGlobalStylesWarning ) {
+				recordTracksEvent( 'calypso_launchpad_global_styles_gating_plan_selected_task_clicked', {
+					flow,
+				} );
+			}
+		},
+		calypso_path: addQueryArgs( `/plans/${ siteInfoQueryArgs?.siteSlug }`, {
+			...( shouldDisplayWarning && {
+				plan: globalStylesMinimumPlan,
+				feature: isVideoPressFlowWithUnsupportedPlan
+					? FEATURE_VIDEO_UPLOADS
+					: FEATURE_STYLE_CUSTOMIZATION,
+			} ),
+		} ),
+		completed: task.completed && ! isVideoPressFlowWithUnsupportedPlan,
+		subtitle: getPlanTaskSubtitle( task ),
+		useCalypsoPath: true,
+	};
+};
+
+export const actions: Partial< TaskActionTable > = {
+	plan_selected: getPlanSelected,
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/post/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/post/index.tsx
@@ -1,9 +1,10 @@
+import { Task } from '@automattic/launchpad';
 import { isBlogOnboardingFlow, isNewsletterFlow } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { recordTaskClickTracksEvent } from '../../tracking';
-import { EnhancedTask, TaskAction, TaskActionTable } from '../../types';
+import { TaskAction, TaskActionTable } from '../../types';
 
-const getFirstPostPublished: TaskAction = ( task, flow, context ): EnhancedTask => {
+const getFirstPostPublished: TaskAction = ( task, flow, context ): Task => {
 	const { siteInfoQueryArgs, isEmailVerified } = context;
 	const mustVerifyEmailBeforePosting = isNewsletterFlow( flow || null ) && ! isEmailVerified;
 	return {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/post/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/post/index.tsx
@@ -1,6 +1,6 @@
 import { isBlogOnboardingFlow, isNewsletterFlow } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
-import { recordTaskClickTracksEvent } from '../../task-helper';
+import { recordTaskClickTracksEvent } from '../../tracking';
 import { EnhancedTask, TaskAction, TaskActionTable } from '../../types';
 
 const getFirstPostPublished: TaskAction = ( task, flow, context ): EnhancedTask => {
@@ -12,12 +12,12 @@ const getFirstPostPublished: TaskAction = ( task, flow, context ): EnhancedTask 
 			mustVerifyEmailBeforePosting ||
 			( task.completed && isBlogOnboardingFlow( flow || null ) ) ||
 			false,
-		actionDispatch: () => recordTaskClickTracksEvent( flow, task.completed, task.id ),
 		calypso_path: ! isBlogOnboardingFlow( flow || null )
 			? `/post/${ siteInfoQueryArgs?.siteSlug }`
 			: addQueryArgs( `https://${ siteInfoQueryArgs?.siteSlug }/wp-admin/post-new.php`, {
 					origin: window.location.origin,
 			  } ),
+		actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
 		useCalypsoPath: true,
 	};
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/post/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/post/index.tsx
@@ -1,0 +1,27 @@
+import { isBlogOnboardingFlow, isNewsletterFlow } from '@automattic/onboarding';
+import { addQueryArgs } from '@wordpress/url';
+import { recordTaskClickTracksEvent } from '../../task-helper';
+import { EnhancedTask, TaskAction, TaskActionTable } from '../../types';
+
+const getFirstPostPublished: TaskAction = ( task, flow, context ): EnhancedTask => {
+	const { siteInfoQueryArgs, isEmailVerified } = context;
+	const mustVerifyEmailBeforePosting = isNewsletterFlow( flow || null ) && ! isEmailVerified;
+	return {
+		...task,
+		disabled:
+			mustVerifyEmailBeforePosting ||
+			( task.completed && isBlogOnboardingFlow( flow || null ) ) ||
+			false,
+		actionDispatch: () => recordTaskClickTracksEvent( flow, task.completed, task.id ),
+		calypso_path: ! isBlogOnboardingFlow( flow || null )
+			? `/post/${ siteInfoQueryArgs?.siteSlug }`
+			: addQueryArgs( `https://${ siteInfoQueryArgs?.siteSlug }/wp-admin/post-new.php`, {
+					origin: window.location.origin,
+			  } ),
+		useCalypsoPath: true,
+	};
+};
+
+export const actions: Partial< TaskActionTable > = {
+	first_post_published: getFirstPostPublished,
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/setup/index.tsx
@@ -1,7 +1,8 @@
+import { Task } from '@automattic/launchpad';
 import { recordTaskClickTracksEvent } from '../../tracking';
-import { EnhancedTask, TaskAction, TaskActionTable } from '../../types';
+import { TaskAction, TaskActionTable } from '../../types';
 
-const getSetupFree: TaskAction = ( task, flow, context ): EnhancedTask => ( {
+const getSetupFree: TaskAction = ( task, flow, context ): Task => ( {
 	...task,
 	actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
 	useCalypsoPath: true,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/setup/index.tsx
@@ -1,12 +1,11 @@
-import { recordTaskClickTracksEvent } from '../../task-helper';
+import { recordTaskClickTracksEvent } from '../../tracking';
 import { EnhancedTask, TaskAction, TaskActionTable } from '../../types';
 
-const getSetupFree: TaskAction = ( task, flow ): EnhancedTask =>
-	( {
-		...task,
-		actionDispatch: () => recordTaskClickTracksEvent( flow, task.completed, task.id ),
-		useCalypsoPath: true,
-	} ) satisfies EnhancedTask;
+const getSetupFree: TaskAction = ( task, flow, context ): EnhancedTask => ( {
+	...task,
+	actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
+	useCalypsoPath: true,
+} );
 
 export const actions: Partial< TaskActionTable > = {
 	setup_free: getSetupFree,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/setup/index.tsx
@@ -1,0 +1,13 @@
+import { recordTaskClickTracksEvent } from '../../task-helper';
+import { EnhancedTask, TaskAction, TaskActionTable } from '../../types';
+
+const getSetupFree: TaskAction = ( task, flow ): EnhancedTask =>
+	( {
+		...task,
+		actionDispatch: () => recordTaskClickTracksEvent( flow, task.completed, task.id ),
+		useCalypsoPath: true,
+	} ) satisfies EnhancedTask;
+
+export const actions: Partial< TaskActionTable > = {
+	setup_free: getSetupFree,
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/site/index.tsx
@@ -1,4 +1,5 @@
 import { OnboardActions, SiteActions } from '@automattic/data-stores';
+import { Task } from '@automattic/launchpad';
 import {
 	isBlogOnboardingFlow,
 	isDesignFirstFlow,
@@ -14,7 +15,7 @@ import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { goToCheckout } from 'calypso/landing/stepper/utils/checkout';
 import { isDomainUpsellCompleted } from '../../task-helper';
 import { recordTaskClickTracksEvent } from '../../tracking';
-import { EnhancedTask, Task, TaskAction, TaskActionTable, TaskContext } from '../../types';
+import { TaskAction, TaskActionTable, TaskContext } from '../../types';
 
 const getCompletedTasks = ( tasks: Task[] ): Record< string, boolean > =>
 	tasks.reduce(
@@ -124,7 +125,7 @@ const completeLaunchSiteTask = async ( task: Task, flow: string, context: TaskCo
 	submit?.();
 };
 
-const getSiteLaunched: TaskAction = ( task, flow, context ): EnhancedTask => {
+const getSiteLaunched: TaskAction = ( task, flow, context ): Task => {
 	return {
 		...task,
 		isLaunchTask: true,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/site/index.tsx
@@ -12,7 +12,8 @@ import { __ } from '@wordpress/i18n';
 import { translate } from 'i18n-calypso';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { goToCheckout } from 'calypso/landing/stepper/utils/checkout';
-import { isDomainUpsellCompleted, recordTaskClickTracksEvent } from '../../task-helper';
+import { isDomainUpsellCompleted } from '../../task-helper';
+import { recordTaskClickTracksEvent } from '../../tracking';
 import { EnhancedTask, Task, TaskAction, TaskActionTable, TaskContext } from '../../types';
 
 const getCompletedTasks = ( tasks: Task[] ): Record< string, boolean > =>
@@ -109,7 +110,7 @@ const completeLaunchSiteTask = async ( task: Task, flow: string, context: TaskCo
 		await launchSite( site.ID );
 		// Waits for half a second so that the loading screen doesn't flash away too quickly
 		await new Promise( ( res ) => setTimeout( res, 500 ) );
-		recordTaskClickTracksEvent( flow, task.completed, task.id );
+		recordTaskClickTracksEvent( task, flow, context );
 
 		return {
 			siteSlug,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/site/index.tsx
@@ -1,0 +1,18 @@
+import { EnhancedTask, TaskAction, TaskActionTable } from '../../types';
+
+const getSiteLaunched: TaskAction = ( task, _, context ): EnhancedTask => {
+	const { getLaunchSiteTaskTitle, getIsLaunchSiteTaskDisabled, completeLaunchSiteTask } = context;
+
+	return {
+		...task,
+		isLaunchTask: true,
+		title: getLaunchSiteTaskTitle( task ),
+		disabled: getIsLaunchSiteTaskDisabled(),
+		actionDispatch: () => completeLaunchSiteTask( task ),
+		useCalypsoPath: false,
+	};
+};
+
+export const actions: Partial< TaskActionTable > = {
+	site_launched: getSiteLaunched,
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/site/index.tsx
@@ -1,13 +1,46 @@
-import { EnhancedTask, TaskAction, TaskActionTable } from '../../types';
+import { isDesignFirstFlow, isSiteAssemblerFlow, isStartWritingFlow } from '@automattic/onboarding';
+import { isDomainUpsellCompleted } from '../../task-helper';
+import { EnhancedTask, TaskAction, TaskActionTable, TaskContext } from '../../types';
 
-const getSiteLaunched: TaskAction = ( task, _, context ): EnhancedTask => {
-	const { getLaunchSiteTaskTitle, getIsLaunchSiteTaskDisabled, completeLaunchSiteTask } = context;
+const getIsLaunchSiteTaskDisabled = ( flow: string, context: TaskContext ) => {
+	const { tasks, site, checklistStatuses } = context;
+	const completedTasks: Record< string, boolean > = tasks.reduce(
+		( acc, cur ) => ( {
+			...acc,
+			[ cur.id ]: cur.completed,
+		} ),
+		{}
+	);
+
+	const firstPostPublished = completedTasks.first_post_published;
+	const planCompleted = completedTasks.plan_completed;
+	const domainUpsellCompleted = isDomainUpsellCompleted( site, checklistStatuses );
+	const setupBlogCompleted = completedTasks.setup_blog || ! isStartWritingFlow( flow );
+	const setupSiteCompleted = completedTasks.setup_free;
+
+	if ( isStartWritingFlow( flow ) ) {
+		return ! ( firstPostPublished && planCompleted && domainUpsellCompleted && setupBlogCompleted );
+	}
+
+	if ( isDesignFirstFlow( flow ) ) {
+		return ! ( planCompleted && domainUpsellCompleted && setupBlogCompleted );
+	}
+
+	if ( isSiteAssemblerFlow( flow ) ) {
+		return ! ( planCompleted && domainUpsellCompleted && setupSiteCompleted );
+	}
+
+	return false;
+};
+
+const getSiteLaunched: TaskAction = ( task, flow, context ): EnhancedTask => {
+	const { getLaunchSiteTaskTitle, completeLaunchSiteTask } = context;
 
 	return {
 		...task,
 		isLaunchTask: true,
 		title: getLaunchSiteTaskTitle( task ),
-		disabled: getIsLaunchSiteTaskDisabled(),
+		disabled: getIsLaunchSiteTaskDisabled( flow, context ),
 		actionDispatch: () => completeLaunchSiteTask( task ),
 		useCalypsoPath: false,
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -289,9 +289,10 @@ export function getEnhancedTasks( {
 				globalStylesMinimumPlan,
 				domainUpsellCompleted,
 				site,
-				completeLaunchSiteTask,
 				isEmailVerified,
 				planCartItem,
+				siteSlug,
+				submit,
 			} );
 
 			if ( enhanced ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_VIDEO_UPLOADS,
 	planHasFeature,
@@ -29,15 +30,16 @@ import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, ReactNode, SetStateAction } from 'react';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ADD_TIER_PLAN_HASH } from 'calypso/my-sites/earn/memberships/constants';
 import { isVideoPressFlow } from 'calypso/signup/is-flow';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import { goToCheckout } from '../../../../utils/checkout';
+import { getTaskDefinition } from './task-definitions';
 import { launchpadFlowTasks } from './tasks';
-import { LaunchpadChecklist, Task } from './types';
+import { EnhancedTask, LaunchpadChecklist, Task } from './types';
 
 interface GetEnhancedTasksProps {
 	tasks: Task[] | null | undefined;
@@ -60,6 +62,14 @@ interface GetEnhancedTasksProps {
 
 const PLANS_LIST = getPlans();
 
+const MIGRATED_FLOWS = [ 'free' ];
+
+const shouldUseNewTaskDefinitions = ( flow: string ) => {
+	if ( isEnabled( 'launchpad/new-task-definition-parser' ) && MIGRATED_FLOWS.includes( flow ) ) {
+		return true;
+	}
+	return false;
+};
 /**
  * Some attributes of these enhanced tasks will soon be fetched through a WordPress REST
  * API, making said enhancements here unnecessary ( Ex. title, subtitle, completed,
@@ -91,7 +101,7 @@ export function getEnhancedTasks( {
 		return [];
 	}
 
-	const enhancedTaskList: Task[] = [];
+	const enhancedTaskList: EnhancedTask[] = [];
 
 	const isCurrentPlanFree = site?.plan ? isFreePlanProduct( site?.plan ) : true;
 
@@ -272,356 +282,433 @@ export function getEnhancedTasks( {
 
 	tasks &&
 		tasks.map( ( task ) => {
-			let taskData = {};
-			switch ( task.id ) {
-				case 'setup_free':
-					taskData = {
-						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.assign(
-								addQueryArgs( `/setup/${ flow }/freePostSetup`, siteInfoQueryArgs )
-							);
-						},
-					};
-					break;
-				case 'setup_blog':
-					taskData = {
-						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.assign(
-								addQueryArgs( `/setup/${ flow }/setup-blog`, siteInfoQueryArgs )
-							);
-						},
-						disabled: task.completed && ! isBlogOnboardingFlow( flow ),
-					};
-					break;
-				case 'setup_newsletter':
-					taskData = {
-						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.assign(
-								addQueryArgs(
-									`/setup/newsletter-post-setup/newsletterPostSetup`,
-									siteInfoQueryArgs
-								)
-							);
-						},
-					};
-					break;
-				case 'design_edited':
-					taskData = {
-						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.assign(
-								addQueryArgs( `/site-editor/${ siteSlug }`, {
-									canvas: 'edit',
-								} )
-							);
-						},
-					};
-					break;
-				case 'plan_selected':
-					/* eslint-disable no-case-declarations */
-					const openPlansPage = () => {
-						recordTaskClickTracksEvent( flow, task.completed, task.id );
-						if ( displayGlobalStylesWarning ) {
-							recordTracksEvent(
-								'calypso_launchpad_global_styles_gating_plan_selected_task_clicked',
-								{ flow }
-							);
-						}
-						const plansUrl = addQueryArgs( `/plans/${ siteSlug }`, {
-							...( shouldDisplayWarning && {
-								plan: globalStylesMinimumPlan,
-								feature: isVideoPressFlowWithUnsupportedPlan
-									? FEATURE_VIDEO_UPLOADS
-									: FEATURE_STYLE_CUSTOMIZATION,
-							} ),
-						} );
-						window.location.assign( plansUrl );
-					};
+			if ( shouldUseNewTaskDefinitions( flow ) ) {
+				const enhanced = getTaskDefinition( flow, task, {
+					getPlanTaskSubtitle,
+					siteInfoQueryArgs,
+					displayGlobalStylesWarning,
+					globalStylesMinimumPlan,
+					domainUpsellCompleted,
+					site,
+					getLaunchSiteTaskTitle,
+					getIsLaunchSiteTaskDisabled,
+					completeLaunchSiteTask,
+					isEmailVerified,
+				} );
 
-					const completed = task.completed && ! isVideoPressFlowWithUnsupportedPlan;
-
-					taskData = {
-						actionDispatch: openPlansPage,
-						completed,
-						subtitle: getPlanTaskSubtitle( task ),
-					};
-					/* eslint-enable no-case-declarations */
-					break;
-				case 'plan_completed':
-					taskData = {
-						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							const plansUrl = addQueryArgs( `/setup/${ flow }/plans`, siteInfoQueryArgs );
-
-							window.location.assign( plansUrl );
-						},
-						badge_text: task.completed ? translatedPlanName : task.badge_text,
-						subtitle: getPlanTaskSubtitle( task ),
-						disabled: task.completed && ! isCurrentPlanFree,
-					};
-					break;
-				case 'subscribers_added':
-					taskData = {
-						actionDispatch: () => {
-							if ( goToStep ) {
-								recordTaskClickTracksEvent( flow, task.completed, task.id );
-								goToStep( 'subscribers' );
-							}
-						},
-					};
-					break;
-				case 'migrate_content':
-					taskData = {
-						disabled: mustVerifyEmailBeforePosting || false,
-						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
-
-							// Mark task done
-							completeMigrateContentTask();
-
-							// Go to importers
-							window.location.assign( `/import/${ siteSlug }` );
-						},
-					};
-					break;
-				case 'first_post_published':
-					taskData = {
-						disabled:
-							mustVerifyEmailBeforePosting ||
-							( task.completed && isBlogOnboardingFlow( flow || null ) ) ||
-							false,
-						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							const newPostUrl = ! isBlogOnboardingFlow( flow || null )
-								? `/post/${ siteSlug }`
-								: addQueryArgs( `https://${ siteSlug }/wp-admin/post-new.php`, {
-										origin: window.location.origin,
-								  } );
-							window.location.assign( newPostUrl );
-						},
-					};
-					break;
-				case 'first_post_published_newsletter':
-					taskData = {
-						isLaunchTask: true,
-						disabled: mustVerifyEmailBeforePosting || false,
-						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.assign( `/post/${ siteSlug }` );
-						},
-					};
-					break;
-				case 'design_selected':
-				case 'design_completed':
-					taskData = {
-						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.assign(
-								addQueryArgs( `/setup/update-design/designSetup`, {
-									...siteInfoQueryArgs,
-									flowToReturnTo: flow,
-								} )
-							);
-						},
-					};
-					break;
-				case 'setup_general':
-					taskData = {
-						disabled: false,
-						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.assign(
-								addQueryArgs( `/setup/update-options/options`, {
-									...siteInfoQueryArgs,
-									flowToReturnTo: flow,
-								} )
-							);
-						},
-					};
-					break;
-				case 'setup_link_in_bio':
-					taskData = {
-						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.assign(
-								addQueryArgs(
-									`/setup/link-in-bio-post-setup/linkInBioPostSetup`,
-									siteInfoQueryArgs
-								)
-							);
-						},
-					};
-					break;
-				case 'links_added':
-					taskData = {
-						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.assign(
-								addQueryArgs( `/site-editor/${ siteSlug }`, {
-									canvas: 'edit',
-								} )
-							);
-						},
-					};
-					break;
-				case 'link_in_bio_launched':
-					taskData = {
-						isLaunchTask: true,
-						actionDispatch: () => {
-							if ( site?.ID ) {
-								const { setPendingAction, setProgressTitle } = dispatch(
-									ONBOARD_STORE
-								) as OnboardActions;
-								const { launchSite } = dispatch( SITE_STORE ) as SiteActions;
-
-								setPendingAction( async () => {
-									setProgressTitle( __( 'Launching Link in bio' ) );
-									await launchSite( site.ID );
-
-									// Waits for half a second so that the loading screen doesn't flash away too quickly
-									await new Promise( ( res ) => setTimeout( res, 500 ) );
-									recordTaskClickTracksEvent( flow, task.completed, task.id );
-									return { goToHome: true, siteSlug };
-								} );
-
-								submit?.();
-							}
-						},
-					};
-					break;
-				case 'site_launched':
-					taskData = {
-						isLaunchTask: true,
-						title: getLaunchSiteTaskTitle( task ),
-						disabled: getIsLaunchSiteTaskDisabled(),
-						actionDispatch: () => {
-							completeLaunchSiteTask( task );
-						},
-					};
-					break;
-				case 'blog_launched': {
-					taskData = {
-						isLaunchTask: true,
-						title: getLaunchSiteTaskTitle( task ),
-						disabled: getIsLaunchSiteTaskDisabled(),
-						actionDispatch: () => {
-							completeLaunchSiteTask( task );
-						},
-					};
-					break;
+				if ( enhanced ) {
+					// eslint-disable-next-line no-console
+					console.log( 'using new task definitions', enhanced.id );
+					return enhancedTaskList.push( enhanced );
 				}
-				case 'videopress_upload':
-					taskData = {
-						actionUrl: launchpadUploadVideoLink,
-						disabled: isVideoPressFlowWithUnsupportedPlan || videoPressUploadCompleted,
-						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.replace( launchpadUploadVideoLink );
-						},
-					};
-					break;
-				case 'videopress_launched':
-					taskData = {
-						isLaunchTask: true,
-						actionDispatch: () => {
-							if ( site?.ID ) {
-								const { setPendingAction, setProgressTitle } = dispatch(
-									ONBOARD_STORE
-								) as OnboardActions;
-								const { launchSite } = dispatch( SITE_STORE ) as SiteActions;
-
-								setPendingAction( async () => {
-									setProgressTitle( __( 'Launching video site' ) );
-									await launchSite( site.ID );
-
-									// Waits for half a second so that the loading screen doesn't flash away too quickly
-									await new Promise( ( res ) => setTimeout( res, 500 ) );
-									window.location.replace(
-										addQueryArgs( `/home/${ siteSlug }`, {
-											forceLoadLaunchpadData: true,
-										} )
-									);
-								} );
-
-								submit?.();
-							}
-						},
-					};
-					break;
-				case 'domain_upsell':
-					taskData = {
-						completed: domainUpsellCompleted,
-						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, domainUpsellCompleted, task.id );
-
-							if ( isBlogOnboardingFlow( flow ) || isSiteAssemblerFlow( flow ) ) {
-								window.location.assign(
-									addQueryArgs( `/setup/${ flow }/domains`, {
-										...siteInfoQueryArgs,
-										flowToReturnTo: flow,
-										new: site?.name,
-										domainAndPlanPackage: true,
-									} )
-								);
-
-								return;
-							}
-
-							const destinationUrl = domainUpsellCompleted
-								? `/domains/manage/${ siteSlug }`
-								: addQueryArgs( `/setup/domain-upsell/domains`, {
-										...siteInfoQueryArgs,
-										flowToReturnTo: flow,
-										new: site?.name,
-								  } );
-							window.location.assign( destinationUrl );
-						},
-						badge_text:
-							domainUpsellCompleted || isBlogOnboardingFlow( flow ) || isSiteAssemblerFlow( flow )
-								? ''
-								: translate( 'Upgrade plan' ),
-					};
-					break;
-				case 'verify_email':
-					taskData = {
-						completed: isEmailVerified,
-						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							window.location.replace( task.calypso_path || '/me/account' );
-						},
-					};
-					break;
-				case 'set_up_payments':
-					taskData = {
-						badge_text: task.completed ? translate( 'Connected' ) : null,
-						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							stripeConnectUrl
-								? window.location.assign( stripeConnectUrl )
-								: window.location.assign( `/earn/payments/${ siteSlug }#launchpad` );
-						},
-					};
-					break;
-				case 'newsletter_plan_created':
-					taskData = {
-						actionDispatch: () => {
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							completePaidNewsletterTask();
-							site?.ID
-								? setShowPlansModal( true )
-								: window.location.assign(
-										`/earn/payments/${ siteSlug }?launchpad=add-product${ ADD_TIER_PLAN_HASH }`
-								  );
-						},
-					};
-					break;
 			}
+
+			// @deprecated code flow, please use the new getTaskDefinition method
+			const taskData = getDeprecatedTaskData(
+				task,
+				flow,
+				siteInfoQueryArgs,
+				siteSlug,
+				displayGlobalStylesWarning,
+				shouldDisplayWarning,
+				globalStylesMinimumPlan,
+				isVideoPressFlowWithUnsupportedPlan,
+				getPlanTaskSubtitle,
+				translatedPlanName,
+				isCurrentPlanFree,
+				goToStep,
+				mustVerifyEmailBeforePosting,
+				completeMigrateContentTask,
+				site,
+				submit,
+				getLaunchSiteTaskTitle,
+				getIsLaunchSiteTaskDisabled,
+				completeLaunchSiteTask,
+				launchpadUploadVideoLink,
+				videoPressUploadCompleted,
+				domainUpsellCompleted,
+				isEmailVerified,
+				stripeConnectUrl,
+				completePaidNewsletterTask,
+				setShowPlansModal
+			);
 			enhancedTaskList.push( { ...task, ...taskData } );
 		} );
 	return enhancedTaskList;
+}
+
+//@deprecated please use the new get task definitions modules
+function getDeprecatedTaskData(
+	task: Task,
+	flow: string,
+	siteInfoQueryArgs:
+		| { siteId: number | undefined; siteSlug?: undefined }
+		| { siteSlug: string | null; siteId?: undefined },
+	siteSlug: string | null,
+	displayGlobalStylesWarning: boolean,
+	shouldDisplayWarning: boolean,
+	globalStylesMinimumPlan: string,
+	isVideoPressFlowWithUnsupportedPlan: boolean,
+	getPlanTaskSubtitle: ( task: Task ) => ReactNode | string | undefined,
+	translatedPlanName: ReactNode | string,
+	isCurrentPlanFree: boolean,
+	goToStep: ( ( step: string ) => void ) | undefined,
+	mustVerifyEmailBeforePosting: boolean,
+	completeMigrateContentTask: () => Promise< void >,
+	site: SiteDetails | null,
+	submit: NavigationControls[ 'submit' ] | undefined,
+	getLaunchSiteTaskTitle: ( task: Task ) => string | undefined,
+	getIsLaunchSiteTaskDisabled: () => boolean,
+	completeLaunchSiteTask: ( task: Task ) => Promise< void >,
+	launchpadUploadVideoLink: string,
+	videoPressUploadCompleted: boolean,
+	domainUpsellCompleted: boolean,
+	isEmailVerified: boolean,
+	stripeConnectUrl: string | undefined,
+	completePaidNewsletterTask: () => Promise< void >,
+	setShowPlansModal: Dispatch< SetStateAction< boolean > >
+) {
+	let taskData = {};
+	switch ( task.id ) {
+		case 'setup_free':
+			taskData = {
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.assign(
+						addQueryArgs( `/setup/${ flow }/freePostSetup`, siteInfoQueryArgs )
+					);
+				},
+			};
+			break;
+		case 'setup_blog':
+			taskData = {
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.assign(
+						addQueryArgs( `/setup/${ flow }/setup-blog`, siteInfoQueryArgs )
+					);
+				},
+				disabled: task.completed && ! isBlogOnboardingFlow( flow ),
+			};
+			break;
+		case 'setup_newsletter':
+			taskData = {
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.assign(
+						addQueryArgs( `/setup/newsletter-post-setup/newsletterPostSetup`, siteInfoQueryArgs )
+					);
+				},
+			};
+			break;
+		case 'design_edited':
+			taskData = {
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.assign(
+						addQueryArgs( `/site-editor/${ siteSlug }`, {
+							canvas: 'edit',
+						} )
+					);
+				},
+			};
+			break;
+		case 'plan_selected':
+			/* eslint-disable no-case-declarations */
+			const openPlansPage = () => {
+				recordTaskClickTracksEvent( flow, task.completed, task.id );
+				if ( displayGlobalStylesWarning ) {
+					recordTracksEvent( 'calypso_launchpad_global_styles_gating_plan_selected_task_clicked', {
+						flow,
+					} );
+				}
+				const plansUrl = addQueryArgs( `/plans/${ siteSlug }`, {
+					...( shouldDisplayWarning && {
+						plan: globalStylesMinimumPlan,
+						feature: isVideoPressFlowWithUnsupportedPlan
+							? FEATURE_VIDEO_UPLOADS
+							: FEATURE_STYLE_CUSTOMIZATION,
+					} ),
+				} );
+				window.location.assign( plansUrl );
+			};
+
+			const completed = task.completed && ! isVideoPressFlowWithUnsupportedPlan;
+
+			taskData = {
+				actionDispatch: openPlansPage,
+				completed,
+				subtitle: getPlanTaskSubtitle( task ),
+			};
+			/* eslint-enable no-case-declarations */
+			break;
+		case 'plan_completed':
+			taskData = {
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					const plansUrl = addQueryArgs( `/setup/${ flow }/plans`, siteInfoQueryArgs );
+
+					window.location.assign( plansUrl );
+				},
+				badge_text: task.completed ? translatedPlanName : task.badge_text,
+				subtitle: getPlanTaskSubtitle( task ),
+				disabled: task.completed && ! isCurrentPlanFree,
+			};
+			break;
+		case 'subscribers_added':
+			taskData = {
+				actionDispatch: () => {
+					if ( goToStep ) {
+						recordTaskClickTracksEvent( flow, task.completed, task.id );
+						goToStep( 'subscribers' );
+					}
+				},
+			};
+			break;
+		case 'migrate_content':
+			taskData = {
+				disabled: mustVerifyEmailBeforePosting || false,
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+
+					// Mark task done
+					completeMigrateContentTask();
+
+					// Go to importers
+					window.location.assign( `/import/${ siteSlug }` );
+				},
+			};
+			break;
+		case 'first_post_published':
+			taskData = {
+				disabled:
+					mustVerifyEmailBeforePosting ||
+					( task.completed && isBlogOnboardingFlow( flow || null ) ) ||
+					false,
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					const newPostUrl = ! isBlogOnboardingFlow( flow || null )
+						? `/post/${ siteSlug }`
+						: addQueryArgs( `https://${ siteSlug }/wp-admin/post-new.php`, {
+								origin: window.location.origin,
+						  } );
+					window.location.assign( newPostUrl );
+				},
+			};
+			break;
+		case 'first_post_published_newsletter':
+			taskData = {
+				isLaunchTask: true,
+				disabled: mustVerifyEmailBeforePosting || false,
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.assign( `/post/${ siteSlug }` );
+				},
+			};
+			break;
+		case 'design_selected':
+		case 'design_completed':
+			taskData = {
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.assign(
+						addQueryArgs( `/setup/update-design/designSetup`, {
+							...siteInfoQueryArgs,
+							flowToReturnTo: flow,
+						} )
+					);
+				},
+			};
+			break;
+		case 'setup_general':
+			taskData = {
+				disabled: false,
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.assign(
+						addQueryArgs( `/setup/update-options/options`, {
+							...siteInfoQueryArgs,
+							flowToReturnTo: flow,
+						} )
+					);
+				},
+			};
+			break;
+		case 'setup_link_in_bio':
+			taskData = {
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.assign(
+						addQueryArgs( `/setup/link-in-bio-post-setup/linkInBioPostSetup`, siteInfoQueryArgs )
+					);
+				},
+			};
+			break;
+		case 'links_added':
+			taskData = {
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.assign(
+						addQueryArgs( `/site-editor/${ siteSlug }`, {
+							canvas: 'edit',
+						} )
+					);
+				},
+			};
+			break;
+		case 'link_in_bio_launched':
+			taskData = {
+				isLaunchTask: true,
+				actionDispatch: () => {
+					if ( site?.ID ) {
+						const { setPendingAction, setProgressTitle } = dispatch(
+							ONBOARD_STORE
+						) as OnboardActions;
+						const { launchSite } = dispatch( SITE_STORE ) as SiteActions;
+
+						setPendingAction( async () => {
+							setProgressTitle( __( 'Launching Link in bio' ) );
+							await launchSite( site.ID );
+
+							// Waits for half a second so that the loading screen doesn't flash away too quickly
+							await new Promise( ( res ) => setTimeout( res, 500 ) );
+							recordTaskClickTracksEvent( flow, task.completed, task.id );
+							return { goToHome: true, siteSlug };
+						} );
+
+						submit?.();
+					}
+				},
+			};
+			break;
+		case 'site_launched':
+			taskData = {
+				isLaunchTask: true,
+				title: getLaunchSiteTaskTitle( task ),
+				disabled: getIsLaunchSiteTaskDisabled(),
+				actionDispatch: () => {
+					completeLaunchSiteTask( task );
+				},
+			};
+			break;
+		case 'blog_launched': {
+			taskData = {
+				isLaunchTask: true,
+				title: getLaunchSiteTaskTitle( task ),
+				disabled: getIsLaunchSiteTaskDisabled(),
+				actionDispatch: () => {
+					completeLaunchSiteTask( task );
+				},
+			};
+			break;
+		}
+		case 'videopress_upload':
+			taskData = {
+				actionUrl: launchpadUploadVideoLink,
+				disabled: isVideoPressFlowWithUnsupportedPlan || videoPressUploadCompleted,
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.replace( launchpadUploadVideoLink );
+				},
+			};
+			break;
+		case 'videopress_launched':
+			taskData = {
+				isLaunchTask: true,
+				actionDispatch: () => {
+					if ( site?.ID ) {
+						const { setPendingAction, setProgressTitle } = dispatch(
+							ONBOARD_STORE
+						) as OnboardActions;
+						const { launchSite } = dispatch( SITE_STORE ) as SiteActions;
+
+						setPendingAction( async () => {
+							setProgressTitle( __( 'Launching video site' ) );
+							await launchSite( site.ID );
+
+							// Waits for half a second so that the loading screen doesn't flash away too quickly
+							await new Promise( ( res ) => setTimeout( res, 500 ) );
+							window.location.replace(
+								addQueryArgs( `/home/${ siteSlug }`, {
+									forceLoadLaunchpadData: true,
+								} )
+							);
+						} );
+
+						submit?.();
+					}
+				},
+			};
+			break;
+		case 'domain_upsell':
+			taskData = {
+				completed: domainUpsellCompleted,
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, domainUpsellCompleted, task.id );
+
+					if ( isBlogOnboardingFlow( flow ) || isSiteAssemblerFlow( flow ) ) {
+						window.location.assign(
+							addQueryArgs( `/setup/${ flow }/domains`, {
+								...siteInfoQueryArgs,
+								flowToReturnTo: flow,
+								new: site?.name,
+								domainAndPlanPackage: true,
+							} )
+						);
+
+						return;
+					}
+
+					const destinationUrl = domainUpsellCompleted
+						? `/domains/manage/${ siteSlug }`
+						: addQueryArgs( `/setup/domain-upsell/domains`, {
+								...siteInfoQueryArgs,
+								flowToReturnTo: flow,
+								new: site?.name,
+						  } );
+					window.location.assign( destinationUrl );
+				},
+				badge_text:
+					domainUpsellCompleted || isBlogOnboardingFlow( flow ) || isSiteAssemblerFlow( flow )
+						? ''
+						: translate( 'Upgrade plan' ),
+			};
+			break;
+		case 'verify_email':
+			taskData = {
+				completed: isEmailVerified,
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					window.location.replace( task.calypso_path || '/me/account' );
+				},
+			};
+			break;
+		case 'set_up_payments':
+			taskData = {
+				badge_text: task.completed ? translate( 'Connected' ) : null,
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					stripeConnectUrl
+						? window.location.assign( stripeConnectUrl )
+						: window.location.assign( `/earn/payments/${ siteSlug }#launchpad` );
+				},
+			};
+			break;
+		case 'newsletter_plan_created':
+			taskData = {
+				actionDispatch: () => {
+					recordTaskClickTracksEvent( flow, task.completed, task.id );
+					completePaidNewsletterTask();
+					site?.ID
+						? setShowPlansModal( true )
+						: window.location.assign(
+								`/earn/payments/${ siteSlug }?launchpad=add-product${ ADD_TIER_PLAN_HASH }`
+						  );
+				},
+			};
+			break;
+	}
+	return taskData;
 }
 
 function isDomainUpsellCompleted(
@@ -632,7 +719,7 @@ function isDomainUpsellCompleted(
 }
 
 // Records a generic task click Tracks event
-function recordTaskClickTracksEvent(
+export function recordTaskClickTracksEvent(
 	flow: string | null | undefined,
 	is_completed: boolean,
 	task_id: string

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -282,7 +282,6 @@ export function getEnhancedTasks( {
 	return ( tasks || [] ).map( ( task ) => {
 		if ( shouldUseNewTaskDefinitions( flow ) ) {
 			const enhanced = getTaskDefinition( flow, task, {
-				getPlanTaskSubtitle,
 				siteInfoQueryArgs,
 				displayGlobalStylesWarning,
 				globalStylesMinimumPlan,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -38,7 +38,7 @@ import { goToCheckout } from '../../../../utils/checkout';
 import { getDeprecatedTaskDefinition } from './get-deprecated-task-data';
 import { getTaskDefinition } from './task-definitions';
 import { launchpadFlowTasks } from './tasks';
-import { EnhancedTask, LaunchpadChecklist, Task } from './types';
+import { LaunchpadChecklist, Task } from './types';
 
 interface GetEnhancedTasksProps {
 	tasks: Task[] | null | undefined;
@@ -99,8 +99,6 @@ export function getEnhancedTasks( {
 	if ( ! tasks ) {
 		return [];
 	}
-
-	const enhancedTaskList: EnhancedTask[] = [];
 
 	const isCurrentPlanFree = site?.plan ? isFreePlanProduct( site?.plan ) : true;
 
@@ -298,11 +296,10 @@ export function getEnhancedTasks( {
 			if ( enhanced ) {
 				// eslint-disable-next-line no-console
 				console.log( 'using new task definitions', enhanced.id );
-				return enhancedTaskList.push( enhanced );
+				return enhanced;
 			}
 		}
 
-		// @deprecated code flow, please use the new getTaskDefinition method
 		return getDeprecatedTaskDefinition(
 			task,
 			flow,
@@ -341,7 +338,9 @@ export function isDomainUpsellCompleted(
 	return ! site?.plan?.is_free || checklistStatuses?.domain_upsell_deferred === true;
 }
 
-// Records a generic task click Tracks event
+/**
+ * @deprecated Please use recordTaskClickTracksEvent instead from tracking.ts
+ */
 export function recordTaskClickTracksEvent(
 	flow: string | null | undefined,
 	is_completed: boolean,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -289,9 +289,9 @@ export function getEnhancedTasks( {
 				globalStylesMinimumPlan,
 				domainUpsellCompleted,
 				site,
-				getLaunchSiteTaskTitle,
 				completeLaunchSiteTask,
 				isEmailVerified,
+				planCartItem,
 			} );
 
 			if ( enhanced ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -2,7 +2,6 @@ import { isEnabled } from '@automattic/calypso-config';
 import {
 	FEATURE_VIDEO_UPLOADS,
 	planHasFeature,
-	FEATURE_STYLE_CUSTOMIZATION,
 	getPlans,
 	isFreePlanProduct,
 	PLAN_PREMIUM,
@@ -30,13 +29,13 @@ import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
-import { Dispatch, ReactNode, SetStateAction } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import { NavigationControls } from 'calypso/landing/stepper/declarative-flow/internals/types';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { ADD_TIER_PLAN_HASH } from 'calypso/my-sites/earn/memberships/constants';
 import { isVideoPressFlow } from 'calypso/signup/is-flow';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
 import { goToCheckout } from '../../../../utils/checkout';
+import { getDeprecatedTaskDefinition } from './get-deprecated-task-data';
 import { getTaskDefinition } from './task-definitions';
 import { launchpadFlowTasks } from './tasks';
 import { EnhancedTask, LaunchpadChecklist, Task } from './types';
@@ -280,435 +279,58 @@ export function getEnhancedTasks( {
 		submit?.();
 	};
 
-	tasks &&
-		tasks.map( ( task ) => {
-			if ( shouldUseNewTaskDefinitions( flow ) ) {
-				const enhanced = getTaskDefinition( flow, task, {
-					getPlanTaskSubtitle,
-					siteInfoQueryArgs,
-					displayGlobalStylesWarning,
-					globalStylesMinimumPlan,
-					domainUpsellCompleted,
-					site,
-					getLaunchSiteTaskTitle,
-					getIsLaunchSiteTaskDisabled,
-					completeLaunchSiteTask,
-					isEmailVerified,
-				} );
-
-				if ( enhanced ) {
-					// eslint-disable-next-line no-console
-					console.log( 'using new task definitions', enhanced.id );
-					return enhancedTaskList.push( enhanced );
-				}
-			}
-
-			// @deprecated code flow, please use the new getTaskDefinition method
-			const taskData = getDeprecatedTaskData(
-				task,
-				flow,
-				siteInfoQueryArgs,
-				siteSlug,
-				displayGlobalStylesWarning,
-				shouldDisplayWarning,
-				globalStylesMinimumPlan,
-				isVideoPressFlowWithUnsupportedPlan,
+	return ( tasks || [] ).map( ( task ) => {
+		if ( shouldUseNewTaskDefinitions( flow ) ) {
+			const enhanced = getTaskDefinition( flow, task, {
 				getPlanTaskSubtitle,
-				translatedPlanName,
-				isCurrentPlanFree,
-				goToStep,
-				mustVerifyEmailBeforePosting,
-				completeMigrateContentTask,
+				siteInfoQueryArgs,
+				displayGlobalStylesWarning,
+				globalStylesMinimumPlan,
+				domainUpsellCompleted,
 				site,
-				submit,
 				getLaunchSiteTaskTitle,
 				getIsLaunchSiteTaskDisabled,
 				completeLaunchSiteTask,
-				launchpadUploadVideoLink,
-				videoPressUploadCompleted,
-				domainUpsellCompleted,
 				isEmailVerified,
-				stripeConnectUrl,
-				completePaidNewsletterTask,
-				setShowPlansModal
-			);
-			enhancedTaskList.push( { ...task, ...taskData } );
-		} );
-	return enhancedTaskList;
-}
+			} );
 
-//@deprecated please use the new get task definitions modules
-function getDeprecatedTaskData(
-	task: Task,
-	flow: string,
-	siteInfoQueryArgs:
-		| { siteId: number | undefined; siteSlug?: undefined }
-		| { siteSlug: string | null; siteId?: undefined },
-	siteSlug: string | null,
-	displayGlobalStylesWarning: boolean,
-	shouldDisplayWarning: boolean,
-	globalStylesMinimumPlan: string,
-	isVideoPressFlowWithUnsupportedPlan: boolean,
-	getPlanTaskSubtitle: ( task: Task ) => ReactNode | string | undefined,
-	translatedPlanName: ReactNode | string,
-	isCurrentPlanFree: boolean,
-	goToStep: ( ( step: string ) => void ) | undefined,
-	mustVerifyEmailBeforePosting: boolean,
-	completeMigrateContentTask: () => Promise< void >,
-	site: SiteDetails | null,
-	submit: NavigationControls[ 'submit' ] | undefined,
-	getLaunchSiteTaskTitle: ( task: Task ) => string | undefined,
-	getIsLaunchSiteTaskDisabled: () => boolean,
-	completeLaunchSiteTask: ( task: Task ) => Promise< void >,
-	launchpadUploadVideoLink: string,
-	videoPressUploadCompleted: boolean,
-	domainUpsellCompleted: boolean,
-	isEmailVerified: boolean,
-	stripeConnectUrl: string | undefined,
-	completePaidNewsletterTask: () => Promise< void >,
-	setShowPlansModal: Dispatch< SetStateAction< boolean > >
-) {
-	let taskData = {};
-	switch ( task.id ) {
-		case 'setup_free':
-			taskData = {
-				actionDispatch: () => {
-					recordTaskClickTracksEvent( flow, task.completed, task.id );
-					window.location.assign(
-						addQueryArgs( `/setup/${ flow }/freePostSetup`, siteInfoQueryArgs )
-					);
-				},
-			};
-			break;
-		case 'setup_blog':
-			taskData = {
-				actionDispatch: () => {
-					recordTaskClickTracksEvent( flow, task.completed, task.id );
-					window.location.assign(
-						addQueryArgs( `/setup/${ flow }/setup-blog`, siteInfoQueryArgs )
-					);
-				},
-				disabled: task.completed && ! isBlogOnboardingFlow( flow ),
-			};
-			break;
-		case 'setup_newsletter':
-			taskData = {
-				actionDispatch: () => {
-					recordTaskClickTracksEvent( flow, task.completed, task.id );
-					window.location.assign(
-						addQueryArgs( `/setup/newsletter-post-setup/newsletterPostSetup`, siteInfoQueryArgs )
-					);
-				},
-			};
-			break;
-		case 'design_edited':
-			taskData = {
-				actionDispatch: () => {
-					recordTaskClickTracksEvent( flow, task.completed, task.id );
-					window.location.assign(
-						addQueryArgs( `/site-editor/${ siteSlug }`, {
-							canvas: 'edit',
-						} )
-					);
-				},
-			};
-			break;
-		case 'plan_selected':
-			/* eslint-disable no-case-declarations */
-			const openPlansPage = () => {
-				recordTaskClickTracksEvent( flow, task.completed, task.id );
-				if ( displayGlobalStylesWarning ) {
-					recordTracksEvent( 'calypso_launchpad_global_styles_gating_plan_selected_task_clicked', {
-						flow,
-					} );
-				}
-				const plansUrl = addQueryArgs( `/plans/${ siteSlug }`, {
-					...( shouldDisplayWarning && {
-						plan: globalStylesMinimumPlan,
-						feature: isVideoPressFlowWithUnsupportedPlan
-							? FEATURE_VIDEO_UPLOADS
-							: FEATURE_STYLE_CUSTOMIZATION,
-					} ),
-				} );
-				window.location.assign( plansUrl );
-			};
-
-			const completed = task.completed && ! isVideoPressFlowWithUnsupportedPlan;
-
-			taskData = {
-				actionDispatch: openPlansPage,
-				completed,
-				subtitle: getPlanTaskSubtitle( task ),
-			};
-			/* eslint-enable no-case-declarations */
-			break;
-		case 'plan_completed':
-			taskData = {
-				actionDispatch: () => {
-					recordTaskClickTracksEvent( flow, task.completed, task.id );
-					const plansUrl = addQueryArgs( `/setup/${ flow }/plans`, siteInfoQueryArgs );
-
-					window.location.assign( plansUrl );
-				},
-				badge_text: task.completed ? translatedPlanName : task.badge_text,
-				subtitle: getPlanTaskSubtitle( task ),
-				disabled: task.completed && ! isCurrentPlanFree,
-			};
-			break;
-		case 'subscribers_added':
-			taskData = {
-				actionDispatch: () => {
-					if ( goToStep ) {
-						recordTaskClickTracksEvent( flow, task.completed, task.id );
-						goToStep( 'subscribers' );
-					}
-				},
-			};
-			break;
-		case 'migrate_content':
-			taskData = {
-				disabled: mustVerifyEmailBeforePosting || false,
-				actionDispatch: () => {
-					recordTaskClickTracksEvent( flow, task.completed, task.id );
-
-					// Mark task done
-					completeMigrateContentTask();
-
-					// Go to importers
-					window.location.assign( `/import/${ siteSlug }` );
-				},
-			};
-			break;
-		case 'first_post_published':
-			taskData = {
-				disabled:
-					mustVerifyEmailBeforePosting ||
-					( task.completed && isBlogOnboardingFlow( flow || null ) ) ||
-					false,
-				actionDispatch: () => {
-					recordTaskClickTracksEvent( flow, task.completed, task.id );
-					const newPostUrl = ! isBlogOnboardingFlow( flow || null )
-						? `/post/${ siteSlug }`
-						: addQueryArgs( `https://${ siteSlug }/wp-admin/post-new.php`, {
-								origin: window.location.origin,
-						  } );
-					window.location.assign( newPostUrl );
-				},
-			};
-			break;
-		case 'first_post_published_newsletter':
-			taskData = {
-				isLaunchTask: true,
-				disabled: mustVerifyEmailBeforePosting || false,
-				actionDispatch: () => {
-					recordTaskClickTracksEvent( flow, task.completed, task.id );
-					window.location.assign( `/post/${ siteSlug }` );
-				},
-			};
-			break;
-		case 'design_selected':
-		case 'design_completed':
-			taskData = {
-				actionDispatch: () => {
-					recordTaskClickTracksEvent( flow, task.completed, task.id );
-					window.location.assign(
-						addQueryArgs( `/setup/update-design/designSetup`, {
-							...siteInfoQueryArgs,
-							flowToReturnTo: flow,
-						} )
-					);
-				},
-			};
-			break;
-		case 'setup_general':
-			taskData = {
-				disabled: false,
-				actionDispatch: () => {
-					recordTaskClickTracksEvent( flow, task.completed, task.id );
-					window.location.assign(
-						addQueryArgs( `/setup/update-options/options`, {
-							...siteInfoQueryArgs,
-							flowToReturnTo: flow,
-						} )
-					);
-				},
-			};
-			break;
-		case 'setup_link_in_bio':
-			taskData = {
-				actionDispatch: () => {
-					recordTaskClickTracksEvent( flow, task.completed, task.id );
-					window.location.assign(
-						addQueryArgs( `/setup/link-in-bio-post-setup/linkInBioPostSetup`, siteInfoQueryArgs )
-					);
-				},
-			};
-			break;
-		case 'links_added':
-			taskData = {
-				actionDispatch: () => {
-					recordTaskClickTracksEvent( flow, task.completed, task.id );
-					window.location.assign(
-						addQueryArgs( `/site-editor/${ siteSlug }`, {
-							canvas: 'edit',
-						} )
-					);
-				},
-			};
-			break;
-		case 'link_in_bio_launched':
-			taskData = {
-				isLaunchTask: true,
-				actionDispatch: () => {
-					if ( site?.ID ) {
-						const { setPendingAction, setProgressTitle } = dispatch(
-							ONBOARD_STORE
-						) as OnboardActions;
-						const { launchSite } = dispatch( SITE_STORE ) as SiteActions;
-
-						setPendingAction( async () => {
-							setProgressTitle( __( 'Launching Link in bio' ) );
-							await launchSite( site.ID );
-
-							// Waits for half a second so that the loading screen doesn't flash away too quickly
-							await new Promise( ( res ) => setTimeout( res, 500 ) );
-							recordTaskClickTracksEvent( flow, task.completed, task.id );
-							return { goToHome: true, siteSlug };
-						} );
-
-						submit?.();
-					}
-				},
-			};
-			break;
-		case 'site_launched':
-			taskData = {
-				isLaunchTask: true,
-				title: getLaunchSiteTaskTitle( task ),
-				disabled: getIsLaunchSiteTaskDisabled(),
-				actionDispatch: () => {
-					completeLaunchSiteTask( task );
-				},
-			};
-			break;
-		case 'blog_launched': {
-			taskData = {
-				isLaunchTask: true,
-				title: getLaunchSiteTaskTitle( task ),
-				disabled: getIsLaunchSiteTaskDisabled(),
-				actionDispatch: () => {
-					completeLaunchSiteTask( task );
-				},
-			};
-			break;
+			if ( enhanced ) {
+				// eslint-disable-next-line no-console
+				console.log( 'using new task definitions', enhanced.id );
+				return enhancedTaskList.push( enhanced );
+			}
 		}
-		case 'videopress_upload':
-			taskData = {
-				actionUrl: launchpadUploadVideoLink,
-				disabled: isVideoPressFlowWithUnsupportedPlan || videoPressUploadCompleted,
-				actionDispatch: () => {
-					recordTaskClickTracksEvent( flow, task.completed, task.id );
-					window.location.replace( launchpadUploadVideoLink );
-				},
-			};
-			break;
-		case 'videopress_launched':
-			taskData = {
-				isLaunchTask: true,
-				actionDispatch: () => {
-					if ( site?.ID ) {
-						const { setPendingAction, setProgressTitle } = dispatch(
-							ONBOARD_STORE
-						) as OnboardActions;
-						const { launchSite } = dispatch( SITE_STORE ) as SiteActions;
 
-						setPendingAction( async () => {
-							setProgressTitle( __( 'Launching video site' ) );
-							await launchSite( site.ID );
-
-							// Waits for half a second so that the loading screen doesn't flash away too quickly
-							await new Promise( ( res ) => setTimeout( res, 500 ) );
-							window.location.replace(
-								addQueryArgs( `/home/${ siteSlug }`, {
-									forceLoadLaunchpadData: true,
-								} )
-							);
-						} );
-
-						submit?.();
-					}
-				},
-			};
-			break;
-		case 'domain_upsell':
-			taskData = {
-				completed: domainUpsellCompleted,
-				actionDispatch: () => {
-					recordTaskClickTracksEvent( flow, domainUpsellCompleted, task.id );
-
-					if ( isBlogOnboardingFlow( flow ) || isSiteAssemblerFlow( flow ) ) {
-						window.location.assign(
-							addQueryArgs( `/setup/${ flow }/domains`, {
-								...siteInfoQueryArgs,
-								flowToReturnTo: flow,
-								new: site?.name,
-								domainAndPlanPackage: true,
-							} )
-						);
-
-						return;
-					}
-
-					const destinationUrl = domainUpsellCompleted
-						? `/domains/manage/${ siteSlug }`
-						: addQueryArgs( `/setup/domain-upsell/domains`, {
-								...siteInfoQueryArgs,
-								flowToReturnTo: flow,
-								new: site?.name,
-						  } );
-					window.location.assign( destinationUrl );
-				},
-				badge_text:
-					domainUpsellCompleted || isBlogOnboardingFlow( flow ) || isSiteAssemblerFlow( flow )
-						? ''
-						: translate( 'Upgrade plan' ),
-			};
-			break;
-		case 'verify_email':
-			taskData = {
-				completed: isEmailVerified,
-				actionDispatch: () => {
-					recordTaskClickTracksEvent( flow, task.completed, task.id );
-					window.location.replace( task.calypso_path || '/me/account' );
-				},
-			};
-			break;
-		case 'set_up_payments':
-			taskData = {
-				badge_text: task.completed ? translate( 'Connected' ) : null,
-				actionDispatch: () => {
-					recordTaskClickTracksEvent( flow, task.completed, task.id );
-					stripeConnectUrl
-						? window.location.assign( stripeConnectUrl )
-						: window.location.assign( `/earn/payments/${ siteSlug }#launchpad` );
-				},
-			};
-			break;
-		case 'newsletter_plan_created':
-			taskData = {
-				actionDispatch: () => {
-					recordTaskClickTracksEvent( flow, task.completed, task.id );
-					completePaidNewsletterTask();
-					site?.ID
-						? setShowPlansModal( true )
-						: window.location.assign(
-								`/earn/payments/${ siteSlug }?launchpad=add-product${ ADD_TIER_PLAN_HASH }`
-						  );
-				},
-			};
-			break;
-	}
-	return taskData;
+		// @deprecated code flow, please use the new getTaskDefinition method
+		return getDeprecatedTaskDefinition(
+			task,
+			flow,
+			siteInfoQueryArgs,
+			siteSlug,
+			displayGlobalStylesWarning,
+			shouldDisplayWarning,
+			globalStylesMinimumPlan,
+			isVideoPressFlowWithUnsupportedPlan,
+			getPlanTaskSubtitle,
+			translatedPlanName,
+			isCurrentPlanFree,
+			goToStep,
+			mustVerifyEmailBeforePosting,
+			completeMigrateContentTask,
+			site,
+			submit,
+			getLaunchSiteTaskTitle,
+			getIsLaunchSiteTaskDisabled,
+			completeLaunchSiteTask,
+			launchpadUploadVideoLink,
+			videoPressUploadCompleted,
+			domainUpsellCompleted,
+			isEmailVerified,
+			stripeConnectUrl,
+			completePaidNewsletterTask,
+			setShowPlansModal
+		);
+	} );
 }
 
 function isDomainUpsellCompleted(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -282,13 +282,14 @@ export function getEnhancedTasks( {
 	return ( tasks || [] ).map( ( task ) => {
 		if ( shouldUseNewTaskDefinitions( flow ) ) {
 			const enhanced = getTaskDefinition( flow, task, {
+				checklistStatuses,
+				tasks,
 				siteInfoQueryArgs,
 				displayGlobalStylesWarning,
 				globalStylesMinimumPlan,
 				domainUpsellCompleted,
 				site,
 				getLaunchSiteTaskTitle,
-				getIsLaunchSiteTaskDisabled,
 				completeLaunchSiteTask,
 				isEmailVerified,
 			} );
@@ -332,7 +333,7 @@ export function getEnhancedTasks( {
 	} );
 }
 
-function isDomainUpsellCompleted(
+export function isDomainUpsellCompleted(
 	site: SiteDetails | null,
 	checklistStatuses: ChecklistStatuses
 ): boolean {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tracking.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tracking.ts
@@ -1,0 +1,35 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Task } from '@automattic/launchpad';
+import { TaskContext } from './types';
+
+/**
+ * Build a function that tracks a task event.
+ * @param event The event name to track.
+ * @returns A function that tracks the event.
+ * @example
+ * const recordTaskClickTracksEvent = buildEventTracker( 'calypso_launchpad_task_clicked' );
+ * recordTaskClickTracksEvent( task, flow, context );
+ */
+const buildEventTracker =
+	( event: string ) =>
+	( task: Task, flow: string, context: TaskContext, extraOptions = {} ) => {
+		const { site, tasks } = context;
+
+		recordTracksEvent( event, {
+			checklist_completed: tasks.every( ( t ) => t.completed ),
+			checklist_slug: site?.options?.site_intent,
+			context: 'fullscreen',
+			flow,
+			is_completed: task.completed,
+			order: task.order,
+			site_intent: site?.options?.site_intent,
+			task_id: task.id,
+			...extraOptions,
+		} );
+	};
+
+export const recordGlobalStylesGattingPlanSelectedResetStylesEvent = buildEventTracker(
+	'calypso_launchpad_global_styles_gating_plan_selected_reset_styles'
+);
+
+export const recordTaskClickTracksEvent = buildEventTracker( 'calypso_launchpad_task_clicked' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -1,19 +1,9 @@
 import { ChecklistStatuses, type SiteDetails } from '@automattic/data-stores';
+//TODO: Temporary export until we can replace all depencecies with ./types.ts Task;
+export type { Task } from '@automattic/launchpad';
+import { Task } from '@automattic/launchpad';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
-import { ReactNode } from 'react';
 import { NavigationControls } from '../../types';
-
-export interface Task {
-	id: string;
-	completed: boolean;
-	disabled: boolean;
-	title?: string;
-	subtitle?: string | React.ReactNode | null;
-	badge_text?: string;
-	actionDispatch?: () => void;
-	isLaunchTask?: boolean;
-	calypso_path?: string;
-}
 
 export type LaunchpadChecklist = Task[];
 
@@ -26,13 +16,6 @@ export interface TranslatedLaunchpadStrings {
 	title: string;
 	launchTitle?: string;
 	subtitle: string;
-}
-
-export interface EnhancedTask extends Omit< Task, 'badge_text' | 'title' > {
-	useCalypsoPath?: boolean;
-	badge_text?: ReactNode | string;
-	title?: ReactNode | string;
-	actionUrl?: string;
 }
 
 export type TaskId =
@@ -81,5 +64,5 @@ export interface TaskContext {
 	submit: NavigationControls[ 'submit' ];
 }
 
-export type TaskAction = ( task: Task, flow: string, context: TaskContext ) => EnhancedTask;
+export type TaskAction = ( task: Task, flow: string, context: TaskContext ) => Task;
 export type TaskActionTable = Record< TaskId, TaskAction >;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -37,29 +37,31 @@ export interface EnhancedTask extends Omit< Task, 'badge_text' | 'title' > {
 
 export type TaskId =
 	| 'setup_free'
-	| 'setup_blog'
-	| 'setup_newsletter'
 	| 'design_edited'
-	| 'plan_selected'
-	| 'plan_completed'
-	| 'subscribers_added'
-	| 'migrate_content'
-	| 'first_post_published'
-	| 'first_post_published_newsletter'
 	| 'design_selected'
-	| 'design_completed'
-	| 'setup_general'
-	| 'setup_link_in_bio'
-	| 'links_added'
-	| 'link_in_bio_launched'
-	| 'site_launched'
-	| 'blog_launched'
-	| 'videopress_upload'
-	| 'videopress_launched'
 	| 'domain_upsell'
-	| 'verify_email'
-	| 'set_up_payments'
-	| 'newsletter_plan_created';
+	| 'first_post_published'
+	| 'site_launched'
+	| 'plan_selected';
+//
+// TODO: Add the rest of the task ids
+// | 'setup_blog'
+// | 'setup_newsletter'
+// | 'plan_completed'
+// | 'subscribers_added'
+// | 'migrate_content'
+// | 'first_post_published_newsletter'
+// | 'design_completed'
+// | 'setup_general'
+// | 'setup_link_in_bio'
+// | 'links_added'
+// | 'link_in_bio_launched'
+// | 'blog_launched'
+// | 'videopress_upload'
+// | 'videopress_launched'
+// | 'verify_email'
+// | 'set_up_payments'
+// | 'newsletter_plan_created';
 
 export interface TaskContext {
 	siteInfoQueryArgs?: { siteId?: number; siteSlug?: string | null };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -1,4 +1,5 @@
-import { type SiteDetails } from '@automattic/data-stores';
+import { ChecklistStatuses, type SiteDetails } from '@automattic/data-stores';
+import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { ReactNode } from 'react';
 
 export interface Task {
@@ -70,7 +71,9 @@ export interface TaskContext {
 	isEmailVerified: boolean;
 	tasks: Task[];
 	checklistStatuses?: ChecklistStatuses;
-	getLaunchSiteTaskTitle: ( task: Task ) => ReactNode;
+	planCartItem?: MinimalRequestCartProduct | null;
+	domainCartItem?: MinimalRequestCartProduct | null;
+	productCartItems?: MinimalRequestCartProduct[] | null;
 	completeLaunchSiteTask: ( task: Task ) => Promise< void >;
 }
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -1,3 +1,6 @@
+import { type SiteDetails } from '@automattic/data-stores';
+import { ReactNode } from 'react';
+
 export interface Task {
 	id: string;
 	completed: boolean;
@@ -22,3 +25,65 @@ export interface TranslatedLaunchpadStrings {
 	launchTitle?: string;
 	subtitle: string;
 }
+
+export interface EnhancedTask extends Omit< Task, 'badge_text' | 'title' > {
+	useCalypsoPath?: boolean;
+	badge_text?: ReactNode | string;
+	title?: ReactNode | string;
+	actionUrl?: string;
+}
+
+export type TaskId =
+	| 'setup_free'
+	| 'setup_blog'
+	| 'setup_newsletter'
+	| 'design_edited'
+	| 'plan_selected'
+	| 'plan_completed'
+	| 'subscribers_added'
+	| 'migrate_content'
+	| 'first_post_published'
+	| 'first_post_published_newsletter'
+	| 'design_selected'
+	| 'design_completed'
+	| 'setup_general'
+	| 'setup_link_in_bio'
+	| 'links_added'
+	| 'link_in_bio_launched'
+	| 'site_launched'
+	| 'blog_launched'
+	| 'videopress_upload'
+	| 'videopress_launched'
+	| 'domain_upsell'
+	| 'verify_email'
+	| 'set_up_payments'
+	| 'newsletter_plan_created';
+
+export interface TaskContext {
+	siteInfoQueryArgs?: { siteId?: number; siteSlug?: string | null };
+	displayGlobalStylesWarning?: boolean;
+	shouldDisplayWarning?: boolean;
+	globalStylesMinimumPlan?: string;
+	isVideoPressFlowWithUnsupportedPlan?: boolean;
+	getPlanTaskSubtitle: ( task: Task ) => ReactNode | string | null;
+	site: SiteDetails | null;
+	domainUpsellCompleted: boolean;
+	isEmailVerified: boolean;
+	// translatedPlanName?: ReactNode | string;
+	// isCurrentPlanFree?: boolean;
+	// goToStep?: NavigationControls[ 'goToStep' ];
+	// mustVerifyEmailBeforePosting?: boolean;
+	// completeMigrateContentTask?: () => Promise< void >;
+	// submit?: NavigationControls[ 'submit' ];
+	getLaunchSiteTaskTitle: ( task: Task ) => ReactNode;
+	getIsLaunchSiteTaskDisabled: () => boolean;
+	completeLaunchSiteTask: ( task: Task ) => Promise< void >;
+	// launchpadUploadVideoLink: string;
+	// videoPressUploadCompleted: boolean;
+	// stripeConnectUrl?: string;
+	// completePaidNewsletterTask: () => Promise< void >;
+	// setShowPlansModal: Dispatch< SetStateAction< boolean > >;
+}
+
+export type TaskAction = ( task: Task, flow: string, context: TaskContext ) => EnhancedTask;
+export type TaskActionTable = Record< TaskId, TaskAction >;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -74,7 +74,8 @@ export interface TaskContext {
 	planCartItem?: MinimalRequestCartProduct | null;
 	domainCartItem?: MinimalRequestCartProduct | null;
 	productCartItems?: MinimalRequestCartProduct[] | null;
-	completeLaunchSiteTask: ( task: Task ) => Promise< void >;
+	siteSlug: string | null;
+	submit: NavigationControls[ 'submit' ];
 }
 
 export type TaskAction = ( task: Task, flow: string, context: TaskContext ) => EnhancedTask;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -1,6 +1,7 @@
 import { ChecklistStatuses, type SiteDetails } from '@automattic/data-stores';
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { ReactNode } from 'react';
+import { NavigationControls } from '../../types';
 
 export interface Task {
 	id: string;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -61,11 +61,10 @@ export type TaskId =
 
 export interface TaskContext {
 	siteInfoQueryArgs?: { siteId?: number; siteSlug?: string | null };
-	displayGlobalStylesWarning?: boolean;
+	displayGlobalStylesWarning: boolean;
 	shouldDisplayWarning?: boolean;
 	globalStylesMinimumPlan?: string;
 	isVideoPressFlowWithUnsupportedPlan?: boolean;
-	getPlanTaskSubtitle: ( task: Task ) => ReactNode | string | null;
 	site: SiteDetails | null;
 	domainUpsellCompleted: boolean;
 	isEmailVerified: boolean;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -68,20 +68,10 @@ export interface TaskContext {
 	site: SiteDetails | null;
 	domainUpsellCompleted: boolean;
 	isEmailVerified: boolean;
-	// translatedPlanName?: ReactNode | string;
-	// isCurrentPlanFree?: boolean;
-	// goToStep?: NavigationControls[ 'goToStep' ];
-	// mustVerifyEmailBeforePosting?: boolean;
-	// completeMigrateContentTask?: () => Promise< void >;
-	// submit?: NavigationControls[ 'submit' ];
+	tasks: Task[];
+	checklistStatuses?: ChecklistStatuses;
 	getLaunchSiteTaskTitle: ( task: Task ) => ReactNode;
-	getIsLaunchSiteTaskDisabled: () => boolean;
 	completeLaunchSiteTask: ( task: Task ) => Promise< void >;
-	// launchpadUploadVideoLink: string;
-	// videoPressUploadCompleted: boolean;
-	// stripeConnectUrl?: string;
-	// completePaidNewsletterTask: () => Promise< void >;
-	// setShowPlansModal: Dispatch< SetStateAction< boolean > >;
 }
 
 export type TaskAction = ( task: Task, flow: string, context: TaskContext ) => EnhancedTask;

--- a/config/development.json
+++ b/config/development.json
@@ -111,6 +111,7 @@
 		"lasagna": true,
 		"launchpad-updates": true,
 		"launchpad/navigator": false,
+		"launchpad/new-task-definition-parser": true,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,

--- a/packages/launchpad/src/types.ts
+++ b/packages/launchpad/src/types.ts
@@ -1,13 +1,16 @@
+import { ReactNode } from 'react';
+
 export interface TaskExtraData {
 	about_page_id?: number;
 }
+
 export interface Task {
 	id: string;
 	completed: boolean;
 	disabled: boolean;
-	title?: string;
+	title?: ReactNode | string;
 	subtitle?: string | React.ReactNode | null;
-	badge_text?: string;
+	badge_text?: ReactNode | string;
 	actionDispatch?: () => void;
 	isLaunchTask?: boolean;
 	extra_data?: TaskExtraData;
@@ -16,6 +19,7 @@ export interface Task {
 	repetition_count?: number;
 	order?: number;
 	useCalypsoPath?: boolean;
+	actionUrl?: string;
 }
 
 export type LaunchpadChecklist = Task[];


### PR DESCRIPTION
Fix part of #85694

## Proposed Changes

* Transform the free flow tasks to links. 
* Refactor the getEnhancedTasks to from task-helper to remove task definitions
* Move all flow `free` definitions to use the code structure.
* Improve the user tracking on the new task definitions
* Unify the Task type definition
* [Adopt strangler fig pattern using feature flag to migrate gradually all task definitions ](https://dennylesmana.medium.com/what-is-the-strangler-fig-pattern-1560443b8459#:~:text=The%20Strangler%20Fig%20pattern%20aims,that%20isn't%20used%20yet)
* The remaining flow will be covered by other PRs (way smaller than this one).

---
### Technical Notes
As part of my task I moved the big switch that was processing the tasks to the function getDeprecatedTaskDefinition  
(https://github.com/Automattic/wp-calypso/pull/86293/files#diff-b088aae90940dec602186724a7f297ec5e369e75cf503e9cdc41816892b2b628R19) 
and create a new module `steps-repository/launchpad/task-definitions/index.ts` with the task definitions divided by domain.  

The overall idea is to migrate all of this task definition by flow, testing them gradually.

Since it is a very sensitive product area and with low test coverage, this change is under a feature flag, so  we are going to remove the old code as soon all tasks were migrated


--- 

## Testing Instructions
* Run the /setup/free on you localmachine or calypso.live (the feature flag is only available on this envs)
* Follow the steps until the launchpad is rendered
* Open the console and check if this messages were rendered 
``` 
using new task definitions plan_selected
task-helper.tsx:249 using new task definitions setup_free
task-helper.tsx:249 using new task definitions design_selected
task-helper.tsx:249 using new task definitions design_edited
task-helper.tsx:249 using new task definitions domain_upsell
task-helper.tsx:249 using new task definitions first_post_published
task-helper.tsx:249 using new task definitions site_launched
``` 
* Check if the all launchpad tasks are links 
* Complete all tasks and launch the site
* Check if the process happened with success
* Check if the events now contains the following attributes:
``` 
blog_id: 227838534 
checklist_completed: false
checklist_slug: free
client: browser
context: fullscreen
environment: development
environment_id: development
flow: free
is_completed: true
order: 3
site_count: 256
site_id_label: wpcom
site_intent: free
site_plan_id: 1
task_id: design_edited
vph: 873
vpw: 2560
``` 


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?