### PR TITLE
Magic login for sites: user bigger icon if available

### DIFF
--- a/client/login/magic-login/request-login-email-form.jsx
+++ b/client/login/magic-login/request-login-email-form.jsx
@@ -174,7 +174,7 @@ class RequestLoginEmailForm extends Component {
 		} = this.props;
 
 		const usernameOrEmail = this.getUsernameOrEmailFromState();
-		const siteIcon = this.state.site?.icon?.ico ?? this.state.site?.icon?.img ?? null;
+		const siteIcon = this.state.site?.icon?.img ?? this.state.site?.icon?.ico ?? null;
 
 		if ( showCheckYourEmail ) {
 			const emailAddress = usernameOrEmail.indexOf( '@' ) > 0 ? usernameOrEmail : null;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

When doing magic login, we show the site's logo if it's available.

Logo should fill 64px area, but `ico` field width was 32px for a Jetpack site, making it look fuzzy. Site logo is bigger, so we should prefer it.

For WP.com simple sites there doesn't seem to be any difference.

**Jetpack site before**

<img width="591" alt="Screenshot 2024-01-12 at 13 28 40" src="https://github.com/Automattic/wp-calypso/assets/87168/1881fa1c-d16c-4665-89e3-d521ebfa317d">
<img width="791" alt="Screenshot 2024-01-12 at 13 12 39" src="https://github.com/Automattic/wp-calypso/assets/87168/3c48c432-2259-4f1c-ac48-e619c3a02ea6">
<img width="197" alt="Screenshot 2024-01-12 at 13 12 20" src="https://github.com/Automattic/wp-calypso/assets/87168/190e117c-03ab-41f2-bd83-07e7af0a0115">


**Jetpack site after**

<img width="590" alt="Screenshot 2024-01-12 at 13 28 51" src="https://github.com/Automattic/wp-calypso/assets/87168/822ed47a-68d4-4bcf-8aa9-857dfc66d52b">

**Wp.com simple site before/after (no difference)**

<img width="776" alt="Screenshot 2024-01-12 at 13 34 09" src="https://github.com/Automattic/wp-calypso/assets/87168/4e3c862b-8628-44a3-ab90-7868f6bf0a6a">


## Proposed Changes

* Prefer `img` as logo over `ico`


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Upload icon for your site from customizer, or WP.com settings 
* Open magic login page for a site, e.g. `http://calypso.localhost:3000/log-in/link?redirect_to=https%3A%2F%2Fsubscribe.wordpress.com%2Fmemberships%2Fjwt%2F%3Fsite_id%3D213158433%26redirect_url%3Dhttps%253A%252F%252Fsimison.jurassic.tube%252Fwp-json%252Fjetpack%252Fv4%252Fsubscribers%252Fauth%253Fredirect_url%253Dhttps%253A%252F%252Fsimison.jurassic.tube%252F2023%252F12%252F18%252Fpost%252F&blog_id=213158433` — replace blog ID with your own Jetpack blog ID
* Previously we loaded smaller file
* Now we load bigger image

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
