### PR TITLE
Jetpack Manage: Add Mobile sidebar navigation in the new payment method pages.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/index.tsx
@@ -15,6 +15,7 @@ import {
 	getAllStoredCards,
 	isFetchingStoredCards,
 } from 'calypso/state/partner-portal/stored-cards/selectors';
+import PartnerPortalSidebarNavigation from '../sidebar-navigation';
 import StoredCreditCardV2 from '../stored-credit-card-v2';
 import EmptyState from './empty-state';
 import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
@@ -57,7 +58,12 @@ export default function PaymentMethodListV2() {
 	};
 
 	return (
-		<Layout className="payment-method-list-v2" title={ title } wide>
+		<Layout
+			className="payment-method-list-v2"
+			title={ title }
+			sidebarNavigation={ <PartnerPortalSidebarNavigation /> }
+			wide
+		>
 			<QueryJetpackPartnerPortalStoredCards paging={ paging } />
 
 			<LayoutTop>

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/index.tsx
@@ -10,6 +10,7 @@ import LayoutHeader, {
 import LayoutTop from 'calypso/jetpack-cloud/components/layout/top';
 import PaymentMethodForm from '../../payment-method-form';
 import PaymentMethodStripeInfo from '../../payment-method-stripe-info';
+import PartnerPortalSidebarNavigation from '../../sidebar-navigation';
 
 import './style.scss';
 
@@ -20,7 +21,12 @@ export default function PaymentMethodListV2() {
 	const subtitle = translate( 'You will only be charged for paid licenses you issue.' );
 
 	return (
-		<Layout className="payment-method-add" title={ title } wide>
+		<Layout
+			className="payment-method-add"
+			title={ title }
+			sidebarNavigation={ <PartnerPortalSidebarNavigation /> }
+			wide
+		>
 			<LayoutTop>
 				<LayoutHeader>
 					<Breadcrumb


### PR DESCRIPTION
This pull request adds a mobile sidebar navigation to the new payment method page.

<img width="395" alt="Screen Shot 2024-01-15 at 6 14 50 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/6f8d560d-a4ae-4423-bb45-6d1143963497">

<img width="393" alt="Screen Shot 2024-01-15 at 6 14 57 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/78758140-adc4-45e3-8a63-57ad87ed0f1a">

Closes https://github.com/Automattic/jetpack-genesis/issues/194

## Proposed Changes

* Set `PartnerPortalSidebarNavigation` as the layout sidebar for both payment method pages.


## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Use the Jetpack cloud live link and go to the payment methods page (`/partner-portal/payment-methods?flags=jetpack/card-addition-improvements`)
* Set your browser's screen to mobile mode.
* Confirm that the mobile sidebar navigation is visible and working.
* Do the same test on the Add payment method page (`/partner-portal/payment-methods/add?flags=jetpack/card-addition-improvements`)

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?