### PR TITLE
Adds plugin not found component and unlisted plugins constant.

### DIFF
--- a/client/my-sites/plugins/constants.js
+++ b/client/my-sites/plugins/constants.js
@@ -77,3 +77,5 @@ export const ECOMMERCE_BUNDLED_PLUGINS = [
 	'tiktok-for-woocommerce',
 	'mailpoet-business',
 ];
+
+export const UNLISTED_PLUGINS = [ 'automated-db-schenker-shipping ' ];

--- a/client/my-sites/plugins/constants.js
+++ b/client/my-sites/plugins/constants.js
@@ -78,4 +78,4 @@ export const ECOMMERCE_BUNDLED_PLUGINS = [
 	'mailpoet-business',
 ];
 
-export const UNLISTED_PLUGINS = [ 'automated-db-schenker-shipping ' ];
+export const UNLISTED_PLUGINS = [ 'automated-db-schenker-shipping' ];

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -11,23 +11,30 @@ import { fetchSitePlans } from 'calypso/state/sites/plans/actions';
 import { isSiteOnECommerceTrial, getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { ALLOWED_CATEGORIES } from './categories/use-categories';
+import { UNLISTED_PLUGINS } from './constants';
 import PlanSetup from './jetpack-plugins-setup';
 import { MailPoetUpgradePage } from './mailpoet-upgrade';
 import PluginListComponent from './main';
 import PluginDetails from './plugin-details';
 import PluginEligibility from './plugin-eligibility';
+import PluginNotFound from './plugin-not-found';
 import PluginBrowser from './plugins-browser';
 import { RelatedPluginsPage } from './related-plugins-page';
 
 function renderSinglePlugin( context, siteUrl ) {
 	const pluginSlug = decodeURIComponent( context.params.plugin );
 
-	// Render single plugin component
-	context.primary = createElement( PluginDetails, {
-		path: context.path,
-		pluginSlug,
-		siteUrl,
-	} );
+	if ( UNLISTED_PLUGINS.includes( pluginSlug ) ) {
+		// Render empty view
+		context.primary = createElement( PluginNotFound );
+	} else {
+		// Render single plugin component
+		context.primary = createElement( PluginDetails, {
+			path: context.path,
+			pluginSlug,
+			siteUrl,
+		} );
+	}
 }
 
 function renderPluginList( context, basePath ) {

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -13,7 +13,6 @@ import QueryProductsList from 'calypso/components/data/query-products-list';
 import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
-import EmptyContent from 'calypso/components/empty-content';
 import MainComponent from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
@@ -30,6 +29,7 @@ import PluginDetailsHeader from 'calypso/my-sites/plugins/plugin-details-header'
 import PluginDetailsNotices from 'calypso/my-sites/plugins/plugin-details-notices';
 import PluginDetailsSidebar from 'calypso/my-sites/plugins/plugin-details-sidebar';
 import PluginDetailsV2 from 'calypso/my-sites/plugins/plugin-management-v2/plugin-details-v2';
+import PluginNotFound from 'calypso/my-sites/plugins/plugin-not-found';
 import PluginSections from 'calypso/my-sites/plugins/plugin-sections';
 import PluginSectionsCustom from 'calypso/my-sites/plugins/plugin-sections/custom';
 import { RelatedPlugins } from 'calypso/my-sites/plugins/related-plugins';
@@ -284,7 +284,7 @@ function PluginDetails( props ) {
 	}
 
 	if ( existingPlugin === false ) {
-		return <PluginDoesNotExistView />;
+		return <PluginNotFound />;
 	}
 
 	const showPlaceholder = existingPlugin === 'unknown';
@@ -478,25 +478,6 @@ function PluginDetails( props ) {
 				</div>
 			) }
 			{ isMarketplaceProduct && ! showPlaceholder && <MarketplaceFooter /> }
-		</MainComponent>
-	);
-}
-
-function PluginDoesNotExistView() {
-	const translate = useTranslate();
-	const selectedSite = useSelector( getSelectedSite );
-	const actionUrl = '/plugins' + ( selectedSite ? '/' + selectedSite.slug : '' );
-	const action = translate( 'Browse all plugins' );
-
-	return (
-		<MainComponent wideLayout>
-			<EmptyContent
-				title={ translate( "Oops! We can't find this plugin!" ) }
-				line={ translate( "The plugin you are looking for doesn't exist." ) }
-				actionURL={ actionUrl }
-				action={ action }
-				illustration="/calypso/images/illustrations/illustration-404.svg"
-			/>
 		</MainComponent>
 	);
 }

--- a/client/my-sites/plugins/plugin-not-found/index.jsx
+++ b/client/my-sites/plugins/plugin-not-found/index.jsx
@@ -1,0 +1,26 @@
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import EmptyContent from 'calypso/components/empty-content';
+import MainComponent from 'calypso/components/main';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+const PluginDoesNotExistView = () => {
+	const translate = useTranslate();
+	const selectedSite = useSelector( getSelectedSite );
+	const actionUrl = '/plugins' + ( selectedSite ? '/' + selectedSite.slug : '' );
+	const action = translate( 'Browse all plugins' );
+
+	return (
+		<MainComponent wideLayout>
+			<EmptyContent
+				title={ translate( "Oops! We can't find this plugin!" ) }
+				line={ translate( "The plugin you are looking for doesn't exist." ) }
+				actionURL={ actionUrl }
+				action={ action }
+				illustration="/calypso/images/illustrations/illustration-404.svg"
+			/>
+		</MainComponent>
+	);
+};
+
+export default PluginDoesNotExistView;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p2PTt2-9DB-p2#comment-56497

## Proposed Changes

* Moves the `PluginDoesNotExistView` to a standalone component
* Renders an empty view if the plugin slug is unlisted

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://wordpress.com/plugins/automated-db-schenker-shipping
* Make sure empty content is rendered
![CleanShot 2024-01-16 at 11 44 32@2x](https://github.com/Automattic/wp-calypso/assets/12430020/80a439f6-0aac-4933-aba9-aee478ee78f8)

* Go to another plugin page, make sure it renders as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?