### PR TITLE
Fix monthly price showing on Paid stats modal

### DIFF
--- a/client/my-sites/stats/stats-upsell-modal/index.tsx
+++ b/client/my-sites/stats/stats-upsell-modal/index.tsx
@@ -28,6 +28,10 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 	const eventPrefix = isEnabled( 'is_running_in_jetpack_site' ) ? 'jetpack_odyssey' : 'calypso';
 	const statType = useSelector( ( state ) => getUpsellModalStatType( state, siteId ) );
 
+	const planPriceShow = plan?.product_display_price.replace(
+		plan.raw_price.toString(),
+		( plan.raw_price / 12 ).toString()
+	);
 	const closeModal = () => {
 		dispatch( toggleUpsellModal( siteId, statType ) );
 	};
@@ -88,7 +92,7 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 						<div
 							className="stats-upsell-modal__price-amount"
 							// eslint-disable-next-line react/no-danger
-							dangerouslySetInnerHTML={ { __html: planMonthly?.product_display_price ?? '' } }
+							dangerouslySetInnerHTML={ { __html: planPriceShow ?? '' } }
 						></div>
 					) }
 					<div className="stats-upsell-modal__price-per-month">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

The monthly price showing in the Paid stats modal is the price from monthly plan, we now show the year/12 price.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?