### PR TITLE
Add custom message for monthly plans with free domain credit:

### DIFF
--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -12,7 +12,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import { DOMAINS_WITH_PLANS_ONLY } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
-import { getSitePlanSlug } from 'calypso/state/sites/plans/selectors';
+import { getSitePlanSlug, hasDomainCredit } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -283,6 +283,7 @@ export default connect( ( state ) => {
 			: true,
 		isCurrentPlan100YearPlan: sitePlanSlug === PLAN_100_YEARS,
 		isBusinessOrEcommerceMonthlyPlan:
-			sitePlanSlug === PLAN_BUSINESS_MONTHLY || sitePlanSlug === PLAN_ECOMMERCE_MONTHLY,
+			( sitePlanSlug === PLAN_BUSINESS_MONTHLY || sitePlanSlug === PLAN_ECOMMERCE_MONTHLY ) &&
+			hasDomainCredit( state, getSelectedSiteId( state ) ),
 	};
 } )( localize( DomainProductPrice ) );

--- a/client/components/domains/domain-product-price/index.jsx
+++ b/client/components/domains/domain-product-price/index.jsx
@@ -1,4 +1,10 @@
-import { PLAN_100_YEARS, PLAN_PERSONAL, getPlan } from '@automattic/calypso-products';
+import {
+	PLAN_100_YEARS,
+	PLAN_PERSONAL,
+	PLAN_BUSINESS_MONTHLY,
+	PLAN_ECOMMERCE_MONTHLY,
+	getPlan,
+} from '@automattic/calypso-products';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -22,6 +28,7 @@ class DomainProductPrice extends Component {
 		isMappingProduct: PropTypes.bool,
 		salePrice: PropTypes.string,
 		isCurrentPlan100YearPlan: PropTypes.bool,
+		isBusinessOrEcommerceMonthlyPlan: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -82,7 +89,12 @@ class DomainProductPrice extends Component {
 	}
 
 	renderReskinFreeWithPlanText() {
-		const { isMappingProduct, translate, isCurrentPlan100YearPlan } = this.props;
+		const {
+			isMappingProduct,
+			translate,
+			isCurrentPlan100YearPlan,
+			isBusinessOrEcommerceMonthlyPlan,
+		} = this.props;
 
 		const domainPriceElement = ( message ) => (
 			<div className="domain-product-price__free-text">{ message }</div>
@@ -94,6 +106,16 @@ class DomainProductPrice extends Component {
 
 		if ( isCurrentPlan100YearPlan ) {
 			return domainPriceElement( translate( 'Free with your plan' ) );
+		}
+
+		if ( isBusinessOrEcommerceMonthlyPlan ) {
+			return domainPriceElement(
+				<>
+					<span className="domain-product-price__free-price">
+						{ translate( 'Free domain for one year' ) }
+					</span>
+				</>
+			);
 		}
 
 		const message = translate( '{{span}}Free for the first year with annual paid plans{{/span}}', {
@@ -252,9 +274,15 @@ class DomainProductPrice extends Component {
 	}
 }
 
-export default connect( ( state ) => ( {
-	domainsWithPlansOnly: getCurrentUser( state )
-		? currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY )
-		: true,
-	isCurrentPlan100YearPlan: getSitePlanSlug( state, getSelectedSiteId( state ) ) === PLAN_100_YEARS,
-} ) )( localize( DomainProductPrice ) );
+export default connect( ( state ) => {
+	const sitePlanSlug = getSitePlanSlug( state, getSelectedSiteId( state ) );
+
+	return {
+		domainsWithPlansOnly: getCurrentUser( state )
+			? currentUserHasFlag( state, DOMAINS_WITH_PLANS_ONLY )
+			: true,
+		isCurrentPlan100YearPlan: sitePlanSlug === PLAN_100_YEARS,
+		isBusinessOrEcommerceMonthlyPlan:
+			sitePlanSlug === PLAN_BUSINESS_MONTHLY || sitePlanSlug === PLAN_ECOMMERCE_MONTHLY,
+	};
+} )( localize( DomainProductPrice ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
This is from 
pdgrnI-2EP-p2

## Proposed Changes
Show a custom message on the domain suggestions page prices for monthly plans with fee domain credit.
*
## Testing Instructions
- Sandbox public-api.wordpress.com
While on the live testing site,
Follow the testing instructions here D132949-code
In the instructions, when you go to the domain search page, verify that the preceding text for each domain price is
**"Free domain for one year"**

<img width="1074" alt="Screenshot 2024-01-17 at 16 50 57" src="https://github.com/Automattic/wp-calypso/assets/11347472/2d7b31af-6f07-479a-9905-509366c6026d">


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?