### PR TITLE
Plans: update grid for introductory offers

### DIFF
--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -61,7 +61,11 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 						{ translate( 'Limited Time Offer' ) }
 					</div>
 				) }
-				<div className="plans-grid-next-header-price__pricing-group is-large-currency">
+				<div
+					className={ clsx( 'plans-grid-next-header-price__pricing-group', {
+						'is-large-currency': isLargeCurrency,
+					} ) }
+				>
 					<PlanPrice
 						currencyCode={ currencyCode }
 						rawPrice={ originalPrice.monthly }

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -61,36 +61,26 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 						{ translate( 'Limited Time Offer' ) }
 					</div>
 				) }
-				{ isLargeCurrency ? (
-					<div className="plans-grid-next-header-price__pricing-group is-large-currency">
-						<PlanPrice
-							currencyCode={ currencyCode }
-							rawPrice={ originalPrice.monthly }
-							displayPerMonthNotation={ false }
-							isLargeCurrency
-							isSmallestUnit
-							priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
-							original
-						/>
-						<PlanPrice
-							currencyCode={ currencyCode }
-							rawPrice={ introOfferPrice }
-							displayPerMonthNotation={ false }
-							isLargeCurrency
-							isSmallestUnit={ false }
-							priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
-							discounted
-						/>
-					</div>
-				) : (
+				<div className="plans-grid-next-header-price__pricing-group is-large-currency">
+					<PlanPrice
+						currencyCode={ currencyCode }
+						rawPrice={ originalPrice.monthly }
+						displayPerMonthNotation={ false }
+						isLargeCurrency
+						isSmallestUnit
+						priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
+						original
+					/>
 					<PlanPrice
 						currencyCode={ currencyCode }
 						rawPrice={ introOfferPrice }
 						displayPerMonthNotation={ false }
+						isLargeCurrency
 						isSmallestUnit={ false }
 						priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
+						discounted
 					/>
-				) }
+				</div>
 			</div>
 		);
 	}

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -65,12 +65,11 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 					<div className="plans-grid-next-header-price__pricing-group is-large-currency">
 						<PlanPrice
 							currencyCode={ currencyCode }
-							rawPrice={ 0 }
+							rawPrice={ originalPrice.monthly }
 							displayPerMonthNotation={ false }
 							isLargeCurrency
 							isSmallestUnit
 							priceDisplayWrapperClassName="plans-grid-next-header-price__display-wrapper"
-							className="is-placeholder-price" // This is a placeholder price to keep the layout consistent
 							original
 						/>
 						<PlanPrice

--- a/packages/plans-grid-next/src/components/shared/header-price/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price/index.tsx
@@ -57,7 +57,7 @@ const HeaderPrice = ( { planSlug, visibleGridPlans }: HeaderPriceProps ) => {
 		return (
 			<div className="plans-grid-next-header-price">
 				{ ! current && (
-					<div className="plans-grid-next-header-price__badge is-intro-offer">
+					<div className="plans-grid-next-header-price__badge">
 						{ translate( 'Limited Time Offer' ) }
 					</div>
 				) }

--- a/packages/plans-grid-next/src/components/shared/header-price/style.scss
+++ b/packages/plans-grid-next/src/components/shared/header-price/style.scss
@@ -93,16 +93,6 @@
 	white-space: nowrap;
 	width: fit-content;
 
-	&.is-intro-offer {
-		background-color: inherit;
-		color: var(--studio-blue-50);
-		font-weight: 600;
-		letter-spacing: inherit;
-		padding: 0;
-		text-align: left;
-		text-transform: uppercase;
-	}
-
 	&.is-hidden {
 		visibility: hidden;
 	}

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -205,30 +205,32 @@ export default function usePlanBillingDescription( {
 				/* If the offer is for X years of a yearly plan */
 				if ( 'year' === introOffer.intervalUnit ) {
 					if ( 1 === introOffer.intervalCount ) {
+						// Note: Leaving out originalPriceFullTermText to
+						// match the existing text but we should probably
+						// include it in the future. See
+						// https://github.com/Automattic/wp-calypso/pull/86434
 						return translate(
-							'per month, %(introOfferFormattedPrice)s for your first year,{{br/}}' +
-								'then %(rawPrice)s billed annually, excl. taxes',
+							'per month, %(introOfferFormattedPrice)s for your first year, excl. taxes',
 							{
 								args: {
 									introOfferFormattedPrice: introOffer.formattedPrice,
-									rawPrice: originalPriceFullTermText,
 								},
-								components: { br: <br /> },
 								comment: 'excl. taxes is short for excluding taxes',
 							}
 						);
 					}
 
+					// Note: Leaving out originalPriceFullTermText to
+					// match the existing text but we should probably
+					// include it in the future. See
+					// https://github.com/Automattic/wp-calypso/pull/86434
 					return translate(
-						'per month, %(introOfferFormattedPrice)s for your first %(introOfferIntervalCount)s years,{{br/}}' +
-							'then %(rawPrice)s billed annually, excl. taxes',
+						'per month, %(introOfferFormattedPrice)s for your first %(introOfferIntervalCount)s years, excl. taxes',
 						{
 							args: {
 								introOfferFormattedPrice: introOffer.formattedPrice,
-								rawPrice: originalPriceFullTermText,
 								introOfferIntervalCount: introOffer.intervalCount,
 							},
-							components: { br: <br /> },
 							comment: 'excl. taxes is short for excluding taxes',
 						}
 					);

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -205,32 +205,30 @@ export default function usePlanBillingDescription( {
 				/* If the offer is for X years of a yearly plan */
 				if ( 'year' === introOffer.intervalUnit ) {
 					if ( 1 === introOffer.intervalCount ) {
-						// Note: Leaving out originalPriceFullTermText to
-						// match the existing text but we should probably
-						// include it in the future. See
-						// https://github.com/Automattic/wp-calypso/pull/86434
 						return translate(
-							'per month, %(introOfferFormattedPrice)s for your first year, excl. taxes',
+							'per month, %(introOfferFormattedPrice)s for your first year,{{br/}}' +
+								'then %(rawPrice)s billed annually, excl. taxes',
 							{
 								args: {
 									introOfferFormattedPrice: introOffer.formattedPrice,
+									rawPrice: originalPriceFullTermText,
 								},
+								components: { br: <br /> },
 								comment: 'excl. taxes is short for excluding taxes',
 							}
 						);
 					}
 
-					// Note: Leaving out originalPriceFullTermText to
-					// match the existing text but we should probably
-					// include it in the future. See
-					// https://github.com/Automattic/wp-calypso/pull/86434
 					return translate(
-						'per month, %(introOfferFormattedPrice)s for your first %(introOfferIntervalCount)s years, excl. taxes',
+						'per month, %(introOfferFormattedPrice)s for your first %(introOfferIntervalCount)s years,{{br/}}' +
+							'then %(rawPrice)s billed annually, excl. taxes',
 						{
 							args: {
 								introOfferFormattedPrice: introOffer.formattedPrice,
+								rawPrice: originalPriceFullTermText,
 								introOfferIntervalCount: introOffer.intervalCount,
 							},
+							components: { br: <br /> },
 							comment: 'excl. taxes is short for excluding taxes',
 						}
 					);

--- a/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
+++ b/packages/plans-grid-next/src/hooks/data-store/use-plan-billing-description.tsx
@@ -109,23 +109,23 @@ export default function usePlanBillingDescription( {
 	 */
 	if ( introOffer?.intervalCount && introOffer.intervalUnit && ! introOffer.isOfferComplete ) {
 		if ( originalPriceFullTermText ) {
+			/* Introductory offers for monthly plans */
 			if ( isMonthlyPlan ) {
-				if ( 1 === introOffer.intervalCount ) {
-					return translate(
-						'per month, for your first %(introOfferIntervalUnit)s,{{br/}}' +
-							'then %(rawPrice)s billed monthly, excl. taxes',
-						{
-							args: {
-								rawPrice: originalPriceFullTermText,
-								introOfferIntervalUnit: introOffer.intervalUnit,
-							},
-							components: { br: <br /> },
-							comment: 'excl. taxes is short for excluding taxes',
-						}
-					);
-				}
-
+				/* If the offer is for X months */
 				if ( 'month' === introOffer.intervalUnit ) {
+					if ( 1 === introOffer.intervalCount ) {
+						return translate(
+							'for your first month,{{br/}}' + 'then %(rawPrice)s billed monthly, excl. taxes',
+							{
+								args: {
+									rawPrice: originalPriceFullTermText,
+								},
+								components: { br: <br /> },
+								comment: 'excl. taxes is short for excluding taxes',
+							}
+						);
+					}
+
 					return translate(
 						'for your first %(introOfferIntervalCount)s months,{{br/}}' +
 							'then %(rawPrice)s billed monthly, excl. taxes',
@@ -140,7 +140,21 @@ export default function usePlanBillingDescription( {
 					);
 				}
 
+				/* If the offer is for X years of monthly intervals */
 				if ( 'year' === introOffer.intervalUnit ) {
+					if ( 1 === introOffer.intervalCount ) {
+						return translate(
+							'for your first year,{{br/}}' + 'then %(rawPrice)s billed monthly, excl. taxes',
+							{
+								args: {
+									rawPrice: originalPriceFullTermText,
+								},
+								components: { br: <br /> },
+								comment: 'excl. taxes is short for excluding taxes',
+							}
+						);
+					}
+
 					return translate(
 						'per month, for your first %(introOfferIntervalCount)s years,{{br/}}' +
 							'then %(rawPrice)s billed monthly, excl. taxes',
@@ -156,23 +170,24 @@ export default function usePlanBillingDescription( {
 				}
 			}
 
+			/* Introductory offers for yearly plans */
 			if ( PLAN_ANNUAL_PERIOD === billingPeriod ) {
-				if ( 1 === introOffer.intervalCount ) {
-					return translate(
-						'per month, for your first %(introOfferIntervalUnit)s,{{br/}}' +
-							'then %(rawPrice)s billed annually, excl. taxes',
-						{
-							args: {
-								rawPrice: originalPriceFullTermText,
-								introOfferIntervalUnit: introOffer.intervalUnit,
-							},
-							components: { br: <br /> },
-							comment: 'excl. taxes is short for excluding taxes',
-						}
-					);
-				}
-
+				/* If the offer is for X months of a yearly plan */
 				if ( 'month' === introOffer.intervalUnit ) {
+					if ( 1 === introOffer.intervalCount ) {
+						return translate(
+							'for your first month,{{br/}}' + 'then %(rawPrice)s billed annually, excl. taxes',
+							{
+								args: {
+									rawPrice: originalPriceFullTermText,
+									introOfferIntervalUnit: introOffer.intervalUnit,
+								},
+								components: { br: <br /> },
+								comment: 'excl. taxes is short for excluding taxes',
+							}
+						);
+					}
+
 					return translate(
 						'for your first %(introOfferIntervalCount)s months,{{br/}}' +
 							'then %(rawPrice)s billed annually, excl. taxes',
@@ -187,12 +202,29 @@ export default function usePlanBillingDescription( {
 					);
 				}
 
+				/* If the offer is for X years of a yearly plan */
 				if ( 'year' === introOffer.intervalUnit ) {
+					if ( 1 === introOffer.intervalCount ) {
+						return translate(
+							'per month, %(introOfferFormattedPrice)s for your first year,{{br/}}' +
+								'then %(rawPrice)s billed annually, excl. taxes',
+							{
+								args: {
+									introOfferFormattedPrice: introOffer.formattedPrice,
+									rawPrice: originalPriceFullTermText,
+								},
+								components: { br: <br /> },
+								comment: 'excl. taxes is short for excluding taxes',
+							}
+						);
+					}
+
 					return translate(
-						'per month, for your first %(introOfferIntervalCount)s years,{{br/}}' +
+						'per month, %(introOfferFormattedPrice)s for your first %(introOfferIntervalCount)s years,{{br/}}' +
 							'then %(rawPrice)s billed annually, excl. taxes',
 						{
 							args: {
+								introOfferFormattedPrice: introOffer.formattedPrice,
 								rawPrice: originalPriceFullTermText,
 								introOfferIntervalCount: introOffer.intervalCount,
 							},


### PR DESCRIPTION
This updates the plans grid to properly account for different introductory offers for WPcom plans. It updates the Introductory Offer plan descriptions and consolidates some of the display logic between discounts and introductory offers.

> [!NOTE]
> The actual text for the offers is a bit long, includes awkward newlines, and could be improved upon. However, that is also true of the existing text returned by `usePlanBillingDescription()` and this is primarily a bug fix for missing behavior (this will allow us to remove an old "temporary" discount and replace it with introductory offers) and is not designed to make the text follow any new designs. Follow-up PRs can be made after this merges.

Requires: D134559-code
See: pbOQVh-4sd-p2

Before             |  After
:-------------------------:|:-------------------------:
<img width="1074" alt="Screenshot 2024-10-04 at 3 17 54 PM" src="https://github.com/user-attachments/assets/2e0c6cce-26ca-40e3-8f36-b0cd191273a0"> | <img width="1046" alt="Screenshot 2024-10-07 at 4 44 08 PM" src="https://github.com/user-attachments/assets/f24c14a4-57ff-4498-ac5d-3a71f690037c">
<img width="1050" alt="Screenshot 2024-10-03 at 5 16 59 PM" src="https://github.com/user-attachments/assets/084320cb-1d6a-424f-974c-61ae813dc6dc"> | <img width="1056" alt="Screenshot 2024-10-07 at 4 44 19 PM" src="https://github.com/user-attachments/assets/c3d222c7-3165-4187-8dc7-f224add987a4">

Here's the logged-out view:

Before             |  After
:-------------------------:|:-------------------------:
<img width="1263" alt="logged-out-before" src="https://github.com/user-attachments/assets/976cf39b-b7e3-407b-85e5-d42b5c59695f"> | <img width="1256" alt="logged-out-after" src="https://github.com/user-attachments/assets/483ac555-4f2c-4f2a-a784-c803eb9ccea5">

**To test:**
- enable Store Sandbox and make sure that `public-api.wordpress.com` is pointing to your sandbox.
- make sure D134559-code is applied to your sandbox.
- create a new user, or use a user that has not previously subscribed to one of these plans
- change your user currency to MXN, PHP, or INR
- create a new site and verify that the different plans grids correctly reflect the introductory offer pricing (reduced monthly breakdown, intro offer full price in the description, and correct billing term in the description)