### PR TITLE
Fix Theme demo preview broken UI regression

### DIFF
--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -15,6 +15,7 @@ import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
 import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
 import { hideThemePreview } from 'calypso/state/themes/actions';
+import { useThemeTierForTheme } from 'calypso/state/themes/hooks/use-theme-tier-for-theme';
 import {
 	getThemeDemoUrl,
 	getThemePreviewThemeOptions,
@@ -42,6 +43,7 @@ class ThemePreview extends Component {
 		isJetpack: PropTypes.bool,
 		themeId: PropTypes.string,
 		themeOptions: PropTypes.object,
+		themeTier: PropTypes.object,
 	};
 
 	state = {
@@ -183,9 +185,9 @@ class ThemePreview extends Component {
 			return;
 		}
 
-		const { themeId } = this.props;
+		const { themeId, themeTier } = this.props;
 		const buttonHref = primaryOption.getUrl
-			? this.appendStyleVariationOptionToUrl( primaryOption.getUrl( themeId ) )
+			? this.appendStyleVariationOptionToUrl( primaryOption.getUrl( themeId, { themeTier } ) )
 			: null;
 
 		return (
@@ -201,9 +203,9 @@ class ThemePreview extends Component {
 			return;
 		}
 
-		const { themeId } = this.props;
+		const { themeId, themeTier } = this.props;
 		const buttonHref = secondaryButton.getUrl
-			? this.appendStyleVariationOptionToUrl( secondaryButton.getUrl( themeId ) )
+			? this.appendStyleVariationOptionToUrl( secondaryButton.getUrl( themeId, { themeTier } ) )
 			: null;
 
 		return (
@@ -278,10 +280,17 @@ class ThemePreview extends Component {
 
 const withSiteGlobalStylesStatus = createHigherOrderComponent(
 	( Wrapped ) => ( props ) => {
-		const { siteId } = props;
+		const { siteId, themeId } = props;
 		const { shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( siteId );
 
-		return <Wrapped { ...props } shouldLimitGlobalStyles={ shouldLimitGlobalStyles } />;
+		const themeTier = useThemeTierForTheme( themeId );
+		return (
+			<Wrapped
+				{ ...props }
+				shouldLimitGlobalStyles={ shouldLimitGlobalStyles }
+				themeTier={ themeTier }
+			/>
+		);
 	},
 	'withSiteGlobalStylesStatus'
 );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fix a regression introduced in https://github.com/Automattic/wp-calypso/pull/86424 That breaks the UI for the theme demo preview. 

Related to https://github.com/Automattic/wp-calypso/pull/86424

## Proposed Changes

* Fixed a regression in the Theme details page > Demo site UI

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the live link and select a free site (the issue is reproduced only when the user doesn't have permission for the theme)
* Go to /theme/carnation
* Click on the "view demo" button displayed in the theme thumbnail
* The UI should load the and CTA should point to the checkout for the `premium` subscription

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?