### PR TITLE
Jetpack Manage: Hide the Add card CTA for the empty state

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/index.tsx
@@ -66,6 +66,8 @@ export default function PaymentMethodListV2() {
 		);
 	};
 
+	const showAddCardButton = ! isFetching && storedCards.length > 0;
+
 	return (
 		<Layout
 			className="payment-method-list-v2"
@@ -80,9 +82,11 @@ export default function PaymentMethodListV2() {
 					<Title>{ title } </Title>
 					<Subtitle>{ subtitle }</Subtitle>
 					<Actions>
-						<Button href="/partner-portal/payment-methods/add" primary>
-							{ translate( 'Add new card' ) }
-						</Button>
+						{ showAddCardButton && (
+							<Button href="/partner-portal/payment-methods/add" primary>
+								{ translate( 'Add new card' ) }
+							</Button>
+						) }
 					</Actions>
 				</LayoutHeader>
 			</LayoutTop>


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/196

## Proposed Changes

This PR hides the `Add card` CTA for the empty state

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Click Purchases > Click Payment Methods
2. Remove all the payment methods > Append the URL with `?flags=jetpack/card-addition-improvements`
3. Verify that the below empty state is displayed as shown below

<img width="499" alt="Screenshot 2024-01-09 at 6 42 01 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/a94acc11-2781-44d1-8fb4-3e137d52b4ce">

4. Add a payment method and verify that the Add card CTA is displayed on top right as shown below

<img width="1395" alt="Screenshot 2024-01-16 at 10 52 45 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/35726763-b3a0-4f2f-a365-248811c37682">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?