### PR TITLE
Big Sky: Add image transformer to the preview block

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-ai-assembler.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-ai-assembler.ts
@@ -60,6 +60,10 @@ export default function useAIAssembler(): [ Function, Function, string, boolean 
 							currentSearchParams.set( 'custom_pages', JSON.stringify( pageTitles ) );
 						}
 
+						if ( response.images ) {
+							currentSearchParams.set( 'images', response.images.join( ',' ) );
+						}
+
 						if ( response.style ) {
 							currentSearchParams.set( 'color_variation_title', response.style );
 						}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/html-transformers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/html-transformers/index.tsx
@@ -1,2 +1,3 @@
 export { default as injectTitlesToPageListBlock } from './inject-titles-to-page-list-block';
 export { default as prependTitleBlockToPagePattern } from './prepend-title-block-to-page-pattern';
+export { default as injectImages } from './inject-images';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/html-transformers/inject-images.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/html-transformers/inject-images.ts
@@ -1,0 +1,10 @@
+export default function injectImages( patternHtml: string, imageURLs: string[] ) {
+	return patternHtml.replace(
+		/<img src="(?<url>http[^"]+)"(?<params>.*?)>/g,
+		( match, url, params ) => {
+			const randomIndex = Math.floor( Math.random() * imageURLs.length );
+			const imageURL = imageURLs[ randomIndex ];
+			return `<img src="${ imageURL }" ${ params }>`;
+		}
+	);
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -5,9 +5,10 @@ import { Popover } from '@wordpress/components';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import React, { useRef, useEffect, useState, useMemo, CSSProperties, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { useDebouncedCallback } from 'use-debounce';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
-import { injectTitlesToPageListBlock } from './html-transformers';
+import { injectTitlesToPageListBlock, injectImages } from './html-transformers';
 import PatternActionBar from './pattern-action-bar';
 import PatternTooltipDeadClick from './pattern-tooltip-dead-click';
 import { encodePatternId } from './utils';
@@ -50,6 +51,7 @@ const PatternLargePreview = ( {
 	recordTracksEvent,
 	isNewSite,
 }: Props ) => {
+	const [ searchParams ] = useSearchParams();
 	const translate = useTranslate();
 	const hasSelectedPattern = Boolean( header || sections.length || footer );
 	const frameRef = useRef< HTMLDivElement | null >( null );
@@ -103,9 +105,16 @@ const PatternLargePreview = ( {
 		( patternHtml: string ) => {
 			const pageTitles = pages?.map( ( page ) => page.title );
 			if ( pageTitles ) {
-				return injectTitlesToPageListBlock( patternHtml, pageTitles, {
+				patternHtml = injectTitlesToPageListBlock( patternHtml, pageTitles, {
 					replaceCurrentPages: isNewSite,
 				} );
+			}
+
+			if ( searchParams.has( 'images' ) ) {
+				const images = searchParams.get( 'images' )?.split( ',' ) || [];
+				if ( images.length ) {
+					patternHtml = injectImages( patternHtml, images );
+				}
 			}
 			return patternHtml;
 		},


### PR DESCRIPTION
This injects images into img blocks if we have images on the API response.
Otherwise, no functional changes

![Zrzut ekranu 2024-01-17 o 18 46 31](https://github.com/Automattic/wp-calypso/assets/3775068/53081da1-94e6-451d-bd4a-040a177a1b5c)

## Testing Instructions

1. Apply D135042-code,
2. Sandbox public-api
3. Go to http://calypso.localhost:3000/setup/ai-assembler/?flags=pattern-assembler/v2
