### PR TITLE
Plans 2023: Fix plan type selector text overflow

### DIFF
--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -77,6 +77,13 @@
 	&.is-hidden {
 		display: none;
 	}
+
+	.plans-features-main__plan-type-selector-layout {
+		@include plan-type-selector-custom-mobile-breakpoint {
+			// Overrides the plans-wrapper parent container margins
+			margin: 0 -20px;
+		}
+	}
 }
 
 // Content group

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -390,6 +390,9 @@ body.is-section-signup.is-white-signup {
 }
 
 .plans-features-main__plan-type-selector-layout {
+	display: flex;
+	justify-content: center;
+
 	.segmented-control.price-toggle {
 		.is-section-signup &,
 		.is-section-stepper & {

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -514,7 +514,7 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 							<PlanTypeSelector
 								{ ...planTypeSelectorProps }
 								title={ translate( 'Billing Cycle' ) }
-								hideDiscountLabel={ true }
+								hideDiscount={ true }
 								coupon={ coupon }
 							/>
 						</PlanTypeSelectorWrapper>

--- a/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -34,7 +34,7 @@ const IntervalTypeOption = styled.div`
 `;
 
 export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
-	const { intervalType, displayedIntervals, onPlanIntervalChange } = props;
+	const { hideDiscount, intervalType, displayedIntervals, onPlanIntervalChange } = props;
 	const supportedIntervalType = (
 		displayedIntervals.includes( intervalType ) ? intervalType : 'yearly'
 	) as SupportedUrlFriendlyTermType;
@@ -45,7 +45,9 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 		name: (
 			<IntervalTypeOption>
 				<span className="name"> { option.name } </span>
-				{ option.discountText ? <span className="discount"> { option.discountText } </span> : null }
+				{ option.discountText && ! hideDiscount ? (
+					<span className="discount"> { option.discountText } </span>
+				) : null }
 			</IntervalTypeOption>
 		),
 	} ) );

--- a/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-toggle.tsx
+++ b/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-toggle.tsx
@@ -16,7 +16,7 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 		intervalType,
 		isInSignup,
 		eligibleForWpcomMonthlyPlans,
-		hideDiscountLabel,
+		hideDiscount,
 		currentSitePlanSlug,
 		displayedIntervals,
 		useCheckPlanAvailabilityForPurchase,
@@ -105,7 +105,7 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 								{ interval === 'yearly' && showBiennialToggle ? translate( 'Pay 1 year' ) : null }
 								{ interval === '2yearly' ? translate( 'Pay 2 years' ) : null }
 							</span>
-							{ ! showBiennialToggle && hideDiscountLabel ? null : (
+							{ ! showBiennialToggle && hideDiscount ? null : (
 								<PopupMessages context={ spanRef } isVisible={ popupIsVisible }>
 									{ translate(
 										'Save up to %(maxDiscount)d%% by paying annually and get a free domain for one year',

--- a/packages/plans-grid-next/src/components/plan-type-selector/style.scss
+++ b/packages/plans-grid-next/src/components/plan-type-selector/style.scss
@@ -2,8 +2,16 @@
 
 .plan-type-selector {
 	width: fit-content;
+	min-width: 275px;
 }
 
+.is-sticky-plan-type-selector {
+	.plan-type-selector {
+		@include plan-type-selector-custom-mobile-breakpoint {
+			width: 100%;
+		}
+	}
+}
 
 .plan-type-selector__title {
 	margin-bottom: 20px;

--- a/packages/plans-grid-next/src/components/plan-type-selector/style.scss
+++ b/packages/plans-grid-next/src/components/plan-type-selector/style.scss
@@ -1,7 +1,7 @@
 @import "../../media-queries";
 
 .plan-type-selector {
-	width: 100%;
+	width: fit-content;
 }
 
 
@@ -71,7 +71,6 @@
 }
 
 .plan-type-selector .plan-type-selector__interval-type-dropdown-container {
-	width: 275px;
 	margin: 0 auto;
 	.is-sticky-plan-type-selector & {
 		width: 100%;

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -189,7 +189,7 @@ export type PlanTypeSelectorProps = {
 	plans: PlanSlug[];
 	eligibleForWpcomMonthlyPlans?: boolean;
 	isPlansInsideStepper: boolean;
-	hideDiscountLabel?: boolean;
+	hideDiscount?: boolean;
 	redirectTo?: string | null;
 	isStepperUpgradeFlow: boolean;
 	currentSitePlanSlug?: PlanSlug | null;
@@ -215,7 +215,7 @@ export type IntervalTypeProps = Pick<
 	| 'isInSignup'
 	| 'eligibleForWpcomMonthlyPlans'
 	| 'isPlansInsideStepper'
-	| 'hideDiscountLabel'
+	| 'hideDiscount'
 	| 'redirectTo'
 	| 'showPlanTypeSelectorDropdown'
 	| 'selectedPlan'


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/86270#top

## Proposed Changes

* Allow the plan type selector dropdown to adapt to width of content
* [Hide discount text in the stickied plan type selector dropdown in the comparison grid ]( https://github.com/Automattic/wp-calypso/issues/86270#issuecomment-1896290261 )( if we don't, we end up with the below )
  * We went in this direction because it still is an incremental step forward and improves the current experience for many non-english locales. It's also worth noting that we also hide the discount hover popup message for the plan type toggle in the stickied comparison grid header
  * I still see value in us displaying the discounts in the stickied plan type selector dropdown to entice the user -- perhaps it's something to continue exploring in v2
<img width="1316" alt="Screenshot 2024-01-16 at 12 32 41 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/7c1dd616-8206-47f2-8b54-2551334df910">

### Other Approaches
I started exploring element overflow detection instead with `getBoundingClientRect` ( [link]( https://github.com/Automattic/wp-calypso/pull/86508 ) ). Perhaps we could hide the discount text only when its overflowing? Either way, it's worth noting that using `getBoundingClientRect` isn't great ( requires a browser layout, and then some calculation on our end, and potentially a re-layout if we detect overlap ).

A natural question that might arise is what about the IntersectionObserver browser API? I investigated it, but unfortunately, the API only detects intersection between a child and its ancestor. We want to identify a sibling to sibling overlap. The IntersectionObserver API v2 looks promising with the addition of `trackVisibility`, but [it's not yet released on Safari or Firefox](https://caniuse.com/intersectionobserver-v2).

Another easy question is why not look to `isLargeCurrency` for inspiration? Well, this is because it simply approximates when a currency is "large" and overflowing by counting the number of characters in a string.

## GIFs + Screenshots
### Before
<img width="1423" alt="Screenshot 2024-01-17 at 11 52 05 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/c28c7d50-5f3c-49b4-bf35-9d2b0ac69d42">

### After
![2024-01-17 11 50 57](https://github.com/Automattic/wp-calypso/assets/5414230/6be02e2c-a870-49ca-a23b-689189fce9c3)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to a non-english language with longer text
* Visit /start/plans
* Verify that the discount text in the plan type selector dropdown is obscured by the chevron symbol

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?