### PR TITLE
ThemeShowcase: Add retained benefits for themes (take two)

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/index.js
+++ b/client/components/theme-tier/theme-tier-badge/index.js
@@ -1,12 +1,9 @@
 import { BUNDLED_THEME, DOT_ORG_THEME, MARKETPLACE_THEME } from '@automattic/design-picker';
 import classNames from 'classnames';
 import { useSelector } from 'calypso/state';
-import {
-	getThemeType,
-	isThemePurchased,
-	getThemeTierForTheme,
-	isThemeAllowedOnSite,
-} from 'calypso/state/themes/selectors';
+import { useIsThemeAllowedOnSite } from 'calypso/state/themes/hooks/use-is-theme-allowed-on-site';
+import { useThemeTierForTheme } from 'calypso/state/themes/hooks/use-theme-tier-for-theme';
+import { getThemeType, isThemePurchased } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { ThemeTierBadgeContextProvider } from './theme-tier-badge-context';
 import ThemeTierBundledBadge from './theme-tier-bundled-badge';
@@ -29,8 +26,8 @@ export default function ThemeTierBadge( {
 	const isLegacyPremiumPurchased = useSelector( ( state ) =>
 		isThemePurchased( state, themeId, siteId )
 	);
-	const themeTier = useSelector( ( state ) => getThemeTierForTheme( state, themeId ) );
-	const isThemeAllowed = useSelector( ( state ) => isThemeAllowedOnSite( state, siteId, themeId ) );
+	const themeTier = useThemeTierForTheme( themeId );
+	const isThemeAllowed = useIsThemeAllowedOnSite( siteId, themeId );
 
 	const getBadge = () => {
 		if ( BUNDLED_THEME === themeType ) {

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-partner-badge.js
@@ -3,10 +3,10 @@ import { PremiumBadge } from '@automattic/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
+import { useIsThemeAllowedOnSite } from 'calypso/state/themes/hooks/use-is-theme-allowed-on-site';
 import {
 	isMarketplaceThemeSubscribed,
 	getMarketplaceThemeSubscriptionPrices,
-	isThemeAllowedOnSite,
 } from 'calypso/state/themes/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ThemeTierBadgeCheckoutLink from './theme-tier-badge-checkout-link';
@@ -24,7 +24,7 @@ export default function ThemeTierPartnerBadge() {
 	const subscriptionPrices = useSelector( ( state ) =>
 		getMarketplaceThemeSubscriptionPrices( state, themeId )
 	);
-	const isThemeAllowed = useSelector( ( state ) => isThemeAllowedOnSite( state, siteId, themeId ) );
+	const isThemeAllowed = useIsThemeAllowedOnSite( siteId, themeId );
 
 	const labelText = isThemeAllowed
 		? translate( 'Subscribe' )
@@ -83,7 +83,7 @@ export default function ThemeTierPartnerBadge() {
 
 	return (
 		<>
-			{ showUpgradeBadge && ( ! isPartnerThemePurchased || ! isThemeAllowedOnSite ) && (
+			{ showUpgradeBadge && ( ! isPartnerThemePurchased || ! isThemeAllowed ) && (
 				<>
 					<ThemeTierBadgeTracker />
 					<PremiumBadge

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
@@ -3,8 +3,7 @@ import { PremiumBadge } from '@automattic/components';
 import { Plans } from '@automattic/data-stores';
 import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import { useSelector } from 'calypso/state';
-import { getThemeTierForTheme } from 'calypso/state/themes/selectors';
+import { useThemeTierForTheme } from 'calypso/state/themes/hooks/use-theme-tier-for-theme';
 import { THEME_TIERS } from '../constants';
 import ThemeTierBadgeCheckoutLink from './theme-tier-badge-checkout-link';
 import { useThemeTierBadgeContext } from './theme-tier-badge-context';
@@ -14,7 +13,7 @@ import ThemeTierTooltipTracker from './theme-tier-tooltip-tracker';
 export default function ThemeTierUpgradeBadge() {
 	const translate = useTranslate();
 	const { themeId } = useThemeTierBadgeContext();
-	const themeTier = useSelector( ( state ) => getThemeTierForTheme( state, themeId ) );
+	const themeTier = useThemeTierForTheme( themeId );
 
 	const tierMinimumUpsellPlan = THEME_TIERS[ themeTier?.slug ]?.minimumUpsellPlan;
 	const mappedPlan = getPlan( tierMinimumUpsellPlan );

--- a/client/data/themes/types.ts
+++ b/client/data/themes/types.ts
@@ -1,0 +1,5 @@
+export type ThemeTier = {
+	slug: string;
+	feature: string | null;
+	platform: string;
+};

--- a/client/data/themes/use-tier-retained-benefits-query.ts
+++ b/client/data/themes/use-tier-retained-benefits-query.ts
@@ -1,26 +1,21 @@
 import { useQuery } from '@tanstack/react-query';
+import { ThemeTier } from 'calypso/data/themes/types';
 import wpcom from 'calypso/lib/wp';
 
 export type RetainedBenefit = {
 	is_eligible: boolean;
 	eligibility_expiration_date: number;
-	tier: {
-		slug: string;
-		feature: string | null;
-		platform: string;
-	};
+	tier: ThemeTier;
 };
 
 export type TierRetainedBenefits = {
-	[ index: string ]: {
-		retained_benefits: RetainedBenefit;
-	};
+	[ index: string ]: RetainedBenefit;
 };
 
 export const useTierRetainedBenefitsQuery = (
 	siteId: number | null,
 	themeSlug: string
-): RetainedBenefit | undefined => {
+): RetainedBenefit | null => {
 	const queryKey = [ 'themeTierRetainedBenefits', siteId ];
 
 	const query = useQuery< TierRetainedBenefits >( {
@@ -34,9 +29,5 @@ export const useTierRetainedBenefitsQuery = (
 		enabled: !! siteId,
 	} );
 
-	if ( ! query || ! query.data || ! query.data[ themeSlug ] ) {
-		return undefined;
-	}
-
-	return query?.data?.[ themeSlug ]?.retained_benefits;
+	return query?.data?.[ themeSlug ] ?? null;
 };

--- a/client/data/themes/use-tier-retained-benefits-query.ts
+++ b/client/data/themes/use-tier-retained-benefits-query.ts
@@ -1,0 +1,42 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+
+export type RetainedBenefit = {
+	is_eligible: boolean;
+	eligibility_expiration_date: number;
+	tier: {
+		slug: string;
+		feature: string | null;
+		platform: string;
+	};
+};
+
+export type TierRetainedBenefits = {
+	[ index: string ]: {
+		retained_benefits: RetainedBenefit;
+	};
+};
+
+export const useTierRetainedBenefitsQuery = (
+	siteId: number | null,
+	themeSlug: string
+): RetainedBenefit | undefined => {
+	const queryKey = [ 'themeTierRetainedBenefits', siteId ];
+
+	const query = useQuery< TierRetainedBenefits >( {
+		queryKey,
+		queryFn: () => {
+			return wpcom.req.get( {
+				path: `/sites/${ siteId }/themes/retained-benefits`,
+				apiNamespace: 'wpcom/v2',
+			} );
+		},
+		enabled: !! siteId,
+	} );
+
+	if ( ! query || ! query.data || ! query.data[ themeSlug ] ) {
+		return undefined;
+	}
+
+	return query?.data?.[ themeSlug ]?.retained_benefits;
+};

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1157,6 +1157,7 @@ class ThemeSheet extends Component {
 			selectedStyleVariationSlug: styleVariationSlug,
 			themeType,
 			siteId,
+			themeTier,
 		} = this.props;
 
 		return (
@@ -1169,7 +1170,7 @@ class ThemeSheet extends Component {
 								tabFilter,
 								tierFilter: tier,
 								styleVariationSlug,
-								themeTier: this.props.themeTier,
+								themeTier,
 						  } )
 						: null
 				}

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -37,7 +37,6 @@ import {
 	isSiteEligibleForManagedExternalThemes,
 	isWpcomTheme,
 	getIsLivePreviewSupported,
-	getThemeTierForTheme,
 } from 'calypso/state/themes/selectors';
 import { isMarketplaceThemeSubscribed } from 'calypso/state/themes/selectors/is-marketplace-theme-subscribed';
 
@@ -59,7 +58,8 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 				} )
 			);
 
-			const themeTier = getThemeTierForTheme( state, themeId );
+			const themeTier = options.themeTier;
+
 			const tierMinimumUpsellPlan = THEME_TIERS[ themeTier?.slug ]?.minimumUpsellPlan;
 			const mappedPlan = getPlan( tierMinimumUpsellPlan );
 			const planPathSlug = mappedPlan?.getPathSlug();

--- a/client/state/themes/hooks/use-is-theme-allowed-on-site.ts
+++ b/client/state/themes/hooks/use-is-theme-allowed-on-site.ts
@@ -1,0 +1,27 @@
+import { useTierRetainedBenefitsQuery } from 'calypso/data/themes/use-tier-retained-benefits-query';
+import { useSelector } from 'calypso/state';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { isThemeAllowedOnSite } from 'calypso/state/themes/selectors';
+
+export function useIsThemeAllowedOnSite( siteId: number, themeId: string ) {
+	const isThemeAllowed = useSelector( ( state ) => isThemeAllowedOnSite( state, siteId, themeId ) );
+
+	const retainedBenefits = useTierRetainedBenefitsQuery( siteId, themeId );
+	const hasFeature = useSelector( ( state ) =>
+		siteHasFeature( state, siteId, retainedBenefits?.tier.feature ?? '' )
+	);
+
+	if ( isThemeAllowed ) {
+		return true;
+	}
+
+	if ( ! retainedBenefits?.is_eligible ) {
+		return false;
+	}
+
+	if ( retainedBenefits.tier.feature === null ) {
+		return true;
+	}
+
+	return hasFeature;
+}

--- a/client/state/themes/hooks/use-theme-tier-for-theme.ts
+++ b/client/state/themes/hooks/use-theme-tier-for-theme.ts
@@ -1,0 +1,12 @@
+import { useTierRetainedBenefitsQuery } from 'calypso/data/themes/use-tier-retained-benefits-query';
+import { useSelector } from 'calypso/state';
+import { getThemeTierForTheme } from 'calypso/state/themes/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+export function useThemeTierForTheme( themeId: string ) {
+	const themeTier = useSelector( ( state ) => getThemeTierForTheme( state, themeId ) );
+
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const retainedBenefits = useTierRetainedBenefitsQuery( siteId as number, themeId );
+	return retainedBenefits?.is_eligible ? retainedBenefits.tier : themeTier;
+}

--- a/client/state/themes/selectors/get-theme-signup-url.js
+++ b/client/state/themes/selectors/get-theme-signup-url.js
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { FREE_THEME, BUNDLED_THEME, MARKETPLACE_THEME } from '@automattic/design-picker';
 import { DESIGN_FIRST_FLOW } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
-import { getThemeType, isThemePremium, getThemeTierForTheme } from 'calypso/state/themes/selectors';
+import { getThemeType, isThemePremium } from 'calypso/state/themes/selectors';
 import 'calypso/state/themes/init';
 
 /**
@@ -22,7 +22,7 @@ export function getThemeSignupUrl( state, themeId, options = {} ) {
 
 	let themeTypeParam = themeType;
 	// Map theme tier values to the values expected by the signup flow.
-	const themeTier = getThemeTierForTheme( state, themeId );
+	const themeTier = options.themeTier;
 	// If there is no themeTier then there's nothing to map (dot-org themes don't have tiers)
 	if ( config.isEnabled( 'themes/tiers' ) && themeTier?.slug ) {
 		switch ( themeTier.slug ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Add support in Theme showcase and Theme Details for theme retained benefits. This allows users who previously used themes on a specific plan to still be able to switch between themes and still be able to go back to a theme that's no longer available on a specific plan. 

Related to https://github.com/Automattic/dotcom-forge/issues/5128

## Proposed Changes
- Retrieve the data from the newly created API endpoint
- Use hooks that combines the tier information with the retained benefits

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D134845-code on your site
* Get a free site and install a free theme
* Go to themes back-end and make the theme paid.
* Switch to another free theme
* Try to switch back to the previous theme
* Make sure that in ThemeShowcase the UI still displays mentions it as free
* Make sure that the theme ui in Theme details displays the activate button
* Make sure that the theme gets installed on the site
* Have a cursory look in LoTS to be sure that we don't break anything there
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?