### PR TITLE
Assembler: dnd-kit/sortable

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -588,6 +588,10 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 		moveDownSection( position );
 	};
 
+	const onReorderSections = ( orderedSections: Pattern[] ) => {
+		setSections( orderedSections );
+	};
+
 	const onDeleteHeader = () => onSelect( 'header', null );
 
 	const onDeleteFooter = () => onSelect( 'footer', null );
@@ -747,6 +751,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 					onDeleteSection={ onDeleteSection }
 					onMoveUpSection={ onMoveUpSection }
 					onMoveDownSection={ onMoveDownSection }
+					onReorderSections={ onReorderSections }
 					onDeleteHeader={ onDeleteHeader }
 					onDeleteFooter={ onDeleteFooter }
 					onShuffle={ onShuffle }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -211,18 +211,16 @@ const PatternLargePreview = ( {
 			style: patternLargePreviewStyle,
 		};
 
-		const listItems = [
-			...( header ? [ renderPattern( 'header', header ) ] : [] ),
-			...sections.map( ( pattern, i ) => renderPattern( 'section', pattern, i ) ),
-			...( footer ? [ renderPattern( 'footer', footer ) ] : [] ),
-		];
+		const sectionItems = sections.map( ( pattern, i ) => renderPattern( 'section', pattern, i ) );
 
 		if ( ! isEnabled( 'pattern-assembler/preview-dnd' ) ) {
 			return (
 				<ul ref={ listRef } { ...listProps }>
-					{ listItems.map( ( item ) => (
+					{ header && <li>{ renderPattern( 'header', header ) }</li> }
+					{ sectionItems.map( ( item ) => (
 						<li key={ item.key }>{ item }</li>
 					) ) }
+					{ footer && <li>{ renderPattern( 'footer', footer ) }</li> }
 				</ul>
 			);
 		}
@@ -234,13 +232,15 @@ const PatternLargePreview = ( {
 
 		return (
 			<ul ref={ listRef } { ...listProps }>
+				{ header && <li>{ renderPattern( 'header', header ) }</li> }
 				<AsyncLoad
 					require="@automattic/dnd-kit-sortable"
 					placeholder={ null }
-					items={ listItems }
+					items={ sectionItems }
 					onDragEnd={ handleDragEnd }
 					{ ...listProps }
 				/>
+				{ footer && <li>{ renderPattern( 'footer', footer ) }</li> }
 			</ul>
 		);
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -155,7 +155,7 @@ const PatternLargePreview = ( {
 		};
 
 		return (
-			// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions
+			// eslint-disable-next-line jsx-a11y/no-noninteractive-element-interactions, jsx-a11y/no-static-element-interactions
 			<div
 				key={ clientId }
 				aria-label={ pattern.title }
@@ -163,8 +163,8 @@ const PatternLargePreview = ( {
 					'pattern-large-preview__pattern--active': isActive,
 				} ) }
 				data-client-id={ clientId }
-				// onMouseDown={ handleMouseDown }
-				// onMouseEnter={ handleMouseEnter }
+				onMouseDown={ handleMouseDown }
+				onMouseEnter={ handleMouseEnter }
 			>
 				{ !! viewportHeight && (
 					<PatternRenderer

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -12,7 +12,7 @@ import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import { injectTitlesToPageListBlock } from './html-transformers';
 import PatternActionBar from './pattern-action-bar';
 import PatternTooltipDeadClick from './pattern-tooltip-dead-click';
-import { encodePatternId } from './utils';
+import { encodePatternId, sortSectionsByKey } from './utils';
 import type { Pattern } from './types';
 import './pattern-large-preview.scss';
 
@@ -25,6 +25,7 @@ interface Props {
 	onDeleteSection: ( position: number ) => void;
 	onMoveUpSection: ( position: number ) => void;
 	onMoveDownSection: ( position: number ) => void;
+	onReorderSections: ( orderedSections: Pattern[] ) => void;
 	onDeleteHeader: () => void;
 	onDeleteFooter: () => void;
 	onShuffle: ( type: string, pattern: Pattern, position?: number ) => void;
@@ -46,6 +47,7 @@ const PatternLargePreview = ( {
 	onDeleteSection,
 	onMoveUpSection,
 	onMoveDownSection,
+	onReorderSections,
 	onDeleteHeader,
 	onDeleteFooter,
 	onShuffle,
@@ -226,7 +228,8 @@ const PatternLargePreview = ( {
 		}
 
 		const handleDragEnd = ( newOrder: any[] ) => {
-			console.log( newOrder );
+			const orderedSections = sortSectionsByKey( [ ...sections ], newOrder );
+			onReorderSections( orderedSections );
 		};
 
 		return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -50,3 +50,6 @@ export const getPagePatternTitle = ( { categories }: Pattern ) => {
 	);
 	return getTitleForRenamedCategories( category );
 };
+
+export const sortSectionsByKey = ( sections: Pattern[], sortOrder: any[] ) =>
+	sections.sort( ( a, b ) => sortOrder.indexOf( a.key ) - sortOrder.indexOf( b.key ) );

--- a/config/development.json
+++ b/config/development.json
@@ -148,6 +148,7 @@
 		"onboarding/interval-dropdown": true,
 		"p2/p2-plus": true,
 		"page/export": true,
+		"pattern-assembler/preview-dnd": true,
 		"pattern-assembler/v2": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -90,6 +90,7 @@
 		"network-connection": true,
 		"onboarding/design-choices": true,
 		"p2/p2-plus": true,
+		"pattern-assembler/preview-dnd": false,
 		"pattern-assembler/v2": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/production.json
+++ b/config/production.json
@@ -115,6 +115,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
 		"p2/p2-plus": true,
+		"pattern-assembler/preview-dnd": false,
 		"pattern-assembler/v2": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -111,6 +111,7 @@
 		"onboarding/interval-dropdown": true,
 		"p2/p2-plus": true,
 		"page/export": true,
+		"pattern-assembler/preview-dnd": false,
 		"pattern-assembler/v2": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -119,6 +119,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
 		"p2/p2-plus": true,
+		"pattern-assembler/preview-dnd": true,
 		"pattern-assembler/v2": false,
 		"plans/hosting-trial": true,
 		"plans/migration-trial": true,

--- a/packages/dnd-kit-sortable/README.md
+++ b/packages/dnd-kit-sortable/README.md
@@ -1,0 +1,3 @@
+# Dnd-Kit-Sortable
+
+Sortable list using dnd kit

--- a/packages/dnd-kit-sortable/jest.config.js
+++ b/packages/dnd-kit-sortable/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+	preset: '../../test/packages/jest-preset.js',
+	testEnvironment: 'jsdom',
+	testMatch: [ '<rootDir>/**/__tests__/**/*.[jt]s?(x)', '!**/.eslintrc.*' ],
+	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],
+};

--- a/packages/dnd-kit-sortable/package.json
+++ b/packages/dnd-kit-sortable/package.json
@@ -1,0 +1,44 @@
+{
+	"name": "@automattic/dnd-kit-sortable",
+	"version": "1.0.0",
+	"description": "Sortable list using dnd-kit",
+	"homepage": "https://github.com/Automattic/wp-calypso",
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic Inc.",
+	"main": "dist/cjs/index.js",
+	"module": "dist/esm/index.js",
+	"calypso:src": "src/index.tsx",
+	"sideEffects": [
+		"*.css",
+		"*.scss"
+	],
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/Automattic/wp-calypso.git",
+		"directory": "packages/dnd-kit-sortable"
+	},
+	"publishConfig": {
+		"access": "public"
+	},
+	"bugs": "https://github.com/Automattic/wp-calypso/issues",
+	"types": "dist/types",
+	"scripts": {
+		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
+		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"prepack": "yarn run clean && yarn run build",
+		"watch": "tsc --build ./tsconfig.json --watch"
+	},
+	"dependencies": {
+		"@dnd-kit/core": "^6.1.0",
+		"@dnd-kit/sortable": "^8.0.0",
+		"@dnd-kit/utilities": "^3.2.2",
+		"react": "^18.2.0",
+		"react-dom": "^18.2.0",
+		"tslib": "^2.3.0"
+	},
+	"devDependencies": {
+		"@automattic/calypso-typescript-config": "workspace:^",
+		"typescript": "^5.3.3"
+	},
+	"private": true
+}

--- a/packages/dnd-kit-sortable/src/index.tsx
+++ b/packages/dnd-kit-sortable/src/index.tsx
@@ -15,6 +15,7 @@ import {
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import type { DragEndEvent } from '@dnd-kit/core';
+import type { CSSProperties } from 'react';
 
 interface DndKitSortableItemProps {
 	id: string;
@@ -36,7 +37,7 @@ const DndKitSortableItem = ( { id, item }: DndKitSortableItemProps ) => {
 		transform: CSS.Translate.toString( transform ),
 		transition,
 		zIndex: isDragging ? 1 : undefined,
-	};
+	} as CSSProperties;
 
 	return (
 		<li ref={ setNodeRef } style={ style } { ...attributes } { ...listeners }>

--- a/packages/dnd-kit-sortable/src/index.tsx
+++ b/packages/dnd-kit-sortable/src/index.tsx
@@ -1,0 +1,82 @@
+import {
+	DndContext,
+	KeyboardSensor,
+	PointerSensor,
+	closestCenter,
+	useSensor,
+	useSensors,
+} from '@dnd-kit/core';
+import {
+	SortableContext,
+	arrayMove,
+	sortableKeyboardCoordinates,
+	useSortable,
+	verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+
+interface DndKitSortableItemProps {
+	id: string;
+	item: any;
+}
+
+interface DndKitSortableProps {
+	items: any[];
+	onDragEnd: ( newOrder: any[] ) => void;
+}
+
+const DndKitSortableItem = ( { id, item }: DndKitSortableItemProps ) => {
+	const { attributes, listeners, setNodeRef, transform, transition } = useSortable( { id } );
+
+	const style = {
+		transform: CSS.Transform.toString( transform ),
+		transition,
+	};
+
+	return (
+		<li ref={ setNodeRef } style={ style } { ...attributes } { ...listeners }>
+			{ item }
+		</li>
+	);
+};
+
+const DndKitSortable = ( { items, onDragEnd }: DndKitSortableProps ) => {
+	const itemsKeys = items.map( ( item ) => item.key );
+
+	const sensors = useSensors(
+		useSensor( PointerSensor ),
+		useSensor( KeyboardSensor, {
+			coordinateGetter: sortableKeyboardCoordinates,
+		} )
+	);
+
+	const handleDragEnd = ( event ) => {
+		const { active, over } = event;
+		if ( active.id === over.id ) {
+			return;
+		}
+
+		const oldIndex = itemsKeys.indexOf( active.id );
+		const newIndex = itemsKeys.indexOf( over.id );
+
+		const newOrder = arrayMove( itemsKeys, oldIndex, newIndex );
+		console.log( '=>', newOrder );
+		onDragEnd( newOrder );
+	};
+
+	return (
+		<DndContext
+			collisionDetection={ closestCenter }
+			sensors={ sensors }
+			onDragEnd={ handleDragEnd }
+		>
+			<SortableContext items={ itemsKeys } strategy={ verticalListSortingStrategy }>
+				{ items.map( ( item ) => (
+					<DndKitSortableItem key={ item.key } id={ item.key } item={ item } />
+				) ) }
+			</SortableContext>
+		</DndContext>
+	);
+};
+
+export default DndKitSortable;

--- a/packages/dnd-kit-sortable/src/index.tsx
+++ b/packages/dnd-kit-sortable/src/index.tsx
@@ -50,7 +50,11 @@ const DndKitSortable = ( { items, onDragEnd }: DndKitSortableProps ) => {
 	const itemsKeys = items.map( ( item ) => item.key );
 
 	const sensors = useSensors(
-		useSensor( PointerSensor ),
+		useSensor( PointerSensor, {
+			activationConstraint: {
+				distance: 5,
+			},
+		} ),
 		useSensor( KeyboardSensor, {
 			coordinateGetter: sortableKeyboardCoordinates,
 		} )

--- a/packages/dnd-kit-sortable/src/index.tsx
+++ b/packages/dnd-kit-sortable/src/index.tsx
@@ -14,6 +14,7 @@ import {
 	verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
+import type { DragEndEvent } from '@dnd-kit/core';
 
 interface DndKitSortableItemProps {
 	id: string;
@@ -26,11 +27,15 @@ interface DndKitSortableProps {
 }
 
 const DndKitSortableItem = ( { id, item }: DndKitSortableItemProps ) => {
-	const { attributes, listeners, setNodeRef, transform, transition } = useSortable( { id } );
+	const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable( {
+		id,
+	} );
 
 	const style = {
+		position: 'relative',
 		transform: CSS.Translate.toString( transform ),
 		transition,
+		zIndex: isDragging ? 1 : undefined,
 	};
 
 	return (
@@ -50,9 +55,9 @@ const DndKitSortable = ( { items, onDragEnd }: DndKitSortableProps ) => {
 		} )
 	);
 
-	const handleDragEnd = ( event ) => {
+	const handleDragEnd = ( event: DragEndEvent ) => {
 		const { active, over } = event;
-		if ( active.id === over.id ) {
+		if ( ! over || active.id === over.id ) {
 			return;
 		}
 

--- a/packages/dnd-kit-sortable/src/index.tsx
+++ b/packages/dnd-kit-sortable/src/index.tsx
@@ -60,7 +60,6 @@ const DndKitSortable = ( { items, onDragEnd }: DndKitSortableProps ) => {
 		const newIndex = itemsKeys.indexOf( over.id );
 
 		const newOrder = arrayMove( itemsKeys, oldIndex, newIndex );
-		console.log( '=>', newOrder );
 		onDragEnd( newOrder );
 	};
 

--- a/packages/dnd-kit-sortable/src/index.tsx
+++ b/packages/dnd-kit-sortable/src/index.tsx
@@ -29,7 +29,7 @@ const DndKitSortableItem = ( { id, item }: DndKitSortableItemProps ) => {
 	const { attributes, listeners, setNodeRef, transform, transition } = useSortable( { id } );
 
 	const style = {
-		transform: CSS.Transform.toString( transform ),
+		transform: CSS.Translate.toString( transform ),
 		transition,
 	};
 

--- a/packages/dnd-kit-sortable/tsconfig-cjs.json
+++ b/packages/dnd-kit-sortable/tsconfig-cjs.json
@@ -1,0 +1,7 @@
+{
+	"extends": "./tsconfig",
+	"compilerOptions": {
+		"module": "commonjs",
+		"outDir": "dist/cjs"
+	}
+}

--- a/packages/dnd-kit-sortable/tsconfig.json
+++ b/packages/dnd-kit-sortable/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"extends": "@automattic/calypso-typescript-config/ts-package.json",
+	"compilerOptions": {
+		"declarationDir": "dist/types",
+		"outDir": "dist/esm",
+		"rootDir": "src",
+		"types": []
+	},
+	"include": [ "src", "src/*.json" ],
+	"exclude": [ "**/__tests__/*", "**/__mocks__/*" ]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -773,6 +773,21 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@automattic/dnd-kit-sortable@workspace:packages/dnd-kit-sortable":
+  version: 0.0.0-use.local
+  resolution: "@automattic/dnd-kit-sortable@workspace:packages/dnd-kit-sortable"
+  dependencies:
+    "@automattic/calypso-typescript-config": "workspace:^"
+    "@dnd-kit/core": "npm:^6.1.0"
+    "@dnd-kit/sortable": "npm:^8.0.0"
+    "@dnd-kit/utilities": "npm:^3.2.2"
+    react: "npm:^18.2.0"
+    react-dom: "npm:^18.2.0"
+    tslib: "npm:^2.3.0"
+    typescript: "npm:^5.3.3"
+  languageName: unknown
+  linkType: soft
+
 "@automattic/domain-picker@workspace:^, @automattic/domain-picker@workspace:packages/domain-picker":
   version: 0.0.0-use.local
   resolution: "@automattic/domain-picker@workspace:packages/domain-picker"
@@ -3796,6 +3811,55 @@ __metadata:
   version: 0.5.7
   resolution: "@discoveryjs/json-ext@npm:0.5.7"
   checksum: e10f1b02b78e4812646ddf289b7d9f2cb567d336c363b266bd50cd223cf3de7c2c74018d91cd2613041568397ef3a4a2b500aba588c6e5bd78c38374ba68f38c
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/accessibility@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "@dnd-kit/accessibility@npm:3.1.0"
+  dependencies:
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 4f9d24e801d66d4fbb551ec389ed90424dd4c5bbdf527000a618e9abb9833cbd84d9a79e362f470ccbccfbd6d00217a9212c92f3cef66e01c951c7f79625b9d7
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/core@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@dnd-kit/core@npm:6.1.0"
+  dependencies:
+    "@dnd-kit/accessibility": "npm:^3.1.0"
+    "@dnd-kit/utilities": "npm:^3.2.2"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    react: ">=16.8.0"
+    react-dom: ">=16.8.0"
+  checksum: c793eb97cb59285ca8937ebcdfcd27cff09d750ae06722e36ca5ed07925e41abc36a38cff98f9f6056f7a07810878d76909826142a2968330e7e22060e6be584
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/sortable@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "@dnd-kit/sortable@npm:8.0.0"
+  dependencies:
+    "@dnd-kit/utilities": "npm:^3.2.2"
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    "@dnd-kit/core": ^6.1.0
+    react: ">=16.8.0"
+  checksum: a6066c652b892c6a11320c7d8f5c18fdf723e721e8eea37f4ab657dee1ac5e7ca710ac32ce0712a57fe968bc07c13bcea5d5599d90dfdd95619e162befd4d2fb
+  languageName: node
+  linkType: hard
+
+"@dnd-kit/utilities@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "@dnd-kit/utilities@npm:3.2.2"
+  dependencies:
+    tslib: "npm:^2.0.0"
+  peerDependencies:
+    react: ">=16.8.0"
+  checksum: 9aa90526f3e3fd567b5acc1b625a63177b9e8d00e7e50b2bd0e08fa2bf4dba7e19529777e001fdb8f89a7ce69f30b190c8364d390212634e0afdfa8c395e85a0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Proposed Changes

This PR implements drag and drop functionality in the Assembler large preview via the library [dnd-kit](https://github.com/clauderic/dnd-kit).

https://github.com/Automattic/wp-calypso/assets/797888/b8f0655e-90a9-4957-8cab-214fd7186f59

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?