### PR TITLE
VBE: Do not copy over compat styles into the iframe

### DIFF
--- a/packages/verbum-block-editor/src/editor/index.tsx
+++ b/packages/verbum-block-editor/src/editor/index.tsx
@@ -7,6 +7,7 @@ import {
 	store as blockEditorStore,
 	// @ts-expect-error - Typings missing
 } from '@wordpress/block-editor';
+import { useCompatibilityStyles } from '@wordpress/block-editor/build-module/components/iframe/use-compatibility-styles';
 import { createBlock, serialize, type BlockInstance } from '@wordpress/blocks';
 import { Popover, SlotFillProvider, KeyboardShortcuts } from '@wordpress/components';
 import { useStateWithHistory, useResizeObserver } from '@wordpress/compose';
@@ -39,6 +40,10 @@ export const Editor: FC< EditorProps > = ( { initialContent = '', onChange, isRT
 		initialContent !== '' ? safeParse( initialContent ) : [ createBlock( 'core/paragraph' ) ]
 	) as unknown as StateWithUndoManager;
 	const [ isEditing, setIsEditing ] = useState( false );
+
+	const compatStylesIds = useCompatibilityStyles().map(
+		( el ) => el.getAttribute( 'id' ) as string
+	);
 
 	const handleContentUpdate = useCallback(
 		( content: BlockInstance[] ) => {
@@ -123,6 +128,9 @@ export const Editor: FC< EditorProps > = ( { initialContent = '', onChange, isRT
 									{ contentResizeListener }
 									<BlockList renderAppender={ false } />
 								</div>
+								{ compatStylesIds.map( ( id: string ) => (
+									<div hidden key={ id } id={ id }></div>
+								) ) }
 							</BlockCanvas>
 						</BlockTools>
 					</div>

--- a/packages/verbum-block-editor/src/editor/index.tsx
+++ b/packages/verbum-block-editor/src/editor/index.tsx
@@ -41,6 +41,10 @@ export const Editor: FC< EditorProps > = ( { initialContent = '', onChange, isRT
 	) as unknown as StateWithUndoManager;
 	const [ isEditing, setIsEditing ] = useState( false );
 
+	/**
+	 * This prevents the editor from copying the theme styles inside the iframe. We don't want to copy the styles inside.
+	 * See: https://github.com/WordPress/gutenberg/blob/4c319590947b5f7853411e3c076861193942c6d2/packages/block-editor/src/components/iframe/index.js#L160
+	 */
 	const compatStylesIds = useCompatibilityStyles().map(
 		( el ) => el.getAttribute( 'id' ) as string
 	);

--- a/packages/verbum-block-editor/src/types.d.ts
+++ b/packages/verbum-block-editor/src/types.d.ts
@@ -26,3 +26,6 @@ declare module '@wordpress/block-library/build-module/*' {
 
 	export = block;
 }
+declare module '@wordpress/block-editor/build-module/components/iframe/use-compatibility-styles' {
+	export const useCompatibilityStyles: () => Array< HTMLStyleElement >;
+}


### PR DESCRIPTION
The Gutenberg `Iframe` component copies the theme styles into the block editor's iframe automatically to create backwards compatibility with WordPress'es `wp_enqueue_styles`. This does the exact opposite of what we want in Verbum. We don't want to be affected by theme styles at all.

Luckily, the hook that copies the styles checks if they exist first, this creates empty hidden elements with the same IDs to trick the Iframe component into thinking they already exist. 

### Testing
1. In prod, visit https://wordpress.tv/2019/09/12/felix-arntz-leveraging-the-power-of-custom-elements-in-gutenberg/ and see the leaked styles issue.
2. Sandbox wptv.wordpress.com, wordpress.tv, and widgets.wp.com.
3. Go to `package/verbum-block-editor`.
4. Run `yarn dev --sync` from this branch.
5. The style leaks should go away!
