### PR TITLE
Add razorpay key to configuration

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -41,6 +41,7 @@
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": true,
+		"checkout/razorpay": true,
 		"cloudflare": true,
 		"comments/filters-in-posts": true,
 		"current-site/domain-warning": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -21,6 +21,7 @@
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": false,
+		"checkout/razorpay": false,
 		"cloudflare": true,
 		"composite-checkout-testing": true,
 		"current-site/domain-warning": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -34,6 +34,7 @@
 		"checkout/google-pay": false,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": false,
+		"checkout/razorpay": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -31,6 +31,7 @@
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": false,
+		"checkout/razorpay": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -33,6 +33,7 @@
 		"checkout/google-pay": false,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": false,
+		"checkout/razorpay": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -33,6 +33,7 @@
 		"checkout/google-pay": false,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": false,
+		"checkout/razorpay": false,
 		"current-site/domain-warning": false,
 		"current-site/notice": false,
 		"current-site/stale-cart-notice": false,

--- a/config/production.json
+++ b/config/production.json
@@ -32,6 +32,7 @@
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": false,
+		"checkout/razorpay": false,
 		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -29,6 +29,7 @@
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": true,
+		"checkout/razorpay": false,
 		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/test.json
+++ b/config/test.json
@@ -31,6 +31,7 @@
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": false,
+		"checkout/razorpay": true,
 		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -29,6 +29,7 @@
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": true,
+		"checkout/razorpay": false,
 		"cloudflare": true,
 		"current-site/domain-warning": true,
 		"current-site/notice": true,


### PR DESCRIPTION
## Proposed Changes

* We are in the process of adding support for a new payment partner, Razorpay. This patch adds new configuration values to allow enabling the new code only in specific environments.

## Testing Instructions

* N/A; this patch just adds configuration keys.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
