### PR TITLE
Rename theme tiers after the plans

### DIFF
--- a/client/components/theme-tier/constants.js
+++ b/client/components/theme-tier/constants.js
@@ -3,6 +3,7 @@ import {
 	PLAN_FREE,
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
+	getPlan,
 } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
 
@@ -22,11 +23,11 @@ export const THEME_TIERS = {
 		minimumUpsellPlan: PLAN_FREE,
 	},
 	personal: {
-		label: translate( 'Starter' ),
+		label: getPlan( PLAN_PERSONAL )?.getTitle(),
 		minimumUpsellPlan: PLAN_PERSONAL,
 	},
 	premium: {
-		label: translate( 'Explorer' ),
+		label: getPlan( PLAN_PREMIUM )?.getTitle(),
 		minimumUpsellPlan: PLAN_PREMIUM,
 	},
 	partner: {

--- a/client/components/theme-tier/constants.js
+++ b/client/components/theme-tier/constants.js
@@ -22,11 +22,11 @@ export const THEME_TIERS = {
 		minimumUpsellPlan: PLAN_FREE,
 	},
 	personal: {
-		label: translate( 'Personal' ),
+		label: translate( 'Starter' ),
 		minimumUpsellPlan: PLAN_PERSONAL,
 	},
 	premium: {
-		label: translate( 'Premium' ),
+		label: translate( 'Explorer' ),
 		minimumUpsellPlan: PLAN_PREMIUM,
 	},
 	partner: {


### PR DESCRIPTION
For greater coherence the theme tiers will be named after the minimum plan level required to use them.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use calypso.live
2. Go to /themes?flags=themes/tiers
3. Click on the theme filters and see the correct names have been used - Starter & Explorer
4. That's it

Before | After
-------|------
<img width="821" alt="Screenshot 2024-01-16 at 17 14 44" src="https://github.com/Automattic/wp-calypso/assets/93301/17ca8827-bfb2-4e38-8ba4-96c4c96a368a"> | <img width="821" alt="Screenshot 2024-01-16 at 17 14 58" src="https://github.com/Automattic/wp-calypso/assets/93301/fb51821f-87ac-480a-a8eb-c56b0274b274">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?