### PR TITLE
Jetpack Manage: implement delete payment card

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-card-v2/hooks/use-delete-card.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-card-v2/hooks/use-delete-card.tsx
@@ -1,0 +1,49 @@
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useState } from 'react';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { deleteStoredCard } from 'calypso/state/partner-portal/stored-cards/actions';
+import { useRecentPaymentMethodsQuery } from '../../hooks';
+import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
+
+export function useDeleteCard( card: PaymentMethod ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const [ isDeleteDialogVisible, setIsDeleteDialogVisible ] = useState( false );
+	const [ isDeleteInProgress, setIsDeleteInProgress ] = useState( false );
+
+	const { data: recentCards } = useRecentPaymentMethodsQuery();
+
+	const nextPrimaryPaymentMethod = ( recentCards?.items || [] ).find(
+		( currCard: PaymentMethod ) => currCard.id !== card.id
+	);
+
+	const closeDialog = useCallback( () => {
+		setIsDeleteDialogVisible( false );
+	}, [] );
+
+	const handleDelete = useCallback( () => {
+		closeDialog();
+		setIsDeleteInProgress( true );
+		dispatch( deleteStoredCard( card, nextPrimaryPaymentMethod?.id ) )
+			.then( () => {
+				setIsDeleteInProgress( false );
+				dispatch( successNotice( translate( 'Payment method deleted successfully' ) ) );
+				dispatch( recordTracksEvent( 'calypso_partner_portal_delete_payment_method' ) );
+			} )
+			.catch( ( error: Error ) => {
+				setIsDeleteInProgress( false );
+				dispatch( errorNotice( error.message ) );
+			} );
+	}, [ closeDialog, dispatch, card, nextPrimaryPaymentMethod?.id, translate ] );
+
+	return {
+		isDeleteDialogVisible,
+		setIsDeleteDialogVisible,
+		closeDialog,
+		handleDelete,
+		isDeleteInProgress,
+	};
+}

--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-card-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-card-v2/index.tsx
@@ -1,7 +1,9 @@
 import { PaymentLogo } from '@automattic/wpcom-checkout';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import PaymentMethodDeleteDialog from 'calypso/jetpack-cloud/sections/partner-portal/payment-method-delete-dialog';
 import CreditCardActions from './credit-card-actions';
+import { useDeleteCard } from './hooks/use-delete-card';
 import { useSetAsPrimaryCard } from './hooks/use-set-as-primary-card';
 import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
 
@@ -31,6 +33,13 @@ export default function StoredCreditCardV2( {
 		: translate( 'Secondary Card' );
 
 	const { isSetAsPrimaryCardPending, setAsPrimaryCard } = useSetAsPrimaryCard();
+	const {
+		isDeleteDialogVisible,
+		setIsDeleteDialogVisible,
+		closeDialog,
+		handleDelete,
+		isDeleteInProgress,
+	} = useDeleteCard( creditCard );
 
 	const cardActions = [
 		{
@@ -46,59 +55,73 @@ export default function StoredCreditCardV2( {
 		{
 			name: translate( 'Delete' ),
 			isEnabled: true,
-			onClick: () => {},
+			onClick: () => {
+				setIsDeleteDialogVisible( true );
+			},
 			className: 'stored-credit-card-v2__card-footer-actions-delete',
 		},
 	];
 
+	const isLoading = isSetAsPrimaryCardPending || isDeleteInProgress;
+
 	return (
-		<div
-			className={ classNames( 'stored-credit-card-v2__card', {
-				'is-loading': isSetAsPrimaryCardPending,
-			} ) }
-		>
-			<div className="stored-credit-card-v2__card-content">
-				<div className="stored-credit-card-v2__card-number">
-					**** **** **** { creditCard.card.last4 }
-				</div>
-				<div className="stored-credit-card-v2__card-details">
-					<span>
-						<div className="stored-credit-card-v2__card-info-heading">
-							{ translate( 'Card Holder name' ) }
-						</div>
-						<div className="stored-credit-card-v2__card-info-value"> { creditCard?.name }</div>
-					</span>
-					<span>
-						<div className="stored-credit-card-v2__card-info-heading">
-							{ translate( 'Expiry Date' ) }
-						</div>
-						<div className="stored-credit-card-v2__card-info-value">{ `${ expiryMonth }/${ expiryYear }` }</div>
-					</span>
-				</div>
-			</div>
-			<div className="stored-credit-card-v2__card-footer">
-				<span>
-					<div className="stored-credit-card-v2__card-footer-title">
-						{ isDefault ? translate( 'Primary Card' ) : secondaryCardCountText }
-					</div>
-					<div className="stored-credit-card-v2__card-footer-subtitle">
-						{ isDefault
-							? translate( 'This card is charged automatically each month.' )
-							: translate( 'This card is charged only if the primary one fails.' ) }
-					</div>
-				</span>
-				<span>
-					<CreditCardActions cardActions={ cardActions } isDisabled={ isSetAsPrimaryCardPending } />
-				</span>
-			</div>
+		<>
 			<div
-				className={ classNames(
-					'stored-credit-card-v2__payment-logo',
-					`stored-credit-card-v2__payment-logo-${ cardBrand }`
-				) }
+				className={ classNames( 'stored-credit-card-v2__card', {
+					'is-loading': isLoading,
+				} ) }
 			>
-				<PaymentLogo brand={ cardBrand } isSummary={ true } />
+				<div className="stored-credit-card-v2__card-content">
+					<div className="stored-credit-card-v2__card-number">
+						**** **** **** { creditCard.card.last4 }
+					</div>
+					<div className="stored-credit-card-v2__card-details">
+						<span>
+							<div className="stored-credit-card-v2__card-info-heading">
+								{ translate( 'Card Holder name' ) }
+							</div>
+							<div className="stored-credit-card-v2__card-info-value"> { creditCard?.name }</div>
+						</span>
+						<span>
+							<div className="stored-credit-card-v2__card-info-heading">
+								{ translate( 'Expiry Date' ) }
+							</div>
+							<div className="stored-credit-card-v2__card-info-value">{ `${ expiryMonth }/${ expiryYear }` }</div>
+						</span>
+					</div>
+				</div>
+				<div className="stored-credit-card-v2__card-footer">
+					<span>
+						<div className="stored-credit-card-v2__card-footer-title">
+							{ isDefault ? translate( 'Primary Card' ) : secondaryCardCountText }
+						</div>
+						<div className="stored-credit-card-v2__card-footer-subtitle">
+							{ isDefault
+								? translate( 'This card is charged automatically each month.' )
+								: translate( 'This card is charged only if the primary one fails.' ) }
+						</div>
+					</span>
+					<span>
+						<CreditCardActions cardActions={ cardActions } isDisabled={ isLoading } />
+					</span>
+				</div>
+				<div
+					className={ classNames(
+						'stored-credit-card-v2__payment-logo',
+						`stored-credit-card-v2__payment-logo-${ cardBrand }`
+					) }
+				>
+					<PaymentLogo brand={ cardBrand } isSummary={ true } />
+				</div>
 			</div>
-		</div>
+			{ isDeleteDialogVisible && (
+				<PaymentMethodDeleteDialog
+					paymentMethod={ creditCard }
+					isVisible={ true }
+					onClose={ closeDialog }
+					onConfirm={ handleDelete }
+				/>
+			) }
+		</>
 	);
 }


### PR DESCRIPTION

Resolves https://github.com/Automattic/jetpack-genesis/issues/188
Resolves https://github.com/Automattic/jetpack-genesis/issues/190

## Proposed Changes

This PR implements the delete payment card functionality.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Click Purchases > Click Payment Methods
2. Append the URL with `?flags=jetpack/card-addition-improvements`
3. Click the `...` icon on the added credit card and verify that the delete action is displayed as shown below. 

For a primary card:

<img width="354" alt="Screenshot 2024-01-15 at 11 19 59 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/319b22a1-03e6-4d6d-b33e-a57bb978496c">

For a secondary card:

<img width="354" alt="Screenshot 2024-01-15 at 11 20 31 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/6297d96e-4dfd-4dda-ae88-0d7b6e831fae">

4. Click the Delete option and verify that the confirmation popup is loaded -> Proceed with delete and verify that the loading animation is displayed as shown below and the success notice is shown.

<img width="354" alt="Screenshot 2024-01-15 at 2 49 15 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/a2092630-5ab8-43c6-897c-1eda7cfb27e0">

<img width="398" alt="Screenshot 2024-01-16 at 9 07 45 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/e3b66a62-e7de-4443-a4b8-56a7b54b631d">

Confirmation popup for different scenarios:

When deleting a primary payment method and there is at least on secondary method added:

<img width="640" alt="Screenshot 2024-01-16 at 9 07 20 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/fb93da7e-db51-4700-b57c-90b6c6e139c3">

When deleting a secondary payment method:

<img width="640" alt="Screenshot 2024-01-16 at 9 07 33 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/115a84d5-2d10-4d61-86f9-a597b00c195a">

When deleting a primary payment method, and there is no secondary method added:

<img width="640" alt="Screenshot 2024-01-16 at 9 08 00 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/a9e98634-7bbd-46e9-8710-441477697537">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?