### PR TITLE
Data Stores: Cleanup onboard store

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/store-profiler/index.tsx
@@ -32,11 +32,8 @@ const StoreProfiler: Step = function StoreProfiler( { navigation, flow } ) {
 		( select ) => ( select( USER_STORE ) as UserSelect ).getNewUser(),
 		[]
 	);
-	const {
-		setSiteTitle: saveSiteTitleToStore,
-		setVerticalId: saveVerticalIdToStore,
-		setStoreLocationCountryCode: saveCountryCodeToStore,
-	} = useDispatch( ONBOARD_STORE );
+	const { setSiteTitle: saveSiteTitleToStore, setVerticalId: saveVerticalIdToStore } =
+		useDispatch( ONBOARD_STORE );
 
 	const verticals = useSiteVerticalsFeatured();
 	const verticalsOptions = React.useMemo( () => {
@@ -82,7 +79,6 @@ const StoreProfiler: Step = function StoreProfiler( { navigation, flow } ) {
 		if ( currentUser || newUser ) {
 			saveSiteTitleToStore( siteTitle );
 			saveVerticalIdToStore( verticalId );
-			saveCountryCodeToStore( storeCountryCode );
 			recordTracksEvent( 'calypso_signup_store_profiler_submit', {
 				has_site_title: !! siteTitle,
 				has_vertical: !! verticalId,

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -204,11 +204,6 @@ export const setDomainSearch = ( domainSearch: string ) => ( {
 	domainSearch,
 } );
 
-export const setHasUsedDomainsStep = ( hasUsedDomainsStep: boolean ) => ( {
-	type: 'SET_HAS_USED_DOMAINS_STEP' as const,
-	hasUsedDomainsStep,
-} );
-
 export const setHasUsedPlansStep = ( hasUsedPlansStep: boolean ) => ( {
 	type: 'SET_HAS_USED_PLANS_STEP' as const,
 	hasUsedPlansStep,
@@ -409,7 +404,6 @@ export type OnboardAction = ReturnType<
 	| typeof setDomain
 	| typeof setDomainCategory
 	| typeof setDomainSearch
-	| typeof setHasUsedDomainsStep
 	| typeof setHasUsedPlansStep
 	| typeof setPluginsToVerify
 	| typeof setProfilerData

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -179,11 +179,6 @@ export const setDomain = ( domain: DomainSuggestion | undefined ) => ( {
 	domain,
 } );
 
-export const setDomainCategory = ( domainCategory: string | undefined ) => ( {
-	type: 'SET_DOMAIN_CATEGORY' as const,
-	domainCategory,
-} );
-
 export const setDomainSearch = ( domainSearch: string ) => ( {
 	type: 'SET_DOMAIN_SEARCH_TERM' as const,
 	domainSearch,
@@ -375,7 +370,6 @@ export type OnboardAction = ReturnType<
 	| typeof setStoreType
 	| typeof setDomainsTransferData
 	| typeof setDomain
-	| typeof setDomainCategory
 	| typeof setDomainSearch
 	| typeof setPluginsToVerify
 	| typeof setProfilerData

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -204,11 +204,6 @@ export const setDomainSearch = ( domainSearch: string ) => ( {
 	domainSearch,
 } );
 
-export const setHasUsedPlansStep = ( hasUsedPlansStep: boolean ) => ( {
-	type: 'SET_HAS_USED_PLANS_STEP' as const,
-	hasUsedPlansStep,
-} );
-
 export const setPlanCartItem = ( planCartItem: MinimalRequestCartProduct | null ) => ( {
 	type: 'SET_PLAN_CART_ITEM' as const,
 	planCartItem,
@@ -404,7 +399,6 @@ export type OnboardAction = ReturnType<
 	| typeof setDomain
 	| typeof setDomainCategory
 	| typeof setDomainSearch
-	| typeof setHasUsedPlansStep
 	| typeof setPluginsToVerify
 	| typeof setProfilerData
 	| typeof setSelectedDesign

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -179,11 +179,6 @@ export const setDomain = ( domain: DomainSuggestion | undefined ) => ( {
 	domain,
 } );
 
-export const setDomainSearch = ( domainSearch: string ) => ( {
-	type: 'SET_DOMAIN_SEARCH_TERM' as const,
-	domainSearch,
-} );
-
 export const setPlanCartItem = ( planCartItem: MinimalRequestCartProduct | null ) => ( {
 	type: 'SET_PLAN_CART_ITEM' as const,
 	planCartItem,
@@ -370,7 +365,6 @@ export type OnboardAction = ReturnType<
 	| typeof setStoreType
 	| typeof setDomainsTransferData
 	| typeof setDomain
-	| typeof setDomainSearch
 	| typeof setPluginsToVerify
 	| typeof setProfilerData
 	| typeof setSelectedDesign

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -239,11 +239,6 @@ export const setProductCartItems = ( productCartItems: MinimalRequestCartProduct
 	productCartItems,
 } );
 
-export const setRandomizedDesigns = ( randomizedDesigns: { featured: Design[] } ) => ( {
-	type: 'SET_RANDOMIZED_DESIGNS' as const,
-	randomizedDesigns,
-} );
-
 export const setSelectedDesign = ( selectedDesign: Design | undefined ) => ( {
 	type: 'SET_SELECTED_DESIGN' as const,
 	selectedDesign,
@@ -459,7 +454,6 @@ export type OnboardAction = ReturnType<
 	| typeof setPlanProductId
 	| typeof setPluginsToVerify
 	| typeof setProfilerData
-	| typeof setRandomizedDesigns
 	| typeof setSelectedDesign
 	| typeof setSelectedStyleVariation
 	| typeof setSelectedSite

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -214,11 +214,6 @@ export const setHasUsedPlansStep = ( hasUsedPlansStep: boolean ) => ( {
 	hasUsedPlansStep,
 } );
 
-export const setIsRedirecting = ( isRedirecting: boolean ) => ( {
-	type: 'SET_IS_REDIRECTING' as const,
-	isRedirecting,
-} );
-
 export const setPlanProductId = ( planProductId: number | undefined ) => ( {
 	type: 'SET_PLAN_PRODUCT_ID' as const,
 	planProductId,
@@ -431,7 +426,6 @@ export type OnboardAction = ReturnType<
 	| typeof setDomainSearch
 	| typeof setHasUsedDomainsStep
 	| typeof setHasUsedPlansStep
-	| typeof setIsRedirecting
 	| typeof setPlanProductId
 	| typeof setPluginsToVerify
 	| typeof setProfilerData

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -299,10 +299,6 @@ export const clearImportGoal = () => ( {
 	type: 'CLEAR_IMPORT_GOAL' as const,
 } );
 
-export const clearDIFMGoal = () => ( {
-	type: 'CLEAR_DIFM_GOAL' as const,
-} );
-
 export const resetGoals = () => ( {
 	type: 'RESET_GOALS' as const,
 } );
@@ -414,7 +410,6 @@ export type OnboardAction = ReturnType<
 	| typeof setProgressTitle
 	| typeof setGoals
 	| typeof clearImportGoal
-	| typeof clearDIFMGoal
 	| typeof resetGoals
 	| typeof resetIntent
 	| typeof resetSelectedDesign

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -214,11 +214,6 @@ export const setHasUsedPlansStep = ( hasUsedPlansStep: boolean ) => ( {
 	hasUsedPlansStep,
 } );
 
-export const setPlanProductId = ( planProductId: number | undefined ) => ( {
-	type: 'SET_PLAN_PRODUCT_ID' as const,
-	planProductId,
-} );
-
 export const setPlanCartItem = ( planCartItem: MinimalRequestCartProduct | null ) => ( {
 	type: 'SET_PLAN_CART_ITEM' as const,
 	planCartItem,
@@ -265,11 +260,6 @@ export const setSiteAccentColor = ( siteAccentColor: string ) => ( {
 	type: 'SET_SITE_ACCENT_COLOR' as const,
 	siteAccentColor,
 } );
-
-export function updatePlan( planProductId: number ) {
-	// keep updatePlan for backwards compat
-	return setPlanProductId( planProductId );
-}
 
 export const startOnboarding = () => ( {
 	type: 'ONBOARDING_START' as const,
@@ -426,7 +416,6 @@ export type OnboardAction = ReturnType<
 	| typeof setDomainSearch
 	| typeof setHasUsedDomainsStep
 	| typeof setHasUsedPlansStep
-	| typeof setPlanProductId
 	| typeof setPluginsToVerify
 	| typeof setProfilerData
 	| typeof setSelectedDesign

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -398,13 +398,6 @@ export const setDomainsTransferData = ( bulkDomainsData: DomainTransferData | un
 	bulkDomainsData,
 } );
 
-export const setShouldImportDomainTransferDnsRecords = (
-	shouldImportDomainTransferDnsRecords: boolean
-) => ( {
-	type: 'SET_SHOULD_IMPORT_DOMAIN_TRANSFER_DNS_RECORDS' as const,
-	shouldImportDomainTransferDnsRecords,
-} );
-
 export const setHideFreePlan = ( hideFreePlan: boolean ) => ( {
 	type: 'SET_HIDE_FREE_PLAN' as const,
 	hideFreePlan,
@@ -443,7 +436,6 @@ export type OnboardAction = ReturnType<
 	| typeof resetOnboardStoreWithSkipFlags
 	| typeof setStoreType
 	| typeof setDomainsTransferData
-	| typeof setShouldImportDomainTransferDnsRecords
 	| typeof setDomain
 	| typeof setDomainCategory
 	| typeof setDomainSearch

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -265,11 +265,6 @@ export const setVerticalId = ( verticalId: string ) => ( {
 	verticalId,
 } );
 
-export const setStoreLocationCountryCode = ( storeLocationCountryCode: string ) => ( {
-	type: 'SET_STORE_LOCATION_COUNTRY_CODE' as const,
-	storeLocationCountryCode,
-} );
-
 export const setEcommerceFlowRecurType = ( ecommerceFlowRecurType: string ) => ( {
 	type: 'SET_ECOMMERCE_FLOW_RECUR_TYPE' as const,
 	ecommerceFlowRecurType,
@@ -357,7 +352,6 @@ export type OnboardAction = ReturnType<
 	| typeof setSiteDescription
 	| typeof setSiteLogo
 	| typeof setVerticalId
-	| typeof setStoreLocationCountryCode
 	| typeof setEcommerceFlowRecurType
 	| typeof setCouponCode
 	| typeof setHideFreePlan

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -201,11 +201,6 @@ export const setSelectedStyleVariation = (
 	selectedStyleVariation,
 } );
 
-export const setSelectedSite = ( selectedSite: number | undefined ) => ( {
-	type: 'SET_SELECTED_SITE' as const,
-	selectedSite,
-} );
-
 export const setSiteTitle = ( siteTitle: string ) => ( {
 	type: 'SET_SITE_TITLE' as const,
 	siteTitle,
@@ -348,7 +343,6 @@ export type OnboardAction = ReturnType<
 	| typeof setProfilerData
 	| typeof setSelectedDesign
 	| typeof setSelectedStyleVariation
-	| typeof setSelectedSite
 	| typeof setSiteTitle
 	| typeof setIntent
 	| typeof setStartingPoint

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -164,10 +164,6 @@ export function* createSenseiSite( {
 	return success;
 }
 
-export const resetFonts = () => ( {
-	type: 'RESET_FONTS' as const,
-} );
-
 export const resetOnboardStore = () => ( {
 	type: 'RESET_ONBOARD_STORE' as const,
 	skipFlags: [] as string[],
@@ -374,7 +370,6 @@ export const setPaidSubscribers = ( paidSubscribers: boolean ) => ( {
 } );
 
 export type OnboardAction = ReturnType<
-	| typeof resetFonts
 	| typeof resetOnboardStore
 	| typeof resetOnboardStoreWithSkipFlags
 	| typeof setStoreType

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -236,15 +236,6 @@ export const setStoreType = ( storeType: string ) => ( {
 	storeType,
 } );
 
-export const setStoreAddressValue = (
-	store_address_field: string,
-	store_address_value: string
-) => ( {
-	type: 'SET_STORE_ADDRESS_VALUE' as const,
-	store_address_field,
-	store_address_value,
-} );
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const setPendingAction = ( pendingAction: undefined | ( () => Promise< any > ) ) => ( {
 	type: 'SET_PENDING_ACTION' as const,
@@ -369,7 +360,6 @@ export type OnboardAction = ReturnType<
 	| typeof setSiteTitle
 	| typeof setIntent
 	| typeof setStartingPoint
-	| typeof setStoreAddressValue
 	| typeof setPendingAction
 	| typeof setProgress
 	| typeof setProgressTitle

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -251,11 +251,6 @@ export const setSelectedSite = ( selectedSite: number | undefined ) => ( {
 	selectedSite,
 } );
 
-export const setShowSignupDialog = ( showSignup: boolean ) => ( {
-	type: 'SET_SHOW_SIGNUP_DIALOG' as const,
-	showSignup,
-} );
-
 export const setSiteTitle = ( siteTitle: string ) => ( {
 	type: 'SET_SITE_TITLE' as const,
 	siteTitle,
@@ -443,7 +438,6 @@ export type OnboardAction = ReturnType<
 	| typeof setSelectedDesign
 	| typeof setSelectedStyleVariation
 	| typeof setSelectedSite
-	| typeof setShowSignupDialog
 	| typeof setSiteTitle
 	| typeof startOnboarding
 	| typeof setIntent

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -8,7 +8,6 @@ import { SiteGoal, STORE_KEY } from './constants';
 import { ProfilerData } from './types';
 import type { DomainTransferData, State } from '.';
 import type { DomainSuggestion } from '../domain-suggestions';
-import type { FeatureId } from '../shared-types';
 // somewhat hacky, but resolves the circular dependency issue
 import type { Design, StyleVariation } from '@automattic/design-picker/src/types';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
@@ -24,11 +23,6 @@ function isBlankCanvasDesign( design: { slug: string } | undefined ): boolean {
 type Language = {
 	value: number;
 };
-
-export const addFeature = ( featureId: FeatureId ) => ( {
-	type: 'ADD_FEATURE' as const,
-	featureId,
-} );
 
 export interface CreateSiteBaseActionParameters {
 	username: string;
@@ -169,11 +163,6 @@ export function* createSenseiSite( {
 
 	return success;
 }
-
-export const removeFeature = ( featureId: FeatureId ) => ( {
-	type: 'REMOVE_FEATURE' as const,
-	featureId,
-} );
 
 export const resetFonts = () => ( {
 	type: 'RESET_FONTS' as const,
@@ -385,8 +374,6 @@ export const setPaidSubscribers = ( paidSubscribers: boolean ) => ( {
 } );
 
 export type OnboardAction = ReturnType<
-	| typeof addFeature
-	| typeof removeFeature
 	| typeof resetFonts
 	| typeof resetOnboardStore
 	| typeof resetOnboardStoreWithSkipFlags

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -256,11 +256,6 @@ export const setSiteLogo = ( siteLogo: string | null ) => ( {
 	siteLogo,
 } );
 
-export const setSiteAccentColor = ( siteAccentColor: string ) => ( {
-	type: 'SET_SITE_ACCENT_COLOR' as const,
-	siteAccentColor,
-} );
-
 export const startOnboarding = () => ( {
 	type: 'ONBOARDING_START' as const,
 } );
@@ -439,7 +434,6 @@ export type OnboardAction = ReturnType<
 	| typeof setDomainCartItem
 	| typeof setSiteDescription
 	| typeof setSiteLogo
-	| typeof setSiteAccentColor
 	| typeof setVerticalId
 	| typeof setStoreLocationCountryCode
 	| typeof setEcommerceFlowRecurType

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -219,11 +219,6 @@ export const setIsRedirecting = ( isRedirecting: boolean ) => ( {
 	isRedirecting,
 } );
 
-export const setLastLocation = ( path: string ) => ( {
-	type: 'SET_LAST_LOCATION' as const,
-	path,
-} );
-
 export const setPlanProductId = ( planProductId: number | undefined ) => ( {
 	type: 'SET_PLAN_PRODUCT_ID' as const,
 	planProductId,
@@ -442,7 +437,6 @@ export type OnboardAction = ReturnType<
 	| typeof setHasUsedDomainsStep
 	| typeof setHasUsedPlansStep
 	| typeof setIsRedirecting
-	| typeof setLastLocation
 	| typeof setPlanProductId
 	| typeof setPluginsToVerify
 	| typeof setProfilerData

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -265,10 +265,6 @@ export const resetIntent = () => ( {
 	type: 'RESET_INTENT' as const,
 } );
 
-export const resetSelectedDesign = () => ( {
-	type: 'RESET_SELECTED_DESIGN' as const,
-} );
-
 export const setVerticalId = ( verticalId: string ) => ( {
 	type: 'SET_VERTICAL_ID' as const,
 	verticalId,
@@ -362,7 +358,6 @@ export type OnboardAction = ReturnType<
 	| typeof setGoals
 	| typeof resetGoals
 	| typeof resetIntent
-	| typeof resetSelectedDesign
 	| typeof setDomainForm
 	| typeof setDomainCartItem
 	| typeof setSiteDescription

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -257,10 +257,6 @@ export const setGoals = ( goals: SiteGoal[] ) => ( {
 	goals,
 } );
 
-export const clearImportGoal = () => ( {
-	type: 'CLEAR_IMPORT_GOAL' as const,
-} );
-
 export const resetGoals = () => ( {
 	type: 'RESET_GOALS' as const,
 } );
@@ -364,7 +360,6 @@ export type OnboardAction = ReturnType<
 	| typeof setProgress
 	| typeof setProgressTitle
 	| typeof setGoals
-	| typeof clearImportGoal
 	| typeof resetGoals
 	| typeof resetIntent
 	| typeof resetSelectedDesign

--- a/packages/data-stores/src/onboard/actions.ts
+++ b/packages/data-stores/src/onboard/actions.ts
@@ -221,10 +221,6 @@ export const setSiteLogo = ( siteLogo: string | null ) => ( {
 	siteLogo,
 } );
 
-export const startOnboarding = () => ( {
-	type: 'ONBOARDING_START' as const,
-} );
-
 export const setIntent = ( intent: string ) => ( {
 	type: 'SET_INTENT' as const,
 	intent,
@@ -371,7 +367,6 @@ export type OnboardAction = ReturnType<
 	| typeof setSelectedStyleVariation
 	| typeof setSelectedSite
 	| typeof setSiteTitle
-	| typeof startOnboarding
 	| typeof setIntent
 	| typeof setStartingPoint
 	| typeof setStoreAddressValue

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -34,7 +34,6 @@ export function register(): typeof STORE_KEY {
 		persist: [
 			'domainTransferNames',
 			'domain',
-			'domainSearch',
 			'domainForm',
 			'goals',
 			'intent',

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -40,7 +40,6 @@ export function register(): typeof STORE_KEY {
 			'paidSubscribers',
 			'selectedDesign',
 			'selectedFeatures',
-			'selectedSite',
 			'siteTitle',
 			'siteDescription',
 			'siteLogo',

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -37,7 +37,6 @@ export function register(): typeof STORE_KEY {
 			'domainSearch',
 			'domainForm',
 			'goals',
-			'hasUsedPlansStep',
 			'intent',
 			'paidSubscribers',
 			'selectedDesign',

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -41,7 +41,6 @@ export function register(): typeof STORE_KEY {
 			'hasUsedPlansStep',
 			'intent',
 			'paidSubscribers',
-			'lastLocation',
 			'planProductId',
 			'selectedDesign',
 			'selectedFeatures',

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -37,7 +37,6 @@ export function register(): typeof STORE_KEY {
 			'domainSearch',
 			'domainForm',
 			'goals',
-			'hasUsedDomainsStep',
 			'hasUsedPlansStep',
 			'intent',
 			'paidSubscribers',

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -47,7 +47,6 @@ export function register(): typeof STORE_KEY {
 			'siteTitle',
 			'siteDescription',
 			'siteLogo',
-			'siteAccentColor',
 			'storeType',
 			'verticalId',
 			'storeLocationCountryCode',

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -45,7 +45,6 @@ export function register(): typeof STORE_KEY {
 			'siteLogo',
 			'storeType',
 			'verticalId',
-			'storeLocationCountryCode',
 			'ecommerceFlowRecurType',
 			'couponCode',
 			'domainCartItem',

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -41,7 +41,6 @@ export function register(): typeof STORE_KEY {
 			'hasUsedPlansStep',
 			'intent',
 			'paidSubscribers',
-			'planProductId',
 			'selectedDesign',
 			'selectedFeatures',
 			'selectedSite',

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -44,7 +44,6 @@ export function register(): typeof STORE_KEY {
 			'paidSubscribers',
 			'lastLocation',
 			'planProductId',
-			'randomizedDesigns',
 			'selectedDesign',
 			'selectedFeatures',
 			'selectedSite',

--- a/packages/data-stores/src/onboard/index.ts
+++ b/packages/data-stores/src/onboard/index.ts
@@ -33,7 +33,6 @@ export function register(): typeof STORE_KEY {
 		selectors,
 		persist: [
 			'domainTransferNames',
-			'shouldImportDomainTransferDnsRecords',
 			'domain',
 			'domainSearch',
 			'domainForm',

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -232,16 +232,6 @@ const hasOnboardingStarted: Reducer< boolean, OnboardAction > = ( state = false,
 	return state;
 };
 
-const lastLocation: Reducer< string, OnboardAction > = ( state = '', action ) => {
-	if ( action.type === 'SET_LAST_LOCATION' ) {
-		return action.path;
-	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
-		return '';
-	}
-	return state;
-};
-
 const intent: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	if ( action.type === 'SET_INTENT' ) {
 		return action.intent;
@@ -531,7 +521,6 @@ const reducer = combineReducers( {
 	showSignupDialog,
 	planProductId,
 	hasOnboardingStarted,
-	lastLocation,
 	intent,
 	startingPoint,
 	pendingAction,

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -28,7 +28,7 @@ const selectedDesign: Reducer< Design | undefined, OnboardAction > = ( state, ac
 	if ( action.type === 'SET_SELECTED_DESIGN' ) {
 		return action.selectedDesign;
 	}
-	if ( [ 'RESET_SELECTED_DESIGN', 'RESET_ONBOARD_STORE' ].includes( action.type ) ) {
+	if ( action.type === 'RESET_ONBOARD_STORE' ) {
 		return undefined;
 	}
 	return state;

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -44,16 +44,6 @@ const domainCategory: Reducer< string | undefined, OnboardAction > = ( state, ac
 	return state;
 };
 
-const hasUsedDomainsStep: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
-	if ( action.type === 'SET_HAS_USED_DOMAINS_STEP' ) {
-		return action.hasUsedDomainsStep;
-	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
-		return false;
-	}
-	return state;
-};
-
 const hasUsedPlansStep: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
 	if ( action.type === 'SET_HAS_USED_PLANS_STEP' ) {
 		return action.hasUsedPlansStep;
@@ -468,7 +458,6 @@ const reducer = combineReducers( {
 	domainSearch,
 	domainCategory,
 	domainForm,
-	hasUsedDomainsStep,
 	hasUsedPlansStep,
 	selectedFeatures,
 	domainTransferNames,

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -208,9 +208,6 @@ const goals: Reducer< SiteGoal[], OnboardAction > = ( state = [], action ) => {
 	if ( action.type === 'SET_GOALS' ) {
 		return action.goals;
 	}
-	if ( action.type === 'CLEAR_IMPORT_GOAL' ) {
-		return state.filter( ( goal ) => goal !== SiteGoal.Import );
-	}
 	if ( [ 'RESET_GOALS', 'RESET_ONBOARD_STORE' ].includes( action.type ) ) {
 		return [];
 	}

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -64,15 +64,6 @@ const hasUsedPlansStep: Reducer< boolean, OnboardAction > = ( state = false, act
 	return state;
 };
 
-const isRedirecting: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
-	if ( action.type === 'SET_IS_REDIRECTING' ) {
-		return action.isRedirecting;
-	}
-	// This reducer is intentionally not cleared by 'RESET_ONBOARD_STORE' to prevent
-	// a flash of the IntentGathering step after the store is reset.
-	return state;
-};
-
 const planProductId: Reducer< number | undefined, OnboardAction > = ( state, action ) => {
 	if ( action.type === 'SET_PLAN_PRODUCT_ID' ) {
 		return action.planProductId;
@@ -497,7 +488,6 @@ const reducer = combineReducers( {
 	domainSearch,
 	domainCategory,
 	domainForm,
-	isRedirecting,
 	hasUsedDomainsStep,
 	hasUsedPlansStep,
 	selectedFeatures,

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -71,20 +71,12 @@ const selectedFeatures: Reducer< FeatureId[], OnboardAction > = (
 	state: FeatureId[] = [],
 	action
 ) => {
-	if ( action.type === 'ADD_FEATURE' ) {
-		return [ ...state, action.featureId ];
-	}
-
 	if ( action.type === 'SET_DOMAIN' && action.domain && ! action.domain?.is_free ) {
 		return [ ...state, 'domain' ];
 	}
 
 	if ( action.type === 'SET_DOMAIN' && action.domain?.is_free ) {
 		return state.filter( ( id ) => id !== 'domain' );
-	}
-
-	if ( action.type === 'REMOVE_FEATURE' ) {
-		return state.filter( ( id ) => id !== action.featureId );
 	}
 
 	if ( action.type === 'RESET_ONBOARD_STORE' ) {

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -501,19 +501,6 @@ export const domainTransferAuthCodes: Reducer<
 	return state;
 };
 
-export const shouldImportDomainTransferDnsRecords: Reducer< boolean, OnboardAction > = (
-	state = true,
-	action
-) => {
-	if ( action.type === 'SET_SHOULD_IMPORT_DOMAIN_TRANSFER_DNS_RECORDS' ) {
-		return action.shouldImportDomainTransferDnsRecords;
-	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
-		return true;
-	}
-	return state;
-};
-
 const paidSubscribers: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
 	if ( action.type === 'SET_PAID_SUBSCRIBERS' ) {
 		return action.paidSubscribers;
@@ -536,7 +523,6 @@ const reducer = combineReducers( {
 	selectedFeatures,
 	domainTransferNames,
 	domainTransferAuthCodes,
-	shouldImportDomainTransferDnsRecords,
 	storeType,
 	selectedDesign,
 	selectedStyleVariation,

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -34,16 +34,6 @@ const domainSearch: Reducer< string, OnboardAction > = ( state = '', action ) =>
 	return state;
 };
 
-const domainCategory: Reducer< string | undefined, OnboardAction > = ( state, action ) => {
-	if ( action.type === 'SET_DOMAIN_CATEGORY' ) {
-		return action.domainCategory;
-	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
-		return undefined;
-	}
-	return state;
-};
-
 const selectedDesign: Reducer< Design | undefined, OnboardAction > = ( state, action ) => {
 	if ( action.type === 'SET_SELECTED_DESIGN' ) {
 		return action.selectedDesign;
@@ -435,7 +425,6 @@ const reducer = combineReducers( {
 	domain,
 	domainCartItem,
 	domainSearch,
-	domainCategory,
 	domainForm,
 	selectedFeatures,
 	domainTransferNames,

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -44,16 +44,6 @@ const domainCategory: Reducer< string | undefined, OnboardAction > = ( state, ac
 	return state;
 };
 
-const hasUsedPlansStep: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
-	if ( action.type === 'SET_HAS_USED_PLANS_STEP' ) {
-		return action.hasUsedPlansStep;
-	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
-		return false;
-	}
-	return state;
-};
-
 const selectedDesign: Reducer< Design | undefined, OnboardAction > = ( state, action ) => {
 	if ( action.type === 'SET_SELECTED_DESIGN' ) {
 		return action.selectedDesign;
@@ -458,7 +448,6 @@ const reducer = combineReducers( {
 	domainSearch,
 	domainCategory,
 	domainForm,
-	hasUsedPlansStep,
 	selectedFeatures,
 	domainTransferNames,
 	domainTransferAuthCodes,

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -64,16 +64,6 @@ const hasUsedPlansStep: Reducer< boolean, OnboardAction > = ( state = false, act
 	return state;
 };
 
-const planProductId: Reducer< number | undefined, OnboardAction > = ( state, action ) => {
-	if ( action.type === 'SET_PLAN_PRODUCT_ID' ) {
-		return action.planProductId;
-	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
-		return undefined;
-	}
-	return state;
-};
-
 const selectedDesign: Reducer< Design | undefined, OnboardAction > = ( state, action ) => {
 	if ( action.type === 'SET_SELECTED_DESIGN' ) {
 		return action.selectedDesign;
@@ -498,7 +488,6 @@ const reducer = combineReducers( {
 	selectedStyleVariation,
 	selectedSite,
 	siteTitle,
-	planProductId,
 	hasOnboardingStarted,
 	intent,
 	startingPoint,

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -24,16 +24,6 @@ const domain: Reducer< DomainSuggestion | undefined, OnboardAction > = ( state, 
 	return state;
 };
 
-const domainSearch: Reducer< string, OnboardAction > = ( state = '', action ) => {
-	if ( action.type === 'SET_DOMAIN_SEARCH_TERM' ) {
-		return action.domainSearch;
-	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
-		return '';
-	}
-	return state;
-};
-
 const selectedDesign: Reducer< Design | undefined, OnboardAction > = ( state, action ) => {
 	if ( action.type === 'SET_SELECTED_DESIGN' ) {
 		return action.selectedDesign;
@@ -424,7 +414,6 @@ const paidSubscribers: Reducer< boolean, OnboardAction > = ( state = false, acti
 const reducer = combineReducers( {
 	domain,
 	domainCartItem,
-	domainSearch,
 	domainForm,
 	selectedFeatures,
 	domainTransferNames,

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -146,16 +146,6 @@ const selectedSite: Reducer< number | undefined, OnboardAction > = (
 	return state;
 };
 
-const showSignupDialog: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
-	if ( action.type === 'SET_SHOW_SIGNUP_DIALOG' ) {
-		return action.showSignup;
-	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
-		return false;
-	}
-	return state;
-};
-
 const siteTitle: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	if ( action.type === 'SET_SITE_TITLE' ) {
 		return action.siteTitle;
@@ -518,7 +508,6 @@ const reducer = combineReducers( {
 	selectedStyleVariation,
 	selectedSite,
 	siteTitle,
-	showSignupDialog,
 	planProductId,
 	hasOnboardingStarted,
 	intent,

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -183,16 +183,6 @@ const planCartItem: Reducer< MinimalRequestCartProduct | null, OnboardAction > =
 	return state;
 };
 
-const siteAccentColor: Reducer< string, OnboardAction > = ( state = '', action ) => {
-	if ( action.type === 'SET_SITE_ACCENT_COLOR' ) {
-		return action.siteAccentColor;
-	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
-		return '';
-	}
-	return state;
-};
-
 const hasOnboardingStarted: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
 	if ( action.type === 'ONBOARDING_START' ) {
 		return true;
@@ -499,7 +489,6 @@ const reducer = combineReducers( {
 	hidePlansFeatureComparison,
 	siteDescription,
 	siteLogo,
-	siteAccentColor,
 	verticalId,
 	storeLocationCountryCode,
 	ecommerceFlowRecurType,

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -211,16 +211,6 @@ const verticalId: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	return state;
 };
 
-const storeLocationCountryCode: Reducer< string, OnboardAction > = ( state = '', action ) => {
-	if ( action.type === 'SET_STORE_LOCATION_COUNTRY_CODE' ) {
-		return action.storeLocationCountryCode;
-	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
-		return '';
-	}
-	return state;
-};
-
 const ecommerceFlowRecurType: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	if ( action.type === 'SET_ECOMMERCE_FLOW_RECUR_TYPE' ) {
 		return action.ecommerceFlowRecurType;
@@ -407,7 +397,6 @@ const reducer = combineReducers( {
 	siteDescription,
 	siteLogo,
 	verticalId,
-	storeLocationCountryCode,
 	ecommerceFlowRecurType,
 	couponCode,
 	planCartItem,

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -83,19 +83,6 @@ const planProductId: Reducer< number | undefined, OnboardAction > = ( state, act
 	return state;
 };
 
-const randomizedDesigns: Reducer< { featured: Design[] }, OnboardAction > = (
-	state = { featured: [] },
-	action
-) => {
-	if ( action.type === 'SET_RANDOMIZED_DESIGNS' ) {
-		return action.randomizedDesigns;
-	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
-		return { featured: [] };
-	}
-	return state;
-};
-
 const selectedDesign: Reducer< Design | undefined, OnboardAction > = ( state, action ) => {
 	if ( action.type === 'SET_SELECTED_DESIGN' ) {
 		return action.selectedDesign;
@@ -557,7 +544,6 @@ const reducer = combineReducers( {
 	siteTitle,
 	showSignupDialog,
 	planProductId,
-	randomizedDesigns,
 	hasOnboardingStarted,
 	lastLocation,
 	intent,

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -249,9 +249,6 @@ const goals: Reducer< SiteGoal[], OnboardAction > = ( state = [], action ) => {
 	if ( action.type === 'CLEAR_IMPORT_GOAL' ) {
 		return state.filter( ( goal ) => goal !== SiteGoal.Import );
 	}
-	if ( action.type === 'CLEAR_DIFM_GOAL' ) {
-		return state.filter( ( goal ) => goal !== SiteGoal.DIFM );
-	}
 	if ( [ 'RESET_GOALS', 'RESET_ONBOARD_STORE' ].includes( action.type ) ) {
 		return [];
 	}

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -66,19 +66,6 @@ const selectedFeatures: Reducer< FeatureId[], OnboardAction > = (
 	return state;
 };
 
-const selectedSite: Reducer< number | undefined, OnboardAction > = (
-	state = undefined,
-	action
-) => {
-	if ( action.type === 'SET_SELECTED_SITE' ) {
-		return action.selectedSite;
-	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
-		return undefined;
-	}
-	return state;
-};
-
 const siteTitle: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	if ( action.type === 'SET_SITE_TITLE' ) {
 		return action.siteTitle;
@@ -408,7 +395,6 @@ const reducer = combineReducers( {
 	storeType,
 	selectedDesign,
 	selectedStyleVariation,
-	selectedSite,
 	siteTitle,
 	intent,
 	startingPoint,

--- a/packages/data-stores/src/onboard/reducer.ts
+++ b/packages/data-stores/src/onboard/reducer.ts
@@ -135,16 +135,6 @@ const planCartItem: Reducer< MinimalRequestCartProduct | null, OnboardAction > =
 	return state;
 };
 
-const hasOnboardingStarted: Reducer< boolean, OnboardAction > = ( state = false, action ) => {
-	if ( action.type === 'ONBOARDING_START' ) {
-		return true;
-	}
-	if ( action.type === 'RESET_ONBOARD_STORE' ) {
-		return false;
-	}
-	return state;
-};
-
 const intent: Reducer< string, OnboardAction > = ( state = '', action ) => {
 	if ( action.type === 'SET_INTENT' ) {
 		return action.intent;
@@ -423,7 +413,6 @@ const reducer = combineReducers( {
 	selectedStyleVariation,
 	selectedSite,
 	siteTitle,
-	hasOnboardingStarted,
 	intent,
 	startingPoint,
 	pendingAction,

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -30,7 +30,6 @@ export const getPlanProductId = ( state: State ) => state.planProductId;
 export const getPlanCartItem = ( state: State ) => state.planCartItem;
 export const getProductCartItems = ( state: State ) => state.productCartItems;
 export const getLastLocation = ( state: State ) => state.lastLocation;
-export const getRandomizedDesigns = ( state: State ) => state.randomizedDesigns;
 export const getSelectedDesign = ( state: State ) => state.selectedDesign;
 export const getSelectedStyleVariation = ( state: State ) => state.selectedStyleVariation;
 export const getSelectedDomain = ( state: State ) => state.domain;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -23,7 +23,6 @@ export const getBulkDomainsData = ( state: State ) => {
 	}
 	return domainTransferData;
 };
-export const getPlanProductId = ( state: State ) => state.planProductId;
 export const getPlanCartItem = ( state: State ) => state.planCartItem;
 export const getProductCartItems = ( state: State ) => state.productCartItems;
 export const getSelectedDesign = ( state: State ) => state.selectedDesign;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -28,7 +28,6 @@ export const getProductCartItems = ( state: State ) => state.productCartItems;
 export const getSelectedDesign = ( state: State ) => state.selectedDesign;
 export const getSelectedStyleVariation = ( state: State ) => state.selectedStyleVariation;
 export const getSelectedDomain = ( state: State ) => state.domain;
-export const getSelectedFeatures = ( state: State ) => state.selectedFeatures;
 export const getSelectedSite = ( state: State ) => state.selectedSite;
 export const getSelectedSiteTitle = ( state: State ) => state.siteTitle;
 export const getSelectedSiteLogo = ( state: State ) => state.siteLogo;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -23,8 +23,6 @@ export const getBulkDomainsData = ( state: State ) => {
 	}
 	return domainTransferData;
 };
-export const getBulkDomainsImportDnsRecords = ( state: State ) =>
-	state.shouldImportDomainTransferDnsRecords;
 export const getIsRedirecting = ( state: State ) => state.isRedirecting;
 export const getPlanProductId = ( state: State ) => state.planProductId;
 export const getPlanCartItem = ( state: State ) => state.planCartItem;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -38,7 +38,6 @@ export const getPendingAction = ( state: State ) => state.pendingAction;
 export const getProgress = ( state: State ) => state.progress;
 export const getProgressTitle = ( state: State ) => state.progressTitle;
 export const getGoals = ( state: State ) => state.goals;
-export const getStoreLocationCountryCode = ( state: State ) => state.storeLocationCountryCode;
 export const getEcommerceFlowRecurType = ( state: State ) => state.ecommerceFlowRecurType;
 export const getCouponCode = ( state: State ) => state.couponCode;
 export const getState = ( state: State ) => state;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -53,12 +53,6 @@ export const hasPaidDesign = ( state: State ): boolean => {
 	}
 	return state.selectedDesign.is_premium;
 };
-export const hasPaidDomain = ( state: State ): boolean => {
-	if ( ! state.domain ) {
-		return false;
-	}
-	return ! state.domain.is_free;
-};
 export const hasSiteTitle = ( state: State ) => state.siteTitle.trim().length > 1; // for valid domain results, we need at least 2 characters
 
 // Selectors dependent on other selectors (cannot be put in alphabetical order)

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -33,7 +33,6 @@ export const getSelectedSite = ( state: State ) => state.selectedSite;
 export const getSelectedSiteTitle = ( state: State ) => state.siteTitle;
 export const getSelectedSiteLogo = ( state: State ) => state.siteLogo;
 export const getSelectedSiteDescription = ( state: State ) => state.siteDescription;
-export const getSelectedSiteAccentColor = ( state: State ) => state.siteAccentColor;
 export const getIntent = ( state: State ) => state.intent;
 export const getStartingPoint = ( state: State ) => state.startingPoint;
 export const getStoreType = ( state: State ) => state.storeType;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -23,7 +23,6 @@ export const getBulkDomainsData = ( state: State ) => {
 	}
 	return domainTransferData;
 };
-export const getIsRedirecting = ( state: State ) => state.isRedirecting;
 export const getPlanProductId = ( state: State ) => state.planProductId;
 export const getPlanCartItem = ( state: State ) => state.planCartItem;
 export const getProductCartItems = ( state: State ) => state.productCartItems;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -28,7 +28,6 @@ export const getProductCartItems = ( state: State ) => state.productCartItems;
 export const getSelectedDesign = ( state: State ) => state.selectedDesign;
 export const getSelectedStyleVariation = ( state: State ) => state.selectedStyleVariation;
 export const getSelectedDomain = ( state: State ) => state.domain;
-export const getSelectedSite = ( state: State ) => state.selectedSite;
 export const getSelectedSiteTitle = ( state: State ) => state.siteTitle;
 export const getSelectedSiteLogo = ( state: State ) => state.siteLogo;
 export const getSelectedSiteDescription = ( state: State ) => state.siteDescription;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -44,17 +44,7 @@ export const getStoreLocationCountryCode = ( state: State ) => state.storeLocati
 export const getEcommerceFlowRecurType = ( state: State ) => state.ecommerceFlowRecurType;
 export const getCouponCode = ( state: State ) => state.couponCode;
 export const getState = ( state: State ) => state;
-export const hasPaidDesign = ( state: State ): boolean => {
-	if ( ! state.selectedDesign ) {
-		return false;
-	}
-	return state.selectedDesign.is_premium;
-};
 export const hasSiteTitle = ( state: State ) => state.siteTitle.trim().length > 1; // for valid domain results, we need at least 2 characters
-
-// Selectors dependent on other selectors (cannot be put in alphabetical order)
-export const hasSelectedDesign = ( state: State ) => !! state.selectedDesign;
-
 export const getDomainForm = ( state: State ) => state.domainForm;
 export const getDomainCartItem = ( state: State ) => state.domainCartItem;
 export const getHideFreePlan = ( state: State ) => state.hideFreePlan;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -44,7 +44,6 @@ export const getStoreLocationCountryCode = ( state: State ) => state.storeLocati
 export const getEcommerceFlowRecurType = ( state: State ) => state.ecommerceFlowRecurType;
 export const getCouponCode = ( state: State ) => state.couponCode;
 export const getState = ( state: State ) => state;
-export const hasSiteTitle = ( state: State ) => state.siteTitle.trim().length > 1; // for valid domain results, we need at least 2 characters
 export const getDomainForm = ( state: State ) => state.domainForm;
 export const getDomainCartItem = ( state: State ) => state.domainCartItem;
 export const getHideFreePlan = ( state: State ) => state.hideFreePlan;

--- a/packages/data-stores/src/onboard/selectors.ts
+++ b/packages/data-stores/src/onboard/selectors.ts
@@ -27,7 +27,6 @@ export const getIsRedirecting = ( state: State ) => state.isRedirecting;
 export const getPlanProductId = ( state: State ) => state.planProductId;
 export const getPlanCartItem = ( state: State ) => state.planCartItem;
 export const getProductCartItems = ( state: State ) => state.productCartItems;
-export const getLastLocation = ( state: State ) => state.lastLocation;
 export const getSelectedDesign = ( state: State ) => state.selectedDesign;
 export const getSelectedStyleVariation = ( state: State ) => state.selectedStyleVariation;
 export const getSelectedDomain = ( state: State ) => state.domain;


### PR DESCRIPTION
## Proposed Changes

This PR removes some unused actions, reducers, and selectors from the Onboard store. Spotted as I was working on a few dependency updates.

## Testing Instructions

Verify everything is green and the removed code is not in use.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?