### PR TITLE
Assembler: Update the large preview device order

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -19,15 +19,6 @@
 			max-width: 1080px;
 		}
 	}
-
-	$device-order: ( "phone": 0, "tablet": 1, "computer": 2, "zoom": 3 );
-	.device-switcher__toolbar-devices {
-		@each $device, $order in $device-order {
-			.#{$device} {
-				order: $order;
-			}
-		}
-	}
 }
 
 .pattern-large-preview__patterns {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86214

## Proposed Changes

This PR updates the device order to align with the design picker.

| Before | After |
| --- | --- |
| ![Screenshot 2024-01-15 at 3 31 57 PM](https://github.com/Automattic/wp-calypso/assets/797888/6b819659-d65d-4433-b9b9-170741324e63) | ![Screenshot 2024-01-15 at 3 31 34 PM](https://github.com/Automattic/wp-calypso/assets/797888/10cc2176-e163-4911-9aca-41adc39099e1) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to the Assembler.
* Select any pattern.
* Ensure that the device order is updated as shown in the screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?