### PR TITLE
Subscribers: Fix Crash When Missing Site ID

### DIFF
--- a/client/controller/index.web.js
+++ b/client/controller/index.web.js
@@ -191,7 +191,7 @@ export function redirectIfCurrentUserCannot( capability ) {
 	return ( context, next ) => {
 		const state = context.store.getState();
 		const site = getSelectedSite( state );
-		const currentUserCan = canCurrentUser( state, site.ID, capability );
+		const currentUserCan = canCurrentUser( state, site?.ID, capability );
 
 		if ( site && ! currentUserCan ) {
 			return page.redirect( `/home/${ site.slug }` );

--- a/client/my-sites/subscribers/index.js
+++ b/client/my-sites/subscribers/index.js
@@ -8,15 +8,8 @@ import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import { subscribers, subscriberDetails, externalSubscriberDetails } from './controller';
 
 export default function () {
-	page(
-		'/subscribers',
-		siteSelection,
-		sites,
-		navigation,
-		redirectIfCurrentUserCannot( 'list_users' ),
-		makeLayout,
-		clientRender
-	);
+	page( '/subscribers', siteSelection, sites, makeLayout, clientRender );
+
 	page(
 		'/subscribers/:domain',
 		siteSelection,

--- a/client/my-sites/subscribers/style.scss
+++ b/client/my-sites/subscribers/style.scss
@@ -60,7 +60,7 @@
 	background-color: $studio-white;
 }
 
-.is-section-subscribers .layout:not( .has-no-sidebar ) .layout__content {
+.is-section-subscribers .layout:not(.has-no-sidebar) .layout__content {
 	padding-left: var(--sidebar-width-max);
 	padding-right: 0;
 	padding-bottom: 0;

--- a/client/my-sites/subscribers/style.scss
+++ b/client/my-sites/subscribers/style.scss
@@ -60,7 +60,7 @@
 	background-color: $studio-white;
 }
 
-.is-section-subscribers .layout__content {
+.is-section-subscribers .layout:not( .has-no-sidebar ) .layout__content {
 	padding-left: var(--sidebar-width-max);
 	padding-right: 0;
 	padding-bottom: 0;


### PR DESCRIPTION
## Proposed Changes

The Subscribers page currently crashes when there is no site ID. This is because of the following:

1) It wrongly tries to check permissions when there isn't a site ID yet

https://github.com/Automattic/wp-calypso/blob/fe960645c6fdc48bf85b6536f77c39a54a427019/client/my-sites/subscribers/index.js#L11-L19

2) The check for permissions added in #85914 never accounted for the Site ID not existing 

https://github.com/Automattic/wp-calypso/blob/af75ec925901bf2a2b75849f8a1ba96dfe24dea4/client/controller/index.web.js#L194

This PR correctly handles page creation when there is no site ID, and also tries to make that check a little more robust in case this happens in future. Some more specific styling is also needed because the Subscribers page changes the layout, which it shouldn't for the site selection screen. 

## Testing Instructions

Go to `/subscribers` and verify that you no longer see this - you should be asked to select a site instead.

<img width="1544" alt="Screenshot 2024-01-17 at 17 49 08" src="https://github.com/Automattic/wp-calypso/assets/43215253/bfae4e35-61f1-4ad6-ab49-92d05a839101">

