### PR TITLE
Checkout: Add list of discounts to sidebar

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -1,0 +1,172 @@
+import { FormStatus, useFormStatus, Button } from '@automattic/composite-checkout';
+import formatCurrency from '@automattic/format-currency';
+import { hasCheckoutVersion } from '@automattic/wpcom-checkout';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import type { Theme } from '@automattic/composite-checkout';
+import type { ResponseCart, RemoveCouponFromCart } from '@automattic/shopping-cart';
+
+const CostOverridesListStyle = styled.div`
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	font-size: 12px;
+	font-weight: 400;
+	margin-top: 10px;
+
+	& .cost-overrides-list-item {
+		display: grid;
+		justify-content: space-between;
+		grid-template-columns: auto auto;
+		margin-top: 4px;
+	}
+
+	& .cost-overrides-list-item--coupon {
+		margin-top: 16px;
+	}
+
+	& .cost-overrides-list-item:nth-of-type( 1 ) {
+		margin-top: 0;
+	}
+
+	& .cost-overrides-list-item__actions {
+		grid-column: 1 / span 2;
+		display: flex;
+		justify-content: flex-end;
+	}
+
+	& .cost-overrides-list-item__actions-remove {
+		color: #787c82;
+	}
+
+	& .cost-overrides-list-item__reason {
+		color: #008a20;
+	}
+
+	& .cost-overrides-list-item__discount {
+		white-space: nowrap;
+	}
+`;
+
+const DeleteButton = styled( Button )< { theme?: Theme } >`
+	width: auto;
+	font-size: ${ hasCheckoutVersion( '2' ) ? '14px' : 'inherit' };
+	color: ${ ( props ) => props.theme.colors.textColorLight };
+`;
+
+export interface CostOverrideForDisplay {
+	humanReadableReason: string;
+	overrideCode: string;
+	discountAmount: number;
+}
+
+export function filterAndGroupCostOverridesForDisplay(
+	responseCart: ResponseCart
+): CostOverrideForDisplay[] {
+	// Collect cost overrides from each line item and group them by type so we
+	// can show them all together after the line item list.
+	const costOverridesGrouped = responseCart.products.reduce<
+		Record< string, CostOverrideForDisplay >
+	>( ( grouped, product ) => {
+		const costOverrides = product?.cost_overrides;
+		if ( ! costOverrides ) {
+			return grouped;
+		}
+
+		costOverrides.forEach( ( costOverride ) => {
+			if ( costOverride.does_override_original_cost ) {
+				// We won't display original cost overrides since they are
+				// included in the original cost that's being displayed. They
+				// are not discounts.
+				return;
+			}
+			const discountAmount = grouped[ costOverride.override_code ]?.discountAmount ?? 0;
+			const newDiscountAmount =
+				costOverride.old_subtotal_integer - costOverride.new_subtotal_integer;
+			grouped[ costOverride.override_code ] = {
+				humanReadableReason: costOverride.human_readable_reason,
+				overrideCode: costOverride.override_code,
+				discountAmount: discountAmount + newDiscountAmount,
+			};
+		} );
+		return grouped;
+	}, {} );
+	return Object.values( costOverridesGrouped );
+}
+
+export function CostOverridesList( {
+	costOverridesList,
+	currency,
+	removeCoupon,
+	couponCode,
+	creditsInteger,
+}: {
+	costOverridesList: Array< CostOverrideForDisplay >;
+	currency: string;
+	removeCoupon: RemoveCouponFromCart;
+	couponCode: ResponseCart[ 'coupon' ];
+	creditsInteger: number;
+} ) {
+	const translate = useTranslate();
+	// Let's put the coupon code last because it will have its own "Remove" button.
+	const nonCouponOverrides = costOverridesList.filter(
+		( override ) => override.overrideCode !== 'coupon-discount'
+	);
+	const couponOverrides = costOverridesList.filter(
+		( override ) => override.overrideCode === 'coupon-discount'
+	);
+	const { formStatus } = useFormStatus();
+	const isDisabled = formStatus !== FormStatus.READY;
+	return (
+		<CostOverridesListStyle>
+			{ nonCouponOverrides.map( ( costOverride ) => {
+				return (
+					<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
+						<span className="cost-overrides-list-item__reason">
+							{ costOverride.humanReadableReason }
+						</span>
+						<span className="cost-overrides-list-item__discount">
+							{ formatCurrency( -costOverride.discountAmount, currency, { isSmallestUnit: true } ) }
+						</span>
+					</div>
+				);
+			} ) }
+			{ creditsInteger > 0 && (
+				<div className="cost-overrides-list-item" key="credits-override">
+					<span className="cost-overrides-list-item__reason">{ translate( 'Credits' ) }</span>
+					<span className="cost-overrides-list-item__discount">
+						{ formatCurrency( -creditsInteger, currency, { isSmallestUnit: true } ) }
+					</span>
+				</div>
+			) }
+			{ couponOverrides.map( ( costOverride ) => {
+				return (
+					<div
+						className="cost-overrides-list-item cost-overrides-list-item--coupon"
+						key={ costOverride.humanReadableReason }
+					>
+						<span className="cost-overrides-list-item__reason">
+							{ couponCode.length > 0
+								? translate( 'Coupon: %(couponCode)s', { args: { couponCode } } )
+								: costOverride.humanReadableReason }
+						</span>
+						<span className="cost-overrides-list-item__discount">
+							{ formatCurrency( -costOverride.discountAmount, currency, { isSmallestUnit: true } ) }
+						</span>
+						<span className="cost-overrides-list-item__actions">
+							<DeleteButton
+								buttonType="text-button"
+								disabled={ isDisabled }
+								className="cost-overrides-list-item__actions-remove"
+								onClick={ removeCoupon }
+								aria-label={ translate( 'Remove coupon' ) }
+							>
+								{ translate( 'Remove' ) }
+							</DeleteButton>
+						</span>
+					</div>
+				);
+			} ) }
+		</CostOverridesListStyle>
+	);
+}

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -13,6 +13,7 @@ const CostOverridesListStyle = styled.div`
 	font-size: 12px;
 	font-weight: 400;
 	margin-top: 10px;
+	margin-bottom: 20px;
 
 	& .cost-overrides-list-item {
 		display: grid;

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -104,7 +104,7 @@ export function CostOverridesList( {
 }: {
 	costOverridesList: Array< CostOverrideForDisplay >;
 	currency: string;
-	removeCoupon: RemoveCouponFromCart;
+	removeCoupon?: RemoveCouponFromCart;
 	couponCode: ResponseCart[ 'coupon' ];
 	creditsInteger: number;
 } ) {
@@ -140,34 +140,54 @@ export function CostOverridesList( {
 					</span>
 				</div>
 			) }
-			{ couponOverrides.map( ( costOverride ) => {
-				return (
-					<div
-						className="cost-overrides-list-item cost-overrides-list-item--coupon"
-						key={ costOverride.humanReadableReason }
-					>
-						<span className="cost-overrides-list-item__reason">
-							{ couponCode.length > 0
-								? translate( 'Coupon: %(couponCode)s', { args: { couponCode } } )
-								: costOverride.humanReadableReason }
-						</span>
-						<span className="cost-overrides-list-item__discount">
-							{ formatCurrency( -costOverride.discountAmount, currency, { isSmallestUnit: true } ) }
-						</span>
-						<span className="cost-overrides-list-item__actions">
-							<DeleteButton
-								buttonType="text-button"
-								disabled={ isDisabled }
-								className="cost-overrides-list-item__actions-remove"
-								onClick={ removeCoupon }
-								aria-label={ translate( 'Remove coupon' ) }
-							>
-								{ translate( 'Remove' ) }
-							</DeleteButton>
-						</span>
-					</div>
-				);
-			} ) }
+			{ ! removeCoupon &&
+				couponOverrides.map( ( costOverride ) => {
+					return (
+						<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
+							<span className="cost-overrides-list-item__reason">
+								{ couponCode.length > 0
+									? translate( 'Coupon: %(couponCode)s', { args: { couponCode } } )
+									: costOverride.humanReadableReason }
+							</span>
+							<span className="cost-overrides-list-item__discount">
+								{ formatCurrency( -costOverride.discountAmount, currency, {
+									isSmallestUnit: true,
+								} ) }
+							</span>
+						</div>
+					);
+				} ) }
+			{ removeCoupon &&
+				couponOverrides.map( ( costOverride ) => {
+					return (
+						<div
+							className="cost-overrides-list-item cost-overrides-list-item--coupon"
+							key={ costOverride.humanReadableReason }
+						>
+							<span className="cost-overrides-list-item__reason">
+								{ couponCode.length > 0
+									? translate( 'Coupon: %(couponCode)s', { args: { couponCode } } )
+									: costOverride.humanReadableReason }
+							</span>
+							<span className="cost-overrides-list-item__discount">
+								{ formatCurrency( -costOverride.discountAmount, currency, {
+									isSmallestUnit: true,
+								} ) }
+							</span>
+							<span className="cost-overrides-list-item__actions">
+								<DeleteButton
+									buttonType="text-button"
+									disabled={ isDisabled }
+									className="cost-overrides-list-item__actions-remove"
+									onClick={ removeCoupon }
+									aria-label={ translate( 'Remove coupon' ) }
+								>
+									{ translate( 'Remove' ) }
+								</DeleteButton>
+							</span>
+						</div>
+					);
+				} ) }
 		</CostOverridesListStyle>
 	);
 }

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -7,8 +7,8 @@ import {
 	NonProductLineItem,
 	hasCheckoutVersion,
 	LineItemType,
-	getCouponLineItemFromCart,
-	getSubtotalWithoutCoupon,
+	getSubtotalWithoutDiscounts,
+	getTotalDiscountsWithoutCredits,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -88,14 +88,25 @@ export default function BeforeSubmitCheckoutHeader() {
 	const { responseCart } = useShoppingCart( cartKey );
 	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
-	const couponLineItem = getCouponLineItemFromCart( responseCart );
 	const translate = useTranslate();
-	const subtotalWithoutCoupon = getSubtotalWithoutCoupon( responseCart );
+
+	const totalDiscount = getTotalDiscountsWithoutCredits( responseCart );
+	const discountLineItem: LineItemType = {
+		id: 'total-discount',
+		type: 'subtotal',
+		label: translate( 'Discounts' ),
+		formattedAmount: formatCurrency( totalDiscount, responseCart.currency, {
+			isSmallestUnit: true,
+			stripZeros: true,
+		} ),
+	};
+
+	const subtotalBeforeDiscounts = getSubtotalWithoutDiscounts( responseCart );
 	const subTotalLineItemWithoutCoupon: LineItemType = {
 		id: 'subtotal-without-coupon',
 		type: 'subtotal',
-		label: translate( 'Subtotal' ),
-		formattedAmount: formatCurrency( subtotalWithoutCoupon, responseCart.currency, {
+		label: translate( 'Subtotal before discounts' ),
+		formattedAmount: formatCurrency( subtotalBeforeDiscounts, responseCart.currency, {
 			isSmallestUnit: true,
 			stripZeros: true,
 		} ),
@@ -113,7 +124,7 @@ export default function BeforeSubmitCheckoutHeader() {
 				<WPOrderReviewSection>
 					<NonTotalPrices>
 						<NonProductLineItem subtotal lineItem={ subTotalLineItemWithoutCoupon } />
-						{ couponLineItem && <NonProductLineItem subtotal lineItem={ couponLineItem } /> }
+						<NonProductLineItem subtotal lineItem={ discountLineItem } />
 						{ taxLineItems.map( ( taxLineItem ) => (
 							<NonProductLineItem key={ taxLineItem.id } tax lineItem={ taxLineItem } />
 						) ) }

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -90,7 +90,7 @@ export default function BeforeSubmitCheckoutHeader() {
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const translate = useTranslate();
 
-	const totalDiscount = getTotalDiscountsWithoutCredits( responseCart );
+	const totalDiscount = getTotalDiscountsWithoutCredits( responseCart, translate );
 	const discountLineItem: LineItemType = {
 		id: 'total-discount',
 		type: 'subtotal',

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -31,6 +31,7 @@ import {
 	hasCheckoutVersion,
 	getSubtotalWithCredits,
 	doesPurchaseHaveFullCredits,
+	getSubtotalWithoutDiscounts,
 } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -135,21 +136,13 @@ function CheckoutSummaryPriceList() {
 		? responseCart.sub_total_with_taxes_integer
 		: responseCart.credits_integer;
 
-	const subtotalBeforeDiscounts = responseCart.products.reduce( ( total, product ) => {
-		// We can't sum the original price for introductory offers because they
-		// are not cost overrides and their original price is actually a later
-		// price that will be charged after the offer ends.
-		if ( product.introductory_offer_terms?.enabled ) {
-			return product.item_subtotal_integer + total;
-		}
-		return product.item_original_subtotal_integer + total;
-	}, 0 );
+	const subtotalBeforeDiscounts = getSubtotalWithoutDiscounts( responseCart );
 
 	return (
 		<>
 			{ ! hasCheckoutVersion( '2' ) && (
 				<CheckoutFirstSubtotalLineItem key="checkout-summary-line-item-subtotal-one">
-					<span>{ translate( 'Products' ) }</span>
+					<span>{ translate( 'Subtotal before discounts' ) }</span>
 					<span>
 						{ formatCurrency( subtotalBeforeDiscounts, responseCart.currency, {
 							isSmallestUnit: true,

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -26,12 +26,10 @@ import { formatCurrency } from '@automattic/format-currency';
 import { isNewsletterOrLinkInBioFlow, isAnyHostingFlow } from '@automattic/onboarding';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import {
-	getCouponLineItemFromCart,
 	getTaxBreakdownLineItemsFromCart,
 	getTotalLineItemFromCart,
 	hasCheckoutVersion,
 	getCreditsLineItemFromCart,
-	getSubtotalWithoutCoupon,
 	getSubtotalWithCredits,
 	doesPurchaseHaveFullCredits,
 } from '@automattic/wpcom-checkout';
@@ -127,12 +125,10 @@ export default function WPCheckoutOrderSummary( {
 function CheckoutSummaryPriceList() {
 	const cartKey = useCartKey();
 	const { responseCart, removeCoupon } = useShoppingCart( cartKey );
-	const couponLineItem = getCouponLineItemFromCart( responseCart );
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
 	const totalLineItem = getTotalLineItemFromCart( responseCart );
 	const translate = useTranslate();
-	const subtotalWithoutCoupon = getSubtotalWithoutCoupon( responseCart );
 	const subtotalWithCredits = getSubtotalWithCredits( responseCart );
 	const costOverridesList = filterAndGroupCostOverridesForDisplay( responseCart );
 	const isFullCredits = doesPurchaseHaveFullCredits( responseCart );
@@ -156,22 +152,12 @@ function CheckoutSummaryPriceList() {
 				<CheckoutSummaryLineItem key="checkout-summary-line-item-subtotal">
 					<span>{ translate( 'Subtotal' ) }</span>
 					<span>
-						{ formatCurrency(
-							hasCheckoutVersion( '2' ) ? subtotalWithCredits : subtotalWithoutCoupon,
-							responseCart.currency,
-							{
-								isSmallestUnit: true,
-								stripZeros: true,
-							}
-						) }
+						{ formatCurrency( subtotalWithCredits, responseCart.currency, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ) }
 					</span>
 				</CheckoutSummaryLineItem>
-				{ ! hasCheckoutVersion( '2' ) && couponLineItem && (
-					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + couponLineItem.id }>
-						<span>{ couponLineItem.label }</span>
-						<span>{ couponLineItem.formattedAmount }</span>
-					</CheckoutSummaryLineItem>
-				) }
 				{ taxLineItems.map( ( taxLineItem ) => (
 					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + taxLineItem.id }>
 						<span>{ taxLineItem.label }</span>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -146,7 +146,7 @@ function CheckoutSummaryPriceList() {
 		<>
 			{ ! hasCheckoutVersion( '2' ) && (
 				<CheckoutFirstSubtotalLineItem key="checkout-summary-line-item-subtotal-one">
-					<span>{ translate( 'Subtotal before discounts' ) }</span>
+					<span>{ translate( 'Products' ) }</span>
 					<span>
 						{ formatCurrency( subtotalBeforeDiscounts, responseCart.currency, {
 							isSmallestUnit: true,

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -135,10 +135,15 @@ function CheckoutSummaryPriceList() {
 		? responseCart.sub_total_with_taxes_integer
 		: responseCart.credits_integer;
 
-	const subtotalBeforeDiscounts = responseCart.products.reduce(
-		( total, product ) => product.item_original_subtotal_integer + total,
-		0
-	);
+	const subtotalBeforeDiscounts = responseCart.products.reduce( ( total, product ) => {
+		// We can't sum the original price for introductory offers because they
+		// are not cost overrides and their original price is actually a later
+		// price that will be charged after the offer ends.
+		if ( product.introductory_offer_terms?.enabled ) {
+			return product.item_subtotal_integer + total;
+		}
+		return product.item_original_subtotal_integer + total;
+	}, 0 );
 
 	return (
 		<>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -124,7 +124,7 @@ export default function WPCheckoutOrderSummary( {
 
 function CheckoutSummaryPriceList() {
 	const cartKey = useCartKey();
-	const { responseCart, removeCoupon } = useShoppingCart( cartKey );
+	const { responseCart } = useShoppingCart( cartKey );
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
 	const totalLineItem = getTotalLineItemFromCart( responseCart );
@@ -159,7 +159,6 @@ function CheckoutSummaryPriceList() {
 				<CostOverridesList
 					costOverridesList={ costOverridesList }
 					currency={ responseCart.currency }
-					removeCoupon={ removeCoupon }
 					couponCode={ responseCart.coupon }
 					creditsInteger={ creditsForDisplay }
 				/>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -137,8 +137,24 @@ function CheckoutSummaryPriceList() {
 		? responseCart.sub_total_with_taxes_integer
 		: responseCart.credits_integer;
 
+	const subtotalBeforeDiscounts = responseCart.products.reduce(
+		( total, product ) => product.item_original_subtotal_integer + total,
+		0
+	);
+
 	return (
 		<>
+			{ ! hasCheckoutVersion( '2' ) && (
+				<CheckoutFirstSubtotalLineItem key="checkout-summary-line-item-subtotal-one">
+					<span>{ translate( 'Subtotal before discounts' ) }</span>
+					<span>
+						{ formatCurrency( subtotalBeforeDiscounts, responseCart.currency, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ) }
+					</span>
+				</CheckoutFirstSubtotalLineItem>
+			) }
 			{ ! hasCheckoutVersion( '2' ) && costOverridesList.length > 0 && (
 				<CostOverridesList
 					costOverridesList={ costOverridesList }
@@ -876,12 +892,31 @@ const CheckoutSummaryAmountWrapper = styled.div`
 	padding: 20px 0;
 `;
 
+const CheckoutFirstSubtotalLineItem = styled.div`
+	display: flex;
+	flex-wrap: wrap;
+	font-size: 14px;
+	justify-content: space-between;
+	line-height: 20px;
+	margin-bottom: 16px;
+
+	&:nth-last-of-type( 2 ) {
+		border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+		margin-bottom: 20px;
+		padding-bottom: 20px;
+	}
+
+	.is-loading & {
+		animation: ${ pulse } 1.5s ease-in-out infinite;
+	}
+`;
+
 const CheckoutSummaryLineItem = styled.div`
 	display: flex;
 	flex-wrap: wrap;
 	font-size: 14px;
 	justify-content: space-between;
-	line-heigh: 20px;
+	line-height: 20px;
 	margin-bottom: 4px;
 
 	&:nth-last-of-type( 2 ) {

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -29,7 +29,6 @@ import {
 	getTaxBreakdownLineItemsFromCart,
 	getTotalLineItemFromCart,
 	hasCheckoutVersion,
-	getCreditsLineItemFromCart,
 	getSubtotalWithCredits,
 	doesPurchaseHaveFullCredits,
 } from '@automattic/wpcom-checkout';
@@ -125,7 +124,6 @@ export default function WPCheckoutOrderSummary( {
 function CheckoutSummaryPriceList() {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
-	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
 	const totalLineItem = getTotalLineItemFromCart( responseCart );
 	const translate = useTranslate();
@@ -179,13 +177,6 @@ function CheckoutSummaryPriceList() {
 						<span>{ taxLineItem.formattedAmount }</span>
 					</CheckoutSummaryLineItem>
 				) ) }
-				{ ! hasCheckoutVersion( '2' ) && creditsLineItem && responseCart.sub_total_integer > 0 && (
-					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + creditsLineItem.id }>
-						<span>{ creditsLineItem.label }</span>
-						<span>{ creditsLineItem.formattedAmount }</span>
-					</CheckoutSummaryLineItem>
-				) }
-
 				<CheckoutSummaryTotal>
 					<span>{ translate( 'Total' ) }</span>
 					<span className="wp-checkout-order-summary__total-price">

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -32,6 +32,7 @@ import {
 	getSubtotalWithCredits,
 	doesPurchaseHaveFullCredits,
 	getSubtotalWithoutDiscounts,
+	filterAndGroupCostOverridesForDisplay,
 } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -49,7 +50,7 @@ import getFlowPlanFeatures from '../lib/get-flow-plan-features';
 import getJetpackProductFeatures from '../lib/get-jetpack-product-features';
 import getPlanFeatures from '../lib/get-plan-features';
 import { CheckIcon } from './check-icon';
-import { CostOverridesList, filterAndGroupCostOverridesForDisplay } from './cost-overrides-list';
+import { CostOverridesList } from './cost-overrides-list';
 import { getRefundPolicies, getRefundWindows, RefundPolicy } from './refund-policies';
 import type { ResponseCart, ResponseCartProduct } from '@automattic/shopping-cart';
 import type { TranslateResult } from 'i18n-calypso';

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -129,7 +129,7 @@ function CheckoutSummaryPriceList() {
 	const totalLineItem = getTotalLineItemFromCart( responseCart );
 	const translate = useTranslate();
 	const subtotalWithCredits = getSubtotalWithCredits( responseCart );
-	const costOverridesList = filterAndGroupCostOverridesForDisplay( responseCart );
+	const costOverridesList = filterAndGroupCostOverridesForDisplay( responseCart, translate );
 	const isFullCredits = doesPurchaseHaveFullCredits( responseCart );
 	// Clamp the credits display value to the total
 	const creditsForDisplay = isFullCredits

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -30,9 +30,9 @@ import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { AkismetProQuantityDropDown } from './akismet-pro-quantity-dropdown';
+import { CostOverridesList } from './cost-overrides-list';
 import { ItemVariationPicker } from './item-variation-picker';
 import type { OnChangeAkProQuantity } from './akismet-pro-quantity-dropdown';
-import type { CostOverridesList } from './cost-overrides-list';
 import type { OnChangeItemVariant } from './item-variation-picker';
 import type { Theme } from '@automattic/composite-checkout';
 import type {

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -18,6 +18,7 @@ import {
 	getPartnerCoupon,
 	hasCheckoutVersion,
 	doesPurchaseHaveFullCredits,
+	filterAndGroupCostOverridesForDisplay,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -29,9 +30,9 @@ import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { AkismetProQuantityDropDown } from './akismet-pro-quantity-dropdown';
-import { filterAndGroupCostOverridesForDisplay, CostOverridesList } from './cost-overrides-list';
 import { ItemVariationPicker } from './item-variation-picker';
 import type { OnChangeAkProQuantity } from './akismet-pro-quantity-dropdown';
+import type { CostOverridesList } from './cost-overrides-list';
 import type { OnChangeItemVariant } from './item-variation-picker';
 import type { Theme } from '@automattic/composite-checkout';
 import type {

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -4,8 +4,7 @@ import {
 	isJetpackPurchasableItem,
 	AKISMET_PRO_500_PRODUCTS,
 } from '@automattic/calypso-products';
-import { FormStatus, useFormStatus, Button } from '@automattic/composite-checkout';
-import formatCurrency from '@automattic/format-currency';
+import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { isCopySiteFlow } from '@automattic/onboarding';
 import {
 	canItemBeRemovedFromCart,
@@ -21,7 +20,6 @@ import {
 	doesPurchaseHaveFullCredits,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
-import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback, useMemo } from 'react';
 import { has100YearPlan } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
@@ -30,6 +28,7 @@ import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { AkismetProQuantityDropDown } from './akismet-pro-quantity-dropdown';
+import { filterAndGroupCostOverridesForDisplay, CostOverridesList } from './cost-overrides-list';
 import { ItemVariationPicker } from './item-variation-picker';
 import type { OnChangeAkProQuantity } from './akismet-pro-quantity-dropdown';
 import type { OnChangeItemVariant } from './item-variation-picker';
@@ -55,171 +54,6 @@ const WPOrderReviewListItem = styled.li`
 	display: block;
 	list-style: none;
 `;
-
-const CostOverridesListStyle = styled.div`
-	display: flex;
-	flex-direction: column;
-	justify-content: space-between;
-	font-size: 12px;
-	font-weight: 400;
-	margin-top: 10px;
-
-	& .cost-overrides-list-item {
-		display: grid;
-		justify-content: space-between;
-		grid-template-columns: auto auto;
-		margin-top: 4px;
-	}
-
-	& .cost-overrides-list-item--coupon {
-		margin-top: 16px;
-	}
-
-	& .cost-overrides-list-item:nth-of-type( 1 ) {
-		margin-top: 0;
-	}
-
-	& .cost-overrides-list-item__actions {
-		grid-column: 1 / span 2;
-		display: flex;
-		justify-content: flex-end;
-	}
-
-	& .cost-overrides-list-item__actions-remove {
-		color: #787c82;
-	}
-
-	& .cost-overrides-list-item__reason {
-		color: #008a20;
-	}
-
-	& .cost-overrides-list-item__discount {
-		white-space: nowrap;
-	}
-`;
-
-interface CostOverrideForDisplay {
-	humanReadableReason: string;
-	overrideCode: string;
-	discountAmount: number;
-}
-
-function filterAndGroupCostOverridesForDisplay(
-	responseCart: ResponseCart
-): CostOverrideForDisplay[] {
-	// Collect cost overrides from each line item and group them by type so we
-	// can show them all together after the line item list.
-	const costOverridesGrouped = responseCart.products.reduce<
-		Record< string, CostOverrideForDisplay >
-	>( ( grouped, product ) => {
-		const costOverrides = product?.cost_overrides;
-		if ( ! costOverrides ) {
-			return grouped;
-		}
-
-		costOverrides.forEach( ( costOverride ) => {
-			if ( costOverride.does_override_original_cost ) {
-				// We won't display original cost overrides since they are
-				// included in the original cost that's being displayed. They
-				// are not discounts.
-				return;
-			}
-			const discountAmount = grouped[ costOverride.override_code ]?.discountAmount ?? 0;
-			const newDiscountAmount =
-				costOverride.old_subtotal_integer - costOverride.new_subtotal_integer;
-			grouped[ costOverride.override_code ] = {
-				humanReadableReason: costOverride.human_readable_reason,
-				overrideCode: costOverride.override_code,
-				discountAmount: discountAmount + newDiscountAmount,
-			};
-		} );
-		return grouped;
-	}, {} );
-	return Object.values( costOverridesGrouped );
-}
-
-const DeleteButton = styled( Button )< { theme?: Theme } >`
-	width: auto;
-	font-size: ${ hasCheckoutVersion( '2' ) ? '14px' : 'inherit' };
-	color: ${ ( props ) => props.theme.colors.textColorLight };
-`;
-
-function CostOverridesList( {
-	costOverridesList,
-	currency,
-	removeCoupon,
-	couponCode,
-	creditsInteger,
-}: {
-	costOverridesList: Array< CostOverrideForDisplay >;
-	currency: string;
-	removeCoupon: RemoveCouponFromCart;
-	couponCode: ResponseCart[ 'coupon' ];
-	creditsInteger: number;
-} ) {
-	const translate = useTranslate();
-	// Let's put the coupon code last because it will have its own "Remove" button.
-	const nonCouponOverrides = costOverridesList.filter(
-		( override ) => override.overrideCode !== 'coupon-discount'
-	);
-	const couponOverrides = costOverridesList.filter(
-		( override ) => override.overrideCode === 'coupon-discount'
-	);
-	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== FormStatus.READY;
-	return (
-		<>
-			{ nonCouponOverrides.map( ( costOverride ) => {
-				return (
-					<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
-						<span className="cost-overrides-list-item__reason">
-							{ costOverride.humanReadableReason }
-						</span>
-						<span className="cost-overrides-list-item__discount">
-							{ formatCurrency( -costOverride.discountAmount, currency, { isSmallestUnit: true } ) }
-						</span>
-					</div>
-				);
-			} ) }
-			{ creditsInteger > 0 && (
-				<div className="cost-overrides-list-item" key="credits-override">
-					<span className="cost-overrides-list-item__reason">{ translate( 'Credits' ) }</span>
-					<span className="cost-overrides-list-item__discount">
-						{ formatCurrency( -creditsInteger, currency, { isSmallestUnit: true } ) }
-					</span>
-				</div>
-			) }
-			{ couponOverrides.map( ( costOverride ) => {
-				return (
-					<div
-						className="cost-overrides-list-item cost-overrides-list-item--coupon"
-						key={ costOverride.humanReadableReason }
-					>
-						<span className="cost-overrides-list-item__reason">
-							{ couponCode.length > 0
-								? translate( 'Coupon: %(couponCode)s', { args: { couponCode } } )
-								: costOverride.humanReadableReason }
-						</span>
-						<span className="cost-overrides-list-item__discount">
-							{ formatCurrency( -costOverride.discountAmount, currency, { isSmallestUnit: true } ) }
-						</span>
-						<span className="cost-overrides-list-item__actions">
-							<DeleteButton
-								buttonType="text-button"
-								disabled={ isDisabled }
-								className="cost-overrides-list-item__actions-remove"
-								onClick={ removeCoupon }
-								aria-label={ translate( 'Remove coupon' ) }
-							>
-								{ translate( 'Remove' ) }
-							</DeleteButton>
-						</span>
-					</div>
-				);
-			} ) }
-		</>
-	);
-}
 
 export function WPOrderReviewSection( {
 	children,
@@ -394,15 +228,13 @@ export function WPOrderReviewLineItems( {
 				/>
 			) }
 			{ hasCheckoutVersion( '2' ) && costOverridesList.length > 0 && (
-				<CostOverridesListStyle>
-					<CostOverridesList
-						costOverridesList={ costOverridesList }
-						currency={ responseCart.currency }
-						removeCoupon={ removeCoupon }
-						couponCode={ responseCart.coupon }
-						creditsInteger={ creditsForDisplay }
-					/>
-				</CostOverridesListStyle>
+				<CostOverridesList
+					costOverridesList={ costOverridesList }
+					currency={ responseCart.currency }
+					removeCoupon={ removeCoupon }
+					couponCode={ responseCart.coupon }
+					creditsInteger={ creditsForDisplay }
+				/>
 			) }
 		</WPOrderReviewList>
 	);

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -20,6 +20,7 @@ import {
 	doesPurchaseHaveFullCredits,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
 import { useState, useCallback, useMemo } from 'react';
 import { has100YearPlan } from 'calypso/lib/cart-values/cart-items';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
@@ -92,6 +93,7 @@ export function WPOrderReviewLineItems( {
 	onRemoveProductCancel?: ( label: string ) => void;
 } ) {
 	const reduxDispatch = useDispatch();
+	const translate = useTranslate();
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const couponLineItem = getCouponLineItemFromCart( responseCart );
 	const { formStatus } = useFormStatus();
@@ -145,7 +147,7 @@ export function WPOrderReviewLineItems( {
 		[ akQuantityOpenId, variantOpenId ]
 	);
 
-	const costOverridesList = filterAndGroupCostOverridesForDisplay( responseCart );
+	const costOverridesList = filterAndGroupCostOverridesForDisplay( responseCart, translate );
 	const isFullCredits = doesPurchaseHaveFullCredits( responseCart );
 	// Clamp the credits display value to the total
 	const creditsForDisplay = isFullCredits

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -43,6 +43,7 @@ export function getEmptyResponseCartProduct(): ResponseCartProduct {
 		item_original_cost_integer: 0,
 		item_original_cost_for_quantity_one_integer: 0,
 		item_subtotal_integer: 0,
+		item_subtotal_before_discounts_integer: 0,
 		product_cost_integer: 0,
 		item_subtotal_monthly_cost_integer: 0,
 		item_original_subtotal_integer: 0,

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -372,6 +372,21 @@ export interface ResponseCartProduct {
 	item_original_cost_integer: number;
 
 	/**
+	 * The cart item's price before discounts with volume in the currency's
+	 * smallest unit. This is similar to `item_original_subtotal_integer`
+	 * except when it comes to introductory offers. Introductory offer
+	 * discounts are not cost overrides; they actually reassign the base cost
+	 * of the product. However, the shopping-cart endpoint then returns the
+	 * "original" cost of the cart item as the product without the introductory
+	 * offer. This is confusing because the introductory offer isn't really a
+	 * savings of any kind in terms of the way we track discounts. The savings
+	 * is only other kinds of discounts (eg: a coupon). In order to calculate
+	 * the actual savings, we need therefore to know the actual subtotal before
+	 * (non-introductory-offer) discounts. That's what this value is.
+	 */
+	item_subtotal_before_discounts_integer: number;
+
+	/**
 	 * The monthly term subtotal of a cart item in the currency's smallest unit.
 	 */
 	item_subtotal_monthly_cost_integer: number;

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1015,16 +1015,6 @@ function DomainDiscountCallout( { product }: { product: ResponseCartProduct } ) 
 	return null;
 }
 
-function CouponDiscountCallout( { product }: { product: ResponseCartProduct } ) {
-	const translate = useTranslate();
-
-	if ( isCouponApplied( product ) ) {
-		return <DiscountCallout>{ translate( 'Discounts applied' ) }</DiscountCallout>;
-	}
-
-	return null;
-}
-
 function GSuiteDiscountCallout( { product }: { product: ResponseCartProduct } ) {
 	const translate = useTranslate();
 
@@ -1219,7 +1209,6 @@ function CheckoutLineItem( {
 					<LineItemMeta>
 						<LineItemSublabelAndPrice product={ product } />
 						<DomainDiscountCallout product={ product } />
-						<CouponDiscountCallout product={ product } />
 						<IntroductoryOfferCallout product={ product } />
 						<JetpackAkismetSaleCouponCallout product={ product } />
 					</LineItemMeta>
@@ -1229,7 +1218,6 @@ function CheckoutLineItem( {
 			{ product && containsPartnerCoupon && (
 				<LineItemMeta>
 					<LineItemSublabelAndPrice product={ product } />
-					<CouponDiscountCallout product={ product } />
 				</LineItemMeta>
 			) }
 

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -142,12 +142,6 @@ export function getSubtotalWithoutCoupon( responseCart: ResponseCart ): number {
 
 export function getSubtotalWithoutDiscounts( responseCart: ResponseCart ): number {
 	return responseCart.products.reduce( ( total, product ) => {
-		// We can't sum the original price for introductory offers because they
-		// are not cost overrides and their original price is actually a later
-		// price that will be charged after the offer ends.
-		if ( product.introductory_offer_terms?.enabled ) {
-			return product.item_subtotal_integer + total;
-		}
 		return product.item_original_subtotal_integer + total;
 	}, 0 );
 }

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -140,6 +140,28 @@ export function getSubtotalWithoutCoupon( responseCart: ResponseCart ): number {
 	return responseCart.sub_total_integer + responseCart.coupon_savings_total_integer;
 }
 
+export function getSubtotalWithoutDiscounts( responseCart: ResponseCart ): number {
+	return responseCart.products.reduce( ( total, product ) => {
+		// We can't sum the original price for introductory offers because they
+		// are not cost overrides and their original price is actually a later
+		// price that will be charged after the offer ends.
+		if ( product.introductory_offer_terms?.enabled ) {
+			return product.item_subtotal_integer + total;
+		}
+		return product.item_original_subtotal_integer + total;
+	}, 0 );
+}
+
+export function getTotalDiscountsWithoutCredits( responseCart: ResponseCart ): number {
+	return -responseCart.products.reduce( ( total, product ) => {
+		product.cost_overrides?.forEach( ( override ) => {
+			const discount = override.old_subtotal_integer - override.new_subtotal_integer;
+			total = total + discount;
+		} );
+		return total;
+	}, 0 );
+}
+
 /**
  * Credits are the only type of cart discount that is applied to the cart as a
  * whole and not to individual line items. The subtotal is only a subtotal of

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -205,12 +205,13 @@ export function getSubtotalWithoutDiscounts( responseCart: ResponseCart ): numbe
 	}, 0 );
 }
 
-export function getTotalDiscountsWithoutCredits( responseCart: ResponseCart ): number {
-	return -responseCart.products.reduce( ( total, product ) => {
-		product.cost_overrides?.forEach( ( override ) => {
-			const discount = override.old_subtotal_integer - override.new_subtotal_integer;
-			total = total + discount;
-		} );
+export function getTotalDiscountsWithoutCredits(
+	responseCart: ResponseCart,
+	translate: ReturnType< typeof useTranslate >
+): number {
+	const filteredOverrides = filterAndGroupCostOverridesForDisplay( responseCart, translate );
+	return -filteredOverrides.reduce( ( total, override ) => {
+		total = total + override.discountAmount;
 		return total;
 	}, 0 );
 }

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -1,5 +1,5 @@
 import { formatCurrency } from '@automattic/format-currency';
-import { translate } from 'i18n-calypso';
+import { translate, useTranslate } from 'i18n-calypso';
 import type { LineItemType } from './types';
 import type { ResponseCart, TaxBreakdownItem } from '@automattic/shopping-cart';
 
@@ -114,6 +114,65 @@ export function getCreditsLineItemFromCart( responseCart: ResponseCart ): LineIt
 			} )
 		),
 	};
+}
+
+export interface CostOverrideForDisplay {
+	humanReadableReason: string;
+	overrideCode: string;
+	discountAmount: number;
+}
+
+export function filterAndGroupCostOverridesForDisplay(
+	responseCart: ResponseCart,
+	translate: ReturnType< typeof useTranslate >
+): CostOverrideForDisplay[] {
+	// Collect cost overrides from each line item and group them by type so we
+	// can show them all together after the line item list.
+	const costOverridesGrouped = responseCart.products.reduce<
+		Record< string, CostOverrideForDisplay >
+	>( ( grouped, product ) => {
+		const costOverrides = product?.cost_overrides;
+		if ( ! costOverrides ) {
+			return grouped;
+		}
+
+		costOverrides.forEach( ( costOverride ) => {
+			if ( costOverride.does_override_original_cost ) {
+				// We won't display original cost overrides since they are
+				// included in the original cost that's being displayed. They
+				// are not discounts.
+				return;
+			}
+			const discountAmount = grouped[ costOverride.override_code ]?.discountAmount ?? 0;
+			const newDiscountAmount =
+				costOverride.old_subtotal_integer - costOverride.new_subtotal_integer;
+			grouped[ costOverride.override_code ] = {
+				humanReadableReason: costOverride.human_readable_reason,
+				overrideCode: costOverride.override_code,
+				discountAmount: discountAmount + newDiscountAmount,
+			};
+		} );
+
+		// Add a fake cost override for introductory offers until D134600-code
+		// is merged because they are otherwise discounts that are invisible to
+		// the list of cost overrides. Remove this once that diff is merged.
+		if (
+			product.introductory_offer_terms?.enabled &&
+			! costOverrides.some( ( override ) => override.override_code === 'introductory-offer' )
+		) {
+			const discountAmount = grouped[ 'introductory-offer' ]?.discountAmount ?? 0;
+			const newDiscountAmount =
+				product.item_original_subtotal_integer - product.item_subtotal_before_discounts_integer;
+			grouped[ 'introductory-offer' ] = {
+				humanReadableReason: translate( 'Introductory offer' ),
+				overrideCode: 'introductory-offer',
+				discountAmount: discountAmount + newDiscountAmount,
+			};
+		}
+		return grouped;
+	}, {} );
+
+	return Object.values( costOverridesGrouped );
 }
 
 /**


### PR DESCRIPTION
## Proposed Changes

This PR adds a list of all checkout discounts to the sidebar, grouped by type below a new item that reads "Subtotal before discounts". The list includes one item for each type of discount no matter how many items in the cart have this discount (eg: if a coupon applies to two items in the cart, it will show only one coupon discount in the sidebar which includes the sum of both; the same is true if two items have a first year free or a prorated discount).

Some common discounts (their labels originate on the server via the "cost overrides" system and each one also has a unique key that can be used to identify it in case we want to do something special later) are as follows:

- `Coupon code`
- `Item on sale`
- `Prorated balance from previous plan`
- `Free domain for first year` 

This should help users better understand what discounts are being applied rather than relying on all the details on each line item (which can get really messy in some cases). It also helps to set the stage for the v2 checkout redesign (https://github.com/Automattic/payments-shilling/issues/1969) which already has this list of discounts in the sidebar. 

> [!NOTE]
> Introductory offer discounts are a little tricky. Currently, they are not actually "discounts" in the way that our payments system considers them. Rather, they are a unique thing wherein the discounted offer price actually becomes the original price of the product. This gets complicated depending on which original cost you're talking about because once the original cost reaches the cart response, it has changed to be the undiscounted price (see https://github.com/Automattic/payments-shilling/issues/2341#issuecomment-1899060553 for a breakdown of how this works). A more consistent solution is to treat introductory offers as discounts, which I'm working on in D134600-code but before then, I've implemented a workaround in this PR to display them as if they were discounts. In either case, introductory offer discounts will be listed as "Introductory offer", which is not very explicit (it does not explain the products which have offers, nor does it explain the length of these offers (1 year? 3 months? etc.) We have that information available and so the discount item could be modified in a future PR to display a more nuanced view but doing so may be complicated to get right. For now it should be ok since the details are available in other parts of the checkout UI - the sidebar list is just a summary.

> [!NOTE]
> Sale discounts will only be displayed as "Item on sale", which is not very explicit as they don't include the items that are on sale. This will be improved by https://github.com/Automattic/wp-calypso/pull/86371 after this PR is merged but isn't included here because there's some complexity to get it looking right. For now this should be ok since the details are available in other parts of the checkout UI - the sidebar is just a summary.

Before (sidebar)            |  After (sidebar)
:-------------------------:|:-------------------------:
<img width="530" alt="Screenshot 2024-01-12 at 2 10 47 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/9c893e2e-8c42-4092-8e77-7c93c4c0ce90"> | <img width="528" alt="Screenshot 2024-01-12 at 7 46 30 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/8937eb61-1ba6-4853-8cd9-140acc39405c">

Before (introductory offer)            |  After (introductory offer)
:-------------------------:|:-------------------------:
<img width="726" alt="Screenshot 2024-01-17 at 7 59 12 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/2f3ffd22-4813-414f-8a91-568119659ed4"> | <img width="734" alt="Screenshot 2024-01-17 at 7 48 14 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/f2d618bf-20a6-437b-8042-18742c2a10c4">

Before  (w/ credits)           |  After (w/ credits)
:-------------------------:|:-------------------------:
<img width="232" alt="Screenshot 2024-01-12 at 5 55 51 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/b0b00019-5c91-48c4-9e93-ee7c1a697de6"> | <img width="238" alt="Screenshot 2024-01-12 at 5 54 36 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/4db76a05-74a9-4739-a104-3e600ee3f5e0">

Before (footer)           |  After (footer)
:-------------------------:|:-------------------------:
<img width="298" alt="Screenshot 2024-01-12 at 7 47 45 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/c6406f18-8470-4219-ac3b-48411b9295fe"> | <img width="302" alt="Screenshot 2024-01-12 at 7 47 36 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/84732664-a9f3-4e84-83b2-8d24989a2b0b">

## Testing Instructions

Add products to your cart with cost overrides (sale coupons, coupon codes, bundled domain, etc.).

Visit checkout and verify that you see the cost overrides in the sidebar and that they look good.

Also test with credits!