### PR TITLE
AI Logo Generator: Add events

### DIFF
--- a/packages/jetpack-ai-calypso/src/constants.ts
+++ b/packages/jetpack-ai-calypso/src/constants.ts
@@ -2,8 +2,22 @@ export const JWT_TOKEN_ID = 'jetpack-ai-jwt';
 export const JWT_TOKEN_EXPIRATION_TIME = 2 * 60 * 1000; // 2 minutes
 
 // Tracks event names
-export const EVENT_PROMPT_SUBMIT = 'calypso_jp_ai_logo_generator_prompt_submit';
-export const EVENT_PROMPT_ENHANCE = 'calypso_jp_ai_logo_generator_prompt_enhance';
+export const EVENT_LOGO_BLOCK_CALLED = 'jetpack_logo_block_ai_called';
+export const EVENT_CALYPSO_LOGO_CALLED = 'jetpack_calypso_ai_logo_called';
+export const EVENT_MODAL_CLOSE = 'jetpack_ai_logo_modal_close';
+export const EVENT_PROMPT_ENHANCE = 'jetpack_ai_logo_modal_enhance';
+export const EVENT_GENERATE = 'jetpack_ai_logo_modal_generate';
+export const EVENT_USE_LOGO = 'jetpack_ai_logo_modal_use';
+export const EVENT_SAVE_TO_LIBRARY = 'jetpack_ai_logo_modal_save';
+export const EVENT_NAVIGATE_LOGOS = 'jetpack_ai_logo_modal_navigate';
+export const EVENT_FEEDBACK = 'jetpack_ai_logo_modal_feedback';
+export const EVENT_UPGRADE = 'jetpack_ai_logo_modal_upgrade';
+
+// Event placement constants
+export const EVENT_PLACEMENT_QUICK_LINKS = 'quick_links';
+export const EVENT_PLACEMENT_INPUT_FOOTER = 'input_footer';
+export const EVENT_PLACEMENT_FREE_USER_SCREEN = 'free_user_screen';
+export const EVENT_PLACEMENT_UPGRADE_PROMPT = 'upgrade_prompt';
 
 // Feature constants
 export const MINIMUM_PROMPT_LENGTH = 10;

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/generator-modal.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Icon, Modal, Button } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -11,6 +12,12 @@ import { useState, useEffect, useCallback } from 'react';
 /**
  * Internal dependencies
  */
+import {
+	EVENT_CALYPSO_LOGO_CALLED,
+	EVENT_FEEDBACK,
+	EVENT_MODAL_CLOSE,
+	EVENT_PLACEMENT_QUICK_LINKS,
+} from '../../constants';
 import useLogoGenerator from '../hooks/use-logo-generator';
 import useRequestErrors from '../hooks/use-request-errors';
 import { isLogoHistoryEmpty } from '../lib/logo-storage';
@@ -112,6 +119,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 	}, [ siteId, getFeature, siteDetails?.domain, generateFirstLogo ] );
 
 	const handleModalOpen = useCallback( async () => {
+		recordTracksEvent( EVENT_CALYPSO_LOGO_CALLED, { placement: EVENT_PLACEMENT_QUICK_LINKS } );
 		loadLogoHistory( siteId );
 
 		initializeModal();
@@ -121,6 +129,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 		setLoadingState( null );
 		setNeedsFeature( false );
 		clearErrors();
+		recordTracksEvent( EVENT_MODAL_CLOSE );
 		onClose();
 	};
 
@@ -131,6 +140,10 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 			// Reload the page to update the logo.
 			window.location.reload();
 		}, 1000 );
+	};
+
+	const handleFeedbackClick = () => {
+		recordTracksEvent( EVENT_FEEDBACK );
 	};
 
 	// Set site details when siteId changes
@@ -180,6 +193,7 @@ export const GeneratorModal: React.FC< GeneratorModalProps > = ( {
 						className="jetpack-ai-logo-generator__feedback-button"
 						href="https://jetpack.com/redirect/?source=jetpack-ai-feedback"
 						target="_blank"
+						onClick={ handleFeedbackClick }
 					>
 						<span>{ __( 'Provide feedback', 'jetpack' ) }</span>
 						<Icon icon={ external } className="icon" />

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/history-carousel.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/history-carousel.tsx
@@ -1,12 +1,14 @@
 /**
  * External dependencies
  */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
 import { useSelect, useDispatch } from '@wordpress/data';
 import classnames from 'classnames';
 /**
  * Internal dependencies
  */
+import { EVENT_NAVIGATE_LOGOS } from '../../constants';
 import { STORE_NAME } from '../store';
 import './history-carousel.scss';
 /**
@@ -24,6 +26,10 @@ export const HistoryCarousel: React.FC = () => {
 	}, [] );
 
 	const handleClick = ( index: number ) => {
+		recordTracksEvent( EVENT_NAVIGATE_LOGOS, {
+			logos_count: logos.length,
+			selected_logo: index + 1,
+		} );
 		setSelectedLogoIndex( index );
 	};
 

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/logo-presenter.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/logo-presenter.tsx
@@ -1,12 +1,14 @@
 /**
  * External dependencies
  */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button, Icon } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
 /**
  * Internal dependencies
  */
+import { EVENT_SAVE_TO_LIBRARY, EVENT_USE_LOGO } from '../../constants';
 import CheckIcon from '../assets/icons/check';
 import LogoIcon from '../assets/icons/logo';
 import MediaIcon from '../assets/icons/media';
@@ -23,11 +25,22 @@ import type React from 'react';
 const debug = debugFactory( 'jetpack-ai-calypso:logo-presenter' );
 
 const SaveInLibraryButton: React.FC = () => {
-	const { saveLogo, selectedLogo, isSavingLogoToLibrary: saving } = useLogoGenerator();
+	const {
+		saveLogo,
+		selectedLogo,
+		isSavingLogoToLibrary: saving,
+		logos,
+		selectedLogoIndex,
+	} = useLogoGenerator();
 	const saved = !! selectedLogo?.mediaId;
 
 	const handleClick = async () => {
 		if ( ! saved && ! saving ) {
+			recordTracksEvent( EVENT_SAVE_TO_LIBRARY, {
+				logos_count: logos.length,
+				selected_logo: selectedLogoIndex ? selectedLogoIndex + 1 : 0,
+			} );
+
 			try {
 				await saveLogo( selectedLogo );
 			} catch ( error ) {
@@ -52,10 +65,22 @@ const SaveInLibraryButton: React.FC = () => {
 };
 
 const UseOnSiteButton: React.FC< { onApplyLogo: () => void } > = ( { onApplyLogo } ) => {
-	const { applyLogo, isSavingLogoToLibrary, isApplyingLogo, selectedLogo } = useLogoGenerator();
+	const {
+		applyLogo,
+		isSavingLogoToLibrary,
+		isApplyingLogo,
+		selectedLogo,
+		logos,
+		selectedLogoIndex,
+	} = useLogoGenerator();
 
 	const handleClick = async () => {
 		if ( ! isApplyingLogo && ! isSavingLogoToLibrary ) {
+			recordTracksEvent( EVENT_USE_LOGO, {
+				logos_count: logos.length,
+				selected_logo: selectedLogoIndex != null ? selectedLogoIndex + 1 : 0,
+			} );
+
 			try {
 				await applyLogo();
 				onApplyLogo();

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
@@ -10,7 +10,13 @@ import { useCallback, useEffect, useState, useRef } from 'react';
 /**
  * Internal dependencies
  */
-import { EVENT_PROMPT_ENHANCE, MINIMUM_PROMPT_LENGTH } from '../../constants';
+import {
+	EVENT_PROMPT_ENHANCE,
+	EVENT_GENERATE,
+	MINIMUM_PROMPT_LENGTH,
+	EVENT_UPGRADE,
+	EVENT_PLACEMENT_INPUT_FOOTER,
+} from '../../constants';
 import AiIcon from '../assets/icons/ai';
 import useLogoGenerator from '../hooks/use-logo-generator';
 import useRequestErrors from '../hooks/use-request-errors';
@@ -74,12 +80,17 @@ export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt 
 	}, [ prompt ] );
 
 	const onGenerate = useCallback( async () => {
+		recordTracksEvent( EVENT_GENERATE );
 		generateLogo( { prompt } );
 	}, [ generateLogo, prompt ] );
 
 	const onPromptInput = useCallback( ( event: React.ChangeEvent< HTMLInputElement > ) => {
 		setPrompt( event.target.textContent || '' );
 	}, [] );
+
+	const onUpgradeClick = () => {
+		recordTracksEvent( EVENT_UPGRADE, { placement: EVENT_PLACEMENT_INPUT_FOOTER } );
+	};
 
 	return (
 		<div className="jetpack-ai-logo-generator__prompt">
@@ -131,7 +142,12 @@ export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt 
 							) }
 						</div>
 						&nbsp;
-						<Button variant="link" href="https://automattic.com/ai-guidelines" target="_blank">
+						<Button
+							variant="link"
+							href="https://automattic.com/ai-guidelines"
+							target="_blank"
+							onClick={ onUpgradeClick }
+						>
 							{ __( 'Upgrade', 'jetpack' ) }
 						</Button>
 						&nbsp;

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-screen.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-screen.tsx
@@ -1,11 +1,13 @@
 /**
  * External dependencies
  */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 /**
  * Types
  */
+import { EVENT_PLACEMENT_FREE_USER_SCREEN, EVENT_UPGRADE } from '../../constants';
 import type React from 'react';
 
 export const UpgradeScreen: React.FC< { onCancel: () => void; upgradeURL: string } > = ( {
@@ -16,6 +18,11 @@ export const UpgradeScreen: React.FC< { onCancel: () => void; upgradeURL: string
 		'Upgrade your Jetpack AI for access to exclusive features, including logo generation. This upgrade will also increase the amount of requests you can use in all AI-powered features.',
 		'jetpack'
 	);
+
+	const handleUpgradeClick = () => {
+		recordTracksEvent( EVENT_UPGRADE, { placement: EVENT_PLACEMENT_FREE_USER_SCREEN } );
+		onCancel();
+	};
 
 	return (
 		<div className="jetpack-ai-logo-generator-modal__notice-message-wrapper">
@@ -30,7 +37,12 @@ export const UpgradeScreen: React.FC< { onCancel: () => void; upgradeURL: string
 				<Button variant="tertiary" onClick={ onCancel }>
 					{ __( 'Cancel', 'jetpack' ) }
 				</Button>
-				<Button variant="primary" href={ upgradeURL } target="_blank" onClick={ onCancel }>
+				<Button
+					variant="primary"
+					href={ upgradeURL }
+					target="_blank"
+					onClick={ handleUpgradeClick }
+				>
 					{ __( 'Upgrade', 'jetpack' ) }
 				</Button>
 			</div>

--- a/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
@@ -1,7 +1,6 @@
 /**
  * External dependencies
  */
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import debugFactory from 'debug';
@@ -9,7 +8,6 @@ import { useCallback } from 'react';
 /**
  * Internal dependencies
  */
-import { EVENT_GENERATE } from '../../constants';
 import { stashLogo } from '../lib/logo-storage';
 import { requestJwt } from '../lib/request-token';
 import { saveToMediaLibrary } from '../lib/save-to-media-library';
@@ -321,7 +319,6 @@ User request: ${ prompt }
 
 		setIsRequestingImage( true );
 		increaseAiAssistantRequestsCount();
-		recordTracksEvent( EVENT_GENERATE );
 
 		try {
 			let image;

--- a/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
@@ -37,6 +37,7 @@ const useLogoGenerator = () => {
 
 	const {
 		logos,
+		selectedLogoIndex,
 		selectedLogo,
 		siteDetails,
 		isSavingLogoToLibrary,
@@ -51,6 +52,7 @@ const useLogoGenerator = () => {
 
 		return {
 			logos: selectors.getLogos(),
+			selectedLogoIndex: selectors.getSelectedLogoIndex(),
 			selectedLogo: selectors.getSelectedLogo(),
 			siteDetails: selectors.getSiteDetails(),
 			isSavingLogoToLibrary: selectors.getIsSavingLogoToLibrary(),
@@ -359,6 +361,7 @@ User request: ${ prompt }
 
 	return {
 		logos,
+		selectedLogoIndex,
 		selectedLogo,
 		setSelectedLogoIndex,
 		site: {

--- a/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
@@ -9,7 +9,7 @@ import { useCallback } from 'react';
 /**
  * Internal dependencies
  */
-import { EVENT_PROMPT_SUBMIT } from '../../constants';
+import { EVENT_GENERATE } from '../../constants';
 import { stashLogo } from '../lib/logo-storage';
 import { requestJwt } from '../lib/request-token';
 import { saveToMediaLibrary } from '../lib/save-to-media-library';
@@ -319,7 +319,7 @@ User request: ${ prompt }
 
 		setIsRequestingImage( true );
 		increaseAiAssistantRequestsCount();
-		recordTracksEvent( EVENT_PROMPT_SUBMIT );
+		recordTracksEvent( EVENT_GENERATE );
 
 		try {
 			let image;

--- a/packages/jetpack-ai-calypso/src/logo-generator/store/selectors.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/store/selectors.ts
@@ -46,6 +46,15 @@ const selectors = {
 	},
 
 	/**
+	 * Get the selected logo index.
+	 * @param {LogoGeneratorStateProp} state - The app state tree.
+	 * @returns {number | null}                The selected logo index.
+	 */
+	getSelectedLogoIndex( state: LogoGeneratorStateProp ): number | null {
+		return state.selectedLogoIndex ?? null;
+	},
+
+	/**
 	 * Get the selected logo.
 	 * @param {LogoGeneratorStateProp} state - The app state tree.
 	 * @returns {Logo}                         The selected logo.

--- a/packages/jetpack-ai-calypso/src/logo-generator/store/types.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/store/types.ts
@@ -150,6 +150,7 @@ export type Selectors = {
 	getAiAssistantFeature( siteId?: string ): Partial< AiFeatureProps >;
 	getIsRequestingAiAssistantFeature(): boolean;
 	getLogos(): Array< Logo >;
+	getSelectedLogoIndex(): number | null;
 	getSelectedLogo(): Logo;
 	getSiteDetails(): SiteDetails;
 	getIsSavingLogoToLibrary(): boolean;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #85858

## Proposed Changes

* Adds the events as described in the events spreadsheet

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the modal
* Use the enhancement feature
* Generate a second logo
* Navigate to the first logo
* Apply it
* After the refresh, open the modal again
* Click on the feedback feature
* Click on the upgrade link (non-functional at this point)
* Close the modal
* Select another site with a free plan
* Open the modal
* Click on the upgrade link
* Wait for around 10 or 15 minutes
* Check that those events are logged

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?