### PR TITLE
`DesignPickerDesignTitle`: Use `ThemeTierBadge` on the badge if the `themes/tiers` flag is enabled

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
@@ -1,10 +1,13 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { PremiumBadge, BundledBadge } from '@automattic/components';
-import { isDefaultGlobalStylesVariationSlug, type Design } from '@automattic/design-picker';
+import {
+	isDefaultGlobalStylesVariationSlug,
+	type Design,
+	StyleVariation,
+} from '@automattic/design-picker';
 import { useSelect } from '@wordpress/data';
 import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
-import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useBundleSettingsByTheme } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
 import { useSite } from '../../../../hooks/use-site';
 import { SITE_STORE } from '../../../../stores';
@@ -16,16 +19,17 @@ import './design-picker-design-title.scss';
 type Props = {
 	designTitle: string;
 	selectedDesign: Design;
+	selectedStyleVariation?: StyleVariation;
 	shouldLimitGlobalStyles: boolean;
 };
 
 const DesignPickerDesignTitle: FC< Props > = ( {
 	designTitle,
 	selectedDesign,
+	selectedStyleVariation,
 	shouldLimitGlobalStyles,
 } ) => {
 	const bundleSettings = useBundleSettingsByTheme( selectedDesign.slug );
-	const queryParams = useQuery();
 	const site = useSite();
 	// TODO: This does not check for individual theme purchases yet.
 	const isPremiumThemeAvailable = Boolean(
@@ -42,9 +46,7 @@ const DesignPickerDesignTitle: FC< Props > = ( {
 
 	let badge: React.ReactNode = null;
 	if ( isEnabled( 'themes/tiers' ) ) {
-		const isDefaultVariation = isDefaultGlobalStylesVariationSlug(
-			queryParams.get( 'style_variation' ) || ''
-		);
+		const isDefaultVariation = isDefaultGlobalStylesVariationSlug( selectedStyleVariation?.slug );
 		const isLockedStyleVariation =
 			( ! selectedDesign.is_premium && shouldLimitGlobalStyles && ! isDefaultVariation ) ?? false;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
@@ -1,13 +1,14 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { PremiumBadge, BundledBadge } from '@automattic/components';
+import { isDefaultGlobalStylesVariationSlug, type Design } from '@automattic/design-picker';
 import { useSelect } from '@wordpress/data';
 import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { useBundleSettingsByTheme } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
 import { useSite } from '../../../../hooks/use-site';
 import { SITE_STORE } from '../../../../stores';
 import type { SiteSelect } from '@automattic/data-stores';
-import type { Design } from '@automattic/design-picker';
 import type { FC } from 'react';
 
 import './design-picker-design-title.scss';
@@ -15,10 +16,16 @@ import './design-picker-design-title.scss';
 type Props = {
 	designTitle: string;
 	selectedDesign: Design;
+	shouldLimitGlobalStyles: boolean;
 };
 
-const DesignPickerDesignTitle: FC< Props > = ( { designTitle, selectedDesign } ) => {
+const DesignPickerDesignTitle: FC< Props > = ( {
+	designTitle,
+	selectedDesign,
+	shouldLimitGlobalStyles,
+} ) => {
 	const bundleSettings = useBundleSettingsByTheme( selectedDesign.slug );
+	const queryParams = useQuery();
 	const site = useSite();
 	// TODO: This does not check for individual theme purchases yet.
 	const isPremiumThemeAvailable = Boolean(
@@ -35,10 +42,16 @@ const DesignPickerDesignTitle: FC< Props > = ( { designTitle, selectedDesign } )
 
 	let badge: React.ReactNode = null;
 	if ( isEnabled( 'themes/tiers' ) ) {
+		const isDefaultVariation = isDefaultGlobalStylesVariationSlug(
+			queryParams.get( 'style_variation' ) || ''
+		);
+		const isLockedStyleVariation =
+			( ! selectedDesign.is_premium && shouldLimitGlobalStyles && ! isDefaultVariation ) ?? false;
+
 		badge = (
 			<ThemeTierBadge
 				className="design-picker-design-title__theme-tier-badge"
-				isLockedStyleVariation={ false }
+				isLockedStyleVariation={ isLockedStyleVariation }
 				themeId={ selectedDesign.slug }
 			/>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
@@ -1,6 +1,8 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { PremiumBadge, BundledBadge } from '@automattic/components';
 import { useSelect } from '@wordpress/data';
+import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
 import { useBundleSettingsByTheme } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
 import { useSite } from '../../../../hooks/use-site';
 import { SITE_STORE } from '../../../../stores';
@@ -16,6 +18,7 @@ type Props = {
 };
 
 const DesignPickerDesignTitle: FC< Props > = ( { designTitle, selectedDesign } ) => {
+	const bundleSettings = useBundleSettingsByTheme( selectedDesign.slug );
 	const site = useSite();
 	// TODO: This does not check for individual theme purchases yet.
 	const isPremiumThemeAvailable = Boolean(
@@ -30,10 +33,16 @@ const DesignPickerDesignTitle: FC< Props > = ( { designTitle, selectedDesign } )
 		)
 	);
 
-	const bundleSettings = useBundleSettingsByTheme( selectedDesign.slug );
-
 	let badge: React.ReactNode = null;
-	if ( selectedDesign.software_sets && selectedDesign.software_sets.length > 0 ) {
+	if ( isEnabled( 'themes/tiers' ) ) {
+		badge = (
+			<ThemeTierBadge
+				className="design-picker-design-title__theme-tier-badge"
+				isLockedStyleVariation={ false }
+				themeId={ selectedDesign.slug }
+			/>
+		);
+	} else if ( selectedDesign.software_sets && selectedDesign.software_sets.length > 0 ) {
 		if ( bundleSettings ) {
 			const BadgeIcon = bundleSettings.iconComponent;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
@@ -1,11 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { PremiumBadge, BundledBadge } from '@automattic/components';
-import {
-	isDefaultGlobalStylesVariationSlug,
-	type Design,
-	StyleVariation,
-} from '@automattic/design-picker';
+import { type Design, StyleVariation } from '@automattic/design-picker';
 import { useSelect } from '@wordpress/data';
 import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
 import { useBundleSettingsByTheme } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
@@ -23,12 +19,7 @@ type Props = {
 	shouldLimitGlobalStyles: boolean;
 };
 
-const DesignPickerDesignTitle: FC< Props > = ( {
-	designTitle,
-	selectedDesign,
-	selectedStyleVariation,
-	shouldLimitGlobalStyles,
-} ) => {
+const DesignPickerDesignTitle: FC< Props > = ( { designTitle, selectedDesign } ) => {
 	const bundleSettings = useBundleSettingsByTheme( selectedDesign.slug );
 	const site = useSite();
 	// TODO: This does not check for individual theme purchases yet.
@@ -46,14 +37,10 @@ const DesignPickerDesignTitle: FC< Props > = ( {
 
 	let badge: React.ReactNode = null;
 	if ( isEnabled( 'themes/tiers' ) ) {
-		const isDefaultVariation = isDefaultGlobalStylesVariationSlug( selectedStyleVariation?.slug );
-		const isLockedStyleVariation =
-			( ! selectedDesign.is_premium && shouldLimitGlobalStyles && ! isDefaultVariation ) ?? false;
-
 		badge = (
 			<ThemeTierBadge
 				className="design-picker-design-title__theme-tier-badge"
-				isLockedStyleVariation={ isLockedStyleVariation }
+				isLockedStyleVariation={ false }
 				themeId={ selectedDesign.slug }
 			/>
 		);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/design-picker-design-title.tsx
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { WPCOM_FEATURES_PREMIUM_THEMES } from '@automattic/calypso-products';
 import { PremiumBadge, BundledBadge } from '@automattic/components';
-import { type Design, StyleVariation } from '@automattic/design-picker';
+import { type Design } from '@automattic/design-picker';
 import { useSelect } from '@wordpress/data';
 import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
 import { useBundleSettingsByTheme } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
@@ -15,8 +15,6 @@ import './design-picker-design-title.scss';
 type Props = {
 	designTitle: string;
 	selectedDesign: Design;
-	selectedStyleVariation?: StyleVariation;
-	shouldLimitGlobalStyles: boolean;
 };
 
 const DesignPickerDesignTitle: FC< Props > = ( { designTitle, selectedDesign } ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -578,6 +578,13 @@ $design-button-primary-color: rgb(17, 122, 201);
 					}
 				}
 			}
+
+		}
+
+		.design-picker-design-title__theme-tier-badge {
+			&:empty {
+				display: none;
+			}
 		}
 
 		.step-container__navigation {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -582,6 +582,8 @@ $design-button-primary-color: rgb(17, 122, 201);
 		}
 
 		.design-picker-design-title__theme-tier-badge {
+			gap: 8px;
+
 			&:empty {
 				display: none;
 			}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -788,7 +788,11 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	if ( selectedDesign && isPreviewingDesign ) {
 		const designTitle = selectedDesign.design_type !== 'vertical' ? selectedDesign.title : '';
 		const headerDesignTitle = (
-			<DesignPickerDesignTitle designTitle={ designTitle } selectedDesign={ selectedDesign } />
+			<DesignPickerDesignTitle
+				designTitle={ designTitle }
+				selectedDesign={ selectedDesign }
+				shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
+			/>
 		);
 
 		// If the user fills out the site title and/or tagline with write or sell intent, we show it on the design preview

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -788,12 +788,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	if ( selectedDesign && isPreviewingDesign ) {
 		const designTitle = selectedDesign.design_type !== 'vertical' ? selectedDesign.title : '';
 		const headerDesignTitle = (
-			<DesignPickerDesignTitle
-				designTitle={ designTitle }
-				selectedDesign={ selectedDesign }
-				selectedStyleVariation={ selectedStyleVariation }
-				shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
-			/>
+			<DesignPickerDesignTitle designTitle={ designTitle } selectedDesign={ selectedDesign } />
 		);
 
 		// If the user fills out the site title and/or tagline with write or sell intent, we show it on the design preview

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -791,6 +791,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			<DesignPickerDesignTitle
 				designTitle={ designTitle }
 				selectedDesign={ selectedDesign }
+				selectedStyleVariation={ selectedStyleVariation }
 				shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
 			/>
 		);


### PR DESCRIPTION
Fixes #86526

## Proposed Changes

On the design picker, show the badge with the new `ThemeTierBadge` component if the `themes/tiers` flag is enabled.

## Testing Instructions

1. Open the live preview and go to `/start`
2. Start a new site on the free plan and work through to the design picker
3. Add `?flags=themes/tiers` to the URL and reload
4. On the theme grid the badges are the new ones
5. Click on a premium theme like Annalee
6. Check that the badge that appears over the theme title says **Upgrade**
7. Go back to the theme list
8. Go to the "Twenty Twenty-Four" theme
9. Click on a style different from the default one, check that this action triggers the appearance of the **Upgrade** badge

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?