### PR TITLE
Signup: add flow-entering callback

### DIFF
--- a/client/lib/signup/flow-controller.ts
+++ b/client/lib/signup/flow-controller.ts
@@ -531,6 +531,10 @@ export default class SignupFlowController {
 
 		this._flowName = flowName;
 		this._flow = flows.getFlow( flowName, userLoggedIn );
+
+		if ( this._flow.onEnterFlow ) {
+			this._flow.onEnterFlow( flowName );
+		}
 	}
 
 	getDestination() {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { HOSTING_LP_FLOW } from '@automattic/onboarding';
 import { translate } from 'i18n-calypso';
+import { onEnterOnboarding } from '../flow-actions';
 
 const noop = () => {};
 
@@ -149,6 +150,7 @@ export function generateFlows( {
 			providesDependenciesInQuery: [ 'coupon' ],
 			optionalDependenciesInQuery: [ 'coupon' ],
 			hideProgressIndicator: true,
+			onEnterFlow: onEnterOnboarding,
 		},
 		{
 			name: 'onboarding-2023-pricing-grid',

--- a/client/signup/flow-actions.ts
+++ b/client/signup/flow-actions.ts
@@ -1,0 +1,8 @@
+import { loadExperimentAssignment } from 'calypso/lib/explat';
+
+export const onEnterOnboarding = ( flowName: string ) => {
+	// just to be extra safe since `loadExperimentAssignment` doesn't have the same eligibility check like `useExperiment` does
+	if ( flowName === 'onboarding' ) {
+		loadExperimentAssignment( 'calypso_gf_signup_onboarding_escape_hatch' );
+	}
+};

--- a/client/signup/types.ts
+++ b/client/signup/types.ts
@@ -20,6 +20,7 @@ export interface Flow {
 	disallowResume?: boolean;
 	showRecaptcha?: boolean;
 	enableBranchSteps?: boolean;
+	onEnterFlow?: ( flowName: string ) => void;
 }
 
 export type GoToStep = ( stepName: string, stepSectionName?: string, flowName?: string ) => void;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#2547

## Proposed Changes

In Automattic/martech#2547, we've identified several common friction points along the main onboarding flow, and described how some of them could actually be mitigated by preloading. This PR implements a flow-entering callback mechanism on the classic signup framework so we can preload some data right from entering a flow. The active experiment at the domain step is preloaded as a demonstration of the general idea. Note that it's meant to be as simple as possible for now and will need to be reworked to support more diversing type of data fetching mechanism, e.g. the redux async actions, react-query, etc.

Before:

https://github.com/Automattic/wp-calypso/assets/1842898/6a23448f-4b66-4c1f-b05a-0d9a80a2399c

After:

https://github.com/Automattic/wp-calypso/assets/1842898/361fdb83-70f2-43e4-8c99-67570e941594

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm that /start works as expected, both logged-in and logged-out. The only difference is that there likely won't be a loader when creating a new account. There will still be a loader if you access `/start` logged-in, since the 1st step will be the domain step. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
