### PR TITLE
Enable tracker init to re-run during runtime

### DIFF
--- a/client/blocks/cookie-banner/index.tsx
+++ b/client/blocks/cookie-banner/index.tsx
@@ -2,6 +2,7 @@ import { getTrackingPrefs, setTrackingPrefs } from '@automattic/calypso-analytic
 import { CookieBanner } from '@automattic/privacy-toolset';
 import cookie from 'cookie';
 import { useCallback, useEffect, useState } from 'react';
+import { loadTrackingScripts } from 'calypso/lib/analytics/ad-tracking/load-tracking-scripts';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
 	refreshCountryCodeCookieGdpr,
@@ -38,6 +39,10 @@ const CookieBannerInner = ( { onClose }: { onClose: () => void } ) => {
 			if ( isLoggedIn ) {
 				setUserAdvertisingOptOut( ! buckets.advertising );
 			}
+
+			// Reload tracking scripts once the user consent changed
+			loadTrackingScripts( true );
+
 			onClose();
 		},
 		[ onClose ]

--- a/client/lib/analytics/ad-tracking/load-tracking-scripts.js
+++ b/client/lib/analytics/ad-tracking/load-tracking-scripts.js
@@ -20,11 +20,11 @@ import {
 	GOOGLE_GTM_SCRIPT_URL,
 	WPCOM_CLARITY_URI,
 } from './constants';
-
-// Ensure setup has run.
-import './setup';
+import { setup } from './setup';
 
 export const loadTrackingScripts = attemptLoad( async () => {
+	setup();
+
 	const scripts = getTrackingScriptsToLoad();
 
 	let hasError = false;
@@ -50,6 +50,8 @@ export const loadTrackingScripts = attemptLoad( async () => {
 
 	// uses JSON.stringify for consistency with recordOrder()
 	debug( 'loadTrackingScripts: dataLayer:', JSON.stringify( window.dataLayer, null, 2 ) );
+
+	return scripts;
 } );
 
 function getTrackingScriptsToLoad() {
@@ -167,24 +169,31 @@ function initLoadedTrackingScripts() {
 //   promise, for the current and all previous callers. That effectively implements a queue.
 function attemptLoad( loader ) {
 	let setLoadResult;
+	let loadResult;
 	let status = 'not-loading';
 
-	const loadResult = new Promise( ( resolve ) => {
-		setLoadResult = resolve;
-	} );
+	function initiateLoad() {
+		loadResult = new Promise( ( resolve ) => {
+			setLoadResult = resolve;
+		} );
 
-	return () => {
-		if ( status === 'not-loading' ) {
-			status = 'loading';
-			loader().then(
-				( result ) => {
-					status = 'loaded';
-					setLoadResult( result );
-				},
-				() => {
-					status = 'not-loading';
-				}
-			);
+		loader().then(
+			( result ) => {
+				status = 'loaded';
+				setLoadResult( result );
+			},
+			() => {
+				status = 'not-loading';
+			}
+		);
+	}
+
+	return ( reload = false ) => {
+		if ( status === 'not-loading' || reload ) {
+			if ( reload ) {
+				status = 'not-loading';
+			}
+			initiateLoad();
 		}
 		return loadResult;
 	};

--- a/client/lib/analytics/ad-tracking/setup.js
+++ b/client/lib/analytics/ad-tracking/setup.js
@@ -10,81 +10,85 @@ import {
 	TRACKING_IDS,
 } from './constants';
 
-if ( typeof window !== 'undefined' ) {
-	if ( mayWeInitTracker( 'ga' ) ) {
-		setupGtag();
-	}
+export function setup() {
+	if ( typeof window !== 'undefined' ) {
+		if ( mayWeInitTracker( 'ga' ) ) {
+			setupGtag();
+		}
 
-	// Facebook
-	if ( mayWeInitTracker( 'facebook' ) ) {
-		setupFacebookGlobal();
-	}
+		// Facebook
+		if ( mayWeInitTracker( 'facebook' ) ) {
+			setupFacebookGlobal();
+		}
 
-	// Bing
-	if ( mayWeInitTracker( 'bing' ) && ! window.uetq ) {
-		window.uetq = [];
-	}
+		// Bing
+		if ( mayWeInitTracker( 'bing' ) && ! window.uetq ) {
+			window.uetq = [];
+		}
 
-	// Criteo
-	if ( mayWeInitTracker( 'criteo' ) && ! window.criteo_q ) {
-		window.criteo_q = [];
-	}
+		// Criteo
+		if ( mayWeInitTracker( 'criteo' ) && ! window.criteo_q ) {
+			window.criteo_q = [];
+		}
 
-	// Quantcast
-	if ( mayWeInitTracker( 'quantcast' ) && ! window._qevents ) {
-		window._qevents = [];
-	}
+		// Quantcast
+		if ( mayWeInitTracker( 'quantcast' ) && ! window._qevents ) {
+			window._qevents = [];
+		}
 
-	// Google Ads Gtag for wordpress.com
-	if ( mayWeInitTracker( 'googleAds' ) ) {
-		setupWpcomGoogleAdsGtag();
-	}
+		// Google Ads Gtag for wordpress.com
+		if ( mayWeInitTracker( 'googleAds' ) ) {
+			setupWpcomGoogleAdsGtag();
+		}
 
-	if ( mayWeInitTracker( 'floodlight' ) ) {
-		setupWpcomFloodlightGtag();
-	}
+		if ( mayWeInitTracker( 'floodlight' ) ) {
+			setupWpcomFloodlightGtag();
+		}
 
-	// Twitter
-	if ( mayWeInitTracker( 'twitter' ) ) {
-		setupTwitterGlobal();
-	}
+		// Twitter
+		if ( mayWeInitTracker( 'twitter' ) ) {
+			setupTwitterGlobal();
+		}
 
-	// Linkedin
-	if ( mayWeInitTracker( 'linkedin' ) ) {
-		setupLinkedinInsight(
-			isJetpackCloud() || isJetpackCheckout() ? TRACKING_IDS.jetpackLinkedinId : null
-		);
-	}
+		// Linkedin
+		if ( mayWeInitTracker( 'linkedin' ) ) {
+			setupLinkedinInsight(
+				isJetpackCloud() || isJetpackCheckout() ? TRACKING_IDS.jetpackLinkedinId : null
+			);
+		}
 
-	// Quora
-	if ( mayWeInitTracker( 'quora' ) ) {
-		setupQuoraGlobal();
-	}
+		// Quora
+		if ( mayWeInitTracker( 'quora' ) ) {
+			setupQuoraGlobal();
+		}
 
-	// Outbrain
-	if ( mayWeInitTracker( 'outbrain' ) ) {
-		setupOutbrainGlobal();
-	}
+		// Outbrain
+		if ( mayWeInitTracker( 'outbrain' ) ) {
+			setupOutbrainGlobal();
+		}
 
-	// Pinterest
-	if ( mayWeInitTracker( 'pinterest' ) ) {
-		setupPinterestGlobal();
-	}
+		// Pinterest
+		if ( mayWeInitTracker( 'pinterest' ) ) {
+			setupPinterestGlobal();
+		}
 
-	// AdRoll
-	if ( mayWeInitTracker( 'adroll' ) ) {
-		setupAdRollGlobal();
-	}
+		// AdRoll
+		if ( mayWeInitTracker( 'adroll' ) ) {
+			setupAdRollGlobal();
+		}
 
-	// GTM
-	if ( mayWeInitTracker( 'googleTagManager' ) ) {
-		setupGtmGtag();
-	}
+		// GTM
+		if ( mayWeInitTracker( 'googleTagManager' ) ) {
+			setupGtmGtag();
+		}
 
-	if ( mayWeInitTracker( 'clarity' ) ) {
-		setupClarityGlobal();
+		if ( mayWeInitTracker( 'clarity' ) ) {
+			setupClarityGlobal();
+		}
 	}
 }
+
+setup();
 
 /**
  * Initializes Linkedin tracking.


### PR DESCRIPTION
## Proposed Changes

It appears that trackers do not initialize after the cookie banner is accepted. That means that the first session, even when cookie consent is given, is not tracked at all. As very often (especially for Jetpack and Akismet), the first visit on the domain wordpress.com is due to checkout process - we might be losing tracked conversions and decrease data quality due to this issue.

This PR tries to improve the process of loading trackers so to make it possible to reload once cookie consent is given.

## Testing Instructions

* Go to http://calypso.localhost:3000/checkout/jetpack/jetpack_creator_yearly?flags=ad-tracking,cookie-banner
* Change country cookie to `ES` (or any other european) and reload the site
* The cookie banner should be presented
* Check DOM before accepting; no trackers should be loaded to DOM
* Accept the cookie banner
* All trackers (e.g. `googletagmanager.com`) should be loaded

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?