### PR TITLE
Design refresh for post-checkout Professional Email upsell

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
@@ -28,7 +28,6 @@ const ContactContainer = styled.div`
 		text-decoration: underline;
 		line-height: 20px;
 		font-size: 14px;
-		padding: 0;
 	}
 	.gridicon {
 		display: block;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/default-contact.tsx
@@ -28,6 +28,7 @@ const ContactContainer = styled.div`
 		text-decoration: underline;
 		line-height: 20px;
 		font-size: 14px;
+		padding: 0;
 	}
 	.gridicon {
 		display: block;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled/index.tsx
@@ -24,8 +24,9 @@ const ItemStyled = styled( Item )`
 	font-size: 14px;
 	font-weight: 500;
 	padding: 0;
-	justify-content: left;
-	flex: 1;
+	flex: none;
+	margin-right: auto;
+	width: auto;
 
 	&:hover {
 		background: var( --studio-white );
@@ -62,7 +63,7 @@ const MasterbarStyled = ( {
 	<MasterbarStyledBlock>
 		<Global
 			styles={ css`
-				body.is-section-checkout-thank-you {
+				body {
 					--masterbar-height: 72px;
 				}
 			` }

--- a/client/my-sites/checkout/upsell-nudge/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/index.tsx
@@ -247,7 +247,6 @@ export class UpsellNudge extends Component< UpsellNudgeProps, UpsellNudgeState >
 			case PROFESSIONAL_EMAIL_UPSELL:
 				return (
 					<ProfessionalEmailUpsell
-						currencyCode={ currencyCode ?? 'USD' }
 						domainName={ upgradeItem ?? '' }
 						handleClickAccept={ this.handleClickAccept }
 						handleClickDecline={ this.handleClickDecline }

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
@@ -1,9 +1,7 @@
-import { TITAN_MAIL_MONTHLY_SLUG, TITAN_MAIL_YEARLY_SLUG } from '@automattic/calypso-products';
-import { Badge, Gridicon } from '@automattic/components';
-import formatCurrency from '@automattic/format-currency';
+import page from '@automattic/calypso-router';
+import { Gridicon } from '@automattic/components';
 import { MOBILE_BREAKPOINT } from '@automattic/viewport';
 import { useBreakpoint } from '@automattic/viewport-react';
-import classNames from 'classnames';
 import i18n, { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import poweredByTitanLogo from 'calypso/assets/images/email-providers/titan/powered-by-titan-caps.svg';
@@ -11,6 +9,7 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { titanMailMonthly, titanMailYearly } from 'calypso/lib/cart-values/cart-items';
 import { BillingIntervalToggle } from 'calypso/my-sites/email/email-providers-comparison/billing-interval-toggle';
 import { IntervalLength } from 'calypso/my-sites/email/email-providers-comparison/interval-length';
+import ProfessionalEmailPrice from 'calypso/my-sites/email/email-providers-comparison/price/professional-email';
 import { MailboxForm } from 'calypso/my-sites/email/form/mailboxes';
 import { NewMailBoxList } from 'calypso/my-sites/email/form/mailboxes/components/new-mailbox-list';
 import { MailboxOperations } from 'calypso/my-sites/email/form/mailboxes/components/utilities/mailbox-operations';
@@ -23,8 +22,8 @@ import {
 import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { getProductCost } from 'calypso/state/products-list/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import MasterbarStyled from '../../checkout-thank-you/redesign-v2/masterbar-styled';
 import ProfessionalEmailUpsellPlaceholder from './placeholder';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import type { TranslateResult } from 'i18n-calypso';
@@ -60,7 +59,6 @@ const getCartItems = (
 };
 
 type ProfessionalEmailUpsellProps = {
-	currencyCode: string;
 	domainName: string;
 	handleClickAccept: ( action: string ) => void;
 	handleClickDecline: () => void;
@@ -70,7 +68,6 @@ type ProfessionalEmailUpsellProps = {
 };
 
 const ProfessionalEmailUpsell = ( {
-	currencyCode,
 	domainName,
 	handleClickAccept,
 	handleClickDecline,
@@ -81,14 +78,6 @@ const ProfessionalEmailUpsell = ( {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const [ selectedIntervalLength, setSelectedIntervalLength ] = useState( intervalLength );
-
-	const productCost = useSelector( ( state ) => {
-		if ( selectedIntervalLength === IntervalLength.ANNUALLY ) {
-			return getProductCost( state, TITAN_MAIL_YEARLY_SLUG );
-		}
-
-		return getProductCost( state, TITAN_MAIL_MONTHLY_SLUG );
-	} );
 
 	const selectedSite = useSelector( getSelectedSite );
 	const isDomainOnlySite =
@@ -106,34 +95,6 @@ const ProfessionalEmailUpsell = ( {
 		);
 	};
 
-	const getFormattedPrice = (
-		currencyCode: string,
-		intervalLength: IntervalLength,
-		productCost: number
-	): TranslateResult => {
-		const translateOptions = {
-			components: {
-				price: (
-					<span className="professional-email-upsell__discounted">
-						{ formatCurrency( productCost ?? 0, currencyCode ) }
-					</span>
-				),
-			},
-			comment: '{{price/}} is the formatted price, e.g. $20',
-		};
-		if ( intervalLength === IntervalLength.MONTHLY ) {
-			return translate( '{{price/}} /mailbox /month', translateOptions );
-		}
-
-		return translate( '{{price/}} /mailbox /year', translateOptions );
-	};
-
-	const formattedPrice = getFormattedPrice(
-		currencyCode,
-		selectedIntervalLength,
-		productCost ?? 0
-	);
-
 	const onSubmit = async ( mailboxOperations: MailboxOperations ) => {
 		if ( ! ( await mailboxOperations.validateAndCheck( false ) ) ) {
 			return;
@@ -146,98 +107,105 @@ const ProfessionalEmailUpsell = ( {
 
 	const pricingComponent = (
 		<div className="professional-email-upsell__pricing">
-			<span>
-				<Badge type="success">{ translate( '3 months free' ) }</Badge>
-			</span>
-			<span
-				className={ classNames( 'professional-email-upsell__standard-price', {
-					'is-discounted': true,
-				} ) }
-			>
-				{ formattedPrice }
-			</span>
+			<ProfessionalEmailPrice intervalLength={ selectedIntervalLength } isDomainInCart />
 		</div>
+	);
+
+	const pageViewTracker = (
+		<PageViewTracker
+			path="/checkout/offer-professional-email/:domain/:receiptId/:site"
+			title="Post Checkout - Professional Email Upsell"
+		/>
+	);
+
+	const content = (
+		<>
+			<header className="professional-email-upsell__header">
+				<h3 className="professional-email-upsell__small-title">
+					{ isDomainOnlySite
+						? translate( "Hold tight, we're getting your domain ready." )
+						: translate( "Hold tight, we're getting your site ready." ) }
+				</h3>
+				<h1 className="professional-email-upsell__title wp-brand-font">
+					{ translate( 'Add Professional Email @%(domain)s', {
+						args: {
+							domain: domainName,
+						},
+						comment: '%(domain)s is a domain name, like example.com',
+					} ) }
+				</h1>
+				<h3 className="professional-email-upsell__small-subtitle">
+					{ i18n.hasTranslation( 'No setup required. Easy to manage.' )
+						? translate( 'No setup required. Easy to manage.' )
+						: null }
+				</h3>
+				<BillingIntervalToggle
+					intervalLength={ selectedIntervalLength }
+					onIntervalChange={ changeIntervalLength }
+				/>
+			</header>
+
+			<div className="professional-email-upsell__content">
+				{ isMobileView && pricingComponent }
+
+				<div className="professional-email-upsell__form">
+					<NewMailBoxList
+						cancelActionText={ translate( 'Skip for now' ) }
+						fieldLabelTexts={ {
+							[ FIELD_MAILBOX ]: translate( 'Enter email address' ),
+							[ FIELD_PASSWORD ]: translate( 'Set password' ),
+						} }
+						hiddenFieldNames={ [ FIELD_NAME, FIELD_PASSWORD_RESET_EMAIL ] }
+						isInitialMailboxPurchase
+						onCancel={ handleClickDecline }
+						onSubmit={ onSubmit }
+						provider={ EmailProvider.Titan }
+						selectedDomainName={ domainName }
+						showCancelButton
+						submitActionText={ translate( 'Add Professional Email' ) }
+					/>
+				</div>
+
+				<div className="professional-email-upsell__features">
+					{ ! isMobileView && pricingComponent }
+					<h2>{ translate( 'Why get Professional Email?' ) }</h2>
+					<ul className="professional-email-upsell__feature-list">
+						<ProfessionalEmailFeature>
+							{ translate( "Trusted email address that's truly yours" ) }
+						</ProfessionalEmailFeature>
+						<ProfessionalEmailFeature>
+							{ translate( 'Increase your credibility' ) }
+						</ProfessionalEmailFeature>
+						<ProfessionalEmailFeature>
+							{ translate( 'Build your brand with every email you send' ) }
+						</ProfessionalEmailFeature>
+						<ProfessionalEmailFeature>
+							{ translate( 'Reach your recipients’ primary inbox' ) }
+						</ProfessionalEmailFeature>
+					</ul>
+
+					<img
+						className="professional-email-upsell__titan-logo"
+						src={ poweredByTitanLogo }
+						alt={ translate( 'Powered by Titan', { textOnly: true } ) }
+					/>
+				</div>
+			</div>
+		</>
 	);
 
 	return (
 		<>
-			<PageViewTracker
-				path="/checkout/offer-professional-email/:domain/:receiptId/:site"
-				title="Post Checkout - Professional Email Upsell"
+			{ pageViewTracker }
+
+			<MasterbarStyled
+				onClick={ () => page( `/home/${ selectedSite?.slug ?? '' }` ) }
+				backText={ translate( 'Back to dashboard' ) }
+				canGoBack={ !! selectedSite?.ID }
+				showContact
 			/>
-			{ isLoading ? (
-				<ProfessionalEmailUpsellPlaceholder />
-			) : (
-				<>
-					<header className="professional-email-upsell__header">
-						<h3 className="professional-email-upsell__small-title">
-							{ isDomainOnlySite
-								? translate( "Hold tight, we're getting your domain ready." )
-								: translate( "Hold tight, we're getting your site ready." ) }
-						</h3>
-						<h1 className="professional-email-upsell__title wp-brand-font">
-							{ translate( 'Add Professional Email @%(domain)s', {
-								args: {
-									domain: domainName,
-								},
-								comment: '%(domain)s is a domain name, like example.com',
-							} ) }
-						</h1>
-						<h3 className="professional-email-upsell__small-subtitle">
-							{ i18n.hasTranslation( 'No setup required. Easy to manage.' )
-								? translate( 'No setup required. Easy to manage.' )
-								: null }
-						</h3>
-						<BillingIntervalToggle
-							intervalLength={ selectedIntervalLength }
-							onIntervalChange={ changeIntervalLength }
-						/>
-					</header>
-					<div className="professional-email-upsell__content">
-						{ isMobileView && pricingComponent }
-						<div className="professional-email-upsell__form">
-							<NewMailBoxList
-								cancelActionText={ translate( 'Skip for now' ) }
-								fieldLabelTexts={ {
-									[ FIELD_MAILBOX ]: translate( 'Enter email address' ),
-									[ FIELD_PASSWORD ]: translate( 'Set password' ),
-								} }
-								hiddenFieldNames={ [ FIELD_NAME, FIELD_PASSWORD_RESET_EMAIL ] }
-								isInitialMailboxPurchase
-								onCancel={ handleClickDecline }
-								onSubmit={ onSubmit }
-								provider={ EmailProvider.Titan }
-								selectedDomainName={ domainName }
-								showCancelButton
-								submitActionText={ translate( 'Add Professional Email' ) }
-							/>
-						</div>
-						<div className="professional-email-upsell__features">
-							{ ! isMobileView && pricingComponent }
-							<h2>{ translate( 'Why get Professional Email?' ) }</h2>
-							<ul className="professional-email-upsell__feature-list">
-								<ProfessionalEmailFeature>
-									{ translate( "Trusted email address that's truly yours" ) }
-								</ProfessionalEmailFeature>
-								<ProfessionalEmailFeature>
-									{ translate( 'Increase your credibility' ) }
-								</ProfessionalEmailFeature>
-								<ProfessionalEmailFeature>
-									{ translate( 'Build your brand with every email you send' ) }
-								</ProfessionalEmailFeature>
-								<ProfessionalEmailFeature>
-									{ translate( 'Reach your recipients’ primary inbox' ) }
-								</ProfessionalEmailFeature>
-							</ul>
-							<img
-								className="professional-email-upsell__titan-logo"
-								src={ poweredByTitanLogo }
-								alt={ translate( 'Powered by Titan', { textOnly: true } ) }
-							/>
-						</div>
-					</div>
-				</>
-			) }
+
+			{ isLoading ? <ProfessionalEmailUpsellPlaceholder /> : content }
 		</>
 	);
 };

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
@@ -111,92 +111,12 @@ const ProfessionalEmailUpsell = ( {
 		</div>
 	);
 
-	const pageViewTracker = (
-		<PageViewTracker
-			path="/checkout/offer-professional-email/:domain/:receiptId/:site"
-			title="Post Checkout - Professional Email Upsell"
-		/>
-	);
-
-	const content = (
-		<>
-			<header className="professional-email-upsell__header">
-				<h3 className="professional-email-upsell__small-title">
-					{ isDomainOnlySite
-						? translate( "Hold tight, we're getting your domain ready." )
-						: translate( "Hold tight, we're getting your site ready." ) }
-				</h3>
-				<h1 className="professional-email-upsell__title wp-brand-font">
-					{ translate( 'Add Professional Email @%(domain)s', {
-						args: {
-							domain: domainName,
-						},
-						comment: '%(domain)s is a domain name, like example.com',
-					} ) }
-				</h1>
-				<h3 className="professional-email-upsell__small-subtitle">
-					{ i18n.hasTranslation( 'No setup required. Easy to manage.' )
-						? translate( 'No setup required. Easy to manage.' )
-						: null }
-				</h3>
-				<BillingIntervalToggle
-					intervalLength={ selectedIntervalLength }
-					onIntervalChange={ changeIntervalLength }
-				/>
-			</header>
-
-			<div className="professional-email-upsell__content">
-				{ isMobileView && pricingComponent }
-
-				<div className="professional-email-upsell__form">
-					<NewMailBoxList
-						cancelActionText={ translate( 'Skip for now' ) }
-						fieldLabelTexts={ {
-							[ FIELD_MAILBOX ]: translate( 'Enter email address' ),
-							[ FIELD_PASSWORD ]: translate( 'Set password' ),
-						} }
-						hiddenFieldNames={ [ FIELD_NAME, FIELD_PASSWORD_RESET_EMAIL ] }
-						isInitialMailboxPurchase
-						onCancel={ handleClickDecline }
-						onSubmit={ onSubmit }
-						provider={ EmailProvider.Titan }
-						selectedDomainName={ domainName }
-						showCancelButton
-						submitActionText={ translate( 'Add Professional Email' ) }
-					/>
-				</div>
-
-				<div className="professional-email-upsell__features">
-					{ ! isMobileView && pricingComponent }
-					<h2>{ translate( 'Why get Professional Email?' ) }</h2>
-					<ul className="professional-email-upsell__feature-list">
-						<ProfessionalEmailFeature>
-							{ translate( "Trusted email address that's truly yours" ) }
-						</ProfessionalEmailFeature>
-						<ProfessionalEmailFeature>
-							{ translate( 'Increase your credibility' ) }
-						</ProfessionalEmailFeature>
-						<ProfessionalEmailFeature>
-							{ translate( 'Build your brand with every email you send' ) }
-						</ProfessionalEmailFeature>
-						<ProfessionalEmailFeature>
-							{ translate( 'Reach your recipients’ primary inbox' ) }
-						</ProfessionalEmailFeature>
-					</ul>
-
-					<img
-						className="professional-email-upsell__titan-logo"
-						src={ poweredByTitanLogo }
-						alt={ translate( 'Powered by Titan', { textOnly: true } ) }
-					/>
-				</div>
-			</div>
-		</>
-	);
-
 	return (
 		<>
-			{ pageViewTracker }
+			<PageViewTracker
+				path="/checkout/offer-professional-email/:domain/:receiptId/:site"
+				title="Post Checkout - Professional Email Upsell"
+			/>
 
 			<MasterbarStyled
 				onClick={ () => page( `/home/${ selectedSite?.slug ?? '' }` ) }
@@ -205,7 +125,84 @@ const ProfessionalEmailUpsell = ( {
 				showContact
 			/>
 
-			{ isLoading ? <ProfessionalEmailUpsellPlaceholder /> : content }
+			{ isLoading ? (
+				<ProfessionalEmailUpsellPlaceholder />
+			) : (
+				<>
+					<header className="professional-email-upsell__header">
+						<h3 className="professional-email-upsell__small-title">
+							{ isDomainOnlySite
+								? translate( "Hold tight, we're getting your domain ready." )
+								: translate( "Hold tight, we're getting your site ready." ) }
+						</h3>
+						<h1 className="professional-email-upsell__title wp-brand-font">
+							{ translate( 'Add Professional Email @%(domain)s', {
+								args: {
+									domain: domainName,
+								},
+								comment: '%(domain)s is a domain name, like example.com',
+							} ) }
+						</h1>
+						<h3 className="professional-email-upsell__small-subtitle">
+							{ i18n.hasTranslation( 'No setup required. Easy to manage.' )
+								? translate( 'No setup required. Easy to manage.' )
+								: null }
+						</h3>
+						<BillingIntervalToggle
+							intervalLength={ selectedIntervalLength }
+							onIntervalChange={ changeIntervalLength }
+						/>
+					</header>
+
+					<div className="professional-email-upsell__content">
+						{ isMobileView && pricingComponent }
+
+						<div className="professional-email-upsell__form">
+							<NewMailBoxList
+								cancelActionText={ translate( 'Skip for now' ) }
+								fieldLabelTexts={ {
+									[ FIELD_MAILBOX ]: translate( 'Enter email address' ),
+									[ FIELD_PASSWORD ]: translate( 'Set password' ),
+								} }
+								hiddenFieldNames={ [ FIELD_NAME, FIELD_PASSWORD_RESET_EMAIL ] }
+								isInitialMailboxPurchase
+								onCancel={ handleClickDecline }
+								onSubmit={ onSubmit }
+								provider={ EmailProvider.Titan }
+								selectedDomainName={ domainName }
+								showCancelButton
+								submitActionText={ translate( 'Add Professional Email' ) }
+							/>
+						</div>
+
+						<div className="professional-email-upsell__features">
+							{ ! isMobileView && pricingComponent }
+
+							<h2>{ translate( 'Why get Professional Email?' ) }</h2>
+							<ul className="professional-email-upsell__feature-list">
+								<ProfessionalEmailFeature>
+									{ translate( "Trusted email address that's truly yours" ) }
+								</ProfessionalEmailFeature>
+								<ProfessionalEmailFeature>
+									{ translate( 'Increase your credibility' ) }
+								</ProfessionalEmailFeature>
+								<ProfessionalEmailFeature>
+									{ translate( 'Build your brand with every email you send' ) }
+								</ProfessionalEmailFeature>
+								<ProfessionalEmailFeature>
+									{ translate( 'Reach your recipients’ primary inbox' ) }
+								</ProfessionalEmailFeature>
+							</ul>
+
+							<img
+								className="professional-email-upsell__titan-logo"
+								src={ poweredByTitanLogo }
+								alt={ translate( 'Powered by Titan', { textOnly: true } ) }
+							/>
+						</div>
+					</div>
+				</>
+			) }
 		</>
 	);
 };

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/style.scss
@@ -7,6 +7,7 @@
 
 .main.professional-email-upsell {
 	max-width: 1040px;
+	margin-top: 40px;
 
 	@include breakpoint-deprecated( "<660px" ) {
 		padding: 1em;
@@ -49,16 +50,29 @@
 }
 
 .professional-email-upsell__pricing {
-	display: flex;
-	flex-direction: column;
-	margin-bottom: 24px;
+	.professional-email-price__trial-badge {
+		background-color: var(--color-success);
+		color: var(--color-text-inverted);
+		margin-bottom: 4px;
+	}
 
-	@include break-mobile {
-		justify-content: center;
-		margin-bottom: 10px;
+	.price-with-interval__sale-price {
+		color: var(--studio-green-50);
+	}
 
-		span + span {
-			margin-left: 8px;
+	.price__cost > span {
+		font-size: $font-title-small;
+		font-weight: 600;
+	}
+
+	.price-information__free-trial {
+		display: block;
+		font-size: $font-body-small;
+		margin-bottom: 0;
+		margin-top: 4px;
+
+		@include break-medium {
+			margin-bottom: 12px;
 		}
 	}
 }
@@ -71,27 +85,14 @@
 }
 
 .professional-email-upsell__content {
-	display: flex;
-	flex-direction: column;
+	display: grid;
+	gap: 40px;
 	margin-top: 2.5em;
 
 	@include break-medium {
-		flex-direction: row;
+		grid-template-columns: 7fr 4fr;
+		gap: 50px;
 		margin-top: 3em;
-
-		> div {
-			padding: 1em;
-
-			&:first-of-type {
-				flex: 1;
-				max-width: 550px;
-				padding-right: 3em;
-			}
-
-			&:last-of-type {
-				padding-left: 3em;
-			}
-		}
 	}
 }
 
@@ -137,11 +138,7 @@
 .professional-email-upsell__features {
 	display: flex;
 	flex-direction: column;
-	margin-top: 2.5em;
-
-	@include break-medium {
-		margin-top: 0;
-	}
+	max-width: 380px;
 
 	h2 {
 		font-size: $font-body-small;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/4485

## Proposed Changes

This PR updates the post-checkout Professional Email upsell page design as per p9Jlb4-9Bv-p2#comment-10468. I've made the following changes:

- Hide the regular masterbar behind the same masterbar that's used on `CheckoutThankYou` pages
- Display the same price terms for the free trial that we do on email management pages
- Tweak the layout (for desktop and mobile)

| Before | After |
| - | - |
| ![upsell-before](https://github.com/Automattic/wp-calypso/assets/1101677/8b17ba1d-b77c-4812-8c3c-f2a72019d699) | ![upsell-after](https://github.com/Automattic/wp-calypso/assets/1101677/80ca6d88-a39d-41fa-989f-f46492e5f192) |
| ![upsell-mobile-before](https://github.com/Automattic/wp-calypso/assets/1101677/b928232f-9133-46dd-9e02-435755b7daaf) | ![upsell-mobile-after](https://github.com/Automattic/wp-calypso/assets/1101677/427181ff-1f18-4fdb-87f1-861e8793fd04) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `/checkout/offer-professional-email/:domain/123/:site_slug`
2. Ensure that the page looks good on desktop and on mobile
3. Get a receipt ID for a domain purchase with the following steps:
  3.1. Go to Upgrades > Purchases > Billing History
  3.2. Look for the domain purchase and click on "View receipt" and you should be able to find the receipt ID
4. Navigate to `/checkout/thank-you/:site_slug/:receipt_id`
5. Ensure that the page looks good on desktop and on mobile

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?