### PR TITLE
Plugin Details: Show a banner asking for reviews on Marketplace Plugins

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import Banner from 'calypso/components/banner';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import QueryPlugins from 'calypso/components/data/query-plugins';
@@ -18,6 +19,7 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import { useESPlugin } from 'calypso/data/marketplace/use-es-query';
+import { useMarketplaceReviewsQuery } from 'calypso/data/marketplace/use-marketplace-reviews';
 import { useWPCOMPlugin } from 'calypso/data/marketplace/use-wpcom-plugins-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { MarketplaceReviewsCards } from 'calypso/my-sites/marketplace/components/reviews-cards';
@@ -45,7 +47,8 @@ import {
 } from 'calypso/state/analytics/actions';
 import { appendBreadcrumb } from 'calypso/state/breadcrumb/actions';
 import { getBreadcrumbs } from 'calypso/state/breadcrumb/selectors';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getCurrentUserId, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { canPublishProductReviews } from 'calypso/state/marketplace/selectors';
 import {
 	getPluginOnSites,
 	isRequestingForAllSites,
@@ -227,6 +230,18 @@ function PluginDetails( props ) {
 		requestingPluginsForSites,
 	] );
 
+	const canPublishReview = useSelector( ( state ) =>
+		canPublishProductReviews( state, 'plugin', fullPlugin.slug, fullPlugin.variations )
+	);
+	const currentUserId = useSelector( getCurrentUserId );
+	const { data: userReviews = [] } = useMarketplaceReviewsQuery( {
+		productType: 'plugin',
+		slug: fullPlugin.slug,
+		perPage: 1,
+		author: currentUserId ?? undefined,
+		status: 'all',
+	} );
+
 	const setBreadcrumbs = ( breadcrumbs = [] ) => {
 		if ( breadcrumbs?.length === 0 ) {
 			dispatch(
@@ -381,6 +396,19 @@ function PluginDetails( props ) {
 				productType="plugin"
 			/>
 			<PluginDetailsNotices selectedSite={ selectedSite } plugin={ fullPlugin } />
+
+			{ userReviews.length === 0 && canPublishReview && (
+				<Banner
+					className="plugin-details__reviews-banner"
+					title={ translate( 'Review this plugin!' ) }
+					description={ translate(
+						'Please help other users sharing your experience with this plugin.'
+					) }
+					onClick={ () => setIsReviewsModalVisible( true ) }
+					disableHref
+					event="calypso_marketplace_reviews_plugin_banner"
+				/>
+			) }
 			<div className="plugin-details__page">
 				<div className={ classnames( 'plugin-details__layout', { 'is-logged-in': isLoggedIn } ) }>
 					<div className="plugin-details__header">

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -560,7 +560,14 @@ body.is-section-plugins #primary {
 	}
 }
 
-.banner.card.plugin-details__reviews-banner:hover {
-	cursor: pointer;
-	box-shadow: 0 0 1px var(--color-neutral), 0 2px 4px var(--color-neutral-10);
+.banner.card.plugin-details__reviews-banner {
+
+	&:hover {
+		cursor: pointer;
+		box-shadow: 0 0 1px var(--color-neutral), 0 2px 4px var(--color-neutral-10);
+	}
+
+	~ .plugin-details__page .plugin-details__layout {
+		padding-top: calc($layout-padding-top - 40px);
+	}
 }

--- a/client/my-sites/plugins/style.scss
+++ b/client/my-sites/plugins/style.scss
@@ -560,3 +560,7 @@ body.is-section-plugins #primary {
 	}
 }
 
+.banner.card.plugin-details__reviews-banner:hover {
+	cursor: pointer;
+	box-shadow: 0 0 1px var(--color-neutral), 0 2px 4px var(--color-neutral-10);
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/86408

## Proposed Changes

Show a banner asking reviews on the Plugin Details page when:
- The user has not left a review yet
- Its a Marketplace plugin
- The user has an active subscription

## Testing Instructions

* Go to the plugin details page of a plugin where you haven't left a review yet. Ex: `/plugins/woocommerce-subscriptions/:site`
* Purchase it if you don't have an active subscription yet.
* Go back to the plugin details page
* Check if the banner is shown for you and if clicking open the Reviews Modal

![CleanShot 2024-01-18 at 11 58 53](https://github.com/Automattic/wp-calypso/assets/5039531/d528d486-75a1-4ce3-9ee9-080fc0fc7512)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?