### PR TITLE
Launchpad: Enable the new task definition parser in production

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -83,7 +83,7 @@
 		"lasagna": true,
 		"launchpad-updates": false,
 		"launchpad/navigator": false,
-		"launchpad/new-task-definition-parser": false,
+		"launchpad/new-task-definition-parser": true,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -78,7 +78,7 @@
 		"lasagna": true,
 		"launchpad-updates": false,
 		"launchpad/navigator": false,
-		"launchpad/new-task-definition-parser": false,
+		"launchpad/new-task-definition-parser": true,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,

--- a/config/test.json
+++ b/config/test.json
@@ -61,7 +61,7 @@
 		"lasagna": false,
 		"launchpad-updates": false,
 		"launchpad/navigator": false,
-		"launchpad/new-task-definition-parser": false,
+		"launchpad/new-task-definition-parser": true,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/86647

## Proposed Changes
This PR is the last one covering the free flow with the following task definitions
* 'plan_selected',
* 'setup_free',
* 'design_selected',
* 'domain_upsell',
* 'first_post_published',
* 'design_edited',
* 'site_launched',

For now the new definitions of them will be only available during the free flow.

## Testing Instructions
* Start the setup/free. flow until reach the ` setup/free/launchpad?`  page
* Check the Webtools console to see info logs describing if the tasks above are running new version. 
Something similar ` Using new task definition parser `  + task name
* Check if you can complete the full flow

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?