### PR TITLE
Site Profiler: Fix Busy Button Colours

### DIFF
--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -71,9 +71,10 @@ html[dir="rtl"] {
 		}
 	}
 
+	// Button style overrides necessary because of conflicting WPcom styles.
 	.button-action {
 		color: #fff;
-		background: var(--wp-admin-theme-color);
+		background: var(--color-accent);
 		border-radius: 4px;
 		font-size: 1rem;
 		font-weight: 500;
@@ -85,7 +86,7 @@ html[dir="rtl"] {
 		}
 
 		&.is-busy {
-			background-image: linear-gradient(-45deg, var(--wp-admin-theme-color) 33%, var(--wp-admin-theme-color-darker-20) 33%, var(--wp-admin-theme-color-darker-20) 70%, var(--wp-admin-theme-color) 70%);
+			background-image: linear-gradient(-45deg, var(--color-accent) 28%, var(--color-accent-60) 28%, var(--color-accent-60) 72%, var(--color-accent) 72%);
 		}
 	}
 


### PR DESCRIPTION
Fixes #86423

## Proposed Changes

As mentioned by @javierarce here, this button should use the accent colour: https://github.com/Automattic/wp-calypso/issues/86423#issuecomment-1893260771

This is ideal because they are registered for each colour scheme, whereas different shades of theme colours are not (which was originally causing this bug). 

## Testing Instructions
On the Site Profiler, switch to a colour scheme like Classic Dark and confirm that the button styles look good.

**Before:**
<img width="1574" alt="Screenshot 2024-01-16 at 12 34 51" src="https://github.com/Automattic/wp-calypso/assets/43215253/86d950fd-678f-47d0-a305-2cca7c1a9b29">

**After:**
<img width="1589" alt="Screenshot 2024-01-16 at 12 14 35" src="https://github.com/Automattic/wp-calypso/assets/43215253/1e901585-6488-4c6b-83da-7138f1155152">

cc @bogiii 