### PR TITLE
JP Manage: 229 - show price for non-Manage purchases if USD

### DIFF
--- a/client/components/data/query-jetpack-partner-portal-partner-key/index.js
+++ b/client/components/data/query-jetpack-partner-portal-partner-key/index.js
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { setActivePartnerKey } from 'calypso/state/partner-portal/partner/actions';
+import {
+	getCurrentPartner,
+	hasActivePartnerKey,
+	hasFetchedPartner,
+	hasJetpackPartnerAccess as hasJetpackPartnerAccessSelector,
+} from 'calypso/state/partner-portal/partner/selectors';
+
+export const useQueryJetpackPartnerKey = () => {
+	const hasJetpackPartnerAccess = useSelector( hasJetpackPartnerAccessSelector );
+	const hasFetched = useSelector( hasFetchedPartner );
+	const partner = useSelector( getCurrentPartner );
+	const hasActiveKey = useSelector( hasActivePartnerKey );
+	const dispatch = useDispatch();
+
+	useEffect( () => {
+		if ( ! hasJetpackPartnerAccess || ! hasFetched ) {
+			return;
+		}
+
+		if ( partner && ! hasActiveKey && partner.keys.length > 0 ) {
+			dispatch( setActivePartnerKey( partner.keys[ 0 ].id ) );
+		}
+	}, [ hasJetpackPartnerAccess, hasFetched, partner, hasActiveKey, dispatch ] );
+};
+
+const QueryJetpackPartnerKey = () => {
+	useQueryJetpackPartnerKey();
+	return null;
+};
+
+export default QueryJetpackPartnerKey;

--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -41,13 +41,13 @@ import type {
 import './style.scss';
 
 interface UpsellProductCardProps {
-	productSlug: string;
+	nonManageProductSlug: string;
 	siteId: number | null;
 	onCtaButtonClick: () => void;
 }
 
 const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
-	productSlug,
+	nonManageProductSlug,
 	siteId,
 	onCtaButtonClick,
 } ) => {
@@ -57,7 +57,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 	const nonManageCurrencyCode = useSelector( getCurrentUserCurrencyCode );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const partner = useSelector( getCurrentPartner );
-	const item = slugToSelectorProduct( productSlug ) as SelectorProduct;
+	const item = slugToSelectorProduct( nonManageProductSlug ) as SelectorProduct;
 	const siteProduct: SiteProduct | undefined = useSelector( ( state ) =>
 		getSiteAvailableProduct( state, siteId, item.productSlug )
 	);
@@ -85,7 +85,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 	const { data: products, isFetching: isFetchingManagePrices } = useProductsQuery();
 
 	if ( hasJetpackPartnerAccess ) {
-		const manageProductSlug = productSlug.replace( '_yearly', '' ).replace( /_/g, '-' );
+		const manageProductSlug = nonManageProductSlug.replace( '_yearly', '' ).replace( /_/g, '-' );
 		manageProduct = products?.find( ( product ) => product.slug === manageProductSlug );
 		isFetchingPrices = isFetchingManagePrices || !! isFetchingNonManagePrices;
 		if ( manageProduct ) {
@@ -148,17 +148,17 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 		textOnly: true,
 	} );
 	const upsellImageUrl = useMemo( () => {
-		if ( isJetpackBackupSlug( productSlug ) ) {
+		if ( isJetpackBackupSlug( nonManageProductSlug ) ) {
 			return BackupImage;
 		}
-		if ( isJetpackScanSlug( productSlug ) ) {
+		if ( isJetpackScanSlug( nonManageProductSlug ) ) {
 			return ScanImage;
 		}
-		if ( isJetpackSearchSlug( productSlug ) ) {
+		if ( isJetpackSearchSlug( nonManageProductSlug ) ) {
 			return SearchImage;
 		}
 		return DefaultImage;
-	}, [ productSlug ] );
+	}, [ nonManageProductSlug ] );
 
 	const { displayName, description, features } = item;
 
@@ -198,9 +198,9 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 				) }
 				{ showLightbox && hasJetpackPartnerAccess && siteId && manageProduct && (
 					<SingleSiteUpsellLightbox
-						currentProduct={ manageProduct }
+						manageProduct={ manageProduct }
 						onClose={ () => setShowLightbox( false ) }
-						productSlug={ productSlug }
+						nonManageProductSlug={ nonManageProductSlug }
 						partnerCanIssueLicense={ true }
 						siteId={ siteId }
 					/>

--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -168,6 +168,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 				</ul>
 				<div className="upsell-product-card__price-container">
 					<DisplayPrice
+						isFree={ originalPrice === 0 }
 						discountedPrice={ discountedPrice }
 						currencyCode={ currencyCode }
 						originalPrice={ originalPrice ?? 0 }

--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -12,6 +12,8 @@ import BackupImage from 'calypso/assets/images/jetpack/rna-image-backup.png';
 import DefaultImage from 'calypso/assets/images/jetpack/rna-image-default.png';
 import ScanImage from 'calypso/assets/images/jetpack/rna-image-scan.png';
 import SearchImage from 'calypso/assets/images/jetpack/rna-image-search.png';
+import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
+import QueryJetpackPartnerKey from 'calypso/components/data/query-jetpack-partner-portal-partner-key';
 import DisplayPrice from 'calypso/components/jetpack/card/jetpack-product-card/display-price';
 import JetpackRnaActionCard from 'calypso/components/jetpack/card/jetpack-rna-action-card';
 import SingleSiteUpsellLightbox from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox/single-site-upsell-lightbox';
@@ -23,7 +25,10 @@ import useItemPrice from 'calypso/my-sites/plans/jetpack-plans/use-item-price';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
-import { hasJetpackPartnerAccess as hasJetpackPartnerAccessSelector } from 'calypso/state/partner-portal/partner/selectors';
+import {
+	getCurrentPartner,
+	hasJetpackPartnerAccess as hasJetpackPartnerAccessSelector,
+} from 'calypso/state/partner-portal/partner/selectors';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { getSiteAvailableProduct } from 'calypso/state/sites/products/selectors';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -51,6 +56,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 	const hasJetpackPartnerAccess = useSelector( hasJetpackPartnerAccessSelector );
 	const nonManageCurrencyCode = useSelector( getCurrentUserCurrencyCode );
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const partner = useSelector( getCurrentPartner );
 	const item = slugToSelectorProduct( productSlug ) as SelectorProduct;
 	const siteProduct: SiteProduct | undefined = useSelector( ( state ) =>
 		getSiteAvailableProduct( state, siteId, item.productSlug )
@@ -213,6 +219,8 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 			cardImage={ upsellImageUrl }
 			cardImageAlt={ upsellImageAlt }
 		>
+			{ hasJetpackPartnerAccess && ! partner && <QueryJetpackPartnerPortalPartner /> }
+			{ hasJetpackPartnerAccess && <QueryJetpackPartnerKey /> }
 			{ renderProductCardBody() }
 		</JetpackRnaActionCard>
 	);

--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -166,6 +166,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 							</li>
 						) ) }
 				</ul>
+				{ hasJetpackPartnerAccess && <b>{ translate( 'Price per Jetpack Manage license:' ) }</b> }
 				<div className="upsell-product-card__price-container">
 					<DisplayPrice
 						isFree={ originalPrice === 0 }

--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -61,6 +61,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 	let ctaButtonURL: string | undefined;
 	let currencyCode: string | null;
 	let discountedPrice: number | undefined;
+	let discountText: TranslateResult | undefined;
 	let isFetchingPrices: boolean;
 	let manageProduct: APIProductFamilyProduct | undefined;
 	let onCtaButtonClickInternal = onCtaButtonClick;
@@ -106,8 +107,23 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 		discountedPrice = nonManageDiscountedPrice;
 		isFetchingPrices = !! isFetchingNonManagePrices;
 		originalPrice = nonManageOriginalPrice;
+
 		if ( nonManagePriceTierList.length > 0 ) {
 			tooltipText = productTooltip( item, nonManagePriceTierList, currencyCode ?? 'USD' );
+		}
+
+		if ( nonManageOriginalPrice !== undefined && nonManageDiscountedPrice !== undefined ) {
+			const percentDiscount = Math.floor(
+				( ( nonManageOriginalPrice - nonManageDiscountedPrice ) / nonManageOriginalPrice ) * 100
+			);
+			if ( !! percentDiscount && percentDiscount > 0 ) {
+				discountText = translate( '%(percent)d%% off', {
+					args: {
+						percent: percentDiscount,
+					},
+					comment: 'Should be as concise as possible.',
+				} );
+			}
 		}
 	}
 
@@ -117,23 +133,6 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 			context: 'The Jetpack product name, ie- Backup, Scan, Search, etc.',
 		},
 	} );
-
-	const percentDiscount =
-		nonManageOriginalPrice !== undefined && nonManageDiscountedPrice !== undefined
-			? Math.floor(
-					( ( nonManageOriginalPrice - nonManageDiscountedPrice ) / nonManageOriginalPrice ) * 100
-			  )
-			: 0;
-
-	const showDiscountLabel = ! hasJetpackPartnerAccess && !! percentDiscount && percentDiscount > 0;
-	const discountText = showDiscountLabel
-		? translate( '%(percent)d%% off', {
-				args: {
-					percent: percentDiscount,
-				},
-				comment: 'Should be as concise as possible.',
-		  } )
-		: null;
 
 	const upsellImageAlt = translate( 'Buy Jetpack %(productName)s', {
 		args: {
@@ -184,7 +183,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 						productName={ displayName }
 						hideSavingLabel={ false }
 					/>
-					{ showDiscountLabel && ! isFetchingPrices && (
+					{ discountText && ! isFetchingPrices && (
 						<div className="upsell-product-card__discount-label">{ discountText }</div>
 					) }
 				</div>

--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -14,7 +14,7 @@ import ScanImage from 'calypso/assets/images/jetpack/rna-image-scan.png';
 import SearchImage from 'calypso/assets/images/jetpack/rna-image-search.png';
 import DisplayPrice from 'calypso/components/jetpack/card/jetpack-product-card/display-price';
 import JetpackRnaActionCard from 'calypso/components/jetpack/card/jetpack-rna-action-card';
-import SingleSellUpsellLightbox from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox/single-site-upsell-lightbox';
+import SingleSiteUpsellLightbox from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox/single-site-upsell-lightbox';
 import { getPurchaseURLCallback } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import productAboveButtonText from 'calypso/my-sites/plans/jetpack-plans/product-card/product-above-button-text';
 import productTooltip from 'calypso/my-sites/plans/jetpack-plans/product-card/product-tooltip';
@@ -190,7 +190,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 					<p className="upsell-product-card__above-button">{ aboveButtonText }</p>
 				) }
 				{ showLightbox && hasJetpackPartnerAccess && siteId && manageProduct && (
-					<SingleSellUpsellLightbox
+					<SingleSiteUpsellLightbox
 						currentProduct={ manageProduct }
 						onClose={ () => setShowLightbox( false ) }
 						productSlug={ productSlug }

--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -78,6 +78,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 	const {
 		originalPrice: nonManageOriginalPrice,
 		discountedPrice: nonManageDiscountedPrice,
+		discountedPriceTotal: nonManageDiscountedPriceTotal,
 		priceTierList: nonManagePriceTierList,
 		isFetching: isFetchingNonManagePrices,
 	} = useItemPrice( siteId, item, item?.monthlyProductSlug || '' );
@@ -201,6 +202,9 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 						manageProduct={ manageProduct }
 						onClose={ () => setShowLightbox( false ) }
 						nonManageProductSlug={ nonManageProductSlug }
+						nonManageProductPrice={
+							nonManageCurrencyCode === 'USD' ? nonManageDiscountedPriceTotal : null
+						}
 						partnerCanIssueLicense={ true }
 						siteId={ siteId }
 					/>

--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -169,7 +169,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 				{ hasJetpackPartnerAccess && <b>{ translate( 'Price per Jetpack Manage license:' ) }</b> }
 				<div className="upsell-product-card__price-container">
 					<DisplayPrice
-						isFree={ originalPrice === 0 }
+						isFree={ ! isFetchingPrices && originalPrice === 0 }
 						discountedPrice={ discountedPrice }
 						currencyCode={ currencyCode }
 						originalPrice={ originalPrice ?? 0 }

--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -7,7 +7,7 @@ import {
 } from '@automattic/calypso-products';
 import { Gridicon } from '@automattic/components';
 import { TranslateResult, useTranslate } from 'i18n-calypso';
-import { useMemo, useState } from 'react';
+import { ReactNode, useMemo, useState } from 'react';
 import BackupImage from 'calypso/assets/images/jetpack/rna-image-backup.png';
 import DefaultImage from 'calypso/assets/images/jetpack/rna-image-default.png';
 import ScanImage from 'calypso/assets/images/jetpack/rna-image-scan.png';
@@ -65,6 +65,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 	let manageProduct: APIProductFamilyProduct | undefined;
 	let onCtaButtonClickInternal = onCtaButtonClick;
 	let originalPrice: number;
+	let tooltipText: TranslateResult | ReactNode;
 
 	// Calculate the product price.
 	const {
@@ -105,6 +106,9 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 		discountedPrice = nonManageDiscountedPrice;
 		isFetchingPrices = !! isFetchingNonManagePrices;
 		originalPrice = nonManageOriginalPrice;
+		if ( nonManagePriceTierList.length > 0 ) {
+			tooltipText = productTooltip( item, nonManagePriceTierList, currencyCode ?? 'USD' );
+		}
 	}
 
 	const ctaButtonLabel = translate( 'Add Jetpack %(productName)s', {
@@ -175,11 +179,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 						originalPrice={ originalPrice ?? 0 }
 						pricesAreFetching={ isFetchingPrices }
 						belowPriceText={ item.belowPriceText }
-						tooltipText={
-							! hasJetpackPartnerAccess &&
-							nonManagePriceTierList.length > 0 &&
-							productTooltip( item, nonManagePriceTierList, currencyCode ?? 'USD' )
-						}
+						tooltipText={ tooltipText }
 						billingTerm={ billingTerm }
 						productName={ displayName }
 						hideSavingLabel={ false }

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/license-lightbox-purchase-via-jetpackcom.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/license-lightbox-purchase-via-jetpackcom.tsx
@@ -13,13 +13,13 @@ import { getSiteSlug } from 'calypso/state/sites/selectors';
 import './style.scss';
 
 type Props = {
-	productSlug: string;
+	nonManageProductSlug: string;
 	onClose: () => void;
 	siteId?: number;
 };
 
 const LicenseLightboxPurchaseViaJetpackcom: FunctionComponent< Props > = ( {
-	productSlug,
+	nonManageProductSlug,
 	onClose,
 	siteId,
 } ) => {
@@ -28,7 +28,7 @@ const LicenseLightboxPurchaseViaJetpackcom: FunctionComponent< Props > = ( {
 
 	const { hideLicenseInfo } = useContext( SitesOverviewContext );
 
-	const item = slugToSelectorProduct( productSlug ) as SelectorProduct;
+	const item = slugToSelectorProduct( nonManageProductSlug ) as SelectorProduct;
 
 	const selectedSiteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) ) || '';
 
@@ -46,11 +46,11 @@ const LicenseLightboxPurchaseViaJetpackcom: FunctionComponent< Props > = ( {
 	const onProceedToCheckout = useCallback( () => {
 		dispatch(
 			recordTracksEvent( 'calypso_jetpack_single_site_upsell_proceed_to_checkout_click', {
-				product: productSlug,
+				product: nonManageProductSlug,
 			} )
 		);
 		onHideLicenseInfo();
-	}, [ productSlug, dispatch, onHideLicenseInfo ] );
+	}, [ nonManageProductSlug, dispatch, onHideLicenseInfo ] );
 
 	const learnMoreLink = localizeUrl(
 		'https://jetpack.com/support/jetpack-manage-instructions/jetpack-manage-billing-payment-faqs'

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/license-lightbox-purchase-via-jetpackcom.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/license-lightbox-purchase-via-jetpackcom.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useContext, useCallback } from 'react';
@@ -64,6 +65,10 @@ const LicenseLightboxPurchaseViaJetpackcom: FunctionComponent< Props > = ( {
 		);
 	}, [ dispatch ] );
 
+	const formattedNonManagePrice = nonManageProductPrice
+		? formatCurrency( nonManageProductPrice, 'USD' )
+		: null;
+
 	return (
 		<>
 			<div className="license-lightbox__secondary-checkout-heading">
@@ -75,7 +80,13 @@ const LicenseLightboxPurchaseViaJetpackcom: FunctionComponent< Props > = ( {
 				href={ checkoutURL }
 				disabled={ false }
 			>
-				{ translate( 'Purchase via Jetpack.com' ) }
+				{ formattedNonManagePrice
+					? translate( 'Purchase for %(formattedNonManagePrice)s', {
+							args: {
+								formattedNonManagePrice,
+							},
+					  } )
+					: translate( 'Purchase via Jetpack.com' ) }
 			</Button>
 			<div className="license-lightbox__secondary-checkout-notice">
 				{ translate(

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/license-lightbox-purchase-via-jetpackcom.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/license-lightbox-purchase-via-jetpackcom.tsx
@@ -14,12 +14,14 @@ import './style.scss';
 
 type Props = {
 	nonManageProductSlug: string;
+	nonManageProductPrice?: number | null;
 	onClose: () => void;
 	siteId?: number;
 };
 
 const LicenseLightboxPurchaseViaJetpackcom: FunctionComponent< Props > = ( {
 	nonManageProductSlug,
+	nonManageProductPrice,
 	onClose,
 	siteId,
 } ) => {

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/single-site-upsell-lightbox.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/single-site-upsell-lightbox.tsx
@@ -73,44 +73,40 @@ export default function SingleSiteUpsellLightbox( {
 	}, [ dispatch ] );
 
 	return (
-		<>
-			{ true && (
-				<LicenseLightbox
-					className="license-lightbox__single-site-upsell"
-					product={ currentProduct }
-					isDisabled={ ! partnerCanIssueLicense }
-					ctaLabel={ translate( 'Issue License' ) }
-					onActivate={ onIssueLicense }
-					onClose={ onClose }
-					extraAsideContent={
-						<div className="review-licenses__notice">
-							{ translate(
-								'You will be billed at the end of every month. Your first month may be less than the above amount. {{a}}Learn more{{/a}}',
-								{
-									components: {
-										a: (
-											<a
-												href={ learnMoreLink }
-												target="_blank"
-												rel="noopener noreferrer"
-												onClick={ onClickLearnMore }
-											/>
-										),
-									},
-								}
-							) }
-						</div>
-					}
-					secondaryAsideContent={
-						<LicenseLightboxPurchaseViaJetpackcom
-							productSlug={ productSlug }
-							onClose={ hideLicenseInfo }
-							siteId={ siteId }
-						/>
-					}
-					showPaymentPlan
+		<LicenseLightbox
+			className="license-lightbox__single-site-upsell"
+			product={ currentProduct }
+			isDisabled={ ! partnerCanIssueLicense }
+			ctaLabel={ translate( 'Issue License' ) }
+			onActivate={ onIssueLicense }
+			onClose={ onClose }
+			extraAsideContent={
+				<div className="review-licenses__notice">
+					{ translate(
+						'You will be billed at the end of every month. Your first month may be less than the above amount. {{a}}Learn more{{/a}}',
+						{
+							components: {
+								a: (
+									<a
+										href={ learnMoreLink }
+										target="_blank"
+										rel="noopener noreferrer"
+										onClick={ onClickLearnMore }
+									/>
+								),
+							},
+						}
+					) }
+				</div>
+			}
+			secondaryAsideContent={
+				<LicenseLightboxPurchaseViaJetpackcom
+					productSlug={ productSlug }
+					onClose={ hideLicenseInfo }
+					siteId={ siteId }
 				/>
-			) }
-		</>
+			}
+			showPaymentPlan
+		/>
 	);
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/single-site-upsell-lightbox.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/single-site-upsell-lightbox.tsx
@@ -11,17 +11,17 @@ import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import getSites from 'calypso/state/selectors/get-sites';
 
 interface Props {
-	currentProduct: APIProductFamilyProduct;
+	manageProduct: APIProductFamilyProduct;
 	partnerCanIssueLicense: boolean;
-	productSlug: string;
+	nonManageProductSlug: string;
 	onClose: () => void;
 	siteId?: number;
 }
 
 export default function SingleSiteUpsellLightbox( {
-	currentProduct,
+	manageProduct,
 	partnerCanIssueLicense,
-	productSlug,
+	nonManageProductSlug,
 	onClose,
 	siteId,
 }: Props ) {
@@ -44,23 +44,23 @@ export default function SingleSiteUpsellLightbox( {
 	const { submitForm } = useSubmitForm( selectedSite );
 
 	const onIssueLicense = useCallback( () => {
-		if ( ! currentProduct ) {
+		if ( ! manageProduct ) {
 			return;
 		}
 
 		dispatch(
 			recordTracksEvent( 'calypso_jetpack_single_site_upsell_purchase_click', {
-				product: currentProduct.slug,
+				product: manageProduct.slug,
 			} )
 		);
 		onHideLicenseInfo();
 		submitForm( [
 			{
-				...currentProduct,
+				...manageProduct,
 				quantity: 1,
 			},
 		] );
-	}, [ currentProduct, dispatch, onHideLicenseInfo, submitForm ] );
+	}, [ manageProduct, dispatch, onHideLicenseInfo, submitForm ] );
 
 	const learnMoreLink = localizeUrl(
 		'https://jetpack.com/support/jetpack-manage-instructions/jetpack-manage-billing-payment-faqs'
@@ -75,7 +75,7 @@ export default function SingleSiteUpsellLightbox( {
 	return (
 		<LicenseLightbox
 			className="license-lightbox__single-site-upsell"
-			product={ currentProduct }
+			product={ manageProduct }
 			isDisabled={ ! partnerCanIssueLicense }
 			ctaLabel={ translate( 'Issue License' ) }
 			onActivate={ onIssueLicense }
@@ -101,7 +101,7 @@ export default function SingleSiteUpsellLightbox( {
 			}
 			secondaryAsideContent={
 				<LicenseLightboxPurchaseViaJetpackcom
-					productSlug={ productSlug }
+					nonManageProductSlug={ nonManageProductSlug }
 					onClose={ hideLicenseInfo }
 					siteId={ siteId }
 				/>

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/single-site-upsell-lightbox.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/single-site-upsell-lightbox.tsx
@@ -14,6 +14,7 @@ interface Props {
 	manageProduct: APIProductFamilyProduct;
 	partnerCanIssueLicense: boolean;
 	nonManageProductSlug: string;
+	nonManageProductPrice?: number | null;
 	onClose: () => void;
 	siteId?: number;
 }
@@ -22,6 +23,7 @@ export default function SingleSiteUpsellLightbox( {
 	manageProduct,
 	partnerCanIssueLicense,
 	nonManageProductSlug,
+	nonManageProductPrice,
 	onClose,
 	siteId,
 }: Props ) {
@@ -102,6 +104,7 @@ export default function SingleSiteUpsellLightbox( {
 			secondaryAsideContent={
 				<LicenseLightboxPurchaseViaJetpackcom
 					nonManageProductSlug={ nonManageProductSlug }
+					nonManageProductPrice={ nonManageProductPrice }
 					onClose={ hideLicenseInfo }
 					siteId={ siteId }
 				/>

--- a/client/my-sites/backup/backup-upsell/index.tsx
+++ b/client/my-sites/backup/backup-upsell/index.tsx
@@ -13,11 +13,8 @@ import UpsellProductCard from 'calypso/components/jetpack/upsell-product-card';
 import { UpsellComponentProps } from 'calypso/components/jetpack/upsell-switch';
 import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
-import { getPurchaseURLCallback } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 
 import './style.scss';
@@ -67,12 +64,6 @@ const BackupsVPActiveBody: FunctionComponent = () => {
 
 const BackupsUpsellBody: FunctionComponent = () => {
 	const siteId = useSelector( getSelectedSiteId ) || -1;
-	const selectedSiteSlug = useSelector( getSelectedSiteSlug ) || '';
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
-	const createCheckoutURL = getPurchaseURLCallback( selectedSiteSlug, {
-		// For the Backup upsell in Jetpack Cloud, we want to redirect back here to the Backup page after checkout.
-		redirect_to: window.location.href,
-	} );
 	const dispatch = useDispatch();
 
 	const onClick = useCallback(
@@ -89,8 +80,6 @@ const BackupsUpsellBody: FunctionComponent = () => {
 			<UpsellProductCard
 				productSlug={ PRODUCT_JETPACK_BACKUP_T1_YEARLY }
 				siteId={ siteId }
-				currencyCode={ currencyCode }
-				getButtonURL={ createCheckoutURL }
 				onCtaButtonClick={ onClick }
 			/>
 		</>

--- a/client/my-sites/backup/backup-upsell/index.tsx
+++ b/client/my-sites/backup/backup-upsell/index.tsx
@@ -78,7 +78,7 @@ const BackupsUpsellBody: FunctionComponent = () => {
 			{ siteId && <QueryIntroOffers siteId={ siteId } /> }
 			{ siteId && <QuerySiteProducts siteId={ siteId } /> }
 			<UpsellProductCard
-				productSlug={ PRODUCT_JETPACK_BACKUP_T1_YEARLY }
+				nonManageProductSlug={ PRODUCT_JETPACK_BACKUP_T1_YEARLY }
 				siteId={ siteId }
 				onCtaButtonClick={ onClick }
 			/>

--- a/client/my-sites/jetpack-search/jetpack-search-upsell/index.tsx
+++ b/client/my-sites/jetpack-search/jetpack-search-upsell/index.tsx
@@ -18,10 +18,8 @@ import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
-import { getPurchaseURLCallback } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
@@ -38,11 +36,6 @@ export default function JetpackSearchUpsell() {
 	);
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
-	const createCheckoutURL = getPurchaseURLCallback( selectedSiteSlug, {
-		// For the Search upsell in Jetpack Cloud, we want to redirect back here to the Search page after checkout.
-		redirect_to: window.location.href,
-	} );
 
 	const WPComUpgradeUrl =
 		'https://jetpack.com/upgrade/search/?utm_campaign=my-sites-jetpack-search&utm_source=calypso&site=' +
@@ -68,8 +61,6 @@ export default function JetpackSearchUpsell() {
 					<UpsellProductCard
 						productSlug={ PRODUCT_JETPACK_SEARCH }
 						siteId={ siteId }
-						currencyCode={ currencyCode }
-						getButtonURL={ createCheckoutURL }
 						onCtaButtonClick={ onClick }
 					/>
 				</div>

--- a/client/my-sites/jetpack-search/jetpack-search-upsell/index.tsx
+++ b/client/my-sites/jetpack-search/jetpack-search-upsell/index.tsx
@@ -59,7 +59,7 @@ export default function JetpackSearchUpsell() {
 					{ siteId && <QueryIntroOffers siteId={ siteId } /> }
 					{ siteId && <QuerySiteProducts siteId={ siteId } /> }
 					<UpsellProductCard
-						productSlug={ PRODUCT_JETPACK_SEARCH }
+						nonManageProductSlug={ PRODUCT_JETPACK_SEARCH }
 						siteId={ siteId }
 						onCtaButtonClick={ onClick }
 					/>

--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -26,6 +26,7 @@ interface ItemPrices {
 	originalPrice: number;
 	discountedPrice?: number;
 	discountedPriceDuration?: number;
+	discountedPriceTotal?: number | null;
 	priceTierList: PriceTierEntry[];
 }
 
@@ -155,8 +156,9 @@ const useItemPrice = (
 	}
 
 	let originalPrice = 0;
-	let discountedPrice = undefined;
-	let discountedPriceDuration = undefined;
+	let discountedPrice;
+	let discountedPriceDuration;
+	const discountedPriceTotal = introductoryOfferPrices.introOfferCost;
 
 	if ( item && itemCost ) {
 		originalPrice = itemCost;
@@ -199,6 +201,7 @@ const useItemPrice = (
 		originalPrice,
 		discountedPrice,
 		discountedPriceDuration,
+		discountedPriceTotal,
 		priceTierList,
 	};
 };

--- a/client/my-sites/scan/scan-upsell/index.jsx
+++ b/client/my-sites/scan/scan-upsell/index.jsx
@@ -16,10 +16,7 @@ import Main from 'calypso/components/main';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { getPurchaseURLCallback } from 'calypso/my-sites/plans/jetpack-plans/get-purchase-url-callback';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 
 import './style.scss';
@@ -65,12 +62,6 @@ function ScanVPActiveBody() {
 
 function ScanUpsellBody() {
 	const siteId = useSelector( getSelectedSiteId ) || -1;
-	const selectedSiteSlug = useSelector( getSelectedSiteSlug ) || '';
-	const currencyCode = useSelector( getCurrentUserCurrencyCode );
-	const createCheckoutURL = getPurchaseURLCallback( selectedSiteSlug, {
-		// For the Scan upsell in Jetpack Cloud, we want to redirect back here to the Scan page after checkout.
-		redirect_to: window.location.href,
-	} );
 	const dispatch = useDispatch();
 
 	const onClick = useCallback(
@@ -87,8 +78,6 @@ function ScanUpsellBody() {
 			<UpsellProductCard
 				productSlug={ PRODUCT_JETPACK_SCAN }
 				siteId={ siteId }
-				currencyCode={ currencyCode }
-				getButtonURL={ createCheckoutURL }
 				onCtaButtonClick={ onClick }
 			/>
 		</>

--- a/client/my-sites/scan/scan-upsell/index.jsx
+++ b/client/my-sites/scan/scan-upsell/index.jsx
@@ -76,7 +76,7 @@ function ScanUpsellBody() {
 			{ siteId && <QueryIntroOffers siteId={ siteId } /> }
 			{ siteId && <QuerySiteProducts siteId={ siteId } /> }
 			<UpsellProductCard
-				productSlug={ PRODUCT_JETPACK_SCAN }
+				nonManageProductSlug={ PRODUCT_JETPACK_SCAN }
 				siteId={ siteId }
 				onCtaButtonClick={ onClick }
 			/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves Automattic/jetpack-manage#229 - show price for non-Manage purchases if USD

## Proposed Changes

Note that this branch is based on #86333 for now. It mainly does the following:

* Renames vars for clarity: `currentProduct` → `manageProduct`, `productSlug` → `nonManageProductSlug`
* Passes through the annual price for the non-Manage purchase if in `USD`, displaying it in the Lightbox

## Testing Instructions
With a JP Manage account:
1. Go to an upsell page: `http://jetpack.cloud.localhost:3000/backup/some-site.example`
2. Click on the upsell button.
    * If your WP.com currency is set to USD, you will see the yearly price as the button label.
    * Otherwise you'll see a generic "Purchase via Jetpack.com" button label.

![image](https://github.com/Automattic/wp-calypso/assets/32492176/def2a11a-6431-4fc3-aeaf-b354057ca293)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
