### PR TITLE
Markeplace Reviews Card: Centralize the text on the leave a review card

### DIFF
--- a/client/my-sites/marketplace/components/reviews-cards/style.scss
+++ b/client/my-sites/marketplace/components/reviews-cards/style.scss
@@ -101,6 +101,7 @@ $cards-gap: 20px;
 		font-size: $font-body;
 		font-weight: 500;
 		line-height: 24px;
+		text-align: center;
 	}
 }
 


### PR DESCRIPTION


## Proposed Changes

Centralize the text on the leave a review card

## Testing Instructions

* Go to a plugin details page of a plugin you have not submitted a review yet
* Scroll down the page to the reviews card
* The text on the leave a review card should be centralized

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-01-15 at 16 17 49@2x](https://github.com/Automattic/wp-calypso/assets/5039531/2a739768-5269-4cd2-b904-c87ca6dadd62)|![CleanShot 2024-01-15 at 16 17 22@2x](https://github.com/Automattic/wp-calypso/assets/5039531/57fc238d-6fcf-4cb5-8b08-8379034fbbf1)|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
