### PR TITLE
Fixing issue with wrong background on mobile segmented control

### DIFF
--- a/client/my-sites/promote-post-i2/components/campaign-item/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item/style.scss
@@ -42,7 +42,7 @@
 
 			.segmented-control {
 				align-items: center;
-				background: var(--studio-gray-0);
+				background: #fff;
 				height: 28px;
 				margin-left: 0;
 

--- a/client/my-sites/promote-post-i2/components/search-bar/style.scss
+++ b/client/my-sites/promote-post-i2/components/search-bar/style.scss
@@ -145,6 +145,9 @@ $font-sf-pro-display: "SF Pro Display", $sans;
 	}
 
 	body.is-section-promote-post-i2:not(.is-sidebar-collapsed) .main.promote-post-i2 {
+		.promote-post-i2__search-bar-wrapper .segmented-control {
+			background: #fff;
+		}
 		.promote-post-i2__search-bar-wrapper .segmented-control.is-primary .segmented-control__item.is-selected {
 			margin: 0;
 		}

--- a/client/my-sites/promote-post-i2/components/search-bar/style.scss
+++ b/client/my-sites/promote-post-i2/components/search-bar/style.scss
@@ -145,9 +145,6 @@ $font-sf-pro-display: "SF Pro Display", $sans;
 	}
 
 	body.is-section-promote-post-i2:not(.is-sidebar-collapsed) .main.promote-post-i2 {
-		.promote-post-i2__search-bar-wrapper .segmented-control {
-			background: #fff;
-		}
 		.promote-post-i2__search-bar-wrapper .segmented-control.is-primary .segmented-control__item.is-selected {
 			margin: 0;
 		}


### PR DESCRIPTION
Small fix. The segmented control on mobile was showing a weird background color in the campaign list.

![Screenshot 2024-01-16 at 14 00 26](https://github.com/Automattic/wp-calypso/assets/5014402/ed39b494-b478-4bc4-9561-edd1529c857e)


## Testing Instructions

- [ ] Open any blog and go to Tools -> Advertising
- [ ] Toggle to campaigns
- [ ] In your browser Inspect the current page and test it in mobile
- [ ] Make sure the background looks as the expected result (Image below)
![Screenshot 2024-01-16 at 11 44 14 a m](https://github.com/Automattic/wp-calypso/assets/5014402/1858a8e0-7dcf-4093-b004-e9ed9140f341)



<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
