### PR TITLE
BBE: call Guides endpoint on step change

### DIFF
--- a/client/signup/steps/design-picker/index.jsx
+++ b/client/signup/steps/design-picker/index.jsx
@@ -17,6 +17,7 @@ import { useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import AsyncCheckoutModal from 'calypso/my-sites/checkout/modal/async';
 import { openCheckoutModal } from 'calypso/my-sites/checkout/modal/utils';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -29,6 +30,7 @@ import './style.scss';
 export default function DesignPickerStep( props ) {
 	const {
 		flowName,
+		stepName,
 		isReskinned,
 		showDesignPickerCategories,
 		showLetUsChoose,
@@ -66,7 +68,8 @@ export default function DesignPickerStep( props ) {
 
 	useEffect(
 		() => {
-			dispatch( saveSignupStep( { stepName: props.stepName } ) );
+			dispatch( saveSignupStep( { stepName: stepName } ) );
+			triggerGuidesForStep( flowName, stepName );
 		},
 		// Ignoring dependencies because we only want to save the step on first mount
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/signup/steps/difm-site-picker/index.tsx
+++ b/client/signup/steps/difm-site-picker/index.tsx
@@ -3,6 +3,7 @@ import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import SiteSelector from 'calypso/components/site-selector';
+import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { useDispatch, useStore } from 'calypso/state';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
@@ -13,6 +14,7 @@ import './styles.scss';
 interface Props {
 	stepSectionName: string | null;
 	stepName: string;
+	flowName: string;
 	goToStep: () => void;
 	goToNextStep: () => void;
 }
@@ -66,7 +68,8 @@ export default function DIFMSitePickerStep( props: Props ) {
 
 	useEffect( () => {
 		dispatch( saveSignupStep( { stepName: props.stepName } ) );
-	}, [ dispatch, props.stepName ] );
+		triggerGuidesForStep( props.flowName, props.stepName );
+	}, [ dispatch, props.flowName, props.stepName ] );
 
 	const handleSiteSelect = ( siteId: number ) => {
 		const siteSlug = getSiteSlug( store.getState(), siteId );

--- a/client/signup/steps/new-or-existing-site/index.tsx
+++ b/client/signup/steps/new-or-existing-site/index.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import difmImage from 'calypso/assets/images/difm/difm.svg';
+import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import DIFMLanding from 'calypso/my-sites/marketing/do-it-for-me/difm-landing';
 import useBranchSteps from 'calypso/signup/hooks/use-branch-steps';
 import StepWrapper from 'calypso/signup/step-wrapper';
@@ -26,7 +27,8 @@ export default function NewOrExistingSiteStep( props: Props ) {
 
 	useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );
-	}, [ dispatch, stepName ] );
+		triggerGuidesForStep( flowName, stepName );
+	}, [ dispatch, flowName, stepName ] );
 
 	const branchSteps = useBranchSteps( stepName, () => [ 'difm-site-picker' ] );
 

--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -9,6 +9,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import InfoPopover from 'calypso/components/info-popover';
+import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import { getRazorpayConfiguration, getStripeConfiguration } from 'calypso/lib/store-transactions';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import PurchaseModal from 'calypso/my-sites/checkout/purchase-modal';
@@ -455,6 +456,7 @@ function DIFMPagePicker( props: StepProps ) {
 
 	useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );
+		triggerGuidesForStep( flowName, stepName );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 

--- a/client/signup/steps/site-options/index.tsx
+++ b/client/signup/steps/site-options/index.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import siteOptionsImage from 'calypso/assets/images/onboarding/site-options.svg';
 import storeImageUrl from 'calypso/assets/images/onboarding/store-onboarding.svg';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { useDispatch } from 'calypso/state';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
@@ -15,13 +16,14 @@ interface Props {
 	isReskinned: boolean;
 	signupDependencies: any;
 	stepName: string;
+	flowName: string;
 	initialContext: any;
 }
 
 export default function SiteOptionsStep( props: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const { stepName, signupDependencies, goToNextStep } = props;
+	const { stepName, signupDependencies, flowName, goToNextStep } = props;
 	const { siteTitle, tagline } = signupDependencies;
 
 	const getSiteOptionsProps = ( stepName: string ) => {
@@ -95,6 +97,7 @@ export default function SiteOptionsStep( props: Props ) {
 	// Only do following things when mounted
 	useEffect( () => {
 		dispatch( saveSignupStep( { stepName } ) );
+		triggerGuidesForStep( flowName, stepName );
 	}, [] );
 
 	return (

--- a/client/signup/steps/social-profiles/index.tsx
+++ b/client/signup/steps/social-profiles/index.tsx
@@ -1,6 +1,7 @@
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import startingPointImageUrl from 'calypso/assets/images/onboarding/starting-point.svg';
+import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import { useDispatch } from 'calypso/state';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
@@ -12,18 +13,20 @@ import './style.scss';
 interface Props {
 	goToNextStep: () => void;
 	stepName: string;
+	flowName: string;
 	signupDependencies: SocialProfilesState;
 }
 
 export default function SocialProfilesStep( props: Props ) {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
-	const { stepName, signupDependencies, goToNextStep } = props;
+	const { stepName, signupDependencies, flowName, goToNextStep } = props;
 
 	const headerText = translate( 'Do you have social media profiles?' );
 	const subHeaderText = translate( 'You can always add them later.' );
 
 	useEffect( () => {
+		triggerGuidesForStep( flowName, stepName );
 		dispatch( saveSignupStep( { stepName: stepName } ) );
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/2393

## Proposed Changes

* Calls the `triggerGuidesForStep` function on step change in the BBE flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me`
* Open the browser network log.
* As you proceed through the steps, confirm that a network request is sent to `guides/trigger` endpoint.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?