### PR TITLE
Marketplace Reviews: Use plain text in Edit reviews textbox

### DIFF
--- a/client/data/marketplace/use-marketplace-reviews.ts
+++ b/client/data/marketplace/use-marketplace-reviews.ts
@@ -62,6 +62,7 @@ export type MarketplaceReviewResponse = {
 	date_gmt: string;
 	content: {
 		rendered: string;
+		raw: string;
 	};
 	author_avatar_urls: { '24': string; '48': string; '96': string };
 	link: string;
@@ -140,6 +141,7 @@ const fetchMarketplaceReviews = (
 			{
 				product_type: productType,
 				product_slug: productSlug,
+				context: 'edit', // https://developer.wordpress.org/rest-api/reference/comments/#retrieve-a-comment
 				page,
 				per_page: perPage,
 				...( author ? { author } : {} ),

--- a/client/my-sites/marketplace/components/review-item/index.tsx
+++ b/client/my-sites/marketplace/components/review-item/index.tsx
@@ -38,7 +38,7 @@ export const MarketplaceReviewItem = ( props: MarketplaceReviewItemProps ) => {
 
 	const setEditing = ( review: MarketplaceReviewResponse ) => {
 		setIsEditing( true );
-		setEditorContent( review.content.rendered );
+		setEditorContent( review.content.raw );
 		setEditorRating( review.meta.wpcom_marketplace_rating );
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/dotcom-forge/issues/5191

## Proposed Changes

* Use the parameter `context` to include the `raw` content in the comments API 
* Use the `raw` content response property to populate the Edit textbox

|Before | After|
|-------|------|
|  ![CleanShot 2024-01-16 at 17 10 49@2x](https://github.com/Automattic/wp-calypso/assets/3519124/125ab355-0add-438a-9e27-682efd195852)  |      ![CleanShot 2024-01-16 at 17 11 12@2x](https://github.com/Automattic/wp-calypso/assets/3519124/d795d43b-9b44-42af-beee-cf4c1dc42c74)      |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to a plugin that you have previously subscribed, e.g. `/plugins/woocommerce-bookings` or that you have reviewed.
* For existing reviews, please delete the cached values by refreshing the IndexedDB of your browser
* Add a review or open an existing review for edit
* Make sure the text does not contain any HTML 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?