### PR TITLE
Prevent theme type badge from wrapping long titles

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -721,7 +721,7 @@ class ThemeSheet extends Component {
 	};
 
 	renderThemeBadge = () => {
-		const { siteId, siteSlug, softLaunched, themeId, themeTier, themeType } = this.props;
+		const { siteId, siteSlug, themeId, themeTier, themeType } = this.props;
 
 		const isCommunityTheme = themeType === DOT_ORG_THEME;
 		const isPartnerTheme = themeTier.slug === 'partner';
@@ -731,14 +731,15 @@ class ThemeSheet extends Component {
 			return null;
 		}
 
-		const className = classNames( 'theme__sheet-main-info-type', {
-			'is-soft-launched': softLaunched,
-		} );
 		return config.isEnabled( 'themes/tiers' ) ? (
-			<ThemeTierBadge className={ className } showUpgradeBadge={ false } themeId={ themeId } />
+			<ThemeTierBadge
+				className="theme__sheet-main-info-type"
+				showUpgradeBadge={ false }
+				themeId={ themeId }
+			/>
 		) : (
 			<ThemeTypeBadge
-				className={ className }
+				className="theme__sheet-main-info-type"
 				siteId={ siteId }
 				siteSlug={ siteSlug }
 				themeId={ themeId }

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -223,11 +223,8 @@ $button-border: 4px;
 	}
 
 	.theme__sheet-main-info-type {
+		flex-basis: unset;
 		margin-left: 8px;
-
-		&.is-soft-launched {
-			flex-basis: unset;
-		}
 	}
 
 	.theme__sheet-main-info-tag {

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -224,6 +224,7 @@ $button-border: 4px;
 
 	.theme__sheet-main-info-type {
 		flex-basis: unset;
+		font-family: $sans;
 		margin-left: 8px;
 	}
 


### PR DESCRIPTION
After deploying https://github.com/Automattic/wp-calypso/pull/86241/, I realized that the theme type badge can wrap long theme titles (e.g. https://wordpress.com/theme/pressbook-green/{SITE_SLUG}.wordpress.com):

![image](https://github.com/Automattic/wp-calypso/assets/8511199/f911be71-3523-4b0c-8f9d-52272dd97fa4)

Also, @matt-west [mentioned](https://github.com/Automattic/wp-calypso/pull/86241/#issuecomment-1888717305) that the font is wrong and should be the default sans-serif.

## Proposed Changes

- Fix the wrapped title by unsetting `flex-basis`
- Fix the `font-family` by setting it to `$sans`

## Testing Instructions

1. Open the live preview
2. Go to `/themes`
3. Search for `pressbook green`
4. Open the theme and check that the title is not wrapped:

![image](https://github.com/Automattic/wp-calypso/assets/8511199/964810d4-3d68-4017-90db-7a98fa615af2)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
