### PR TITLE
Addition of Add new card CTA

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/index.tsx
@@ -1,11 +1,12 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import CardHeading from 'calypso/components/card-heading';
-import Layout from '../layout';
-import LayoutHeader from '../layout/header';
-import LayoutTop from '../layout/top';
-
-import './styles.scss';
+import Layout from 'calypso/jetpack-cloud/components/layout';
+import LayoutHeader, {
+	LayoutHeaderActions as Actions,
+	LayoutHeaderSubtitle as Subtitle,
+	LayoutHeaderTitle as Title,
+} from 'calypso/jetpack-cloud/components/layout/header';
+import LayoutTop from 'calypso/jetpack-cloud/components/layout/top';
 
 export default function PaymentMethodListV2() {
 	const translate = useTranslate();
@@ -19,12 +20,14 @@ export default function PaymentMethodListV2() {
 		<Layout className="payment-method-list" title={ title } wide>
 			<LayoutTop>
 				<LayoutHeader>
-					<CardHeading size={ 36 }>{ title }</CardHeading>
-					<Button href="/partner-portal/payment-methods/add" primary>
-						{ translate( 'Add new card' ) }
-					</Button>
+					<Title>{ title } </Title>
+					<Subtitle>{ subtitle }</Subtitle>
+					<Actions>
+						<Button href="/partner-portal/payment-methods/add" primary>
+							{ translate( 'Add new card' ) }
+						</Button>
+					</Actions>
 				</LayoutHeader>
-				<p className="payment-method-list__description">{ subtitle }</p>
 			</LayoutTop>
 		</Layout>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/index.tsx
@@ -1,10 +1,11 @@
+import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import Layout from 'calypso/jetpack-cloud/components/layout';
-import LayoutHeader, {
-	LayoutHeaderSubtitle as Subtitle,
-	LayoutHeaderTitle as Title,
-} from 'calypso/jetpack-cloud/components/layout/header';
-import LayoutTop from 'calypso/jetpack-cloud/components/layout/top';
+import CardHeading from 'calypso/components/card-heading';
+import Layout from '../layout';
+import LayoutHeader from '../layout/header';
+import LayoutTop from '../layout/top';
+
+import './styles.scss';
 
 export default function PaymentMethodListV2() {
 	const translate = useTranslate();
@@ -18,9 +19,12 @@ export default function PaymentMethodListV2() {
 		<Layout className="payment-method-list" title={ title } wide>
 			<LayoutTop>
 				<LayoutHeader>
-					<Title>{ title } </Title>
-					<Subtitle>{ subtitle }</Subtitle>
+					<CardHeading size={ 36 }>{ title }</CardHeading>
+					<Button href="/partner-portal/payment-methods/add" primary>
+						{ translate( 'Add new card' ) }
+					</Button>
 				</LayoutHeader>
+				<p className="payment-method-list__description">{ subtitle }</p>
 			</LayoutTop>
 		</Layout>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/styles.scss
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/styles.scss
@@ -1,7 +1,0 @@
-.payment-method-list__description {
-	font-size: 1rem;
-	color: var(--studio-gray-60);
-	margin: 0;
-	font-weight: 400;
-	line-height: 1.2;
-}

--- a/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/styles.scss
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/styles.scss
@@ -1,0 +1,7 @@
+.payment-method-list__description {
+	font-size: 1rem;
+	color: var(--studio-gray-60);
+	margin: 0;
+	font-weight: 400;
+	line-height: 1.2;
+}


### PR DESCRIPTION
Add the "Add new card CTA" to the payments method page for Jetpack Manage

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/jetpack-genesis/issues/189


## Proposed Changes

* Update the Payments Method page to use the partner portal styles and add the new "Add new card" CTA in the top right.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Jetpack cloud live link below and go to the new Payment Methods page (/partner-portal/payment-methods/add?flags=jetpack/card-addition-improvements)
* Verify that the styles for the header are now consistent with the other pages in the Purchases
* Verify that the "Add new card" CTA is visible
* Verify that the page is responsive and works as expected for different screen sizes


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
