### PR TITLE
ETK: Replace `i18n-calypso` translate calls with `@wordpress/i18n`

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/blogging-prompts-modal/index.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/blogging-prompts-modal/index.js
@@ -3,8 +3,8 @@ import apiFetch from '@wordpress/api-fetch';
 import { createBlock } from '@wordpress/blocks';
 import { Button, Modal } from '@wordpress/components';
 import { dispatch, select } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 import { addQueryArgs, getQueryArg } from '@wordpress/url';
-import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
 import { useEffect, useState } from 'react';
 import { ArrowLeftIcon, ArrowRightIcon } from './icons';
@@ -12,7 +12,6 @@ import { ArrowLeftIcon, ArrowRightIcon } from './icons';
 import './style.scss';
 
 export const BloggingPromptsModalInner = () => {
-	const translate = useTranslate();
 	const [ isOpen, setIsOpen ] = useState( true );
 	const [ prompts, setPrompts ] = useState( [] );
 	const [ promptIndex, setPromptIndex ] = useState( 0 );
@@ -60,7 +59,7 @@ export const BloggingPromptsModalInner = () => {
 		<Modal
 			onRequestClose={ closeModal }
 			className="blogging-prompts-modal"
-			title={ translate( 'Some ideas for writing topics' ) }
+			title={ __( 'Some ideas for writing topics', 'full-site-editing' ) }
 		>
 			<div className="blogging-prompts-modal__prompt">
 				<div className="blogging-prompts-modal__prompt-navigation">
@@ -71,7 +70,7 @@ export const BloggingPromptsModalInner = () => {
 							}
 							return setPromptIndex( promptIndex - 1 );
 						} }
-						aria-label={ translate( 'Show previous prompt' ) }
+						aria-label={ __( 'Show previous prompt', 'full-site-editing' ) }
 						variant="secondary"
 						className="blogging-prompts-modal__prompt-navigation-button"
 					>
@@ -80,7 +79,7 @@ export const BloggingPromptsModalInner = () => {
 					<h2 className="blogging-prompts-modal__prompt-text">{ prompts[ promptIndex ]?.text }</h2>
 					<Button
 						onClick={ () => setPromptIndex( ( promptIndex + 1 ) % prompts.length ) }
-						aria-label={ translate( 'Show next prompt' ) }
+						aria-label={ __( 'Show next prompt', 'full-site-editing' ) }
 						variant="secondary"
 						className="blogging-prompts-modal__prompt-navigation-button"
 					>
@@ -88,7 +87,7 @@ export const BloggingPromptsModalInner = () => {
 					</Button>
 				</div>
 				<Button onClick={ selectPrompt } variant="secondary">
-					{ translate( 'Post Answer' ) }
+					{ __( 'Post Answer', 'full-site-editing' ) }
 				</Button>
 			</div>
 		</Modal>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 721-gh-Automattic/i18n-issues 703-gh-Automattic/i18n-issues

Using `i18n-calypso` in the ETK plugin results in the following problems:

* `translate()` are not being extracted on [translate.wordpress.org](https://translate.wordpress.org/projects/wp-plugins/full-site-editing/).
* Translation data is not being loaded into the `i18n-calypso` instance, and therefore `translate` calls are not being translate.

## Proposed Changes

* Replace `translate()` calls from `i18n-calypso` with `__()` calls from `@wordpress/i18n` in ~~`<LivePreviewModal />` and~~ `<BloggingPromptsModal />` components. 

Edit: `<LivePreviewModal />` has been removed https://github.com/Automattic/wp-calypso/pull/86385.

<details><summary><strike>LivePreviewModal</strike></summary>
<img src="https://github.com/Automattic/wp-calypso/assets/2722412/bef8c2fb-0278-4abe-b23f-17bdd0c0b6c8" />
</details>

![BloggingPromptsModal Screenshot](https://github.com/Automattic/wp-calypso/assets/2722412/93492e49-816f-4ee3-9d2f-8dad87b74d28)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Review changes.
* Install ETK version from this branch on your sandbox with `install-plugin.sh editing-toolkit fix/replace-i18n-calypso-translate-calls`.
* ~~Go to `<SITE>/wp-admin/site-editor.php?wp_theme_preview=pub%2Fpomme`, where `<SITE>` is a simple site.
* Confirm the preview modal is rendered as expected.~~
* ~~Go to `<SITE>/wp-admin/post-new.php?new_prompt=1`, where `<SITE>` is a simple site.~~
* Confirm the blogging prompt modal is rendered as expected.
* Note that translations are still not available and it's likely that the content will still be rendered untranslated.
* _Optional:_ Download the plugin from **Build Calypso Apps**  TeamCity job artifacts and install the plugin on an atomic site.
* Repeat the same testing steps to confirm the modal is rendered as expected on atomic sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
