### PR TITLE
Created HostingActivateStatus component for reusing it at the plugins/themes/hosting pages

### DIFF
--- a/client/my-sites/hosting/hosting-activate-status.tsx
+++ b/client/my-sites/hosting/hosting-activate-status.tsx
@@ -1,0 +1,77 @@
+import { translate } from 'i18n-calypso';
+import { connect } from 'react-redux';
+import Notice from 'calypso/components/notice';
+import { useAtomicTransferQuery } from 'calypso/state/atomic-transfer/use-atomic-transfer-query';
+import { transferStates } from 'calypso/state/automated-transfer/constants';
+import { initiateThemeTransfer } from 'calypso/state/themes/actions';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import type { AppState } from 'calypso/types';
+
+interface HostingActivateStatusProps {
+	context: 'themes' | 'plugins' | 'hosting';
+	siteId: number | null;
+}
+
+const HostingActivateStatus = ( { context, siteId }: HostingActivateStatusProps ) => {
+	const { isTransferring, transferStatus } = useAtomicTransferQuery( siteId, {
+		refetchInterval: 5000,
+	} );
+
+	const getLoadingText = () => {
+		switch ( context ) {
+			case 'themes':
+				return translate( 'Please wait while we activate the themes features.' );
+				break;
+			case 'plugins':
+				return translate( 'Please wait while we activate the plugins features.' );
+				break;
+			default:
+				return translate( 'Please wait while we activate the hosting features.' );
+		}
+	};
+
+	const getErrorText = () => {
+		switch ( context ) {
+			case 'themes':
+				return translate( 'There was an error activating themes features.' );
+				break;
+			case 'plugins':
+				return translate( 'There was an error activating plugins features.' );
+				break;
+			default:
+				return translate( 'There was an error activating hosting features.' );
+		}
+	};
+
+	if ( transferStatus === transferStates.ERROR ) {
+		return <Notice status="is-error" showDismiss={ false } text={ getErrorText() } icon="bug" />;
+	}
+
+	if ( isTransferring ) {
+		return (
+			<Notice
+				className="hosting__activating-notice"
+				status="is-info"
+				showDismiss={ false }
+				text={ getLoadingText() }
+				icon="sync"
+			/>
+		);
+	}
+};
+
+const mapStateToProps = ( state: AppState ) => {
+	const siteId = getSelectedSiteId( state );
+	const siteSlug = getSelectedSiteSlug( state );
+
+	return {
+		siteId,
+		siteSlug,
+	};
+};
+
+const mapDispatchToProps = {
+	initiateTransfer: initiateThemeTransfer,
+};
+
+export default connect( mapStateToProps, mapDispatchToProps )( HostingActivateStatus );

--- a/client/my-sites/hosting/hosting-activate-status.tsx
+++ b/client/my-sites/hosting/hosting-activate-status.tsx
@@ -3,13 +3,12 @@ import { connect } from 'react-redux';
 import Notice from 'calypso/components/notice';
 import { useAtomicTransferQuery } from 'calypso/state/atomic-transfer/use-atomic-transfer-query';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
-import { initiateThemeTransfer } from 'calypso/state/themes/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import type { AppState } from 'calypso/types';
 
 interface HostingActivateStatusProps {
 	context: 'themes' | 'plugins' | 'hosting';
-	siteId: number | null;
+	siteId: number;
 }
 
 const HostingActivateStatus = ( { context, siteId }: HostingActivateStatusProps ) => {
@@ -61,7 +60,7 @@ const HostingActivateStatus = ( { context, siteId }: HostingActivateStatusProps 
 };
 
 const mapStateToProps = ( state: AppState ) => {
-	const siteId = getSelectedSiteId( state );
+	const siteId = getSelectedSiteId( state ) || 0;
 	const siteSlug = getSelectedSiteSlug( state );
 
 	return {
@@ -70,8 +69,4 @@ const mapStateToProps = ( state: AppState ) => {
 	};
 };
 
-const mapDispatchToProps = {
-	initiateTransfer: initiateThemeTransfer,
-};
-
-export default connect( mapStateToProps, mapDispatchToProps )( HostingActivateStatus );
+export default connect( mapStateToProps )( HostingActivateStatus );

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -225,7 +225,7 @@ const Hosting = ( props ) => {
 	};
 
 	const getAtomicActivationNotice = () => {
-		if ( showHostingActivationBanner ) {
+		if ( showHostingActivationBanner && ! isTransferring ) {
 			return (
 				<Notice
 					className="hosting__activating-notice"

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -41,6 +41,7 @@ import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import CacheCard from './cache-card';
+import HostingActivateStatus from './hosting-activate-status';
 import { HostingUpsellNudge } from './hosting-upsell-nudge';
 import PhpMyAdminCard from './phpmyadmin-card';
 import RestorePlanSoftwareCard from './restore-plan-software-card';
@@ -224,51 +225,20 @@ const Hosting = ( props ) => {
 	};
 
 	const getAtomicActivationNotice = () => {
-		// Transfer in progress
-		if ( isTransferring ) {
-			return (
-				<>
-					<Notice
-						className="hosting__activating-notice"
-						status="is-info"
-						showDismiss={ false }
-						text={ translate( 'Please wait while we activate the hosting features.' ) }
-						icon="sync"
-					/>
-				</>
-			);
-		}
-
-		const failureNotice = transferStatus === transferStates.ERROR && (
-			<Notice
-				status="is-error"
-				showDismiss={ false }
-				text={ translate( 'There was an error activating hosting features.' ) }
-				icon="bug"
-			/>
-		);
 		if ( showHostingActivationBanner ) {
 			return (
-				<>
-					{ failureNotice }
-					<Notice
-						className="hosting__activating-notice"
-						status="is-info"
-						showDismiss={ false }
-						text={ translate(
-							'Please activate the hosting access to begin using these features.'
-						) }
-						icon="globe"
-					>
-						<TrackComponentView eventName="calypso_hosting_configuration_activate_impression" />
-						<NoticeAction
-							onClick={ clickActivate }
-							href={ `/hosting-config/activate/${ siteSlug }` }
-						>
-							{ translate( 'Activate' ) }
-						</NoticeAction>
-					</Notice>
-				</>
+				<Notice
+					className="hosting__activating-notice"
+					status="is-info"
+					showDismiss={ false }
+					text={ translate( 'Please activate the hosting access to begin using these features.' ) }
+					icon="globe"
+				>
+					<TrackComponentView eventName="calypso_hosting_configuration_activate_impression" />
+					<NoticeAction onClick={ clickActivate } href={ `/hosting-config/activate/${ siteSlug }` }>
+						{ translate( 'Activate' ) }
+					</NoticeAction>
+				</Notice>
 			);
 		}
 	};
@@ -328,6 +298,7 @@ const Hosting = ( props ) => {
 				title={ translate( 'Hosting Configuration' ) }
 				subtitle={ translate( 'Access your website’s database and more advanced settings.' ) }
 			/>
+			<HostingActivateStatus context="hosting" />
 			{ ! isBusinessTrial && banner }
 			{ isBusinessTrial && (
 				<TrialBanner

--- a/client/my-sites/hosting/test/hosting-activate-status.jsx
+++ b/client/my-sites/hosting/test/hosting-activate-status.jsx
@@ -1,0 +1,121 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import { transferStates } from '../../../state/automated-transfer/constants';
+import HostingActivateStatus from '../hosting-activate-status';
+
+const initialState = {
+	sites: {
+		items: [],
+		requesting: {},
+		plans: {},
+	},
+	ui: {
+		selectedSiteId: 1,
+	},
+	currentUser: {
+		id: 12,
+		user: {
+			email_verified: true,
+		},
+	},
+	notices: {
+		items: [],
+	},
+};
+
+let mockIsTransferring = true;
+let mockTransferStatus = '';
+
+jest.mock( 'calypso/state/atomic-transfer/use-atomic-transfer-query', () => {
+	return {
+		useAtomicTransferQuery: ( siteId ) => {
+			if ( siteId === initialState.ui.selectedSiteId ) {
+				return {
+					isTransferring: mockIsTransferring,
+					transferStatus: mockTransferStatus,
+				};
+			}
+		},
+	};
+} );
+
+describe( 'index', () => {
+	test( 'Should show the transferring notice when the site is transferring to Atomic based on context', async () => {
+		mockTransferStatus = transferStates.PENDING;
+		const mockStore = configureStore();
+		const store = mockStore( initialState );
+
+		render(
+			<Provider store={ store }>
+				<HostingActivateStatus context="hosting" />
+			</Provider>
+		);
+
+		expect(
+			screen.getByText( 'Please wait while we activate the hosting features.' )
+		).toBeInTheDocument();
+
+		render(
+			<Provider store={ store }>
+				<HostingActivateStatus context="plugins" />
+			</Provider>
+		);
+		expect(
+			screen.getByText( 'Please wait while we activate the plugins features.' )
+		).toBeInTheDocument();
+
+		render(
+			<Provider store={ store }>
+				<HostingActivateStatus context="themes" />
+			</Provider>
+		);
+		expect(
+			screen.getByText( 'Please wait while we activate the themes features.' )
+		).toBeInTheDocument();
+	} );
+
+	test( 'Should show error status and the transfer fails', async () => {
+		const mockStore = configureStore();
+		const store = mockStore( initialState );
+
+		mockIsTransferring = true;
+		mockTransferStatus = transferStates.ERROR;
+
+		render(
+			<Provider store={ store }>
+				<HostingActivateStatus context="hosting" />
+			</Provider>
+		);
+
+		expect(
+			screen.queryByText( 'Please wait while we activate the hosting features.' )
+		).not.toBeInTheDocument();
+
+		expect(
+			screen.queryByText( 'There was an error activating hosting features.' )
+		).toBeInTheDocument();
+
+		render(
+			<Provider store={ store }>
+				<HostingActivateStatus context="plugins" />
+			</Provider>
+		);
+		expect(
+			screen.getByText( 'There was an error activating plugins features.' )
+		).toBeInTheDocument();
+
+		render(
+			<Provider store={ store }>
+				<HostingActivateStatus context="themes" />
+			</Provider>
+		);
+		expect(
+			screen.getByText( 'There was an error activating themes features.' )
+		).toBeInTheDocument();
+	} );
+} );

--- a/client/state/atomic-transfer/use-atomic-transfer-query.ts
+++ b/client/state/atomic-transfer/use-atomic-transfer-query.ts
@@ -1,15 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { transferStates, TransferStates } from 'calypso/state/automated-transfer/constants';
-import { SiteSlug } from 'calypso/types';
 
 interface SuccessResponse {
 	status: TransferStates;
 }
 
-const fetchLatestAtomicTransfer = ( siteSlug: SiteSlug ): Promise< SuccessResponse > =>
+const fetchLatestAtomicTransfer = ( siteId: number ): Promise< SuccessResponse > =>
 	wpcom.req.get( {
-		path: `/sites/${ siteSlug }/atomic/transfers/latest`,
+		path: `/sites/${ siteId }/atomic/transfers/latest`,
 		apiNamespace: 'wpcom/v2',
 	} );
 
@@ -26,17 +25,17 @@ const endStates: TransferStates[] = [
 	transferStates.REVERTED,
 ];
 
-export function useAtomicTransferQueryQueryKey( siteSlug: string ) {
-	return [ 'sites', siteSlug, 'atomic', 'transfers', 'latest' ];
+export function useAtomicTransferQueryQueryKey( siteId: number ) {
+	return [ 'sites', siteId, 'atomic', 'transfers', 'latest' ];
 }
 
 export const useAtomicTransferQuery = (
-	siteSlug: SiteSlug,
+	siteId: number,
 	{ refetchInterval }: UseAtomicTransferQueryOptions
 ) => {
 	const { data, failureReason } = useQuery( {
-		queryKey: useAtomicTransferQueryQueryKey( siteSlug ),
-		queryFn: () => fetchLatestAtomicTransfer( siteSlug ),
+		queryKey: useAtomicTransferQueryQueryKey( siteId ),
+		queryFn: () => fetchLatestAtomicTransfer( siteId ),
 		refetchInterval,
 	} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5097

We're extracting the Atomic status from the /hosting page to reuse this HostingActivateStatus component at the /themes and /or plugins page once we do the Atomic transfer inside the pages without redirects. 

## Proposed Changes

* Created a new HostingActivateStatus component
* Changed /hosting page to use it
* Added new copy versions specific to "plugins" and "themes" context
* Did a small refactor by adding `siteId` instead of `siteSlug` to `fetchLatestAtomicTransfer` due to https://github.com/Automattic/wp-calypso/pull/86351

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure the /hosting Atomic site flow works as expected by showing the correct `Please wait while we activate the hosting features.` message.

	1. Go to http://calypso.localhost:3000/hosting-config/YOUR-FREE-SITE
	2. Enable hosting plan buying it
	3. Go back to the /hosting-config page and check if you still see the enabling Atomic message:

	<img width="1390" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/f3c3da85-dc34-44e9-8751-393e315619ab">


* Run tests: `yarn run test-client client/my-sites/hosting/test/hosting-activate-status.jsx`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
