### PR TITLE
JP Manage: 237 - Upsell polish tasks

### DIFF
--- a/client/components/jetpack/upsell-product-card/index.tsx
+++ b/client/components/jetpack/upsell-product-card/index.tsx
@@ -73,6 +73,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 	let discountText: TranslateResult | undefined;
 	let isFetchingPrices: boolean;
 	let manageProduct: APIProductFamilyProduct | undefined;
+	let nonManageProductPrice: number | null = null;
 	let onCtaButtonClickInternal = onCtaButtonClick;
 	let originalPrice: number;
 	let tooltipText: TranslateResult | ReactNode;
@@ -80,6 +81,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 	// Calculate the product price.
 	const {
 		originalPrice: nonManageOriginalPrice,
+		originalPriceTotal: nonManageOriginalPriceTotal,
 		discountedPrice: nonManageDiscountedPrice,
 		discountedPriceTotal: nonManageDiscountedPriceTotal,
 		priceTierList: nonManagePriceTierList,
@@ -134,6 +136,14 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 					comment: 'Should be as concise as possible.',
 				} );
 			}
+		}
+	}
+
+	if ( nonManageCurrencyCode === 'USD' ) {
+		if ( nonManageDiscountedPriceTotal ) {
+			nonManageProductPrice = nonManageDiscountedPriceTotal;
+		} else if ( nonManageOriginalPriceTotal ) {
+			nonManageProductPrice = nonManageOriginalPriceTotal;
 		}
 	}
 
@@ -205,9 +215,7 @@ const UpsellProductCard: React.FC< UpsellProductCardProps > = ( {
 						manageProduct={ manageProduct }
 						onClose={ () => setShowLightbox( false ) }
 						nonManageProductSlug={ nonManageProductSlug }
-						nonManageProductPrice={
-							nonManageCurrencyCode === 'USD' ? nonManageDiscountedPriceTotal : null
-						}
+						nonManageProductPrice={ nonManageProductPrice }
 						partnerCanIssueLicense={ true }
 						siteId={ siteId }
 					/>

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/license-lightbox-jetpack-manage-license.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/license-lightbox-jetpack-manage-license.tsx
@@ -17,7 +17,7 @@ const LicenseLightboxJetpackManageLicense: FunctionComponent< Props > = ( {
 	return (
 		<div className="license-lightbox__jetpack-manage-license">
 			<h3 className="license-lightbox__jetpack-manage-license-title">
-				{ translate( 'Jetpack Manage License:' ) }
+				{ translate( 'Jetpack Manage license:' ) }
 			</h3>
 
 			<div className="license-lightbox__pricing">

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/style.scss
@@ -18,6 +18,7 @@
 	display: block;
 	width: 100%;
 	padding: 10px 16px;
+	font-size: 1rem;
 
 	.license-lightbox__cta-button-external-link {
 		inset-inline-start: 4px;

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/style.scss
@@ -6,7 +6,9 @@
 }
 
 .license-lightbox__jetpack-manage-license-title {
+	color: var(--studio-black);
 	font-size: 1rem;
+	font-weight: 700;
 	margin-block-end: 8px;
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/single-site-upsell-lightbox/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/single-site-upsell-lightbox/index.tsx
@@ -82,7 +82,7 @@ export default function SingleSiteUpsellLightbox( {
 			className="license-lightbox__single-site-upsell"
 			product={ manageProduct }
 			isDisabled={ ! partnerCanIssueLicense }
-			ctaLabel={ translate( 'Issue License' ) }
+			ctaLabel={ translate( 'Issue license' ) }
 			onActivate={ onIssueLicense }
 			fireCloseOnCTAClick={ false }
 			onClose={ onHideLicenseInfo }

--- a/client/jetpack-cloud/sections/partner-portal/single-site-upsell-lightbox/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/single-site-upsell-lightbox/style.scss
@@ -1,4 +1,4 @@
-.license-lightbox__secondary-content-button {
+.button.license-lightbox__secondary-content-button {
 	border: 2px solid var(--color-accent);
 	font-weight: 700;
 	font-size: 1rem;

--- a/client/jetpack-cloud/sections/partner-portal/single-site-upsell-lightbox/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/single-site-upsell-lightbox/style.scss
@@ -2,7 +2,6 @@
 	border: 2px solid var(--color-accent);
 	font-weight: 700;
 	font-size: 1rem;
-	margin-block-start: 1rem;
 	margin-block-end: 0;
 	width: 100%;
 	padding: 10px 16px;
@@ -12,4 +11,5 @@
 	color: var(--studio-black);
 	font-size: 1rem;
 	font-weight: 700;
+	margin-block-end: 8px;
 }

--- a/client/jetpack-cloud/sections/partner-portal/single-site-upsell-lightbox/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/single-site-upsell-lightbox/style.scss
@@ -9,5 +9,7 @@
 }
 
 .license-lightbox__secondary-checkout-heading {
+	color: var(--studio-black);
+	font-size: 1rem;
 	font-weight: 700;
 }

--- a/client/my-sites/plans/jetpack-plans/use-item-price.ts
+++ b/client/my-sites/plans/jetpack-plans/use-item-price.ts
@@ -24,9 +24,10 @@ import type { PriceTierEntry } from '@automattic/calypso-products';
 interface ItemPrices {
 	isFetching: boolean | null;
 	originalPrice: number;
+	originalPriceTotal?: number;
 	discountedPrice?: number;
-	discountedPriceDuration?: number;
 	discountedPriceTotal?: number | null;
+	discountedPriceDuration?: number;
 	priceTierList: PriceTierEntry[];
 }
 
@@ -156,17 +157,20 @@ const useItemPrice = (
 	}
 
 	let originalPrice = 0;
+	let originalPriceTotal;
 	let discountedPrice;
 	let discountedPriceDuration;
-	const discountedPriceTotal = introductoryOfferPrices.introOfferCost;
+	let discountedPriceTotal;
 
 	if ( item && itemCost ) {
 		originalPrice = itemCost;
 		if ( item.term !== TERM_MONTHLY ) {
 			originalPrice = getMonthlyPrice( itemCost ); // monthlyItemCost - See comment above.
+			originalPriceTotal = itemCost;
 			discountedPrice = introductoryOfferPrices.introOfferCost
 				? getMonthlyPrice( introductoryOfferPrices.introOfferCost )
 				: undefined;
+			discountedPriceTotal = introductoryOfferPrices.introOfferCost;
 
 			// Override Jetpack Social Advanced price by hard-coding it for now
 			if (
@@ -199,6 +203,7 @@ const useItemPrice = (
 	return {
 		isFetching,
 		originalPrice,
+		originalPriceTotal,
 		discountedPrice,
 		discountedPriceDuration,
 		discountedPriceTotal,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves Automattic/jetpack-manage#237 - Upsell polish tasks

## Proposed Changes

This ensures Search prices show in the upsell lightbox if in USD. It wasn't working previously because Search didn't have a discounted price, which we now account for.

I also adjusted some styles to closer match the Figma.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Before:
![image](https://github.com/Automattic/wp-calypso/assets/32492176/d72948af-9e96-4a98-a734-7d35074bbfb9)


After:
![image](https://github.com/Automattic/wp-calypso/assets/32492176/f9cd59af-59da-4bfc-b44f-a9e33a0e41e4)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
