### PR TITLE
Fixes a bug in the WooCommerce logo on the landing page

### DIFF
--- a/client/components/woocommerce-logo/index.jsx
+++ b/client/components/woocommerce-logo/index.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 
 import './style.scss';
 
-function WooCommerceLogo( { className = 'woocommerce-logo', size = 72 } ) {
+function WooCommerceLogo( { className = 'woo-logo', size = 72 } ) {
 	return (
 		<svg className={ className } width={ size } viewBox="0 0 72 43">
 			<path

--- a/client/components/woocommerce-logo/style.scss
+++ b/client/components/woocommerce-logo/style.scss
@@ -1,4 +1,4 @@
-.woocommerce-logo {
+.woo-logo {
 	margin: 0 auto 20px;
 	path {
 		fill: var(--studio-black);


### PR DESCRIPTION
Check this comment: https://github.com/Automattic/wp-calypso/pull/85165#issuecomment-1886551052

When I added a new Woo logo to use as a placeholder in Woo mobile apps, I introduced a conflict in CSS and made the logo on the WooCommerce landing page appear all black. 

This PR removes that conflict, so both logos can coexist without affecting each other.

![Screenshot 2024-01-11 at 11 01 03](https://github.com/Automattic/wp-calypso/assets/1258162/b25e193d-69a0-46be-a70f-f5586bd20ecf)

## Proposed Changes

* Change the class name of the Woo logo so it does not interfere with the long WooCommerce logo.

## Testing Instructions

* Open the live preview and click the WooCommerce menu option
* Verify that the WooCommerce logo is shown correctly

![Screenshot 2024-01-11 at 11 02 39](https://github.com/Automattic/wp-calypso/assets/1258162/a5c668db-b297-4da0-8b06-ce22cd445ced)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?