### PR TITLE
Jetpack Manage: Show payment notice in site payment methods page

### DIFF
--- a/client/me/purchases/payment-methods/payment-method-list.tsx
+++ b/client/me/purchases/payment-methods/payment-method-list.tsx
@@ -3,8 +3,10 @@ import { Button, CompactCard } from '@automattic/components';
 import { CheckoutProvider } from '@automattic/composite-checkout';
 import { localize, translate } from 'i18n-calypso';
 import { Component } from 'react';
+import Notice from 'calypso/components/notice';
 import SectionHeader from 'calypso/components/section-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import PaymentMethod from 'calypso/me/purchases/payment-methods/payment-method';
 import { withStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
 import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
@@ -69,13 +71,28 @@ class PaymentMethodList extends Component<
 		const paymentMethods = this.props.paymentMethodsState.paymentMethods;
 
 		return (
-			<div className="payment-method-list">
-				<SectionHeader label={ this.props.translate( 'Manage Your Payment Methods' ) }>
-					{ this.renderAddPaymentMethodButton() }
-				</SectionHeader>
+			<>
+				{ isJetpackCloud() && (
+					<Notice status="is-info" showDismiss={ false }>
+						{ this.props.translate(
+							'The cards stored here are used for purchases made via Jetpack.com. ' +
+								'If you intend to update your card to make purchases in Jetpack Manage, then do so {{a}}here{{/a}}.',
+							{
+								components: {
+									a: <a href="/partner-portal/payment-methods" />,
+								},
+							}
+						) }
+					</Notice>
+				) }
+				<div className="payment-method-list">
+					<SectionHeader label={ this.props.translate( 'Manage Your Payment Methods' ) }>
+						{ this.renderAddPaymentMethodButton() }
+					</SectionHeader>
 
-				{ this.renderPaymentMethods( paymentMethods ) }
-			</div>
+					{ this.renderPaymentMethods( paymentMethods ) }
+				</div>
+			</>
 		);
 	}
 }

--- a/client/me/purchases/payment-methods/payment-method-list.tsx
+++ b/client/me/purchases/payment-methods/payment-method-list.tsx
@@ -3,20 +3,24 @@ import { Button, CompactCard } from '@automattic/components';
 import { CheckoutProvider } from '@automattic/composite-checkout';
 import { localize, translate } from 'i18n-calypso';
 import { Component } from 'react';
+import { connect } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import SectionHeader from 'calypso/components/section-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import PaymentMethod from 'calypso/me/purchases/payment-methods/payment-method';
 import { withStoredPaymentMethods } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
+import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import type { StoredPaymentMethod } from 'calypso/lib/checkout/payment-methods';
 import type { WithStoredPaymentMethodsProps } from 'calypso/my-sites/checkout/src/hooks/use-stored-payment-methods';
+import type { IAppState } from 'calypso/state/types';
 
 import 'calypso/me/purchases/payment-methods/style.scss';
 
 interface PaymentMethodListProps {
 	addPaymentMethodUrl: string;
 	translate: typeof translate;
+	isAgencyUser: boolean;
 }
 
 class PaymentMethodList extends Component<
@@ -72,7 +76,7 @@ class PaymentMethodList extends Component<
 
 		return (
 			<>
-				{ isJetpackCloud() && (
+				{ isJetpackCloud() && this.props.isAgencyUser && (
 					<Notice status="is-info" showDismiss={ false }>
 						{ this.props.translate(
 							'The cards stored here are used for purchases made via Jetpack.com. ' +
@@ -97,7 +101,6 @@ class PaymentMethodList extends Component<
 	}
 }
 
-export default withStoredPaymentMethods( localize( PaymentMethodList ), {
-	type: 'all',
-	expired: true,
-} );
+export default connect( ( state: IAppState ) => ( {
+	isAgencyUser: isAgencyUser( state ),
+} ) )( withStoredPaymentMethods( localize( PaymentMethodList ), { type: 'all', expired: true } ) );

--- a/client/state/partner-portal/partner/selectors.ts
+++ b/client/state/partner-portal/partner/selectors.ts
@@ -9,6 +9,7 @@ import type {
 } from 'calypso/state/partner-portal/types';
 // Required for modular state.
 import 'calypso/state/partner-portal/init';
+import type { IAppState } from 'calypso/state/types';
 
 export function getActivePartnerKeyId( state: PartnerPortalStore ): number {
 	return state.partnerPortal.partner.activePartnerKey;
@@ -56,7 +57,7 @@ export function hasJetpackPartnerAccess( state: PartnerPortalStore ): boolean {
 	return currentUser?.has_jetpack_partner_access ?? false;
 }
 
-export function isAgencyUser( state: PartnerPortalStore ): boolean {
+export function isAgencyUser( state: PartnerPortalStore | IAppState ): boolean {
 	const currentUser = getCurrentUser( state );
 	return (
 		( currentUser?.jetpack_partner_types?.includes( 'agency' ) ||


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/192

## Proposed Changes

This PR implements a notice that shows up in the payment methods page in the site details page in Jetpack Cloud.

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

1. Visit the Jetpack Cloud live link > You will be redirected to /dashboard
2. Click `All Sites` to switch sites and select a site > Click the `Purchases` left nav item
3. Now click the Payment Methods tab and verify that a notice is displayed as shown below and verify that clicking the `managed here` link takes you to `/partner-portal/payment-methods`

<img width="1184" alt="Screenshot 2024-01-18 at 3 49 16 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/2f41bb46-9a29-4d4d-acfc-1a1ac2a663d1">


4. Now, click the Calypso live link > Visit /me/purchases/payment-methods and verify that the notice is no more shown:

<img width="1184" alt="Screenshot 2024-01-18 at 11 44 56 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/208fd9f4-be02-45b4-895a-a9e17376c04d">

5. Verify that you can add a credit card

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?