### PR TITLE
Improve Calypso user management

### DIFF
--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -167,7 +167,7 @@ class PeopleListItem extends PureComponent {
 		const { translate, requestingSend } = this.props;
 
 		return (
-			<div>
+			<div className="people-list-item__invite-status">
 				<Button
 					busy={ requestingSend?.progress }
 					className="people-list-item__invite-send"

--- a/client/my-sites/people/people-list-item/index.jsx
+++ b/client/my-sites/people/people-list-item/index.jsx
@@ -12,6 +12,7 @@ import {
 	isRequestingInviteResend,
 	didInviteResendSucceed,
 	didInviteDeletionSucceed,
+	getSendInviteState,
 } from 'calypso/state/invites/selectors';
 
 import './style.scss';
@@ -121,10 +122,14 @@ class PeopleListItem extends PureComponent {
 	};
 
 	onSendInvite = ( event ) => {
-		const { siteId, user } = this.props;
+		const { requestingSend, siteId, user } = this.props;
 		// Prevents navigation to invite-details screen and onClick event.
 		event.preventDefault();
 		event.stopPropagation();
+
+		if ( requestingSend?.progress ) {
+			return null;
+		}
 
 		this.props.sendInvites( siteId, [ user.email ], user.roles[ 0 ], '', false );
 	};
@@ -159,11 +164,17 @@ class PeopleListItem extends PureComponent {
 	};
 
 	renderInviteButton = () => {
-		const { translate } = this.props;
+		const { translate, requestingSend } = this.props;
 
 		return (
 			<div>
-				<Button onClick={ this.onSendInvite }>{ translate( 'Invite' ) }</Button>
+				<Button
+					busy={ requestingSend?.progress }
+					className="people-list-item__invite-send"
+					onClick={ this.onSendInvite }
+				>
+					{ translate( 'Invite' ) }
+				</Button>
 			</div>
 		);
 	};
@@ -257,6 +268,7 @@ export default connect(
 		return {
 			requestingResend: isRequestingInviteResend( state, siteId, inviteKey ),
 			resendSuccess: didInviteResendSucceed( state, siteId, inviteKey ),
+			requestingSend: getSendInviteState( state ),
 			siteId,
 			inviteKey,
 			inviteWasDeleted,

--- a/client/my-sites/people/people-list-item/style.scss
+++ b/client/my-sites/people/people-list-item/style.scss
@@ -49,6 +49,10 @@
 	}
 }
 
+.people-list-item.is-not-linked-user {
+	background: var(--studio-gray-10);
+}
+
 .people-list-item__invite-status {
 	align-self: center;
 	flex-shrink: 0;

--- a/client/my-sites/people/people-list-item/style.scss
+++ b/client/my-sites/people/people-list-item/style.scss
@@ -90,7 +90,8 @@
 }
 
 .people-list-item__invite-resend.button,
-.people-list-item__invite-revoke.button {
+.people-list-item__invite-revoke.button,
+.people-list-item__invite-send {
 	vertical-align: baseline;
 	margin-left: 0.75rem;
 


### PR DESCRIPTION
Needs D135326-code to have the email of the invited user

Temporary, not so beautiful, design. 

![image](https://github.com/Automattic/wp-calypso/assets/52076348/8017e1aa-d95f-4959-adb8-0bd72bda95e9)

It can be shipped behind a flag only on development, or wait for design.

## Testing
1. Apply the diff to your sandbox.
2. Sandbox public api.
3. Visit `[live link]/people/team/[site slug]`
4. Invite a user that is not connected to a wp.com user (should be gray)