### PR TITLE
Fix error on manage all domains button

### DIFF
--- a/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
+++ b/client/my-sites/domains/domain-management/list/empty-domains-list-card.jsx
@@ -28,9 +28,9 @@ function EmptyDomainsListCard( { selectedSite, hasDomainCredit, isCompact, hasNo
 	);
 	let secondLine;
 	let action = translate( 'Upgrade to a plan' );
-	let actionURL = `/plans/${ selectedSite.slug }`;
+	let actionURL = `/plans/${ selectedSite?.slug }`;
 	let secondaryAction = translate( 'Just search for a domain' );
-	let secondaryActionURL = domainAddNew( selectedSite.slug );
+	let secondaryActionURL = domainAddNew( selectedSite?.slug );
 	let contentType = 'no_plan';
 
 	const domainRegistrationProduct = useSelector( ( state ) =>


### PR DESCRIPTION
Slack: p1704990654603139-slack-CKZHG0QCR

## Proposed Changes

Going to `/domains/manage/:your-site` and clicking into `Manage all domains` button causes an error.
This PR fixes it.

## Testing Instructions

- Go to `/domains/manage/:your-site`
- Click on the button on the bottom of the page `Manage all domains`
- It should opens the manage all domains page.
