### PR TITLE
Spike: Auto enable chat support for the failed imports

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -1,10 +1,11 @@
 import { ProgressBar } from '@automattic/components';
-import { Hooray, Progress, SubTitle, Title, NextButton } from '@automattic/onboarding';
+import { Hooray, Progress, SubTitle, Title } from '@automattic/onboarding';
 import { createElement, createInterpolateElement } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import { connect } from 'react-redux';
+import MigrationError from 'calypso/blocks/importer/wordpress/import-everything/migration-error';
 import PreMigrationScreen from 'calypso/blocks/importer/wordpress/import-everything/pre-migration';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { EVERY_FIVE_SECONDS, EVERY_TEN_SECONDS, Interval } from 'calypso/lib/interval';
@@ -263,25 +264,9 @@ export class ImportEverything extends SectionMigrate {
 	}
 
 	renderMigrationError() {
-		const { translate } = this.props;
+		const { targetSite } = this.props;
 
-		return (
-			<div className="import-layout__center">
-				<div>
-					<div className="import__heading import__heading-center">
-						<Title>{ translate( 'Import failed' ) }</Title>
-						<SubTitle>
-							{ translate( 'There was an error with your import.' ) }
-							<br />
-							{ translate( 'Please try again soon or contact support for help.' ) }
-						</SubTitle>
-						<div className="import__buttons-group">
-							<NextButton onClick={ this.resetMigration }>{ translate( 'Try again' ) }</NextButton>
-						</div>
-					</div>
-				</div>
-			</div>
-		);
+		return <MigrationError siteUrl={ targetSite.URL } resetMigration={ this.resetMigration } />;
 	}
 
 	renderDefaultHoorayScreen() {

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -325,6 +325,10 @@ export class ImportEverything extends SectionMigrate {
 	}
 
 	render() {
+		if ( this.props.forceErrorScreen ) {
+			return this.renderMigrationError();
+		}
+
 		switch ( this.state.migrationStatus ) {
 			case MigrationStatus.UNKNOWN:
 				return this.renderLoading();
@@ -357,6 +361,7 @@ export const connector = connect(
 			isTargetSitePlanCompatible: !! isTargetSitePlanCompatible( ownProps.targetSite ),
 			sourceSite: ownProps.sourceSiteId && getSite( state, ownProps.sourceSiteId ),
 			startMigration: !! get( getCurrentQueryArguments( state ), 'start', false ),
+			forceErrorScreen: !! get( getCurrentQueryArguments( state ), 'forceErrorScreen', false ),
 			sourceSiteHasJetpack: false,
 			targetSiteId: ownProps.targetSiteId,
 			targetSiteImportAdminUrl: getSiteAdminUrl(

--- a/client/blocks/importer/wordpress/import-everything/migration-error.tsx
+++ b/client/blocks/importer/wordpress/import-everything/migration-error.tsx
@@ -1,0 +1,41 @@
+import { useChatWidget } from '@automattic/help-center/src/hooks';
+import { NextButton, SubTitle, Title } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+
+interface Props {
+	siteUrl: string;
+	resetMigration: () => void;
+}
+export default function MigrationError( props: Props ) {
+	const translate = useTranslate();
+	const { openChatWidget } = useChatWidget();
+	const { siteUrl, resetMigration } = props;
+
+	useEffect( () => {
+		openChatWidget( {
+			message: 'Import onboarding flow: migration failed',
+			siteUrl: siteUrl,
+		} );
+	}, [] );
+
+	return (
+		<>
+			<div className="import-layout__center">
+				<div>
+					<div className="import__heading import__heading-center">
+						<Title>{ translate( 'Import failed' ) }</Title>
+						<SubTitle>
+							{ translate( 'There was an error with your import.' ) }
+							<br />
+							{ translate( 'Please try again soon or contact support for help.' ) }
+						</SubTitle>
+						<div className="import__buttons-group">
+							<NextButton onClick={ resetMigration }>{ translate( 'Try again' ) }</NextButton>
+						</div>
+					</div>
+				</div>
+			</div>
+		</>
+	);
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/85819

## Proposed Changes

* Created MigrationError functional component in order to consume hook
* Shown the support popup when the import fails, and error screen comes out

It is worth mentioning that we can control when to open the support popup; it can be a link "contact support" that triggers the popup opening. Also, the support initial message is configurable.

## Testing Instructions

For testing purposes, there is a temporary `forceErrorScreen` query param 

* Go to `setup/import-focused/importerWordpress?siteSlug={ATOMIC_SITE}&from={JN_SITE}&option=everything&forceErrorScreen=true`
* Check if the chat support pops up

<img width="1425" alt="Screenshot 2024-01-16 at 12 37 45" src="https://github.com/Automattic/wp-calypso/assets/1241413/bf20a45d-fa76-448c-af2c-1a312947d5cc">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?