### PR TITLE
Domains: Add option to restore default email records in DNS management page

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-records.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-records.jsx
@@ -62,6 +62,38 @@ class DnsRecords extends Component {
 		return dns?.records?.some( ( record ) => record?.type === 'A' && record?.protected_field );
 	};
 
+	hasDefaultEmailRecords = () => {
+		const { dns, selectedDomainName } = this.props;
+
+		const hasDefaultDkim1Record = dns?.records?.some(
+			( record ) =>
+				record.type === 'CNAME' &&
+				record.name === `wpcloud1._domainkey` &&
+				record.data === 'wpcloud1._domainkey.wpcloud.com.'
+		);
+		const hasDefaultDkim2Record = dns?.records?.some(
+			( record ) =>
+				record?.type === 'CNAME' &&
+				record.name === `wpcloud2._domainkey` &&
+				record.data === 'wpcloud2._domainkey.wpcloud.com.'
+		);
+		const hasDefaultDmarcRecord = dns?.records?.some(
+			( record ) =>
+				record.type === 'TXT' && record.name === `_dmarc` && record.data?.startsWith( 'v=DMARC1' )
+		);
+		const hasDefaultSpfRecord = dns?.records?.some(
+			( record ) =>
+				record.type === 'TXT' &&
+				record.name === `${ selectedDomainName }.` &&
+				record.data?.startsWith( 'v=spf1' ) &&
+				record.data?.match( /\binclude:_spf.wpcloud.com\b/ )
+		);
+
+		return (
+			hasDefaultDkim1Record && hasDefaultDkim2Record && hasDefaultDmarcRecord && hasDefaultSpfRecord
+		);
+	};
+
 	renderHeader = () => {
 		const { domains, translate, selectedSite, currentRoute, selectedDomainName, dns } = this.props;
 		const selectedDomain = domains?.find( ( domain ) => domain?.name === selectedDomainName );
@@ -98,6 +130,7 @@ class DnsRecords extends Component {
 				dns={ dns }
 				hasDefaultARecords={ this.hasDefaultARecords() }
 				hasDefaultCnameRecord={ this.hasDefaultCnameRecord() }
+				hasDefaultEmailRecords={ this.hasDefaultEmailRecords() }
 			/>
 		);
 

--- a/client/my-sites/domains/domain-management/dns/restore-default-email-records-dialog.jsx
+++ b/client/my-sites/domains/domain-management/dns/restore-default-email-records-dialog.jsx
@@ -1,0 +1,38 @@
+import { Dialog } from '@automattic/components';
+import { useI18n } from '@wordpress/react-i18n';
+
+function RestoreDefaultemailRecordsDialog( { onClose, visible } ) {
+	const { __ } = useI18n();
+
+	const onRestore = () => {
+		onClose( { shouldRestoreDefaultRecords: true } );
+	};
+
+	const onCancel = () => {
+		onClose( { shouldRestoreDefaultRecords: false } );
+	};
+
+	const buttons = [
+		{
+			action: 'cancel',
+			label: __( 'Cancel' ),
+		},
+		{
+			action: 'restore',
+			label: __( 'Restore' ),
+			isPrimary: true,
+			onClick: onRestore,
+		},
+	];
+
+	return (
+		<Dialog isVisible={ visible } buttons={ buttons } onClose={ onCancel }>
+			<h1>{ __( 'Restore default email authentication records' ) }</h1>
+			<p>
+				{ __( 'This will restore SPF, DKIM and DMARC records to their default configurations.' ) }
+			</p>
+		</Dialog>
+	);
+}
+
+export default RestoreDefaultemailRecordsDialog;

--- a/client/my-sites/domains/domain-management/dns/types.ts
+++ b/client/my-sites/domains/domain-management/dns/types.ts
@@ -36,6 +36,7 @@ export type DnsMenuOptionsButtonProps = {
 	domain: ResponseDomain | undefined;
 	hasDefaultARecords: boolean;
 	hasDefaultCnameRecord: boolean;
+	hasDefaultEmailRecords: boolean;
 	dns: Dns;
 	dispatchApplyDnsTemplate: UnpackPromisedValue< typeof applyDnsTemplate >;
 	dispatchUpdateDns: UnpackPromisedValue< typeof updateDns >;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86325

## Proposed Changes

This PR adds a menu option in the DNS management page to restore default email DNS records for a domain. That option will only appear if the domain is primary and attached to an Atomic site. Also, it will only be enabled if the domain's email DNS records (SPF, DKIM and DMARC) are different from the default ones.

### Screenshots

- Restore default email records menu option in the DNS management page

> ![Markup on 2024-01-18 at 16:28:23](https://github.com/Automattic/wp-calypso/assets/5324818/e383c782-8c2f-4ec1-9a94-569ef67cfeeb)

- Confirmation dialog before restoring default records

> <img width="649" alt="Screenshot 2024-01-18 at 16 28 31" src="https://github.com/Automattic/wp-calypso/assets/5324818/f9ddf92e-ff53-4be1-9e10-914da6570af1">

- Disabled option when the existing DNS records are the same as the default ones

> <img width="287" alt="Screenshot 2024-01-18 at 16 28 49" src="https://github.com/Automattic/wp-calypso/assets/5324818/fc667bfd-8301-4735-9341-e8621cd10a9f">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open the live Calypso link or build this branch locally
- Open the DNS management page for the primary domain in an Atomic site or hack your backend so that the diagnostics endpoint thinks your site is atomic
- Change your DNS email records (SPF, DKIM 1 and 2, DMARC) to incorrect values (see pcYYhz-1KI-p2 for the expected values)
- Ensure the "Restore default email records" menu option is enabled
- Click the option and ensure all default email records were restored
- Ensure the "Restore default email records" menu option is disabled now
- Go to the DNS management page for a domain that is not primary or not attached to an Atomic
- Ensure the "Restore default email records" menu option is not shown

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?