### PR TITLE
Design Choices: Update copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/index.tsx
@@ -5,6 +5,7 @@ import {
 } from '@automattic/design-picker';
 import { StepContainer } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { Icon, info } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -73,11 +74,8 @@ const DesignChoicesStep: Step = ( { navigation, flow, stepName } ) => {
 							/>
 						</div>
 						<div className="design-choices__footer">
-							<p>
-								{ translate( 'Explore our themes or design your own.' ) }
-								<br />
-								{ translate( 'You can return here if you change your mind.' ) }
-							</p>
+							<Icon icon={ info } size={ 20 } />
+							<span>{ translate( 'You can return here if you change your mind.' ) }</span>
 						</div>
 					</>
 				}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-choices/style.scss
@@ -13,9 +13,19 @@
 }
 
 .design-choices__footer {
-	margin-top: 52px;
-	text-align: center;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	gap: 4px;
+	margin-top: 38px;
+	font-size: $font-body-small;
+	font-weight: 400;
+	line-height: 20px;
 	color: var(--studio-gray-60);
+
+	svg {
+		fill: currentColor;
+	}
 }
 
 .design-choices__design-your-own {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1705491446964969-slack-CRWCHQGUB

## Proposed Changes

* Add the info icon and update the copy

| Before | After | 
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/162dc254-04a3-43ba-8513-1d5fd67dd1c7) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/6eadf178-fb07-45f4-8eed-156f51e98350) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=your_site
* Continue directly
* On the Design Choices screen, make sure the copy is update-to-date

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?