### PR TITLE
Assembler v2: remove page title from page preview

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview.tsx
@@ -1,4 +1,5 @@
 import { PatternRenderer } from '@automattic/block-renderer';
+import { isEnabled } from '@automattic/calypso-config';
 import { __unstableCompositeItem as CompositeItem } from '@wordpress/components';
 import classnames from 'classnames';
 import { CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -40,6 +41,9 @@ const Page = ( { className, style, patterns, transformPatternHtml }: PageProps )
 	const transformPagePatternHtml = useCallback(
 		( patternHtml: string ) => {
 			const transformedPatternHtml = transformPatternHtml( patternHtml );
+			if ( isEnabled( 'pattern-assembler/v2' ) ) {
+				return transformedPatternHtml;
+			}
 			return prependTitleBlockToPagePattern( transformedPatternHtml, pageTitle );
 		},
 		[ transformPatternHtml, pageTitle ]


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/issues/86265

## Proposed Changes

The [page.html template in Assembler ](https://github.com/Automattic/themes/blob/trunk/assembler/templates/page.html) does not include the page title, so we don't need to prepend it.

|Before|After|
|-|-|
|<img width="1238" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/6fd15db9-c4e6-4a47-908e-378015e31210">|<img width="1238" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/0e0996fa-e2d5-44ec-a7ba-1ac87b3d70e2">|

## Testing Instructions

1. Go to the Assembler v2 flow.
2. In the Add more pages screen, verify that the pages do not show duplicate titles as shown in the screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?