### PR TITLE
Sensei: Support plan slug "creator"

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/sensei-plan-products.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/sensei-plan-products.ts
@@ -43,7 +43,7 @@ export function useBusinessPlanPricing( billingPeriod: PlanBillingPeriod ) {
 	const { supportedPlans } = useSupportedPlans( locale, billingPeriod );
 
 	const businessPlan = supportedPlans.find( ( plan ) => {
-		return plan && 'business' === plan.periodAgnosticSlug;
+		return plan && [ 'business', 'creator' ].includes( plan.periodAgnosticSlug );
 	} );
 
 	const slug = businessPlan?.periodAgnosticSlug;


### PR DESCRIPTION
## Proposed Changes

See p1705045799972909-slack-C029GN3KD. Currently the code looks for a plan with the slug `business` but the API endpoint returns the updated slug `creator`. This PR updates the code to support either.

> [!NOTE]
> There are similar code that needs updating, can be done in a follow up PR. https://github.com/search?q=repo%3AAutomattic%2Fwp-calypso+plan.periodAgnosticSlug&type=code

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/setup/sensei/senseiPlan`.
* Continue until the plan screen.
* Ensure that the price is shown correctly.
* Continue the flow until reaching the checkout cart.
* Ensure that the plan Creator and the product Sensei are both in the cart.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?