### PR TITLE
AI Logo Generator: Show upgrade nudge when the site reaches the limit of requests

### DIFF
--- a/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/prompt.tsx
@@ -14,6 +14,7 @@ import { EVENT_PROMPT_ENHANCE, MINIMUM_PROMPT_LENGTH } from '../../constants';
 import AiIcon from '../assets/icons/ai';
 import useLogoGenerator from '../hooks/use-logo-generator';
 import useRequestErrors from '../hooks/use-request-errors';
+import { UpgradeNudge } from './upgrade-nudge';
 import './prompt.scss';
 
 const debug = debugFactory( 'jetpack-ai-calypso:prompt-box' );
@@ -121,7 +122,7 @@ export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt 
 				</Button>
 			</div>
 			<div className="jetpack-ai-logo-generator__prompt-footer">
-				{ ! isUnlimited && (
+				{ ! isUnlimited && ! requireUpgrade && (
 					<div className="jetpack-ai-logo-generator__prompt-requests">
 						<div>
 							{ sprintf(
@@ -138,6 +139,7 @@ export const Prompt: React.FC< { initialPrompt?: string } > = ( { initialPrompt 
 						<Icon className="prompt-footer__icon" icon={ info } />
 					</div>
 				) }
+				{ ! isUnlimited && requireUpgrade && <UpgradeNudge /> }
 				{ enhancePromptFetchError && (
 					<div className="jetpack-ai-logo-generator__prompt-error">
 						{ __( 'Error enhancing prompt. Please try again.', 'jetpack' ) }

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-nudge.scss
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-nudge.scss
@@ -1,0 +1,43 @@
+@import "@automattic/color-studio/dist/color-variables";
+
+.jetpack-upgrade-plan-banner .jetpack-upgrade-plan-banner__wrapper {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	font-size: $font-body-small;
+	background: $studio-black;
+	padding: 8px 16px;
+	border-radius: 2px;
+}
+
+.jetpack-upgrade-plan-banner .jetpack-upgrade-plan-banner__wrapper .jetpack-upgrade-plan-banner__banner-description {
+	color: $studio-white;
+	line-height: 21px;
+	word-wrap: break-word;
+	vertical-align: middle;
+}
+
+.jetpack-upgrade-plan-banner .jetpack-upgrade-plan-banner__wrapper .jetpack-upgrade-plan-banner__icon {
+	width: 24px;
+	height: 24px;
+	position: relative;
+	vertical-align: middle;
+	margin-right: 8px;
+
+	path {
+		fill: $studio-gray-30;
+	}
+}
+
+.jetpack-upgrade-plan-banner .jetpack-upgrade-plan-banner__wrapper .components-button {
+	height: auto;
+	line-height: 20px;
+	font-size: $font-body-extra-small;
+	font-weight: 600;
+	padding: 4px 8px;
+}
+
+.jetpack-upgrade-plan-banner .jetpack-upgrade-plan-banner__wrapper .components-button.is-primary {
+	background: $studio-white;
+	color: $studio-black;
+}

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-nudge.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-nudge.tsx
@@ -17,7 +17,7 @@ export const UpgradeNudge = () => {
 						You reached your plan request limit. <strong>Upgrade now to increase it.</strong>
 					</span>
 				</div>
-				<Button href={ checkoutUrl } target="_top" className="is-primary">
+				<Button href={ checkoutUrl } target="_blank" className="is-primary">
 					{ buttonText }
 				</Button>
 			</div>

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-nudge.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-nudge.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, warning } from '@wordpress/icons';
 /**
@@ -12,6 +13,15 @@ import './upgrade-nudge.scss';
 export const UpgradeNudge = () => {
 	const buttonText = __( 'Upgrade', 'jetpack' );
 	const checkoutUrl = 'https://wordpress.com/';
+	const upgradeMessage = createInterpolateElement(
+		__(
+			'You reached your plan request limit. <strong>Upgrade now to increase it.</strong>',
+			'jetpack'
+		),
+		{
+			strong: <strong />,
+		}
+	);
 
 	return (
 		<div className="jetpack-upgrade-plan-banner">
@@ -19,7 +29,7 @@ export const UpgradeNudge = () => {
 				<div>
 					<Icon className="jetpack-upgrade-plan-banner__icon" icon={ warning } />
 					<span className="jetpack-upgrade-plan-banner__banner-description">
-						You reached your plan request limit. <strong>Upgrade now to increase it.</strong>
+						{ upgradeMessage }
 					</span>
 				</div>
 				<Button href={ checkoutUrl } target="_blank" className="is-primary">

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-nudge.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-nudge.tsx
@@ -1,0 +1,26 @@
+import { Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, warning } from '@wordpress/icons';
+
+import './upgrade-nudge.scss';
+
+export const UpgradeNudge = () => {
+	const buttonText = __( 'Upgrade', 'jetpack' );
+	const checkoutUrl = 'https://wordpress.com/';
+
+	return (
+		<div className="jetpack-upgrade-plan-banner">
+			<div className="jetpack-upgrade-plan-banner__wrapper">
+				<div>
+					<Icon className="jetpack-upgrade-plan-banner__icon" icon={ warning } />
+					<span className="jetpack-upgrade-plan-banner__banner-description">
+						You reached your plan request limit. <strong>Upgrade now to increase it.</strong>
+					</span>
+				</div>
+				<Button href={ checkoutUrl } target="_top" className="is-primary">
+					{ buttonText }
+				</Button>
+			</div>
+		</div>
+	);
+};

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-nudge.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-nudge.tsx
@@ -1,7 +1,12 @@
+/**
+ * External dependencies
+ */
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, warning } from '@wordpress/icons';
-
+/**
+ * Internal dependencies
+ */
 import './upgrade-nudge.scss';
 
 export const UpgradeNudge = () => {

--- a/packages/jetpack-ai-calypso/src/logo-generator/store/reducer.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/store/reducer.ts
@@ -82,9 +82,8 @@ export default function reducer(
 					aiAssistantFeature: {
 						...action.feature,
 						// re evaluate requireUpgrade as the logo generator does not allow free usage
-						requireUpgrade: action.feature?.currentTier
-							? action.feature.currentTier.value === 0
-							: action.feature?.requireUpgrade,
+						requireUpgrade:
+							action.feature?.requireUpgrade || action.feature?.currentTier?.value === 0,
 						_meta: {
 							...state?.features?.aiAssistantFeature?._meta,
 							isRequesting: false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/issues/34720.

## Proposed Changes

* Update the reducer code for the `requireUpgrade` flag, so it's true when:
   * the value that came from the backend is true, meaning the site reached the requests limit
   * the site is on the free tier, as the code was doing before
* Introduce the `UpgradeNudge` component (Figma: kJj8rPzRgHXAMHzhsmrfpy-fi-4278_2365)
* Show the `UpgradeNudge` component when the flag `requireUpgrade` is true

What I left out:

* the correct checkout URL; the plan is to follow-up on this PR, extracting the code used for the upgrade screen to a hook, then using it here
* event tracking for the upgrade click; also planned for a follow-up

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test on a site with a tiered plan (you can buy it following the upgrade path on the site editor)
* Run this branch locally:
   * run `yarn start` on one terminal
   * run `yarn workspace @automattic/jetpack-ai-calypso run copy-assets` on another, and then `yarn workspace @automattic/jetpack-ai-calypso run watch` right after
* Sandbox the `public-api` endpoint on you machine
* Connect to your sandbox and add a filter to the `0-sandbox.php` file:

```
// play with this number to see the results on the UI
// set it lower than your current tier to make the upgrade banner disapear
// set it on the limit of your current tier to make the upgrade banner show up
add_filter( 'jetpack_ai_current_period_requests_count', function() { return 200; } );
```

* On your local calypso instance, go to "My Home" for the testing site
* Look for the "Create a logo with Jetpack AI" link and click it to launch the generator modal
* When the backend filter is set on the limit of your tier, you should see the upgrade banner
   * Confirm you see the banner
   * Confirm you can click the button and the target of it opens on a new window
   * Confirm the prompt field, the enhance prompt link and the generate button are disabled

<img width="600" alt="Screenshot 2024-01-18 at 18 26 52" src="https://github.com/Automattic/wp-calypso/assets/6760046/659a52b7-ca65-4460-bdfd-70c11b20cb8e">

* When the backend filter is set lower than the limit of your tier, you should see the original version of the modal:
   * Confirm you don't see the banner
   * Confirm the prompt field, the enhance prompt link and the generate button are working as expected

<img width="600" alt="Screenshot 2024-01-18 at 18 47 44" src="https://github.com/Automattic/wp-calypso/assets/6760046/431882b9-bab2-4e13-953a-ecd0071c49fa">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?