### PR TITLE
Close notifications on accessibility mode.

### DIFF
--- a/apps/notifications/src/panel/templates/index.jsx
+++ b/apps/notifications/src/panel/templates/index.jsx
@@ -456,6 +456,7 @@ class Layout extends Component {
 						initialLoad={ this.props.notes === null }
 						notes={ filteredNotes }
 						selectedNote={ this.state.selectedNote }
+						closePanel={ this.props.closePanel }
 					/>
 				) }
 

--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -339,6 +339,13 @@ export class NoteList extends Component {
 			'is-empty-list': emptyNoteList,
 		} );
 
+		const notificationsListAriaProps = {
+			[ 'aria-live' ]: 'polite',
+			[ 'aria-description' ]: this.props.translate(
+				'Filter notifications. Press the Escape key to close the notifications, or continue navigating to read them.'
+			),
+		};
+
 		return (
 			<div className={ classes } id="wpnc__note-list">
 				<FilterBar controller={ this.props.filterController } />
@@ -346,7 +353,7 @@ export class NoteList extends Component {
 					{ this.props.translate( 'Close notifications' ) }
 				</button>
 				<div ref={ this.storeScrollableContainer } className={ listViewClasses }>
-					<ol ref={ this.storeNoteList } className="wpnc__notes" aria-live="polite">
+					<ol ref={ this.storeNoteList } className="wpnc__notes" { ...notificationsListAriaProps }>
 						<StatusBar
 							statusClasses={ this.state.statusClasses }
 							statusMessage={ this.state.statusMessage }

--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -342,7 +342,7 @@ export class NoteList extends Component {
 		const notificationsListAriaProps = {
 			[ 'aria-live' ]: 'polite',
 			[ 'aria-description' ]: this.props.translate(
-				'Filter notifications. Press the Escape key to close the notifications, or continue navigating to read them.'
+				'Press the Escape key to close the notifications, or continue navigating to read them.'
 			),
 		};
 

--- a/apps/notifications/src/panel/templates/note-list.jsx
+++ b/apps/notifications/src/panel/templates/note-list.jsx
@@ -342,6 +342,9 @@ export class NoteList extends Component {
 		return (
 			<div className={ classes } id="wpnc__note-list">
 				<FilterBar controller={ this.props.filterController } />
+				<button className="screen-reader-text" onClick={ this.props.closePanel }>
+					{ this.props.translate( 'Close notifications' ) }
+				</button>
 				<div ref={ this.storeScrollableContainer } className={ listViewClasses }>
 					<ol ref={ this.storeNoteList } className="wpnc__notes" aria-live="polite">
 						<StatusBar

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -246,6 +246,11 @@ export class Notifications extends Component {
 					window.open( href, '_blank' );
 				},
 			],
+			CLOSE_PANEL: [
+				() => {
+					this.props.checkToggle();
+				},
+			],
 		};
 
 		return (


### PR DESCRIPTION
Related to # https://github.com/Automattic/wp-calypso/issues/86477

## Proposed Changes

When the notification panel is focused we are may not able to close the with the ESC key. This is hard to notice if using a mouse to interact with the UI, but if using keyboard o accessibility tools to navigate, it is very hard to close the panel.

That happens because the notification panel can be manifested in two ways:
1 - If you open a blog like https://testandregardi.wordpress.com it will be presented as widget wrapped on a iframe.
2 - If you open the admin panel on https://wordpress.com, it will not be wrapped on iframe, but rendered as a component on the same React app, because the page itself is calypso.

The standalone version has a messager at `apps/notifications/src/standalone/messaging.js` that signals to the `window.parent` the message `togglePanel`. But when the panel is not wrapped on iframe, there is no parent to listen or close the panel when the `CLOSE_PANEL` action is triggered.

On calypso admin page, the component is instantiated at `client/notifications/index.jsx`. At the point we were able to add a custom middleware that intercepts the `CLOSE_PANEL` action and close to take action, making the ESC key also work on when the panel is focused.

We are also adding a accessibility `Close notifications` button.

## Testing Instructions
- Start this branch on your local calypso.
- Open http://calypso.localhost:3000/
- Click on the bell icon on the top right of the page.
- Press Tab just once.
- Press ESC key, it should close the panel.
- Click on the bell icon again.
- Click press Tab 6 times and you will see `Close notifications` accessibility button.
- Click on the button, it should close the panel.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
