### PR TITLE
Signup: Flag user as developer if signing up from developer.wordpress.com

### DIFF
--- a/client/blocks/signup-form/passwordless.jsx
+++ b/client/blocks/signup-form/passwordless.jsx
@@ -81,7 +81,7 @@ class PasswordlessSignupForm extends Component {
 		} );
 
 		const { flowName, queryArgs = {} } = this.props;
-		const { oauth2_client_id, oauth2_redirect } = queryArgs;
+		const { oauth2_client_id, oauth2_redirect, ref } = queryArgs;
 
 		try {
 			const response = await wpcom.req.post( '/users/new', {
@@ -97,10 +97,12 @@ class PasswordlessSignupForm extends Component {
 					oauth2_redirect: oauth2_redirect && `0@${ oauth2_redirect }`,
 				} ),
 				anon_id: getTracksAnonymousUserId(),
+				is_dev_account: ref === 'developer-lp',
 			} );
+
 			this.createAccountCallback( response );
-		} catch ( err ) {
-			this.createAccountError( err );
+		} catch ( error ) {
+			this.createAccountError( error );
 		}
 	};
 

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -8,6 +8,7 @@ import { login } from 'calypso/lib/paths';
 import { isWpccFlow } from 'calypso/signup/is-flow';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 
@@ -33,13 +34,11 @@ class SocialSignupForm extends Component {
 			return;
 		}
 
-		let extraUserData = {};
+		const extraUserData = { is_dev_account: this.props.isDevAccount };
 
 		if ( response.user ) {
-			extraUserData = {
-				user_name: response.user.name,
-				user_email: response.user.email,
-			};
+			extraUserData.user_name = response.user.name;
+			extraUserData.user_email = response.user.email;
 		}
 
 		this.props.handleResponse( 'apple', null, response.id_token, extraUserData );
@@ -54,7 +53,9 @@ class SocialSignupForm extends Component {
 			social_account_type: 'google',
 		} );
 
-		this.props.handleResponse( 'google', tokens.access_token, tokens.id_token );
+		this.props.handleResponse( 'google', tokens.access_token, tokens.id_token, {
+			is_dev_account: this.props.isDevAccount,
+		} );
 	};
 
 	trackSocialSignup = ( service ) => {
@@ -118,12 +119,17 @@ class SocialSignupForm extends Component {
 }
 
 export default connect(
-	( state ) => ( {
-		currentRoute: getCurrentRoute( state ),
-		oauth2Client: getCurrentOAuth2Client( state ),
-		isWoo:
-			isWooOAuth2Client( getCurrentOAuth2Client( state ) ) ||
-			isWooCommerceCoreProfilerFlow( state ),
-	} ),
+	( state ) => {
+		const query = getCurrentQueryArguments( state );
+
+		return {
+			currentRoute: getCurrentRoute( state ),
+			oauth2Client: getCurrentOAuth2Client( state ),
+			isDevAccount: query?.ref === 'developer-lp',
+			isWoo:
+				isWooOAuth2Client( getCurrentOAuth2Client( state ) ) ||
+				isWooCommerceCoreProfilerFlow( state ),
+		};
+	},
 	{ recordTracksEvent }
 )( localize( SocialSignupForm ) );


### PR DESCRIPTION
This pull request seeks to identify users who sign up from https://developer.wordpress.com/ as _developers_:

![image](https://github.com/Automattic/wp-calypso/assets/594356/4ba6aeaf-6637-4b19-96be-131720730df3)

More specifically, it sets the `is_dev_account` parameter sent to the API endpoints in charge of passwordless and social signups when a user clicks on the `Try WordPress.com for free` [call-to-action](https://wordpress.com/start/hosting?ref=developer-lp&flow=new-hosted-site).

#### Testing instructions

See D135214-code.