### PR TITLE
Plans 2024: Pass recordTracksEvent as a prop and add to context

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -898,6 +898,7 @@ const PlansFeaturesMain = ( {
 									allFeaturesList={ FEATURES_LIST }
 									onStorageAddOnClick={ handleStorageAddOnClick }
 									showRefundPeriod={ isAnyHostingFlow( flowName ) }
+									recordTracksEvent={ recordTracksEvent }
 									coupon={ coupon }
 								/>
 								{ showEscapeHatch && hidePlansFeatureComparison && (
@@ -962,6 +963,7 @@ const PlansFeaturesMain = ( {
 													! hidePlanSelector ? planTypeSelectorProps : undefined
 												}
 												coupon={ coupon }
+												recordTracksEvent={ recordTracksEvent }
 											/>
 											<ComparisonGridToggle
 												onClick={ toggleShowPlansComparisonGrid }

--- a/client/my-sites/plans-grid/components/actions.tsx
+++ b/client/my-sites/plans-grid/components/actions.tsx
@@ -21,7 +21,6 @@ import styled from '@emotion/styled';
 import { useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { localize, TranslateResult, useTranslate } from 'i18n-calypso';
-import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useManageTooltipToggle } from 'calypso/my-sites/plans-grid/hooks/use-manage-tooltip-toggle';
 import { usePlansGridContext } from '../grid-context';
 import useDefaultStorageOption from '../hooks/npm-ready/data-store/use-default-storage-option';
@@ -426,7 +425,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 	storageOptions,
 } ) => {
 	const translate = useTranslate();
-	const { gridPlansIndex } = usePlansGridContext();
+	const { gridPlansIndex, helpers } = usePlansGridContext();
 	const {
 		planTitle,
 		pricing: { currencyCode, originalPrice, discountedPrice },
@@ -438,7 +437,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			const upgradePlan = isFreeTrialPlan && freeTrialPlanSlug ? freeTrialPlanSlug : planSlug;
 
 			if ( ! isFreePlan( planSlug ) ) {
-				recordTracksEvent( 'calypso_plan_features_upgrade_click', {
+				helpers.recordTracksEvent?.( 'calypso_plan_features_upgrade_click', {
 					current_plan: currentSitePlanSlug,
 					upgrading_to: upgradePlan,
 					saw_free_trial_offer: !! freeTrialPlanSlug,
@@ -446,7 +445,7 @@ const PlanFeaturesActionsButton: React.FC< PlanFeaturesActionsButtonProps > = ( 
 			}
 			onUpgradeClick?.( upgradePlan );
 		},
-		[ currentSitePlanSlug, freeTrialPlanSlug, onUpgradeClick, planSlug ]
+		[ currentSitePlanSlug, freeTrialPlanSlug, helpers, onUpgradeClick, planSlug ]
 	);
 
 	if ( isWpcomEnterpriseGridPlan( planSlug ) ) {

--- a/client/my-sites/plans-grid/grid-context.tsx
+++ b/client/my-sites/plans-grid/grid-context.tsx
@@ -12,6 +12,7 @@ interface PlansGridContext {
 	allFeaturesList: FeatureList;
 	helpers: {
 		useCheckPlanAvailabilityForPurchase: Plans.UseCheckPlanAvailabilityForPurchase;
+		recordTracksEvent?: GridContextProps[ 'recordTracksEvent' ];
 	};
 	coupon?: string;
 }
@@ -22,6 +23,7 @@ const PlansGridContextProvider = ( {
 	intent,
 	gridPlans,
 	useCheckPlanAvailabilityForPurchase,
+	recordTracksEvent,
 	allFeaturesList,
 	selectedSiteId,
 	children,
@@ -43,7 +45,7 @@ const PlansGridContextProvider = ( {
 				gridPlans,
 				gridPlansIndex,
 				allFeaturesList,
-				helpers: { useCheckPlanAvailabilityForPurchase },
+				helpers: { useCheckPlanAvailabilityForPurchase, recordTracksEvent },
 				coupon,
 			} }
 		>

--- a/client/my-sites/plans-grid/index.tsx
+++ b/client/my-sites/plans-grid/index.tsx
@@ -15,6 +15,7 @@ const WrappedComparisonGrid = ( {
 	intent,
 	gridPlans,
 	useCheckPlanAvailabilityForPurchase,
+	recordTracksEvent,
 	allFeaturesList,
 	onUpgradeClick,
 	intervalType,
@@ -40,6 +41,7 @@ const WrappedComparisonGrid = ( {
 			selectedSiteId={ selectedSiteId }
 			gridPlans={ gridPlans }
 			useCheckPlanAvailabilityForPurchase={ useCheckPlanAvailabilityForPurchase }
+			recordTracksEvent={ recordTracksEvent }
 			allFeaturesList={ allFeaturesList }
 			coupon={ coupon }
 		>
@@ -67,6 +69,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		intent,
 		gridPlans,
 		useCheckPlanAvailabilityForPurchase,
+		recordTracksEvent,
 		allFeaturesList,
 		onUpgradeClick,
 		coupon,
@@ -96,6 +99,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 			gridPlans={ gridPlans }
 			coupon={ coupon }
 			useCheckPlanAvailabilityForPurchase={ useCheckPlanAvailabilityForPurchase }
+			recordTracksEvent={ recordTracksEvent }
 			allFeaturesList={ allFeaturesList }
 		>
 			<FeaturesGrid

--- a/client/my-sites/plans-grid/types.ts
+++ b/client/my-sites/plans-grid/types.ts
@@ -80,6 +80,7 @@ export type GridContextProps = {
 	intent?: PlansIntent;
 	selectedSiteId?: number | null;
 	useCheckPlanAvailabilityForPurchase: Plans.UseCheckPlanAvailabilityForPurchase;
+	recordTracksEvent?: ( eventName: string, eventProperties: Record< string, unknown > ) => void;
 	children: React.ReactNode;
 	coupon?: string;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/79006

## Proposed Changes

Removes `calypso/lib/analytics/tracks` dependency from plans-grid and passes a `recordTracksEvent` prop (and adds to `helpers` in the context). 

This is only used in the actions component, and we could have potentially abstracted behind a relevant wrapper callback. However, this being such a common utility, why not just pass it through for now? We may potentially track other interactions down the line (although better abstractions there might work too). We can revisit and remove the prop altogether behind a better abstraction in the future cc @jdc91 / @jeyip

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plans/[ site ]` and `/start/plans`
* Click on any button to purchase/upgrade the site's plan
* Inspect Network tab and confirm the event `calypso_plan_features_upgrade_click ` is sent through (a gif request with the relevant props - see the code changes)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?