### PR TITLE
Checkout: Hide upgrade credit line item label when no upgrade credit exists

### DIFF
--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -846,6 +846,14 @@ const UpgradeCreditHelpIconLink = () => {
 	);
 };
 
+function hasUpgradeCredit( product: ResponseCartProduct ): boolean {
+	return (
+		product.cost_overrides?.some(
+			( override ) => override.override_code === 'recent-plan-proration'
+		) ?? false
+	);
+}
+
 function UpgradeCreditInformation( { product }: { product: ResponseCartProduct } ) {
 	const translate = useTranslate();
 	const origCost = product.item_original_subtotal_integer;
@@ -864,7 +872,9 @@ function UpgradeCreditInformation( { product }: { product: ResponseCartProduct }
 		// Do not display discount reason if this is a renewal.
 		isRenewal ||
 		// Do not display discount reason if a coupon is applied.
-		isCouponApplied( product )
+		isCouponApplied( product ) ||
+		// Do not display upgrade credit if there is no upgrade credit.
+		! hasUpgradeCredit( product )
 	) {
 		return null;
 	}


### PR DESCRIPTION
## Proposed Changes

When creating a new site with a plan along with a first-year promotional discount, the discount is incorrectly labelled as "Upgrade Credits".

In this PR we hide the label if there is no upgrade credit applied.

NOTE: I think this issue as reported may have been "fixed" by pbOQVh-4sd-p2 which changes the first-year promotional discount into an introductory offer but the bug is still possible without this PR.

Fixes https://github.com/Automattic/wp-calypso/issues/83956

## Testing Instructions

- Switch to a currency that has a first year promotional discount. (326bf-pb)
- Go to https://wordpress.com/start
- On the plans page, select any paid plan and proceed to checkout.
- Verify that you do not see "Upgrade Credit" listed below the line item.