### PR TITLE
Changes the label for views in Promote Post

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -460,7 +460,7 @@ export default function CampaignItemDetails( props: Props ) {
 
 											{ databarTotal > 0 && (
 												<span className="campaign-item-details__label">
-													{ translate( 'Views' ) }
+													{ translate( 'Visitors' ) }
 												</span>
 											) }
 										</div>

--- a/client/my-sites/promote-post-i2/components/post-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/post-item/index.tsx
@@ -87,8 +87,8 @@ export default function PostItem( { post }: { post: BlazablePost } ) {
 				<div className="post-item__post-data-row post-item__post-data-row-mobile">
 					<div className="post-item__stats-mobile">
 						{ sprintf(
-							// translators: %s is number of post's views
-							_n( '%s view', '%s views', viewCount ),
+							// translators: %s is number of post's visitors
+							_n( '%s visitor', '%s visitors', viewCount ),
 							formatNumber( viewCount, true )
 						) }
 						{ mobileStatsSeparator }

--- a/client/my-sites/promote-post-i2/components/posts-list/header.tsx
+++ b/client/my-sites/promote-post-i2/components/posts-list/header.tsx
@@ -21,7 +21,7 @@ export default function PostsListHeader() {
 		},
 		{
 			id: 'views',
-			title: translate( 'Views' ),
+			title: translate( 'Visitors' ),
 		},
 		{
 			id: 'likes',


### PR DESCRIPTION
This PR changes the label for Views in the Advertising section (Blaze) to Visitors. This change is part of the Woo Blaze project.
![Screenshot 2024-01-11 at 15 00 46](https://github.com/Automattic/wp-calypso/assets/1258162/761bb163-1150-482a-afdf-a9ba0307489f)

![Screenshot 2024-01-11 at 15 01 11](https://github.com/Automattic/wp-calypso/assets/1258162/f4e2b14a-94dd-46c7-8bbe-55ba289ff04c)

![Screenshot 2024-01-11 at 15 00 27](https://github.com/Automattic/wp-calypso/assets/1258162/5fb37deb-1cca-4e18-a72a-b9c3470d7a19)

## Proposed Changes

* Changes the label for Views to Visitors

## Testing Instructions

* Open the live preview and navigate to Tools->Advertising
* Verify that the post page shows the new Visitors label in the table
* Change the screen size to mobile and verify that Visitors is also changed there
* Go to the campaigns page by clicking on the campaigns tab
* Go to the details of any campaign that has some clicks on it
* in the campaign details page, verify that the Visitors label is changed next to the Traffic breakdown section.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?