### PR TITLE
Remove Revoke License duplicate button label

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/revoke-license-dialog/index.tsx
@@ -69,7 +69,6 @@ export default function RevokeLicenseDialog( {
 
 		<Button primary scary busy={ mutation.isPending } onClick={ revoke }>
 			{ isParentLicense ? translate( 'Revoke bundle' ) : translate( 'Revoke License' ) }
-			{ translate( 'Revoke License' ) }
 		</Button>,
 	];
 


### PR DESCRIPTION
Fix issue with the Revoke License button text being duplicated

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Currently the text on the Revoke License button is duplicated. This removes the second occurrence and the text will only be displayed once if the license is not a parent license for a bundle.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to Jetpack Cloud and visit the license page at `partner-portal/licenses`
* Attempt to revoke a single license or a child license of a bundle. Notice the `Revoke LicenseRevoke License` button text.
* Use the Jetpack Cloud Live link below to access the licenses page
* Attempt to revoke a single license or child license and ensure that the duplicate `Revoke License` text is no longer displayed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
