### PR TITLE
Jetpack Manage: Implement a loading state for the new Payment method page.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/index.tsx
@@ -23,6 +23,7 @@ import {
 import PartnerPortalSidebarNavigation from '../sidebar-navigation';
 import StoredCreditCardV2 from '../stored-credit-card-v2';
 import EmptyState from './empty-state';
+import LoadingState from './loading-state';
 import type { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
 
 import './style.scss';
@@ -77,7 +78,7 @@ export default function PaymentMethodListV2() {
 
 	const getBody = () => {
 		if ( isFetching ) {
-			return 'Loading...';
+			return <LoadingState />;
 		}
 
 		if ( storedCards.length > 0 ) {

--- a/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/loading-state.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/loading-state.tsx
@@ -1,0 +1,9 @@
+import StoreCreditPlaceholderCard from '../stored-credit-placeholder-card';
+
+export default function LoadingState() {
+	return (
+		<div className="payment-method-list-v2__stored-cards">
+			<StoreCreditPlaceholderCard />
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-placeholder-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-placeholder-card/index.tsx
@@ -1,0 +1,10 @@
+import './style.scss';
+
+export default function StoreCreditPlaceholderCard() {
+	return (
+		<div className="store-credit-placeholder-card">
+			<div className="store-credit-placeholder-card-content"></div>
+			<div className="store-credit-placeholder-card-footer"></div>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/stored-credit-placeholder-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/stored-credit-placeholder-card/style.scss
@@ -1,0 +1,20 @@
+.store-credit-placeholder-card {
+	width: 360px;
+}
+
+.store-credit-placeholder-card-content {
+	min-height: 220px;
+	border-radius: 18px; /* stylelint-disable-line scales/radii */
+	margin-block-end: 16px;
+}
+
+.store-credit-placeholder-card-footer {
+	min-height: 44px;
+	border-radius: 8px; /* stylelint-disable-line scales/radii */
+}
+
+.store-credit-placeholder-card-content,
+.store-credit-placeholder-card-footer {
+	animation: loading-fade 1.6s ease-in-out infinite;
+	background: var(--color-neutral-10);
+}


### PR DESCRIPTION
This pull request improves the user experience by adding a loading state to the new payment method page. 

https://github.com/Automattic/wp-calypso/assets/56598660/3077c0e8-275e-48d3-af4b-69f6c64db94d

Closes https://github.com/Automattic/jetpack-genesis/issues/193

## Proposed Changes

* Implement a `StoreCreditPlaceholderCard` component as the placeholder visual.
* Loads the placeholder card when the page is in a loading state.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Use the Jetpack cloud live link and go to the payment methods page (`/partner-portal/payment-methods?flags=jetpack/card-addition-improvements`)
* During the initial load, confirm that you see the new loading experience.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?