### PR TITLE
Upsell Nudge: migrate to TS

### DIFF
--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -34,22 +34,6 @@ import './style.scss';
 
 const debug = debugFactory( 'calypso:upsell-nudge' );
 
-function shouldShowOneClickCheckout( {
-	isOneClickCheckoutEnabled,
-	isEligibleForOneClickCheckout,
-	plan,
-	siteSlug,
-	canUserUpgrade,
-} ) {
-	return (
-		isOneClickCheckoutEnabled &&
-		isEligibleForOneClickCheckout?.result === true &&
-		plan &&
-		siteSlug &&
-		canUserUpgrade
-	);
-}
-
 /**
  * @param {any} props Props declared as `any` to prevent errors in TSX files that use this component.
  */
@@ -156,13 +140,11 @@ export const UpsellNudge = ( {
 
 	const handleClick = ( e ) => {
 		if (
-			shouldShowOneClickCheckout( {
-				isOneClickCheckoutEnabled,
-				isEligibleForOneClickCheckout,
-				plan,
-				siteSlug,
-				canUserUpgrade,
-			} )
+			isOneClickCheckoutEnabled &&
+			isEligibleForOneClickCheckout?.result === true &&
+			plan &&
+			siteSlug &&
+			canUserUpgrade
 		) {
 			e.preventDefault();
 			setShowPurchaseModal( true );
@@ -251,7 +233,7 @@ const ConnectedUpsellNudge = connect( ( state, ownProps ) => {
 } )( UpsellNudge );
 
 export default function Wrapper( props ) {
-	if ( shouldShowOneClickCheckout( props ) ) {
+	if ( props.isOneClickCheckoutEnabled ) {
 		return (
 			<AsyncLoad
 				require="../../my-sites/checkout/purchase-modal/is-eligible-for-one-click-checkout-wrapper"

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -34,6 +34,22 @@ import './style.scss';
 
 const debug = debugFactory( 'calypso:upsell-nudge' );
 
+function shouldShowOneClickCheckout( {
+	isOneClickCheckoutEnabled,
+	isEligibleForOneClickCheckout,
+	plan,
+	siteSlug,
+	canUserUpgrade,
+} ) {
+	return (
+		isOneClickCheckoutEnabled &&
+		isEligibleForOneClickCheckout?.result === true &&
+		plan &&
+		siteSlug &&
+		canUserUpgrade
+	);
+}
+
 /**
  * @param {any} props Props declared as `any` to prevent errors in TSX files that use this component.
  */
@@ -140,11 +156,13 @@ export const UpsellNudge = ( {
 
 	const handleClick = ( e ) => {
 		if (
-			isOneClickCheckoutEnabled &&
-			isEligibleForOneClickCheckout?.result === true &&
-			plan &&
-			siteSlug &&
-			canUserUpgrade
+			shouldShowOneClickCheckout( {
+				isOneClickCheckoutEnabled,
+				isEligibleForOneClickCheckout,
+				plan,
+				siteSlug,
+				canUserUpgrade,
+			} )
 		) {
 			e.preventDefault();
 			setShowPurchaseModal( true );
@@ -233,7 +251,7 @@ const ConnectedUpsellNudge = connect( ( state, ownProps ) => {
 } )( UpsellNudge );
 
 export default function Wrapper( props ) {
-	if ( props.isOneClickCheckoutEnabled ) {
+	if ( shouldShowOneClickCheckout( props ) ) {
 		return (
 			<AsyncLoad
 				require="../../my-sites/checkout/purchase-modal/is-eligible-for-one-click-checkout-wrapper"

--- a/client/blocks/upsell-nudge/index.jsx
+++ b/client/blocks/upsell-nudge/index.jsx
@@ -91,7 +91,6 @@ export const UpsellNudge = ( {
 	isOneClickCheckoutEnabled = false,
 } ) => {
 	const [ showPurchaseModal, setShowPurchaseModal ] = useState( false );
-
 	const shouldNotDisplay =
 		isVip ||
 		! canManageSite ||

--- a/client/blocks/upsell-nudge/index.tsx
+++ b/client/blocks/upsell-nudge/index.tsx
@@ -10,6 +10,7 @@ import {
 	WPCOM_FEATURES_NO_ADVERTS,
 	isFreePlanProduct,
 } from '@automattic/calypso-products';
+import { SiteDetails } from '@automattic/data-stores';
 import classnames from 'classnames';
 import debugFactory from 'debug';
 import { useState } from 'react';
@@ -29,10 +30,68 @@ import {
 } from 'calypso/state/sites/plans/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import type { IsEligibleForOneClickCheckoutReturnValue } from 'calypso/my-sites/checkout/purchase-modal/use-is-eligible-for-one-click-checkout';
+import type { IAppState } from 'calypso/state/types';
+import type { SiteSlug } from 'calypso/types';
+import type { TranslateResult } from 'i18n-calypso';
 
 import './style.scss';
 
 const debug = debugFactory( 'calypso:upsell-nudge' );
+
+type Props = Partial< {
+	callToAction: TranslateResult;
+	secondaryCallToAction: TranslateResult;
+	canManageSite: boolean;
+	canUserUpgrade: boolean;
+	className?: string;
+	compact: boolean;
+	compactButton: boolean;
+	customerType: string;
+	description: TranslateResult;
+	disableHref: boolean;
+	dismissPreferenceName: string;
+	dismissTemporary: boolean;
+	event: string;
+	secondaryEvent: string;
+	feature: string;
+	forceDisplay: boolean;
+	forceHref: boolean;
+	horizontal: boolean;
+	href: string;
+	secondaryHref: string;
+	isJetpackDevDocs: boolean;
+	isJetpack: boolean;
+	isAtomic: boolean;
+	isVip: boolean;
+	siteIsWPForTeams: boolean;
+	list: TranslateResult[] | unknown[];
+	renderListItem: ( arg: any ) => void;
+	onClick: () => void;
+	secondaryOnClick: () => void;
+	onDismissClick: () => void;
+	plan: string;
+	price: number[];
+	primaryButton: boolean;
+	selectedSiteHasFeature: boolean;
+	showIcon: boolean;
+	icon: string;
+	site: SiteDetails | null | undefined;
+	siteSlug: SiteSlug | null;
+	target: string;
+	title: TranslateResult;
+	tracksClickName: string;
+	tracksClickProperties: Record< string, unknown >;
+	tracksDismissName: string;
+	tracksDismissProperties: Record< string, unknown >;
+	tracksImpressionName: string;
+	tracksImpressionProperties: Record< string, unknown >;
+	displayAsLink: boolean;
+	isSiteWooExpressOrEcomFreeTrial: boolean;
+	isBusy: boolean;
+	isEligibleForOneClickCheckout: IsEligibleForOneClickCheckoutReturnValue;
+	isOneClickCheckoutEnabled: boolean;
+} >;
 
 /**
  * @param {any} props Props declared as `any` to prevent errors in TSX files that use this component.
@@ -44,7 +103,7 @@ export const UpsellNudge = ( {
 	canUserUpgrade,
 	className,
 	compact,
-	compactButton,
+	compactButton = true,
 	customerType,
 	description,
 	disableHref,
@@ -70,7 +129,7 @@ export const UpsellNudge = ( {
 	onDismissClick,
 	plan,
 	price,
-	primaryButton,
+	primaryButton = true,
 	selectedSiteHasFeature,
 	showIcon = false,
 	icon = 'star',
@@ -88,8 +147,8 @@ export const UpsellNudge = ( {
 	isSiteWooExpressOrEcomFreeTrial,
 	isBusy,
 	isEligibleForOneClickCheckout,
-	isOneClickCheckoutEnabled = false,
-} ) => {
+	isOneClickCheckoutEnabled,
+}: Props ) => {
 	const [ showPurchaseModal, setShowPurchaseModal ] = useState( false );
 	const shouldNotDisplay =
 		isVip ||
@@ -98,8 +157,8 @@ export const UpsellNudge = ( {
 		typeof site !== 'object' ||
 		typeof site.jetpack !== 'boolean' ||
 		( feature && selectedSiteHasFeature ) ||
-		( ! feature && ! isFreePlanProduct( site.plan ) ) ||
-		( feature === WPCOM_FEATURES_NO_ADVERTS && site.options.wordads ) ||
+		( ! feature && ! ( site.plan && isFreePlanProduct( site.plan ) ) ) ||
+		( feature === WPCOM_FEATURES_NO_ADVERTS && site?.options?.wordads ) ||
 		( ! isJetpack && site.jetpack ) ||
 		( isJetpack && ! site.jetpack );
 
@@ -138,7 +197,7 @@ export const UpsellNudge = ( {
 		);
 	}
 
-	const handleClick = ( e ) => {
+	const handleClick = ( e: MouseEvent ) => {
 		if (
 			isOneClickCheckoutEnabled &&
 			isEligibleForOneClickCheckout?.result === true &&
@@ -208,31 +267,27 @@ export const UpsellNudge = ( {
 	);
 };
 
-UpsellNudge.defaultProps = {
-	primaryButton: true,
-	compactButton: true,
-};
-
-const ConnectedUpsellNudge = connect( ( state, ownProps ) => {
+const ConnectedUpsellNudge = connect( ( state: IAppState, ownProps: Props ) => {
 	const siteId = getSelectedSiteId( state );
 
 	return {
-		site: getSite( state, siteId ),
-		selectedSiteHasFeature: siteHasFeature( state, siteId, ownProps.feature ),
+		site: getSite( state, siteId || undefined ),
+		selectedSiteHasFeature: siteHasFeature( state, siteId, ownProps.feature || '' ) || false,
 		canManageSite: canCurrentUser( state, siteId, 'manage_options' ),
-		isJetpack: isJetpackSite( state, siteId ),
-		isAtomic: isSiteAutomatedTransfer( state, siteId ),
-		isVip: isVipSite( state, siteId ),
-		isSiteWooExpressOrEcomFreeTrial:
-			isSiteOnECommerceTrial( state, siteId ) || isSiteOnWooExpress( state, siteId ),
+		isJetpack: isJetpackSite( state, siteId ) || false,
+		isAtomic: isSiteAutomatedTransfer( state, siteId ) || false,
+		isVip: ( siteId && isVipSite( state, siteId ) ) || false,
+		isSiteWooExpressOrEcomFreeTrial: siteId
+			? isSiteOnECommerceTrial( state, siteId ) || isSiteOnWooExpress( state, siteId )
+			: false,
 		currentPlan: getCurrentPlan( state, siteId ),
 		siteSlug: ownProps.disableHref ? null : getSelectedSiteSlug( state ),
 		canUserUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
-		siteIsWPForTeams: isSiteWPForTeams( state, getSelectedSiteId( state ) ),
+		siteIsWPForTeams: isSiteWPForTeams( state, getSelectedSiteId( state ) ) || false,
 	};
 } )( UpsellNudge );
 
-export default function Wrapper( props ) {
+export default function Wrapper( props: Props ) {
 	if ( props.isOneClickCheckoutEnabled ) {
 		return (
 			<AsyncLoad

--- a/client/blocks/upsell-nudge/index.tsx
+++ b/client/blocks/upsell-nudge/index.tsx
@@ -10,7 +10,6 @@ import {
 	WPCOM_FEATURES_NO_ADVERTS,
 	isFreePlanProduct,
 } from '@automattic/calypso-products';
-import { SiteDetails } from '@automattic/data-stores';
 import classnames from 'classnames';
 import debugFactory from 'debug';
 import { useState } from 'react';
@@ -30,6 +29,7 @@ import {
 } from 'calypso/state/sites/plans/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import type { SiteDetails } from '@automattic/data-stores';
 import type { IsEligibleForOneClickCheckoutReturnValue } from 'calypso/my-sites/checkout/purchase-modal/use-is-eligible-for-one-click-checkout';
 import type { IAppState } from 'calypso/state/types';
 import type { SiteSlug } from 'calypso/types';

--- a/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
+++ b/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
@@ -59,9 +59,7 @@ export function HostingUpsellNudge( { siteId, targetPlan }: HostingUpsellNudgePr
 	const title = targetPlan ? targetPlan.title : titleText;
 	const isEligibleForTrial = useSelector( isUserEligibleForFreeHostingTrial );
 	const secondaryCallToAction =
-		config.isEnabled( 'hosting-trial' ) && isEligibleForTrial
-			? translate( 'Start for free' )
-			: null;
+		config.isEnabled( 'hosting-trial' ) && isEligibleForTrial ? translate( 'Start for free' ) : '';
 	const { mutateAsync: addHostingTrial } = useAddHostingTrialMutation();
 
 	const secondaryOnClick = async () => {
@@ -81,7 +79,7 @@ export function HostingUpsellNudge( { siteId, targetPlan }: HostingUpsellNudgePr
 			callToAction={ callToAction }
 			secondaryCallToAction={ secondaryCallToAction }
 			secondaryOnClick={ secondaryOnClick }
-			plan={ plan }
+			plan={ plan as string }
 			feature={ feature }
 			showIcon={ true }
 			list={ features }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* This PR migrates the `<UpsellNudge/>` component to Typescript.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Since there are no functional changes, following the testing instructions from https://github.com/Automattic/wp-calypso/pull/85633 should be enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?