### PR TITLE
Fix cache image generation

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -141,6 +141,7 @@ object CalypsoApps: BuildType({
 			name = "Build artifacts"
 			scriptContent = """
 				set -x
+				export IS_CI=true
 				apps=""
 				for dir in ./apps/*/; do
 					# Only include apps which define the "teamcity:build-app" script.

--- a/.teamcity/settings.kts
+++ b/.teamcity/settings.kts
@@ -162,7 +162,7 @@ object BuildBaseImages : BuildType({
 					registry.a8c.com/calypso/base:%image_tag%
 					registry.a8c.com/calypso/base:%build.number%
 				""".trimIndent()
-				commandArgs = "--no-cache --target base"
+				commandArgs = "--no-cache --target base --build-arg commit_sha=${Settings.WpCalypso.paramRefs.buildVcsNumber}"
 			}
 			param("dockerImage.platform", "linux")
 		}

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ ENV BUILD_TRANSLATION_CHUNKS true
 ENV PLAYWRIGHT_SKIP_DOWNLOAD true
 ENV SKIP_TSC true
 ENV NODE_OPTIONS --max-old-space-size=$node_memory
+ENV IS_CI=true
 WORKDIR /calypso
 
 # Build a "base" layer
@@ -63,7 +64,7 @@ RUN bash /tmp/env-config.sh
 # This layer is populated with up-to-date files from
 # Calypso development.
 COPY . /calypso/
-RUN yarn install --immutable --check-cache
+RUN yarn install --immutable --check-cache --inline-builds
 RUN node --version && yarn --version && npm --version
 
 # Build the final layer

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -6,6 +6,7 @@ FROM node:20.8.1-bullseye-slim as cache
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG node_memory=8192
+ARG commit_sha="(unknown)"
 WORKDIR /calypso
 ENV NPM_CONFIG_CACHE=/calypso/.cache
 ENV PERSISTENT_CACHE=true
@@ -16,10 +17,12 @@ ENV CALYPSO_ENV=production
 ENV BUILD_TRANSLATION_CHUNKS=true
 ENV NODE_OPTIONS=--max-old-space-size=$node_memory
 ENV HOME=/calypso
+ENV IS_CI=true
+ENV COMMIT_SHA $commit_sha
 
 COPY . .
 
-RUN yarn \
+RUN yarn --inline-builds \
 	# Prime webpack caches, including sourcemaps.
 	&& NODE_ENV=production SOURCEMAP=hidden-source-map yarn build-client
 

--- a/packages/calypso-apps-builder/index.js
+++ b/packages/calypso-apps-builder/index.js
@@ -42,11 +42,14 @@ const VERBOSE = argv.verbose;
 try {
 	await runBuilder( argv );
 } catch ( e ) {
-	const { pid } = process;
-	if ( VERBOSE ) {
-		console.log( `Removing children of PID: ${ pid }` );
+	// treeKill doesn't really work in CI and also isn't necessary.
+	if ( process.env.IS_CI !== 'true' ) {
+		const { pid } = process;
+		if ( VERBOSE ) {
+			console.log( `Removing children of PID: ${ pid }` );
+		}
+		treeKill( pid );
 	}
-	treeKill( pid );
 	showTips( e.tasks );
 	console.error( e.message );
 }


### PR DESCRIPTION
The cache image has been broken since yesterday. This PR fixes it to speed up trunk builds again.

The root issue was a new package was added which is a "calypso app." Since it's also a package, it is a dependency of the main calypso app, which causes it to get built as a dependency during `yarn install`. The build script is the same as all calypso apps, and relies on the `commit_sha` env var being defined.

This was not previously defined in the base image, because no calypso apps were previously built during the base image build, and that only changed when this new package was added.

The main docker image build (not base image) was working correctly, because it _does_ define the `commit_sha` variable so that it's available for something else.

I also added `--inline-builds` to the yarn install commands, because errors were previously getting swallowed into a /tmp logfile that you can't see in CI. ([see here for an example](https://teamcity.a8c.com/buildConfiguration/calypso_BuildBaseImages/11647499?hideTestsFromDependencies=false&hideProblemsFromDependencies=false&expandBuildDeploymentsSection=false&expandBuildChangesSection=true&expandBuildProblemsSection=true&showLog=11647499_550_143&logView=flowAware).) This will be useful for debugging in the future.

I also noticed a red-herring in the errors, which is that `treeKill` does not work in CI, because `ps` is not available. This shouldn't be necessary -- I only added it to handle edge cases in local development where you could end up with dangling node & rsync processes that didn't get stopped in watch mode. This scenario shouldn't apply in CI, and even if it did, they would be closed as soon as the docker build is finished. I added an `IS_CI` variable to make sure we only run that locally.

To verify the fix, you can see in this build the commit_sha is shown:

https://teamcity.a8c.com/buildConfiguration/calypso_BuildBaseImages/11648836?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true&showLog=11648836_925_168&logView=linear

Whereas in previous failing builds, you got this error (`.replace` didn't work, which was trying to operate on the commit_sha which was undefined)

https://teamcity.a8c.com/buildConfiguration/calypso_BuildBaseImages/11648779?buildTab=log&linesState=163&logView=flowAware&focusLine=931