### PR TITLE
Domains: Add domain diagnostics notice in `Home` component

### DIFF
--- a/client/lib/url/support.js
+++ b/client/lib/url/support.js
@@ -59,6 +59,7 @@ export const REFUNDS = `${ root }/refunds/`;
 export const REGISTER_DOMAIN = `${ root }/domains/register-domain/`;
 export const SETTING_PRIMARY_DOMAIN = `${ root }/domains/set-a-primary-address/`;
 export const SETTING_UP_PREMIUM_SERVICES = `${ root }/setting-up-premium-services/`;
+export const SET_UP_EMAIL_AUTHENTICATION_FOR_YOUR_DOMAIN = `${ root }/set-up-email-authentication-for-your-domain/`;
 export const SITE_REDIRECT = `${ root }/site-redirect/`;
 export const SUPPORT_ROOT = `${ root }/`;
 export const TRANSFER_DOMAIN_REGISTRATION = `${ root }/transfer-domain-registration/`;

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -94,7 +94,7 @@ const Home = ( {
 		useDomainDiagnosticsQuery( customDomain?.name, {
 			staleTime: 5 * 60 * 1000,
 			gcTime: 5 * 60 * 1000,
-			enabled: customDomain !== undefined,
+			enabled: customDomain !== undefined && customDomain.isMappedToAtomicSite,
 		} );
 	const emailDnsDiagnostics = domainDiagnosticData?.email_dns_records;
 

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -228,41 +228,34 @@ const Home = ( {
 		) {
 			return null;
 		}
-		const hasErrors = Object.values( emailDnsDiagnostics.records ).some(
-			( record ) => record.status === 'incorrect'
-		);
 
-		if ( hasErrors ) {
-			return (
-				<Notice
-					text={ translate(
-						// TODO: Add the corresponding support doc link when it's published
-						"There are some issues with your domain's email DNS settings. {{a}}Click here{{/a}} to see the full diagnostic for your domain.",
-						{
-							components: {
-								a: (
-									<a
-										href={ domainManagementEdit( siteId, customDomain.name, null, {
-											diagnostics: true,
-										} ) }
-									/>
-								),
-							},
-						}
-					) }
-					icon="cross-circle"
-					showDismiss={ true }
-					onDismissClick={ () => {
-						setDismissedEmailDnsDiagnostics( true );
-						setDomainNotice( customDomain.name, 'email-dns-records-diagnostics', 'ignored', () => {
-							refetchDomainDiagnosticData();
-						} );
-					} }
-					status="is-warning"
-				/>
-			);
-		}
-		return null;
+		return (
+			<Notice
+				text={ translate(
+					"There are some issues with your domain's email DNS settings. {{a}}Click here{{/a}} to see the full diagnostic for your domain.",
+					{
+						components: {
+							a: (
+								<a
+									href={ domainManagementEdit( siteId, customDomain.name, null, {
+										diagnostics: true,
+									} ) }
+								/>
+							),
+						},
+					}
+				) }
+				icon="cross-circle"
+				showDismiss={ true }
+				onDismissClick={ () => {
+					setDismissedEmailDnsDiagnostics( true );
+					setDomainNotice( customDomain.name, 'email-dns-records-diagnostics', 'ignored', () => {
+						refetchDomainDiagnosticData();
+					} );
+				} }
+				status="is-warning"
+			/>
+		);
 	};
 
 	return (

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -92,15 +92,18 @@ const Home = ( {
 	const siteDomains = useSelector( ( state ) => getDomainsBySiteId( state, siteId ) );
 	const customDomains = siteDomains?.filter( ( domain ) => ! domain.isWPCOMDomain );
 	const customDomain = customDomains?.length ? customDomains[ 0 ] : undefined;
+	const primaryDomain = customDomains?.length
+		? customDomains.find( ( domain ) => domain.isPrimary )
+		: undefined;
 
 	const {
 		data: domainDiagnosticData,
 		isFetching: isFetchingDomainDiagnostics,
 		refetch: refetchDomainDiagnosticData,
-	} = useDomainDiagnosticsQuery( customDomain?.name, {
+	} = useDomainDiagnosticsQuery( primaryDomain?.name, {
 		staleTime: 5 * 60 * 1000,
 		gcTime: 5 * 60 * 1000,
-		enabled: customDomain !== undefined && customDomain.isMappedToAtomicSite,
+		enabled: primaryDomain !== undefined && primaryDomain.isMappedToAtomicSite,
 	} );
 	const emailDnsDiagnostics = domainDiagnosticData?.email_dns_records;
 	const [ dismissedEmailDnsDiagnostics, setDismissedEmailDnsDiagnostics ] = useState( false );
@@ -239,7 +242,7 @@ const Home = ( {
 						components: {
 							diagnosticLink: (
 								<a
-									href={ domainManagementEdit( siteId, customDomain.name, null, {
+									href={ domainManagementEdit( siteId, primaryDomain.name, null, {
 										diagnostics: true,
 									} ) }
 								/>
@@ -254,7 +257,7 @@ const Home = ( {
 				showDismiss={ true }
 				onDismissClick={ () => {
 					setDismissedEmailDnsDiagnostics( true );
-					setDomainNotice( customDomain.name, 'email-dns-records-diagnostics', 'ignored', () => {
+					setDomainNotice( primaryDomain.name, 'email-dns-records-diagnostics', 'ignored', () => {
 						refetchDomainDiagnosticData();
 					} );
 				} }

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -234,7 +234,7 @@ const Home = ( {
 		return (
 			<Notice
 				text={ translate(
-					"There are some issues with your domain's email DNS settings. {{diagnosticLink}}Click here{{/diagnosticLink}} to see the full diagnostic for your domain. {{supportLink}}Learn more{{/supportLink}}",
+					"There are some issues with your domain's email DNS settings. {{diagnosticLink}}Click here{{/diagnosticLink}} to see the full diagnostic for your domain. {{supportLink}}Learn more{{/supportLink}}.",
 					{
 						components: {
 							diagnosticLink: (

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -236,6 +236,7 @@ const Home = ( {
 			return (
 				<Notice
 					text={ translate(
+						// TODO: Add the corresponding support doc link when it's published
 						"There are some issues with your domain's email DNS settings. {{a}}Click here{{/a}} to see the full diagnostic for your domain.",
 						{
 							components: {

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -1,5 +1,6 @@
 import { isFreePlanProduct } from '@automattic/calypso-products/src';
 import { Button } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useQueryClient } from '@tanstack/react-query';
 import { ExternalLink } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
@@ -25,6 +26,7 @@ import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
 import { setDomainNotice } from 'calypso/lib/domains/set-domain-notice';
 import { preventWidows } from 'calypso/lib/formatting';
 import { getQueryArgs } from 'calypso/lib/query-args';
+import { SET_UP_EMAIL_AUTHENTICATION_FOR_YOUR_DOMAIN } from 'calypso/lib/url/support';
 import Primary from 'calypso/my-sites/customer-home/locations/primary';
 import Secondary from 'calypso/my-sites/customer-home/locations/secondary';
 import Tertiary from 'calypso/my-sites/customer-home/locations/tertiary';
@@ -232,15 +234,18 @@ const Home = ( {
 		return (
 			<Notice
 				text={ translate(
-					"There are some issues with your domain's email DNS settings. {{a}}Click here{{/a}} to see the full diagnostic for your domain.",
+					"There are some issues with your domain's email DNS settings. {{diagnosticLink}}Click here{{/diagnosticLink}} to see the full diagnostic for your domain. {{supportLink}}Learn more{{/supportLink}}",
 					{
 						components: {
-							a: (
+							diagnosticLink: (
 								<a
 									href={ domainManagementEdit( siteId, customDomain.name, null, {
 										diagnostics: true,
 									} ) }
 								/>
+							),
+							supportLink: (
+								<a href={ localizeUrl( SET_UP_EMAIL_AUTHENTICATION_FOR_YOUR_DOMAIN ) } />
 							),
 						},
 					}

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -92,9 +92,7 @@ const Home = ( {
 	const siteDomains = useSelector( ( state ) => getDomainsBySiteId( state, siteId ) );
 	const customDomains = siteDomains?.filter( ( domain ) => ! domain.isWPCOMDomain );
 	const customDomain = customDomains?.length ? customDomains[ 0 ] : undefined;
-	const primaryDomain = customDomains?.length
-		? customDomains.find( ( domain ) => domain.isPrimary )
-		: undefined;
+	const primaryDomain = customDomains?.find( ( domain ) => domain.isPrimary );
 
 	const {
 		data: domainDiagnosticData,

--- a/client/my-sites/domains/domain-management/settings/cards/domain-diagnostics-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-diagnostics-card.tsx
@@ -8,6 +8,7 @@ import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import useDomainDiagnosticsQuery from 'calypso/data/domains/diagnostics/use-domain-diagnostics-query';
 import { setDomainNotice } from 'calypso/lib/domains/set-domain-notice';
+import { SET_UP_EMAIL_AUTHENTICATION_FOR_YOUR_DOMAIN } from 'calypso/lib/url/support';
 import wpcom from 'calypso/lib/wp';
 import { useDispatch } from 'calypso/state';
 import { fetchDns } from 'calypso/state/domains/dns/actions';
@@ -161,12 +162,11 @@ export default function DomainDiagnosticsCard( { domain }: { domain: ResponseDom
 		);
 	};
 
-	const supportLink = 'https://wordpress.com/support/set-up-email-authentication-for-your-domain/';
 	const noticeText = translate(
 		'If you use this domain name to send email from your WordPress.com website, the following email records are required. {{a}}Learn more{{/a}}.',
 		{
 			components: {
-				a: <a href={ localizeUrl( supportLink ) } />,
+				a: <a href={ localizeUrl( SET_UP_EMAIL_AUTHENTICATION_FOR_YOUR_DOMAIN ) } />,
 			},
 		}
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the one linked issue.
-->

Related to #86325.

## Proposed Changes
Includes a notice on the home page for the diagnostics of the primary domain, pointing the user to the management card if the domain needs attention.

## Testing Instructions
- Open the home page for a domain in an atomic site or hack your backend so that the diagnostics endpoint thinks your site is atomic;
- On your primary domain, change your DNS email records (SPF, DKIM 1 and 2, DMARC) to incorrect values (see pcYYhz-1KI-p2 for the expected values);
- Ensure the notice is displayed.
- In the case the domain uses WPCOM name servers:
  - Click on the "Fix DNS issues automatically" button and go back to the home page;
  - Ensure the notice isn't displayed anymore.
- In the case the domain doesn't use WPCOM name servers:
  - Use the correct DNS email records;
  - Wait 5 minutes (cached data stale time) and go back to the home page;
  - Ensure the notice isn't displayed anymore.
- Ensure the dismiss button works as intended - clicking the button should dismiss the notice permanently, even after browsing to the diagnostic page.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
### Screenshot
![image](https://github.com/Automattic/wp-calypso/assets/18705930/06769673-d708-4c4e-a9d8-bb28bdb37533)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?