### PR TITLE
Plans Grid 2023: Fix plan type selector text overflow

### DIFF
--- a/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/client/my-sites/plans-grid/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 import { CustomSelectControl } from '@wordpress/components';
+import { useLayoutEffect, useState } from '@wordpress/element';
+import { detectElementOverlap } from 'calypso/my-sites/plans-grid/util';
 import useIntervalOptions from '../hooks/use-interval-options';
 import { IntervalTypeProps, SupportedUrlFriendlyTermType } from '../types';
 
@@ -39,6 +41,27 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 		displayedIntervals.includes( intervalType ) ? intervalType : 'yearly'
 	) as SupportedUrlFriendlyTermType;
 	const optionsList = useIntervalOptions( props );
+	const [ hasOverlap, setHasOverlap ] = useState( false );
+	const [ selectedItem, setSelectedItem ] = useState( null );
+
+	// TODO: Fix overlap detection ( need to make two selections before overlap detects properly )
+	// TODO: Consider generalizing this for the storage add-on dropdown
+	useLayoutEffect( () => {
+		// TODO: Use a ref here
+		const discountTextElement = document.querySelector< HTMLDivElement >(
+			'.components-custom-select-control__button .discount'
+		);
+
+		const chevronElement = document.querySelector< HTMLDivElement >(
+			'.components-input-control__suffix svg'
+		);
+
+		if ( ! discountTextElement || ! chevronElement ) {
+			return setHasOverlap( false );
+		}
+
+		setHasOverlap( detectElementOverlap( discountTextElement, chevronElement ) );
+	}, [ selectedItem ] );
 
 	const selectOptionsList = Object.values( optionsList ).map( ( option ) => ( {
 		key: option.key,
@@ -57,10 +80,20 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 				label=""
 				options={ selectOptionsList }
 				value={ selectOptionsList.find( ( { key } ) => key === supportedIntervalType ) }
-				onChange={ ( { selectedItem }: { selectedItem: { key: SupportedUrlFriendlyTermType } } ) =>
-					onPlanIntervalChange && onPlanIntervalChange( selectedItem )
-				}
+				onChange={ ( {
+					selectedItem,
+				}: {
+					selectedItem: { key: SupportedUrlFriendlyTermType };
+				} ) => {
+					onPlanIntervalChange && onPlanIntervalChange( selectedItem );
+					setSelectedItem( selectedItem );
+				} }
 			/>
+			{ hasOverlap && (
+				<div className="storage-add-on-dropdown__offset-price-container">
+					<span className="storage-add-on-dropdown__offset-price">Discount text placeholder</span>
+				</div>
+			) }
 		</div>
 	);
 };

--- a/client/my-sites/plans-grid/util.ts
+++ b/client/my-sites/plans-grid/util.ts
@@ -60,3 +60,18 @@ export const usePricingBreakpoint = ( targetBreakpoint: number ) => {
 
 	return breakpoint;
 };
+
+function getRect( element: HTMLElement ) {
+	return element.getBoundingClientRect();
+}
+
+export function detectElementOverlap( element1: HTMLElement, element2: HTMLElement ) {
+	const element1Rect = getRect( element1 );
+	const element2Rect = getRect( element2 );
+
+	const overlapX = element1Rect.left < element2Rect.right && element1Rect.right > element2Rect.left;
+	const overlapY = element1Rect.bottom < element2Rect.top && element1Rect.top > element2Rect.bottom;
+
+	// TODO: Double check logic
+	return overlapX || overlapY;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/86270#top

## Proposed Changes

* Add detection when discount pricing and dropdown chevron overlap
* Implement UX solution when overlap is detected. [This still needs confirmation]( https://github.com/Automattic/wp-calypso/issues/86270#issuecomment-1894486377 ), but moving forward with behavior that matches the storage add-on dropdown whereby overflowing text is shown outside and below the dropdown

### Other Approaches
We considered another design approach, [where we allow the size of the dropdown to expand with its content, but the sticky plan type selector dropdown in the comparison grid collides with plan headers with extra long text]( https://github.com/Automattic/wp-calypso/issues/86270#issuecomment-1894471459 ).

<img width="1316" alt="Screenshot 2024-01-16 at 12 32 41 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/7c1dd616-8206-47f2-8b54-2551334df910">

Because of this, I started exploring element overflow detection instead with `getBoundingClientRect`. It's worth noting that using `getBoundingClientRect` isn't great ( requires a browser layout, and then some calculation on our end, and potentially a re-layout if we detect overlap ).

A natural question that might arise is what about the IntersectionObserver browser API? I investigated it, but unfortunately, the API only detects intersection between a child and its ancestor. We want to identify a sibling to sibling overlap. The IntersectionObserver API v2 looks promising with the addition of `trackVisibility`, but [it's not yet released on Safari or Firefox](https://caniuse.com/intersectionobserver-v2).

Another easy question is why not look to `isLargeCurrency` for inspiration? Well, this is because it simply approximates when a currency is "large" and overflowing by counting the number of characters in a string. Because overflow bugs have appeared several times throughout the development of the plans grid, this seems like a good place to start thinking about broader, more widely applicable abstractions.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to a non-english language with longer text
* Visit /start/plans
* Verify that the discount text in the plan type selector dropdown is obscured by the chevron symbol

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?