### PR TITLE
Impact Affiliate i2: Use .wordpress.com as domain for impact affiliate irclickid cookie

### DIFF
--- a/client/lib/analytics/impact-affiliate.js
+++ b/client/lib/analytics/impact-affiliate.js
@@ -17,6 +17,7 @@ export default function saveImpactAffiliateClickId() {
 	document.cookie = cookie.serialize( 'irclickid', clickId, {
 		path: '/',
 		expires: new Date( Date.now() + 30 * 24 * 60 * 60 * 1000 ), // 30 days
+		domain: '.wordpress.com',
 	} );
 
 	recordTracksEvent( 'calypso_impact_affiliate_visit', {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5239

The cookie that stores the impact affiliate `irclickid` is not set on the correct domain. It has to be set on `.wordpress.com` so that it will be used for its subdomains as well.

## Proposed Changes

* Add `.wordpress.com` as the cookie domain for the `irclickid` cookie that is set when the `irclickid` GET param is provided.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This can not be tested locally due to browser security restrictions preventing the placement of cross-domain cookies.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?