### PR TITLE
Marketplace: Allow user to manage purchase for siteless marketplace products

### DIFF
--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -47,6 +47,7 @@ import {
 	isTemporarySitePurchase,
 	isJetpackTemporarySitePurchase,
 	isAkismetTemporarySitePurchase,
+	isMarketplaceTemporarySitePurchase,
 } from '../utils';
 import OwnerInfo from './owner-info';
 import 'calypso/me/purchases/style.scss';
@@ -75,7 +76,11 @@ class PurchaseItem extends Component {
 			} );
 		}
 
-		if ( isDisconnectedSite && ! isAkismetTemporarySitePurchase( purchase ) ) {
+		if (
+			isDisconnectedSite &&
+			! isAkismetTemporarySitePurchase( purchase ) &&
+			! isMarketplaceTemporarySitePurchase( purchase )
+		) {
 			if ( isJetpackTemporarySitePurchase( purchase ) ) {
 				return (
 					<>
@@ -519,6 +524,10 @@ class PurchaseItem extends Component {
 					<img src={ akismetIcon } alt="Akismet icon" />
 				</div>
 			);
+		}
+
+		if ( isMarketplaceTemporarySitePurchase( purchase ) ) {
+			return <SiteIcon size={ 36 } />;
 		}
 
 		if ( isDisconnectedSite ) {

--- a/client/me/purchases/utils.js
+++ b/client/me/purchases/utils.js
@@ -40,10 +40,10 @@ function getAddNewPaymentMethodPath() {
 
 function isTemporarySitePurchase( purchase ) {
 	const { domain } = purchase;
-	// Currently only Jeypack & Akismet allow siteless/userless(license-based) purchases which require a temporary
+	// Currently only Jeypack, Akismet and some Marketplace products allow siteless/userless(license-based) purchases which require a temporary
 	// site(s) to work. This function may need to be updated in the future as additional products types
 	// incorporate siteless/userless(licensebased) product based purchases..
-	return /^siteless.(jetpack|akismet).com$/.test( domain );
+	return /^siteless.(jetpack|akismet|marketplace.wp).com$/.test( domain );
 }
 
 function getTemporarySiteType( purchase ) {
@@ -54,6 +54,11 @@ function getTemporarySiteType( purchase ) {
 function isAkismetTemporarySitePurchase( purchase ) {
 	const { productType } = purchase;
 	return isTemporarySitePurchase( purchase ) && productType === 'akismet';
+}
+
+function isMarketplaceTemporarySitePurchase( purchase ) {
+	const { productType } = purchase;
+	return isTemporarySitePurchase( purchase ) && productType === 'saas_plugin';
 }
 
 function isJetpackTemporarySitePurchase( purchase ) {
@@ -70,4 +75,5 @@ export {
 	getTemporarySiteType,
 	isJetpackTemporarySitePurchase,
 	isAkismetTemporarySitePurchase,
+	isMarketplaceTemporarySitePurchase,
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/4944

## Proposed Changes

* Allow user to go in purchase detail screen from `/me/purchases` screen so that they can manage the purchase. 

#### Before
![CleanShot 2024-01-16 at 16 57 08@2x](https://github.com/Automattic/wp-calypso/assets/86406124/c858a424-02b0-48ec-94bc-35b98d675582)

#### After
![CleanShot 2024-01-16 at 16 56 19@2x](https://github.com/Automattic/wp-calypso/assets/86406124/05068f62-ee2a-4939-8102-498993993344)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

If you have account with marketplace siteless purchase then skip to `check purchases screen` section.

**Checkout marketplace siteless product.**

* Sandbox the public api. 
* Sandbox the store by following instructions at PCYsg-IA-p2#sandbox.
* Logout from WordPress.com
* Visit `/checkout/marketplace/233`
* Complete the checkout. 

**Check purchases screen**

* Visit `/me/purchases` on the account with marketplace siteless purchase.
* Make you are able to click the list item and it takes you to purchase details screen. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?