### PR TITLE
Fix missing jetpack features in comparison grid

### DIFF
--- a/client/my-sites/plans-grid/lib/filter-unused-features-object.ts
+++ b/client/my-sites/plans-grid/lib/filter-unused-features-object.ts
@@ -17,7 +17,9 @@ const filterUnusedFeaturesObject = (
 		new Set(
 			visibleGridPlans
 				.map( ( gridPlan ) =>
-					gridPlan.features.wpcomFeatures.map( ( feature ) => feature.getSlug() )
+					[ ...gridPlan.features.wpcomFeatures, ...gridPlan.features.jetpackFeatures ].map(
+						( feature ) => feature.getSlug()
+					)
 				)
 				.flat()
 		)

--- a/client/my-sites/plans-grid/lib/filter-unused-features-object.ts
+++ b/client/my-sites/plans-grid/lib/filter-unused-features-object.ts
@@ -13,20 +13,18 @@ const filterUnusedFeaturesObject = (
 	}
 
 	// Get all unique feature slugs in all gridPlans.
-	const uniqueFeaturesAvailable = Array.from(
-		new Set(
-			visibleGridPlans
-				.map( ( gridPlan ) =>
-					[ ...gridPlan.features.wpcomFeatures, ...gridPlan.features.jetpackFeatures ].map(
-						( feature ) => feature.getSlug()
-					)
+	const uniqueFeaturesAvailable = new Set(
+		visibleGridPlans
+			.map( ( gridPlan ) =>
+				[ ...gridPlan.features.wpcomFeatures, ...gridPlan.features.jetpackFeatures ].map(
+					( feature ) => feature.getSlug()
 				)
-				.flat()
-		)
+			)
+			.flat()
 	);
 
 	return features.filter( ( feature ) => {
-		return uniqueFeaturesAvailable.includes( feature.getSlug() );
+		return uniqueFeaturesAvailable.has( feature.getSlug() );
 	} );
 };
 

--- a/client/my-sites/plans-grid/lib/test/filter-plan-features-object.ts
+++ b/client/my-sites/plans-grid/lib/test/filter-plan-features-object.ts
@@ -7,13 +7,21 @@ const feature1 = { getSlug: () => 'feature1' } as FeatureObject;
 const feature2 = { getSlug: () => 'feature2' } as FeatureObject;
 const feature3 = { getSlug: () => 'feature3' } as FeatureObject;
 const feature4 = { getSlug: () => 'feature4' } as FeatureObject;
+const feature5 = { getSlug: () => 'feature5-jetpack' } as FeatureObject;
+const feature6 = { getSlug: () => 'feature6-jetpack' } as FeatureObject;
 
 const planA = {
-	features: { wpcomFeatures: [ feature1, feature2 ] },
+	features: {
+		wpcomFeatures: [ feature1, feature2 ],
+		jetpackFeatures: [ feature5, feature6 ],
+	},
 } as GridPlan;
 
 const planB = {
-	features: { wpcomFeatures: [ feature2, feature3 ] },
+	features: {
+		wpcomFeatures: [ feature2, feature3 ],
+		jetpackFeatures: [ feature5, feature6 ],
+	},
 } as GridPlan;
 
 describe( 'filterUnusedFeaturesObject', () => {
@@ -25,9 +33,9 @@ describe( 'filterUnusedFeaturesObject', () => {
 	it( 'should return only the features used in any plan', () => {
 		const filteredFeatures = filterUnusedFeaturesObject(
 			[ planA, planB ],
-			[ feature1, feature2, feature3, feature4 ]
+			[ feature1, feature2, feature3, feature4, feature5 ]
 		);
-		expect( filteredFeatures ).toEqual( [ feature1, feature2, feature3 ] );
+		expect( filteredFeatures ).toEqual( [ feature1, feature2, feature3, feature5 ] );
 	} );
 
 	it( 'should return an empty array when no features are used in plans', () => {
@@ -37,10 +45,16 @@ describe( 'filterUnusedFeaturesObject', () => {
 
 	it( 'should handle duplicate features across plans correctly', () => {
 		const planC = {
-			features: { wpcomFeatures: [ feature1, feature1 ] },
+			features: {
+				wpcomFeatures: [ feature1, feature1 ],
+				jetpackFeatures: [ feature5, feature6, feature6 ],
+			},
 		} as GridPlan;
-		const filteredFeatures = filterUnusedFeaturesObject( [ planC ], [ feature1, feature2 ] );
-		expect( filteredFeatures ).toEqual( [ feature1 ] );
+		const filteredFeatures = filterUnusedFeaturesObject(
+			[ planC ],
+			[ feature1, feature2, feature6 ]
+		);
+		expect( filteredFeatures ).toEqual( [ feature1, feature6 ] );
 	} );
 
 	it( 'should handle invalid input gracefully', () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes Automattic/martech#2553

## Proposed Changes

Jetpack features are currently not displayed in the feature comparison grid on `/pricing/plans`. The function `filterUnusedFeaturesObject` filters out features that are 'unused', however it is filtering based only on `gridPlan.features.wpcomFeatures`. This changes updates the filtering to include `gridPlan.features.jetpackFeatures`.

🤔 Questions:

- Is this the appropriate place to make the change, or are there other components (outside the plans grid) that I'm not aware of that might also be missing Jetpack features?  
- What impact will this have on other pages that display the comparison grid ie. is displaying Jetpack features _always_ relevant, or are the pages where we purposefully exclude any reference to Jetpack?


## Testing Instructions

1. Visit `/pricing/plans`
2. Scroll down and click 'Compare plans'
3. Scroll down the comparison grid and confirm that jetpack features are displayed

| Before | After |
| -- | -- |
|![CleanShot 2024-01-17 at 14 55 03@2x](https://github.com/Automattic/wp-calypso/assets/69198925/525adbd1-221a-459d-8df6-c3cdc81400a9)|![CleanShot 2024-01-17 at 14 54 26@2x](https://github.com/Automattic/wp-calypso/assets/69198925/4388d371-faee-43bf-bddf-d6e1387dc92c)|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?