### PR TITLE
Subscription management: translate copy

### DIFF
--- a/client/landing/subscriptions/components/tab-views/pending/pending.tsx
+++ b/client/landing/subscriptions/components/tab-views/pending/pending.tsx
@@ -1,9 +1,12 @@
 import { SubscriptionManager } from '@automattic/data-stores';
+import { useTranslate } from 'i18n-calypso';
 import { Notice, NoticeType } from 'calypso/landing/subscriptions/components/notice';
 import { PendingPostList, PendingSiteList } from '../../pending-list';
 import TabView from '../tab-view';
 
 const Pending = () => {
+	const translate = useTranslate();
+
 	const {
 		data: { pendingSites, totalCount: totalPendingSitesCount = 0 },
 		isLoading: isLoadingPendingSites,
@@ -16,12 +19,11 @@ const Pending = () => {
 		error: errorPendingPosts,
 	} = SubscriptionManager.usePendingPostSubscriptionsQuery();
 
-	// todo: translate when we have agreed on the error message
 	let errorMessage;
 	if ( errorPendingSites ) {
-		errorMessage = 'An error occurred while fetching your site subscriptions.';
+		errorMessage = translate( 'An error occurred while fetching your site subscriptions.' );
 	} else if ( errorPendingPosts ) {
-		errorMessage = 'An error occurred while fetching your post subscriptions.';
+		errorMessage = translate( 'An error occurred while fetching your post subscriptions.' );
 	}
 
 	if (
@@ -30,8 +32,11 @@ const Pending = () => {
 		! totalPendingSitesCount &&
 		! totalPendingPostsCount
 	) {
-		// todo: translate when we have agreed on the empty view message
-		return <Notice type={ NoticeType.Warning }>No pending subscriptions were found.</Notice>;
+		return (
+			<Notice type={ NoticeType.Success }>
+				{ translate( 'All set! No pending subscriptions.' ) }
+			</Notice>
+		);
 	}
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

I noticed some copy wasn't translated, and it was rather error-y to see it after confirming all my pending subscriptions for the page, so made it more like "all done" type thing.

@crisbusquets lemme know if you have thoughts on copy!

**Before**
<img width="755" alt="Screenshot 2024-01-18 at 14 49 05" src="https://github.com/Automattic/wp-calypso/assets/87168/8d5880f6-451e-4219-a8fa-f05dd2d79f46">

**After**
<img width="623" alt="Screenshot 2024-01-18 at 14 49 00" src="https://github.com/Automattic/wp-calypso/assets/87168/8e150212-a860-4ad3-a111-e284d7014d4d">

## Proposed Changes

*  Update and translate copy at "pending subscriptions" page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/read/subscriptions/pending` while you don't have any pending subscriptions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?