### PR TITLE
Impact Affiliate i2: Store irclick id in a cookie when passed as a query param

### DIFF
--- a/client/lib/analytics/impact-affiliate.js
+++ b/client/lib/analytics/impact-affiliate.js
@@ -1,0 +1,25 @@
+import cookie from 'cookie';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import urlParseAmpCompatible from './utils/url-parse-amp-compatible';
+
+/**
+ * Save Impact Affiliate Click ID in a cookie if it is set as a query parameter.
+ */
+export default function saveImpactAffiliateClickId() {
+	// Read click ID query argument, return early if there is none.
+	const parsedUrl = urlParseAmpCompatible( window.location.href );
+	const clickId = parsedUrl?.searchParams.get( 'irclickid' );
+
+	if ( ! clickId ) {
+		return;
+	}
+
+	document.cookie = cookie.serialize( 'irclickid', clickId, {
+		path: '/',
+		expires: new Date( Date.now() + 30 * 24 * 60 * 60 * 1000 ), // 30 days
+	} );
+
+	recordTracksEvent( 'calypso_impact_affiliate_visit', {
+		page: parsedUrl.host + parsedUrl.pathname,
+	} );
+}

--- a/client/lib/analytics/page-view.js
+++ b/client/lib/analytics/page-view.js
@@ -3,6 +3,7 @@
 import { recordTracksPageViewWithPageParams } from '@automattic/calypso-analytics';
 import { resolveDeviceTypeByViewPort } from '@automattic/viewport';
 import { retarget as retargetAdTrackers } from 'calypso/lib/analytics/ad-tracking';
+import saveImpactAffiliateClickId from 'calypso/lib/analytics/impact-affiliate';
 import { updateQueryParamsTracking } from 'calypso/lib/analytics/sem';
 import { refreshCountryCodeCookieGdpr, saveCouponQueryArgument } from 'calypso/lib/analytics/utils';
 import { gaRecordPageView } from './ga';
@@ -25,6 +26,7 @@ export function recordPageView( urlPath, pageTitle, params = {}, options = {} ) 
 			options?.useAkismetGoogleAnalytics
 		);
 		referRecordPageView();
+		saveImpactAffiliateClickId();
 
 		// Retargeting.
 		saveCouponQueryArgument();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to: https://github.com/Automattic/dotcom-forge/issues/5148

When a user arrives in the Calypso UI through an Impact Affiliate link, a click id (irclickid) is added to the url as a query param. We need to add this clickid to a cookie that can be used by the public api. 

## Proposed Changes

* Creates a cookie when the irclickid query param is set in the URL of the requested page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to any page in Calypso and add `?irclickid=123456` to the url
* Open developer tools and ensure that a cookie named `irclickid` has been set with a value of `123456`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?