### PR TITLE
Jetpack Manage: Show stepper on Add payment method other flows.

### DIFF
--- a/client/jetpack-cloud/components/layout/stepper.tsx
+++ b/client/jetpack-cloud/components/layout/stepper.tsx
@@ -1,0 +1,56 @@
+import { Gridicon } from '@automattic/components';
+import classnames from 'classnames';
+import { Fragment } from 'react';
+
+type Props = {
+	steps: string[];
+	current: number;
+};
+
+function getStepClassName( currentStep: number, step: number ): string {
+	return classnames( {
+		'is-current': currentStep === step,
+		'is-next': currentStep < step,
+		'is-complete': currentStep > step,
+	} );
+}
+
+function Marker( { currentStep, step }: { currentStep: number; step: number } ) {
+	if ( currentStep > step ) {
+		return (
+			<span className="jetpack-cloud-layout__stepper-step-circle">
+				<Gridicon icon="checkmark" size={ 16 } />
+			</span>
+		);
+	}
+
+	return (
+		<span className="jetpack-cloud-layout__stepper-step-circle">
+			<span>{ step }</span>
+		</span>
+	);
+}
+
+export default function LayoutStepper( { steps, current }: Props ) {
+	return (
+		<div className="jetpack-cloud-layout__stepper">
+			{ steps.map( ( label, index ) => (
+				<Fragment key={ `step-${ index }` }>
+					<div
+						className={ `jetpack-cloud-layout__stepper-step ${ getStepClassName(
+							current,
+							index
+						) }` }
+					>
+						<Marker currentStep={ current + 1 } step={ index + 1 } />
+						<span className="jetpack-cloud-layout__stepper-step-name">{ label }</span>
+					</div>
+
+					{ index < steps.length - 1 && (
+						<div className="jetpack-cloud-layout__stepper-step-separator" />
+					) }
+				</Fragment>
+			) ) }
+		</div>
+	);
+}

--- a/client/jetpack-cloud/components/layout/style.scss
+++ b/client/jetpack-cloud/components/layout/style.scss
@@ -213,6 +213,83 @@
 	}
 }
 
-.jetpack-cloud-layout__viewport {
-	margin-inline-start: 0;
+
+.jetpack-cloud-layout__stepper {
+	display: flex;
+	justify-content: flex-start;
+	align-items: center;
+	margin-block: 16px 32px;
+}
+
+.jetpack-cloud-layout__stepper-step {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+
+	.jetpack-cloud-layout__stepper-step-circle {
+		width: 20px;
+		height: 20px;
+		display: flex;
+		border-radius: 50%;
+		justify-content: center;
+		align-content: center;
+		align-items: center;
+		font-size: 0.75rem;
+	}
+
+	.jetpack-cloud-layout__stepper-step-name {
+		margin-left: 0.5rem;
+		white-space: nowrap;
+	}
+
+	.jetpack-cloud-layout__viewport {
+		margin-inline-start: 0;
+	}
+
+	&.is-current > .jetpack-cloud-layout__stepper-step-circle {
+		background-color: var(--studio-gray-60);
+		border: 2px solid var(--studio-gray-60);
+		color: var(--studio-white);
+	}
+
+	&.is-next > .jetpack-cloud-layout__stepper-step-circle {
+		border: 2px solid var(--studio-gray-60);
+		color: var(--studio-gray-80);
+	}
+
+	&.is-complete > .jetpack-cloud-layout__stepper-step-circle {
+		background-color: var(--studio-jetpack-green-50);
+		border: 2px solid var(--studio-jetpack-green-50);
+		color: var(--studio-white);
+	}
+
+	&.is-next > .jetpack-cloud-layout__stepper-step-name {
+		display: none;
+
+		@include break-medium {
+			display: flex;
+		}
+	}
+
+	&.is-complete > .jetpack-cloud-layout__stepper-step-name,
+	&.is-complete > .jetpack-cloud-layout__stepper-step-circle,
+	&.is-complete + .jetpack-cloud-layout__stepper-step-separator {
+		display: none;
+
+		@include break-medium {
+			display: flex;
+		}
+	}
+}
+
+.jetpack-cloud-layout__stepper-step-separator {
+	border: 1px solid var(--studio-gray-80);
+	width: 20px;
+	height: 0;
+	margin: 0 0.75rem;
+
+	@include break-medium {
+		width: 40px;
+		margin: 0 1.25rem;
+	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/hooks/use-payment-method-stepper.ts
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/hooks/use-payment-method-stepper.ts
@@ -1,0 +1,41 @@
+import { getQueryArg } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+
+export function usePaymentMethodStepper() {
+	const translate = useTranslate();
+
+	const products = ( getQueryArg( window.location.href, 'products' ) ?? '' ).toString();
+	const product = ( getQueryArg( window.location.href, 'product' ) ?? '' ).toString();
+	const source = ( getQueryArg( window.location.href, 'source' ) || '' ).toString();
+
+	const isIssueLicenseFlow = !! products;
+	const isSiteCreationFlow = source === 'create-site' && !! product;
+
+	return useMemo( () => {
+		if ( isIssueLicenseFlow ) {
+			return {
+				steps: [
+					translate( 'Select licenses' ),
+					translate( 'Review selections' ),
+					translate( 'Add Payment Method' ),
+					translate( 'Assign licenses' ),
+				],
+				current: 2,
+			};
+		}
+
+		if ( isSiteCreationFlow ) {
+			return {
+				steps: [
+					translate( 'Select plan' ),
+					translate( 'Add Payment Method' ),
+					translate( 'Create site' ),
+				],
+				current: 1,
+			};
+		}
+
+		return null;
+	}, [ isIssueLicenseFlow, isSiteCreationFlow, translate ] );
+}

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/index.tsx
@@ -7,10 +7,12 @@ import LayoutHeader, {
 	LayoutHeaderTitle as Title,
 	LayoutHeaderBreadcrumb as Breadcrumb,
 } from 'calypso/jetpack-cloud/components/layout/header';
+import LayoutStepper from 'calypso/jetpack-cloud/components/layout/stepper';
 import LayoutTop from 'calypso/jetpack-cloud/components/layout/top';
 import PaymentMethodForm from '../../payment-method-form';
 import PaymentMethodStripeInfo from '../../payment-method-stripe-info';
 import PartnerPortalSidebarNavigation from '../../sidebar-navigation';
+import { usePaymentMethodStepper } from './hooks/use-payment-method-stepper';
 
 import './style.scss';
 
@@ -20,6 +22,8 @@ export default function PaymentMethodListV2() {
 	const title = translate( 'Add new card' );
 	const subtitle = translate( 'You will only be charged for paid licenses you issue.' );
 
+	const stepper = usePaymentMethodStepper();
+
 	return (
 		<Layout
 			className="payment-method-add"
@@ -27,14 +31,18 @@ export default function PaymentMethodListV2() {
 			sidebarNavigation={ <PartnerPortalSidebarNavigation /> }
 			wide
 		>
+			{ !! stepper && <LayoutStepper steps={ stepper.steps } current={ stepper.current } /> }
+
 			<LayoutTop>
 				<LayoutHeader>
-					<Breadcrumb
-						items={ [
-							{ label: translate( 'Payment Methods' ), href: '/partner-portal/payment-methods' },
-							{ label: translate( 'Add new card' ) },
-						] }
-					/>
+					{ ! stepper && (
+						<Breadcrumb
+							items={ [
+								{ label: translate( 'Payment Methods' ), href: '/partner-portal/payment-methods' },
+								{ label: translate( 'Add new card' ) },
+							] }
+						/>
+					) }
 					<Title>{ title } </Title>
 					<Subtitle>{ subtitle }</Subtitle>
 				</LayoutHeader>


### PR DESCRIPTION
This pull request displays a stepper on the 'Add Payment Method' page to indicate the current flow.

<img width="940" alt="Screen Shot 2024-01-15 at 5 05 27 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/e750edcb-4936-4b3c-bd56-cad1cbdf398b">

<img width="964" alt="Screen Shot 2024-01-15 at 5 05 53 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/33bd1214-6313-456e-8901-857fc33bcd12">

Closes https://github.com/Automattic/jetpack-genesis/issues/191 

## Proposed Changes

* Implement a reusable layout stepper component.
* Add a stepper to the **'Add Payment method'** page. The page will determine whether it is part of the Site creation flow or Issue Licenses flow and display the corresponding steps.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.
* First, clear all payment methods on the Payment Methods page. (`/partner-portal/payment-methods`)
* Once you have cleared all the payment methods, go to the Issue licenses page and issue any license (`/partner-portal/issue-license?flags=jetpack/card-addition-improvements`)
* Proceed to issue this until you reach the **'Add payment method'** page.
* Confirm that the stepper shows the correct steps above the header. 
  <img width="964" alt="Screen Shot 2024-01-15 at 5 05 53 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/33bd1214-6313-456e-8901-857fc33bcd12">
* Next, go to the site creation page (`/partner-portal/create-site?flags=jetpack/card-addition-improvements`)
* Select any plan to reach the **'Add payment method'** page.
* Confirm that the stepper shows the correct steps above the header.
  <img width="940" alt="Screen Shot 2024-01-15 at 5 05 27 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/e750edcb-4936-4b3c-bd56-cad1cbdf398b">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?