### PR TITLE
Google My Business: Update Strings to Google Business Profile

### DIFF
--- a/client/blocks/product-purchase-features-list/google-my-business.js
+++ b/client/blocks/product-purchase-features-list/google-my-business.js
@@ -7,11 +7,11 @@ export default localize( ( { selectedSite, translate } ) => {
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail
 				icon={ <img alt="" src={ googleMyBusinessImage } /> }
-				title={ translate( 'Google My Business' ) }
+				title={ translate( 'Google Business Profile' ) }
 				description={ translate(
-					'Create a Google business listing, connect with customers, and discover how customers find you on Google by connecting to a Google My Business location.'
+					'Create a Google business listing, connect with customers, and discover how customers find you on Google by connecting to a Google Business Profile location.'
 				) }
-				buttonText={ translate( 'Connect to Google My Business' ) }
+				buttonText={ translate( 'Connect to Google Business Profile' ) }
 				href={ '/google-my-business/' + selectedSite.slug }
 			/>
 		</div>

--- a/client/blocks/stats-navigation/constants.ts
+++ b/client/blocks/stats-navigation/constants.ts
@@ -72,7 +72,7 @@ const wordads = {
 	showIntervals: true,
 } as NavItem;
 const googleMyBusiness = {
-	label: translate( 'Google My Business' ),
+	label: translate( 'Google Business Profile' ),
 	path: '/google-my-business/stats',
 	showIntervals: false,
 } as NavItem;
@@ -115,5 +115,5 @@ Object.defineProperty( insights, 'label', { get: () => translate( 'Insights' ) }
 Object.defineProperty( store, 'label', { get: () => translate( 'Store' ) } );
 Object.defineProperty( wordads, 'label', { get: () => translate( 'Ads' ) } );
 Object.defineProperty( googleMyBusiness, 'label', {
-	get: () => translate( 'Google My Business' ),
+	get: () => translate( 'Google Business Profile' ),
 } );

--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -624,11 +624,11 @@ export const FEATURES_LIST: FeatureList = {
 
 	[ FEATURE_GOOGLE_MY_BUSINESS ]: {
 		getSlug: () => FEATURE_GOOGLE_MY_BUSINESS,
-		getTitle: () => i18n.translate( 'Google My Business' ),
+		getTitle: () => i18n.translate( 'Google Business Profile' ),
 		getDescription: () =>
 			i18n.translate(
 				'See how customers find you on Google -- and whether they visited your site ' +
-					'and looked for more info on your business -- by connecting to a Google My Business location.'
+					'and looked for more info on your business -- by connecting to a Google Business Profile location.'
 			),
 	},
 

--- a/client/my-sites/google-my-business/new-account/index.js
+++ b/client/my-sites/google-my-business/new-account/index.js
@@ -79,12 +79,12 @@ class GoogleMyBusinessNewAccount extends Component {
 						/>
 
 						<h1 className="gmb-new-account__heading">
-							{ translate( 'It looks like you might be new to Google My Business' ) }
+							{ translate( 'It looks like you might be new to Google Business Profile' ) }
 						</h1>
 
 						<p>
 							{ translate(
-								'Google My Business lists your local business on Google Search and Google Maps. ' +
+								'Google Business Profile lists your local business on Google Search and Google Maps. ' +
 									'It works for businesses that have a physical location, or serve a local area.'
 							) }
 						</p>

--- a/client/my-sites/google-my-business/new-account/index.js
+++ b/client/my-sites/google-my-business/new-account/index.js
@@ -62,7 +62,10 @@ class GoogleMyBusinessNewAccount extends Component {
 		/* eslint-disable wpcalypso/jsx-classname-namespace */
 		return (
 			<Main className="gmb-new-account" wideLayout>
-				<PageViewTracker path="/google-my-business/new/:site" title="Google My Business > New" />
+				<PageViewTracker
+					path="/google-my-business/new/:site"
+					title="Google Business Profile > New"
+				/>
 
 				<DocumentHead title={ translate( 'Google Business Profile' ) } />
 

--- a/client/my-sites/google-my-business/new-account/index.js
+++ b/client/my-sites/google-my-business/new-account/index.js
@@ -64,10 +64,10 @@ class GoogleMyBusinessNewAccount extends Component {
 			<Main className="gmb-new-account" wideLayout>
 				<PageViewTracker path="/google-my-business/new/:site" title="Google My Business > New" />
 
-				<DocumentHead title={ translate( 'Google My Business' ) } />
+				<DocumentHead title={ translate( 'Google Business Profile' ) } />
 
 				<HeaderCake isCompact={ false } alwaysShowActionText={ false } onClick={ this.goBack }>
-					{ translate( 'Google My Business' ) }
+					{ translate( 'Google Business Profile' ) }
 				</HeaderCake>
 
 				<Card>

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -92,7 +92,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 				>
 					{ translate( 'Connect to Google Business Profile', {
 						comment:
-							'Call to Action to connect the site to a business listing in Google My Business',
+							'Call to Action to connect the site to a business listing in Google Business Profile',
 					} ) }
 				</KeyringConnectButton>
 			);

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -158,7 +158,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 			<Main className="gmb-select-business-type" wideLayout>
 				<PageViewTracker
 					path="/google-my-business/select-business-type/:site"
-					title="Google My Business > Select Business Type"
+					title="Google Business Profile > Select Business Type"
 				/>
 
 				<DocumentHead title={ translate( 'Google Business Profile' ) } />

--- a/client/my-sites/google-my-business/select-business-type/index.js
+++ b/client/my-sites/google-my-business/select-business-type/index.js
@@ -90,7 +90,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 					forceReconnect
 					primary
 				>
-					{ translate( 'Connect to Google My Business', {
+					{ translate( 'Connect to Google Business Profile', {
 						comment:
 							'Call to Action to connect the site to a business listing in Google My Business',
 					} ) }
@@ -105,7 +105,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 					onClick={ this.trackCreateListingClick }
 				>
 					{ translate( 'Create Listing', {
-						comment: 'Call to Action to add a business listing to Google My Business',
+						comment: 'Call to Action to add a business listing to Google Business Profile',
 					} ) }{ ' ' }
 					<Gridicon icon="external" />
 				</Button>
@@ -161,14 +161,14 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 					title="Google My Business > Select Business Type"
 				/>
 
-				<DocumentHead title={ translate( 'Google My Business' ) } />
+				<DocumentHead title={ translate( 'Google Business Profile' ) } />
 
 				<QueryKeyringServices />
 				<QuerySiteKeyrings siteId={ siteId } />
 				<QueryKeyringConnections />
 
 				<HeaderCake isCompact={ false } alwaysShowActionText={ false } onClick={ this.goBack }>
-					{ translate( 'Google My Business' ) }
+					{ translate( 'Google Business Profile' ) }
 				</HeaderCake>
 
 				<Card className="gmb-select-business-type__explanation">
@@ -179,7 +179,7 @@ class GoogleMyBusinessSelectBusinessType extends Component {
 
 						<p>
 							{ translate(
-								'{{link}}Google My Business{{/link}} lists your local business on Google Search and Google Maps. ' +
+								'{{link}}Google Business Profile{{/link}} lists your local business on Google Search and Google Maps. ' +
 									'It works for businesses that have a physical location, or serve a local area.',
 								{
 									components: {

--- a/client/my-sites/google-my-business/select-location/index.js
+++ b/client/my-sites/google-my-business/select-location/index.js
@@ -79,7 +79,7 @@ class GoogleMyBusinessSelectLocation extends Component {
 			<Main className="gmb-select-location" wideLayout>
 				<PageViewTracker
 					path="/google-my-business/select-location/:site"
-					title="Google My Business > Select Location"
+					title="Google Business Profile > Select Location"
 				/>
 
 				<DocumentHead title={ translate( 'Google Business Profile' ) } />

--- a/client/my-sites/google-my-business/select-location/index.js
+++ b/client/my-sites/google-my-business/select-location/index.js
@@ -82,14 +82,14 @@ class GoogleMyBusinessSelectLocation extends Component {
 					title="Google My Business > Select Location"
 				/>
 
-				<DocumentHead title={ translate( 'Google My Business' ) } />
+				<DocumentHead title={ translate( 'Google Business Profile' ) } />
 
 				<QueryKeyringServices />
 				<QuerySiteKeyrings siteId={ siteId } />
 				<QueryKeyringConnections />
 
 				<HeaderCake isCompact={ false } alwaysShowActionText={ false } onClick={ this.goBack }>
-					{ translate( 'Google My Business' ) }
+					{ translate( 'Google Business Profile' ) }
 				</HeaderCake>
 
 				<CompactCard>

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -199,7 +199,7 @@ class GoogleMyBusinessStats extends Component {
 			<Main fullWidthLayout>
 				<PageViewTracker
 					path="/google-my-business/stats/:site"
-					title="Google My Business > Stats"
+					title="Google Business Profile > Stats"
 				/>
 
 				<DocumentHead title={ translate( 'Jetpack Stats' ) } />

--- a/client/my-sites/google-my-business/stats/index.js
+++ b/client/my-sites/google-my-business/stats/index.js
@@ -237,7 +237,7 @@ class GoogleMyBusinessStats extends Component {
 						<Notice
 							status="is-error"
 							showDismiss={ false }
-							text={ translate( 'There is an error with your Google My Business account.' ) }
+							text={ translate( 'There is an error with your Google Business Profile account.' ) }
 						>
 							<NoticeAction href={ CALYPSO_CONTACT }>
 								{ translate( 'Contact Support' ) }

--- a/client/my-sites/google-my-business/utils.js
+++ b/client/my-sites/google-my-business/utils.js
@@ -4,7 +4,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 /**
  * Enhances any Redux action that denotes the recording of an analytics event with two additional properties which
- * specify the number of verified and unverified locations of the Google My Business account currently connected.
+ * specify the number of verified and unverified locations of the Google Business Profile account currently connected.
  * @param {Object} action - Redux action as a plain object
  * @param {Function} getState - Redux function that can be used to retrieve the current state tree
  * @returns {Object} the new Redux action

--- a/client/my-sites/marketing/connections/service-description.jsx
+++ b/client/my-sites/marketing/connections/service-description.jsx
@@ -188,13 +188,13 @@ class SharingServiceDescription extends Component {
 			},
 			google_my_business: function () {
 				if ( this.props.numberOfConnections > 0 ) {
-					return this.props.translate( 'Connected to your Google My Business account.', {
-						comment: 'Description for Google My Business when an account is connected',
+					return this.props.translate( 'Connected to your Google Business Profile account.', {
+						comment: 'Description for Google Business Profile when an account is connected',
 					} );
 				}
 
-				return this.props.translate( 'Connect to your Google My Business account.', {
-					comment: 'Description for Google My Business when no account is connected',
+				return this.props.translate( 'Connect to your Google Business Profile account.', {
+					comment: 'Description for Google Business Profile when no account is connected',
 				} );
 			},
 			p2_slack: function () {

--- a/client/my-sites/marketing/connections/service-examples.jsx
+++ b/client/my-sites/marketing/connections/service-examples.jsx
@@ -237,11 +237,13 @@ class SharingServiceExamples extends Component {
 			{
 				image: {
 					src: '/calypso/images/google-my-business/stats-screenshot-cropped.png',
-					alt: this.props.translate( 'Manage Google My Business locations', { textOnly: true } ),
+					alt: this.props.translate( 'Manage Google Business Profile locations', {
+						textOnly: true,
+					} ),
 				},
 				label: this.props.translate(
 					'{{strong}}Connect{{/strong}} to view stats and other useful information from your ' +
-						'Google My Business account inside WordPress.com.',
+						'Google Business Profile account inside WordPress.com.',
 					{
 						components: {
 							strong: <strong />,

--- a/client/my-sites/marketing/connections/services/google-my-business.js
+++ b/client/my-sites/marketing/connections/services/google-my-business.js
@@ -113,7 +113,7 @@ export class GoogleMyBusiness extends SharingService {
 	}
 
 	renderLogo() {
-		// Render a custom logo here because Google My Business is not part of SocialLogos
+		// Render a custom logo here because Google Business Profile is not part of SocialLogos
 		return (
 			<GoogleMyBusinessLogo
 				// eslint-disable-next-line wpcalypso/jsx-classname-namespace

--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -556,7 +556,7 @@ class StatsSite extends Component {
 				{ config.isEnabled( 'stats/paid-wpcom-v2' ) && ! isOdysseyStats && (
 					<QuerySiteFeatures siteIds={ [ siteId ] } />
 				) }
-				{ /* Odyssey: Google My Business pages are currently unsupported. */ }
+				{ /* Odyssey: Google Business Profile pages are currently unsupported. */ }
 				{ ! isOdysseyStats && (
 					<>
 						<QueryKeyringConnections />

--- a/client/state/data-layer/wpcom/sites/stats/google-my-business/test/index.js
+++ b/client/state/data-layer/wpcom/sites/stats/google-my-business/test/index.js
@@ -3,7 +3,7 @@ import { receiveGoogleMyBusinessStats } from 'calypso/state/google-my-business/a
 import { fetchStats, receiveStats } from '..';
 
 describe( '#fetchStats', () => {
-	test( 'should dispatch HTTP request to Google My Business stats endpoint', () => {
+	test( 'should dispatch HTTP request to Google Business Profile stats endpoint', () => {
 		const action = {
 			siteId: 12345,
 			statType: 'queries',

--- a/client/state/google-my-business/ui/actions.js
+++ b/client/state/google-my-business/ui/actions.js
@@ -4,7 +4,7 @@ import 'calypso/state/google-my-business/init';
 
 /**
  * Returns an action object to be used in signalling that the interval of the
- * Google My Business stats chart should change
+ * Google Business Profile stats chart should change
  * @param  {number} siteId Site ID
  * @param  {string} statType 'QUERIES' | 'VIEWS' | 'ACTIONS'
  * @param  {string} interval 'week' | 'month' | 'quarter'

--- a/client/state/google-my-business/ui/selectors.js
+++ b/client/state/google-my-business/ui/selectors.js
@@ -3,7 +3,7 @@ import { get } from 'lodash';
 import 'calypso/state/google-my-business/init';
 
 /**
- * Returns the current interval of a Google My Business stats chart or the
+ * Returns the current interval of a Google Business Profile stats chart or the
  * default value, 'week'
  * @param  {Object} state Global state tree
  * @param  {number} siteId Site ID

--- a/client/state/selectors/get-google-my-business-connected-location.js
+++ b/client/state/selectors/get-google-my-business-connected-location.js
@@ -2,7 +2,7 @@ import { filter, last } from 'lodash';
 import getGoogleMyBusinessLocations from 'calypso/state/selectors/get-google-my-business-locations';
 
 /**
- * Returns the Google My Business location/external user the given site
+ * Returns the Google Business Profile location/external user the given site
  * is connected to
  * @param  {Object} state  Global state tree
  * @param  {?number} siteId The site ID

--- a/client/state/selectors/get-google-my-business-stats-error.js
+++ b/client/state/selectors/get-google-my-business-stats-error.js
@@ -1,7 +1,7 @@
 import { get } from 'lodash';
 
 /**
- * Retrieves Google My Business stats error for the specified criteria.
+ * Retrieves Google Business Profile stats error for the specified criteria.
  * @param {Object} state - Global state tree
  * @param {number} siteId - Id of the site
  * @param {string} statType - Type of metrics (e.g. 'queries')

--- a/client/state/selectors/get-google-my-business-stats.js
+++ b/client/state/selectors/get-google-my-business-stats.js
@@ -1,7 +1,7 @@
 import { get } from 'lodash';
 
 /**
- * Retrieves Google My Business stats for the specified criteria.
+ * Retrieves Google Business Profile stats for the specified criteria.
  * @param {Object} state - Global state tree
  * @param {number} siteId - Id of the site
  * @param {string} statType - Type of metrics (e.g. 'queries')

--- a/client/state/selectors/get-site-user-connections-for-google-my-business.js
+++ b/client/state/selectors/get-site-user-connections-for-google-my-business.js
@@ -10,7 +10,7 @@ function isConnected( keyringConnection, externalUser, siteKeyring ) {
 }
 
 /**
- * Returns a list of site connections to Google My Business keyring.
+ * Returns a list of site connections to Google Business Profile keyring.
  * Given that, in the case of GMB, the id of the keyring connection
  * is stored in the site's settings, there can only be one item in this list.
  * The format of the `connections` returned matches the one returned by
@@ -20,7 +20,7 @@ function isConnected( keyringConnection, externalUser, siteKeyring ) {
  * @returns {Object}        List of GMB connections for this site
  */
 export default function getSiteUserConnectionsForGoogleMyBusiness( state, siteId ) {
-	// Google My Business can only have one location connected at a time
+	// Google Business Profile can only have one location connected at a time
 	const googleMyBusinessSiteKeyring = last(
 		getSiteKeyringsForService( state, siteId, 'google_my_business' )
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #84970

## Proposed Changes

* Replaces "Google My Business" with "Google Business Profile" for users following Google's rebranding of the service 

I've only touched translatable strings because I don't want to mess up any actual code, and I don't want to mess up any analytics either. But also, it seems that's what happens in Calypso when other services are renamed (eg. Twitter) so I don't think that's a problem - let me know if it should be changed though!  

Only other thing that needs updating is the endpoints `/connections` and `/external-services`, which I don't think I can do. 

## Testing Instructions

Should be a case of making sure the code looks sane since it's only strings, and confirming that the strings are updated on Calypso. 

<img width="1076" alt="Screenshot 2024-01-11 at 14 23 00" src="https://github.com/Automattic/wp-calypso/assets/43215253/7431e139-c104-4bde-b738-5c8043c2a6c7">

cc @stephanethomas @creativecoder