### PR TITLE
Inline Help: change help button variant to link and remove link for Paragraph block

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/block-links-map.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/block-links-map.ts
@@ -76,10 +76,6 @@ const blockInfoMapping: { [ key: string ]: { link: string; postId: number } } = 
 		link: 'https://wordpress.com/support/wordpress-editor/blocks/preformatted-block/',
 		postId: 149339,
 	},
-	'core/paragraph': {
-		link: 'https://wordpress.com/support/wordpress-editor/blocks/paragraph-block/',
-		postId: 148375,
-	},
 	'core/more': {
 		link: 'https://wordpress.com/support/wordpress-editor/blocks/more-block/',
 		postId: 148614,

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/inline-support-link.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/inline-support-link.tsx
@@ -42,10 +42,10 @@ export default function DescriptionSupportLink( {
 							support_link: url,
 						} );
 					} }
-					style={ { marginTop: 10 } }
+					style={ { marginTop: 10, height: 'unset' } }
 					ref={ ( reference ) => ref !== reference && setRef( reference ) }
 					className="fse-inline-support-link is-compact"
-					variant="primary"
+					variant="link"
 				>
 					{ __( 'Learn more', 'full-site-editing' ) }
 				</Button>


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/86067

### Buttons block
<img width="283" alt="image" src="https://github.com/Automattic/wp-calypso/assets/17054134/b9219052-9530-4a3b-98f5-6a62c28d2222">

### Paragraph block
<img width="280" alt="image" src="https://github.com/Automattic/wp-calypso/assets/17054134/a5f73757-900a-4331-a0c6-5a1b41a1f296">
