### PR TITLE
Stats: Update and reposition benefit listing

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -112,6 +112,11 @@ const PersonalPurchase = ( {
 
 	return (
 		<div>
+			<StatsBenefitsListing
+				subscriptionValue={ subscriptionValue }
+				defaultStartingValue={ defaultStartingValue }
+			/>
+
 			<div className={ `${ COMPONENT_CLASS_NAME }__notice` }>
 				{ translate(
 					'This plan is for non-commercial sites only. Sites with any commercial activity {{Button}}require a commercial license{{/Button}}.',
@@ -155,29 +160,6 @@ const PersonalPurchase = ( {
 					onSliderChange={ handleSliderChanged }
 				/>
 			) }
-
-			<div className={ `${ COMPONENT_CLASS_NAME }__benefits` }>
-				<ul>
-					{ subscriptionValue > 0 ? (
-						<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--included` }>
-							{ translate( 'Instant access to upcoming features' ) }
-						</li>
-					) : (
-						<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--not-included` }>
-							{ translate( 'No access to upcoming features' ) }
-						</li>
-					) }
-					{ subscriptionValue >= defaultStartingValue ? (
-						<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--included` }>
-							{ translate( 'Priority support' ) }
-						</li>
-					) : (
-						<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--not-included` }>
-							{ translate( 'No priority support' ) }
-						</li>
-					) }
-				</ul>
-			</div>
 
 			{ subscriptionValue === 0 && (
 				<div className={ `${ COMPONENT_CLASS_NAME }__persnal-checklist` }>
@@ -265,5 +247,53 @@ const PersonalPurchase = ( {
 		</div>
 	);
 };
+
+interface StatsBenefitsListingProps {
+	subscriptionValue: number;
+	defaultStartingValue: number;
+}
+
+function StatsBenefitsListing( {
+	subscriptionValue,
+	defaultStartingValue,
+}: StatsBenefitsListingProps ) {
+	const translate = useTranslate();
+	return (
+		<div className={ `${ COMPONENT_CLASS_NAME }__benefits` }>
+			<ul>
+				<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--included` }>
+					{ translate( 'Real-time data on visitors' ) }
+				</li>
+				<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--included` }>
+					{ translate( 'Traffic stats and trends for posts and pages' ) }
+				</li>
+				<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--included` }>
+					{ translate( 'Detailed statistics about links leading to your site' ) }
+				</li>
+				<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--included` }>
+					{ translate( 'GDPR compliance' ) }
+				</li>
+				{ subscriptionValue > 0 ? (
+					<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--included` }>
+						{ translate( 'Access to upcoming advanced features' ) }
+					</li>
+				) : (
+					<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--not-included` }>
+						{ translate( 'No access to upcoming advanced features' ) }
+					</li>
+				) }
+				{ subscriptionValue >= defaultStartingValue ? (
+					<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--included` }>
+						{ translate( 'Priority support' ) }
+					</li>
+				) : (
+					<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--not-included` }>
+						{ translate( 'No priority support' ) }
+					</li>
+				) }
+			</ul>
+		</div>
+	);
+}
 
 export default PersonalPurchase;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86128.

## Proposed Changes

* Moves the list of plan benefits higher up the page.
* Expands the listing to match updated designs.

<img width="623" alt="SCR-20240112-qnqs" src="https://github.com/Automattic/wp-calypso/assets/40267301/9b08884f-e2bb-4149-af72-4fc7abfbfbd0">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch Calypso Live link.
* Visit Stats purchase page: `/stats/purchase/SITE-SLUG?flags=stats/checkout-flows-v2`
* Confirm it matches above screenshot.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?