### PR TITLE
Manage Purchases: add support links for BBE purchases

### DIFF
--- a/client/me/purchases/manage-purchase/index.tsx
+++ b/client/me/purchases/manage-purchase/index.tsx
@@ -52,7 +52,7 @@ import {
 } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import classNames from 'classnames';
-import { localize, LocalizeProps, numberFormat } from 'i18n-calypso';
+import { localize, LocalizeProps, numberFormat, useTranslate } from 'i18n-calypso';
 import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
@@ -112,6 +112,7 @@ import {
 	getCancelPurchaseUrlFor,
 	getAddNewPaymentMethodUrlFor,
 } from 'calypso/my-sites/purchases/paths';
+import { useSelector } from 'calypso/state';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import {
 	currentUserHasFlag,
@@ -131,9 +132,10 @@ import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getPrimaryDomainBySiteId from 'calypso/state/selectors/get-primary-domain-by-site-id';
 import isDomainOnly from 'calypso/state/selectors/is-domain-only-site';
 import isSiteAtomic from 'calypso/state/selectors/is-site-automated-transfer';
+import { useGetWebsiteContentQuery } from 'calypso/state/signup/steps/website-content/hooks/use-get-website-content-query';
 import { hasLoadedSiteDomains, getAllDomains } from 'calypso/state/sites/domains/selectors';
 import { getSitePlanRawPrice } from 'calypso/state/sites/plans/selectors';
-import { getSite, isRequestingSites } from 'calypso/state/sites/selectors';
+import { getSite, getSiteSlug, isRequestingSites } from 'calypso/state/sites/selectors';
 import { getCanonicalTheme } from 'calypso/state/themes/selectors';
 import { CalypsoDispatch, IAppState } from 'calypso/state/types';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -1065,39 +1067,7 @@ class ManagePurchase extends Component<
 		}
 
 		if ( isDIFMProduct( purchase ) ) {
-			const difmTieredPurchaseDetails = getDIFMTieredPurchaseDetails( purchase );
-			if ( difmTieredPurchaseDetails && ( difmTieredPurchaseDetails.extraPageCount ?? 0 ) > 0 ) {
-				// We know there are some pages due to the above check.
-				const extraPageCount = difmTieredPurchaseDetails.extraPageCount as number;
-				const numberOfIncludedPages = difmTieredPurchaseDetails.numberOfIncludedPages as number;
-
-				return (
-					<>
-						{ numberOfIncludedPages === 1
-							? translate(
-									'A professionally built single page website in 4 business days or less.'
-							  )
-							: translate(
-									'A professionally built %(numberOfIncludedPages)s-page website in 4 business days or less.',
-									{
-										args: {
-											numberOfIncludedPages,
-										},
-									}
-							  ) }{ ' ' }
-						{ translate(
-							'This purchase includes %(numberOfPages)d extra page.',
-							'This purchase includes %(numberOfPages)d extra pages.',
-							{
-								count: extraPageCount ?? 0,
-								args: {
-									numberOfPages: extraPageCount,
-								},
-							}
-						) }
-					</>
-				);
-			}
+			return <BBEPurchaseDescription purchase={ purchase } />;
 		}
 
 		return purchaseType( purchase );
@@ -1510,6 +1480,90 @@ function addPaymentMethodLinkText( {
 		linkText = translate( 'Add payment method' );
 	}
 	return linkText;
+}
+
+function BBEPurchaseDescription( { purchase }: { purchase: Purchase } ) {
+	const translate = useTranslate();
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, purchase.siteId ) );
+	const { isLoading, data: websiteContentQueryResult } = useGetWebsiteContentQuery( siteSlug );
+	const difmTieredPurchaseDetails = getDIFMTieredPurchaseDetails( purchase );
+	if ( ! difmTieredPurchaseDetails ) {
+		return;
+	}
+
+	const extraPageCount = difmTieredPurchaseDetails.extraPageCount || 0;
+	const numberOfIncludedPages = difmTieredPurchaseDetails.numberOfIncludedPages as number;
+
+	const BBESupportLink = (
+		<a
+			href={ `mailto:builtby+express@wordpress.com?subject=${ encodeURIComponent(
+				`I have a question about my project: ${ siteSlug }`
+			) }` }
+		/>
+	);
+
+	return (
+		<div
+			className={ classNames( 'manage-purchase__description', {
+				'is-placeholder': isLoading,
+			} ) }
+		>
+			{ ! isLoading && (
+				<>
+					<div>
+						{ numberOfIncludedPages === 1
+							? translate(
+									'A professionally built single page website in 4 business days or less.'
+							  )
+							: translate(
+									'A professionally built %(numberOfIncludedPages)s-page website in 4 business days or less.',
+									{
+										args: {
+											numberOfIncludedPages,
+										},
+									}
+							  ) }{ ' ' }
+						{ extraPageCount > 0
+							? translate(
+									'This purchase includes %(numberOfPages)d extra page.',
+									'This purchase includes %(numberOfPages)d extra pages.',
+									{
+										count: extraPageCount ?? 0,
+										args: {
+											numberOfPages: extraPageCount,
+										},
+									}
+							  )
+							: null }
+					</div>
+					<div>
+						{ websiteContentQueryResult?.isWebsiteContentSubmitted
+							? translate(
+									'{{BBESupportLink}}Contact us{{/BBESupportLink}} with any questions or inquiries about your project.',
+									{
+										components: {
+											BBESupportLink,
+										},
+									}
+							  )
+							: translate(
+									'{{FormLink}}Submit content{{/FormLink}} for your website build or {{BBESupportLink}}contact us{{/BBESupportLink}} with any questions about your project.',
+									{
+										components: {
+											FormLink: (
+												<a
+													href={ `/start/site-content-collection/website-content?siteSlug=${ siteSlug }` }
+												/>
+											),
+											BBESupportLink,
+										},
+									}
+							  ) }
+					</div>
+				</>
+			) }
+		</div>
+	);
 }
 
 function PlanOverlapNotice( {

--- a/client/me/purchases/manage-purchase/style.scss
+++ b/client/me/purchases/manage-purchase/style.scss
@@ -118,6 +118,10 @@
 	}
 }
 
+.manage-purchase__description.is-placeholder {
+	@include placeholder( --color-neutral-10 );
+}
+
 .manage-purchase__header,
 .manage-purchase__content {
 	padding: 16px 24px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/2470

## Proposed Changes

* Adds support links on the Manage Purchase page for BBE purchases.
* If the content has not been submitted, the text also contains a link to the content form.

**Content not submitted**
<img width="1096" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/f1488c16-d966-417c-814e-7d6cdcae1956">

**Content submitted**
<img width="1173" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/188f3cff-2363-4a41-9c48-331ffacc86e2">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* If you do not have an existing BBE purchase, go to `/start/do-it-for-me` and follow the steps to purchase.
* Go to Manage Purchases, and click on the BBE purchase.
* Confirm that the page contains the new text and links correctly to the content submission form.
* Confirm that the "Contact Support" link opens the email client.
* Use the form to submit content.
* Visit the purchases page again and confirm that the text does not have the link to the content form.
* Check the Manage Purchase page for any other purchase to check for regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?