### PR TITLE
Reader recommended posts - replace follow button with post options menu

### DIFF
--- a/client/blocks/reader-post-options-menu/index.jsx
+++ b/client/blocks/reader-post-options-menu/index.jsx
@@ -16,7 +16,9 @@ class ReaderPostOptionsMenu extends Component {
 	static propTypes = {
 		post: PropTypes.object,
 		feed: PropTypes.object,
+		followSource: PropTypes.string,
 		onBlock: PropTypes.func,
+		openSuggestedFollows: PropTypes.func,
 		showFollow: PropTypes.bool,
 		showVisitPost: PropTypes.bool,
 		showEditPost: PropTypes.bool,
@@ -33,11 +35,13 @@ class ReaderPostOptionsMenu extends Component {
 			post,
 			site,
 			feed,
+			followSource,
 			teams,
 			translate,
 			position,
 			posts,
 			onBlock,
+			openSuggestedFollows,
 			showVisitPost,
 			showReportPost,
 			showReportSite,
@@ -73,6 +77,8 @@ class ReaderPostOptionsMenu extends Component {
 					showEditPost={ showEditPost }
 					showFollow={ showFollow }
 					showConversationFollow={ showConversationFollow }
+					openSuggestedFollows={ openSuggestedFollows }
+					followSource={ followSource }
 				/>
 			</span>
 		);

--- a/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
+++ b/client/blocks/reader-post-options-menu/reader-post-ellipsis-menu.jsx
@@ -38,6 +38,7 @@ class ReaderPostEllipsisMenu extends Component {
 	static propTypes = {
 		post: PropTypes.object,
 		feed: PropTypes.object,
+		followSource: PropTypes.string,
 		onBlock: PropTypes.func,
 		openSuggestedFollows: PropTypes.func,
 		showFollow: PropTypes.bool,
@@ -53,6 +54,7 @@ class ReaderPostEllipsisMenu extends Component {
 
 	static defaultProps = {
 		onBlock: noop,
+		followSource: READER_POST_OPTIONS_MENU,
 		openSuggestedFollows: noop,
 		position: 'top left',
 		showFollow: true,
@@ -66,7 +68,7 @@ class ReaderPostEllipsisMenu extends Component {
 
 	openSuggestedFollowsModal = ( shouldOpen ) => {
 		if ( shouldOpen ) {
-			this.props.openSuggestedFollows();
+			this.props.openSuggestedFollows( shouldOpen );
 		}
 	};
 
@@ -263,6 +265,7 @@ class ReaderPostEllipsisMenu extends Component {
 			currentRoute,
 			hasOrganization,
 			isLoggedIn,
+			followSource,
 		} = this.props;
 
 		const { ID: postId, site_ID: siteId } = post;
@@ -298,7 +301,7 @@ class ReaderPostEllipsisMenu extends Component {
 						siteId={ siteId }
 						postId={ postId }
 						post={ post }
-						followSource={ READER_POST_OPTIONS_MENU }
+						followSource={ followSource }
 						followIcon={ ReaderFollowConversationIcon( { iconSize: 20 } ) }
 						followingIcon={ ReaderFollowingConversationIcon( { iconSize: 20 } ) }
 					/>
@@ -308,7 +311,7 @@ class ReaderPostEllipsisMenu extends Component {
 					<ReaderFollowButton
 						tagName={ PopoverMenuItem }
 						siteUrl={ post.feed_URL || post.site_URL }
-						followSource={ READER_POST_OPTIONS_MENU }
+						followSource={ followSource }
 						iconSize={ 20 }
 						followLabel={ translate( 'Subscribe' ) }
 						followingLabel={ translate( 'Unsubscribe' ) }

--- a/client/blocks/reader-related-card/index.jsx
+++ b/client/blocks/reader-related-card/index.jsx
@@ -7,13 +7,11 @@ import { connect } from 'react-redux';
 import ReaderAuthorLink from 'calypso/blocks/reader-author-link';
 import ReaderFeaturedImage from 'calypso/blocks/reader-featured-image';
 import ReaderFeaturedVideo from 'calypso/blocks/reader-featured-video';
+import ReaderPostOptionsMenu from 'calypso/blocks/reader-post-options-menu';
 import ReaderSuggestedFollowsDialog from 'calypso/blocks/reader-suggested-follows/dialog';
 import QueryReaderSite from 'calypso/components/data/query-reader-site';
 import Gravatar from 'calypso/components/gravatar';
 import { areEqualIgnoringWhitespaceAndCase } from 'calypso/lib/string';
-import ReaderFollowFeedIcon from 'calypso/reader/components/icons/follow-feed-icon';
-import ReaderFollowingFeedIcon from 'calypso/reader/components/icons/following-feed-icon';
-import FollowButton from 'calypso/reader/follow-button';
 import { getPostUrl, getStreamUrl } from 'calypso/reader/route';
 import { getPostById } from 'calypso/state/reader/posts/selectors';
 import { getSite } from 'calypso/state/reader/sites/selectors';
@@ -53,13 +51,16 @@ function AuthorAndSiteFollow( { post, site, onSiteClick, followSource, onFollowT
 					</span>
 				) }
 			</div>
-			<FollowButton
-				siteUrl={ post.site_URL }
+			<ReaderPostOptionsMenu
+				showFollow={ true }
+				showConversationFollow={ true }
+				showVisitPost={ true }
+				showEditPost={ false }
+				showReportSite={ true }
+				showReportPost={ true }
+				openSuggestedFollows={ onFollowToggle }
 				followSource={ followSource }
-				railcar={ post.railcar }
-				followIcon={ ReaderFollowFeedIcon( { iconSize: 20 } ) }
-				followingIcon={ ReaderFollowingFeedIcon( { iconSize: 20 } ) }
-				onFollowToggle={ onFollowToggle }
+				post={ post }
 			/>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/pull/86009 - continuing with last scoped improvement

## Proposed Changes

* Replaces the follow button on the related post card with the post options menu.
* Passes followSource and openSuggestedFollows props through to the ellipsis menu, so we can retain the same behavior and tracking events.

BEFORE:
<img width="659" alt="Screenshot 2024-01-11 at 3 06 12 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/179e2752-b1b9-4461-a65e-dfb34baee3b7">



AFTER:

<img width="651" alt="Screenshot 2024-01-11 at 3 03 59 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/ba08e710-91e3-424c-b561-7d30336de140">
<img width="670" alt="Screenshot 2024-01-11 at 3 04 06 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/5409a386-f27a-4185-b56b-c8a00eea0fcf">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch.
* Navigate to the reader.
* Go to your "Recent" feed and scroll down to find a recommended post block. For simplicity in development testing I altered[ this LOC locally](https://github.com/Automattic/wp-calypso/blob/54c371ed8d70c0f0dacd1452f8c50bfb4fd1d550/client/reader/stream/post-lifecycle.jsx#L89) to always run and return null, filling my recent feed with nothing but recommended posts.
* Verify the ellipsis menu is in place and works as expected.
* Verify subscribing to a site via this sends `calypso_reader_site_followed` tracking event with property `source: in-stream-recommendation`. Tracks vigilante may help, or viewing network requests to t.gif.
* Verify the suggested follows modal opens on subscribe.
* Find a standard reader post card in a stream. Verify subscribing via the ellipsis menu here has `calypso_reader_site_followed` tracking event has `source: reader-post-options-menu`. 
* Navigate to the "Search" stream. 
* Verify the subscribing to a site via the ellipsis menu on standard cards sends event `calypso_reader_site_followed` tracking event with property `source: reader-post-options-menu`. 
* Verify the suggested follow dialog opens from the above step.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
