### PR TITLE
Theme upgrade modals: Change tier names

### DIFF
--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -130,7 +130,7 @@ export const ThemeUpgradeModal = ( {
 			text: (
 				<p>
 					{ translate(
-						'Get access to %(plan)s themes, and a ton of other features, with a subscription to the %(plan)s plan. It’s {{strong}}%(planPrice)s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
+						'Get access to this theme, and a ton of other features, with a subscription to the %(plan)s plan. It’s {{strong}}%(planPrice)s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
 						{
 							components: {
 								strong: <strong />,
@@ -174,7 +174,7 @@ export const ThemeUpgradeModal = ( {
 			text: (
 				<p>
 					{ translate(
-						'Get access to our %(premiumPlanName)s themes, and a ton of other features, with a subscription to the %(premiumPlanName)s plan. It’s {{strong}}%(planPrice)s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
+						'Get access to this theme, and a ton of other features, with a subscription to the %(premiumPlanName)s plan. It’s {{strong}}%(planPrice)s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
 						{
 							components: {
 								strong: <strong />,

--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -125,14 +125,12 @@ export const ThemeUpgradeModal = ( {
 
 		return {
 			header: (
-				<h1 className="theme-upgrade-modal__heading">
-					{ translate( 'Unlock this personal theme' ) }
-				</h1>
+				<h1 className="theme-upgrade-modal__heading">{ translate( 'Unlock this theme' ) }</h1>
 			),
 			text: (
 				<p>
 					{ translate(
-						'Get access to Personal themes, and a ton of other features, with a subscription to the %(plan)s plan. It’s {{strong}}%(planPrice)s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
+						'Get access to %(plan)s themes, and a ton of other features, with a subscription to the %(plan)s plan. It’s {{strong}}%(planPrice)s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
 						{
 							components: {
 								strong: <strong />,
@@ -171,14 +169,12 @@ export const ThemeUpgradeModal = ( {
 
 		return {
 			header: (
-				<h1 className="theme-upgrade-modal__heading">
-					{ translate( 'Unlock this premium theme' ) }
-				</h1>
+				<h1 className="theme-upgrade-modal__heading">{ translate( 'Unlock this theme' ) }</h1>
 			),
 			text: (
 				<p>
 					{ translate(
-						'Get access to our Premium themes, and a ton of other features, with a subscription to the %(premiumPlanName)s plan. It’s {{strong}}%(planPrice)s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
+						'Get access to our %(premiumPlanName)s themes, and a ton of other features, with a subscription to the %(premiumPlanName)s plan. It’s {{strong}}%(planPrice)s{{/strong}} a year, risk-free with a 14-day money-back guarantee.',
 						{
 							components: {
 								strong: <strong />,

--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -1958,7 +1958,17 @@ export const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_PREMIUM_THEMES_V2 ]: {
 		getSlug: () => FEATURE_PREMIUM_THEMES_V2,
-		getTitle: () => i18n.translate( 'Explorer themes' ),
+		getTitle: () => {
+			const localeSlug = i18n.getLocaleSlug();
+			const shouldShowNewString =
+				isEnabled( 'themes/tiers' ) &&
+				( ( localeSlug && config< string >( 'english_locales' ).includes( localeSlug ) ) ||
+					i18n.hasTranslation( 'Explorer themes' ) );
+
+			return shouldShowNewString
+				? i18n.translate( 'Explorer themes' )
+				: i18n.translate( 'Premium themes' );
+		},
 		getIcon: () => <img src={ Theme2Image } alt={ i18n.translate( 'Explorer themes' ) } />,
 		getCompareTitle: () => i18n.translate( 'A collection of premium design templates' ),
 		getDescription: () => i18n.translate( 'Switch between a collection of premium design themes.' ),

--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -541,10 +541,10 @@ export const FEATURES_LIST: FeatureList = {
 
 	[ FEATURE_PERSONAL_THEMES ]: {
 		getSlug: () => FEATURE_PERSONAL_THEMES,
-		getTitle: () => i18n.translate( 'Unlimited personal themes' ),
+		getTitle: () => i18n.translate( 'Unlimited starter themes' ),
 		getDescription: () =>
 			i18n.translate(
-				'Unlimited access to all of our personal themes, including designs specifically tailored for businesses.'
+				'Unlimited access to all of our starter themes, including designs specifically tailored for businesses.'
 			),
 	},
 

--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -1958,8 +1958,8 @@ export const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_PREMIUM_THEMES_V2 ]: {
 		getSlug: () => FEATURE_PREMIUM_THEMES_V2,
-		getTitle: () => i18n.translate( 'Premium themes' ),
-		getIcon: () => <img src={ Theme2Image } alt={ i18n.translate( 'Premium themes' ) } />,
+		getTitle: () => i18n.translate( 'Explorer themes' ),
+		getIcon: () => <img src={ Theme2Image } alt={ i18n.translate( 'Explorer themes' ) } />,
 		getCompareTitle: () => i18n.translate( 'A collection of premium design templates' ),
 		getDescription: () => i18n.translate( 'Switch between a collection of premium design themes.' ),
 	},

--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -1959,11 +1959,8 @@ export const FEATURES_LIST: FeatureList = {
 	[ FEATURE_PREMIUM_THEMES_V2 ]: {
 		getSlug: () => FEATURE_PREMIUM_THEMES_V2,
 		getTitle: () => {
-			const localeSlug = i18n.getLocaleSlug();
 			const shouldShowNewString =
-				isEnabled( 'themes/tiers' ) &&
-				( ( localeSlug && config< string >( 'english_locales' ).includes( localeSlug ) ) ||
-					i18n.hasTranslation( 'Explorer themes' ) );
+				isEnabled( 'themes/tiers' ) && i18n.hasTranslation( 'Explorer themes' );
 
 			return shouldShowNewString
 				? i18n.translate( 'Explorer themes' )


### PR DESCRIPTION
Make some of the theme tier names align with the plans required for them and upgrade modals to match.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86482

## Proposed Changes

Change the tier names for the personal and premium plans in the modal. I've purposefully changed the heading to "Unlock this theme" so that it fits on one line which looks nicer and also to reduce the repetition of Starter/Explorer everywhere.

I also considered making the Explorer themes modal list "Starter themes" in the plan benefits, but thought maybe that's just too confusing and isn't exactly related to the aim of "changing tier names".

## Testing Instructions

### Modals
1. Use the calypso live link
2. Go through to the design picker using a free plan
3. Reload the page after appending flags=themes/tiers to the url
4. Choose a Starter theme like Epi, press "Unlock theme"
5. Choose an Explorer theme like Annalee, press "Unlock theme"

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Theme type | Before | After
----|---|------
Starter | <img width="821" alt="Screenshot 2024-01-17 at 09 26 06" src="https://github.com/Automattic/wp-calypso/assets/93301/cf52659c-6d3e-474a-ad7c-c9135534a6e4">  | <img width="803" alt="Screenshot 2024-01-17 at 11 53 46" src="https://github.com/Automattic/wp-calypso/assets/93301/8e4733c5-7792-43c0-b0c6-dbe79e9a6768">
Explorer | <img width="817" alt="Screenshot 2024-01-17 at 09 32 48" src="https://github.com/Automattic/wp-calypso/assets/93301/84657602-dee5-427b-8173-fb0ec2edfd43">  | <img width="803" alt="Screenshot 2024-01-17 at 11 53 09" src="https://github.com/Automattic/wp-calypso/assets/93301/3ed86301-69dc-4166-a6a4-b1ba8f8635c9">

### Plans grid
1. Use the calypso live link
2. Go to /plans/:siteslug

Before | After
-------|------
<img width="860" alt="Screenshot 2024-01-17 at 12 02 15" src="https://github.com/Automattic/wp-calypso/assets/93301/843ef53e-0185-4ff3-a2ac-c0a6f54714c2"> |<img width="860" alt="Screenshot 2024-01-17 at 12 01 42" src="https://github.com/Automattic/wp-calypso/assets/93301/c3a0898d-f88b-445f-a3b0-413643667753">





## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?