### PR TITLE
Jetpack Manage: Fix issue with Bundle license row rendering duplicate Child licenses.

### DIFF
--- a/client/state/partner-portal/licenses/hooks/use-bundle-licenses-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-bundle-licenses-query.ts
@@ -72,9 +72,14 @@ export default function useBundleLicensesQuery(
 	useEffect( () => {
 		if ( data ) {
 			setTotal( data.total );
-			setLicenses( ( licenses ) => [ ...licenses, ...data.licenses ] );
+
+			if ( page === 1 ) {
+				setLicenses( data.licenses );
+			} else {
+				setLicenses( ( licenses ) => [ ...licenses, ...data.licenses ] );
+			}
 		}
-	}, [ data ] );
+	}, [ data, page ] );
 
 	return {
 		licenses,


### PR DESCRIPTION
There is a tendency for a bundle license row to render a duplicate list of child licenses. This PR aims to fix this by ensuring that the child licenses list is refreshed when reloading from page 1.

Closes https://github.com/Automattic/jetpack-manage/issues/224

## Proposed Changes

* In the `useBundleLicenseQuery` hook, we ensure that whenever we load child licenses starting from page 1, we create a new array instead of simply concatenating it. This is done to prevent an issue where the `BundleDetails` component - which is not destroyed in this case - tries to re-render the list and gets a duplicated list.

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Reproducing the issue**
1. Go to the Licenses overview page (`/partner-portal/licenses`)
2. Look for a bundle license and expand it.
3. Do any action to one of the Child licenses (e.g., Revoking or Assigning)
4. After completing the action, you will return to the Licenses Overview page.
5. This time, look for the same bundle license you expanded earlier, then expand it again.
6. **_Notice that the child licenses list has duplicate licenses._**

**Testing the fix**
1. Use the Jetpack cloud live link below and go to the Licenses overview page (`/partner-portal/licenses`)
2. Do the exact steps to reproduce the issue.
3. Confirm that you no longer see a duplicated license.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
