### PR TITLE
Verbum Block Editor: minor CSS fixes

### DIFF
--- a/packages/verbum-block-editor/src/editor/editor-style.scss
+++ b/packages/verbum-block-editor/src/editor/editor-style.scss
@@ -1,13 +1,14 @@
 /* stylelint-disable declaration-property-unit-allowed-list */
-@import "@wordpress/components/build-style/style";
-@import "@wordpress/edit-post/build-style/style";
-@import "@wordpress/block-editor/build-style/style";
-@import "@wordpress/block-editor/build-style/content.css";
+@use "sass:meta";
 
 .verbum-editor-wrapper {
 	width: 100%;
 	box-sizing: border-box;
 
+	@import "@wordpress/components/build-style/style";
+	@import "@wordpress/edit-post/build-style/style";
+	@import "@wordpress/block-editor/build-style/style";
+	@import "@wordpress/block-editor/build-style/content";
 
 	.editor__header {
 		top: 0;
@@ -33,6 +34,10 @@
 			align-items: center;
 			min-height: 52px;
 			border-bottom: solid 1px #dcdcde;
+
+			button {
+				box-shadow: none;
+			}
 
 			.editor__header-toolbar {
 				flex-grow: 1;

--- a/packages/verbum-block-editor/src/editor/editor-style.scss
+++ b/packages/verbum-block-editor/src/editor/editor-style.scss
@@ -1,14 +1,13 @@
 /* stylelint-disable declaration-property-unit-allowed-list */
-@use "sass:meta";
 
 .verbum-editor-wrapper {
 	width: 100%;
 	box-sizing: border-box;
 
-	@include meta.load-css("@wordpress/components/build-style/style");
-	@include meta.load-css("@wordpress/edit-post/build-style/style");
-	@include meta.load-css("@wordpress/block-editor/build-style/style");
-	@include meta.load-css("@wordpress/block-editor/build-style/content");
+	@import "@wordpress/components/build-style/style";
+	@import "@wordpress/edit-post/build-style/style";
+	@import "@wordpress/block-editor/build-style/style";
+	@import "@wordpress/block-editor/build-style/content";
 
 	.editor__header {
 		top: 0;

--- a/packages/verbum-block-editor/src/editor/editor-style.scss
+++ b/packages/verbum-block-editor/src/editor/editor-style.scss
@@ -5,10 +5,10 @@
 	width: 100%;
 	box-sizing: border-box;
 
-	@import "@wordpress/components/build-style/style";
-	@import "@wordpress/edit-post/build-style/style";
-	@import "@wordpress/block-editor/build-style/style";
-	@import "@wordpress/block-editor/build-style/content";
+	@include meta.load-css("@wordpress/components/build-style/style");
+	@include meta.load-css("@wordpress/edit-post/build-style/style");
+	@include meta.load-css("@wordpress/block-editor/build-style/style");
+	@include meta.load-css("@wordpress/block-editor/build-style/content");
 
 	.editor__header {
 		top: 0;


### PR DESCRIPTION
This PR improves the editor styles


Related to #86425

## Proposed Changes

* Use better import for related styles
* Avoid editor header button overrides

## Testing Instructions
- In prod, visit [wordpress.tv/2019/09/12/felix-arntz-leveraging-the-power-of-custom-elements-in-gutenberg](https://wordpress.tv/2019/09/12/felix-arntz-leveraging-the-power-of-custom-elements-in-gutenberg/) and see the leaked styles issue.
- Sandbox wptv.wordpress.com, wordpress.tv, and widgets.wp.com.
- Go to package/verbum-block-editor.
- Run yarn dev --sync from this branch.
- The editor button border should look nice
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
