### PR TITLE
Marketplace Reviews: Add track event for Add Review themes

### DIFF
--- a/client/my-sites/marketplace/components/review-modal/index.tsx
+++ b/client/my-sites/marketplace/components/review-modal/index.tsx
@@ -1,7 +1,8 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Dialog, Button, Card, Spinner } from '@automattic/components';
 import { TextareaControl } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
-import { useState } from 'react';
+import { type FormEvent, useState } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import ReviewsRatingsStars from 'calypso/components/reviews-rating-stars/reviews-ratings-stars';
 import {
@@ -25,12 +26,37 @@ export const ReviewModal = ( { isVisible, onClose, slug, productName, productTyp
 
 	const createReview = useCreateMarketplaceReviewMutation( { productType, slug } );
 
+	const handleSubmit = ( e: FormEvent ) => {
+		e.preventDefault();
+		createReview.mutate( {
+			productType,
+			slug: slug,
+			content: content,
+			rating: Number( rating ),
+		} );
+
+		recordTracksEvent( 'calypso_marketplace_reviews_add_submit', {
+			product_type: productType,
+			slug: slug,
+			rating: Number( rating ),
+		} );
+	};
+
+	const handleClose = () => {
+		recordTracksEvent( 'calypso_marketplace_reviews_add_dismiss', {
+			completed: createReview.isSuccess,
+			is_error: createReview.isError,
+		} );
+
+		onClose();
+	};
+
 	if ( createReview.isSuccess ) {
 		return (
 			<Dialog
 				className="marketplace-review-modal"
 				isVisible={ isVisible }
-				onClose={ onClose }
+				onClose={ handleClose }
 				showCloseIcon
 			>
 				<Card className="marketplace-review-modal__card-success">
@@ -51,25 +77,14 @@ export const ReviewModal = ( { isVisible, onClose, slug, productName, productTyp
 		<Dialog
 			className="marketplace-review-modal"
 			isVisible={ isVisible }
-			onClose={ onClose }
+			onClose={ handleClose }
 			showCloseIcon
 		>
 			<Card className="marketplace-review-modal__card">
 				<CardHeading tagName="h1" size={ 21 }>
 					{ translate( 'Add New Review for %(productName)s', { args: { productName } } ) }
 				</CardHeading>
-				<form
-					onSubmit={ ( e ) => {
-						e.preventDefault();
-						const requestData = {
-							productType: productType,
-							slug: slug,
-							content: content,
-							rating: Number( rating ),
-						};
-						createReview.mutate( requestData );
-					} }
-				>
+				<form onSubmit={ handleSubmit }>
 					<TextareaControl
 						rows={ 12 }
 						cols={ 40 }
@@ -89,7 +104,7 @@ export const ReviewModal = ( { isVisible, onClose, slug, productName, productTyp
 							{ createReview.isPending && <Spinner className="card__icon" /> }
 							<span>{ translate( 'Submit' ) }</span>
 						</Button>
-						<Button onClick={ onClose }>{ translate( 'Cancel' ) }</Button>
+						<Button onClick={ handleClose }>{ translate( 'Cancel' ) }</Button>
 					</div>
 				</form>
 				{ createReview.isError && (

--- a/client/my-sites/marketplace/components/review-modal/index.tsx
+++ b/client/my-sites/marketplace/components/review-modal/index.tsx
@@ -44,7 +44,7 @@ export const ReviewModal = ( { isVisible, onClose, slug, productName, productTyp
 
 	const handleClose = () => {
 		recordTracksEvent( 'calypso_marketplace_reviews_add_dismiss', {
-			completed: createReview.isSuccess,
+			is_success: createReview.isSuccess,
 			is_error: createReview.isError,
 		} );
 

--- a/client/my-sites/marketplace/components/reviews-summary/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-summary/index.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
@@ -9,6 +10,7 @@ import {
 	type ProductProps,
 } from 'calypso/data/marketplace/use-marketplace-reviews';
 import { ReviewModal } from 'calypso/my-sites/marketplace/components/review-modal';
+
 import './styles.scss';
 
 type Props = ProductProps & {
@@ -40,6 +42,14 @@ export const ReviewsSummary = ( { slug, productName, productType }: Props ) => {
 		averageRating = ( averageRating * 100 ) / 5;
 	}
 
+	const handleAddReviewClick = () => {
+		recordTracksEvent( 'calypso_marketplace_reviews_add_button_click', {
+			product_type: productType,
+			slug,
+		} );
+		setIsVisible( true );
+	};
+
 	return (
 		<>
 			<ReviewModal
@@ -64,7 +74,7 @@ export const ReviewsSummary = ( { slug, productName, productType }: Props ) => {
 					</div>
 				) }
 				{ userCanPublishReviews && (
-					<Button onClick={ () => setIsVisible( true ) }>{ translate( 'Add Review' ) }</Button>
+					<Button onClick={ handleAddReviewClick }>{ translate( 'Add Review' ) }</Button>
 				) }
 			</div>
 		</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/dotcom-forge/issues/5144

## Proposed Changes

* Add a new track event when clicking the `Add Review` button on themes
* The new event is named `calypso_marketplace_reviews_add_button_click`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch and navigate to a theme in an environment with the following flags enabled: `marketplace-add-review` and `marketplace-reviews-show`
* Open developer tools and activate logging for track events running `localStorage.debug='calypso:analytics'`. Make sure you have logging level set to `Verbose` in dev tools. Keep the Console tab open
* Go to a theme details that you are able to review, e.g. `/theme/spiel`
* Click on the `Add Review` button
* Make sure you can see a tracks event logged named `calypso_marketplace_reviews_add_button_click` with the `productType` as `theme` and the name of the theme as `slug`
* Dismiss the modal, clicking on the `X` or pressing `ESC` key
* Make sure you can see a tracks event logged named `calypso_marketplace_reviews_add_dismiss` with the `completed` field to `false`.
* Click on the `Add Review` button again, add a review and click on `Submit`
* Make sure you can see a tracks event logged named `calypso_marketplace_reviews_add_submit` with the product_type, slug and rating
* Close the Thank You message and make sure you see the `calypso_marketplace_reviews_add_dismiss` with the `completed` field as `true`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?