### PR TITLE
Stats: return original tiers when usage unavailable

### DIFF
--- a/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
+++ b/client/my-sites/stats/stats-purchase/use-available-upgrade-tiers.tsx
@@ -141,41 +141,46 @@ function useAvailableUpgradeTiers(
 		return MOCK_PLAN_DATA;
 	}
 
-	const currentTierPrice = usageData.current_tier.minimum_price;
+	let tiersForUi = [];
 
-	let tiersForUi = commercialProduct.price_tier_list.map(
-		( tier: PriceTierListItemProps ): StatsPlanTierUI => {
-			// TODO: Some description of transform logic here.
-			// So as to clarify what we should expect from the API.
-			let tierUpgradePrice = 0;
+	// If usage is not available then we do not filter tiers lower than current tier.
+	if ( usageData ) {
+		const currentTierPrice = usageData?.current_tier?.minimum_price;
 
-			// If there is a purchased paid tier,
-			// the upgrade price is the difference between the current tier and the target tier.
-			if ( currentTierPrice && tier.minimum_price > currentTierPrice ) {
-				tierUpgradePrice = tier.minimum_price - currentTierPrice;
-			}
+		tiersForUi = commercialProduct.price_tier_list.map(
+			( tier: PriceTierListItemProps ): StatsPlanTierUI => {
+				// TODO: Some description of transform logic here.
+				// So as to clarify what we should expect from the API.
+				let tierUpgradePrice = 0;
 
-			if ( tier?.maximum_units === null ) {
-				// Special transformation for highest tier extension.
+				// If there is a purchased paid tier,
+				// the upgrade price is the difference between the current tier and the target tier.
+				if ( currentTierPrice && tier.minimum_price > currentTierPrice ) {
+					tierUpgradePrice = tier.minimum_price - currentTierPrice;
+				}
+
+				if ( tier?.maximum_units === null ) {
+					// Special transformation for highest tier extension.
+					return {
+						minimum_price: tier.minimum_price,
+						upgrade_price: tierUpgradePrice,
+						price: tier.minimum_price_monthly_display,
+						views: EXTENSION_THRESHOLD_IN_MILLION * ( tier.transform_quantity_divide_by || 1 ),
+						extension: true,
+						transform_quantity_divide_by: tier.transform_quantity_divide_by,
+						per_unit_fee: tier.per_unit_fee,
+					};
+				}
+
 				return {
 					minimum_price: tier.minimum_price,
 					upgrade_price: tierUpgradePrice,
 					price: tier.minimum_price_monthly_display,
-					views: EXTENSION_THRESHOLD_IN_MILLION * ( tier.transform_quantity_divide_by || 1 ),
-					extension: true,
-					transform_quantity_divide_by: tier.transform_quantity_divide_by,
-					per_unit_fee: tier.per_unit_fee,
+					views: tier.maximum_units,
 				};
 			}
-
-			return {
-				minimum_price: tier.minimum_price,
-				upgrade_price: tierUpgradePrice,
-				price: tier.minimum_price_monthly_display,
-				views: tier.maximum_units,
-			};
-		}
-	);
+		);
+	}
 
 	tiersForUi = tiersForUi.length > 0 ? tiersForUi : MOCK_PLAN_DATA;
 


### PR DESCRIPTION
## Proposed Changes

* Return transformed tiers even when usage is not available, which is useful when it's the siteless flow or on older Jetpack versions.

## Testing Instructions

* Open Calypso Live with the siteless checkout `/stats/purchase` <- without any site slug!
* Ensure the pricing is localized
<img width="1192" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/ef424260-644c-4a2a-8f5c-cdf39cfdb34d">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?