### PR TITLE
Design Choices: Update copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/design-choice.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/design-choice.tsx
@@ -1,4 +1,5 @@
 import classnames from 'classnames';
+import { preventWidows } from 'calypso/lib/formatting';
 import './design-choice.scss';
 
 interface Props {
@@ -24,7 +25,7 @@ const DesignChoice = ( {
 		onClick={ () => onSelect( destination ) }
 	>
 		<div className="design-choice__title">{ title }</div>
-		<div className="design-choice__description">{ description }</div>
+		<div className="design-choice__description">{ preventWidows( description ) }</div>
 		<div className="design-choice__image-container">
 			<img src={ imageSrc } alt={ title } />
 		</div>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
@@ -66,7 +66,7 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 							<DesignChoice
 								className="design-choices__design-your-own"
 								title={ translate( 'Design your own' ) }
-								description={ translate( 'Design your site with custom patterns, pages, styles.' ) }
+								description={ translate( 'Design your site with patterns, pages, styles.' ) }
 								imageSrc={ assemblerIllustrationImage }
 								destination="pattern-assembler"
 								onSelect={ handleSubmit }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
@@ -66,9 +66,7 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 							<DesignChoice
 								className="design-choices__design-your-own"
 								title={ translate( 'Design your own' ) }
-								description={ translate(
-									'Design your own homepage with custom styles and pages.'
-								) }
+								description={ translate( 'Design your site with custom patterns, pages, styles.' ) }
 								imageSrc={ assemblerIllustrationImage }
 								destination="pattern-assembler"
 								onSelect={ handleSubmit }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pdtkmj-2iu-p2#comment-4101

## Proposed Changes

* Update copy as requested.

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/a503e162-d566-45c8-8d31-ee5025023977) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/41984f4c-c7d3-4c83-8d87-3ff5df5084e4) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=your_site
* Continue
* Make sure the Design Choices step looks as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?