### PR TITLE
Domain transfer: replace lookup.icann link with site-profiler

### DIFF
--- a/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
@@ -116,7 +116,7 @@ export default function ConnectDomainStepLogin( {
 									{
 										em: createElement( 'em' ),
 										a: createElement( 'a', {
-											href: 'https://wordpress.com/site-profiler',
+											href: localizeUrl( 'https://wordpress.com/site-profiler' ),
 											target: '_blank',
 										} ),
 									}

--- a/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
+++ b/client/components/domains/connect-domain-step/connect-domain-step-login.jsx
@@ -115,7 +115,10 @@ export default function ConnectDomainStepLogin( {
 									),
 									{
 										em: createElement( 'em' ),
-										a: createElement( 'a', { href: 'https://lookup.icann.org', target: '_blank' } ),
+										a: createElement( 'a', {
+											href: 'https://wordpress.com/site-profiler',
+											target: '_blank',
+										} ),
 									}
 								) }
 							</p>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p7DVsv-iPf-p2#comment-48866

## Proposed Changes

* Replaced lookup.icann.org link with our own site-profiler tool

## Testing Instructions

- Go to domain transfer flow and check the link

<img width="719" alt="Screenshot 2024-01-11 at 23 17 25" src="https://github.com/Automattic/wp-calypso/assets/1241413/8cd1c374-219d-45aa-9ca5-116cc90edd03">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?