### PR TITLE
Assembler v2: show Gallery page instead of Portfolio

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -53,7 +53,7 @@ export const PATTERN_CATEGORIES = [
 	//'media', -- Not exist
 	'newsletter',
 	//'podcast', -- Hidden
-	'portfolio', // For page patterns only
+	'portfolio', // For page patterns only in v1
 	//'quotes', -- Not exist
 	'services',
 	'store',
@@ -79,7 +79,8 @@ export const INITIAL_PAGES = [ 'about' ];
 export const PATTERN_PAGES_CATEGORIES = [
 	'about',
 	'contact',
-	'portfolio',
+	'portfolio', // only in v1
+	'gallery', // only in v2
 	'posts',
 	'services',
 	'store',
@@ -88,7 +89,8 @@ export const PATTERN_PAGES_CATEGORIES = [
 export const ORDERED_PATTERN_PAGES_CATEGORIES = [
 	'about',
 	'services',
-	'portfolio',
+	'portfolio', // only in v1
+	'gallery', // only in v2
 	'store',
 	'posts',
 	'contact',


### PR DESCRIPTION
## Proposed Changes

In Assembler v2, it is decided that we use Gallery page instead of Portfolio page (see: p1705472129998159-slack-CRWCHQGUB).

## Testing Instructions

1. Go to the "Add more pages" in v1, verify that we can see the Portfolio page
1. Go to the "Add more pages" in v2, verify that we can see the Gallery page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?