### PR TITLE
My Home: Update task banners to match provided designs

### DIFF
--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
@@ -12,7 +12,7 @@ import { useMemo } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
-import domainUpsellMobileIllustration from 'calypso/assets/images/customer-home/illustration--task-domain-upsell-mobile.svg';
+import domainUpsellIllustration from 'calypso/assets/images/customer-home/illustration--task-domain-upsell.svg';
 import { useQueryProductsList } from 'calypso/components/data/query-products-list';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -191,16 +191,6 @@ export function RenderDomainUpsell( { isFreePlan, isMonthlyPlan, searchTerm, sit
 			  )
 			: cardSubtitleFreePlansCopy;
 
-	const domainNameSVG = (
-		<svg viewBox="0 0 40 18" id="map">
-			<text x="-115" y="15">
-				{ domainSuggestionName.length > 34
-					? `${ domainSuggestionName.slice( 0, 32 ) }...`
-					: domainSuggestionName }
-			</text>
-		</svg>
-	);
-
 	return (
 		<Task
 			customClass="task__domain-upsell"
@@ -212,9 +202,8 @@ export function RenderDomainUpsell( { isFreePlan, isMonthlyPlan, searchTerm, sit
 			hasSecondaryAction={ true }
 			secondaryActionText={ translate( 'Find other domains' ) }
 			secondaryActionUrl={ searchLink }
-			illustration={ domainUpsellMobileIllustration }
-			illustrationHeader={ domainSuggestionName ? domainNameSVG : null }
-			badgeText={ domainSuggestionName }
+			illustration={ domainUpsellIllustration }
+			illustrationAlwaysShow={ true }
 			taskId={ TASK_DOMAIN_UPSELL }
 		/>
 	);

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/index.jsx
@@ -12,7 +12,7 @@ import { useMemo } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import { useSelector } from 'react-redux';
-import domainUpsellIllustration from 'calypso/assets/images/customer-home/illustration--task-domain-upsell.svg';
+import domainUpsellMobileIllustration from 'calypso/assets/images/customer-home/illustration--task-domain-upsell-mobile.svg';
 import { useQueryProductsList } from 'calypso/components/data/query-products-list';
 import { domainRegistration } from 'calypso/lib/cart-values/cart-items';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -202,7 +202,7 @@ export function RenderDomainUpsell( { isFreePlan, isMonthlyPlan, searchTerm, sit
 			hasSecondaryAction={ true }
 			secondaryActionText={ translate( 'Find other domains' ) }
 			secondaryActionUrl={ searchLink }
-			illustration={ domainUpsellIllustration }
+			illustration={ domainUpsellMobileIllustration }
 			illustrationAlwaysShow={ true }
 			taskId={ TASK_DOMAIN_UPSELL }
 		/>

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/style.scss
@@ -9,6 +9,7 @@
 			margin-right: 0 !important;
 			margin-top: 0 !important;
 			background: url(calypso/assets/images/customer-home/illustration--task-domain-upsell.svg) no-repeat right top;
+			background-size: 350px auto;
 		}
 
 		@media ( min-width: ( $break-large + 1 ) ) and ( max-width: $break-wide ) {
@@ -21,15 +22,18 @@
 
 		.task__text {
 			margin-bottom: 32px;
-			margin-top: 32px;
 			min-width: 360px;
 
 			@media (min-width: ( $break-wide + 1 ) ) {
 				max-width: calc(100% - 200px);
 
+				.task__description {
+					padding-right: 16px;
+				}
+
 				.task__description,
 				.task__title {
-					max-width: 70%;
+					max-width: 68%;
 				}
 			}
 
@@ -76,6 +80,10 @@
 
 		}
 
+		.task__actions .is-link {
+			margin-left: 8px;
+		}
+
 		.task__illustration {
 			position: relative;
 			width: 100%;
@@ -95,25 +103,6 @@
 				left: 35%;
 				height: 7%;
 				width: 70%;
-			}
-		}
-
-		.task__badge {
-			background: none;
-			color: #000;
-			position: absolute;
-			right: 0;
-			top: 119px;
-			width: 270px;
-			word-break: break-all;
-			overflow: hidden;
-			padding: 0;
-			display: inline-flex;
-			@media (max-width: $break-wide) {
-				width: 155px;
-			}
-			@media (max-width: $break-large) {
-				display: none;
 			}
 		}
 	}

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/style.scss
@@ -80,8 +80,18 @@
 
 		}
 
-		.task__actions .is-link {
-			margin-left: 8px;
+		.task__actions {
+			button {
+				width: auto;
+			}
+			.is-link {
+				padding-left: 0;
+
+				@media (min-width: ( $break-wide + 1 ) ) {
+					padding-left: 8px;
+					margin-left: 8px;
+				}
+			}
 		}
 
 		.task__illustration {

--- a/client/my-sites/customer-home/cards/tasks/domain-upsell/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/domain-upsell/style.scss
@@ -29,6 +29,7 @@
 
 				.task__description {
 					padding-right: 16px;
+					min-height: 140px;
 				}
 
 				.task__description,

--- a/client/my-sites/customer-home/cards/tasks/style.scss
+++ b/client/my-sites/customer-home/cards/tasks/style.scss
@@ -4,6 +4,7 @@
 .task {
 	display: flex;
 	position: relative;
+	margin-top: 0;
 	margin-bottom: 30px;
 	border-radius: 3px;
 
@@ -29,6 +30,7 @@
 	.task__text {
 		display: flex;
 		flex-direction: column;
+		margin-top: 16px;
 		align-items: flex-start;
 	}
 
@@ -62,7 +64,7 @@
 		@extend .wp-brand-font;
 		font-size: $font-title-large;
 		line-height: 36px;
-		margin-bottom: 4px;
+		margin-bottom: 16px;
 
 		@include breakpoint-deprecated( ">800px" ) {
 			line-height: 40px;
@@ -71,7 +73,7 @@
 
 	.task__description {
 		margin-bottom: 24px;
-		font-size: $font-body;
+		font-size: $font-body-small;
 		line-height: 24px;
 		color: var(--color-text);
 

--- a/client/my-sites/customer-home/locations/secondary/index.jsx
+++ b/client/my-sites/customer-home/locations/secondary/index.jsx
@@ -49,7 +49,7 @@ const Secondary = ( { cards, siteId } ) => {
 	return (
 		<>
 			{ cards.map( ( card, index ) => {
-				if ( Array.isArray( card ) ) {
+				if ( Array.isArray( card ) && card.length > 0 ) {
 					return (
 						<DotPager
 							key={ 'my_home_secondary_pager_' + index }

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -256,7 +256,7 @@ body.is-section-home.theme-default.color-scheme {
 	// edges of the space with it's inner list.
 	.card,
 	.task {
-		margin: 32px;
+		margin: 0 32px 32px;
 	}
 
 	// Extend the checklist to the edge of the primary content area
@@ -301,7 +301,7 @@ body.is-section-home.theme-default.color-scheme {
 
 		// 32px spacing for everything except the space before the CTA (48px)
 		.task__text {
-			gap: 32px;
+			gap: 16px;
 
 			& > * {
 				margin-top: 0;

--- a/client/my-sites/customer-home/style.scss
+++ b/client/my-sites/customer-home/style.scss
@@ -256,7 +256,11 @@ body.is-section-home.theme-default.color-scheme {
 	// edges of the space with it's inner list.
 	.card,
 	.task {
-		margin: 0 32px 32px;
+		margin: 32px;
+
+		@media ( min-width: ( $break-wide + 1 ) ) {
+			margin: 0 32px 32px;
+		}
 	}
 
 	// Extend the checklist to the edge of the primary content area


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/83465

## Proposed Changes

* Update spacing and font sizes for the task banners to better accommodate a narrower column width in the near future.

Figma for reference: hZXxD82mw1AAXfOpSpIJBZ-fi-3_2425

**Before**

<img width="716" alt="Screenshot 2024-01-15 at 2 45 31 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/be345e57-5696-4f00-8010-746fc82ec014">

**After**

<img width="710" alt="Screenshot 2024-01-15 at 2 04 11 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/dcde8a4e-2261-48c4-a94d-8a7e15eafb07">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Add the following filters to your 0-sandbox.php:

```
add_filter( 'enable_legacy_site_setup_launchpad', '__return_true' );

add_filter( 'wpcom_my_home_force_two_column_layout', '__return_true' );
```
* Sandbox `public-api.wordpress.com`
* Create a new site from `/setup/free`
* Launch the site.
* Using `calypso.live` or a local Calypso instance, open My Home for your test site and click "Skip site setup"
* You should see the carousel with the domain upsell banner.
* Note the spacing changes. Don't forget to check mobile.
* Disable the two-column layout on your sandbox by removing the `wpcom_my_home_force_two_column_layout` filter, or disable line 174 of `wp-content/lib/home/cards.php`
* Check the layout/changes on the wide banner layout. Nothing should look broken as a result of these changes.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?