### PR TITLE
Revert "Odie: update user ratings values (#86299)"

### DIFF
--- a/client/odie/components/message/was-this-helpful-buttons.tsx
+++ b/client/odie/components/message/was-this-helpful-buttons.tsx
@@ -1,6 +1,5 @@
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { ODIE_THUMBS_DOWN_RATING_VALUE, ODIE_THUMBS_UP_RATING_VALUE } from '../../';
 import { noop, useOdieAssistantContext } from '../../context';
 import { useOdieSendMessageFeedback } from '../../query';
 import { ThumbsDownIcon, ThumbsUpIcon } from './thumbs-icons';
@@ -15,6 +14,9 @@ const WasThisHelpfulButtons = ( {
 	message: Message;
 	onDislike?: () => void;
 } ) => {
+	const THUMBS_DOWN_RATING_VALUE = 2;
+	const THUMBS_UP_RATING_VALUE = 4;
+
 	const translate = useTranslate();
 	const { setMessageLikedStatus, trackEvent } = useOdieAssistantContext();
 	const { mutateAsync: sendOdieMessageFeedback } = useOdieSendMessageFeedback();
@@ -26,7 +28,7 @@ const WasThisHelpfulButtons = ( {
 	const handleIsHelpful = ( isHelpful: boolean ) => {
 		sendOdieMessageFeedback( {
 			message,
-			rating_value: isHelpful ? ODIE_THUMBS_UP_RATING_VALUE : ODIE_THUMBS_DOWN_RATING_VALUE,
+			rating_value: isHelpful ? THUMBS_UP_RATING_VALUE : THUMBS_DOWN_RATING_VALUE,
 		} );
 
 		setMessageLikedStatus( message, isHelpful );

--- a/client/odie/index.tsx
+++ b/client/odie/index.tsx
@@ -12,9 +12,6 @@ export const WAPUU_ERROR_MESSAGE = i18n.translate(
 	{ comment: 'Error message when Wapuu fails to send a message', textOnly: true }
 );
 
-export const ODIE_THUMBS_DOWN_RATING_VALUE = 0;
-export const ODIE_THUMBS_UP_RATING_VALUE = 1;
-
 const ForwardedChatMessage = forwardRef( ChatMessage );
 
 const OdieAssistant = () => {

--- a/client/odie/query/index.ts
+++ b/client/odie/query/index.ts
@@ -2,7 +2,7 @@ import { useMutation, UseMutationResult, useQuery } from '@tanstack/react-query'
 import apiFetch from '@wordpress/api-fetch';
 import { canAccessWpcomApis } from 'wpcom-proxy-request';
 import wpcom from 'calypso/lib/wp';
-import { WAPUU_ERROR_MESSAGE, ODIE_THUMBS_DOWN_RATING_VALUE } from '..';
+import { WAPUU_ERROR_MESSAGE } from '..';
 import { useOdieAssistantContext } from '../context';
 import { setOdieStorage } from '../data';
 import type { Chat, Message, MessageRole, MessageType, OdieAllowedBots } from '../types';
@@ -187,6 +187,7 @@ export const useOdieGetChat = (
 		refetchOnWindowFocus: false,
 		enabled: !! chatId && ! chat.chat_id,
 		select: ( data ) => {
+			const negativeFeedbackThreshold = 3;
 			const modifiedMessages: Message[] = [];
 
 			data.messages.forEach( ( message ) => {
@@ -195,7 +196,7 @@ export const useOdieGetChat = (
 				// Check if the message has negative feedback
 				if (
 					message.rating_value &&
-					message.rating_value === ODIE_THUMBS_DOWN_RATING_VALUE &&
+					message.rating_value < negativeFeedbackThreshold &&
 					! message.context?.flags?.forward_to_human_support
 				) {
 					// Add a new 'dislike-feedback' message right after the current message


### PR DESCRIPTION
This reverts commit 1ce1ad4193a9e267b6bc27d0f0f0001a39fc7a13  from https://github.com/Automattic/wp-calypso/pull/86299 - backend isn't ready yet

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86299

## Proposed Changes

* Revert #86299 until the backend is ready.


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?