### PR TITLE
Hosting Command Palette: Simplify animation logic for Safari

### DIFF
--- a/client/sites-dashboard/components/hosting-command-palette-banner.tsx
+++ b/client/sites-dashboard/components/hosting-command-palette-banner.tsx
@@ -35,6 +35,7 @@ const fadeIn = keyframes`
 	opacity: 1;
   }
   100% {
+	opacity: 1,
     transform: translateX(0);
   }
 `;
@@ -46,9 +47,9 @@ const fadeOut = keyframes`
   }
   50% {
     opacity: 0;
-	transform: translateX(-15%);
   }
   100% {
+    opacity: 0;
 	transform: translateX(-50%);
   }
 `;
@@ -71,8 +72,6 @@ const CommandBox = styled.div( {
 	display: 'flex',
 	justifyContent: 'flex-start',
 	alignItems: 'center',
-	opacity: 0,
-	transition: 'opacity 1s ease-in-out',
 	marginLeft: 'auto',
 	minWidth: 253,
 	fontSize: 13,
@@ -82,10 +81,11 @@ const CommandBox = styled.div( {
 	boxShadow: '1px 1px 1px 0px #0000001F',
 	'&.command-box__fadeIn': {
 		animation: `${ fadeIn } 1s ease-in-out`,
-		opacity: 1,
+		zIndex: 10,
 	},
 	'&.command-box__fadeOut': {
 		animation: `${ fadeOut } 1s ease-in-out`,
+		zIndex: 5,
 	},
 	svg: {
 		width: 24,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/wp-calypso/pull/85564
- Reported on p1705396640039889-slack-C9EJ7KSGH

## Proposed Changes

* Improve the banner animation on Safari

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/sites` on your desktop using Safari, Chrome and Firefox
* Observe the banner animation works as expected.


## Screencasts

**Safari**

https://github.com/Automattic/wp-calypso/assets/779993/4d8ee99d-48f6-4100-af44-69949d9770ad



**Chrome**

https://github.com/Automattic/wp-calypso/assets/779993/b2746324-a993-4b95-bd6f-180547733ebe



**Firefox**

https://github.com/Automattic/wp-calypso/assets/779993/4673b961-393b-4ca7-99d5-1897dcdf5555


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?