### PR TITLE
Make free plan card less obscure

### DIFF
--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -8,6 +8,7 @@ import {
 	isWooExpressSmallPlan,
 	isWpComFreePlan,
 	isWpcomEnterpriseGridPlan,
+	isFreePlan,
 } from '@automattic/calypso-products';
 import {
 	BloombergLogo,
@@ -130,13 +131,15 @@ class FeaturesGrid extends Component< FeaturesGridProps > {
 			getPlanClass( gridPlanForSpotlight.planSlug )
 		);
 
+		const isNotFreePlan = ! isFreePlan( gridPlanForSpotlight.planSlug );
+
 		return (
 			<div className={ spotlightPlanClasses }>
 				{ this.renderPlanLogos( [ gridPlanForSpotlight ] ) }
 				{ this.renderPlanHeaders( [ gridPlanForSpotlight ] ) }
-				{ this.renderPlanTagline( [ gridPlanForSpotlight ] ) }
-				{ this.renderPlanPrice( [ gridPlanForSpotlight ] ) }
-				{ this.renderBillingTimeframe( [ gridPlanForSpotlight ] ) }
+				{ isNotFreePlan && this.renderPlanTagline( [ gridPlanForSpotlight ] ) }
+				{ isNotFreePlan && this.renderPlanPrice( [ gridPlanForSpotlight ] ) }
+				{ isNotFreePlan && this.renderBillingTimeframe( [ gridPlanForSpotlight ] ) }
 				{ this.renderPlanStorageOptions( [ gridPlanForSpotlight ] ) }
 				{ this.renderTopButtons( [ gridPlanForSpotlight ] ) }
 			</div>
@@ -171,6 +174,16 @@ class FeaturesGrid extends Component< FeaturesGridProps > {
 					'plan-features-2023-grid__mobile-plan-card',
 					getPlanClass( gridPlan.planSlug )
 				);
+
+				if ( isFreePlan( gridPlan.planSlug ) ) {
+					return (
+						<div className={ planCardClasses } key={ `${ gridPlan.planSlug }-${ index }` }>
+							{ this.renderPlanLogos( [ gridPlan ] ) }
+							{ this.renderPlanHeaders( [ gridPlan ] ) }
+						</div>
+					);
+				}
+
 				const planCardJsx = (
 					<div className={ planCardClasses } key={ `${ gridPlan.planSlug }-${ index }` }>
 						{ this.renderPlanLogos( [ gridPlan ] ) }

--- a/client/my-sites/plans-grid/components/features-grid/index.tsx
+++ b/client/my-sites/plans-grid/components/features-grid/index.tsx
@@ -147,7 +147,7 @@ class FeaturesGrid extends Component< FeaturesGridProps > {
 	}
 
 	renderMobileView() {
-		const { translate, selectedFeature, gridPlans, gridPlanForSpotlight } = this.props;
+		const { translate, selectedFeature, gridPlans, gridPlanForSpotlight, isInSignup } = this.props;
 		const CardContainer = (
 			props: React.ComponentProps< typeof FoldableCard > & { planSlug: string }
 		) => {
@@ -175,22 +175,15 @@ class FeaturesGrid extends Component< FeaturesGridProps > {
 					getPlanClass( gridPlan.planSlug )
 				);
 
-				if ( isFreePlan( gridPlan.planSlug ) ) {
-					return (
-						<div className={ planCardClasses } key={ `${ gridPlan.planSlug }-${ index }` }>
-							{ this.renderPlanLogos( [ gridPlan ] ) }
-							{ this.renderPlanHeaders( [ gridPlan ] ) }
-						</div>
-					);
-				}
+				const isNotFreePlan = ! isFreePlan( gridPlan.planSlug );
 
 				const planCardJsx = (
 					<div className={ planCardClasses } key={ `${ gridPlan.planSlug }-${ index }` }>
 						{ this.renderPlanLogos( [ gridPlan ] ) }
 						{ this.renderPlanHeaders( [ gridPlan ] ) }
-						{ this.renderPlanTagline( [ gridPlan ] ) }
-						{ this.renderPlanPrice( [ gridPlan ] ) }
-						{ this.renderBillingTimeframe( [ gridPlan ] ) }
+						{ isNotFreePlan && isInSignup && this.renderPlanTagline( [ gridPlan ] ) }
+						{ isNotFreePlan && this.renderPlanPrice( [ gridPlan ] ) }
+						{ isNotFreePlan && this.renderBillingTimeframe( [ gridPlan ] ) }
 						{ this.renderMobileFreeDomain( gridPlan ) }
 						{ this.renderPlanStorageOptions( [ gridPlan ] ) }
 						{ this.renderTopButtons( [ gridPlan ] ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#2357

## Proposed Changes

We've got an urgent request to fix the issue that the Free plan is too prominent, obscuring the price toggling by the new dropdown term selector. e.g.

On desktop:

https://github.com/Automattic/wp-calypso/assets/1842898/52ed5977-1cc7-4e81-8583-02cde4d3d876

On iPhone 14 pro:

https://github.com/Automattic/wp-calypso/assets/1842898/8fda422d-576d-47fd-9267-390095e47f7d

As an interim solution, this PR removes several comparingly less important info from the Free plan card on mobile, and the spotlight plan card on desktop:

/plans, desktop:
![CleanShot 2024-01-15 at 18 03 07@2x](https://github.com/Automattic/wp-calypso/assets/1842898/a3b67eff-1b8f-48f6-b56d-338daea355b9)

/plans, mobile:
![CleanShot 2024-01-15 at 18 02 11@2x](https://github.com/Automattic/wp-calypso/assets/1842898/6c368646-3bdf-4d84-870b-1a51a7faba31)

signup:
![CleanShot 2024-01-15 at 18 02 42@2x](https://github.com/Automattic/wp-calypso/assets/1842898/32b2dee9-1871-4033-bed6-74cf0a72f8af)

## Testing Instructions

* Confirm that the paid plan cards are brought towards the top in `/plans` and the signup flows as demonstrated above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
