### PR TITLE
Shopping Cart: Remove unused cost_before_coupon and coupon_savings

### DIFF
--- a/client/my-sites/checkout/src/test/translate-cart.js
+++ b/client/my-sites/checkout/src/test/translate-cart.js
@@ -15,7 +15,6 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 					cost: 144,
 					currency: 'BRL',
 					volume: 1,
-					cost_before_coupon: 144,
 					extra: {
 						context: 'signup',
 						domain_to_bundle: 'foo.cash',
@@ -84,7 +83,6 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 					cost: 144,
 					currency: 'BRL',
 					volume: 1,
-					cost_before_coupon: 144,
 					extra: {
 						context: 'signup',
 						domain_to_bundle: 'foo.cash',
@@ -111,7 +109,6 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 					cost: 0,
 					currency: 'BRL',
 					volume: 1,
-					cost_before_coupon: 88,
 					extra: {
 						privacy: true,
 						context: 'signup',
@@ -183,7 +180,6 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 					cost: 144,
 					currency: 'USD',
 					volume: 1,
-					cost_before_coupon: 144,
 					extra: {
 						context: 'signup',
 						domain_to_bundle: 'foo.cash',
@@ -210,7 +206,6 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 					cost: 0,
 					currency: 'USD',
 					volume: 1,
-					cost_before_coupon: 88,
 					extra: {
 						privacy: true,
 						context: 'signup',
@@ -241,7 +236,6 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 					cost: 72,
 					currency: 'USD',
 					volume: 2,
-					cost_before_coupon: null,
 					extra: {
 						context: 'signup',
 						google_apps_users: [
@@ -320,7 +314,6 @@ describe( 'translateResponseCartToWPCOMCart', function () {
 					cost: 127,
 					currency: 'USD',
 					volume: 1,
-					cost_before_coupon: 144,
 					extra: {
 						context: 'signup',
 						domain_to_bundle: 'foo.cash',

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -255,8 +255,8 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	total_cost_integer: number;
 
 	/**
-	 * The difference between `cost_before_coupon` and the actual price for all
-	 * products in the currency's smallest unit.
+	 * The difference between the cost before any coupon and the actual price
+	 * for all products in the currency's smallest unit.
 	 *
 	 * Note that the difference may be caused by many factors, not just coupons.
 	 * It's best not to rely on it.
@@ -403,28 +403,6 @@ export interface ResponseCartProduct {
 	 * @deprecated This is a float and is unreliable. Use item_subtotal_integer
 	 */
 	cost: number;
-
-	/**
-	 * The cart item's price before a coupon (if any) was applied.
-	 *
-	 * This is slightly misleading because although this is the product's cost
-	 * before a coupon was applied, it already includes sale coupons (which are
-	 * actually discounts), and other discounts and does not include certain
-	 * other price changes (eg: domain discounts). It's best not to rely on it.
-	 * @deprecated This is a float and is unreliable. Use
-	 * item_original_subtotal_integer if you
-	 * can, although those have slightly different meanings.
-	 */
-	cost_before_coupon?: number;
-
-	/**
-	 * The difference between `cost_before_coupon` and the actual price.
-	 *
-	 * Note that the difference may be caused by many factors, not just coupons.
-	 * It's best not to rely on it.
-	 * @deprecated This is a float and is unreliable. Use coupon_savings_integer
-	 */
-	coupon_savings?: number;
 
 	/**
 	 * The amount of the local currency deducted by an applied coupon, if any.


### PR DESCRIPTION
## Proposed Changes

This PR removes the unused shopping cart properties `cost_before_coupon` and `coupon_savings` so they can be removed from the backend to simplify and speed up the shopping-cart endpoint.

## Testing Instructions

Make sure that these properties are not used anywhere.