### PR TITLE
Adding logic to use Post & Pages in the same segmented control

### DIFF
--- a/client/my-sites/promote-post-i2/components/posts-woo-filter/index.tsx
+++ b/client/my-sites/promote-post-i2/components/posts-woo-filter/index.tsx
@@ -34,12 +34,8 @@ export default function WooItemsFilter( props: Props ) {
 			label: translate( 'Products' ),
 		},
 		{
-			value: 'post',
-			label: translate( 'Posts' ),
-		},
-		{
-			value: 'page',
-			label: translate( 'Page' ),
+			value: 'post,page',
+			label: translate( 'Posts & Pages' ),
 		},
 	];
 

--- a/client/my-sites/promote-post-i2/components/search-bar/index.tsx
+++ b/client/my-sites/promote-post-i2/components/search-bar/index.tsx
@@ -104,12 +104,8 @@ export default function SearchBar( props: Props ) {
 			label: translate( 'Products' ),
 		},
 		{
-			value: 'post',
-			label: translate( 'Posts' ),
-		},
-		{
-			value: 'page',
-			label: translate( 'Page' ),
+			value: 'post,page',
+			label: translate( 'Posts & Pages' ),
 		},
 	];
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This change unifies posts and pages in one single tab for the filter when running a woo store. 

## Proposed Changes

* unify post and pages in one single filter option.

## Testing Instructions

- [ ] Open a woo store and then go to the advertising tab
- [ ] Notice that now there's a segmented control to filter between Products and Posts & Pages
- [ ] Verify that the filter is working by checking if the posts displayed correspond to the current filter.

## Screenshots
![Screenshot 2024-01-15 at 7 19 16 p m](https://github.com/Automattic/wp-calypso/assets/5014402/928b22c0-23c5-4df8-b7f7-5930ed70e305)

![Screenshot 2024-01-15 at 7 19 24 p m](https://github.com/Automattic/wp-calypso/assets/5014402/1b56f04f-4686-45d3-94d7-93a54a8cc7c1)

Mobile Web:

![Screenshot 2024-01-15 at 7 32 07 p m](https://github.com/Automattic/wp-calypso/assets/5014402/96f61bfc-ed36-464b-941f-895b18233d4a)


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
