### PR TITLE
Monetize: update copy from "Subscriber" to "Supporter" at profile page

### DIFF
--- a/client/my-sites/earn/customers/customer/customer-details.tsx
+++ b/client/my-sites/earn/customers/customer/customer-details.tsx
@@ -61,7 +61,7 @@ const CustomerDetails = ( { customer }: CustomerDetailsProps ) => {
 			</div>
 			<div className="customer-details__content">
 				<h3 className="customer-details__content-title">
-					{ translate( 'Subscriber information' ) }
+					{ translate( 'Supporter information' ) }
 				</h3>
 				<div className="customer-details__content-body">
 					<div className="customer-details__content-column">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Copy "subscriber" works only if they're actually subscribed to the site or have paid subscription, but doesn't work for customers who did one-off purchases. 

#### Before

<img width="1225" alt="Screenshot 2024-01-18 at 13 06 32" src="https://github.com/Automattic/wp-calypso/assets/87168/036e55c8-2f26-44f5-9417-060f833d05c6">


#### After

![image](https://github.com/Automattic/wp-calypso/assets/87168/b29f079b-3d6d-417d-9b5f-4debeea932c5)


## Proposed Changes

- Update copy

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* See customer profile from Monetize

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
