### PR TITLE
Site Profiler: Minor Styling Tweaks

### DIFF
--- a/client/site-profiler/components/heading-information/styles.scss
+++ b/client/site-profiler/components/heading-information/styles.scss
@@ -41,10 +41,18 @@
 
 	.cta-wrapper {
 		display: flex;
+		flex-wrap: wrap;
 		gap: 1rem;
+
+		@media ( max-width: $break-mobile ) {
+			.button-action {
+				justify-content: center;
+				width: 100%;
+			}
+		}
 	}
 
-	@media (max-width: $break-small ) {
+	@media ( max-width: $break-small ) {
 		.domain {
 			font-size: 2rem;
 			line-height: 1;

--- a/client/site-profiler/components/site-profiler.tsx
+++ b/client/site-profiler/components/site-profiler.tsx
@@ -71,7 +71,7 @@ export default function SiteProfiler( props: Props ) {
 	return (
 		<>
 			{ ! showResultScreen && (
-				<LayoutBlock className="domain-analyzer-block" width="medium">
+				<LayoutBlock className="domain-analyzer-block">
 					<DocumentHead title={ translate( 'Site Profiler' ) } />
 					<DomainAnalyzer
 						domain={ domain }

--- a/client/site-profiler/components/styles.scss
+++ b/client/site-profiler/components/styles.scss
@@ -40,6 +40,11 @@ html[dir="rtl"] {
 		font-size: 2.5rem;
 		line-height: 1.15;
 		margin-bottom: 1rem;
+
+		@media ( max-width: $break-small ) {
+			/* stylelint-disable-next-line */
+			font-size: 1.875em;
+		}
 	}
 
 	h3 {


### PR DESCRIPTION
## Proposed Changes

Makes the header full width. Fixes #86426 

<img width="1534" alt="Screenshot 2024-01-16 at 12 46 47" src="https://github.com/Automattic/wp-calypso/assets/43215253/79e6d1b9-6b1a-4669-80e6-1b5b5f7acb28">

***

Improves the design on mobile. Fixes #86446 

1) Ensures the button is full width on mobile
<img width="371" alt="Screenshot 2024-01-16 at 12 46 01" src="https://github.com/Automattic/wp-calypso/assets/43215253/bf46f023-374e-4a06-8fb7-48fae850c8d1">

2) Reduces the size of the bottom heading - @javierarce, just to confirm, am I correct in understanding that this change is only for mobile? 
<img width="373" alt="Screenshot 2024-01-16 at 12 48 21" src="https://github.com/Automattic/wp-calypso/assets/43215253/844614b7-6250-414d-9ce8-a4e3a2cee40d">

## Testing instructions

See screenshots above; both can be tested on the Site Profiler.

cc @bogiii
