### PR TITLE
Assembler: Use featured pages or first page in category on pages screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-category-patterns-map.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-category-patterns-map.ts
@@ -40,7 +40,13 @@ const useCategoryPatternsMap = ( patterns: Pattern[] ) => {
 				const isPage = isPagePattern( pattern );
 
 				insert( allCategoryPatternsMap, category, pattern );
-				if ( isPage && pageCategoryPatternsMap.hasOwnProperty( category ) ) {
+				// @TODO: For the future feature to shuffle pages will have to remove isPriorityPattern( pattern ) from this condition.
+				// It's only being used here just to help testing priority pages as the rest are excluded.
+				if (
+					isPage &&
+					pageCategoryPatternsMap.hasOwnProperty( category ) &&
+					isPriorityPattern( pattern )
+				) {
 					insert( pageCategoryPatternsMap, category, pattern );
 				}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
@@ -1,11 +1,11 @@
 import { useSearchParams } from 'react-router-dom';
 import { INITIAL_PAGES, ORDERED_PATTERN_PAGES_CATEGORIES } from '../constants';
 import { useCategoriesOrder } from '../hooks';
-import { getPagePatternTitle } from '../utils';
+import { getPagePatternTitle, isPriorityPattern } from '../utils';
 import type { Pattern, Category, CustomPageTitle } from '../types';
 
 const usePatternPages = (
-	pagesMapByCategory: Record< string, Pattern[] >,
+	pageCategoryPatternsMap: Record< string, Pattern[] >,
 	categories: Category[],
 	dotcomPatterns: Pattern[]
 ): {
@@ -82,13 +82,17 @@ const usePatternPages = (
 		pageSlugs = INITIAL_PAGES;
 	}
 
+	const getFeaturedPageOrFirstInCategory = ( name: string ) =>
+		pageCategoryPatternsMap[ name ]?.find( isPriorityPattern ) ||
+		pageCategoryPatternsMap[ name ]?.[ 0 ];
+
 	pages = pageSlugs
-		.map( ( slug ) => {
-			const firstPage = pagesMapByCategory[ slug ]?.[ 0 ];
-			if ( firstPage ) {
+		.map( ( name ) => {
+			const page = getFeaturedPageOrFirstInCategory( name );
+			if ( page ) {
 				return {
-					...firstPage,
-					title: getPagePatternTitle( firstPage ),
+					...page,
+					title: getPagePatternTitle( page ),
 				};
 			}
 		} )
@@ -96,12 +100,12 @@ const usePatternPages = (
 
 	pagesToShow = pageCategoriesInOrder
 		.map( ( category: Category ) => {
-			const { name } = category;
-			const firstPage = name && pagesMapByCategory[ name ]?.[ 0 ];
-			if ( firstPage ) {
+			const { name = '' } = category;
+			const page = getFeaturedPageOrFirstInCategory( name );
+			if ( page ) {
 				return {
 					name,
-					title: getPagePatternTitle( firstPage ),
+					title: getPagePatternTitle( page ),
 					isSelected: pageSlugs.includes( name ),
 				};
 			}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/86283

## Proposed Changes

* Use the featured page or the first in each category for the pages screen in assembler

**Assembler V2**

|BEFORE|AFTER (only featured pages)|
|-|-|
|<img width="1222" alt="Screenshot 2567-01-12 at 16 22 41" src="https://github.com/Automattic/wp-calypso/assets/1881481/e880338c-ffb1-4b8e-8cba-2318fadedd8a">|<img width="1221" alt="Screenshot 2567-01-12 at 16 21 49" src="https://github.com/Automattic/wp-calypso/assets/1881481/abf271c1-9587-4d88-9725-5308a521dff7">|


We only see that page because that's the only featured page on the source site.

<img width="1063" alt="Screenshot 2567-01-12 at 16 09 19" src="https://github.com/Automattic/wp-calypso/assets/1881481/476cadf5-50a1-41fe-9ddb-fa075fbc60f6">


**Production**

|BEFORE|AFTER (no changes)|
|-|-|
|<img width="1223" alt="Screenshot 2567-01-12 at 16 25 00" src="https://github.com/Automattic/wp-calypso/assets/1881481/06733ed6-35df-44fb-801f-c36378acd463">|<img width="1223" alt="Screenshot 2567-01-12 at 16 25 00" src="https://github.com/Automattic/wp-calypso/assets/1881481/06733ed6-35df-44fb-801f-c36378acd463">|




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access Assembler pages screen with the flag `pattern-assembler/v2`
* Verify you see only the page "About" because that's the only pattern in the category "Pages" and "Featured"
* Remove the flag and refresh the browser
* Verify you see the same list of pages as on production

Here is a video showing how a featured page from the source site shows in Assembler V2.


https://github.com/Automattic/wp-calypso/assets/1881481/6b2836b2-f692-4765-8b8e-d2bf940c852f



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?