### PR TITLE
Limited Global Styles: Remove usePlans hook to fix notices and modal

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/modal.js
@@ -1,8 +1,7 @@
 /* global wpcomGlobalStyles */
 
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Plans } from '@automattic/data-stores';
-import { PLAN_PREMIUM } from '@automattic/data-stores/src/plans/constants';
+import { getPlan, PLAN_PREMIUM } from '@automattic/calypso-products';
 import { Button, Modal } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -16,7 +15,6 @@ import './modal.scss';
 const GlobalStylesModal = () => {
 	const isSiteEditor = useSelect( ( select ) => !! select( 'core/edit-site' ), [] );
 	const { viewCanvasPath } = useCanvas();
-	const plans = Plans.usePlans( { coupon: undefined } );
 
 	const isVisible = useSelect(
 		( select ) => {
@@ -64,13 +62,14 @@ const GlobalStylesModal = () => {
 		return null;
 	}
 
+	const planName = getPlan( PLAN_PREMIUM ).getTitle();
 	const description = sprintf(
 		/* translators: %s is the short-form Premium plan name */
 		__(
 			"Change all of your site's fonts, colors and more. Available on the %s plan.",
 			'full-site-editing'
 		),
-		plans.data?.[ PLAN_PREMIUM ]?.productNameShort || ''
+		planName
 	);
 
 	return (

--- a/apps/editing-toolkit/package.json
+++ b/apps/editing-toolkit/package.json
@@ -50,6 +50,7 @@
 		"@automattic/calypso-analytics": "workspace:^",
 		"@automattic/calypso-build": "workspace:^",
 		"@automattic/calypso-polyfills": "workspace:^",
+		"@automattic/calypso-products": "workspace:^",
 		"@automattic/calypso-router": "workspace:^",
 		"@automattic/components": "workspace:^",
 		"@automattic/data-stores": "workspace:^",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1981,6 +1981,7 @@ __metadata:
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-eslint-overrides": "workspace:^"
     "@automattic/calypso-polyfills": "workspace:^"
+    "@automattic/calypso-products": "workspace:^"
     "@automattic/calypso-router": "workspace:^"
     "@automattic/components": "workspace:^"
     "@automattic/data-stores": "workspace:^"


### PR DESCRIPTION
## Proposed Changes

Fixed a regression caused by the new plans names that were causing the limited Global Styles warning to be hidden or to display an empty plan name.

Seems that the `usePlans` hook doesn't work inside ETK properly, so this PR replaces the logic to get the plan name using the `getPlan` helper from `@automattic/calypso-products` (props to @claudiucelfilip).

Before | After
--- | ---
<img width="785" alt="Screenshot 2024-01-15 at 15 41 51" src="https://github.com/Automattic/wp-calypso/assets/1233880/61e93144-584e-4283-8799-3438584640e7"> | <img width="790" alt="Screenshot 2024-01-15 at 15 43 06" src="https://github.com/Automattic/wp-calypso/assets/1233880/dc58bfd5-caf0-41bd-8e16-2328a53b76d8">
<img width="349" alt="Screenshot 2024-01-15 at 15 39 48" src="https://github.com/Automattic/wp-calypso/assets/1233880/1f5886c5-b6b5-48e4-a150-00f5418d81ee"> | <img width="355" alt="Screenshot 2024-01-15 at 15 43 13" src="https://github.com/Automattic/wp-calypso/assets/1233880/aa0572d9-8d3f-4837-ba39-6d573be2d566">
<img width="802" alt="Screenshot 2024-01-15 at 15 39 56" src="https://github.com/Automattic/wp-calypso/assets/1233880/6ff00f48-cc64-4a7a-a3e0-54d8df9b8054"> | <img width="753" alt="Screenshot 2024-01-15 at 15 43 19" src="https://github.com/Automattic/wp-calypso/assets/1233880/b4db4203-1890-4a8d-a570-86c488ba4f98">

## Testing Instructions

- Apply these changes to your sandbox: `install-plugin.sh etk fix/limited-gs-use-plans-hook`
- Sandbox a new site (you won't see the GS modal on an existing site if you already dismissed it)
- Open the site editor
- Select "Styles" in the left navigation bar
- Make sure the GS modal with the correct plan name shows up 
- Dismiss it and select a non-default style variation
- Make sure the GS notice with the correct plan name shows up at the bottom of the left navigation bar
- Switch to the "edit" mode (by clicking on the pencil icon)
- Make sure the GS notice with the correct plan name shows up at the top of the editor