### PR TITLE
Launchpad: Migrate design steps on free flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/design/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/design/index.tsx
@@ -1,0 +1,40 @@
+import { Task } from '@automattic/launchpad';
+import { addQueryArgs } from '@wordpress/url';
+import { recordTaskClickTracksEvent } from '../../tracking';
+import { TaskAction } from '../../types';
+
+const getDesignSelectedTask: TaskAction = ( task, flow, context ): Task => {
+	const { siteInfoQueryArgs } = context;
+
+	return {
+		...task,
+		actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
+		calypso_path: addQueryArgs( task.calypso_path, {
+			...siteInfoQueryArgs,
+			flowToReturnTo: flow,
+		} ),
+		useCalypsoPath: true,
+	};
+};
+
+const getDesignCompletedTask = getDesignSelectedTask;
+
+const getDesignEdited: TaskAction = ( task, flow, context ) => {
+	const { siteInfoQueryArgs } = context;
+
+	return {
+		...task,
+		actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
+		calypso_path: addQueryArgs( task.calypso_path, {
+			...siteInfoQueryArgs,
+			canvas: 'edit',
+		} ),
+		useCalypsoPath: true,
+	};
+};
+
+export const actions = {
+	design_selected: getDesignSelectedTask,
+	design_completed: getDesignCompletedTask,
+	design_edited: getDesignEdited,
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/index.ts
@@ -1,10 +1,12 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Task, TaskId, TaskContext, TaskActionTable } from '../types';
-import * as setupActions from './setup';
+import { actions as designActions } from './design';
+import { actions as setupActions } from './setup';
 
-const DEFINITIONS: TaskActionTable = {
-	setup_free: setupActions.getSetupFreeTask,
-};
+const DEFINITIONS = {
+	...setupActions,
+	...designActions,
+} satisfies TaskActionTable;
 
 const MIGRATED_FLOWS = [ 'free' ];
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/setup/index.tsx
@@ -3,7 +3,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { recordTaskClickTracksEvent } from '../../tracking';
 import { TaskAction } from '../../types';
 
-export const getSetupFreeTask: TaskAction = ( task, flow, context ): Task => {
+const getSetupFreeTask: TaskAction = ( task, flow, context ): Task => {
 	const { siteInfoQueryArgs } = context;
 
 	return {
@@ -12,4 +12,8 @@ export const getSetupFreeTask: TaskAction = ( task, flow, context ): Task => {
 		calypso_path: addQueryArgs( `/setup/${ flow }/freePostSetup`, siteInfoQueryArgs ),
 		useCalypsoPath: true,
 	};
+};
+
+export const actions = {
+	setup_free: getSetupFreeTask,
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -274,6 +274,7 @@ export function getEnhancedTasks( {
 	tasks &&
 		tasks.map( ( task ) => {
 			let taskData = {};
+			let deprecatedData = {};
 
 			const context: TaskContext = {
 				site,
@@ -285,7 +286,7 @@ export function getEnhancedTasks( {
 				case 'setup_free':
 					// DEPRECATED: This task is deprecated and will be removed in the future
 					// eslint-disable-next-line no-case-declarations
-					const deprecatedData = {
+					deprecatedData = {
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
@@ -321,7 +322,7 @@ export function getEnhancedTasks( {
 					};
 					break;
 				case 'design_edited':
-					taskData = {
+					deprecatedData = {
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
@@ -331,6 +332,7 @@ export function getEnhancedTasks( {
 							);
 						},
 					};
+					taskData = getTaskDefinition( flow, task, context ) || deprecatedData;
 					break;
 				case 'plan_selected':
 					/* eslint-disable no-case-declarations */
@@ -428,7 +430,7 @@ export function getEnhancedTasks( {
 					break;
 				case 'design_selected':
 				case 'design_completed':
-					taskData = {
+					deprecatedData = {
 						actionDispatch: () => {
 							recordTaskClickTracksEvent( flow, task.completed, task.id );
 							window.location.assign(
@@ -439,7 +441,8 @@ export function getEnhancedTasks( {
 							);
 						},
 					};
-					break;
+
+					taskData = getTaskDefinition( flow, task, context ) || deprecatedData;
 				case 'setup_general':
 					taskData = {
 						disabled: false,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -16,7 +16,7 @@ export interface TranslatedLaunchpadStrings {
 	subtitle: string;
 }
 
-export type TaskId = 'setup_free';
+export type TaskId = 'setup_free' | 'design_selected' | 'design_completed' | 'design_edited';
 
 export interface TaskContext {
 	tasks: Task[];


### PR DESCRIPTION
Continue the work related to #86432

## Proposed Changes
Steps migrated: 
*  design_selected
*  design_completed -- NOT TESTABLE USING THE FREE FLOW
*  design_edited


The new step definition will only by available on the free flow for testing purposes. 

## Review instructions
- Check the same step definition on the backend (specially calypso_path), I am prioritizing use the backend definition and when divergence is found, maintain the existent frontend definition.

## Testing Instructions
* Start the setup/free. flow until reach the ` setup/free/launchpad?`  page
* Enable the toggle adding the param  `&flags=launchpad/new-task-definition-parser`  on the page url 
* Check the Webtools console to see info logs describing if the tasks above are running new version. 
Something similar ` Using new task definition parser `  + task name
* Check if the behaviour is same with the feature ON/OFF
* Check if all migrate tasks where the useCalypsoPath is set as true are links



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
