### PR TITLE
Subscribers: Fix mobile styles on subscriber screen

### DIFF
--- a/client/my-sites/earn/customers/customer/style.scss
+++ b/client/my-sites/earn/customers/customer/style.scss
@@ -1,5 +1,6 @@
 @import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
 
 .customer {
 	.customer__header {
@@ -41,6 +42,15 @@
 			max-width: 30px;
 			margin-bottom: 20px;
 		}
+		.customer__stats-list {
+			@media ( max-width: $break-large ) {
+				flex-flow: column;
+				gap: 24px;
+				padding-left: 0;
+				padding-right: 0;
+				overflow-x: visible;
+			}
+		}
 	}
 
 	.customer-details__content {
@@ -67,6 +77,9 @@
 			flex: 1 1 0;
 			overflow: hidden;
 			word-wrap: break-word;
+			@media ( max-width: $break-large ) {
+				flex: auto;
+			}
 		}
 
 		.customer-details__content-label {
@@ -85,6 +98,10 @@
 			font-size: $font-body-small;
 			line-height: rem(20px);
 			letter-spacing: -0.15px;
+		}
+
+		@media ( max-width: $break-large ) {
+			flex-direction: column;
 		}
 	}
 

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -3,7 +3,7 @@
 @import "@wordpress/base-styles/mixins";
 
 #earn-navigation {
-	margin-bottom: 40px;
+	margin-bottom: 30px;
 }
 
 // Small override for card component headers
@@ -144,5 +144,12 @@ h3.ads__table-header-title {
 	max-width: 98%;
 	h1 {
 		margin-bottom: 1em;
+	}
+}
+
+/* Media Queries */
+@media ( max-width: $break-large ) {
+	.earn.main {
+		padding: 20px;
 	}
 }

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -146,3 +146,10 @@ h3.ads__table-header-title {
 		margin-bottom: 1em;
 	}
 }
+
+/* Media Queries */
+@media ( max-width: $break-large ) {
+	.earn.main {
+		padding: 20px;
+	}
+}

--- a/client/my-sites/earn/style.scss
+++ b/client/my-sites/earn/style.scss
@@ -3,7 +3,7 @@
 @import "@wordpress/base-styles/mixins";
 
 #earn-navigation {
-	margin-bottom: 30px;
+	margin-bottom: 40px;
 }
 
 // Small override for card component headers
@@ -144,12 +144,5 @@ h3.ads__table-header-title {
 	max-width: 98%;
 	h1 {
 		margin-bottom: 1em;
-	}
-}
-
-/* Media Queries */
-@media ( max-width: $break-large ) {
-	.earn.main {
-		padding: 20px;
 	}
 }

--- a/client/my-sites/subscribers/components/subscriber-details/styles.scss
+++ b/client/my-sites/subscribers/components/subscriber-details/styles.scss
@@ -1,5 +1,6 @@
 @import "@automattic/color-studio/dist/color-variables";
 @import "@automattic/typography/styles/variables";
+@import "@wordpress/base-styles/breakpoints";
 
 .subscriber-details {
 	.subscriber-details__header {
@@ -23,6 +24,9 @@
 			flex: 1 1 0;
 			overflow: hidden;
 			word-wrap: break-word;
+			@media ( max-width: $break-large ) {
+				flex: auto;
+			}
 		}
 	}
 
@@ -50,6 +54,9 @@
 			font-size: $font-body-small;
 			line-height: rem(20px);
 			letter-spacing: -0.15px;
+		}
+		@media ( max-width: $break-large ) {
+			flex-direction: column;
 		}
 	}
 }

--- a/client/my-sites/subscribers/components/subscriber-stats/style.scss
+++ b/client/my-sites/subscribers/components/subscriber-stats/style.scss
@@ -1,4 +1,5 @@
 @import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/breakpoints";
 
 .subscriber-details .subscriber-stats {
 	margin-bottom: 32px;
@@ -17,6 +18,18 @@
 
 		path {
 			fill: var(--studio-gray-50);
+		}
+	}
+}
+
+/* Media Queries */
+@media ( max-width: $break-large ) {
+	.subscriber-stats__list {
+		flex-flow: column;
+		padding: 0;
+		overflow: visible;
+		.card.highlight-card {
+			margin: 10px 0;
 		}
 	}
 }

--- a/client/my-sites/subscribers/subscriber-details-style.scss
+++ b/client/my-sites/subscribers/subscriber-details-style.scss
@@ -2,6 +2,9 @@
 
 .subscriber-details-page.main {
 	padding: 0 32px;
+	@media ( max-width: $break-large ) {
+		padding: 0 20px 30px;
+	}
 }
 
 .subscriber-details-page__loading {
@@ -14,5 +17,8 @@
 @media ( max-width: $break-medium ) {
 	.is-section-subscribers .subscriber-details {
 		margin-top: 108px;
+		@media ( max-width: $break-large ) {
+			margin-top: 0;
+		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves #86474

## Proposed Changes

Updates mobile styles on Users > Subscribers > Single Subscriber and Monetize > Supporters > Single Supporter screens. 

**Users > Subscribers > Single Subscriber**
<img width="995" alt="subscribers-mkobile" src="https://github.com/Automattic/wp-calypso/assets/21228350/616315f9-8018-4cdf-9579-5ac7ac0eab85">

**Monetize > Supporters > Single Supporter**
<img width="1019" alt="supporters-mobile" src="https://github.com/Automattic/wp-calypso/assets/21228350/eecc021c-edc8-4234-9784-7caf6b4fc2b5">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1) Go to http://calypso.localhost:3000/subscribers/YOURSITESLUG. Click the three dots for a single subscriber, then click View, and confirm the mobile styles look good and match the new screenshot above. 

1) Go to http://calypso.localhost:3000/subscribers/YOURSITESLUG. Click the three dots for a single subscriber, click View, and confirm the mobile styles look good and match the new screenshot above. 

1) Go to http://calypso.localhost:3000/earn/supporters/YOURSITESLUG. Click the three dots for a single supporter, click View, and confirm the mobile styles look good and match the new screenshot above. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?