### PR TITLE
Support multiple domains in Professional Email upsell on congrats page

### DIFF
--- a/client/components/thank-you-v2/upsell/index.tsx
+++ b/client/components/thank-you-v2/upsell/index.tsx
@@ -6,14 +6,14 @@ export type ThankYouUpsellProps = {
 	title: React.ReactNode;
 	description: React.ReactNode;
 	image: string;
-	action?: React.ReactNode;
+	actions?: React.ReactNode;
 };
 
 export default function ThankYouUpsell( {
 	title,
 	description,
 	image,
-	action,
+	actions,
 }: ThankYouUpsellProps ) {
 	const translate = useTranslate();
 
@@ -35,7 +35,7 @@ export default function ThankYouUpsell( {
 					<p className="thank-you__upsell-description">{ description }</p>
 				</div>
 
-				<div className="thank-you__upsell-actions">{ action }</div>
+				<div className="thank-you__upsell-actions">{ actions }</div>
 			</div>
 		</div>
 	);

--- a/client/components/thank-you-v2/upsell/style.scss
+++ b/client/components/thank-you-v2/upsell/style.scss
@@ -59,11 +59,12 @@
 
 .thank-you__upsell-actions {
 	display: flex;
-	gap: 8px;
+	gap: 12px;
 	margin-top: 20px;
 
 	@media (max-width: $break-small ) {
 		flex-direction: column;
+		gap: 16px;
 	}
 
 	a.components-button {
@@ -80,5 +81,18 @@
 			background: var(--black-white-black, #333);
 			color: var(--black-white-white, #fff);
 		}
+	}
+
+	.components-base-control__field {
+		margin-bottom: 0;
+	}
+	.components-select-control {
+		height: 36px;
+	}
+	.components-select-control__input {
+		font-size: $font-body-small !important;
+	}
+	.components-input-control__backdrop {
+		border-color: var(--color-border-subtle) !important;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/4483

## Proposed Changes

Some domain-only orders contain multiple domains, in which case we want to support that in the Professional Email upsell. This PR implements that in accordance with these mocks VLoPHWqcewxNKZYjjkDu3O-fi-3277%3A5510

| Desktop | Mobile |
| - | - |
| ![desktop](https://github.com/Automattic/wp-calypso/assets/1101677/eeb9af09-acf3-4aa1-83c1-416782347820) | ![mobile](https://github.com/Automattic/wp-calypso/assets/1101677/86d58bb8-d5dd-45bd-ac3b-03312ec72e5e) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `Upgrades > Domains > Add a domain > Search for a domain`
2. Search for a domain, click Select
3. On the next page, click `Back` and add a second domain to the cart
4. Skip the Professional Email upsell
7. Ensure that the thank you page matches the mocks
8. Ensure that the CTA button leads to the Professional Email upsell page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?