### PR TITLE
[Woo Express] Fix unable to upload themes

### DIFF
--- a/client/my-sites/themes/theme-showcase-header.jsx
+++ b/client/my-sites/themes/theme-showcase-header.jsx
@@ -5,8 +5,6 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { preventWidows } from 'calypso/lib/formatting';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { isWooCYSEligibleSite } from 'calypso/state/sites/selectors';
-import { isDefaultWooExpressThemeActive } from 'calypso/state/themes/selectors/is-wooexpress-default-theme-active';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import InstallThemeButton from './install-theme-button';
 import PatternAssemblerButton from './pattern-assembler-button';
@@ -23,15 +21,13 @@ export default function ThemeShowcaseHeader( {
 	noIndex = false,
 	onPatternAssemblerButtonClick,
 	isSiteWooExpressOrEcomFreeTrial = false,
+	isSiteECommerceFreeTrial = false,
 } ) {
 	// eslint-disable-next-line no-shadow
 	const translate = useTranslate();
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const selectedSiteId = useSelector( getSelectedSiteId );
-	const _isDefaultWooExpressThemeActive = useSelector( ( state ) =>
-		isDefaultWooExpressThemeActive( state, selectedSiteId )
-	);
-	const isWooCYSSite = useSelector( ( state ) => isWooCYSEligibleSite( state, selectedSiteId ) );
+
 	const description = useThemeShowcaseDescription( { filter, tier, vertical } );
 	const title = useThemeShowcaseTitle( { filter, tier, vertical } );
 	const loggedOutSeoContent = useThemeShowcaseLoggedOutSeoContent( filter, tier );
@@ -56,9 +52,8 @@ export default function ThemeShowcaseHeader( {
 		  }
 		: loggedOutSeoContent;
 
-	// Don't show the Install Theme button if the site is Woo CYS site and the default WooExpress theme is active
-	const showInstallThemeButton =
-		! ( isWooCYSSite && _isDefaultWooExpressThemeActive ) && !! selectedSiteId;
+	// Don't show the Install Theme button if the site is on a Ecommerce free trial or siteID is not available
+	const showInstallThemeButton = ! isSiteECommerceFreeTrial && !! selectedSiteId;
 
 	const metas = [
 		{

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -547,6 +547,7 @@ class ThemeShowcase extends Component {
 			filterString,
 			isMultisite,
 			premiumThemesEnabled,
+			isSiteECommerceFreeTrial,
 			isSiteWooExpressOrEcomFreeTrial,
 			isCollectionView,
 			isJetpackSite,
@@ -606,6 +607,7 @@ class ThemeShowcase extends Component {
 					noIndex={ isCollectionView }
 					onPatternAssemblerButtonClick={ this.onDesignYourOwnClick }
 					isSiteWooExpressOrEcomFreeTrial={ isSiteWooExpressOrEcomFreeTrial }
+					isSiteECommerceFreeTrial={ isSiteECommerceFreeTrial }
 				/>
 				{ isLoggedIn && (
 					<ThemeShowcaseSurvey


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/86380

We removed the "Install New Theme" button when the site is eligible for Customize Your Store and uses Tsubaki in https://github.com/Automattic/wp-calypso/issues/81993. However, it should only apply to free trial sites and should not relate to the CYS. - p1705313626803619/1705146343.712439-slack-C03Q87XT1QF


## Proposed Changes

*  Update the logic only to hide "Install New Theme" when the site is an E-commerce free trial site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a Woo Express free trial site
* Go to /themes/<site-slug>
* Observe that "Install New Theme" button is not shown.
* Upgrade the site to the Essential and Performance  plan
* Go to /themes/<site-slug>
* Observe that "Install New Theme" button is shown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?