### PR TITLE
Big Sky: make it work with v2 patterns

### DIFF
--- a/client/landing/stepper/declarative-flow/ai-assembler.ts
+++ b/client/landing/stepper/declarative-flow/ai-assembler.ts
@@ -126,6 +126,9 @@ const withAIAssemblerFlow: Flow = {
 				siteSlug: selectedSiteSlug,
 				siteId: selectedSiteId,
 			} );
+			if ( config.isEnabled( 'pattern-assembler/v2' ) ) {
+				params.set( 'flags', 'pattern-assembler/v2' );
+			}
 
 			if ( isNewSite ) {
 				params.set( 'isNewSite', 'true' );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-ai-assembler.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-ai-assembler.ts
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import wpcomRequest from 'wpcom-proxy-request';
@@ -20,6 +21,7 @@ export default function useAIAssembler(): [ Function, Function, string, boolean 
 			apiNamespace: 'wpcom/v2',
 			body: {
 				description: prompt,
+				patterns_version: isEnabled( 'pattern-assembler/v2' ) ? '2' : '1',
 			},
 		} )
 			.catch( ( err ) => {
@@ -69,6 +71,11 @@ export default function useAIAssembler(): [ Function, Function, string, boolean 
 						// So that we close the drawer with patterns when moving to the assembler:
 						currentSearchParams.set( 'screen', 'main' );
 						currentSearchParams.delete( 'screen_parameter' );
+
+						if ( isEnabled( 'pattern-assembler/v2' ) ) {
+							// This sometimes gets lost in all the redirects.
+							currentSearchParams.set( 'flags', 'pattern-assembler/v2' );
+						}
 
 						return currentSearchParams;
 					},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-ai-assembler.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-ai-assembler.ts
@@ -72,11 +72,6 @@ export default function useAIAssembler(): [ Function, Function, string, boolean 
 						currentSearchParams.set( 'screen', 'main' );
 						currentSearchParams.delete( 'screen_parameter' );
 
-						if ( isEnabled( 'pattern-assembler/v2' ) ) {
-							// This sometimes gets lost in all the redirects.
-							currentSearchParams.set( 'flags', 'pattern-assembler/v2' );
-						}
-
 						return currentSearchParams;
 					},
 					{ replace: true }


### PR DESCRIPTION
This makes the AI assembler work with V2 Patterns

![Zrzut ekranu 2024-01-16 o 20 17 11](https://github.com/Automattic/wp-calypso/assets/3775068/a65777f9-f6d7-47fc-9cfd-dd43ff2be79d)

## Testing Instructions

1. Apply D134894-code
2. Sandbox public-api.wordpress.com
3. Load http://calypso.localhost:3000/setup/ai-assembler/?flags=pattern-assembler/v2
4. Chose new site so you get proper theme
5. Once you get to the prompt step, add `&flags=pattern-assembler%2Fv2` and reload **becalse it is loosing the flag**
6. Fill your prompt
7. Cick continue
8. Marvel at new patterns in the pattern assembler

## Known issues

- I don't know why header and footers are selected in the left sidebar but not previewed ?
- I don't know, the choices look totally random?


