### PR TITLE
Marketplace: update popular plugins section wording.

### DIFF
--- a/client/my-sites/plugins/categories/use-categories.tsx
+++ b/client/my-sites/plugins/categories/use-categories.tsx
@@ -94,8 +94,8 @@ export const getCategories: () => Record< string, Category > = () => ( {
 	},
 	popular: {
 		menu: __( 'Popular plugins' ),
-		title: __( 'The free essentials' ),
-		description: __( 'Add and install the very best free plugins' ),
+		title: __( 'Popular plugins' ),
+		description: __( 'Add and install the most popular free plugins' ),
 		slug: 'popular',
 		tags: [],
 		preview: [],

--- a/packages/calypso-e2e/src/lib/pages/plugins-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/plugins-page.ts
@@ -61,7 +61,7 @@ export class PluginsPage {
 
 	static paidSection = 'Must-have premium plugins';
 	static featuredSection = 'Our developers’ favorites';
-	static freeSection = 'The free essentials';
+	static freeSection = 'Popular Plugins';
 
 	/**
 	 * Constructs an instance.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1704734500401819/1704384900.694629-slack-C029JEQRVRT

## Proposed Changes

|Before | After|
|-------|------|
|![CleanShot 2024-01-15 at 14 59 16@2x](https://github.com/Automattic/wp-calypso/assets/12430020/164d28a7-3364-4054-9551-db3530ffc09b)|![CleanShot 2024-01-15 at 15 00 18@2x](https://github.com/Automattic/wp-calypso/assets/12430020/0ed22657-e64e-4948-bda8-1fbd540b484e)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?