### PR TITLE
Remove the hiding free subdomain test

### DIFF
--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -1,4 +1,4 @@
-import { PLAN_PERSONAL, isFreeWordPressComDomain } from '@automattic/calypso-products';
+import { PLAN_PERSONAL } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Spinner } from '@automattic/components';
 import { VIDEOPRESS_FLOW, isWithThemeFlow, isHostingSignupFlow } from '@automattic/onboarding';
@@ -36,8 +36,7 @@ import {
 	getFixedDomainSearch,
 } from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
-import { ProvideExperimentData, useExperiment } from 'calypso/lib/explat';
-import { logToLogstash } from 'calypso/lib/logstash';
+import { useExperiment } from 'calypso/lib/explat';
 import { getSitePropertyDefaults } from 'calypso/lib/signup/site-properties';
 import { maybeExcludeEmailsStep } from 'calypso/lib/signup/step-actions';
 import wpcom from 'calypso/lib/wp';
@@ -1000,90 +999,65 @@ export class RenderDomainsStep extends Component {
 		const promoTlds = this.props?.queryObject?.tld?.split( ',' ) ?? null;
 
 		return (
-			<ProvideExperimentData
-				name="calypso_gf_signup_onboardingpm_domains_hide_free_subdomain_v2"
-				options={ {
-					isEligible: this.props.flowName === 'onboarding-pm',
-				} }
-			>
-				{ ( isLoadingExperiment, experimentAssignment ) => (
-					<RegisterDomainStep
-						key="domainForm"
-						path={ this.props.path }
-						initialState={ initialState }
-						onAddDomain={ async ( suggestion, position, previousState ) => {
-							if (
-								experimentAssignment?.variationName === 'treatment' &&
-								isFreeWordPressComDomain( suggestion )
-							) {
-								logToLogstash( {
-									feature: 'calypso_client',
-									message:
-										'hide free subdomain test: treatment group has falsely picked a free dotcom subdomain',
-									severity: 'error',
-								} );
-							}
-							await this.handleAddDomain( suggestion, position, previousState );
-						} }
-						onMappingError={ this.handleDomainMappingError }
-						checkDomainAvailabilityPromises={ this.state.checkDomainAvailabilityPromises }
-						isCartPendingUpdate={ this.props.shoppingCartManager.isPendingUpdate }
-						isCartPendingUpdateDomain={ this.state.isCartPendingUpdateDomain }
-						products={ this.props.productsList }
-						basePath={ this.props.path }
-						promoTlds={ promoTlds }
-						mapDomainUrl={ this.getUseYourDomainUrl() }
-						otherManagedSubdomains={ this.props.otherManagedSubdomains }
-						otherManagedSubdomainsCountOverride={ this.props.otherManagedSubdomainsCountOverride }
-						transferDomainUrl={ this.getUseYourDomainUrl() }
-						useYourDomainUrl={ this.getUseYourDomainUrl() }
-						onAddMapping={ this.handleAddMapping.bind( this, { sectionName: 'domainForm' } ) }
-						onSave={ this.handleSave.bind( this, 'domainForm' ) }
-						offerUnavailableOption={ ! this.props.isDomainOnly }
-						isDomainOnly={ this.props.isDomainOnly }
-						analyticsSection={ this.getAnalyticsSection() }
-						domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
-						includeWordPressDotCom={
-							experimentAssignment?.variationName === 'treatment' ? false : includeWordPressDotCom
-						}
-						includeOwnedDomainInSuggestions={ ! this.props.isDomainOnly }
-						includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
-						isSignupStep
-						isPlanSelectionAvailableInFlow={ this.props.isPlanSelectionAvailableLaterInFlow }
-						showExampleSuggestions={ showExampleSuggestions }
-						suggestion={ initialQuery }
-						designType={ this.getDesignType() }
-						vendor={ getSuggestionsVendor( {
-							isSignup: true,
-							isDomainOnly: this.props.isDomainOnly,
-							flowName: this.props.flowName,
-						} ) }
-						deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
-						selectedSite={ this.props.selectedSite }
-						showSkipButton={ this.props.showSkipButton }
-						onSkip={ this.handleSkip }
-						hideFreePlan={ this.handleSkip }
-						forceHideFreeDomainExplainerAndStrikeoutUi={
-							this.props.forceHideFreeDomainExplainerAndStrikeoutUi
-						}
-						isReskinned={ this.props.isReskinned }
-						reskinSideContent={ this.getSideContent() }
-						isInLaunchFlow={ 'launch-site' === this.props.flowName }
-						promptText={
-							this.isHostingFlow()
-								? this.props.translate( 'Stand out with a short and memorable domain' )
-								: undefined
-						}
-						wpcomSubdomainSelected={ this.state.wpcomSubdomainSelected }
-						hasPendingRequests={ isLoadingExperiment }
-						temporaryCart={ this.state.temporaryCart }
-						domainRemovalQueue={ this.state.domainRemovalQueue }
-						forceExactSuggestion={ this.props?.queryObject?.source === 'general-settings' }
-						replaceDomainFailedMessage={ this.state.replaceDomainFailedMessage }
-						dismissReplaceDomainFailed={ this.dismissReplaceDomainFailed }
-					/>
-				) }
-			</ProvideExperimentData>
+			<RegisterDomainStep
+				key="domainForm"
+				path={ this.props.path }
+				initialState={ initialState }
+				onAddDomain={ this.handleAddDomain }
+				onMappingError={ this.handleDomainMappingError }
+				checkDomainAvailabilityPromises={ this.state.checkDomainAvailabilityPromises }
+				isCartPendingUpdate={ this.props.shoppingCartManager.isPendingUpdate }
+				isCartPendingUpdateDomain={ this.state.isCartPendingUpdateDomain }
+				products={ this.props.productsList }
+				basePath={ this.props.path }
+				promoTlds={ promoTlds }
+				mapDomainUrl={ this.getUseYourDomainUrl() }
+				otherManagedSubdomains={ this.props.otherManagedSubdomains }
+				otherManagedSubdomainsCountOverride={ this.props.otherManagedSubdomainsCountOverride }
+				transferDomainUrl={ this.getUseYourDomainUrl() }
+				useYourDomainUrl={ this.getUseYourDomainUrl() }
+				onAddMapping={ this.handleAddMapping.bind( this, { sectionName: 'domainForm' } ) }
+				onSave={ this.handleSave.bind( this, 'domainForm' ) }
+				offerUnavailableOption={ ! this.props.isDomainOnly }
+				isDomainOnly={ this.props.isDomainOnly }
+				analyticsSection={ this.getAnalyticsSection() }
+				domainsWithPlansOnly={ this.props.domainsWithPlansOnly }
+				includeWordPressDotCom={ includeWordPressDotCom }
+				includeOwnedDomainInSuggestions={ ! this.props.isDomainOnly }
+				includeDotBlogSubdomain={ this.shouldIncludeDotBlogSubdomain() }
+				isSignupStep
+				isPlanSelectionAvailableInFlow={ this.props.isPlanSelectionAvailableLaterInFlow }
+				showExampleSuggestions={ showExampleSuggestions }
+				suggestion={ initialQuery }
+				designType={ this.getDesignType() }
+				vendor={ getSuggestionsVendor( {
+					isSignup: true,
+					isDomainOnly: this.props.isDomainOnly,
+					flowName: this.props.flowName,
+				} ) }
+				deemphasiseTlds={ this.props.flowName === 'ecommerce' ? [ 'blog' ] : [] }
+				selectedSite={ this.props.selectedSite }
+				showSkipButton={ this.props.showSkipButton }
+				onSkip={ this.handleSkip }
+				hideFreePlan={ this.handleSkip }
+				forceHideFreeDomainExplainerAndStrikeoutUi={
+					this.props.forceHideFreeDomainExplainerAndStrikeoutUi
+				}
+				isReskinned={ this.props.isReskinned }
+				reskinSideContent={ this.getSideContent() }
+				isInLaunchFlow={ 'launch-site' === this.props.flowName }
+				promptText={
+					this.isHostingFlow()
+						? this.props.translate( 'Stand out with a short and memorable domain' )
+						: undefined
+				}
+				wpcomSubdomainSelected={ this.state.wpcomSubdomainSelected }
+				temporaryCart={ this.state.temporaryCart }
+				domainRemovalQueue={ this.state.domainRemovalQueue }
+				forceExactSuggestion={ this.props?.queryObject?.source === 'general-settings' }
+				replaceDomainFailedMessage={ this.state.replaceDomainFailedMessage }
+				dismissReplaceDomainFailed={ this.dismissReplaceDomainFailed }
+			/>
 		);
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/growth-foundations#212

## Proposed Changes

Since the hiding free subdomain test has been concluded with the recommendation of shipping `control`, this PR cleans up the accompanied code and keeps the `control` behavior.`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the paid media flow, `/start/onboarding-pm`
* Make sure the free subdomain is shown as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
