### PR TITLE
bump w.js version

### DIFF
--- a/apps/notifications/src/index.ejs
+++ b/apps/notifications/src/index.ejs
@@ -15,7 +15,7 @@
 
 <body class="wpnc">
 	<div class="wpnc__main"></div>
-	<script charset="UTF-8" src="https://stats.wp.com/w.js?64"></script>
+	<script charset="UTF-8" src="https://stats.wp.com/w.js?67"></script>
 	<% htmlWebpackPlugin.files.js.forEach( function( script ) { %><script charset="UTF-8" src="<%= script %>"></script><% } ) %>
 </body>
 

--- a/apps/notifications/src/standalone/root.html
+++ b/apps/notifications/src/standalone/root.html
@@ -14,7 +14,7 @@
 
 <body>
 	<div class="wpnc__main"></div>
-	<script charset="UTF-8" src="https://stats.wp.com/w.js?64"></script>
+	<script charset="UTF-8" src="https://stats.wp.com/w.js?67"></script>
 <script type="text/javascript" src="../../../../../../Downloads/ntfs/build.min.js?a0ff59cf6957666700e1"></script></body>
 
 </html>

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -42,7 +42,7 @@ let _superProps: any; // Added to all Tracks events.
 let _loadTracksResult = Promise.resolve(); // default value for non-BOM environments.
 
 if ( typeof document !== 'undefined' ) {
-	_loadTracksResult = loadScript( '//stats.wp.com/w.js?64' );
+	_loadTracksResult = loadScript( '//stats.wp.com/w.js?67' );
 }
 
 function createRandomId( randomBytesLength = 9 ): string {


### PR DESCRIPTION
## Proposed Changes

* Bump `w.js` version.

This was shipped in the analytics repo in this PR: https://github.com/Automattic/analytics/pull/73 

## Testing Instructions

* Visual check
* CI tests

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?