### PR TITLE
Import flow: Show Essential plan as a upsell plan for woo trial users

### DIFF
--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -1,4 +1,10 @@
-import { planHasFeature, FEATURE_UPLOAD_THEMES_PLUGINS } from '@automattic/calypso-products';
+import {
+	planHasFeature,
+	FEATURE_UPLOAD_THEMES_PLUGINS,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	PLAN_BUSINESS,
+	PLAN_WOOEXPRESS_SMALL,
+} from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Card, CompactCard, ProgressBar, Gridicon, Spinner } from '@automattic/components';
 import { getLocaleSlug, localize } from 'i18n-calypso';
@@ -289,9 +295,11 @@ export class SectionMigrate extends Component {
 	};
 
 	goToCart = () => {
-		const { sourceSite, targetSiteSlug } = this.props;
+		const { sourceSite, targetSiteSlug, targetSite } = this.props;
 		const sourceSiteSlug = get( sourceSite, 'slug' );
-		const plan = 'business';
+		const currentPlanSlug = get( targetSite, 'plan.product_slug' );
+		const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
+		const plan = isEcommerceTrial ? PLAN_WOOEXPRESS_SMALL : PLAN_BUSINESS;
 
 		page(
 			`/checkout/${ targetSiteSlug }/${ plan }?redirect_to=/migrate/from/${ sourceSiteSlug }/to/${ targetSiteSlug }%3Fstart%3Dtrue`

--- a/client/my-sites/migrate/step-confirm-migration.jsx
+++ b/client/my-sites/migrate/step-confirm-migration.jsx
@@ -70,14 +70,31 @@ class StepConfirmMigration extends Component {
 		return planSlug && planHasFeature( planSlug, FEATURE_UPLOAD_THEMES_PLUGINS );
 	}
 
-	renderCardFooter() {
+	getFooterText() {
 		const { translate, targetSite } = this.props;
 		const currentPlanSlug = get( targetSite, 'plan.product_slug' );
 		const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
 		const upsellPlanName = isEcommerceTrial
 			? getPlan( PLAN_WOOEXPRESS_SMALL )?.getTitle()
 			: getPlan( PLAN_BUSINESS )?.getTitle();
+		if ( isEcommerceTrial ) {
+			// translators: %(essentialPlanName)s is the name of the Essential plan
+			return translate( 'An %(essentialPlanName)s Plan is required to import everything.', {
+				args: {
+					essentialPlanName: upsellPlanName,
+				},
+			} );
+		}
 
+		// translators: %(businessPlanName)s is the name of the Creator/Business plan
+		return translate( 'A %(businessPlanName)s Plan is required to import everything.', {
+			args: {
+				businessPlanName: upsellPlanName,
+			},
+		} );
+	}
+
+	renderCardFooter() {
 		// If the site is has an appropriate plan, no upgrade footer is required
 		if ( this.isTargetSitePlanCompatible() ) {
 			return null;
@@ -86,16 +103,7 @@ class StepConfirmMigration extends Component {
 		return (
 			<CompactCard className="migrate__card-footer">
 				<Gridicon className="migrate__card-footer-gridicon" icon="info-outline" size={ 12 } />
-				<span className="migrate__card-footer-text">
-					{
-						// translators: %(upsellPlanName)s is the name of the Creator/Business/Essential plan
-						translate( 'A %(upsellPlanName)s Plan is required to import everything.', {
-							args: {
-								upsellPlanName: upsellPlanName,
-							},
-						} )
-					}
-				</span>
+				<span className="migrate__card-footer-text">{ this.getFooterText() }</span>
 			</CompactCard>
 		);
 	}

--- a/client/my-sites/migrate/step-confirm-migration.jsx
+++ b/client/my-sites/migrate/step-confirm-migration.jsx
@@ -1,8 +1,10 @@
 import {
 	planHasFeature,
 	FEATURE_UPLOAD_THEMES_PLUGINS,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
 	getPlan,
 	PLAN_BUSINESS,
+	PLAN_WOOEXPRESS_SMALL,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, CompactCard, Gridicon } from '@automattic/components';
@@ -68,8 +70,13 @@ class StepConfirmMigration extends Component {
 		return planSlug && planHasFeature( planSlug, FEATURE_UPLOAD_THEMES_PLUGINS );
 	}
 
-	renderCardBusinessFooter() {
-		const { translate } = this.props;
+	renderCardFooter() {
+		const { translate, targetSite } = this.props;
+		const currentPlanSlug = get( targetSite, 'plan.product_slug' );
+		const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
+		const upsellPlanName = isEcommerceTrial
+			? getPlan( PLAN_WOOEXPRESS_SMALL )?.getTitle()
+			: getPlan( PLAN_BUSINESS )?.getTitle();
 
 		// If the site is has an appropriate plan, no upgrade footer is required
 		if ( this.isTargetSitePlanCompatible() ) {
@@ -80,11 +87,14 @@ class StepConfirmMigration extends Component {
 			<CompactCard className="migrate__card-footer">
 				<Gridicon className="migrate__card-footer-gridicon" icon="info-outline" size={ 12 } />
 				<span className="migrate__card-footer-text">
-					{ translate( 'A %(businessPlanName)s Plan is required to import everything.', {
-						args: {
-							businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle(),
-						},
-					} ) }
+					{
+						// translators: %(upsellPlanName)s is the name of the Creator/Business/Essential plan
+						translate( 'A %(upsellPlanName)s Plan is required to import everything.', {
+							args: {
+								upsellPlanName: upsellPlanName,
+							},
+						} )
+					}
 				</span>
 			</CompactCard>
 		);
@@ -159,7 +169,7 @@ class StepConfirmMigration extends Component {
 					</div>
 					{ this.renderMigrationButton() }
 				</CompactCard>
-				{ this.renderCardBusinessFooter() }
+				{ this.renderCardFooter() }
 			</>
 		);
 	}

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -32,6 +32,24 @@ class StepUpgrade extends Component {
 		this.props.recordTracksEvent( 'calypso_site_migration_business_viewed' );
 	}
 
+	getHeadingText( isEcommerceTrial, upsellPlanName ) {
+		const { translate } = this.props;
+
+		if ( isEcommerceTrial ) {
+			// translators: %(essentialPlanName)s is the name of the Essential plan
+			return translate( 'An %(essentialPlanName)s Plan is required to import everything.', {
+				args: {
+					essentialPlanName: upsellPlanName,
+				},
+			} );
+		}
+
+		// translators: %(businessPlanName)s is the name of the Creator/Business plan
+		return translate( 'A %(businessPlanName)s Plan is required to import everything.', {
+			args: { businessPlanName: upsellPlanName },
+		} );
+	}
+
 	render() {
 		const {
 			billingTimeFrame,
@@ -60,14 +78,7 @@ class StepUpgrade extends Component {
 				<HeaderCake backHref={ backHref }>{ translate( 'Import Everything' ) }</HeaderCake>
 
 				<CompactCard>
-					<CardHeading>
-						{
-							// translators: %(upsellPlanName)s is the name of the Creator/Business/Essential plan
-							translate( 'A %(upsellPlanName)s Plan is required to import everything.', {
-								args: { upsellPlanName: upsellPlanName },
-							} )
-						}
-					</CardHeading>
+					<CardHeading>{ this.getHeadingText( isEcommerceTrial, upsellPlanName ) }</CardHeading>
 					<div>
 						{ translate(
 							'To import your themes, plugins, users, and settings from %(sourceSiteDomain)s we need to upgrade your WordPress.com site.',

--- a/client/my-sites/migrate/step-upgrade.jsx
+++ b/client/my-sites/migrate/step-upgrade.jsx
@@ -1,4 +1,9 @@
-import { getPlan, PLAN_BUSINESS } from '@automattic/calypso-products';
+import {
+	getPlan,
+	PLAN_ECOMMERCE_TRIAL_MONTHLY,
+	PLAN_BUSINESS,
+	PLAN_WOOEXPRESS_SMALL,
+} from '@automattic/calypso-products';
 import { CompactCard, ProductIcon, Gridicon, PlanPrice } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
@@ -43,6 +48,11 @@ class StepUpgrade extends Component {
 		const sourceSiteDomain = get( sourceSite, 'domain' );
 		const targetSiteDomain = get( targetSite, 'domain' );
 		const backHref = `/migrate/from/${ sourceSiteSlug }/to/${ targetSiteSlug }`;
+		const currentPlanSlug = get( targetSite, 'plan.product_slug' );
+		const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
+		const upsellPlanName = isEcommerceTrial
+			? getPlan( PLAN_WOOEXPRESS_SMALL )?.getTitle()
+			: getPlan( PLAN_BUSINESS )?.getTitle();
 
 		return (
 			<>
@@ -51,9 +61,12 @@ class StepUpgrade extends Component {
 
 				<CompactCard>
 					<CardHeading>
-						{ translate( 'A %(businessPlanName)s Plan is required to import everything.', {
-							args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() },
-						} ) }
+						{
+							// translators: %(upsellPlanName)s is the name of the Creator/Business/Essential plan
+							translate( 'A %(upsellPlanName)s Plan is required to import everything.', {
+								args: { upsellPlanName: upsellPlanName },
+							} )
+						}
 					</CardHeading>
 					<div>
 						{ translate(
@@ -110,9 +123,9 @@ class StepUpgrade extends Component {
 							<div className="migrate__plan-upsell-info">
 								<div className="migrate__plan-name">
 									{
-										// translators: %(planName)s is the name of the Creator/Business plan
+										// translators: %(planName)s is the name of the Creator/Business/Essential plan
 										translate( 'WordPress.com %(planName)s', {
-											args: { planName: getPlan( PLAN_BUSINESS )?.getTitle() },
+											args: { planName: upsellPlanName },
 										} )
 									}
 								</div>
@@ -136,10 +149,12 @@ class StepUpgrade extends Component {
 }
 
 export default connect(
-	( state ) => {
-		const plan = getPlan( PLAN_BUSINESS );
+	( state, ownProps ) => {
+		const { targetSite } = ownProps;
+		const currentPlanSlug = get( targetSite, 'plan.product_slug' );
+		const isEcommerceTrial = currentPlanSlug === PLAN_ECOMMERCE_TRIAL_MONTHLY;
+		const plan = isEcommerceTrial ? getPlan( PLAN_WOOEXPRESS_SMALL ) : getPlan( PLAN_BUSINESS );
 		const planId = plan.getProductId();
-
 		return {
 			billingTimeFrame: plan.getBillingTimeFrame(),
 			currency: getCurrentUserCurrencyCode( state ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85824

## Proposed Changes

* Currently if a user with a Woo trial plan comes to the Tools > Import page, we try to upsell the Creator plan, which is wrong here. In the PR, we address it and show Essential Woo Express plan to Woo Express trial users if they try to migrate their site on Tools > Import page.
* Replace hardcoded `business` string in the `section-migrate.jsx` file

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Spin up a site Woo Trial plan, you can navigate to `https://wordpress.com/setup/wooexpress/`
2. Once that's done, go to `http://calypso.localhost:3000/migrate/WOO_TRIAL_SLUG`
3. Type in a source site you want to migrate from, you can use a JN site here
4. Establish Jetpack connection and choose import everything and click continue
5. Make sure at the bottom of the page it shows the `Essential` plan instead of `Creator` plan
![Screen Shot 2024-01-17 at 9 14 21 PM](https://github.com/Automattic/wp-calypso/assets/4074459/534c4fbf-d8e2-4508-9b5a-88c5540670eb)

6. Click Import Everything and make sure Essential plan info shows correctly in the screen
![Screen Shot 2024-01-17 at 9 14 15 PM](https://github.com/Automattic/wp-calypso/assets/4074459/d23a87ab-1d1e-423c-8f28-f062ae25cce7)

7. Click `Upgrade and import` and make sure the correct plan is in the cart.
8. Try with a simple site and start from the step 2 and go through steps again, make sure it shows Creator plan as it is now.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?