### PR TITLE
Link the Let's work on your site button to the full screen launchpad

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/plan-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/plan-product.tsx
@@ -67,7 +67,7 @@ export default function ThankYouPlanProduct( {
 		} else {
 			setRedirectTo( 'home' );
 		}
-	}, [ launchpad ] );
+	}, [ launchpad, hasRemainingTasks ] );
 
 	useEffect( () => {
 		setLetsWorkButtonBusy( isLoading );
@@ -95,7 +95,7 @@ export default function ThankYouPlanProduct( {
 				redirect();
 			}
 		},
-		[ launchpad, letsWorkHref, redirectTo ]
+		[ launchpad.launchpad_screen, letsWorkHref, redirectTo, saveSiteSettings, siteId ]
 	);
 
 	return (

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/plan-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/plan-product.tsx
@@ -1,8 +1,11 @@
+import { useLaunchpad } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
+import { useDispatch as useWPDispatch } from '@wordpress/data';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
-import { useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import ThankYouProduct from 'calypso/components/thank-you-v2/product';
+import { SITE_STORE } from 'calypso/landing/stepper/stores';
 import { getPurchaseByProductSlug } from 'calypso/lib/purchases/utils';
 import { useSelector } from 'calypso/state';
 import {
@@ -39,6 +42,62 @@ export default function ThankYouPlanProduct( {
 			? translate( 'Expires on %s', { args: moment( productPurchase.expiryDate ).format( 'LL' ) } )
 			: '';
 
+	const [ letsWorkButtonBusy, setLetsWorkButtonBusy ] = useState< boolean >( false );
+	const [ redirectTo, setRedirectTo ] = useState< 'home' | 'launchpad' >( 'home' );
+
+	const { saveSiteSettings } = useWPDispatch( SITE_STORE );
+
+	const { data: launchpad, isLoading } = useLaunchpad( siteSlug, 'intent-build' );
+
+	const hasRemainingTasks =
+		launchpad && launchpad.checklist
+			? launchpad.checklist.filter(
+					( item ) => item?.completed === false && item?.disabled === false
+			  ).length > 0
+			: false;
+
+	useEffect( () => {
+		if (
+			launchpad &&
+			launchpad.is_enabled &&
+			hasRemainingTasks &&
+			launchpad.launchpad_screen !== 'off'
+		) {
+			setRedirectTo( 'launchpad' );
+		} else {
+			setRedirectTo( 'home' );
+		}
+	}, [ launchpad ] );
+
+	useEffect( () => {
+		setLetsWorkButtonBusy( isLoading );
+	}, [ isLoading ] );
+
+	const letsWorkHref =
+		redirectTo === 'launchpad' && hasRemainingTasks
+			? `/setup/build/launchpad?siteSlug=${ siteSlug }&showLaunchpad=true`
+			: `/home/${ siteSlug }`;
+
+	const letsWorkButtonOnClick = useCallback(
+		( e: React.MouseEvent< HTMLElement > ) => {
+			if ( redirectTo === 'launchpad' ) {
+				e.preventDefault();
+				setLetsWorkButtonBusy( true );
+
+				const redirect = async () => {
+					if ( launchpad.launchpad_screen === 'skipped' ) {
+						await saveSiteSettings( siteId, { launchpad_screen: 'full' } );
+					}
+					setLetsWorkButtonBusy( false );
+					window.location.assign( letsWorkHref );
+				};
+
+				redirect();
+			}
+		},
+		[ launchpad, letsWorkHref, redirectTo ]
+	);
+
 	return (
 		<ThankYouProduct
 			name={ translate( '%(productName)s plan', {
@@ -50,7 +109,12 @@ export default function ThankYouPlanProduct( {
 			details={ expirationDate }
 			actions={
 				<>
-					<Button variant="primary" href={ `/home/${ siteSlug }` }>
+					<Button
+						isBusy={ letsWorkButtonBusy }
+						variant="primary"
+						href={ letsWorkHref }
+						onClick={ letsWorkButtonOnClick }
+					>
 						{ translate( 'Let’s work on the site' ) }
 					</Button>
 					<Button variant="secondary" href={ `/plans/my-plan/${ siteSlug }` }>


### PR DESCRIPTION
Previous PR was borked: https://github.com/Automattic/wp-calypso/pull/86234

Closes #85197

## Proposed Changes

This changes the href of the Let's work on your site button you see after you've upgraded your plan:
- If you still have tasks to be completed on the Launchpad, it links to the full screen launchpad
- Else it links to `/home`


## Testing Instructions

- Start on https://wordpress.com/start
- Start a free site, choose an intent that lands you in the build intent (other, promote, ...), choose a design and skip somewhere during the launchpad (click Skip for now)
- Upgrade your site to a paid plan (give yourself some free credits through User RC)
- You'll land on the Thank You screen. Replace `https://wordpress.com/ `in your address bar with `http://calypso.localhost:3000`

Please verify that the button links to the launchpad while there are still tasks open, and links to home when the launchpad is completed.

Beware that two tasks can't be finished in the launchpad itself:
- Write first post
- Launch your site

However, when linking to the launchpad with these tasks still open, the launchpad will redirect to /home, which is the behavior we want.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?