### PR TITLE
Notifications: call requestStorageAccess before creating the REST proxy iframe

### DIFF
--- a/apps/notifications/src/panel/Notifications.jsx
+++ b/apps/notifications/src/panel/Notifications.jsx
@@ -98,10 +98,6 @@ export class Notifications extends PureComponent {
 		client.setVisibility( { isShowing, isVisible } );
 	}
 
-	componentDidMount() {
-		store.dispatch( { type: 'APP_IS_READY' } );
-	}
-
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
 	UNSAFE_componentWillReceiveProps( { isShowing, isVisible, wpcom } ) {
 		debug( 'Component will recieve props', {

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -1045,4 +1045,9 @@ $with-sidebar-min-page-width: 1114px;
 			}
 		}
 	}
+
+	.wpnc__loading {
+		background: #f6f7f7;
+		padding: 10px;
+	}
 }

--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -1,7 +1,6 @@
 import clsx from 'clsx';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
-import ReactDOM from 'react-dom';
 import { connect } from 'react-redux';
 import actions from '../state/actions';
 import getFilterName from '../state/selectors/get-filter-name';
@@ -51,11 +50,11 @@ export class NoteList extends Component {
 	}
 
 	componentDidMount() {
-		ReactDOM.findDOMNode( this.scrollableContainer ).addEventListener( 'scroll', this.onScroll );
+		this.scrollableContainer.addEventListener( 'scroll', this.onScroll );
 	}
 
 	componentWillUnmount() {
-		ReactDOM.findDOMNode( this.scrollableContainer ).removeEventListener( 'scroll', this.onScroll );
+		this.scrollableContainer.removeEventListener( 'scroll', this.onScroll );
 	}
 
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
@@ -68,7 +67,7 @@ export class NoteList extends Component {
 
 	componentDidUpdate( prevProps ) {
 		if ( this.noteList && ! this.props.isLoading ) {
-			const element = ReactDOM.findDOMNode( this.scrollableContainer );
+			const element = this.scrollableContainer;
 			if (
 				element.clientHeight > 0 &&
 				element.scrollTop + element.clientHeight >= this.noteList.clientHeight - 300
@@ -91,7 +90,7 @@ export class NoteList extends Component {
 
 		requestAnimationFrame( () => ( this.isScrolling = false ) );
 
-		const element = ReactDOM.findDOMNode( this.scrollableContainer );
+		const element = this.scrollableContainer;
 		if ( ! this.state.scrolling || this.state.scrollY !== element.scrollTop ) {
 			// only set state and trigger render if something has changed
 			this.setState( {
@@ -349,7 +348,6 @@ export class NoteList extends Component {
 
 		return (
 			<>
-				{ /* Keep the wpnc__note-list as the first child of the Fragment to ensure the ReactDOM.findDOMNode returns the list element */ }
 				<div className={ classes } id="wpnc__note-list" ref={ this.props.listElementRef }>
 					<FilterBar
 						controller={ this.props.filterController }

--- a/apps/notifications/src/standalone/client/index.js
+++ b/apps/notifications/src/standalone/client/index.js
@@ -2,7 +2,7 @@ import createIframeProxyClient from './iframe-proxy';
 import createOauthClient from './oauth';
 
 export function createClient() {
-	const isProduction = 'production' === process.env.NODE_ENV;
+	const isProduction = true; // 'production' === process.env.NODE_ENV;
 	const clientFactory = isProduction ? createIframeProxyClient : createOauthClient;
 	return clientFactory();
 }

--- a/apps/notifications/src/standalone/index.jsx
+++ b/apps/notifications/src/standalone/index.jsx
@@ -1,6 +1,6 @@
 import '@automattic/calypso-polyfills';
 import { useState, useEffect, useCallback } from 'react';
-import ReactDOM from 'react-dom';
+import ReactDOM from 'react-dom/client';
 import Notifications, { refreshNotes } from '../panel/Notifications';
 import { createClient } from './client';
 import { receiveMessage, sendMessage } from './messaging';
@@ -197,7 +197,7 @@ const NotesWrapper = () => {
 
 	if ( hasAccess === false ) {
 		return (
-			<div style={ { background: '#f6f7f7', padding: '10px' } }>
+			<div className="wpnc__note-list wpnc__loading">
 				<button
 					className="wpnc__button"
 					style={ { margin: '0px auto' } }
@@ -210,7 +210,7 @@ const NotesWrapper = () => {
 	}
 
 	if ( ! wpcom ) {
-		return null;
+		return <div className="wpnc__note-list wpnc__loading">Loading wpcom</div>;
 	}
 
 	return (
@@ -230,7 +230,8 @@ const NotesWrapper = () => {
 const render = () => {
 	document.body.classList.add( 'font-smoothing-antialiased' );
 
-	ReactDOM.render( <NotesWrapper />, document.getElementsByClassName( 'wpnc__main' )[ 0 ] );
+	const root = ReactDOM.createRoot( document.querySelector( '.wpnc__main' ) );
+	root.render( <NotesWrapper /> );
 };
 
 render();

--- a/apps/notifications/src/standalone/index.jsx
+++ b/apps/notifications/src/standalone/index.jsx
@@ -1,5 +1,5 @@
 import '@automattic/calypso-polyfills';
-import { useEffect, useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import ReactDOM from 'react-dom';
 import Notifications, { refreshNotes } from '../panel/Notifications';
 import { createClient } from './client';
@@ -17,7 +17,6 @@ const customEnhancer = ( next ) => ( reducer, initialState ) =>
 	( store = next( reducer, initialState ) );
 
 const customMiddleware = {
-	APP_IS_READY: [ () => sendMessage( { action: 'iFrameReady' } ) ],
 	APP_RENDER_NOTES: [
 		( st, { latestType, newNoteCount } ) =>
 			newNoteCount > 0
@@ -72,10 +71,53 @@ const customMiddleware = {
 	],
 };
 
-const NotesWrapper = ( { wpcom } ) => {
+function useStorageAccess() {
+	const [ hasAccess, setAccess ] = useState( null );
+
+	useEffect( () => {
+		document.hasStorageAccess().then( ( value ) => setAccess( value ) );
+	}, [] );
+
+	const requestAccess = useCallback( () => {
+		document
+			.requestStorageAccess()
+			.then( () => setAccess( true ) )
+			.catch( ( error ) => {
+				// eslint-disable-next-line no-console
+				console.error( 'requestStorageAccess failed:', error );
+				setAccess( false );
+			} );
+	}, [] );
+
+	return {
+		hasAccess,
+		requestAccess,
+	};
+}
+
+const setTracksUser = ( wpcom ) => {
+	return wpcom
+		.me()
+		.get( { fields: 'ID,username' } )
+		.then( ( { ID, username } ) => {
+			window._tkq = window._tkq || [];
+			window._tkq.push( [ 'identifyUser', ID, username ] );
+		} )
+		.catch( () => {} );
+};
+
+async function createAndSetupClient() {
+	const wpcom = await createClient();
+	await setTracksUser( wpcom );
+	return wpcom;
+}
+
+const NotesWrapper = () => {
 	const [ isShowing, setIsShowing ] = useState( false );
 	const [ isVisible, setIsVisible ] = useState( document.visibilityState === 'visible' );
 	const [ isShortcutsPopoverVisible, setShortcutsPopoverVisible ] = useState( false );
+	const { hasAccess, requestAccess } = useStorageAccess();
+	const [ wpcom, setWpcom ] = useState( null );
 
 	debug( 'wrapper state update', { isShowing, isVisible } );
 
@@ -139,6 +181,38 @@ const NotesWrapper = ( { wpcom } ) => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [] );
 
+	useEffect( () => {
+		sendMessage( { action: 'iFrameReady' } );
+	}, [] );
+
+	useEffect( () => {
+		if ( ! wpcom && hasAccess ) {
+			createAndSetupClient().then( ( c ) => setWpcom( c ) );
+		}
+	}, [ wpcom, hasAccess ] );
+
+	if ( hasAccess === null ) {
+		return null;
+	}
+
+	if ( hasAccess === false ) {
+		return (
+			<div style={ { background: '#f6f7f7', padding: '10px' } }>
+				<button
+					className="wpnc__button"
+					style={ { margin: '0px auto' } }
+					onClick={ () => requestAccess() }
+				>
+					Request Access
+				</button>
+			</div>
+		);
+	}
+
+	if ( ! wpcom ) {
+		return null;
+	}
+
 	return (
 		<Notifications
 			customEnhancer={ customEnhancer }
@@ -153,29 +227,10 @@ const NotesWrapper = ( { wpcom } ) => {
 	);
 };
 
-const render = ( wpcom ) => {
+const render = () => {
 	document.body.classList.add( 'font-smoothing-antialiased' );
 
-	ReactDOM.render(
-		<NotesWrapper wpcom={ wpcom } />,
-		document.getElementsByClassName( 'wpnc__main' )[ 0 ]
-	);
+	ReactDOM.render( <NotesWrapper />, document.getElementsByClassName( 'wpnc__main' )[ 0 ] );
 };
 
-const setTracksUser = ( wpcom ) => {
-	wpcom
-		.me()
-		.get( { fields: 'ID,username' } )
-		.then( ( { ID, username } ) => {
-			window._tkq = window._tkq || [];
-			window._tkq.push( [ 'identifyUser', ID, username ] );
-		} )
-		.catch( () => {} );
-};
-
-const init = ( wpcom ) => {
-	setTracksUser( wpcom );
-	render( wpcom );
-};
-
-createClient().then( init );
+render();


### PR DESCRIPTION
Request access to `wordpress.com` cookies before creating the REST proxy iframe. Makes the Notifications widget work when embedded on a 3rd party domain.