### PR TITLE
Checkout V2: Update styles for Site Preview component

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -66,11 +66,32 @@ const CouponEnableButton = styled.button`
 `;
 
 const SitePreviewWrapper = styled.div`
-	& .home-site-preview {
-		padding-bottom: 1.5em;
-	}
-	& .home-site-preview .home-site-preview__remove-pointer {
-		aspect-ratio: 16 / 9;
+	.home-site-preview {
+		margin-bottom: 1.5em;
+		padding: 0.5em;
+		box-shadow:
+			0 0 0 1px var( --color-border-subtle ),
+			rgba( 0, 0, 0, 0.2 ) 0 7px 30px -10px;
+		border-radius: 6px;
+
+		& .home-site-preview__thumbnail-wrapper {
+			aspect-ratio: 16 / 9;
+			border-radius: 6px;
+			box-shadow: none;
+			min-width: 100%;
+
+			&:hover {
+				box-shadow: unset;
+
+				& .home-site-preview__thumbnail {
+					opacity: unset;
+				}
+			}
+		}
+
+		& home-site-preview__thumbnail {
+			opacity: 1;
+		}
 	}
 `;
 

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -770,14 +770,14 @@ const CheckoutSummaryBody = styled.div`
 	margin: 0 auto;
 	max-width: 600px;
 	width: 100%;
-	padding: 0 24px 25px;
+	padding: 24px;
 
 	.is-visible & {
 		display: block;
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		padding: 0 0 25px;
+		padding: 24px;
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {


### PR DESCRIPTION
This PR updates the styling for the checkout v2 site preview component.

![image](https://github.com/Automattic/wp-calypso/assets/16580129/974d27ca-aa81-4334-a535-0fa2d38b69a8)

Related to https://github.com/Automattic/payments-shilling/issues/1969

## Proposed Changes

* Remove hover effects from iframe wrapper
* Add white trim and border radius
* Move box shadow to wrapper trim
* Adjust min-width for better responsiveness
* Adjust top padding of CheckoutSummaryBody for mobile and tablet breakpoints

## Testing Instructions
* Open checkout for any site
* Ensure flag is set by adding `?checkoutVersion=2` to the checkout URL
* Make sure the sidebar's site preview component loads at the top, isn't clickable, doesn't have hover effects, and renders correctly according to the Figma in the project thread pbOQVh-45k-p2
* Ensure that the site preview properly resizes on smaller devices
