### PR TITLE
Checkout: Update cart modal messages

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -469,7 +469,7 @@ function returnModalCopy(
 	isRenewal = false,
 	product?: ResponseCartProduct
 ): ModalCopy {
-	const domainNameString = product ? product.meta : 'your selected domain';
+	const domainNameString = product ? product.meta : translate( 'your selected domain' );
 
 	switch ( productType ) {
 		case 'gift purchase':

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -427,7 +427,13 @@ function returnModalCopyForProduct(
 		isPwpoUser
 	);
 	const isRenewal = isWpComProductRenewal( product );
-	return returnModalCopy( productType, translate, createUserAndSiteBeforeTransaction, isRenewal );
+	return returnModalCopy(
+		productType,
+		translate,
+		createUserAndSiteBeforeTransaction,
+		isRenewal,
+		product
+	);
 }
 
 function getProductTypeForModalCopy(
@@ -460,15 +466,18 @@ function returnModalCopy(
 	productType: string,
 	translate: ReturnType< typeof useTranslate >,
 	createUserAndSiteBeforeTransaction: boolean,
-	isRenewal = false
+	isRenewal = false,
+	product?: ResponseCartProduct
 ): ModalCopy {
+	const domainNameString = product ? product.meta : 'your selected domain';
+
 	switch ( productType ) {
 		case 'gift purchase':
 			return {
 				title: String( translate( 'You are about to remove your gift from the cart' ) ),
 				description: String(
 					translate(
-						"When you press Continue, we'll remove all gift products in the cart, and your gift will not be given."
+						'When you press Continue, all gift products in the cart will be removed, and your gift will not be given.'
 					)
 				),
 			};
@@ -478,7 +487,7 @@ function returnModalCopy(
 					title: String( translate( 'You are about to remove your plan renewal from the cart' ) ),
 					description: String(
 						translate(
-							"Since some of your other product(s) depend on your plan to be purchased, they will also be removed from the cart. When you press Continue, we'll remove them along with your plan in the cart, and your plan will keep its current expiry date."
+							'Since some of your other product(s) depend on your plan to be purchased, they will also be removed from the cart. When you press Continue, these product(s) along with your plan renewal will be removed from the cart, and your plan will keep its current expiry date.'
 						)
 					),
 				};
@@ -488,7 +497,7 @@ function returnModalCopy(
 				title: String( translate( 'You are about to remove your plan from the cart' ) ),
 				description: String(
 					translate(
-						"Since some of your other product(s) depend on your plan to be purchased, they will also be removed from the cart. When you press Continue, we'll remove them along with your new plan in the cart, and your site will continue to run its current plan."
+						'Since some of your other product(s) depend on your plan to be purchased, they will also be removed from the cart. When you press Continue, these product(s) along with your new plan will be removed from the cart, and your site will continue to run on its current plan.'
 					)
 				),
 			};
@@ -498,7 +507,7 @@ function returnModalCopy(
 					title: String( translate( 'You are about to remove your plan renewal from the cart' ) ),
 					description: String(
 						translate(
-							'When you press Continue, we will remove your plan renewal from the cart and your plan will keep its current expiry date.'
+							'When you press Continue, your plan renewal will be removed from the cart and your plan will keep its current expiry date.'
 						)
 					),
 				};
@@ -509,13 +518,13 @@ function returnModalCopy(
 			if ( createUserAndSiteBeforeTransaction ) {
 				description = String(
 					translate(
-						'When you press Continue, we will remove your plan from the cart. Your site will be created on the free plan when you complete payment for the other product(s) in your cart.'
+						'When you press Continue, your plan will be removed from the cart. Your site will be created with the free plan when you complete payment for the other product(s) in your cart.'
 					)
 				);
 			} else {
 				description = String(
 					translate(
-						"Since some of your other product(s) depend on your plan to be purchased, they will also be removed from the cart. When you press Continue, we'll remove them along with your new plan in the cart, and your site will continue to run its current plan."
+						'Since some of your other product(s) depend on your plan to be purchased, they will also be removed from the cart. When you press Continue, these product(s) will be removed along with your new plan in the cart, and your site will continue to run with its current plan.'
 					)
 				);
 			}
@@ -527,7 +536,7 @@ function returnModalCopy(
 					title: String( translate( 'You are about to remove your plan renewal from the cart' ) ),
 					description: String(
 						translate(
-							'When you press Continue, we will remove your plan renewal from the cart and your plan will keep its current expiry date.'
+							'When you press Continue, your plan renewal will be removed from the cart and your plan will keep its current expiry date.'
 						)
 					),
 				};
@@ -537,9 +546,9 @@ function returnModalCopy(
 				title: String( translate( 'You are about to remove your plan from the cart' ) ),
 				description: String(
 					createUserAndSiteBeforeTransaction
-						? translate( 'When you press Continue, we will remove your plan from the cart.' )
+						? translate( 'When you press Continue, your plan will be removed from the cart.' )
 						: translate(
-								'When you press Continue, we will remove your plan from the cart and your site will continue to run with its current plan.'
+								'When you press Continue, your plan will be removed from the cart and your site will continue to run with its current plan.'
 						  )
 				),
 			};
@@ -549,17 +558,24 @@ function returnModalCopy(
 					title: String( translate( 'You are about to remove your domain renewal from the cart' ) ),
 					description: String(
 						translate(
-							'When you press Continue, we will remove your domain renewal from the cart and your domain will keep its current expiry date.'
+							'When you press Continue, your domain renewal will be removed from the cart and your domain will keep its current expiry date.'
 						)
 					),
 				};
 			}
 
 			return {
-				title: String( translate( 'You are about to remove your domain from the cart' ) ),
+				title: String(
+					translate( 'You are about to remove %(domainName)s from the cart', {
+						args: { domainName: domainNameString },
+					} )
+				),
 				description: String(
 					translate(
-						'When you press Continue, we will remove your domain from the cart and you will have no claim for the domain name you picked.'
+						'When you press Continue, %(domainName)s will be removed from the cart and will become available for anyone to register.',
+						{
+							args: { domainName: domainNameString },
+						}
 					)
 				),
 			};

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -583,7 +583,7 @@ function returnModalCopy(
 			return {
 				title: String( translate( 'You are about to remove your coupon from the cart' ) ),
 				description: String(
-					translate( 'When you press Continue, we will need you to confirm your payment details.' )
+					translate( 'When you press Continue, you will need to confirm your payment details.' )
 				),
 			};
 		default:
@@ -592,7 +592,7 @@ function returnModalCopy(
 					title: String( translate( 'You are about to remove your renewal from the cart' ) ),
 					description: String(
 						translate(
-							'When you press Continue, we will remove your renewal from the cart and your product will keep its current expiry date.'
+							'When you press Continue, your renewal will be removed from the cart and your product will keep its current expiry date.'
 						)
 					),
 				};
@@ -602,9 +602,9 @@ function returnModalCopy(
 				title: String( translate( 'You are about to remove your product from the cart' ) ),
 				description: String(
 					createUserAndSiteBeforeTransaction
-						? translate( 'When you press Continue, we will remove your product from the cart.' )
+						? translate( 'When you press Continue, your product will be removed from the cart.' )
 						: translate(
-								'When you press Continue, we will remove your product from the cart and your site will continue to run without it.'
+								'When you press Continue, your product will be removed from the cart and your site will continue to run without it.'
 						  )
 				),
 			};


### PR DESCRIPTION
As discussed in https://github.com/Automattic/payments-shilling/issues/2175, the language used for the cart modal message when removing a domain felt a bit odd - this PR attempts to correct that.

| Before | After |
| ----- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/16580129/477b3de6-dd78-464d-bde0-148c5d9ee8ff) | ![image](https://github.com/Automattic/wp-calypso/assets/16580129/7a38fbfd-4f2d-41d0-9ba2-a99fb0d9b7af) |

I used a pretty long test domain, but currently the modal's behavior is to not break words across lines...not sure if this is something we should consider?

Related to https://github.com/Automattic/payments-shilling/issues/2175

## Proposed Changes

* Updates to cart modal warning messages to focus more on the action that is occuring when the customer clicks on 'Continue'
* As for domain's specifically, remove assumption that the customer 'owns' the domain at this point, as the domain hasn't been paid for yet.
* Additionally, I chose to pull in the domain from the cart for the removal modal to emphasize which specific domain was being removed. Please add multiple domains to your cart and try removing each one, the domain you try to remove should be displayed in the modal message.

## Testing Instructions

- Add a variety of different products, both new purchases and renewals, to checkout and click on 'Remove' to trigger to cart warning modal.
- Check that there aren't any obvious errors such as incorrect grammar or spelling.
- Review changes in code to ensure new strings follow a uniform, active, voice and grammar.