### PR TITLE
Domains Mini Cart: Use user currency as a fallback in the cart total

### DIFF
--- a/client/signup/steps/domains/domains-mini-cart.jsx
+++ b/client/signup/steps/domains/domains-mini-cart.jsx
@@ -59,7 +59,7 @@ export function BoldTLD( { domain } ) {
 	);
 }
 
-class DomainsMiniCart extends Component {
+export class DomainsMiniCart extends Component {
 	domainNameAndCost = ( domain ) => {
 		const isRemoving = this.props.domainRemovalQueue.some( ( item ) => item.meta === domain.meta );
 		const formattedOriginalCost = domain.temporary

--- a/client/signup/steps/domains/domains-mini-cart.jsx
+++ b/client/signup/steps/domains/domains-mini-cart.jsx
@@ -4,7 +4,9 @@ import { isMobile } from '@automattic/viewport';
 import { Icon, chevronDown, chevronUp } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
 import { Component } from 'react';
+import { connect } from 'react-redux';
 import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
+import { getCurrentUserCurrencyCode } from 'calypso/state/currency-code/selectors';
 import { shouldUseMultipleDomainsInCart } from './utils';
 
 // Referenced from WordAds_Ads_Txt
@@ -149,6 +151,7 @@ class DomainsMiniCart extends Component {
 	};
 
 	mobile = () => {
+		const userCurrency = this.props.userCurrency ?? 'USD';
 		const MobileHeader = (
 			<div className="domains__domain-cart-title">
 				<div className="domains__domain-cart-total">
@@ -161,7 +164,7 @@ class DomainsMiniCart extends Component {
 					<div key="rowtotalprice" className="domains__domain-cart-total-price">
 						{ formatCurrency(
 							this.props.domainsInCart.reduce( ( total, item ) => total + item.cost, 0 ),
-							this.props.domainsInCart.length ? this.props.domainsInCart[ 0 ].currency : 'USD'
+							this.props.domainsInCart?.[ 0 ]?.currency ?? userCurrency
 						) }
 					</div>
 				</div>
@@ -221,6 +224,8 @@ class DomainsMiniCart extends Component {
 			return this.mobile();
 		}
 
+		const userCurrency = this.props.userCurrency ?? 'USD';
+
 		return (
 			<div className="domains__domain-side-content domains__domain-cart">
 				<div className="domains__domain-cart-title">{ translate( 'Your domains' ) }</div>
@@ -245,7 +250,7 @@ class DomainsMiniCart extends Component {
 								? '...'
 								: formatCurrency(
 										this.props.domainsInCart.reduce( ( total, item ) => total + item.cost, 0 ),
-										this.props.domainsInCart.length ? this.props.domainsInCart[ 0 ].currency : 'USD'
+										this.props.domainsInCart?.[ 0 ]?.currency ?? userCurrency
 								  ) }
 						</strong>
 					</div>
@@ -274,4 +279,6 @@ class DomainsMiniCart extends Component {
 	}
 }
 
-export default DomainsMiniCart;
+export default connect( ( state ) => ( {
+	userCurrency: getCurrentUserCurrencyCode( state ),
+} ) )( DomainsMiniCart );

--- a/client/signup/steps/domains/test/domains-mini-cart.test.js
+++ b/client/signup/steps/domains/test/domains-mini-cart.test.js
@@ -3,7 +3,7 @@
  */
 import { render, fireEvent } from '@testing-library/react';
 import React from 'react';
-import DomainsMiniCart from '../domains-mini-cart';
+import { DomainsMiniCart } from '../domains-mini-cart';
 
 describe( 'DomainsMiniCart', () => {
 	it( 'renders the correct number of domains in the cart with free wpcom subdomain', () => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 717-gh-Automattic/i18n-issues

## Proposed Changes

* Use the user currency from the state a fallback for empty domains cart instead of hardcoded `USD`.

**Before:**
![CleanShot 2024-01-17 at 17 18 42](https://github.com/Automattic/wp-calypso/assets/2722412/fc0812bf-ed1a-4a01-9495-f7b1e4148db2)

**After:**
![CleanShot 2024-01-17 at 17 19 14](https://github.com/Automattic/wp-calypso/assets/2722412/0e0853eb-b623-4f97-a79d-ea6e62192276)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/start/domains` using an account that has currency other than USD.
* Search for a domain name and select the free **<domain>.wordpress.com** option.
* Verify that the total amount in the sidebar is rendered with the user's currency.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
