### PR TITLE
JP Manage: 218 - Attach SingleSellUpsellLightbox to UpsellProductCard

### DIFF
--- a/client/components/data/query-jetpack-partner-portal-partner-key/index.js
+++ b/client/components/data/query-jetpack-partner-portal-partner-key/index.js
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { setActivePartnerKey } from 'calypso/state/partner-portal/partner/actions';
+import {
+	getCurrentPartner,
+	hasActivePartnerKey,
+	hasFetchedPartner,
+	hasJetpackPartnerAccess as hasJetpackPartnerAccessSelector,
+} from 'calypso/state/partner-portal/partner/selectors';
+
+export const useQueryJetpackPartnerKey = () => {
+	const hasJetpackPartnerAccess = useSelector( hasJetpackPartnerAccessSelector );
+	const hasFetched = useSelector( hasFetchedPartner );
+	const partner = useSelector( getCurrentPartner );
+	const hasActiveKey = useSelector( hasActivePartnerKey );
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		if ( ! hasJetpackPartnerAccess || ! hasFetched ) {
+			return;
+		}
+
+		if ( partner && ! hasActiveKey && partner.keys.length > 0 ) {
+			dispatch( setActivePartnerKey( partner.keys[ 0 ].id ) );
+		}
+	}, [ hasJetpackPartnerAccess, hasFetched, partner, hasActiveKey, dispatch ] );
+};
+
+const QueryJetpackPartnerKey = () => {
+	useQueryJetpackPartnerKey();
+	return null;
+};
+
+export default QueryJetpackPartnerKey;

--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -168,6 +168,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 				</ul>
 				<div className="upsell-product-card__price-container">
 					<DisplayPrice
+						isFree={ originalPrice === 0 }
 						discountedPrice={ discountedPrice }
 						currencyCode={ currencyCode }
 						originalPrice={ originalPrice ?? 0 }

--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -12,6 +12,8 @@ import BackupImage from 'calypso/assets/images/jetpack/rna-image-backup.png';
 import DefaultImage from 'calypso/assets/images/jetpack/rna-image-default.png';
 import ScanImage from 'calypso/assets/images/jetpack/rna-image-scan.png';
 import SearchImage from 'calypso/assets/images/jetpack/rna-image-search.png';
+import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
+import QueryJetpackPartnerKey from 'calypso/components/data/query-jetpack-partner-portal-partner-key';
 import DisplayPrice from 'calypso/components/jetpack/card/jetpack-product-card/display-price';
 import JetpackRnaActionCard from 'calypso/components/jetpack/card/jetpack-rna-action-card';
 import SingleSiteUpsellLightbox from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox/single-site-upsell-lightbox';
@@ -23,7 +25,10 @@ import useItemPrice from 'calypso/my-sites/plans/jetpack-plans/use-item-price';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
-import { hasJetpackPartnerAccess as hasJetpackPartnerAccessSelector } from 'calypso/state/partner-portal/partner/selectors';
+import {
+	getCurrentPartner,
+	hasJetpackPartnerAccess as hasJetpackPartnerAccessSelector,
+} from 'calypso/state/partner-portal/partner/selectors';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { getSiteAvailableProduct } from 'calypso/state/sites/products/selectors';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -51,6 +56,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 	const hasJetpackPartnerAccess = useSelector( hasJetpackPartnerAccessSelector );
 	const nonManageCurrencyCode = useSelector( getCurrentUserCurrencyCode );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const partner = useSelector( getCurrentPartner );
 	const item = slugToSelectorProduct( productSlug ) as SelectorProduct;
 	const siteProduct: SiteProduct | undefined = useSelector( ( state ) =>
 		getSiteAvailableProduct( state, siteId, item.productSlug )
@@ -213,6 +219,8 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 			cardImage={ upsellImageUrl }
 			cardImageAlt={ upsellImageAlt }
 		>
+			{ hasJetpackPartnerAccess && ! partner && <QueryJetpackPartnerPortalPartner /> }
+			{ hasJetpackPartnerAccess && <QueryJetpackPartnerKey /> }
 			{ renderProductCardBody() }
 		</JetpackRnaActionCard>
 	);

--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -166,6 +166,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 							</li>
 						) ) }
 				</ul>
+				{ hasJetpackPartnerAccess && <b>{ translate( 'Price per Jetpack Manage license:' ) }</b> }
 				<div className="upsell-product-card__price-container">
 					<DisplayPrice
 						isFree={ originalPrice === 0 }

--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -61,6 +61,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 	let ctaButtonURL: string | undefined;
 	let currencyCode: string | null;
 	let discountedPrice: number | undefined;
+	let discountText: TranslateResult | undefined;
 	let isFetchingPrices: boolean;
 	let manageProduct: APIProductFamilyProduct | undefined;
 	let onCtaButtonClickInternal = onCtaButtonClick;
@@ -106,8 +107,23 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 		discountedPrice = nonManageDiscountedPrice;
 		isFetchingPrices = !! isFetchingNonManagePrices;
 		originalPrice = nonManageOriginalPrice;
+
 		if ( nonManagePriceTierList.length > 0 ) {
 			tooltipText = productTooltip( item, nonManagePriceTierList, currencyCode ?? 'USD' );
+		}
+
+		if ( nonManageOriginalPrice !== undefined && nonManageDiscountedPrice !== undefined ) {
+			const percentDiscount = Math.floor(
+				( ( nonManageOriginalPrice - nonManageDiscountedPrice ) / nonManageOriginalPrice ) * 100
+			);
+			if ( !! percentDiscount && percentDiscount > 0 ) {
+				discountText = translate( '%(percent)d%% off', {
+					args: {
+						percent: percentDiscount,
+					},
+					comment: 'Should be as concise as possible.',
+				} );
+			}
 		}
 	}
 
@@ -117,23 +133,6 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 			context: 'The Jetpack product name, ie- Backup, Scan, Search, etc.',
 		},
 	} );
-
-	const percentDiscount =
-		nonManageOriginalPrice !== undefined && nonManageDiscountedPrice !== undefined
-			? Math.floor(
-					( ( nonManageOriginalPrice - nonManageDiscountedPrice ) / nonManageOriginalPrice ) * 100
-			  )
-			: 0;
-
-	const showDiscountLabel = ! hasJetpackPartnerAccess && !! percentDiscount && percentDiscount > 0;
-	const discountText = showDiscountLabel
-		? translate( '%(percent)d%% off', {
-				args: {
-					percent: percentDiscount,
-				},
-				comment: 'Should be as concise as possible.',
-		  } )
-		: null;
 
 	const upsellImageAlt = translate( 'Buy Jetpack %(productName)s', {
 		args: {
@@ -184,7 +183,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 						productName={ displayName }
 						hideSavingLabel={ false }
 					/>
-					{ showDiscountLabel && ! isFetchingPrices && (
+					{ discountText && ! isFetchingPrices && (
 						<div className="upsell-product-card__discount-label">{ discountText }</div>
 					) }
 				</div>

--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -14,7 +14,7 @@ import ScanImage from 'calypso/assets/images/jetpack/rna-image-scan.png';
 import SearchImage from 'calypso/assets/images/jetpack/rna-image-search.png';
 import DisplayPrice from 'calypso/components/jetpack/card/jetpack-product-card/display-price';
 import JetpackRnaActionCard from 'calypso/components/jetpack/card/jetpack-rna-action-card';
-import SingleSellUpsellLightbox from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox/single-site-upsell-lightbox';
+import SingleSiteUpsellLightbox from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox/single-site-upsell-lightbox';
 import { getPurchaseURLCallback } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import productAboveButtonText from 'calypso/my-sites/plans/jetpack-plans/product-card/product-above-button-text';
 import productTooltip from 'calypso/my-sites/plans/jetpack-plans/product-card/product-tooltip';
@@ -190,7 +190,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 					<p className="upsell-product-card__above-button">{ aboveButtonText }</p>
 				) }
 				{ showLightbox && hasJetpackPartnerAccess && siteId && manageProduct && (
-					<SingleSellUpsellLightbox
+					<SingleSiteUpsellLightbox
 						currentProduct={ manageProduct }
 						onClose={ () => setShowLightbox( false ) }
 						productSlug={ productSlug }

--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -169,7 +169,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 				{ hasJetpackPartnerAccess && <b>{ translate( 'Price per Jetpack Manage license:' ) }</b> }
 				<div className="upsell-product-card__price-container">
 					<DisplayPrice
-						isFree={ originalPrice === 0 }
+						isFree={ ! isFetchingPrices && originalPrice === 0 }
 						discountedPrice={ discountedPrice }
 						currencyCode={ currencyCode }
 						originalPrice={ originalPrice ?? 0 }

--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -7,7 +7,7 @@ import {
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
-import { useMemo, useState } from 'react';
+import { ReactNode, useMemo, useState } from 'react';
 import BackupImage from 'calypso/assets/images/jetpack/rna-image-backup.png';
 import DefaultImage from 'calypso/assets/images/jetpack/rna-image-default.png';
 import ScanImage from 'calypso/assets/images/jetpack/rna-image-scan.png';
@@ -65,6 +65,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 	let manageProduct: APIProductFamilyProduct | undefined;
 	let onCtaButtonClickInternal = onCtaButtonClick;
 	let originalPrice: number;
+	let tooltipText: TranslateResult | ReactNode;
 
 	// Calculate the product price.
 	const {
@@ -105,6 +106,9 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 		discountedPrice = nonManageDiscountedPrice;
 		isFetchingPrices = !! isFetchingNonManagePrices;
 		originalPrice = nonManageOriginalPrice;
+		if ( nonManagePriceTierList.length > 0 ) {
+			tooltipText = productTooltip( item, nonManagePriceTierList, currencyCode ?? 'USD' );
+		}
 	}
 
 	const ctaButtonLabel = translate( 'Add Jetpack %(productName)s', {
@@ -175,11 +179,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 						originalPrice={ originalPrice ?? 0 }
 						pricesAreFetching={ isFetchingPrices }
 						belowPriceText={ item.belowPriceText }
-						tooltipText={
-							! hasJetpackPartnerAccess &&
-							nonManagePriceTierList.length > 0 &&
-							productTooltip( item, nonManagePriceTierList, currencyCode ?? 'USD' )
-						}
+						tooltipText={ tooltipText }
 						billingTerm={ billingTerm }
 						productName={ displayName }
 						hideSavingLabel={ false }

--- a/client/my-sites/backup/backup-upsell/index.tsx
+++ b/client/my-sites/backup/backup-upsell/index.tsx
@@ -13,11 +13,8 @@ import UpsellProductCard from 'calypso/components/jetpack/upsell-product-card';
 import { UpsellComponentProps } from 'calypso/components/jetpack/upsell-switch';
 import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
-import { getPurchaseURLCallback } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 
 import './style.scss';
@@ -67,12 +64,6 @@ const BackupsVPActiveBody: FunctionComponent = () => {
 
 const BackupsUpsellBody: FunctionComponent = () => {
 	const siteId = useSelector( getSelectedSiteId ) || -1;
-	const selectedSiteSlug = useSelector( getSelectedSiteSlug ) || '';
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
-	const createCheckoutURL = getPurchaseURLCallback( selectedSiteSlug, {
-		// For the Backup upsell in Jetpack Cloud, we want to redirect back here to the Backup page after checkout.
-		redirect_to: window.location.href,
-	} );
 	const dispatch = useDispatch();
 
 	const onClick = useCallback(
@@ -89,8 +80,6 @@ const BackupsUpsellBody: FunctionComponent = () => {
 			<UpsellProductCard
 				productSlug={ PRODUCT_JETPACK_BACKUP_T1_YEARLY }
 				siteId={ siteId }
-				currencyCode={ currencyCode }
-				getButtonURL={ createCheckoutURL }
 				onCtaButtonClick={ onClick }
 			/>
 		</>

--- a/client/my-sites/jetpack-search/jetpack-search-upsell/index.tsx
+++ b/client/my-sites/jetpack-search/jetpack-search-upsell/index.tsx
@@ -18,10 +18,8 @@ import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
-import { getPurchaseURLCallback } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
@@ -38,11 +36,6 @@ export default function JetpackSearchUpsell() {
 	);
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
-	const createCheckoutURL = getPurchaseURLCallback( selectedSiteSlug, {
-		// For the Search upsell in Jetpack Cloud, we want to redirect back here to the Search page after checkout.
-		redirect_to: window.location.href,
-	} );
 
 	const WPComUpgradeUrl =
 		'https://jetpack.com/upgrade/search/?utm_campaign=my-sites-jetpack-search&utm_source=calypso&site=' +
@@ -68,8 +61,6 @@ export default function JetpackSearchUpsell() {
 					<UpsellProductCard
 						productSlug={ PRODUCT_JETPACK_SEARCH }
 						siteId={ siteId }
-						currencyCode={ currencyCode }
-						getButtonURL={ createCheckoutURL }
 						onCtaButtonClick={ onClick }
 					/>
 				</div>

--- a/client/my-sites/scan/scan-upsell/index.jsx
+++ b/client/my-sites/scan/scan-upsell/index.jsx
@@ -16,10 +16,7 @@ import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { getPurchaseURLCallback } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 
 import './style.scss';
@@ -65,12 +62,6 @@ function ScanVPActiveBody() {
 
 function ScanUpsellBody() {
 	const siteId = useSelector( getSelectedSiteId ) || -1;
-	const selectedSiteSlug = useSelector( getSelectedSiteSlug ) || '';
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
-	const createCheckoutURL = getPurchaseURLCallback( selectedSiteSlug, {
-		// For the Scan upsell in Jetpack Cloud, we want to redirect back here to the Scan page after checkout.
-		redirect_to: window.location.href,
-	} );
 	const dispatch = useDispatch();
 
 	const onClick = useCallback(
@@ -87,8 +78,6 @@ function ScanUpsellBody() {
 			<UpsellProductCard
 				productSlug={ PRODUCT_JETPACK_SCAN }
 				siteId={ siteId }
-				currencyCode={ currencyCode }
-				getButtonURL={ createCheckoutURL }
 				onCtaButtonClick={ onClick }
 			/>
 		</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves Automattic/jetpack-manage#218

## Proposed Changes

This adjusts the `UpsellProductCard` component so that it shows JP Manage pricing if one has access to JP Manage, and shows a Lightbox with product information if one clicks the button:
![image](https://github.com/Automattic/wp-calypso/assets/32492176/b5c25441-c57f-445e-9405-4e76df293b88)

![image](https://github.com/Automattic/wp-calypso/assets/32492176/aeb30f1c-c566-483f-9ec3-ac7074feb68f)

If one does not have JP Manage pricing, it will behave as before, with the button going to the WordPress.com checkout:

![image](https://github.com/Automattic/wp-calypso/assets/32492176/f4ae86ab-1a26-438a-9d6a-3f18adf596fc)

## Testing Instructions

For best coverage, create a new WP.com account (no Manage access), switch its currency, and then a JN site to it (e.g. via a private browser window). Test all three product upsell pages (Backup, Scan, and Search) and make sure they render as expected.

Then do the same with a WP.com account that has Manage access. The prices should render in USD and the button should open the lightbox.

Edge cases accounted for:
* Free billing code schemes show "free" instead of the "$0.01" placeholder.
* Multi-key partners with no partner/key loaded will now load the partner and then autoload the first key.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
