### PR TITLE
Plans 2023: Fix divergent styling between plan type selector and storage add on dropdown

### DIFF
--- a/packages/plans-grid-next/src/components/storage-add-on-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/storage-add-on-dropdown.tsx
@@ -49,7 +49,7 @@ const StorageAddOnOption = ( {
 	return (
 		<>
 			{ price && ! isLargeCurrency && ! priceOnSeparateLine ? (
-				<div>
+				<div className="storage-add-on-dropdown-option__text-container">
 					<span className="storage-add-on-dropdown-option__title">{ title }</span>
 					<div className="storage-add-on-dropdown-option__price-container">
 						<span>

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -414,6 +414,8 @@ $mobile-card-max-width: 440px;
 }
 
 .components-custom-select-control {
+	line-height: 0px;
+
 	.storage-add-on-dropdown-option__text-container {
 		padding: 6px 0;
 		line-height: 20px;

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -419,17 +419,19 @@ $mobile-card-max-width: 440px;
 	}
 
 	.storage-add-on-dropdown-option__title {
-		font-size: 0.75rem;
+		color: var(--color-text);
+		font-weight: 500;
 	}
 
 	.storage-add-on-dropdown-option__price,
 	.storage-add-on-dropdown-option__per-month {
-		color: var(--studio-green-40);
+		color: var(--studio-green-50);
 		display: inline-block;
 
-		// Non standard rem allows us to match font size of other storage labels
-		/* stylelint-disable-next-line scales/font-sizes */
-		font-size: 0.7rem;
+		// // Non standard rem allows us to match font size of other storage labels
+		// /* stylelint-disable-next-line scales/font-sizes */
+		// font-size: 0.7rem;
+		font-weight: 500;
 	}
 
 	.storage-add-on-dropdown-option__price {
@@ -443,11 +445,10 @@ $mobile-card-max-width: 440px;
 	text-align: left;
 
 	.storage-add-on-dropdown__offset-price {
-		color: var(--studio-green-40);
+		color: var(--studio-green-50);
 
-		// Non standard rem allows us to match font size of other storage labels
-		/* stylelint-disable-next-line scales/font-sizes */
-		font-size: 0.7rem;
+		font-size: 0.75rem;
+		font-weight: 500;
 	}
 }
 

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -414,6 +414,11 @@ $mobile-card-max-width: 440px;
 }
 
 .components-custom-select-control {
+	.storage-add-on-dropdown-option__text-container {
+		padding: 6px 0;
+		line-height: 20px;
+	}
+
 	.storage-add-on-dropdown-option__price-container {
 		display: inline-block;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1704738838441369/1704736051.206559-slack-C059R8S4ALT

## Proposed Changes

* Align styling between the plan type selector dropdown and the storage add-on dropdown
* Fix line height being too large for storage add-on dropdown

**TODO in a follow-up:**
* Look into creating styling or component abstractions between the two dropdowns

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Navigate to `/start/plans`
* Verify that color, font-size, and font-weight match between the plan type selector dropdown and the storage add-on dropdown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?