### PR TITLE
Domains: Show domain connection setup instructions button

### DIFF
--- a/client/components/domains/connect-domain-step/constants.ts
+++ b/client/components/domains/connect-domain-step/constants.ts
@@ -67,6 +67,16 @@ export const domainLockStatusType = {
 	UNKNOWN: 'unknown',
 } as const;
 
+export const domainMappingInstructionsMode = {
+	[ modeType.SUGGESTED ]: stepSlug.SUGGESTED_UPDATE,
+	[ modeType.ADVANCED ]: stepSlug.ADVANCED_UPDATE,
+} as const;
+
+export const subdomainMappingInstructionsMode = {
+	[ modeType.SUGGESTED ]: stepSlug.SUBDOMAIN_SUGGESTED_UPDATE,
+	[ modeType.ADVANCED ]: stepSlug.SUBDOMAIN_ADVANCED_UPDATE,
+} as const;
+
 export const stepsHeading = {
 	get SUGGESTED() {
 		return __( 'Suggested setup' );

--- a/client/my-sites/domains/domain-management/settings/cards/connected-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/connected-domain-details.tsx
@@ -2,7 +2,12 @@
 
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import {
+	domainMappingInstructionsMode,
+	subdomainMappingInstructionsMode,
+} from 'calypso/components/domains/connect-domain-step/constants';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { isSubdomain } from 'calypso/lib/domains';
 import { type as domainTypes } from 'calypso/lib/domains/constants';
 import { domainMappingSetup } from 'calypso/my-sites/domains/paths';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
@@ -44,7 +49,12 @@ const ConnectedDomainDetails = ( {
 			return null;
 		}
 
-		const setupStep = domain.connectionMode === 'advanced' ? 'advanced_update' : 'suggested_update';
+		const mappingInstructionsMode = isSubdomain( domain.domain )
+			? subdomainMappingInstructionsMode
+			: domainMappingInstructionsMode;
+
+		const modeType = domain.connectionMode as keyof typeof mappingInstructionsMode;
+		const setupStep = mappingInstructionsMode[ modeType ];
 
 		return (
 			<Button

--- a/client/my-sites/domains/domain-management/settings/cards/connected-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/connected-domain-details.tsx
@@ -39,11 +39,8 @@ const ConnectedDomainDetails = ( {
 	};
 
 	const renderMappingInstructionsButton = () => {
-		const registrationDatePlus3Days = moment.utc( domain.registrationDate ).add( 3, 'days' );
 		const shouldRenderMappingInstructions =
-			domain.type === domainTypes.MAPPED &&
-			! domain.pointsToWpcom &&
-			moment.utc().isAfter( registrationDatePlus3Days );
+			domain.type === domainTypes.MAPPED && ! domain.pointsToWpcom;
 
 		if ( ! shouldRenderMappingInstructions ) {
 			return null;

--- a/client/my-sites/domains/domain-management/settings/cards/connected-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/connected-domain-details.tsx
@@ -51,7 +51,7 @@ const ConnectedDomainDetails = ( {
 				href={ domainMappingSetup( selectedSite.slug, domain.domain, setupStep ) }
 				disabled={ isLoadingPurchase }
 			>
-				{ translate( 'View mapping instructions' ) }
+				{ translate( 'View connection setup instructions' ) }
 			</Button>
 		);
 	};

--- a/client/my-sites/domains/domain-management/settings/cards/connected-domain-details.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/connected-domain-details.tsx
@@ -3,6 +3,8 @@
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { type as domainTypes } from 'calypso/lib/domains/constants';
+import { domainMappingSetup } from 'calypso/my-sites/domains/paths';
 import { getManagePurchaseUrlFor } from 'calypso/my-sites/purchases/paths';
 import type { DetailsCardProps } from './types';
 
@@ -27,6 +29,29 @@ const ConnectedDomainDetails = ( {
 				disabled={ isLoadingPurchase }
 			>
 				{ translate( 'View plan settings' ) }
+			</Button>
+		);
+	};
+
+	const renderMappingInstructionsButton = () => {
+		const registrationDatePlus3Days = moment.utc( domain.registrationDate ).add( 3, 'days' );
+		const shouldRenderMappingInstructions =
+			domain.type === domainTypes.MAPPED &&
+			! domain.pointsToWpcom &&
+			moment.utc().isAfter( registrationDatePlus3Days );
+
+		if ( ! shouldRenderMappingInstructions ) {
+			return null;
+		}
+
+		const setupStep = domain.connectionMode === 'advanced' ? 'advanced_update' : 'suggested_update';
+
+		return (
+			<Button
+				href={ domainMappingSetup( selectedSite.slug, domain.domain, setupStep ) }
+				disabled={ isLoadingPurchase }
+			>
+				{ translate( 'View mapping instructions' ) }
 			</Button>
 		);
 	};
@@ -61,7 +86,10 @@ const ConnectedDomainDetails = ( {
 	return (
 		<div className="details-card">
 			<div className="details-card__section">{ getDescriptionText() }</div>
-			<div className="details-card__section">{ renderPlanDetailsButton() }</div>
+			<div className="details-card__section">
+				{ renderPlanDetailsButton() }
+				{ renderMappingInstructionsButton() }
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Adds back the button for the mapping setup instructions - users are unable to see them again, so they can't get the required A records for the mapping.

## Testing Instructions
- Go to `/domains/manage` and select a domain that matches the button render condition (or hack the backend to use a mock domain):
  - It should be a mapping;
  - It should not point to us;
- Ensure you see the "View mapping instructions" button;
- Confirm that clicking the button points you to the previously selected mapping setup - suggested or advanced.

## Screenshot
![image](https://github.com/Automattic/wp-calypso/assets/18705930/38925dd8-5f9a-48e3-b7f0-d4922dea9090)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?