### PR TITLE
Assembler v2: ensure page title is not Featured

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils.ts
@@ -46,7 +46,7 @@ export const getTitleForRenamedCategories = ( category: Category = {} ) => {
 
 export const getPagePatternTitle = ( { categories }: Pattern ) => {
 	const category = ( Object.values( categories ) as Category[] ).find(
-		( { slug } ) => 'page' !== slug
+		( { slug } ) => 'page' !== slug && 'featured' !== slug
 	);
 	return getTitleForRenamedCategories( category );
 };


### PR DESCRIPTION
## Proposed Changes

In Assembler v2, each page pattern has 3 categories: `page`, `featured`, and its page category.

In this PR, we ensure that we are showing the "category" name, not `Page` or `Featured`.

## Testing Instructions

1. Go to Assembler v2.
2. Go all the way to the "Add more pages" step.
3. Verify:

|Before|After|
|-|-|
|<img width="341" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/5f33f525-45a7-452d-9b68-96143ffac4df">|<img width="323" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/473c0e55-9306-481e-aad1-f36807bce3fd">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?