### PR TITLE
Jetpack Backup: fix backup download confirmation button

### DIFF
--- a/client/my-sites/backup/rewind-flow/download.tsx
+++ b/client/my-sites/backup/rewind-flow/download.tsx
@@ -80,7 +80,8 @@ const BackupDownloadFlow: FunctionComponent< Props > = ( {
 	);
 
 	const isDownloadInfoRequestComplete = downloadInfoRequest?.hasLoaded;
-	const isOtherDownloadInfo = downloadRewindId !== rewindId || requestedBackup !== downloadId;
+	const isOtherDownloadInfo =
+		downloadRewindId !== rewindId || ( downloadId !== 0 && requestedBackup !== downloadId );
 	const isOtherDownloadInProgress = isOtherDownloadInfo && downloadProgress !== undefined;
 	const isDownloadURLNotReady = downloadUrl === undefined || downloadUrl === '';
 


### PR DESCRIPTION
Currently, if you did download a backup before and try to download a new one, on the confirmation page it says `Another downloadable file is being created` very quickly when you click on `Create downloadable file`.

![CleanShot 2024-01-18 at 19 59 35](https://github.com/Automattic/wp-calypso/assets/1488641/7926509d-b097-4f47-bf2a-90c94b2aaa8a)

## Proposed Changes

* Prevent the backup download confirmation button to displaying `Another downloadable file is being created` when starting a new download by validating if the `downloadId` is not 0 because when we start a new download it sets that value to 0 temporarily while we get the new value.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Calypso or Jetpack Cloud Live Branch
* Pick a site with a Jetpack VaultPress Backup plan that have at least one backup
* Navigate to the backup page
* Pick one of the backups and click on `Actions (+)` then `Download backup`.
* After clicking on `Create downloadable file`, ensure the button doesn't switches to `Another downloadable file is being created`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?