### PR TITLE
Fix `isPartnerSignupQuery` URIError

### DIFF
--- a/client/state/login/test/utils.js
+++ b/client/state/login/test/utils.js
@@ -1,0 +1,44 @@
+import { isPartnerSignupQuery } from '../utils';
+
+describe( 'isPartnerSignupQuery', () => {
+	it( 'should return false when currentQuery is undefined', () => {
+		const result = isPartnerSignupQuery( undefined );
+		expect( result ).toBe( false );
+	} );
+
+	it( 'should return false when currentQuery is null', () => {
+		const result = isPartnerSignupQuery( null );
+		expect( result ).toBe( false );
+	} );
+
+	it( 'should return true when currentQuery has is_partner_signup', () => {
+		const currentQuery = { is_partner_signup: true };
+		const result = isPartnerSignupQuery( currentQuery );
+		expect( result ).toBe( true );
+	} );
+
+	it( 'should return true when currentQuery has redirect_to with partner-signup', () => {
+		const currentQuery = { redirect_to: 'https://woocommerce.com/partner-signup' };
+		const result = isPartnerSignupQuery( currentQuery );
+		expect( result ).toBe( true );
+	} );
+
+	it( 'should return true when currentQuery has oauth2_redirect with partner-signup', () => {
+		const currentQuery = { oauth2_redirect: 'https://woocommerce.com/partner-signup' };
+		const result = isPartnerSignupQuery( currentQuery );
+		expect( result ).toBe( true );
+	} );
+
+	it( 'should throw an error when an unexpected error occurs', () => {
+		const currentQuery = { redirect_to: 'https://woocommerce.com/partner-signup' };
+		const originalDecodeURIComponent = global.decodeURIComponent;
+		global.decodeURIComponent = jest.fn( () => {
+			throw new Error( 'Unexpected error' );
+		} );
+
+		expect( () => isPartnerSignupQuery( currentQuery ) ).toThrow( 'Unexpected error' );
+
+		// Restore the original decodeURIComponent function
+		global.decodeURIComponent = originalDecodeURIComponent;
+	} );
+} );

--- a/client/state/login/utils.js
+++ b/client/state/login/utils.js
@@ -190,18 +190,27 @@ export function isPartnerSignupQuery( currentQuery ) {
 		return true;
 	}
 
-	// Handles login through /log-in/?redirect_to=...
-	if ( typeof currentQuery?.redirect_to === 'string' ) {
-		return /woocommerce\.(?:com|test)\/partner-signup/.test(
-			decodeURIComponent( currentQuery.redirect_to )
-		);
-	}
+	try {
+		// Handles login through /log-in/?redirect_to=...
+		if ( typeof currentQuery?.redirect_to === 'string' ) {
+			return /woocommerce\.(?:com|test)\/partner-signup/.test(
+				decodeURIComponent( currentQuery.redirect_to )
+			);
+		}
 
-	// Handles user creation through /start/wpcc?oauth2_redirect=...
-	if ( typeof currentQuery?.oauth2_redirect === 'string' ) {
-		return /woocommerce\.(?:com|test)\/partner-signup/.test(
-			decodeURIComponent( currentQuery.oauth2_redirect )
-		);
+		// Handles user creation through /start/wpcc?oauth2_redirect=...
+		if ( typeof currentQuery?.oauth2_redirect === 'string' ) {
+			return /woocommerce\.(?:com|test)\/partner-signup/.test(
+				decodeURIComponent( currentQuery.oauth2_redirect )
+			);
+		}
+	} catch ( e ) {
+		if ( e instanceof URIError ) {
+			// Ignore the URIError
+			return false;
+		}
+		// Should not happen, re-throw the error
+		throw e;
 	}
 
 	return false;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1705444212258879-slack-C04U5A26MJB

An unhandled `URIError` exception occurs when the `redirect_to` query is an invalid URI.

## Proposed Changes

* Wrap the decodeURIComponent call in a try-catch block to handle cases where `redirect_to` or `oauth2_redirect` is malformed
* Added unit tests

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/account/user-social?redirect_to=https://wordpress.com%learn`
* Confirm it shows the screen without errors

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?