### PR TITLE
Onboarding: Change the default theme of write flow to Hey

### DIFF
--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -2,7 +2,7 @@ import type { Design } from '@automattic/design-picker';
 
 export const WRITE_INTENT_DEFAULT_DESIGN: Design = {
 	slug: 'hey',
-	title: 'hey',
+	title: 'Hey',
 	is_premium: false,
 	categories: [],
 	theme: 'hey',

--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -1,11 +1,11 @@
 import type { Design } from '@automattic/design-picker';
 
 export const WRITE_INTENT_DEFAULT_DESIGN: Design = {
-	slug: 'livro',
-	title: 'Livro',
+	slug: 'hey',
+	title: 'hey',
 	is_premium: false,
 	categories: [],
-	theme: 'livro',
+	theme: 'hey',
 };
 
 export const SITE_PICKER_FILTER_CONFIG = [ 'wpcom', 'atomic' ];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/85397

## Proposed Changes

* Update the default theme of the write flow from Livro to Hey

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /setup?siteSlug=your_site
* Select “Write & Publish” and continue
* Finish the “Give your blog a name” screen
* On the “Now it’s time to get creative.” screen, select “Start writing” or “Skip to dashboard”
* Make sure the active theme on your site is Hey

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?