### PR TITLE
Checkout: Fix height differences between payment method buttons

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/style.scss
@@ -70,10 +70,8 @@
 			padding: 0;
 		}
 
-		button {
-			&.checkout-button {
-				border-radius: var(--jetpack-corners-soft);
-			}
+		.checkout-submit-button button {
+			border-radius: var(--jetpack-corners-soft);
 		}
 	}
 

--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -41,7 +41,7 @@ const selectors = {
 	countryCode: `select[aria-labelledby="country-selector-label"]`,
 	postalCode: `input[id="contact-postal-code"]`,
 	submitBillingInformationButton:
-		'[data-testid="contact-form--visible"] button.checkout-button.is-status-primary',
+		'[data-testid="contact-form--visible"] checkout-submit-button button.is-status-primary',
 
 	// Payment method cards
 	existingCreditCard: ( cardHolderName: string ) =>
@@ -61,12 +61,12 @@ const selectors = {
 	couponCodeInput: `input[id="order-review-coupon"]`,
 	couponCodeApplyButton: `button:text("Apply")`,
 	disabledButton: 'button[disabled]:has-text("Processing")',
-	paymentButton: `button.checkout-button`,
+	paymentButton: `checkout-submit-button button`,
 	totalAmount:
 		envVariables.VIEWPORT_NAME === 'mobile'
 			? '.wp-checkout__total-price'
 			: '.wp-checkout-order-summary__total-price',
-	purchaseButton: `button.checkout-button:has-text("Pay")`,
+	purchaseButton: `checkout-submit-button button:has-text("Pay")`,
 	thirdPartyDeveloperCheckboxLabel:
 		'You agree that an account may be created on a third party developer’s site related to the products you have purchased.',
 

--- a/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/cart-checkout-page.ts
@@ -41,7 +41,7 @@ const selectors = {
 	countryCode: `select[aria-labelledby="country-selector-label"]`,
 	postalCode: `input[id="contact-postal-code"]`,
 	submitBillingInformationButton:
-		'[data-testid="contact-form--visible"] checkout-submit-button button.is-status-primary',
+		'[data-testid="contact-form--visible"] .checkout-submit-button button.is-status-primary',
 
 	// Payment method cards
 	existingCreditCard: ( cardHolderName: string ) =>
@@ -61,12 +61,12 @@ const selectors = {
 	couponCodeInput: `input[id="order-review-coupon"]`,
 	couponCodeApplyButton: `button:text("Apply")`,
 	disabledButton: 'button[disabled]:has-text("Processing")',
-	paymentButton: `checkout-submit-button button`,
+	paymentButton: `.checkout-submit-button button`,
 	totalAmount:
 		envVariables.VIEWPORT_NAME === 'mobile'
 			? '.wp-checkout__total-price'
 			: '.wp-checkout-order-summary__total-price',
-	purchaseButton: `checkout-submit-button button:has-text("Pay")`,
+	purchaseButton: `.checkout-submit-button button:has-text("Pay")`,
 	thirdPartyDeveloperCheckboxLabel:
 		'You agree that an account may be created on a third party developer’s site related to the products you have purchased.',
 

--- a/packages/composite-checkout/src/components/button.tsx
+++ b/packages/composite-checkout/src/components/button.tsx
@@ -73,7 +73,6 @@ const Button: React.FC< ButtonProps & React.ButtonHTMLAttributes< HTMLButtonElem
 	...props
 } ) => {
 	const classNames = joinClasses( [
-		'checkout-button',
 		...( buttonType ? [ 'is-status-' + buttonType ] : [] ),
 		...( isBusy ? [ 'is-busy' ] : [] ),
 		...( className ? [ className ] : [] ),

--- a/packages/composite-checkout/src/components/button.tsx
+++ b/packages/composite-checkout/src/components/button.tsx
@@ -6,6 +6,7 @@ import { Theme } from '../lib/theme';
 const CallToAction = styled( 'button' )< CallToActionProps >`
 	display: block;
 	width: ${ ( props: CallToActionProps ) => ( props.fullWidth ? '100%' : 'auto' ) };
+	height: 50px;
 	font-size: 16px;
 	border-radius: 4px;
 	padding: ${ ( props ) => ( props.buttonType === 'text-button' ? '0' : '10px 15px' ) };

--- a/packages/composite-checkout/src/components/button.tsx
+++ b/packages/composite-checkout/src/components/button.tsx
@@ -6,7 +6,6 @@ import { Theme } from '../lib/theme';
 const CallToAction = styled( 'button' )< CallToActionProps >`
 	display: block;
 	width: ${ ( props: CallToActionProps ) => ( props.fullWidth ? '100%' : 'auto' ) };
-	height: 50px;
 	font-size: 16px;
 	border-radius: 4px;
 	padding: ${ ( props ) => ( props.buttonType === 'text-button' ? '0' : '10px 15px' ) };

--- a/packages/composite-checkout/src/components/checkout-steps.tsx
+++ b/packages/composite-checkout/src/components/checkout-steps.tsx
@@ -551,15 +551,7 @@ export const SubmitButtonWrapper = styled.div`
 		left: auto;
 	}
 
-	.checkout-button {
-		margin: 0 auto;
-	}
-
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		.checkout-button {
-			width: 100%;
-		}
-
 		.checkout__step-wrapper--last-step & {
 			position: relative;
 			box-shadow: none;

--- a/packages/composite-checkout/src/components/checkout-submit-button.tsx
+++ b/packages/composite-checkout/src/components/checkout-submit-button.tsx
@@ -9,6 +9,10 @@ import CheckoutErrorBoundary from './checkout-error-boundary';
 import type { PaymentMethod, PaymentProcessorSubmitData, ProcessPayment } from '../types';
 
 const CheckoutSubmitButtonWrapper = styled.div`
+	& > button {
+		height: 50px;
+	}
+
 	&.checkout-submit-button--inactive {
 		display: none;
 	}


### PR DESCRIPTION
In checkout, the different payment methods provide their own stylized payment 'submit' buttons, but these buttons do not have the same height which can provide an odd user experience. This PR adjusts all of the checkout submission buttons to use the same height:

<img width="1393" alt="image" src="https://github.com/Automattic/wp-calypso/assets/16580129/a888caa2-beee-4ccc-9a0b-69a9d51ac613">


Fixes https://github.com/Automattic/payments-shilling/issues/1295

## Proposed Changes

* Hard code a height value for composite-checkout's `CallToAction` component
* Currently, CallToAction is only used for the submit buttons so any changes to the component's height can be made on a case by case basis
* I'm not too sure if this is overly broad applying a height for all CallToAction buttons in composite-checkout, it seems like the right place... Alternatively, there is a `SubmitButtonWrapper` component in `checkout-steps.tsx` which also applies a class `.checkout-button` to the same `CallToAction` component provided by composite-checkout...so effectively there are two places styling this same button which could lead to confusion
* I went ahead and removed the `.checkout-button` for simplicity since it didn't really change too much*
* There was a border-radius applied by the `.checkout-button` class to the submit button in the[ Jetpack Cloud partner portal](https://github.com/Automattic/wp-calypso/blob/trunk/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add/style.scss#L75)...not quite sure where to find this for testing
* The `.checkout-button` was used in a couple places for e2e testing, I updated this selector to `checkout-submit-button button` - automated tests should prove whether this worked or not

## Testing Instructions

* Go to checkout
* Ensure payment submit button is 50px tall for all payment types (Google Pay, Apple Pay, PayPal, Credit card)
* Ensure the button is still full width and looks as expected
* Also check on different device sizes
* Add a Jetpack product to your cart, you can use `http://calypso.localhost:3000/checkout/jetpack/jetpack_backup_t1_yearly` to do so, and check the payment button there as well