### PR TITLE
Shopping Cart: Remove free_trial cart property from a few more places

### DIFF
--- a/client/lib/analytics/ad-tracking/record-add-to-cart.js
+++ b/client/lib/analytics/ad-tracking/record-add-to-cart.js
@@ -46,7 +46,6 @@ export async function recordAddToCart( cartItem ) {
 			'AddToCart',
 			{
 				product_slug: cartItem.product_slug,
-				free_trial: Boolean( cartItem.free_trial ),
 			},
 		];
 		debug( 'recordAddToCart: [Facebook]', params );
@@ -59,7 +58,6 @@ export async function recordAddToCart( cartItem ) {
 			'AddToCart',
 			{
 				product_slug: cartItem.product_slug,
-				free_trial: Boolean( cartItem.free_trial ),
 			},
 		];
 		debug( 'recordAddToCart: [Jetpack]', params );

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1308,7 +1308,6 @@ export const buildUpgradeFunction = ( planProps, cartItems ) => {
 	if ( planCartItem ) {
 		planProps.recordTracksEvent( 'calypso_signup_plan_select', {
 			product_slug: planCartItem.product_slug,
-			free_trial: planCartItem.free_trial,
 			from_section: stepSectionName ? stepSectionName : 'default',
 		} );
 

--- a/client/signup/steps/plans/test/index.jsx
+++ b/client/signup/steps/plans/test/index.jsx
@@ -120,7 +120,7 @@ describe( 'Plans.onSelectPlan', () => {
 	test( 'Should call recordEvent when cartItem is specified', () => {
 		const recordTracksEvent = jest.fn();
 		const comp = new PlansStep( { ...tplProps, recordTracksEvent } );
-		comp.onSelectPlan( getCartItems( { free_trial: false } ) );
+		comp.onSelectPlan( getCartItems( {} ) );
 
 		expect( recordTracksEvent ).toHaveBeenCalled();
 
@@ -129,7 +129,6 @@ describe( 'Plans.onSelectPlan', () => {
 		expect( args[ 0 ] ).toEqual( 'calypso_signup_plan_select' );
 		expect( args[ 1 ] ).toEqual( {
 			product_slug: PLAN_FREE,
-			free_trial: false,
 			from_section: 'Step section name',
 		} );
 	} );


### PR DESCRIPTION
## Proposed Changes

This PR removes some remaining instances of the `free_trial` property on shopping cart items. This property is never set on cart items and will soon be removed entirely by D134038-code.

## Testing Instructions

Verify that I'm removing this property only on cart items. I think it still exists on data from other endpoints like maybe the plans endpoint?