### PR TITLE
Big Sky: Fixes to make assembler use the assembler theme with V2 patterns

### DIFF
--- a/client/landing/stepper/declarative-flow/ai-assembler.ts
+++ b/client/landing/stepper/declarative-flow/ai-assembler.ts
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import { Onboard, updateLaunchpadSettings } from '@automattic/data-stores';
-import { DEFAULT_ASSEMBLER_DESIGN, isAssemblerSupported } from '@automattic/design-picker';
+import { isAssemblerSupported, getAssemblerDesign } from '@automattic/design-picker';
 import { useLocale } from '@automattic/i18n-utils';
 import { AI_ASSEMBLER_FLOW } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -35,7 +35,7 @@ const withAIAssemblerFlow: Flow = {
 			[]
 		);
 		const { setSelectedDesign, setIntent } = useDispatch( ONBOARD_STORE );
-		const selectedTheme = DEFAULT_ASSEMBLER_DESIGN.slug;
+		const selectedTheme = getAssemblerDesign().slug;
 		const theme = useSelector( ( state ) => getTheme( state, 'wpcom', selectedTheme ) );
 
 		// We have to query theme for the Jetpack site.


### PR DESCRIPTION
This will make AI Assembler use assembler theme when using V2 patterns.

![Zrzut ekranu 2024-01-17 o 16 53 16](https://github.com/Automattic/wp-calypso/assets/3775068/a6cb438d-52c7-4934-a4b1-86ceeba74d3d)


## Testing Instructions



1. Load http://calypso.localhost:3000/setup/ai-assembler/?flags=pattern-assembler%2Fv2
2. Observe Assembler theme loading
3. Observe in the console:

```
The assembler theme is loading...
```