### PR TITLE
Jetpack Manage: Update the payment method delete confirmation messages

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/payment-method-delete-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-delete-dialog/index.tsx
@@ -51,7 +51,7 @@ const PaymentMethodDeleteDialog: FunctionComponent< Props > = ( {
 			</h2>
 			<p>
 				{ translate(
-					'The payment method {{paymentMethodSummary/}} will be removed from your account and from all the associated subscriptions.',
+					'The payment method {{paymentMethodSummary/}} will be removed from your account',
 					{
 						components: {
 							paymentMethodSummary: <strong>{ paymentMethodSummary }</strong>,

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-delete-primary-confirmation/index.tsx
@@ -27,7 +27,8 @@ const PaymentMethodDeletePrimaryConfirmation: FunctionComponent< Props > = ( {
 				<div className="payment-method-delete-primary-confirmation__card">
 					<p className="payment-method-delete-primary-confirmation__notice">
 						{ translate(
-							'Issuing new licenses will be paused until you add a new primary payment method.'
+							'Issuing new licenses will be paused until you add a new primary payment method. ' +
+								'Additionally, the existing licenses will be revoked at the end of their respective terms.'
 						) }
 					</p>
 				</div>


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/199

## Proposed Changes

This PR updates the payment method delete confirmation messages

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Click Purchases > Click Payment Methods
3. Click the `...` icon > Click the `Delete` option and verify the below messages are displayed 

Confirmation popup for different scenarios:

When deleting a primary payment method, and there is at least one secondary method added:

<img width="585" alt="Screenshot 2024-01-16 at 11 20 07 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/b5f95c8c-0629-4276-91d4-bb76663a5723">

When deleting a secondary payment method:

<img width="585" alt="Screenshot 2024-01-16 at 11 20 20 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/8c9c2094-3628-4ca5-90c9-c72a68152d81">

When deleting a primary payment method, and there is no secondary method added:

<img width="633" alt="Screenshot 2024-01-16 at 11 29 12 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/4497c0e7-6c6e-457b-a3ba-49d5930e7907">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?