### PR TITLE
Purchases: Add `excluding taxes` string on purchase screens

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -81,6 +81,27 @@ export default function PurchaseMeta( {
 			? translate( 'Renewal Price' )
 			: translate( 'Price' );
 
+	// To-do: There isn't currently a way to get the taxName based on the country.
+	// The country is not includedin the purchase information envelope
+	// We should add this information so we can utilize useTaxName to retrieve the correct taxName
+	// For now, we are using a fallback tax name
+	const taxName =
+		getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'tax' )
+			? translate( 'tax' )
+			: translate( 'tax (VAT/GST/CT)' );
+
+	/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
+	const excludeTaxStringAbbrevation = translate( 'excludes %s', {
+		textOnly: true,
+		args: [ taxName ],
+	} );
+
+	/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
+	const excludeTaxStringTitle = translate( 'Renewal price exlcudes any applicable %s', {
+		textOnly: true,
+		args: [ taxName ],
+	} );
+
 	return (
 		<>
 			<ul className="manage-purchase__meta">
@@ -90,6 +111,9 @@ export default function PurchaseMeta( {
 					<span className="manage-purchase__detail">
 						<PurchaseMetaPrice purchase={ purchase } />
 						<PurchaseMetaIntroductoryOfferDetail purchase={ purchase } />
+					</span>
+					<span>
+						<abbr title={ excludeTaxStringTitle }>{ excludeTaxStringAbbrevation }</abbr>
 					</span>
 				</li>
 				<PurchaseMetaExpiration

--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -82,7 +82,7 @@ export default function PurchaseMeta( {
 			: translate( 'Price' );
 
 	// To-do: There isn't currently a way to get the taxName based on the country.
-	// The country is not includedin the purchase information envelope
+	// The country is not included in the purchase information envelope
 	// We should add this information so we can utilize useTaxName to retrieve the correct taxName
 	// For now, we are using a fallback tax name
 	const taxName =
@@ -91,13 +91,13 @@ export default function PurchaseMeta( {
 			: translate( 'tax (VAT/GST/CT)' );
 
 	/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
-	const excludeTaxStringAbbrevation = translate( 'excludes %s', {
+	const excludeTaxStringAbbreviation = translate( 'excludes %s', {
 		textOnly: true,
 		args: [ taxName ],
 	} );
 
 	/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
-	const excludeTaxStringTitle = translate( 'Renewal price exlcudes any applicable %s', {
+	const excludeTaxStringTitle = translate( 'Renewal price excludes any applicable %s', {
 		textOnly: true,
 		args: [ taxName ],
 	} );
@@ -113,7 +113,7 @@ export default function PurchaseMeta( {
 						<PurchaseMetaIntroductoryOfferDetail purchase={ purchase } />
 					</span>
 					<span>
-						<abbr title={ excludeTaxStringTitle }>{ excludeTaxStringAbbrevation }</abbr>
+						<abbr title={ excludeTaxStringTitle }>{ excludeTaxStringAbbreviation }</abbr>
 					</span>
 				</li>
 				<PurchaseMetaExpiration

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -68,7 +68,7 @@ class PurchaseItem extends Component {
 		const { purchase, translate, locale, moment, name, isJetpack, isDisconnectedSite } = this.props;
 		const expiry = moment( purchase.expiryDate );
 		// To-do: There isn't currently a way to get the taxName based on the country.
-		// The country is not includedin the purchase information envelope
+		// The country is not included in the purchase information envelope
 		// We should add this information so we can utilize useTaxName to retrieve the correct taxName
 		// For now, we are using a fallback tax name
 		const taxName =
@@ -76,15 +76,14 @@ class PurchaseItem extends Component {
 				? translate( 'tax' )
 				: translate( 'tax (VAT/GST/CT)' );
 
-		/* translators: "excl."" is an abbrevation of the word "exclude" */
 		/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
-		const excludeTaxStringAbbrevation = translate( '(excl. %s)', {
+		const excludeTaxStringAbbreviation = translate( '(excludes %s)', {
 			textOnly: true,
 			args: [ taxName ],
 		} );
 
 		/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
-		const excludeTaxStringTitle = translate( 'Renewal price exlcudes any applicable %s', {
+		const excludeTaxStringTitle = translate( 'Renewal price excludes any applicable %s', {
 			textOnly: true,
 			args: [ taxName ],
 		} );
@@ -179,7 +178,7 @@ class PurchaseItem extends Component {
 					) )
 			) {
 				return translate(
-					'Free trial ends on {{span}}%(date)s{{/span}}, renews automatically at %(amount)s {{abbr}}%(excludeTaxStringAbbrevation)s{{/abbr}}',
+					'Free trial ends on {{span}}%(date)s{{/span}}, renews automatically at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}}',
 					{
 						args: {
 							date: expiry.format( 'LL' ),
@@ -187,7 +186,7 @@ class PurchaseItem extends Component {
 								isSmallestUnit: true,
 								stripZeros: true,
 							} ),
-							excludeTaxStringAbbrevation: excludeTaxStringAbbrevation,
+							excludeTaxStringAbbreviation: excludeTaxStringAbbreviation,
 						},
 						components: {
 							span: <span className="purchase-item__date" />,
@@ -260,7 +259,7 @@ class PurchaseItem extends Component {
 							isSmallestUnit: true,
 							stripZeros: true,
 						} ),
-						excludeTaxStringAbbrevation: excludeTaxStringAbbrevation,
+						excludeTaxStringAbbreviation: excludeTaxStringAbbreviation,
 						date: renewDate.format( 'LL' ),
 					},
 					components: {
@@ -275,7 +274,7 @@ class PurchaseItem extends Component {
 							i18n.hasTranslation( 'Renews monthly at %(amount)s on {{span}}%(date)s{{/span}}' )
 						) {
 							return translate(
-								'Renews monthly at %(amount)s {{abbr}}%(excludeTaxStringAbbrevation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
+								'Renews monthly at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
 								translateOptions
 							);
 						}
@@ -285,7 +284,7 @@ class PurchaseItem extends Component {
 							i18n.hasTranslation( 'Renews yearly at %(amount)s on {{span}}%(date)s{{/span}}' )
 						) {
 							return translate(
-								'Renews yearly at %(amount)s {{abbr}}%(excludeTaxStringAbbrevation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
+								'Renews yearly at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
 								translateOptions
 							);
 						}
@@ -293,11 +292,11 @@ class PurchaseItem extends Component {
 						if (
 							locale === 'en' ||
 							i18n.hasTranslation(
-								'Renews every two years at %(amount)s {{abbr}}%(excludeTaxStringAbbrevation)s{{/abbr}} on {{span}}%(date)s{{/span}}'
+								'Renews every two years at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}'
 							)
 						) {
 							return translate(
-								'Renews every two years at %(amount)s {{abbr}}%(excludeTaxStringAbbrevation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
+								'Renews every two years at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
 								translateOptions
 							);
 						}
@@ -305,11 +304,11 @@ class PurchaseItem extends Component {
 						if (
 							locale === 'en' ||
 							i18n.hasTranslation(
-								'Renews every three years at %(amount)s {{abbr}}%(excludeTaxStringAbbrevation)s{{/abbr}} on {{span}}%(date)s{{/span}}'
+								'Renews every three years at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}'
 							)
 						) {
 							return translate(
-								'Renews every three years at %(amount)s {{abbr}}%(excludeTaxStringAbbrevation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
+								'Renews every three years at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
 								translateOptions
 							);
 						}
@@ -317,14 +316,14 @@ class PurchaseItem extends Component {
 			}
 
 			return translate(
-				'Renews at %(amount)s {{abbr}}%(excludeTaxStringAbbrevation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
+				'Renews at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
 				{
 					args: {
 						amount: formatCurrency( purchase.priceInteger, purchase.currencyCode, {
 							isSmallestUnit: true,
 							stripZeros: true,
 						} ),
-						excludeTaxStringAbbrevation: excludeTaxStringAbbrevation,
+						excludeTaxStringAbbreviation: excludeTaxStringAbbreviation,
 						date: renewDate.format( 'LL' ),
 					},
 					components: {

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -13,7 +13,7 @@ import formatCurrency from '@automattic/format-currency';
 import { ExternalLink } from '@wordpress/components';
 import { Icon, warning as warningIcon } from '@wordpress/icons';
 import classNames from 'classnames';
-import i18n, { localize, useTranslate } from 'i18n-calypso';
+import i18n, { localize, getLocaleSlug, useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import akismetIcon from 'calypso/assets/images/icons/akismet-icon.svg';
@@ -67,6 +67,27 @@ class PurchaseItem extends Component {
 	getStatus() {
 		const { purchase, translate, locale, moment, name, isJetpack, isDisconnectedSite } = this.props;
 		const expiry = moment( purchase.expiryDate );
+		// To-do: There isn't currently a way to get the taxName based on the country.
+		// The country is not includedin the purchase information envelope
+		// We should add this information so we can utilize useTaxName to retrieve the correct taxName
+		// For now, we are using a fallback tax name
+		const taxName =
+			getLocaleSlug()?.startsWith( 'en' ) || i18n.hasTranslation( 'tax' )
+				? translate( 'tax' )
+				: translate( 'tax (VAT/GST/CT)' );
+
+		/* translators: "excl."" is an abbrevation of the word "exclude" */
+		/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
+		const excludeTaxStringAbbrevation = translate( '(excl. %s)', {
+			textOnly: true,
+			args: [ taxName ],
+		} );
+
+		/* translators: %s is the name of taxes in the country (eg: "VAT" or "GST"). */
+		const excludeTaxStringTitle = translate( 'Renewal price exlcudes any applicable %s', {
+			textOnly: true,
+			args: [ taxName ],
+		} );
 
 		if ( purchase && isPartnerPurchase( purchase ) ) {
 			return translate( 'Managed by %(partnerName)s', {

--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -179,7 +179,7 @@ class PurchaseItem extends Component {
 					) )
 			) {
 				return translate(
-					'Free trial ends on {{span}}%(date)s{{/span}}, renews automatically at %(amount)s',
+					'Free trial ends on {{span}}%(date)s{{/span}}, renews automatically at %(amount)s {{abbr}}%(excludeTaxStringAbbrevation)s{{/abbr}}',
 					{
 						args: {
 							date: expiry.format( 'LL' ),
@@ -187,9 +187,11 @@ class PurchaseItem extends Component {
 								isSmallestUnit: true,
 								stripZeros: true,
 							} ),
+							excludeTaxStringAbbrevation: excludeTaxStringAbbrevation,
 						},
 						components: {
 							span: <span className="purchase-item__date" />,
+							abbr: <abbr title={ excludeTaxStringTitle } />,
 						},
 					}
 				);
@@ -258,9 +260,11 @@ class PurchaseItem extends Component {
 							isSmallestUnit: true,
 							stripZeros: true,
 						} ),
+						excludeTaxStringAbbrevation: excludeTaxStringAbbrevation,
 						date: renewDate.format( 'LL' ),
 					},
 					components: {
+						abbr: <abbr title={ excludeTaxStringTitle } />,
 						span: <span className="purchase-item__date" />,
 					},
 				};
@@ -271,7 +275,7 @@ class PurchaseItem extends Component {
 							i18n.hasTranslation( 'Renews monthly at %(amount)s on {{span}}%(date)s{{/span}}' )
 						) {
 							return translate(
-								'Renews monthly at %(amount)s on {{span}}%(date)s{{/span}}',
+								'Renews monthly at %(amount)s {{abbr}}%(excludeTaxStringAbbrevation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
 								translateOptions
 							);
 						}
@@ -281,7 +285,7 @@ class PurchaseItem extends Component {
 							i18n.hasTranslation( 'Renews yearly at %(amount)s on {{span}}%(date)s{{/span}}' )
 						) {
 							return translate(
-								'Renews yearly at %(amount)s on {{span}}%(date)s{{/span}}',
+								'Renews yearly at %(amount)s {{abbr}}%(excludeTaxStringAbbrevation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
 								translateOptions
 							);
 						}
@@ -289,11 +293,11 @@ class PurchaseItem extends Component {
 						if (
 							locale === 'en' ||
 							i18n.hasTranslation(
-								'Renews every two years at %(amount)s on {{span}}%(date)s{{/span}}'
+								'Renews every two years at %(amount)s {{abbr}}%(excludeTaxStringAbbrevation)s{{/abbr}} on {{span}}%(date)s{{/span}}'
 							)
 						) {
 							return translate(
-								'Renews every two years at %(amount)s on {{span}}%(date)s{{/span}}',
+								'Renews every two years at %(amount)s {{abbr}}%(excludeTaxStringAbbrevation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
 								translateOptions
 							);
 						}
@@ -301,29 +305,34 @@ class PurchaseItem extends Component {
 						if (
 							locale === 'en' ||
 							i18n.hasTranslation(
-								'Renews every three years at %(amount)s on {{span}}%(date)s{{/span}}'
+								'Renews every three years at %(amount)s {{abbr}}%(excludeTaxStringAbbrevation)s{{/abbr}} on {{span}}%(date)s{{/span}}'
 							)
 						) {
 							return translate(
-								'Renews every three years at %(amount)s on {{span}}%(date)s{{/span}}',
+								'Renews every three years at %(amount)s {{abbr}}%(excludeTaxStringAbbrevation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
 								translateOptions
 							);
 						}
 				}
 			}
 
-			return translate( 'Renews at %(amount)s on {{span}}%(date)s{{/span}}', {
-				args: {
-					amount: formatCurrency( purchase.priceInteger, purchase.currencyCode, {
-						isSmallestUnit: true,
-						stripZeros: true,
-					} ),
-					date: renewDate.format( 'LL' ),
-				},
-				components: {
-					span: <span className="purchase-item__date" />,
-				},
-			} );
+			return translate(
+				'Renews at %(amount)s {{abbr}}%(excludeTaxStringAbbrevation)s{{/abbr}} on {{span}}%(date)s{{/span}}',
+				{
+					args: {
+						amount: formatCurrency( purchase.priceInteger, purchase.currencyCode, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ),
+						excludeTaxStringAbbrevation: excludeTaxStringAbbrevation,
+						date: renewDate.format( 'LL' ),
+					},
+					components: {
+						abbr: <abbr title={ excludeTaxStringTitle } />,
+						span: <span className="purchase-item__date" />,
+					},
+				}
+			);
 		}
 
 		if ( isExpiring( purchase ) && ! isAkismetFreeProduct( purchase ) ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/payments-shilling/issues/2184

## Proposed Changes

Outside the USA, it is not often assumed that displayed prices are exclusive of tax. This can be a jarring experience when a customer gets to checkout and has an increase to their total because taxes are added. 

To help mitigate this experience, all amounts within the `me/purchases` section of Calypso should explicitly state whether they are exclusive or inclusive of taxes. Billing receipts already display any tax amounts within the `(incl. $xx.xx tax)` strings. 

This PR appends a string stating `(excl. tax)` to any amounts shown on the purchases list or an individual purchase management screen. The `<abbr>` tag surrounding the string has a `title` added which acts as a tool-tip when hovered over. 

**Before**

<img width="650" alt="Screenshot 2024-01-16 at 12 36 25" src="https://github.com/Automattic/wp-calypso/assets/12505355/eba72104-d0f3-4f8f-a7c1-60ef73c9d07b">

<img width="650" alt="Screenshot 2024-01-16 at 12 36 40" src="https://github.com/Automattic/wp-calypso/assets/12505355/b66c281d-ee01-48ee-a90c-f50912ebfc2e">

**AFTER**

<img width="650" alt="Screenshot 2024-01-18 at 12 32 02" src="https://github.com/Automattic/wp-calypso/assets/12505355/415e1d19-59c6-4889-9eea-31578a7dd93d">

<img width="650" alt="Screenshot 2024-01-18 at 12 32 37" src="https://github.com/Automattic/wp-calypso/assets/12505355/990f8430-7811-48e9-8c0e-f0b69577c29b">

<img width="650" alt="Screenshot 2024-01-16 at 11 12 13" src="https://github.com/Automattic/wp-calypso/assets/12505355/7ff641c4-fd53-4517-90bf-067b38493495">

<img width="650" alt="Screenshot 2024-01-16 at 11 12 30" src="https://github.com/Automattic/wp-calypso/assets/12505355/e2d5b7ae-0966-4c23-adb4-bd21a37de0f7">


Currently, the country information for the purchase is not included in these screens (or at least I am not sure how to access it). Only the locale information is available. This means we cannot yet utilize the official tax names for a country (e.g. "VAT" for the EU, "CT" for Japan, etc). We are relying on the Locale translation of `tax` or the fallback of `tax (VAT/GST/CT)` instead.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch and visit `me/purchases`. Any purchases which have a renewal amount should have ` (excl. tax)` appended to the amount. 
* From `me/purchases` click on a purchase with a renewal amount. On the purchase management screen, you should see `excludes tax` or `excludes tax (VAT/GST/CT)` under the renewal amount.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
