### PR TITLE
Use new plan names in declarative flow plan checks

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/intro/index.tsx
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { TIMELESS_PLAN_BUSINESS, TIMELESS_PLAN_PREMIUM } from '@automattic/data-stores/src/plans';
 import { useLocale } from '@automattic/i18n-utils';
 import {
 	ECOMMERCE_FLOW,
@@ -22,7 +23,6 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import IntroStep, { IntroContent } from './intro';
 import VideoPressIntroModalContent from './videopress-intro-modal-content';
 import type { Step } from '../../types';
-
 import './styles.scss';
 
 const useIntroContent = ( flowName: string | null ): IntroContent => {
@@ -41,11 +41,11 @@ const useIntroContent = ( flowName: string | null ): IntroContent => {
 	if ( VIDEOPRESS_FLOW === flowName ) {
 		const isTrialEnabled = config.isEnabled( 'videomaker-trial' );
 		let defaultSupportedPlan = supportedPlans.find( ( plan ) => {
-			return plan.periodAgnosticSlug === 'premium';
+			return plan.periodAgnosticSlug === TIMELESS_PLAN_PREMIUM;
 		} );
 		if ( ! defaultSupportedPlan ) {
 			defaultSupportedPlan = supportedPlans.find( ( plan ) => {
-				return plan.periodAgnosticSlug === 'business';
+				return plan.periodAgnosticSlug === TIMELESS_PLAN_BUSINESS;
 			} );
 		}
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/sensei-plan-products.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/sensei-plan-products.ts
@@ -1,4 +1,5 @@
 import { ProductsList } from '@automattic/data-stores';
+import { TIMELESS_PLAN_BUSINESS } from '@automattic/data-stores/src/plans';
 import { useLocale } from '@automattic/i18n-utils';
 import { useSelect } from '@wordpress/data';
 import { useSupportedPlans } from 'calypso/../packages/plans-grid/src/hooks';
@@ -43,7 +44,7 @@ export function useBusinessPlanPricing( billingPeriod: PlanBillingPeriod ) {
 	const { supportedPlans } = useSupportedPlans( locale, billingPeriod );
 
 	const businessPlan = supportedPlans.find( ( plan ) => {
-		return plan && [ 'business', 'creator' ].includes( plan.periodAgnosticSlug );
+		return plan && TIMELESS_PLAN_BUSINESS === plan.periodAgnosticSlug;
 	} );
 
 	const slug = businessPlan?.periodAgnosticSlug;

--- a/client/landing/stepper/declarative-flow/videopress-tv-purchase.ts
+++ b/client/landing/stepper/declarative-flow/videopress-tv-purchase.ts
@@ -1,3 +1,4 @@
+import { TIMELESS_PLAN_BUSINESS, TIMELESS_PLAN_PREMIUM } from '@automattic/data-stores/src/plans';
 import { useLocale } from '@automattic/i18n-utils';
 import { VIDEOPRESS_TV_PURCHASE_FLOW } from '@automattic/onboarding';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -104,9 +105,13 @@ const videopressTvPurchase: Flow = {
 				setIntentOnSite( _siteSlug || '', VIDEOPRESS_TV_PURCHASE_FLOW );
 
 				// select the premium plan for now. This will be replaced with our video plan.
-				let planObject = supportedPlans.find( ( plan ) => 'premium' === plan.periodAgnosticSlug );
+				let planObject = supportedPlans.find(
+					( plan ) => TIMELESS_PLAN_PREMIUM === plan.periodAgnosticSlug
+				);
 				if ( ! planObject ) {
-					planObject = supportedPlans.find( ( plan ) => 'business' === plan.periodAgnosticSlug );
+					planObject = supportedPlans.find(
+						( plan ) => TIMELESS_PLAN_BUSINESS === plan.periodAgnosticSlug
+					);
 				}
 
 				const cartKey = _siteSlug

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -1,5 +1,6 @@
 import config from '@automattic/calypso-config';
 import { PlansSelect, SiteSelect } from '@automattic/data-stores';
+import { TIMELESS_PLAN_BUSINESS, TIMELESS_PLAN_PREMIUM } from '@automattic/data-stores/src/plans';
 import { StyleVariation } from '@automattic/design-picker';
 import { useLocale } from '@automattic/i18n-utils';
 import { VIDEOPRESS_FLOW } from '@automattic/onboarding';
@@ -238,9 +239,13 @@ const videopress: Flow = {
 					blogdescription: siteDescription,
 				} );
 
-				let planObject = supportedPlans.find( ( plan ) => 'premium' === plan.periodAgnosticSlug );
+				let planObject = supportedPlans.find(
+					( plan ) => TIMELESS_PLAN_PREMIUM === plan.periodAgnosticSlug
+				);
 				if ( ! planObject ) {
-					planObject = supportedPlans.find( ( plan ) => 'business' === plan.periodAgnosticSlug );
+					planObject = supportedPlans.find(
+						( plan ) => TIMELESS_PLAN_BUSINESS === plan.periodAgnosticSlug
+					);
 				}
 
 				const planProductObject = getPlanProduct( planObject?.periodAgnosticSlug, 'MONTHLY' );

--- a/packages/data-stores/src/plans/constants.ts
+++ b/packages/data-stores/src/plans/constants.ts
@@ -15,6 +15,11 @@ export const plansSlugs = [
 	TIMELESS_PLAN_PREMIUM,
 	TIMELESS_PLAN_BUSINESS,
 	TIMELESS_PLAN_ECOMMERCE,
+	// Keeping the old slugs for backwards compatibility.
+	'personal',
+	'premium',
+	'business',
+	'ecommerce',
 ] as const;
 
 export const DEFAULT_PAID_PLAN = TIMELESS_PLAN_PREMIUM;

--- a/packages/data-stores/src/plans/constants.ts
+++ b/packages/data-stores/src/plans/constants.ts
@@ -4,10 +4,10 @@ export const FREE_PLAN_PRODUCT_ID = 1;
 
 // plans constants
 export const TIMELESS_PLAN_FREE = 'free';
-export const TIMELESS_PLAN_PERSONAL = 'personal';
-export const TIMELESS_PLAN_PREMIUM = 'premium';
-export const TIMELESS_PLAN_BUSINESS = 'business';
-export const TIMELESS_PLAN_ECOMMERCE = 'ecommerce';
+export const TIMELESS_PLAN_PERSONAL = 'starter';
+export const TIMELESS_PLAN_PREMIUM = 'explorer';
+export const TIMELESS_PLAN_BUSINESS = 'creator';
+export const TIMELESS_PLAN_ECOMMERCE = 'entrepreneur';
 
 export const plansSlugs = [
 	TIMELESS_PLAN_FREE,

--- a/packages/data-stores/src/plans/mock/apis/plans.ts
+++ b/packages/data-stores/src/plans/mock/apis/plans.ts
@@ -76,17 +76,17 @@ export const API_PLAN_DETAILS: MockDetailsAPIResponse = {
 					plan_id: 1013,
 				},
 			],
-			name: 'WordPress.com Premium',
-			short_name: 'Premium',
-			nonlocalized_short_name: 'Premium',
-			tagline: 'Mock premium plan',
+			name: 'WordPress.com Explorer',
+			short_name: 'Explorer',
+			nonlocalized_short_name: 'Explorer',
+			tagline: 'Mock explorer plan',
 			description:
 				'Build a unique website with advanced design tools, CSS editing, lots of space for audio and video, and the ability to monetize your site with ads.',
 			features: [ 'custom-domain', 'support-live', 'recurring-payments', 'wordads' ],
 			highlighted_features: [
 				MockData.API_FEATURE_CUSTOM_DOMAIN.name,
 				MockData.API_FEATURE_LIVE_SUPPORT.name,
-				'Premium plan highlighted feature',
+				'Explorer plan highlighted feature',
 			],
 			storage: '13 GB',
 			icon: 'https://s0.wordpress.com/i/store/mobile/plans-premium.png',
@@ -147,7 +147,7 @@ export const API_PLAN_PRICE_FREE: MockPricedAPIPlanFree = {
 
 export const API_PLAN_PRICE_PREMIUM_ANNUALLY: MockPricedAPIPlanPaidAnnually = {
 	product_id: 1003,
-	product_name: 'WordPress.com Premium',
+	product_name: 'WordPress.com Explorer',
 	meta: null,
 	cost: 96,
 	blog_id: null,
@@ -163,7 +163,7 @@ export const API_PLAN_PRICE_PREMIUM_ANNUALLY: MockPricedAPIPlanPaidAnnually = {
 	outer_slug: null,
 	extra: '',
 	capability: 'manage_options',
-	product_name_short: 'Premium',
+	product_name_short: 'Explorer',
 	icon: 'https://s0.wordpress.com/i/store/plan-premium.png',
 	icon_active: 'https://s0.wordpress.com/i/store/plan-premium-active.png',
 	bundle_product_ids: [
@@ -199,7 +199,7 @@ export const API_PLAN_PRICE_PREMIUM_ANNUALLY: MockPricedAPIPlanPaidAnnually = {
 
 export const API_PLAN_PRICE_PREMIUM_MONTHLY: MockPricedAPIPlanPaidMonthly = {
 	product_id: 1013,
-	product_name: 'WordPress.com Premium',
+	product_name: 'WordPress.com Explorer',
 	meta: null,
 	cost: 14,
 	blog_id: null,
@@ -214,7 +214,7 @@ export const API_PLAN_PRICE_PREMIUM_MONTHLY: MockPricedAPIPlanPaidMonthly = {
 	outer_slug: null,
 	extra: null,
 	capability: 'manage_options',
-	product_name_short: 'Premium',
+	product_name_short: 'Explorer',
 	bundle_product_ids: [ 9, 12, 45, 15, 6, 16, 49, 50 ],
 	bill_period_label: 'per month',
 	price: '€14',

--- a/packages/data-stores/src/plans/mock/store/plans.ts
+++ b/packages/data-stores/src/plans/mock/store/plans.ts
@@ -20,7 +20,7 @@ export const STORE_PLAN_FREE: Plan = {
 	productIds: [ 1 ],
 };
 export const STORE_PLAN_PREMIUM: Plan = {
-	description: 'Mock premium plan',
+	description: 'Mock explorer plan',
 	features: [
 		{
 			name: MockData.API_FEATURE_CUSTOM_DOMAIN.name,
@@ -31,12 +31,12 @@ export const STORE_PLAN_PREMIUM: Plan = {
 			requiresAnnuallyBilledPlan: true,
 		},
 		{
-			name: 'Premium plan highlighted feature',
+			name: 'Explorer plan highlighted feature',
 			requiresAnnuallyBilledPlan: false,
 		},
 	],
 	storage: '13 GB',
-	title: 'Premium',
+	title: 'Explorer',
 	featuresSlugs: {
 		'custom-domain': true,
 		'support-live': true,
@@ -45,6 +45,6 @@ export const STORE_PLAN_PREMIUM: Plan = {
 	},
 	isFree: false,
 	isPopular: true,
-	periodAgnosticSlug: 'premium',
+	periodAgnosticSlug: 'explorer',
 	productIds: [ 1003, 1013 ],
 };

--- a/packages/data-stores/src/plans/mock/store/products.ts
+++ b/packages/data-stores/src/plans/mock/store/products.ts
@@ -14,7 +14,7 @@ export const STORE_PRODUCT_FREE: PlanProduct = {
 export const STORE_PRODUCT_PREMIUM_ANNUALLY: PlanProduct = {
 	productId: 1003,
 	billingPeriod: 'ANNUALLY',
-	periodAgnosticSlug: 'premium',
+	periodAgnosticSlug: 'explorer',
 	storeSlug: 'value_bundle',
 	rawPrice: 96,
 	pathSlug: 'premium',
@@ -25,7 +25,7 @@ export const STORE_PRODUCT_PREMIUM_ANNUALLY: PlanProduct = {
 export const STORE_PRODUCT_PREMIUM_MONTHLY: PlanProduct = {
 	productId: 1013,
 	billingPeriod: 'MONTHLY',
-	periodAgnosticSlug: 'premium',
+	periodAgnosticSlug: 'explorer',
 	storeSlug: 'value_bundle_monthly',
 	rawPrice: 14,
 	price: '€14',

--- a/packages/data-stores/src/plans/test/selectors.ts
+++ b/packages/data-stores/src/plans/test/selectors.ts
@@ -285,7 +285,7 @@ describe( 'Plans selectors', () => {
 		} );
 
 		it( 'should return undefined if the plan slug does not match any plans in the store', () => {
-			expect( Selectors.getPlanByPath( mockState, 'ecommerce', MOCK_LOCALE_1 ) ).toBeUndefined();
+			expect( Selectors.getPlanByPath( mockState, 'entrepreneur', MOCK_LOCALE_1 ) ).toBeUndefined();
 		} );
 
 		it( 'should select the correct plan for the given locale', () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86339

## Proposed Changes

This replaces hardcoded `premium` and `business` periodAgnosticSlug checks in the Sensei and VideoPress flows. It replaces them with updated `TIMELESS_PLAN_*` [constants](https://github.com/Automattic/wp-calypso/blob/trunk/packages/data-stores/src/plans/constants.ts#L6). 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/setup/sensei/senseiPlan`.
* Continue until the plan screen.
* Ensure that the price is shown correctly.
* Continue the flow until reaching the checkout cart.
* Ensure that the plan Creator and the product Sensei are both in the cart.

* Double-check `/setup/videopress` flow works as before.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
