### PR TITLE
Jetpack Manage: Implement payment card footer

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/index.tsx
@@ -34,16 +34,25 @@ export default function PaymentMethodListV2() {
 
 	const [ paging ] = useState( { startingAfter: '', endingBefore: '' } ); // TODO: Implement pagination.
 
+	const primaryCard = storedCards.find( ( card ) => card.is_default );
+	const secondaryCards = storedCards.filter( ( card ) => ! card.is_default );
+
 	const getBody = () => {
 		if ( isFetching ) {
 			return 'Loading...';
 		}
 
-		if ( storedCards.length ) {
+		if ( storedCards.length > 0 ) {
 			return (
 				<div className="payment-method-list-v2__stored-cards">
-					{ storedCards.map( ( card: PaymentMethod ) => (
-						<StoredCreditCardV2 key={ card.id } creditCard={ card } />
+					{ primaryCard && <StoredCreditCardV2 creditCard={ primaryCard } /> }
+					{ secondaryCards.map( ( card: PaymentMethod, index ) => (
+						<StoredCreditCardV2
+							key={ card.id }
+							creditCard={ card }
+							showSecondaryCardCount={ secondaryCards.length > 1 }
+							secondaryCardCount={ index + 1 }
+						/>
 					) ) }
 				</div>
 			);

--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-card-v2/credit-card-actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-card-v2/credit-card-actions.tsx
@@ -1,0 +1,60 @@
+import { Gridicon, Button } from '@automattic/components';
+import classNames from 'classnames';
+import { useRef, useState } from 'react';
+import PopoverMenu from 'calypso/components/popover-menu';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+
+export default function CreditCardActions( {
+	cardActions,
+}: {
+	cardActions: {
+		name: string;
+		isEnabled: boolean;
+		onClick: () => void;
+		className?: string;
+	}[];
+} ) {
+	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
+	const [ isOpen, setIsOpen ] = useState( false );
+
+	const showActions = () => {
+		setIsOpen( true );
+	};
+
+	const closeDropdown = () => {
+		setIsOpen( false );
+	};
+
+	return (
+		<>
+			<Button
+				borderless
+				compact
+				onClick={ showActions }
+				ref={ buttonActionRef }
+				className="stored-credit-card-v2__card-footer-actions"
+			>
+				<Gridicon icon="ellipsis" size={ 18 } />
+			</Button>
+			<PopoverMenu
+				className="stored-credit-card-v2__card-footer-actions-popover"
+				context={ buttonActionRef.current }
+				isVisible={ isOpen }
+				onClose={ closeDropdown }
+				position="bottom left"
+			>
+				{ cardActions
+					.filter( ( action ) => action.isEnabled )
+					.map( ( action ) => (
+						<PopoverMenuItem
+							className={ classNames( action.className ) }
+							key={ action.name }
+							onClick={ action.onClick }
+						>
+							{ action.name }
+						</PopoverMenuItem>
+					) ) }
+			</PopoverMenu>
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-card-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-card-v2/index.tsx
@@ -1,19 +1,84 @@
 import { PaymentLogo } from '@automattic/wpcom-checkout';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import CreditCardActions from './credit-card-actions';
 import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
 
 import './style.scss';
 
-export default function StoredCreditCardV2( { creditCard }: { creditCard: PaymentMethod } ) {
+export default function StoredCreditCardV2( {
+	creditCard,
+	showSecondaryCardCount = false,
+	secondaryCardCount = 0,
+}: {
+	creditCard: PaymentMethod;
+	showSecondaryCardCount?: boolean;
+	secondaryCardCount?: number;
+} ) {
 	const translate = useTranslate();
 
 	const cardBrand = creditCard?.card.brand;
 	const expiryMonth = creditCard?.card.exp_month;
 	const expiryYear = creditCard?.card.exp_year.toString().slice( -2 ); // Take the last two digits of the year.
 
+	const isDefault = creditCard?.is_default;
+
+	const secondaryCardCountText = showSecondaryCardCount
+		? translate( 'Secondary Card %(secondaryCardCount)d', {
+				args: { secondaryCardCount },
+		  } )
+		: translate( 'Secondary Card' );
+
+	const cardActions = [
+		{
+			name: translate( 'Set as primary card' ),
+			isEnabled: ! isDefault,
+			onClick: () => {},
+		},
+		{
+			name: translate( 'Delete' ),
+			isEnabled: true,
+			onClick: () => {},
+			className: 'stored-credit-card-v2__card-footer-actions-delete',
+		},
+	];
+
 	return (
 		<div className="stored-credit-card-v2__card">
+			<div className="stored-credit-card-v2__card-content">
+				<div className="stored-credit-card-v2__card-number">
+					**** **** **** { creditCard.card.last4 }
+				</div>
+				<div className="stored-credit-card-v2__card-details">
+					<span>
+						<div className="stored-credit-card-v2__card-info-heading">
+							{ translate( 'Card Holder name' ) }
+						</div>
+						<div className="stored-credit-card-v2__card-info-value"> { creditCard?.name }</div>
+					</span>
+					<span>
+						<div className="stored-credit-card-v2__card-info-heading">
+							{ translate( 'Expiry Date' ) }
+						</div>
+						<div className="stored-credit-card-v2__card-info-value">{ `${ expiryMonth }/${ expiryYear }` }</div>
+					</span>
+				</div>
+			</div>
+			<div className="stored-credit-card-v2__card-footer">
+				<span>
+					<div className="stored-credit-card-v2__card-footer-title">
+						{ isDefault ? translate( 'Primary Card' ) : secondaryCardCountText }
+					</div>
+					<div className="stored-credit-card-v2__card-footer-subtitle">
+						{ isDefault
+							? translate( 'This card is charged automatically each month.' )
+							: translate( 'This card is charged only if the primary one fails.' ) }
+					</div>
+				</span>
+				<span>
+					<CreditCardActions cardActions={ cardActions } />
+				</span>
+			</div>
 			<div
 				className={ classNames(
 					'stored-credit-card-v2__payment-logo',
@@ -21,23 +86,6 @@ export default function StoredCreditCardV2( { creditCard }: { creditCard: Paymen
 				) }
 			>
 				<PaymentLogo brand={ cardBrand } isSummary={ true } />
-			</div>
-			<div className="stored-credit-card-v2__card-number">
-				**** **** **** { creditCard.card.last4 }
-			</div>
-			<div className="stored-credit-card-v2__card-details">
-				<span>
-					<div className="stored-credit-card-v2__card-info-heading">
-						{ translate( 'Card Holder name' ) }
-					</div>
-					<div className="stored-credit-card-v2__card-info-value"> { creditCard?.name }</div>
-				</span>
-				<span>
-					<div className="stored-credit-card-v2__card-info-heading">
-						{ translate( 'Expiry Date' ) }
-					</div>
-					<div className="stored-credit-card-v2__card-info-value">{ `${ expiryMonth }/${ expiryYear }` }</div>
-				</span>
 			</div>
 		</div>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-card-v2/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-card-v2/style.scss
@@ -3,33 +3,35 @@
 
 .stored-credit-card-v2__card {
 	position: relative;
-	width: 305px;
-	padding-inline: 24px;
-	height: 220px;
-	border-radius: 18px; /* stylelint-disable-line scales/radii */
-	color: var(--studio-white);
-	background: url(calypso/assets/images/jetpack/credit-card-1.svg) no-repeat;
+
+	.stored-credit-card-v2__card-content {
+		padding-inline: 24px;
+		height: 220px;
+		border-radius: 18px; /* stylelint-disable-line scales/radii */
+		color: var(--studio-white);
+		background: url(calypso/assets/images/jetpack/credit-card-1.svg) no-repeat;
+	}
 
 	// Apply background images to every second card
-	&:nth-child(3n-1) {
+	&:nth-child(3n-1) .stored-credit-card-v2__card-content {
 		background: url(calypso/assets/images/jetpack/credit-card-2.svg) no-repeat;
 	}
 
 	// Apply background images to every third card
-	&:nth-child(3n) {
+	&:nth-child(3n) .stored-credit-card-v2__card-content {
 		background: url(calypso/assets/images/jetpack/credit-card-3.svg) no-repeat;
 	}
 }
 
 .stored-credit-card-v2__card-number {
-	margin-block-start: 90px;
+	padding-block-start: 90px;
 	font-size: rem(24px);
 	font-weight: 700;
 	line-height: 1.5;
 
 	@include break-mobile {
 		font-size: rem(35px);
-		margin-block-start: 65px;
+		padding-block-start: 65px;
 	}
 }
 
@@ -90,3 +92,49 @@
 	}
 }
 
+.stored-credit-card-v2__card-footer {
+	display: flex;
+	flex-direction: row;
+	justify-content: space-between;
+	margin-block-start: 16px;
+}
+
+.stored-credit-card-v2__card-footer-title {
+	font-size: rem(16px);
+	font-weight: 500;
+}
+
+.stored-credit-card-v2__card-footer-subtitle {
+	font-size: rem(12px);
+	font-weight: 400;
+}
+
+button.button.stored-credit-card-v2__card-footer-actions {
+	padding: 16px;
+}
+
+.stored-credit-card-v2__card-footer-actions-popover {
+	.popover__menu-item {
+		padding-block: 12px;
+
+		&:hover,
+		&:focus {
+			background: var(--color-sidebar-menu-hover-background);
+			color: var(--color-text);
+			fill: var(--color-text);
+
+			.gridicon {
+				fill: var(--color-text);
+			}
+		}
+	}
+
+
+	.popover__menu-item.stored-credit-card-v2__card-footer-actions-delete {
+		&,
+		&:hover,
+		&:focus {
+			color: var(--studio-red-50);
+		}
+	}
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/185
Resolves https://github.com/Automattic/jetpack-genesis/issues/186

## Proposed Changes

This PR:

- adds a heading & subheading to showcase the card info
- adds more options menu that shows the available actions

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Click Purchases > Click Payment Methods
2. Append the URL with `?flags=jetpack/card-addition-improvements`
3. Verify that the card heading, subheading, and more actions `...` are displayed as shown below.

When there is one `Primary Card`

<img width="1482" alt="Screenshot 2024-01-15 at 10 49 32 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/2964241b-3212-489b-926d-628c2dda9060">

When there is one `Primary Card`and one `Secondary Card`

<img width="1482" alt="Screenshot 2024-01-15 at 11 13 01 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3b091747-270e-4a70-82b6-4c9cff9d699b">

When there is one `Primary Card`and multiple `Secondary Card`

<img width="1482" alt="Screenshot 2024-01-15 at 11 17 46 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/1f5a5c6f-13c6-4485-b15f-cc214e8fe774">


4. Click the `...` icon and verify that the actions are displayed as shown below. The actions are not implemented yet, and will be implemented in upcoming PRs.

For Primary 

<img width="354" alt="Screenshot 2024-01-15 at 11 19 59 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/67682e61-f50f-44d1-b503-880d33699422">

For Secondary

<img width="354" alt="Screenshot 2024-01-15 at 11 20 31 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/f5a4c2ea-19ab-4ee7-8405-adc5c27e15c1">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?