### PR TITLE
Jetpack Manage: Fix the mobile views for new payment method pages

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/payment-methods-v2/style.scss
@@ -1,6 +1,17 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
+.payment-method-list-v2 {
+	@include breakpoint-deprecated( "<660px" ) {
+		.jetpack-cloud-layout__header-main {
+			margin-block-end: 16px;
+		}
+
+		.jetpack-cloud-layout__header-actions .button {
+			width: 100%;
+		}
+	}
+}
 
 .payment-method-list-v2-empty-state {
 	margin-block-start: 60px;
@@ -68,4 +79,8 @@
 	display: flex;
 	flex-wrap: wrap;
 	gap: 24px;
+
+	@include breakpoint-deprecated( "<660px" ) {
+		margin-block-start: 32px;
+	}
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/style.scss
@@ -17,6 +17,10 @@
 	flex-direction: column;
 	gap: 27px;
 
+	@include breakpoint-deprecated( "<660px" ) {
+		padding-block: 32px;
+	}
+
 	@include break-xlarge {
 		flex-direction: row;
 	}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/197

## Proposed Changes

This PR fixes the mobile views for new payment method pages

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud link > Click Purchases > Click Payment Methods
2. Append the URL with `?flags=jetpack/card-addition-improvements`.
3. Verify the page looks good on all the devices.
4. Click on Add new card > Verify the page looks good on all the devices.


<table>
<tr>
<th colspan=2>
Page: Payment Methods 

</th>
</tr>

<tr>
<th>
Mobile
</th>
<th>
Tablet
</th>
</tr>
<tr>
<td>

![mobile (60)](https://github.com/Automattic/wp-calypso/assets/10586875/62e0a41b-7f24-4228-a633-3ad08445f289)

</td>
<td>

![mobile (61)](https://github.com/Automattic/wp-calypso/assets/10586875/640e8844-63da-4775-a3ea-6492afa7f2c5)


</tr>

<tr>
<th colspan=2>
Page: Add card

</th>
</tr>

<tr>
<td>

![mobile (62)](https://github.com/Automattic/wp-calypso/assets/10586875/d2e7bc87-33ad-44d2-b5cd-a036d19373f1)

</td>
<td>

![mobile (63)](https://github.com/Automattic/wp-calypso/assets/10586875/19cef259-8dd0-4b06-ac17-fa69be28a6f3)


</tr>

</table>

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?