### PR TITLE
Jetpack Manage: implement the "Set as primary card" functionality for secondary credit cards.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-card-v2/credit-card-actions.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-card-v2/credit-card-actions.tsx
@@ -6,6 +6,7 @@ import PopoverMenuItem from 'calypso/components/popover-menu/item';
 
 export default function CreditCardActions( {
 	cardActions,
+	isDisabled,
 }: {
 	cardActions: {
 		name: string;
@@ -13,6 +14,7 @@ export default function CreditCardActions( {
 		onClick: () => void;
 		className?: string;
 	}[];
+	isDisabled: boolean;
 } ) {
 	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
 	const [ isOpen, setIsOpen ] = useState( false );
@@ -28,6 +30,7 @@ export default function CreditCardActions( {
 	return (
 		<>
 			<Button
+				disabled={ isDisabled }
 				borderless
 				compact
 				onClick={ showActions }

--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-card-v2/hooks/use-set-as-primary-card.ts
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-card-v2/hooks/use-set-as-primary-card.ts
@@ -1,0 +1,54 @@
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { useDispatch } from 'calypso/state';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { fetchStoredCards } from 'calypso/state/partner-portal/stored-cards/actions';
+import useSetAsPrimaryCardMutation from 'calypso/state/partner-portal/stored-cards/hooks/use-set-as-primary-card-mutation';
+import type { SetAsPrimaryCardProps } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+
+const NOTIFICATION_DURATION = 3000;
+
+export function useSetAsPrimaryCard(): {
+	setAsPrimaryCard: ( params: SetAsPrimaryCardProps ) => void;
+	isSetAsPrimaryCardPending: boolean;
+} {
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const { mutate, isPending, isSuccess, isError } = useSetAsPrimaryCardMutation( {
+		retry: false,
+	} );
+
+	useEffect( () => {
+		if ( isSuccess ) {
+			dispatch(
+				fetchStoredCards( {
+					startingAfter: '',
+					endingBefore: '',
+				} )
+			);
+			dispatch(
+				successNotice( translate( 'Card set as primary.' ), {
+					duration: NOTIFICATION_DURATION,
+					id: 'set-as-primary-card-success',
+				} )
+			);
+		}
+	}, [ dispatch, isSuccess, translate ] );
+
+	useEffect( () => {
+		if ( isError ) {
+			dispatch(
+				errorNotice( translate( 'Something went wrong. Please try again.' ), {
+					duration: NOTIFICATION_DURATION,
+					id: 'set-as-primary-card-error',
+				} )
+			);
+		}
+	}, [ dispatch, isError, translate ] );
+
+	return {
+		setAsPrimaryCard: mutate,
+		isSetAsPrimaryCardPending: isPending,
+	};
+}

--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-card-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-card-v2/index.tsx
@@ -2,6 +2,7 @@ import { PaymentLogo } from '@automattic/wpcom-checkout';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import CreditCardActions from './credit-card-actions';
+import { useSetAsPrimaryCard } from './hooks/use-set-as-primary-card';
 import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
 
 import './style.scss';
@@ -29,11 +30,18 @@ export default function StoredCreditCardV2( {
 		  } )
 		: translate( 'Secondary Card' );
 
+	const { isSetAsPrimaryCardPending, setAsPrimaryCard } = useSetAsPrimaryCard();
+
 	const cardActions = [
 		{
 			name: translate( 'Set as primary card' ),
 			isEnabled: ! isDefault,
-			onClick: () => {},
+			onClick: () => {
+				setAsPrimaryCard( {
+					paymentMethodId: creditCard.id,
+					useAsPrimaryPaymentMethod: true,
+				} );
+			},
 		},
 		{
 			name: translate( 'Delete' ),
@@ -44,7 +52,11 @@ export default function StoredCreditCardV2( {
 	];
 
 	return (
-		<div className="stored-credit-card-v2__card">
+		<div
+			className={ classNames( 'stored-credit-card-v2__card', {
+				'is-loading': isSetAsPrimaryCardPending,
+			} ) }
+		>
 			<div className="stored-credit-card-v2__card-content">
 				<div className="stored-credit-card-v2__card-number">
 					**** **** **** { creditCard.card.last4 }
@@ -76,7 +88,7 @@ export default function StoredCreditCardV2( {
 					</div>
 				</span>
 				<span>
-					<CreditCardActions cardActions={ cardActions } />
+					<CreditCardActions cardActions={ cardActions } isDisabled={ isSetAsPrimaryCardPending } />
 				</span>
 			</div>
 			<div

--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-card-v2/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-card-v2/style.scss
@@ -4,6 +4,10 @@
 .stored-credit-card-v2__card {
 	position: relative;
 
+	&.is-loading {
+		opacity: 0.3;
+	}
+
 	.stored-credit-card-v2__card-content {
 		padding-inline: 24px;
 		height: 220px;

--- a/client/jetpack-cloud/sections/partner-portal/types.ts
+++ b/client/jetpack-cloud/sections/partner-portal/types.ts
@@ -51,3 +51,8 @@ export interface LicenseAction {
 	isExternalLink?: boolean;
 	className?: string;
 }
+
+export interface SetAsPrimaryCardProps {
+	paymentMethodId: string;
+	useAsPrimaryPaymentMethod: boolean;
+}

--- a/client/state/partner-portal/stored-cards/hooks/use-set-as-primary-card-mutation.ts
+++ b/client/state/partner-portal/stored-cards/hooks/use-set-as-primary-card-mutation.ts
@@ -1,0 +1,30 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+import type { SetAsPrimaryCardProps } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+
+interface APIResponse {
+	success: boolean;
+}
+
+function mutationSetAsPrimaryCard( {
+	paymentMethodId,
+	useAsPrimaryPaymentMethod,
+}: SetAsPrimaryCardProps ): Promise< APIResponse > {
+	return wpcomJpl.req.post( {
+		apiNamespace: 'wpcom/v2',
+		path: `/jetpack-licensing/stripe/payment-method`,
+		body: {
+			payment_method_id: paymentMethodId,
+			use_as_primary_payment_method: useAsPrimaryPaymentMethod,
+		},
+	} );
+}
+
+export default function useSetAsPrimaryCardMutation< TContext = unknown >(
+	options?: UseMutationOptions< APIResponse, Error, SetAsPrimaryCardProps, TContext >
+): UseMutationResult< APIResponse, Error, SetAsPrimaryCardProps, TContext > {
+	return useMutation< APIResponse, Error, SetAsPrimaryCardProps, TContext >( {
+		...options,
+		mutationFn: mutationSetAsPrimaryCard,
+	} );
+}


### PR DESCRIPTION

Resolves https://github.com/Automattic/jetpack-genesis/issues/187

## Proposed Changes

This PR implements the "Set as primary card" functionality for secondary credit cards.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Click Purchases > Click Payment Methods
2. Append the URL with `?flags=jetpack/card-addition-improvements`
3. Click the `...` icon on the added credit card and verify that the actions are displayed as shown below. 

<img width="354" alt="Screenshot 2024-01-15 at 11 20 31 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8659dde5-5443-4d6a-ab8d-ba16c93359e7">


4. Click the Set as primary card option and verify that the loading animation is displayed as shown below and the success notice is shown.

<img width="354" alt="Screenshot 2024-01-15 at 2 49 15 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/b8c39bf9-e180-4f30-95c8-af90210cc24d">

<img width="379" alt="Screenshot 2024-01-15 at 2 58 54 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/1d751790-ec9a-4db1-ad09-4ece54d00178">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?