### PR TITLE
Expose Hosting Trial: Expose trial CTAs on the logged-out Plugins page

### DIFF
--- a/client/my-sites/plugins/plugin-details-CTA/index.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/index.jsx
@@ -409,6 +409,10 @@ function PrimaryButton( {
 	);
 	const isDisabledForWpcomStaging = isWpcomStaging && isMarketplaceProduct;
 
+	//only show free trial button for free plugins to logged out users
+	const { monthly, yearly } = plugin?.variations ?? {};
+	const shouldStartFreeTrial = ! monthly?.product_id && ! yearly?.product_id;
+
 	const onClick = useCallback( () => {
 		dispatch(
 			recordTracksEvent( 'calypso_plugin_details_get_started_click', {
@@ -429,6 +433,7 @@ function PrimaryButton( {
 		return (
 			<GetStartedButton
 				onClick={ onClick }
+				startFreeTrial={ shouldStartFreeTrial }
 				plugin={ plugin }
 				isMarketplaceProduct={ isMarketplaceProduct }
 			/>
@@ -457,18 +462,20 @@ function PrimaryButton( {
 	);
 }
 
-function GetStartedButton( { onClick, plugin, isMarketplaceProduct } ) {
+function GetStartedButton( { onClick, plugin, isMarketplaceProduct, startFreeTrial = false } ) {
 	const translate = useTranslate();
 	const sectionName = useSelector( getSectionName );
 	const billingPeriod = useSelector( getBillingInterval );
-
+	const buttonText = startFreeTrial
+		? translate( 'Start your free trial' )
+		: translate( 'Get started' );
 	const startUrl = addQueryArgs(
 		{
 			ref: sectionName + '-lp',
 			plugin: plugin.slug,
 			billing_period: isMarketplaceProduct ? billingPeriod : '',
 		},
-		'/start/with-plugin'
+		startFreeTrial ? 'start/hosting' : '/start/with-plugin'
 	);
 	return (
 		<Button
@@ -478,7 +485,7 @@ function GetStartedButton( { onClick, plugin, isMarketplaceProduct } ) {
 			onClick={ onClick }
 			href={ startUrl }
 		>
-			{ translate( 'Get started' ) }
+			{ buttonText }
 		</Button>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/5111

## Proposed Changes

* Change CTA to "Start your trial" and redirect to `/start/hosting` 

![image](https://github.com/Automattic/wp-calypso/assets/47489215/b2adf436-e577-416c-9e13-f6dcb68c7578)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* On logged out home page go to `/plugins/instagram-feed`
* Verify CTA "Start your free trial" and redirects to `/start/hosting`
* Verify paid plugins CTA still has "Get Started" and redirects to `/start/with-plugin`
* As a logged in user go to plugins page
* Verify any free plugin doesn't show "Start your trial"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?