### PR TITLE
Jetpack Manage: Fix stepper alignment in the Payment method page.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/index.tsx
@@ -31,9 +31,9 @@ export default function PaymentMethodListV2() {
 			sidebarNavigation={ <PartnerPortalSidebarNavigation /> }
 			wide
 		>
-			{ !! stepper && <LayoutStepper steps={ stepper.steps } current={ stepper.current } /> }
-
 			<LayoutTop>
+				{ !! stepper && <LayoutStepper steps={ stepper.steps } current={ stepper.current } /> }
+
 				<LayoutHeader>
 					{ ! stepper && (
 						<Breadcrumb


### PR DESCRIPTION
This pull request resolves the problem of the Stepper component becoming misaligned on wider screens.

**Before**
<img width="2216" alt="Screen Shot 2024-01-16 at 3 15 56 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/a51d794b-2d6b-4036-ab80-e81a3c2f8861">

**After**
<img width="2250" alt="Screen Shot 2024-01-16 at 3 11 49 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/52e553a5-f56b-4ebc-b4ea-8a880fc271cd">

## Proposed Changes

* Move the Stepper component inside the Top container to ensure it stays within the layout displayable area.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* First, clear all payment methods on the Payment Methods page. (`/partner-portal/payment-methods`)
* Once you have cleared all the payment methods, go to the Issue Licenses page and issue any license (`/partner-portal/issue-license?flags=jetpack/card-addition-improvements`)
* Proceed to issue this until you reach the **'Add payment method'** page.
* In the **'Add payment method'** page, Zoom out your browser to simulate a wider screen.
* Confirm that the stepper does not misaligned.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?