### PR TITLE
Stats: fixed some edge cases on the condition showing different products on the purchase page

### DIFF
--- a/client/my-sites/stats/hooks/use-stats-purchases.ts
+++ b/client/my-sites/stats/hooks/use-stats-purchases.ts
@@ -13,7 +13,7 @@ import type { Purchase } from 'calypso/lib/purchases/types';
 
 const JETPACK_STATS_TIERED_BILLING_LIVE_DATE = '2024-01-04T05:30:00+00:00';
 
-const filterPurchasesByProduct = ( ownedPurchases: Purchase[], productSlugs: string[] ) => {
+const filterPurchasesByProducts = ( ownedPurchases: Purchase[], productSlugs: string[] ) => {
 	if ( ! ownedPurchases.length ) {
 		return [];
 	}
@@ -25,7 +25,7 @@ const filterPurchasesByProduct = ( ownedPurchases: Purchase[], productSlugs: str
 };
 
 const isProductOwned = ( ownedPurchases: Purchase[], searchedProduct: string ) => {
-	return filterPurchasesByProduct( ownedPurchases, [ searchedProduct ] ).length > 0;
+	return filterPurchasesByProducts( ownedPurchases, [ searchedProduct ] ).length > 0;
 };
 
 export default function useStatsPurchases( siteId: number | null ) {
@@ -58,7 +58,7 @@ export default function useStatsPurchases( siteId: number | null ) {
 	);
 
 	const isLegacyCommercialLicense = useMemo( () => {
-		const purchases = filterPurchasesByProduct( sitePurchases, [
+		const purchases = filterPurchasesByProducts( sitePurchases, [
 			PRODUCT_JETPACK_STATS_MONTHLY,
 			PRODUCT_JETPACK_STATS_YEARLY,
 			PRODUCT_JETPACK_STATS_BI_YEARLY,

--- a/client/my-sites/stats/hooks/use-stats-purchases.ts
+++ b/client/my-sites/stats/hooks/use-stats-purchases.ts
@@ -11,7 +11,7 @@ import { useSelector } from 'calypso/state';
 import { isFetchingSitePurchases, getSitePurchases } from 'calypso/state/purchases/selectors';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
-const JETPACK_STATS_TIERED_BILLING_LIVE_DATE = '2024-01-04T05:30:00+00:00';
+const JETPACK_STATS_TIERED_BILLING_LIVE_DATE_2024_01_04 = '2024-01-04T05:30:00+00:00';
 
 const filterPurchasesByProducts = ( ownedPurchases: Purchase[], productSlugs: string[] ) => {
 	if ( ! ownedPurchases?.length ) {
@@ -67,7 +67,7 @@ export default function useStatsPurchases( siteId: number | null ) {
 		if ( purchases.length === 0 ) {
 			return false;
 		}
-		return purchases[ 0 ].subscribedDate < JETPACK_STATS_TIERED_BILLING_LIVE_DATE;
+		return purchases[ 0 ].subscribedDate < JETPACK_STATS_TIERED_BILLING_LIVE_DATE_2024_01_04;
 	}, [ sitePurchases ] );
 
 	return {

--- a/client/my-sites/stats/hooks/use-stats-purchases.ts
+++ b/client/my-sites/stats/hooks/use-stats-purchases.ts
@@ -14,7 +14,7 @@ import type { Purchase } from 'calypso/lib/purchases/types';
 const JETPACK_STATS_TIERED_BILLING_LIVE_DATE = '2024-01-04T05:30:00+00:00';
 
 const filterPurchasesByProducts = ( ownedPurchases: Purchase[], productSlugs: string[] ) => {
-	if ( ! ownedPurchases.length ) {
+	if ( ! ownedPurchases?.length ) {
 		return [];
 	}
 

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -231,9 +231,7 @@ const StatsPurchasePage = ( {
 								// blog is commercial, we are forcing a product or the site is not identified yet - show the commercial purchase page
 								// TODO: remove StatsPurchaseWizard component as it's not in use anymore.
 								( ( ! isForceProductRedirect &&
-									( isCommercial || isCommercial === null ) &&
-									// If user has already got a commercial plan, we should not show the PWYW plan.
-									! isCommercialOwned ) ||
+									( isCommercial || isCommercial === null || isCommercialOwned ) ) ||
 									redirectToCommercial ) && (
 									<div className="stats-purchase-page__notice">
 										<StatsSingleItemPagePurchase
@@ -250,7 +248,8 @@ const StatsPurchasePage = ( {
 							}
 							{
 								// blog is personal or we are forcing a product - show the personal purchase page
-								( ( ! isForceProductRedirect && ( isCommercial === false || isCommercialOwned ) ) ||
+								// If user has already got a commercial license, we should not show the PWYW plan.
+								( ( ! isForceProductRedirect && isCommercial === false && ! isCommercialOwned ) ||
 									redirectToPersonal ) && (
 									<StatsSingleItemPersonalPurchasePage
 										siteSlug={ siteSlug || '' }

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -62,6 +62,7 @@ const StatsPurchasePage = ( {
 		isPWYWOwned,
 		isCommercialOwned,
 		supportCommercialUse,
+		isLegacyCommercialLicense,
 	} = useStatsPurchases( siteId );
 
 	useEffect( () => {
@@ -147,7 +148,8 @@ const StatsPurchasePage = ( {
 	// Whether it's forced to redirect to a product
 	const isForceProductRedirect = redirectToPersonal || redirectToCommercial;
 	const noPlanOwned = ! supportCommercialUse && ! isFreeOwned && ! isPWYWOwned;
-	const allowCommercialTierUpgrade = isTierUpgradeSliderEnabled && isCommercialOwned;
+	const allowCommercialTierUpgrade =
+		isTierUpgradeSliderEnabled && isCommercialOwned && ! isLegacyCommercialLicense;
 	// We show purchase page if there is no plan owned or if we are forcing a product redirect
 	const showPurchasePage = noPlanOwned || isForceProductRedirect || allowCommercialTierUpgrade;
 
@@ -228,7 +230,10 @@ const StatsPurchasePage = ( {
 							{
 								// blog is commercial, we are forcing a product or the site is not identified yet - show the commercial purchase page
 								// TODO: remove StatsPurchaseWizard component as it's not in use anymore.
-								( ( ! isForceProductRedirect && ( isCommercial || isCommercial === null ) ) ||
+								( ( ! isForceProductRedirect &&
+									( isCommercial || isCommercial === null ) &&
+									// If user has already got a commercial plan, we should not show the PWYW plan.
+									! isCommercialOwned ) ||
 									redirectToCommercial ) && (
 									<div className="stats-purchase-page__notice">
 										<StatsSingleItemPagePurchase
@@ -245,7 +250,7 @@ const StatsPurchasePage = ( {
 							}
 							{
 								// blog is personal or we are forcing a product - show the personal purchase page
-								( ( ! isForceProductRedirect && isCommercial === false ) ||
+								( ( ! isForceProductRedirect && ( isCommercial === false || isCommercialOwned ) ) ||
 									redirectToPersonal ) && (
 									<StatsSingleItemPersonalPurchasePage
 										siteSlug={ siteSlug || '' }


### PR DESCRIPTION
Related to #

## Proposed Changes

* For legacy commercial license, we show notice "you already have a commercial license..."
* If a user already owns a commercial license, we show him the tier slider rather than still determining his site type

## Testing Instructions

* Open `/stats/purchase/:siteSlug` for a site with legacy commercial license
* Ensure you see the benefit page
<img width="948" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/843d23b5-7497-4f42-ae9a-5bd8357331d7">


* Open `/stats/purchase/:siteSlug` for a site (identified as personal or not identified yet) with tiered commercial license
* Ensure it show the tier slider
<img width="887" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/b661385a-4e64-4efe-98e5-8172762c07f4">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?