### PR TITLE
Users: Tidy up Edit Team Member Form

### DIFF
--- a/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
+++ b/client/my-sites/people/edit-team-member-form/edit-user-form.jsx
@@ -312,7 +312,8 @@ class EditUserForm extends Component {
 			return null;
 		}
 
-		const { autoSave, translate, hasWPCOMAccountLinked, disabled, isUpdating } = this.props;
+		const { autoSave, currentUser, user, translate, hasWPCOMAccountLinked, disabled, isUpdating } =
+			this.props;
 
 		return (
 			<form
@@ -322,10 +323,10 @@ class EditUserForm extends Component {
 				onChange={ () => this.onFormChange() }
 			>
 				{ editableFields.map( ( fieldId ) => this.renderField( fieldId, isUpdating ) ) }
-				{ hasWPCOMAccountLinked && (
+				{ hasWPCOMAccountLinked && user.ID !== currentUser.ID && (
 					<p className="edit-team-member-form__explanation">
 						{ translate(
-							'This user has a WordPress.com account, only they are allowed to update their personal information through their WordPress.com profile settings.'
+							'This user has a WordPress.com account. Only they are allowed to update their personal information through their WordPress.com profile settings.'
 						) }
 					</p>
 				) }

--- a/client/my-sites/people/edit-team-member-form/style.scss
+++ b/client/my-sites/people/edit-team-member-form/style.scss
@@ -14,5 +14,5 @@
 }
 
 .edit-team-member-form__explanation {
-	color: var(--color-neutral-light);
+	color: var(--color-text-subtle);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Tidies one string for users that have a WordPress.com account:

- Ensures that the colour contrast is accessible
- Fixes a typo
- Hides the string for the current user, for whom it doesn't make sense. 

## Testing Instructions

Go to My Sites > Users > All Users and select an account (you might need to invite a test account to your site). Verify that the colour contrast is accessible, and that it no longer displays if it's the account which you're signed into.

<img width="776" alt="Screenshot 2024-01-14 at 20 00 55" src="https://github.com/Automattic/wp-calypso/assets/43215253/68358b1a-1e53-415b-b41b-21a34a9e2880">

cc @cpapazoglou - looks like you added this? :)
