### PR TITLE
E2E: Update `CookieBannerComponent.acceptCookie()`

### DIFF
--- a/packages/calypso-e2e/src/lib/components/cookie-banner-component.ts
+++ b/packages/calypso-e2e/src/lib/components/cookie-banner-component.ts
@@ -2,7 +2,7 @@ import { Page } from 'playwright';
 import { EditorComponent } from './editor-component';
 
 const selectors = {
-	acceptCookie: '.a8c-cookie-banner__ok-button',
+	acceptCookie: '.a8c-cookie-banner__ok-button, .a8c-cookie-banner__accept-all-button',
 };
 
 /**
@@ -32,6 +32,11 @@ export class CookieBannerComponent {
 
 		// Whether the cookie banner appears is not deterministic.
 		// If it is not present, exit early.
+		try {
+			await locator.waitFor( { timeout: 100 } );
+		} catch ( e ) {
+			// Probably doesn't exist. That's ok.
+		}
 		if ( ( await locator.count() ) === 0 ) {
 			return;
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Two things seem to be needed here:

1. The cookie banner's "accept" button may have a different class, depending on whether it's v1 or v2 of the banner.
2. It seems there's a slight delay before it shows up, so account for that.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try running `yarn workspace wp-e2e-tests build && JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/editor/editor__post-basic-flow.ts` on trunk. If it fails due to the cookie banner being in the way, good. If not, try this:
  * Run with `debug` instead of `test`. Don't hit the :play_or_pause_button: right away.
  * Go to wordpress.com.
  * Open the developer console.
  * Go to Application (probably under the >> button at the top).
  * Find the section for Storage → Cookies. Select `https://wordpress.com`.
  * Find the `country_code` cookie and change its value to "DE".
  * Now you can hit :play_or_pause_button:.
* Check out this PR, and do again what you did above. You should be able to see the cookie banner for about 0.1s before it gets dismissed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?