### PR TITLE
Block user from import subscribers if they haven't verified the email

### DIFF
--- a/client/components/email-verification/email-verification-gate/email-unverified-notice.jsx
+++ b/client/components/email-verification/email-verification-gate/email-unverified-notice.jsx
@@ -138,12 +138,7 @@ class EmailUnverifiedNotice extends Component {
 		);
 
 		return (
-			<Notice
-				text={ noticeText }
-				icon="info"
-				showDismiss={ false }
-				status={ this.props.noticeStatus }
-			>
+			<Notice text={ noticeText } showDismiss={ false } status={ this.props.noticeStatus }>
 				{ this.props.noticeText && (
 					<NoticeAction onClick={ this.handleSendVerificationEmail }>
 						{ this.props.translate( 'Resend Email' ) }

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -1,15 +1,16 @@
 import page from '@automattic/calypso-router';
 import { Button, Gridicon } from '@automattic/components';
-import { HelpCenter } from '@automattic/data-stores';
+import { HelpCenter, Subscriber as SubscriberDataStore } from '@automattic/data-stores';
 import { useIsEnglishLocale, useLocalizeUrl } from '@automattic/i18n-utils';
-import { useDispatch as useDataStoreDispatch } from '@wordpress/data';
+import { useDispatch as useDataStoreDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { translate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { navItems } from 'calypso/blocks/stats-navigation/constants';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryMembershipsSettings from 'calypso/components/data/query-memberships-settings';
+import EmailVerificationGate from 'calypso/components/email-verification/email-verification-gate';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import GiftSubscriptionModal from 'calypso/my-sites/subscribers/components/gift-modal/gift-modal';
@@ -31,11 +32,12 @@ import './style.scss';
 
 type SubscribersHeaderProps = {
 	selectedSiteId: number | undefined;
+	isUnverified: boolean;
 };
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
-const SubscribersHeader = ( { selectedSiteId }: SubscribersHeaderProps ) => {
+const SubscribersHeader = ( { selectedSiteId, isUnverified }: SubscribersHeaderProps ) => {
 	const { setShowAddSubscribersModal } = useSubscribersPage();
 	const localizeUrl = useLocalizeUrl();
 	const { setShowHelpCenter, setShowSupportDoc } = useDataStoreDispatch( HELP_CENTER_STORE );
@@ -87,6 +89,7 @@ const SubscribersHeader = ( { selectedSiteId }: SubscribersHeaderProps ) => {
 			<Button
 				className="add-subscribers-button"
 				primary
+				disabled={ isUnverified }
 				onClick={ () => setShowAddSubscribersModal( true ) }
 			>
 				<Gridicon icon="plus" size={ 24 } />
@@ -132,6 +135,21 @@ const SubscribersPage = ( {
 		sortTerm,
 	};
 
+	const importSelector = useSelect(
+		( select ) => select( SubscriberDataStore.store ).getImportSubscribersSelector(),
+		[]
+	);
+
+	const isUnverified = importSelector?.error?.code === 'unverified_email';
+
+	const { getSubscribersImports } = useDataStoreDispatch( SubscriberDataStore.store );
+
+	useEffect( () => {
+		if ( siteId ) {
+			getSubscribersImports( siteId );
+		}
+	}, [ siteId ] );
+
 	const { currentSubscriber, onClickUnsubscribe, onConfirmModal, resetSubscriber } =
 		useUnsubscribeModal( selectedSite?.ID, pageArgs );
 	const onClickView = ( { subscription_id, user_id }: Subscriber ) => {
@@ -142,7 +160,6 @@ const SubscribersPage = ( {
 		setGiftUserId( user_id );
 		setGiftUsername( display_name );
 	};
-
 	return (
 		<SubscribersPageProvider
 			siteId={ siteId }
@@ -159,32 +176,38 @@ const SubscribersPage = ( {
 			<Main wideLayout className="subscribers">
 				<DocumentHead title={ translate( 'Subscribers' ) } />
 
-				<SubscribersHeader selectedSiteId={ selectedSite?.ID } />
-
-				<SubscriberListContainer
-					siteId={ siteId }
-					onClickView={ onClickView }
-					onGiftSubscription={ onGiftSubscription }
-					onClickUnsubscribe={ onClickUnsubscribe }
-				/>
-
-				<UnsubscribeModal
-					subscriber={ currentSubscriber }
-					onCancel={ resetSubscriber }
-					onConfirm={ onConfirmModal }
-				/>
-
-				{ giftUserId !== 0 && (
-					<GiftSubscriptionModal
-						siteId={ selectedSite?.ID ?? 0 }
-						userId={ giftUserId }
-						username={ giftUsername }
-						onCancel={ () => setGiftUserId( 0 ) }
-						onConfirm={ () => setGiftUserId( 0 ) }
+				<SubscribersHeader selectedSiteId={ selectedSite?.ID } isUnverified={ isUnverified } />
+				{ /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */ }
+				{ /* @ts-ignore */ }
+				<EmailVerificationGate
+					noticeText={ translate( 'You must verify your email to add subscribers.' ) }
+					noticeStatus="is-info"
+				>
+					<SubscriberListContainer
+						siteId={ siteId }
+						onClickView={ onClickView }
+						onGiftSubscription={ onGiftSubscription }
+						onClickUnsubscribe={ onClickUnsubscribe }
 					/>
-				) }
-				{ selectedSite && <AddSubscribersModal site={ selectedSite } /> }
-				{ selectedSite && <MigrateSubscribersModal /> }
+
+					<UnsubscribeModal
+						subscriber={ currentSubscriber }
+						onCancel={ resetSubscriber }
+						onConfirm={ onConfirmModal }
+					/>
+
+					{ giftUserId !== 0 && (
+						<GiftSubscriptionModal
+							siteId={ selectedSite?.ID ?? 0 }
+							userId={ giftUserId }
+							username={ giftUsername }
+							onCancel={ () => setGiftUserId( 0 ) }
+							onConfirm={ () => setGiftUserId( 0 ) }
+						/>
+					) }
+					{ selectedSite && <AddSubscribersModal site={ selectedSite } /> }
+					{ selectedSite && <MigrateSubscribersModal /> }
+				</EmailVerificationGate>
 			</Main>
 		</SubscribersPageProvider>
 	);

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -181,7 +181,7 @@ const SubscribersPage = ( {
 				{ /* @ts-ignore */ }
 				<EmailVerificationGate
 					noticeText={ translate( 'You must verify your email to add subscribers.' ) }
-					noticeStatus="is-info"
+					noticeStatus="is-warning"
 				>
 					<SubscriberListContainer
 						siteId={ siteId }

--- a/packages/data-stores/src/subscriber/actions.ts
+++ b/packages/data-stores/src/subscriber/actions.ts
@@ -132,14 +132,18 @@ export function createActions() {
 	} );
 
 	function* getSubscribersImports( siteId: number, status?: ImportJobStatus ) {
-		const path = `/sites/${ encodeURIComponent( siteId ) }/subscribers/import`;
-		const data: GetSubscribersImportsResponse = yield wpcomRequest( {
-			path: ! status ? path : `${ path }?status=${ encodeURIComponent( status ) }`,
-			method: 'GET',
-			apiNamespace: 'wpcom/v2',
-		} );
+		try {
+			const path = `/sites/${ encodeURIComponent( siteId ) }/subscribers/import`;
+			const data: GetSubscribersImportsResponse = yield wpcomRequest( {
+				path: ! status ? path : `${ path }?status=${ encodeURIComponent( status ) }`,
+				method: 'GET',
+				apiNamespace: 'wpcom/v2',
+			} );
 
-		yield getSubscribersImportsSuccess( siteId, data );
+			yield getSubscribersImportsSuccess( siteId, data );
+		} catch ( error ) {
+			yield importCsvSubscribersStartFailed( siteId, error as ImportSubscribersError );
+		}
 	}
 
 	return {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* See context here: p1705476727748589-slack-C01A60HCGUA
* In this PR, we add the functionality to block users from importing subscribers if the email is unverified.

![Screen Shot 2024-01-17 at 8 15 24 PM](https://github.com/Automattic/wp-calypso/assets/4074459/6be63730-9857-4a02-a614-82fcdb3a9ded)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Register a new user account and don't verify the email address
* Navigate to `http://calypso.localhost:3000/subscribers/SITE_SLUG`
* Make sure the page is gated by email verification and show as the screenshot above.
* Click Resend email and activate the email address.
* Refresh the page and see if you can add subscribers and there's no email verification blocking the page anymore.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?