### PR TITLE
Checkout: Render sale discounts separately per item in sidebar

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -83,7 +83,10 @@ export function CostOverridesList( {
 		<CostOverridesListStyle>
 			{ nonCouponOverrides.map( ( costOverride ) => {
 				return (
-					<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
+					<div
+						className="cost-overrides-list-item"
+						key={ costOverride.humanReadableReason + costOverride.overrideCode }
+					>
 						<span className="cost-overrides-list-item__reason">
 							{ costOverride.humanReadableReason }
 						</span>

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -143,6 +143,23 @@ export function filterAndGroupCostOverridesForDisplay(
 				// are not discounts.
 				return;
 			}
+
+			// Do not group Sale Coupons because we want to show the name of each item on sale.
+			if ( costOverride.override_code === 'sale-coupon-discount-1' ) {
+				const newDiscountAmount =
+					costOverride.old_subtotal_integer - costOverride.new_subtotal_integer;
+
+				grouped[ costOverride.override_code + '__' + product.uuid ] = {
+					humanReadableReason: translate( 'Sale: %(productName)s', {
+						textOnly: true,
+						args: { productName: product.product_name },
+					} ),
+					overrideCode: costOverride.override_code,
+					discountAmount: newDiscountAmount,
+				};
+				return;
+			}
+
 			const discountAmount = grouped[ costOverride.override_code ]?.discountAmount ?? 0;
 			const newDiscountAmount =
 				costOverride.old_subtotal_integer - costOverride.new_subtotal_integer;


### PR DESCRIPTION
## Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/86360 which renders line item discounts in the sidebar, grouped by type. One difficulty with that system is that sale discounts are grouped together as "Item on sale", and since the discounts are displayed separately from the items to which they belong, it's not easy to tell which item is on sale.

In this diff we split out sale discounts into individual lines and include the name of each item.

Before             |  After
:-------------------------:|:-------------------------:
<img width="304" alt="Screenshot 2024-01-22 at 4 39 43 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/95e1d4f0-6cae-414d-9937-fdb201df119e"> | <img width="302" alt="Screenshot 2024-01-22 at 4 44 45 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/3fff0e85-8ca1-4f0a-82ea-a34faac1c3b5">

This is part of the checkout v2 redesign: https://github.com/Automattic/payments-shilling/issues/1969

## Testing Instructions

Add two products which have sale discounts (eg: many domains in the production tables) to your cart and visit checkout. Verify that each one's sale price is included separately in the sidebar.