### PR TITLE
ThemeUpgradeModal: Use getPlan not usePlans

### DIFF
--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -25,9 +25,10 @@ import {
 	PLAN_ECOMMERCE,
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
+	getPlan,
 } from '@automattic/calypso-products';
 import { Button, Dialog, ScreenReaderText } from '@automattic/components';
-import { Plans, ProductsList } from '@automattic/data-stores';
+import { ProductsList } from '@automattic/data-stores';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { Tooltip } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -110,10 +111,14 @@ export const ThemeUpgradeModal = ( {
 		( select ) => select( ProductsList.store ).getProductBySlug( 'business-bundle-monthly' ),
 		[]
 	);
-	const plans = Plans.usePlans( { coupon: undefined } );
 
 	//Wait until we have theme and product data to show content
 	const isLoading = ! premiumPlanProduct || ! businessPlanProduct || ! theme.data;
+
+	const personalPlanName = getPlan( PLAN_PERSONAL )?.getTitle() || '';
+	const premiumPlanName = getPlan( PLAN_PREMIUM )?.getTitle() || '';
+	const businessPlanName = getPlan( PLAN_BUSINESS )?.getTitle() || '';
+	const ecommercePlanName = getPlan( PLAN_ECOMMERCE )?.getTitle() || '';
 
 	const getPersonalPlanModalData = (): UpgradeModalContent => {
 		const planPrice = personalPlanProduct?.combined_cost_display;
@@ -134,7 +139,7 @@ export const ThemeUpgradeModal = ( {
 							},
 							args: {
 								planPrice: planPrice || '',
-								plan: plans.data?.[ PLAN_PERSONAL ]?.productNameShort || '',
+								plan: personalPlanName,
 							},
 						}
 					) }
@@ -180,7 +185,7 @@ export const ThemeUpgradeModal = ( {
 							},
 							args: {
 								planPrice: planPrice || '',
-								premiumPlanName: plans.data?.[ PLAN_PREMIUM ]?.productNameShort || '',
+								premiumPlanName: premiumPlanName,
 							},
 						}
 					) }
@@ -247,7 +252,7 @@ export const ThemeUpgradeModal = ( {
 						{
 							args: {
 								businessPlanPrice: businessPlanPrice || '',
-								businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '',
+								businessPlanName: businessPlanName,
 							},
 						}
 					) }
@@ -303,8 +308,8 @@ export const ThemeUpgradeModal = ( {
 							'This partner theme is only available to buy on the %(businessPlanName)s or %(commercePlanName)s plans.',
 							{
 								args: {
-									businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '',
-									commercePlanName: plans.data?.[ PLAN_ECOMMERCE ]?.productNameShort || '',
+									businessPlanName: businessPlanName,
+									commercePlanName: ecommercePlanName,
 								},
 							}
 						) }
@@ -328,7 +333,7 @@ export const ThemeUpgradeModal = ( {
 									<label>
 										{ translate( '%(businessPlanName)s plan', {
 											args: {
-												businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '',
+												businessPlanName: businessPlanName,
 											},
 										} ) }
 									</label>
@@ -424,13 +429,13 @@ export const ThemeUpgradeModal = ( {
 		modalData = getBundledFirstPartyPurchaseModalData();
 		featureList = getBundledFirstPartyPurchaseFeatureList();
 		featureListHeader = translate( 'Included with your %(businessPlanName)s plan', {
-			args: { businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '' },
+			args: { businessPlanName: businessPlanName },
 		} );
 	} else if ( isExternallyManaged ) {
 		modalData = getExternallyManagedPurchaseModalData();
 		featureList = getExternallyManagedFeatureList();
 		featureListHeader = translate( 'Included with your %(businessPlanName)s plan', {
-			args: { businessPlanName: plans.data?.[ PLAN_BUSINESS ]?.productNameShort || '' },
+			args: { businessPlanName: businessPlanName },
 		} );
 	} else if (
 		config.isEnabled( 'themes/tiers' ) &&
@@ -439,13 +444,13 @@ export const ThemeUpgradeModal = ( {
 		modalData = getPersonalPlanModalData();
 		featureList = getPersonalPlanFeatureList();
 		featureListHeader = translate( 'Included with your %(plan)s plan', {
-			args: { plan: plans.data?.[ PLAN_PERSONAL ]?.productNameShort || '' },
+			args: { plan: personalPlanName || '' },
 		} );
 	} else {
 		modalData = getStandardPurchaseModalData();
 		featureList = getStandardPurchaseFeatureList();
 		featureListHeader = translate( 'Included with your %(premiumPlanName)s plan', {
-			args: { premiumPlanName: plans.data?.[ PLAN_PREMIUM ]?.productNameShort || '' },
+			args: { premiumPlanName: premiumPlanName },
 		} );
 	}
 

--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -444,7 +444,7 @@ export const ThemeUpgradeModal = ( {
 		modalData = getPersonalPlanModalData();
 		featureList = getPersonalPlanFeatureList();
 		featureListHeader = translate( 'Included with your %(plan)s plan', {
-			args: { plan: personalPlanName || '' },
+			args: { plan: personalPlanName },
 		} );
 	} else {
 		modalData = getStandardPurchaseModalData();


### PR DESCRIPTION
The ThemeUpgradeModal is used in both calypso proper and in wpcom-block-editor. usePlans isn't working in wpcom-block-editor - it doesn't return any data, so switching to getPlan instead.

This isn't currently a problem in production, but it is a problem on trunk. Probably no-one has deployed in a while.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label toSimil
the linked issue.
-->

Similar to #86411 which was about ETK. This was found while working on #86528

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Calypso

1.  Use the calypso live link
2.  Go through the new site process until the design picker, using a free plan
3.  Reload the page after appending flags=themes/tiers to the url
4.  Try different paywalled themes like Annalee, press "Unlock theme"
5. The plan name should appear in the modal that appears

### wpcom-block-editor
1. Use the instructions below to install wpcom-block-editor on your sandbox
2. Use a free site and sandbox it
3. Go to /themes and click on some paywalled themes
4. On the theme details page click "Preview & customize"
5. In the bottom left corner press the button there to unlock the theme
6. The plan name should appear in the modal that appears

<img width="817" alt="test" src="https://github.com/Automattic/wp-calypso/assets/93301/d1825dc1-c497-4101-8fb8-07e9e7616a47">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?