### PR TITLE
Delete Site: Redirect to /sites instead of /read after deleting the site-fix

### DIFF
--- a/client/root.js
+++ b/client/root.js
@@ -88,8 +88,8 @@ async function getLoggedInLandingPage( { dispatch, getState } ) {
 	const primarySiteSlug = getSiteSlug( getState(), primarySiteId );
 
 	if ( ! primarySiteSlug ) {
-		// there is no primary site or the site info couldn't be fetched. Redirect to Reader.
-		return '/read';
+		// there is no primary site or the site info couldn't be fetched. Redirect to Sites Dashboard.
+		return '/sites';
 	}
 
 	const isCustomerHomeEnabled = canCurrentUserUseCustomerHome( getState(), primarySiteId );

--- a/client/test/root-section.ts
+++ b/client/test/root-section.ts
@@ -36,13 +36,13 @@ describe( 'Logged Out Landing Page', () => {
 } );
 
 describe( 'Logged In Landing Page', () => {
-	test( 'user with no sites goes to reader', async () => {
+	test( 'user with no sites goes to Sites Dashboard', async () => {
 		const state = { currentUser: { id: 1 }, sites: { items: {} } };
 		const { page } = initRouter( { state } );
 
 		page( '/' );
 
-		await waitFor( () => expect( page.current ).toBe( '/read' ) );
+		await waitFor( () => expect( page.current ).toBe( '/sites' ) );
 	} );
 
 	test( 'user with a primary site but no permissions goes to stats', async () => {

--- a/test/e2e/specs/onboarding/signup__wpcc.ts
+++ b/test/e2e/specs/onboarding/signup__wpcc.ts
@@ -68,7 +68,7 @@ describe( DataHelper.createSuiteTitle( 'Signup: WordPress.com WPCC' ), function 
 			// Waiting for `networkidle` is required so Calypso loading won't swallow up
 			// the click on navbar in the Close Account steps.
 			await Promise.all( [
-				page.waitForNavigation( { url: '**/read', waitUntil: 'load' } ),
+				page.waitForNavigation( { url: '**/sites', waitUntil: 'load' } ),
 				page.goto( DataHelper.getCalypsoURL() ),
 			] );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5101

## Proposed Changes

It's the same as https://github.com/Automattic/wp-calypso/pull/86345. 
But I had to redo that, as there was a pre-release test that was failing.

## Testing Instructions
See https://github.com/Automattic/wp-calypso/pull/86345
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?