### PR TITLE
Checkout: fix contact detail validation styling

### DIFF
--- a/client/my-sites/checkout/src/components/wp-contact-form.tsx
+++ b/client/my-sites/checkout/src/components/wp-contact-form.tsx
@@ -9,16 +9,23 @@ import type { CountryListItem, ContactDetailsType } from '@automattic/wpcom-chec
 const BillingFormFields = styled.div`
 	margin-bottom: 16px;
 
-	.form-input-validation {
+	& .form-input-validation {
 		padding: 6px 6px 11px;
 	}
 
-	.form-input-validation .gridicon {
+	& .form-input-validation .gridicon,
+	& .form-input-validation svg {
 		float: none;
 		margin-left: 0;
+		margin-right: 2px;
 		width: 18px;
 		vertical-align: text-top;
 		height: 18px;
+
+		.rtl & {
+			margin-left: 2px;
+			margin-right: 0;
+		}
 	}
 `;
 


### PR DESCRIPTION
The inline styling for `BillingFormFields` is missing an `&` to denote the parent-child relationship to its child components (used to style the form validation messages). This ultimately means that the styles weren't being applied to anything. This diff adds the `&`.

See: p1705053878136189-slack-C0117V2PCAE

| Before      | After |
| ----------- | ----------- |
| <img width="679" alt="Screenshot 2024-01-12 at 9 23 55 AM" src="https://github.com/Automattic/wp-calypso/assets/942359/3afd7218-ad78-44ab-9244-1c8fb0b26fcd">      | <img width="657" alt="Screenshot 2024-01-12 at 9 36 17 AM" src="https://github.com/Automattic/wp-calypso/assets/942359/238d1ce9-858b-40ea-a5ce-00d67b442c08">      |

**To test:**
- for a new user or an existing user without billing information
- add a domain to your cart and visit checkout
- attempt to submit the billing information step without filling out the fields
- verify that the validation error looks correct