### PR TITLE
Allow glue records editing

### DIFF
--- a/client/data/domains/glue-records/use-create-glue-record-mutation.ts
+++ b/client/data/domains/glue-records/use-create-glue-record-mutation.ts
@@ -1,14 +1,15 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { domainGlueRecordQueryKey } from 'calypso/data/domains/glue-records/domain-glue-record-query-key';
+import { DomainsApiError } from 'calypso/lib/domains/types';
+import wp from 'calypso/lib/wp';
 import {
 	GlueRecordObject,
 	GlueRecordQueryData,
-} from 'calypso/data/domains/glue-records/use-domain-glue-records-query';
-import { DomainsApiError } from 'calypso/lib/domains/types';
-import wp from 'calypso/lib/wp';
+	mapGlueRecordObjectToApiObject,
+} from './use-domain-glue-records-query';
 
-export default function useDeleteGlueRecordMutation(
+export default function useCreateGlueRecordMutation(
 	domainName: string,
 	queryOptions: {
 		onSuccess?: () => void;
@@ -21,12 +22,12 @@ export default function useDeleteGlueRecordMutation(
 			wp.req
 				.post(
 					{
-						path: `/domains/glue-records/${ domainName }`,
+						path: `/domains/glue-records`,
 						apiNamespace: 'wpcom/v2',
-						method: 'DELETE',
 					},
 					{
-						name_server: glueRecord.nameserver,
+						name_server: glueRecord.nameserver.toLowerCase(),
+						ip_addresses: [ glueRecord.address ],
 					}
 				)
 				.then( () => glueRecord ),
@@ -35,20 +36,23 @@ export default function useDeleteGlueRecordMutation(
 			const key = domainGlueRecordQueryKey( domainName );
 			queryClient.setQueryData( key, ( old: GlueRecordQueryData ) => {
 				if ( ! old ) {
-					return [];
+					return [ mapGlueRecordObjectToApiObject( glueRecord ) ];
 				}
-				return old.filter( ( item ) => item.nameserver !== glueRecord.nameserver );
+				return [ ...old, mapGlueRecordObjectToApiObject( glueRecord ) ];
 			} );
 			queryOptions.onSuccess?.();
+		},
+		onError( error: DomainsApiError ) {
+			queryOptions.onError?.( error );
 		},
 	} );
 
 	const { mutate } = mutation;
 
-	const deleteGlueRecord = useCallback(
+	const createGlueRecord = useCallback(
 		( glueRecord: GlueRecordObject ) => mutate( glueRecord ),
 		[ mutate ]
 	);
 
-	return { deleteGlueRecord, ...mutation };
+	return { createGlueRecord, ...mutation };
 }

--- a/client/data/domains/glue-records/use-create-glue-record-mutation.ts
+++ b/client/data/domains/glue-records/use-create-glue-record-mutation.ts
@@ -1,13 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { domainGlueRecordQueryKey } from 'calypso/data/domains/glue-records/domain-glue-record-query-key';
-import { DomainsApiError } from 'calypso/lib/domains/types';
 import wp from 'calypso/lib/wp';
-import {
-	GlueRecordObject,
-	GlueRecordQueryData,
-	mapGlueRecordObjectToApiObject,
-} from './use-domain-glue-records-query';
+import { mapGlueRecordObjectToApiObject } from './use-domain-glue-records-query';
+import type { GlueRecordObject, GlueRecordQueryData } from './use-domain-glue-records-query';
+import type { DomainsApiError } from 'calypso/lib/domains/types';
 
 export default function useCreateGlueRecordMutation(
 	domainName: string,

--- a/client/data/domains/glue-records/use-delete-glue-record-mutation.ts
+++ b/client/data/domains/glue-records/use-delete-glue-record-mutation.ts
@@ -1,12 +1,12 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { domainGlueRecordQueryKey } from 'calypso/data/domains/glue-records/domain-glue-record-query-key';
-import {
+import wp from 'calypso/lib/wp';
+import type {
 	GlueRecordObject,
 	GlueRecordQueryData,
 } from 'calypso/data/domains/glue-records/use-domain-glue-records-query';
-import { DomainsApiError } from 'calypso/lib/domains/types';
-import wp from 'calypso/lib/wp';
+import type { DomainsApiError } from 'calypso/lib/domains/types';
 
 export default function useDeleteGlueRecordMutation(
 	domainName: string,

--- a/client/data/domains/glue-records/use-domain-glue-records-query.ts
+++ b/client/data/domains/glue-records/use-domain-glue-records-query.ts
@@ -6,7 +6,7 @@ export type Maybe< T > = T | null | undefined;
 export type GlueRecordResponse = GlueRecordObject[] | null | undefined;
 
 export type GlueRecordObject = {
-	record: string;
+	nameserver: string;
 	address: string;
 };
 
@@ -19,7 +19,7 @@ export type GlueRecordApiObject = {
 
 export const mapGlueRecordObjectToApiObject = ( record: GlueRecordObject ): GlueRecordApiObject => {
 	return {
-		nameserver: record.record.toLowerCase(),
+		nameserver: record.nameserver.toLowerCase(),
 		ip_addresses: [ record.address ],
 	};
 };
@@ -31,7 +31,7 @@ const selectGlueRecords = ( response: GlueRecordApiObject[] | null ): GlueRecord
 
 	return response?.map( ( record: GlueRecordApiObject ) => {
 		return {
-			record: record.nameserver.toLowerCase(),
+			nameserver: record.nameserver.toLowerCase(),
 			address: record.ip_addresses[ 0 ],
 		};
 	} );

--- a/client/data/domains/glue-records/use-update-glue-record-mutation.ts
+++ b/client/data/domains/glue-records/use-update-glue-record-mutation.ts
@@ -20,13 +20,14 @@ export default function useUpdateGlueRecordMutation(
 	const mutation = useMutation( {
 		mutationFn: ( glueRecord: GlueRecordObject ) =>
 			wp.req
-				.post(
+				.put(
 					{
 						path: `/domains/glue-records`,
 						apiNamespace: 'wpcom/v2',
+						method: 'PUT',
 					},
 					{
-						name_server: glueRecord.record.toLowerCase(),
+						name_server: glueRecord.nameserver.toLowerCase(),
 						ip_addresses: [ glueRecord.address ],
 					}
 				)

--- a/client/data/domains/glue-records/use-update-glue-record-mutation.ts
+++ b/client/data/domains/glue-records/use-update-glue-record-mutation.ts
@@ -1,13 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { domainGlueRecordQueryKey } from 'calypso/data/domains/glue-records/domain-glue-record-query-key';
-import { DomainsApiError } from 'calypso/lib/domains/types';
 import wp from 'calypso/lib/wp';
-import {
-	GlueRecordObject,
-	GlueRecordQueryData,
-	mapGlueRecordObjectToApiObject,
-} from './use-domain-glue-records-query';
+import { mapGlueRecordObjectToApiObject } from './use-domain-glue-records-query';
+import type { GlueRecordObject, GlueRecordQueryData } from './use-domain-glue-records-query';
+import type { DomainsApiError } from 'calypso/lib/domains/types';
 
 export default function useUpdateGlueRecordMutation(
 	domainName: string,

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -251,7 +251,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 					<Button
 						scary
 						disabled={ isSaving || isRemoving }
-						className="edit-redirect-button"
+						className="edit-glue-record-button"
 						onClick={ () => handleEdit( child ) }
 					>
 						<Gridicon icon="pencil" />
@@ -260,7 +260,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 					<Button
 						scary
 						disabled={ isSaving || isRemoving }
-						className="edit-redirect-button"
+						className="delete-glue-record-button"
 						onClick={ () => handleDelete( child ) }
 					>
 						<Gridicon icon="trash" />
@@ -271,14 +271,20 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		</FormFieldset>
 	);
 
-	const FormRowEditable = ( { child }: { child: GlueRecordObject } ) => (
+	const FormRowEditable = ( {
+		child,
+		isEditing = false,
+	}: {
+		child: GlueRecordObject;
+		isEditing: boolean;
+	} ) => (
 		<>
 			<FormFieldset key={ `edit-${ child.nameserver }` }>
 				<FormLabel>{ translate( 'Name server' ) }</FormLabel>
 				<div>
 					<FormTextInputWithAffixes
 						placeholder={ translate( 'Enter subdomain (e.g. ns1)' ) }
-						disabled={ isLoadingData || isSaving }
+						disabled={ isLoadingData || isSaving || isEditing }
 						name="nameserver"
 						onChange={ handleNameserverChange }
 						value={ nameserver }
@@ -370,6 +376,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 								nameserver: '',
 								address: '',
 							},
+							isEditing: false,
 						} ) }
 					{ isEditing &&
 						FormRowEditable( {
@@ -377,6 +384,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 								nameserver,
 								address: ipAddress,
 							},
+							isEditing: true,
 						} ) }
 				</form>
 

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -8,6 +8,7 @@ import FormButton from 'calypso/components/forms/form-button';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormTextInputWithAffixes from 'calypso/components/forms/form-text-input-with-affixes';
+import useCreateGlueRecordMutation from 'calypso/data/domains/glue-records/use-create-glue-record-mutation';
 import useDeleteGlueRecordMutation from 'calypso/data/domains/glue-records/use-delete-glue-record-mutation';
 import useDomainGlueRecordsQuery, {
 	GlueRecordObject,
@@ -30,10 +31,11 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	const [ isExpanded, setIsExpanded ] = useState( false );
 	const [ isSaving, setIsSaving ] = useState( false );
 	const [ isRemoving, setIsRemoving ] = useState( false );
+	const [ isAdding, setIsAdding ] = useState( false );
 	const [ isEditing, setIsEditing ] = useState( false );
-	const [ record, setRecord ] = useState( '' );
+	const [ nameserver, setNameserver ] = useState( '' );
 	const [ ipAddress, setIpAddress ] = useState( '' );
-	const [ isValidRecord, setIsValidRecord ] = useState( true );
+	const [ isValidNameserver, setIsValidNameserver ] = useState( true );
 	const [ isValidIpAddress, setIsValidIpAddress ] = useState( true );
 
 	const {
@@ -45,19 +47,33 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	} = useDomainGlueRecordsQuery( domain.name );
 
 	const clearState = () => {
+		setIsAdding( false );
 		setIsEditing( false );
-		setRecord( '' );
+		setNameserver( '' );
 		setIpAddress( '' );
 		setIsSaving( false );
 		setIsRemoving( false );
-		setIsValidRecord( true );
+		setIsValidNameserver( true );
 		setIsValidIpAddress( true );
 	};
+
+	// Display success notices when the glue record is created
+	const { createGlueRecord } = useCreateGlueRecordMutation( domain.name, {
+		onSuccess() {
+			dispatch( successNotice( translate( 'Glue record updated.' ), noticeOptions ) );
+			clearState();
+		},
+		onError( error ) {
+			dispatch( errorNotice( error.message, noticeOptions ) );
+			clearState();
+		},
+	} );
 
 	// Display success notices when the glue record is updated
 	const { updateGlueRecord } = useUpdateGlueRecordMutation( domain.name, {
 		onSuccess() {
-			dispatch( successNotice( translate( 'Glue record updated and enabled.' ), noticeOptions ) );
+			dispatch( successNotice( translate( 'Glue record created and enabled.' ), noticeOptions ) );
+			refetchGlueRecordsData();
 			clearState();
 		},
 		onError( error ) {
@@ -96,7 +112,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	}, [ isError, dispatch, translate ] );
 
 	const showGlueRecordForm = () => {
-		setIsEditing( true );
+		setIsAdding( true );
 	};
 
 	useEffect( () => {
@@ -122,10 +138,10 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		setIpAddress( ipAddress );
 	};
 
-	const handleRecordChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
-		const record = event.target.value;
+	const handleNameserverChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
+		const nameserver = event.target.value;
 
-		setRecord( record.toLowerCase() );
+		setNameserver( nameserver.toLowerCase() );
 	};
 
 	const handleDelete = ( record: GlueRecordObject ) => {
@@ -134,16 +150,22 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 
 		recordTracksEvent( 'calypso_domain_glue_records_delete_record', {
 			domain: domain.domain,
-			record: record.record,
+			record: record.nameserver,
 			address: record.address,
 		} );
 	};
 
-	const validateRecord = () => {
-		if ( ! record ) {
+	const handleEdit = ( record: GlueRecordObject ) => {
+		setNameserver( record.nameserver.replace( `.${ domain.domain }`, '' ) );
+		setIpAddress( record.address );
+		setIsEditing( true );
+	};
+
+	const validateNameserver = () => {
+		if ( ! nameserver ) {
 			return false;
 		}
-		if ( ! record.match( /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/ ) ) {
+		if ( ! nameserver.match( /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/ ) ) {
 			return false;
 		}
 		return true;
@@ -160,12 +182,12 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	};
 
 	const validateGlueRecord = () => {
-		const recordIsValid = validateRecord();
+		const nameserverIsValid = validateNameserver();
 		const ipAddressIsValid = validateIpAddress();
-		setIsValidRecord( recordIsValid );
+		setIsValidNameserver( nameserverIsValid );
 		setIsValidIpAddress( ipAddressIsValid );
 
-		return recordIsValid && ipAddressIsValid;
+		return nameserverIsValid && ipAddressIsValid;
 	};
 
 	const handleSubmit = () => {
@@ -174,16 +196,29 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		}
 
 		setIsSaving( true );
-		updateGlueRecord( {
-			record: `${ record }.${ domain.domain }`,
-			address: ipAddress,
-		} );
 
-		recordTracksEvent( 'calypso_domain_glue_records_add_record', {
-			domain: domain.domain,
-			record: `${ record }.${ domain.domain }`,
-			address: ipAddress,
-		} );
+		if ( isEditing ) {
+			updateGlueRecord( {
+				nameserver: `${ nameserver }.${ domain.domain }`,
+				address: ipAddress,
+			} );
+		} else {
+			createGlueRecord( {
+				nameserver: `${ nameserver }.${ domain.domain }`,
+				address: ipAddress,
+			} );
+		}
+
+		recordTracksEvent(
+			isEditing
+				? 'calypso_domain_glue_records_update_record'
+				: 'calypso_domain_glue_records_add_record',
+			{
+				domain: domain.domain,
+				nameserver: `${ nameserver }.${ domain.domain }`,
+				address: ipAddress,
+			}
+		);
 	};
 
 	const handleCancel = () => {
@@ -195,13 +230,13 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 	};
 
 	const FormViewRow = ( { child: child }: { child: GlueRecordObject } ) => (
-		<FormFieldset key={ `view-${ child.record }` }>
+		<FormFieldset key={ `view-${ child.nameserver }` }>
 			<div className="domain-glue-records-card__fields">
 				<div className="glue-record-data">
 					<div className="domain-glue-records-card__fields-row">
 						<div className="label">{ translate( 'Name server' ) }:</div>
 						<div className="value">
-							<strong>{ child.record }</strong>
+							<strong>{ child.nameserver }</strong>
 						</div>
 					</div>
 
@@ -213,6 +248,15 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 					</div>
 				</div>
 				<div>
+					<Button
+						scary
+						disabled={ isSaving || isRemoving }
+						className="edit-redirect-button"
+						onClick={ () => handleEdit( child ) }
+					>
+						<Gridicon icon="pencil" />
+						{ translate( 'Edit' ) }
+					</Button>
 					<Button
 						scary
 						disabled={ isSaving || isRemoving }
@@ -229,20 +273,20 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 
 	const FormRowEditable = ( { child }: { child: GlueRecordObject } ) => (
 		<>
-			<FormFieldset key={ `edit-${ child.record }` }>
+			<FormFieldset key={ `edit-${ child.nameserver }` }>
 				<FormLabel>{ translate( 'Name server' ) }</FormLabel>
 				<div>
 					<FormTextInputWithAffixes
 						placeholder={ translate( 'Enter subdomain (e.g. ns1)' ) }
 						disabled={ isLoadingData || isSaving }
-						name="record"
-						onChange={ handleRecordChange }
-						value={ record }
+						name="nameserver"
+						onChange={ handleNameserverChange }
+						value={ nameserver }
 						maxLength={ 1000 }
 						suffix={ <FormLabel>.{ domain.domain }</FormLabel> }
-						isError={ ! isValidRecord }
+						isError={ ! isValidNameserver }
 					/>
-					{ ! isValidRecord && (
+					{ ! isValidNameserver && (
 						<div className="domain-glue-records-card__error-field">
 							<FormInputValidation isError text={ translate( 'Invalid subdomain' ) } />
 						</div>
@@ -320,16 +364,23 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 					} }
 				>
 					{ data?.map( ( item ) => FormViewRow( { child: item } ) ) }
+					{ isAdding &&
+						FormRowEditable( {
+							child: {
+								nameserver: '',
+								address: '',
+							},
+						} ) }
 					{ isEditing &&
 						FormRowEditable( {
 							child: {
-								record: '',
-								address: '',
+								nameserver,
+								address: ipAddress,
 							},
 						} ) }
 				</form>
 
-				{ ! isEditing && data && data.length < 3 && (
+				{ ! isAdding && data && data.length < 3 && (
 					<Button borderless className="link-button" onClick={ () => showGlueRecordForm() }>
 						{ translate( '+ Add Glue Record' ) }
 					</Button>

--- a/client/my-sites/domains/domain-management/settings/cards/style.scss
+++ b/client/my-sites/domains/domain-management/settings/cards/style.scss
@@ -439,6 +439,10 @@
 		height: 100px;
 		@include placeholder();
 	}
+
+	.edit-glue-record-button {
+		margin-right: 8px;
+	}
 }
 
 .domain-glue-records-card__accordion {


### PR DESCRIPTION
## Proposed Changes
This PR enables glue records editing after creation.

Depends on D135175-code

![edit-glue-records](https://github.com/Automattic/wp-calypso/assets/2797601/75768ee8-35ba-424f-a4c9-c2f0ddec50fe)

## Testing Instructions

Apply this patch (and the backend patch too). Visit a domain set page and create a new glue record under Glue Records card.

After creating the record, verify that the record can be updated using the "Edit" button.

Note: only the ip address field can be updated!

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?