### PR TITLE
Notifications Accessibility: Add missing styles

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/note-common.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/note-common.scss
@@ -20,3 +20,31 @@ div.wpnc__note-actions {
 	border-top: none;
 	margin-top: 0;
 }
+
+// Taken from packages/components/src/screen-reader-text/style.scss
+.screen-reader-text {
+	clip: rect(1px, 1px, 1px, 1px);
+	position: absolute !important;
+
+	&:hover,
+	&:active,
+	&:focus {
+		background-color: #f1f1f1;
+		border-radius: 3px;
+		box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
+		clip: auto !important;
+		color: #21759b;
+		display: block;
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+		font-size: 14px;
+		font-weight: bold;
+		height: auto;
+		left: 5px;
+		line-height: normal;
+		padding: 15px 23px 14px;
+		text-decoration: none;
+		top: 5px;
+		width: auto;
+		z-index: z-index("screen-reader-text-parent", ".screen-reader-text:focus"); // Above WP toolbar
+	}
+}


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/86476

## Proposed Changes

`screen-reader-text` is only available to calypso env; when building to wpcom, it's missing. Importing the component would likely increase the build size as it would require introducing a new `@automattic/components` dependency to the notifications app. So I just copied the existing styling from the `ScreenReaderText` component to fix this issue.

## Testing Instructions

* Ensure it's working as before by following the testing instructions from this PR: https://github.com/Automattic/wp-calypso/pull/85845
* Apply this PR to your sandbox running `install-plugin.sh notifications fix/notifications-accessibility-sr-text`
* Make sure `widgets.wp.com` is sandboxed
* Open any wpcom site and check if the changes on the notification widget were applied
* Navigate to any notification details and check if the `Back to notifications` button is displayed as expected (only while focused) and if it's working as intended

<img width="446" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/7c304cca-d609-4085-961c-c916e54380d5">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?