### PR TITLE
Theme Preview: Use newer plan names for theme types

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { getPlan, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useState, useMemo } from 'react';
 import wpcom from 'calypso/lib/wp';
@@ -78,17 +79,16 @@ export const usePreviewingTheme = () => {
 	const [ previewingThemeType, setPreviewingThemeType ] =
 		useState< ReturnType< typeof getThemeType > >( undefined );
 
-	// @TODO Find a better solution once we have Theme Tiers live. we could use the theme_tier slug or feature slug instead for simplicity.
-	let previewingThemeTypeDisplay;
+	let previewingThemePlan;
 	switch ( previewingThemeType ) {
 		case WOOCOMMERCE_THEME:
-			previewingThemeTypeDisplay = 'WooCommerce';
+			previewingThemePlan = getPlan( PLAN_BUSINESS ).getTitle();
 			break;
 		case PREMIUM_THEME:
-			previewingThemeTypeDisplay = config.isEnabled( 'themes/tiers' ) ? 'Explorer' : 'Premium';
+			previewingThemePlan = getPlan( PLAN_PREMIUM ).getTitle();
 			break;
 		case PERSONAL_THEME:
-			previewingThemeTypeDisplay = 'Starter';
+			previewingThemePlan = getPlan( PLAN_PERSONAL ).getTitle();
 			break;
 	}
 
@@ -117,6 +117,6 @@ export const usePreviewingTheme = () => {
 		name: previewingThemeName,
 		type: previewingThemeType,
 		requiredFeature: previewingThemeFeature,
-		typeDisplay: previewingThemeTypeDisplay,
+		plan: previewingThemePlan,
 	};
 };

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
@@ -85,10 +85,10 @@ export const usePreviewingTheme = () => {
 			previewingThemeTypeDisplay = 'WooCommerce';
 			break;
 		case PREMIUM_THEME:
-			previewingThemeTypeDisplay = 'Premium';
+			previewingThemeTypeDisplay = config.isEnabled( 'themes/tiers' ) ? 'Explorer' : 'Premium';
 			break;
 		case PERSONAL_THEME:
-			previewingThemeTypeDisplay = 'Personal';
+			previewingThemeTypeDisplay = 'Starter';
 			break;
 	}
 

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
@@ -20,13 +20,12 @@ export const LivePreviewUpgradeNotice: FC< {
 	useHideTemplatePartHint();
 
 	const noticeText = sprintf(
-		// translators: %1$s: The previewing theme name, %2$s: The theme type ('WooCommerce' or 'Premium')
+		// translators: %s: plan name (e.g. Starter, Explorer).
 		__(
-			'You are previewing %1$s, a %2$s theme. You can try out your own style customizations, which will only be saved if you upgrade and activate this theme.',
+			'Get access to this theme, and a ton of other features, with a subscription to the %s plan.',
 			'wpcom-live-preview'
 		),
-		previewingTheme.name,
-		previewingTheme.typeDisplay
+		previewingTheme.plan
 	);
 
 	/**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86482

## Proposed Changes

Simplifies the text displayed in the Live Preview notices so the theme tier/type is no longer displayed. Instead, we now indicates what's the required plan to use the theme.

Before | After
--- | ---
<img width="357" alt="Screenshot 2024-01-23 at 16 24 56" src="https://github.com/Automattic/wp-calypso/assets/1233880/0ae8deaf-34ca-472c-9f2e-f82240d99716"> | <img width="356" alt="Screenshot 2024-01-23 at 16 25 07" src="https://github.com/Automattic/wp-calypso/assets/1233880/4fb7508f-e9d1-4738-8474-ea05011da2bb">
<img width="352" alt="Screenshot 2024-01-23 at 16 26 24" src="https://github.com/Automattic/wp-calypso/assets/1233880/2909f0e0-3390-4ae2-ac4b-70b0b9815498"> | <img width="354" alt="Screenshot 2024-01-23 at 16 25 26" src="https://github.com/Automattic/wp-calypso/assets/1233880/c6fc9079-257e-4cc8-8bd5-50833d3db583">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Update your wpcom sandbox by running `install-plugin.sh wpcom-block-editor update/live-preview-plan-names`
2. Sandbox a free site and widgets.wp.com
3. Go to `/wp-admin/site-editor.php?wp_theme_preview=premium%2Fpodcasty` using your free site
4. Make sure the notice in the bottom left says "Get access to this theme, and a ton of other features, with a subscription to the Explorer plan"
5. Go to `/wp-admin/site-editor.php?wp_theme_preview=premium%2Ftsubaki` 
7. Make sure the notice in the bottom left says "Get access to this theme, and a ton of other features, with a subscription to the Business plan"