### PR TITLE
AI Logo Generator: Add upgrade screen for free users

### DIFF
--- a/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.scss
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.scss
@@ -9,8 +9,8 @@
 	}
 
 	.components-modal__content {
-		padding: 32px 32px 0 32px;
-		margin-bottom: 32px;
+		padding: 32px 32px 2px 32px;
+		margin-bottom: 30px;
 
 		> div:not(.components-modal__header) {
 			height: 100%;

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-screen.scss
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-screen.scss
@@ -1,0 +1,22 @@
+.jetpack-ai-logo-generator-modal__body.needs-feature {
+	@media (min-width: 700px) {
+		width: 470px;
+		min-height: unset;
+	}
+}
+
+.jetpack-ai-logo-generator-modal__upgrade-message-wrapper {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+}
+
+.jetpack-ai-logo-generator-modal__upgrade-message {
+	font-size: $font-body-small;
+}
+
+.jetpack-ai-logo-generator-modal__upgrade-actions {
+	display: flex;
+	justify-content: flex-end;
+	gap: 12px;
+}

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-screen.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-screen.tsx
@@ -1,0 +1,43 @@
+/**
+ * External dependencies
+ */
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import './upgrade-screen.scss';
+/**
+ * Types
+ */
+import type React from 'react';
+
+export const UpgradeScreen: React.FC< { onCancel: () => void; upgradeURL: string } > = ( {
+	onCancel,
+	upgradeURL,
+} ) => {
+	const upgradeMessage = __(
+		'Upgrade your Jetpack AI for access to exclusive features, including logo generation. This upgrade will also increase the amount of requests you can use in all AI-powered features.',
+		'jetpack'
+	);
+
+	return (
+		<div className="jetpack-ai-logo-generator-modal__upgrade-message-wrapper">
+			<div className="jetpack-ai-logo-generator-modal__upgrade-message">
+				<span className="jetpack-ai-logo-generator-modal__loading-message">{ upgradeMessage }</span>
+				&nbsp;
+				<Button variant="link" href="https://jetpack.com/ai/" target="_blank">
+					{ __( 'Learn more', 'jetpack' ) }
+				</Button>
+			</div>
+			<div className="jetpack-ai-logo-generator-modal__upgrade-actions">
+				<Button variant="tertiary" onClick={ onCancel }>
+					{ __( 'Cancel', 'jetpack' ) }
+				</Button>
+				<Button variant="primary" href={ upgradeURL } target="_blank" onClick={ onCancel }>
+					{ __( 'Upgrade', 'jetpack' ) }
+				</Button>
+			</div>
+		</div>
+	);
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #86322

## Proposed Changes

* Adds an UpgradeScreen component
* Links to the checkout page using the site details and feature data

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With a site that has a plan selected, open the generator modal. No changes are expected.
* Switch to a free site and open the generator modal. A screen asking for an upgrade should be displayed.
* Check that the Cancel button closes the modal
* Check that the Upgrade button links to the checkout page of the Jetpack AI tiered plan, the same as the Jetpack AI Add-on page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?