### PR TITLE
Theme Tiers: Fix style variations layout in Design Picker

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -378,18 +378,17 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 			( product ) => product.product_slug === marketplaceProductSlug
 		) || marketplaceThemeProducts[ 0 ];
 
-	const didPurchaseSelectedTheme = useSelector( ( state ) => {
-		if ( ! site || ! selectedDesignThemeId ) {
-			return false;
-		}
+	const didPurchaseSelectedTheme = useSelector( ( state ) =>
+		site && selectedDesignThemeId
+			? isThemePurchased( state, selectedDesignThemeId, site.ID )
+			: false
+	);
 
-		if ( isEnabled( 'themes/tiers' ) ) {
-			return isThemeAllowedOnSite( state, site.ID, selectedDesignThemeId );
-		}
-
-		// @TODO Remove this once we have the new theme tiers live.
-		return isThemePurchased( state, selectedDesignThemeId, site.ID );
-	} );
+	const canSiteActivateTheme = useSelector( ( state ) =>
+		site && selectedDesignThemeId
+			? isThemeAllowedOnSite( state, site.ID, selectedDesignThemeId )
+			: false
+	);
 
 	const isMarketplaceThemeSubscribed = useSelector(
 		( state ) =>
@@ -417,7 +416,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const isLockedTheme =
 		( isEnabled( 'themes/tiers' ) &&
 			selectedDesignTier === PERSONAL_THEME &&
-			! didPurchaseSelectedTheme ) ||
+			! canSiteActivateTheme ) ||
 		( selectedDesign?.is_premium && ! isPremiumThemeAvailable && ! didPurchaseSelectedTheme ) ||
 		( selectedDesign?.is_externally_managed &&
 			( ! isMarketplaceThemeSubscribed || ! isExternallyManagedThemeAvailable ) ) ||


### PR DESCRIPTION
## Proposed Changes

Fixes a regression introduced in https://github.com/Automattic/wp-calypso/pull/86407 that caused the paid style variations to be incorrectly grouped with the default free style variation.

Before | After
--- | ---
<img width="320" alt="Screenshot 2024-01-18 at 15 34 05" src="https://github.com/Automattic/wp-calypso/assets/1233880/88c465f1-b8f7-449d-a0bb-45a55f4ad755"> | <img width="315" alt="Screenshot 2024-01-18 at 15 33 44" src="https://github.com/Automattic/wp-calypso/assets/1233880/249137c3-b74e-47fa-a561-226aaa5e345b">

The culprit was that `didPurchaseSelectedTheme` started to return true for Free themes, although the theme has never been purchased technically, causing the logic below to believe that the theme was a purchased premium theme and thus shouldn't split the style variations.

## Testing Instructions

- Use the Calypso live link below
- Go to `/setup/site-setup/designSetup?siteSlug=<FREE_SITE_DOMAIN>&flags=themes/tiers`
- Make sure the paid style variations are split from the default free style variation