### PR TITLE
Marketplace Reviews: Allow empty content in reviews

### DIFF
--- a/client/data/marketplace/use-marketplace-reviews.ts
+++ b/client/data/marketplace/use-marketplace-reviews.ts
@@ -9,6 +9,8 @@ import {
 import wpcom from 'calypso/lib/wp';
 import { BASE_STALE_TIME } from 'calypso/state/constants';
 
+export const EMPTY_PLACEHOLDER = '&nbsp;';
+
 const apiBase = '/sites/marketplace.wordpress.com';
 const reviewsApiBase = `${ apiBase }/comments`;
 const reviewsApiNamespace = 'wp/v2';
@@ -173,7 +175,7 @@ const createReview = ( {
 		{
 			product_type: productType,
 			product_slug: slug,
-			content,
+			content: content || EMPTY_PLACEHOLDER,
 			meta: { wpcom_marketplace_rating: rating },
 		}
 	);
@@ -194,7 +196,7 @@ const updateReview = ( {
 		{
 			product_type: productType,
 			product_slug: slug,
-			content,
+			content: content || EMPTY_PLACEHOLDER,
 			meta: { wpcom_marketplace_rating: rating },
 		}
 	);

--- a/client/my-sites/marketplace/components/review-item/index.tsx
+++ b/client/my-sites/marketplace/components/review-item/index.tsx
@@ -14,6 +14,7 @@ import {
 	MarketplaceReviewsQueryProps,
 	useDeleteMarketplaceReviewMutation,
 	useUpdateMarketplaceReviewMutation,
+	EMPTY_PLACEHOLDER,
 } from 'calypso/data/marketplace/use-marketplace-reviews';
 import { getAvatarURL } from 'calypso/data/marketplace/utils';
 import { sanitizeSectionContent } from 'calypso/lib/plugins/sanitize-section-content';
@@ -38,7 +39,7 @@ export const MarketplaceReviewItem = ( props: MarketplaceReviewItemProps ) => {
 
 	const setEditing = ( review: MarketplaceReviewResponse ) => {
 		setIsEditing( true );
-		setEditorContent( review.content.raw );
+		setEditorContent( review.content.raw.replace( new RegExp( `^${ EMPTY_PLACEHOLDER }$` ), '' ) );
 		setEditorRating( review.meta.wpcom_marketplace_rating );
 	};
 

--- a/client/my-sites/marketplace/components/review-item/index.tsx
+++ b/client/my-sites/marketplace/components/review-item/index.tsx
@@ -37,9 +37,11 @@ export const MarketplaceReviewItem = ( props: MarketplaceReviewItemProps ) => {
 	const [ editorContent, setEditorContent ] = useState< string >( '' );
 	const [ editorRating, setEditorRating ] = useState< number >( 0 );
 
+	const isEmptyContent = review.content.raw === EMPTY_PLACEHOLDER;
+
 	const setEditing = ( review: MarketplaceReviewResponse ) => {
 		setIsEditing( true );
-		setEditorContent( review.content.raw.replace( new RegExp( `^${ EMPTY_PLACEHOLDER }$` ), '' ) );
+		setEditorContent( isEmptyContent ? '' : review.content.raw );
 		setEditorRating( review.meta.wpcom_marketplace_rating );
 	};
 
@@ -88,6 +90,23 @@ export const MarketplaceReviewItem = ( props: MarketplaceReviewItemProps ) => {
 			}
 		);
 		clearEditing();
+	};
+
+	const maybeRenderContent = () => {
+		if ( isEmptyContent ) {
+			return null;
+		}
+
+		return (
+			<div
+				// sanitized with sanitizeSectionContent
+				// eslint-disable-next-line react/no-danger
+				dangerouslySetInnerHTML={ {
+					__html: sanitizeSectionContent( review.content.rendered ),
+				} }
+				className="marketplace-review-item__content"
+			></div>
+		);
 	};
 
 	return (
@@ -153,14 +172,7 @@ export const MarketplaceReviewItem = ( props: MarketplaceReviewItemProps ) => {
 					/>
 				</>
 			) : (
-				<div
-					// sanitized with sanitizeSectionContent
-					// eslint-disable-next-line react/no-danger
-					dangerouslySetInnerHTML={ {
-						__html: sanitizeSectionContent( review.content.rendered ),
-					} }
-					className="marketplace-review-item__content"
-				></div>
+				maybeRenderContent()
 			) }
 			<div className="marketplace-review-item__review-actions">
 				{ isEditing && review.author === currentUserId && (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Solves #https://github.com/Automattic/dotcom-forge/issues/5028


## Proposed Changes

* Allow empty content to be sent in a review
* Send `&nbsp;` when the content is empty to avoid the restrictions of the comments API that requires some content
* Replace `&nbsp;` when editing a comment

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Using an environment with the following flags enabled: `marketplace-add-review,marketplace-reviews-show`
* Go to a plugin and add an empty review
* Edit the added review, save it, edit it again and delete the content.
* In both cases, make sure the review can be saved successfully.
* Ensure the display of the review without content is fine.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?