### PR TITLE
Paid Stats: Update modal to show the discounted annual monthly price

### DIFF
--- a/client/my-sites/stats/stats-upsell-modal/index.tsx
+++ b/client/my-sites/stats/stats-upsell-modal/index.tsx
@@ -1,19 +1,20 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isEnabled } from '@automattic/calypso-config';
-import { PLAN_PREMIUM, PLAN_PREMIUM_MONTHLY } from '@automattic/calypso-products';
+import { PLAN_PREMIUM } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { Gridicon } from '@automattic/components';
+import { Gridicon, PlanPrice } from '@automattic/components';
 import { Button, Modal } from '@wordpress/components';
 import { close } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useDispatch } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
+import usePricingMetaForGridPlans from 'calypso/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans';
 import { useSelector } from 'calypso/state';
 import { getPlanBySlug } from 'calypso/state/plans/selectors';
 import { toggleUpsellModal } from 'calypso/state/stats/paid-stats-upsell/actions';
 import { getUpsellModalStatType } from 'calypso/state/stats/paid-stats-upsell/selectors';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 
@@ -21,7 +22,14 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const plan = useSelector( ( state ) => getPlanBySlug( state, PLAN_PREMIUM ) );
-	const planMonthly = useSelector( ( state ) => getPlanBySlug( state, PLAN_PREMIUM_MONTHLY ) );
+	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const planMonthly = usePricingMetaForGridPlans( {
+		planSlugs: [ PLAN_PREMIUM ],
+		storageAddOns: null,
+		selectedSiteId,
+		coupon: undefined,
+	} );
+	const pricing = planMonthly?.[ PLAN_PREMIUM ];
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const planName = plan?.product_name_short ?? '';
 	const isLoading = ! plan || ! planMonthly;
@@ -85,11 +93,16 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 						{ isLoading ? '' : translate( '%(planName)s plan', { args: { planName } } ) }
 					</h2>
 					{ ! isLoading && (
-						<div
-							className="stats-upsell-modal__price-amount"
-							// eslint-disable-next-line react/no-danger
-							dangerouslySetInnerHTML={ { __html: planMonthly?.product_display_price ?? '' } }
-						></div>
+						<div className="stats-upsell-modal__price-amount">
+							<PlanPrice
+								className="screen-upsell__plan-price"
+								currencyCode={ pricing?.currencyCode }
+								rawPrice={ pricing?.originalPrice?.monthly }
+								displayPerMonthNotation={ false }
+								isLargeCurrency
+								isSmallestUnit
+							/>
+						</div>
 					) }
 					<div className="stats-upsell-modal__price-per-month">
 						{ isLoading

--- a/client/my-sites/stats/stats-upsell-modal/index.tsx
+++ b/client/my-sites/stats/stats-upsell-modal/index.tsx
@@ -10,6 +10,7 @@ import { useDispatch } from 'react-redux';
 import QueryPlans from 'calypso/components/data/query-plans';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import usePricingMetaForGridPlans from 'calypso/my-sites/plans-features-main/hooks/data-store/use-pricing-meta-for-grid-plans';
+import useCheckPlanAvailabilityForPurchase from 'calypso/my-sites/plans-features-main/hooks/use-check-plan-availability-for-purchase';
 import { useSelector } from 'calypso/state';
 import { getPlanBySlug } from 'calypso/state/plans/selectors';
 import { toggleUpsellModal } from 'calypso/state/stats/paid-stats-upsell/actions';
@@ -25,10 +26,12 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const planMonthly = usePricingMetaForGridPlans( {
 		planSlugs: [ PLAN_PREMIUM ],
-		storageAddOns: null,
 		selectedSiteId,
 		coupon: undefined,
+		useCheckPlanAvailabilityForPurchase,
+		storageAddOns: null,
 	} );
+
 	const pricing = planMonthly?.[ PLAN_PREMIUM ];
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const planName = plan?.product_name_short ?? '';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1705092367632779-slack-CKZHG0QCR

## Proposed Changes

* This PR updates the Jetpack Stats modal's price to show the discounted annual monthly price.

Before | After
--|--
<img width="656" alt="Screenshot 2024-01-12 at 3 42 47 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/72cc1115-f574-4680-aace-e1bda7029b5e"> | <img width="748" alt="Screenshot 2024-01-12 at 3 41 39 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/fac77403-2342-4fc9-8468-a88536b27406">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/stats/day/:siteSlug on a recently created free test site.
* Observe the price matches the picture above.
* Check to console for errors.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?