### PR TITLE
Paid Stats - Update stats pricing tooltip copy

### DIFF
--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -1969,7 +1969,9 @@ export const FEATURES_LIST: FeatureList = {
 		getSlug: () => FEATURE_STATS_PAID,
 		getTitle: () => i18n.translate( 'Advanced stats' ),
 		getDescription: () =>
-			i18n.translate( 'Finesse your scaling up strategy with detailed insights and data.' ),
+			i18n.translate(
+				'Deep-dive analytics and conversion data to help you make decisions to grow your site.'
+			),
 	},
 	[ FEATURE_BANDWIDTH ]: {
 		getSlug: () => FEATURE_BANDWIDTH,
@@ -2231,7 +2233,7 @@ export const FEATURES_LIST: FeatureList = {
 		getSlug: () => FEATURE_STATS_JP,
 		getTitle: () => i18n.translate( 'Visitor stats' ),
 		getDescription: () =>
-			i18n.translate( 'At-a-glance and deep-dive data to measure your site’s success.' ),
+			i18n.translate( 'Basic integrated analytics to measure your site’s performance.' ),
 	},
 	[ FEATURE_SPAM_JP ]: {
 		getSlug: () => FEATURE_SPAM_JP,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5130

## Proposed Changes

* This diff updates the pricing tooltips for basic and advanced stats features in the pricing grid.

Advanced stats | Visitor stats
--|--
<img width="1260" alt="Screenshot 2024-01-11 at 3 23 16 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/214577d1-0457-42cc-bac4-2da1dd1d8932">  | <img width="1328" alt="Screenshot 2024-01-11 at 3 23 24 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/08834df0-d8f7-4e87-9d05-c6efe868851b">





## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/plans/:site and view the updated tooltips

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?