### PR TITLE
Marketplace Reviews: Show an error if the user try to leave a review without a subscription

### DIFF
--- a/client/my-sites/marketplace/components/review-item/create-review-item.tsx
+++ b/client/my-sites/marketplace/components/review-item/create-review-item.tsx
@@ -4,7 +4,7 @@ import Card from '@automattic/components/src/card';
 import { CheckboxControl, TextareaControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useSelector } from 'react-redux';
 import Gravatar from 'calypso/components/gravatar';
 import ReviewsRatingsStars from 'calypso/components/reviews-rating-stars/reviews-ratings-stars';
@@ -30,7 +30,6 @@ export function MarketplaceCreateReviewItem( props: MarketplaceCreateReviewItemP
 	const [ errorMessage, setErrorMessage ] = useState( '' );
 	const [ showThankYouSection, setShowThankYouSection ] = useState( false );
 	const [ showContentArea, setShowContentArea ] = useState( false );
-	const [ cannotPublishReviewError, setCannotPublishReviewError ] = useState( '' );
 
 	const { data: userReviews, isFetching: isFetchingUserReviews } = useMarketplaceReviewsQuery( {
 		productType,
@@ -46,18 +45,6 @@ export function MarketplaceCreateReviewItem( props: MarketplaceCreateReviewItemP
 		setContent( '' );
 		setRating( 0 );
 	};
-
-	useEffect( () => {
-		if ( canPublishReview ) {
-			setCannotPublishReviewError( '' );
-		} else {
-			setCannotPublishReviewError(
-				translate(
-					'Only active users can leave a review. Please purchase a new subscription of the product to leave a review.'
-				)
-			);
-		}
-	}, [ canPublishReview ] );
 
 	const createReviewMutation = useCreateMarketplaceReviewMutation( { productType, slug } );
 	const createReview = () => {
@@ -118,12 +105,14 @@ export function MarketplaceCreateReviewItem( props: MarketplaceCreateReviewItemP
 							onSelectRating={ onSelectRating }
 						/>
 					</div>
-					{ showContentArea && cannotPublishReviewError && (
+					{ showContentArea && ! canPublishReview && (
 						<Card className="marketplace-review-item__error-message" highlight="error">
-							{ cannotPublishReviewError }
+							{ translate(
+								'Only active users can leave a review. Please purchase a new subscription of the product to leave a review.'
+							) }
 						</Card>
 					) }
-					{ showContentArea && ! cannotPublishReviewError && (
+					{ showContentArea && canPublishReview && (
 						<>
 							<TextareaControl
 								rows={ 4 }

--- a/client/my-sites/marketplace/components/reviews-modal/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-modal/index.tsx
@@ -139,6 +139,7 @@ export const ReviewsModal = ( props: Props ) => {
 					productType={ productType }
 					slug={ slug }
 					forceShowThankYou={ editCompletedTimes }
+					canPublishReview={ canPublishReview || false }
 				/>
 
 				<div className="marketplace-reviews-modal__reviews-list">


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5027

## Proposed Changes

Show a warning when the user tries to create a review but doesn't have an active subscription of the product in any of their sites.

![CleanShot 2024-01-15 at 16 09 42](https://github.com/Automattic/wp-calypso/assets/5039531/72d7745b-0ab0-4984-8b60-8961e00db551)


## Testing Instructions

* Go to a plugin details page of a plugin:
  * you don't have an active subscription in any of your sites
  * you have not submit a review yet
* Open the reviews modal by clicking on the number of reviews
* Click on the star to create a new review
* You should see a warning as above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
