### PR TITLE
Marketplace Reviews: Render the review-actions div only when needed

### DIFF
--- a/client/my-sites/marketplace/components/review-item/index.tsx
+++ b/client/my-sites/marketplace/components/review-item/index.tsx
@@ -161,62 +161,64 @@ export const MarketplaceReviewItem = ( props: MarketplaceReviewItemProps ) => {
 					className="marketplace-review-item__content"
 				></div>
 			) }
-			<div className="marketplace-review-item__review-actions">
-				{ isEditing && review.author === currentUserId && (
-					<>
-						<div>
-							{ isEnabled( 'marketplace-reviews-notification' ) && (
-								<CheckboxControl
-									className="marketplace-review-item__checkbox"
-									label={ translate( 'Notify me when my review is approved and published.' ) }
-									checked={ false }
-									onChange={ () => alert( 'Not implemented yet' ) }
-								/>
-							) }
-						</div>
+			{ review.author === currentUserId && (
+				<div className="marketplace-review-item__review-actions">
+					{ isEditing && (
+						<>
+							<div>
+								{ isEnabled( 'marketplace-reviews-notification' ) && (
+									<CheckboxControl
+										className="marketplace-review-item__checkbox"
+										label={ translate( 'Notify me when my review is approved and published.' ) }
+										checked={ false }
+										onChange={ () => alert( 'Not implemented yet' ) }
+									/>
+								) }
+							</div>
+							<div className="marketplace-review-item__review-actions-editable">
+								<Button className="is-link" onClick={ clearEditing }>
+									{ translate( 'Cancel' ) }
+								</Button>
+								<Button
+									className="marketplace-review-item__review-submit"
+									primary
+									onClick={ () => updateReview( review.id ) }
+								>
+									{ translate( 'Save my review' ) }
+								</Button>
+							</div>
+						</>
+					) }
+					{ ! isEditing && (
 						<div className="marketplace-review-item__review-actions-editable">
-							<Button className="is-link" onClick={ clearEditing }>
-								{ translate( 'Cancel' ) }
-							</Button>
-							<Button
-								className="marketplace-review-item__review-submit"
-								primary
-								onClick={ () => updateReview( review.id ) }
+							<button
+								className="marketplace-review-item__review-actions-editable-button"
+								onClick={ () => setEditing( review ) }
 							>
-								{ translate( 'Save my review' ) }
-							</Button>
+								<Gridicon icon="pencil" size={ 18 } />
+								{ translate( 'Edit my review' ) }
+							</button>
+							<button
+								className="marketplace-review-item__review-actions-editable-button"
+								onClick={ () => setIsConfirmModalVisible( true ) }
+							>
+								<Gridicon icon="trash" size={ 18 } />
+								{ translate( 'Delete my review' ) }
+							</button>
+							<div className="marketplace-review-item__review-actions-editable-confirm-modal">
+								<ConfirmModal
+									isVisible={ isConfirmModalVisible }
+									confirmButtonLabel={ translate( 'Yes' ) }
+									text={ translate( 'Do you really want to delete your review?' ) }
+									title={ translate( 'Delete my review' ) }
+									onCancel={ () => setIsConfirmModalVisible( false ) }
+									onConfirm={ () => deleteReview( review.id ) }
+								/>
+							</div>
 						</div>
-					</>
-				) }
-				{ ! isEditing && review.author === currentUserId && (
-					<div className="marketplace-review-item__review-actions-editable">
-						<button
-							className="marketplace-review-item__review-actions-editable-button"
-							onClick={ () => setEditing( review ) }
-						>
-							<Gridicon icon="pencil" size={ 18 } />
-							{ translate( 'Edit my review' ) }
-						</button>
-						<button
-							className="marketplace-review-item__review-actions-editable-button"
-							onClick={ () => setIsConfirmModalVisible( true ) }
-						>
-							<Gridicon icon="trash" size={ 18 } />
-							{ translate( 'Delete my review' ) }
-						</button>
-						<div className="marketplace-review-item__review-actions-editable-confirm-modal">
-							<ConfirmModal
-								isVisible={ isConfirmModalVisible }
-								confirmButtonLabel={ translate( 'Yes' ) }
-								text={ translate( 'Do you really want to delete your review?' ) }
-								title={ translate( 'Delete my review' ) }
-								onCancel={ () => setIsConfirmModalVisible( false ) }
-								onConfirm={ () => deleteReview( review.id ) }
-							/>
-						</div>
-					</div>
-				) }
-			</div>
+					) }
+				</div>
+			) }
 		</div>
 	);
 };


### PR DESCRIPTION
## Proposed Changes


Avoid rendering the actions div when not needed.
This div will be empty when this is not the user review, thus will not be rendered anymore.

## Testing Instructions

* go to a plugin where there are reviews from others. Ex: `/plugins/woocommerce-subscriptions`
* Click on the reviews number to open the reviews modal
* Check the DOM to guarantee the actions div is not rendered on this page.
* The list should look like the ones below:

| Before  | After |
| ------------- | ------------- |
|![CleanShot 2024-01-17 at 13 36 41@2x](https://github.com/Automattic/wp-calypso/assets/5039531/f4d35ee9-07ef-4047-9341-4ca474e8c114)|![CleanShot 2024-01-17 at 13 36 11@2x](https://github.com/Automattic/wp-calypso/assets/5039531/d46429a4-44ab-4eee-8762-f959bb9417a4)|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?