### PR TITLE
Checkoutv2: Create sidebar nudge wrapper component

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -482,9 +482,7 @@ export default function WPCheckout( {
 									onChangeSelection={ changeSelection }
 									nextDomainIsFree={ responseCart?.next_domain_is_free }
 								/>
-								{ hasCheckoutVersion( '2' ) && (
-									<CheckoutSidebarNudge responseCart={ responseCart } />
-								) }
+								<CheckoutSidebarNudge responseCart={ responseCart } />
 								<SecondaryCartPromotions
 									responseCart={ responseCart }
 									addItemToCart={ addItemToCart }

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -82,7 +82,7 @@ import JetpackAkismetCheckoutSidebarPlanUpsell from './jetpack-akismet-checkout-
 import BeforeSubmitCheckoutHeader from './payment-method-step';
 import SecondaryCartPromotions from './secondary-cart-promotions';
 import WPCheckoutOrderReview from './wp-checkout-order-review';
-import { CheckoutSummaryFeaturedList, WPCheckoutOrderSummary } from './wp-checkout-order-summary';
+import { WPCheckoutOrderSummary } from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
 import WPContactFormSummary from './wp-contact-form-summary';
 import type { OnChangeItemVariant } from './item-variation-picker';
@@ -491,14 +491,6 @@ export default function WPCheckout( {
 										{ renderCheckoutSidebarNudge() }
 									</CheckoutSidebarNudgeWrapper>
 								) }
-								{ hasCheckoutVersion( '2' ) && (
-									<CheckoutSummaryFeaturedList
-										responseCart={ responseCart }
-										siteId={ siteId }
-										isCartUpdating={ FormStatus.VALIDATING === formStatus }
-										onChangeSelection={ changeSelection }
-									/>
-								) }
 								<SecondaryCartPromotions
 									responseCart={ responseCart }
 									addItemToCart={ addItemToCart }
@@ -814,6 +806,10 @@ const CheckoutSummaryBody = styled.div`
 const CheckoutSidebarNudgeWrapper = styled.div`
 	display: flex;
 	flex-direction: column;
+
+	& > * {
+		max-width: 288px;
+	}
 `;
 
 const CheckoutTermsAndCheckboxesWrapper = styled.div`

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -433,10 +433,10 @@ export default function WPCheckout( {
 	function CheckoutSidebarNudge() {
 		if ( ! isWcMobile && ! isDIFMInCart && ! hasMonthlyProduct ) {
 			return (
-				<>
+				<CheckoutSidebarNudgeWrapper>
 					<CheckoutSidebarPlanUpsell />
 					<JetpackAkismetCheckoutSidebarPlanUpsell />
-				</>
+				</CheckoutSidebarNudgeWrapper>
 			);
 		}
 		return null;
@@ -484,11 +484,7 @@ export default function WPCheckout( {
 									onChangeSelection={ changeSelection }
 									nextDomainIsFree={ responseCart?.next_domain_is_free }
 								/>
-								{ hasCheckoutVersion( '2' ) && (
-									<CheckoutSidebarNudgeWrapper>
-										<CheckoutSidebarNudge />
-									</CheckoutSidebarNudgeWrapper>
-								) }
+								{ hasCheckoutVersion( '2' ) && <CheckoutSidebarNudge /> }
 								<SecondaryCartPromotions
 									responseCart={ responseCart }
 									addItemToCart={ addItemToCart }

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -429,6 +429,21 @@ export default function WPCheckout( {
 			? translate( 'Continue to payment', { textOnly: true } )
 			: translate( 'Continue', { textOnly: true } );
 
+	/* Include a condition for your use case here if you want to show a specific nudge in the checkout sidebar */
+	const renderCheckoutSidebarNudge = () => {
+		let upsellNudgeVariant = null;
+
+		if ( ! isWcMobile && ! isDIFMInCart && ! hasMonthlyProduct ) {
+			upsellNudgeVariant = (
+				<>
+					<CheckoutSidebarPlanUpsell />
+					<JetpackAkismetCheckoutSidebarPlanUpsell />
+				</>
+			);
+		}
+		return upsellNudgeVariant;
+	};
+
 	return (
 		<WPCheckoutWrapper>
 			<WPCheckoutSidebarContent>
@@ -466,12 +481,15 @@ export default function WPCheckout( {
 									/>
 								) }
 
-								<WPCheckoutOrderSummary siteId={ siteId } onChangeSelection={ changeSelection } />
-								{ ! isWcMobile && ! isDIFMInCart && ! hasMonthlyProduct && (
-									<>
-										<CheckoutSidebarPlanUpsell />
-										<JetpackAkismetCheckoutSidebarPlanUpsell />
-									</>
+								<WPCheckoutOrderSummary
+									siteId={ siteId }
+									onChangeSelection={ changeSelection }
+									nextDomainIsFree={ responseCart?.next_domain_is_free }
+								/>
+								{ hasCheckoutVersion( '2' ) && (
+									<CheckoutSidebarNudgeWrapper>
+										{ renderCheckoutSidebarNudge() }
+									</CheckoutSidebarNudgeWrapper>
 								) }
 								{ hasCheckoutVersion( '2' ) && (
 									<CheckoutSummaryFeaturedList
@@ -791,6 +809,11 @@ const CheckoutSummaryBody = styled.div`
 			box-shadow: none;
 		}
 	}
+`;
+
+const CheckoutSidebarNudgeWrapper = styled.div`
+	display: flex;
+	flex-direction: column;
 `;
 
 const CheckoutTermsAndCheckboxesWrapper = styled.div`

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -224,6 +224,22 @@ const getPresalesChatKey = ( responseCart: ObjectWithProducts ) => {
 	return 'wpcom';
 };
 
+/* Include a condition for your use case here if you want to show a specific nudge in the checkout sidebar */
+function CheckoutSidebarNudge( { responseCart }: { responseCart: ResponseCart } ) {
+	const isWcMobile = isWcMobileApp();
+	const isDIFMInCart = hasDIFMProduct( responseCart );
+	const hasMonthlyProduct = responseCart?.products?.some( isMonthlyProduct );
+
+	if ( ! isWcMobile && ! isDIFMInCart && ! hasMonthlyProduct ) {
+		return (
+			<CheckoutSidebarNudgeWrapper>
+				<CheckoutSidebarPlanUpsell />
+				<JetpackAkismetCheckoutSidebarPlanUpsell />
+			</CheckoutSidebarNudgeWrapper>
+		);
+	}
+	return null;
+}
 export default function WPCheckout( {
 	addItemToCart,
 	changeSelection,
@@ -369,8 +385,6 @@ export default function WPCheckout( {
 		clearDomainContactErrorMessages,
 	} = checkoutActions;
 
-	const isWcMobile = isWcMobileApp();
-
 	if ( transactionStatus === TransactionStatus.COMPLETE ) {
 		debug( 'rendering post-checkout redirecting page' );
 		return (
@@ -421,26 +435,10 @@ export default function WPCheckout( {
 		);
 	}
 
-	const isDIFMInCart = hasDIFMProduct( responseCart );
-	const hasMonthlyProduct = responseCart?.products?.some( isMonthlyProduct );
-
 	const nextStepButtonText =
 		locale.startsWith( 'en' ) || i18n.hasTranslation( 'Continue to payment' )
 			? translate( 'Continue to payment', { textOnly: true } )
 			: translate( 'Continue', { textOnly: true } );
-
-	/* Include a condition for your use case here if you want to show a specific nudge in the checkout sidebar */
-	function CheckoutSidebarNudge() {
-		if ( ! isWcMobile && ! isDIFMInCart && ! hasMonthlyProduct ) {
-			return (
-				<CheckoutSidebarNudgeWrapper>
-					<CheckoutSidebarPlanUpsell />
-					<JetpackAkismetCheckoutSidebarPlanUpsell />
-				</CheckoutSidebarNudgeWrapper>
-			);
-		}
-		return null;
-	}
 
 	return (
 		<WPCheckoutWrapper>
@@ -484,7 +482,9 @@ export default function WPCheckout( {
 									onChangeSelection={ changeSelection }
 									nextDomainIsFree={ responseCart?.next_domain_is_free }
 								/>
-								{ hasCheckoutVersion( '2' ) && <CheckoutSidebarNudge /> }
+								{ hasCheckoutVersion( '2' ) && (
+									<CheckoutSidebarNudge responseCart={ responseCart } />
+								) }
 								<SecondaryCartPromotions
 									responseCart={ responseCart }
 									addItemToCart={ addItemToCart }

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -430,19 +430,17 @@ export default function WPCheckout( {
 			: translate( 'Continue', { textOnly: true } );
 
 	/* Include a condition for your use case here if you want to show a specific nudge in the checkout sidebar */
-	const renderCheckoutSidebarNudge = () => {
-		let upsellNudgeVariant = null;
-
+	function CheckoutSidebarNudge() {
 		if ( ! isWcMobile && ! isDIFMInCart && ! hasMonthlyProduct ) {
-			upsellNudgeVariant = (
+			return (
 				<>
 					<CheckoutSidebarPlanUpsell />
 					<JetpackAkismetCheckoutSidebarPlanUpsell />
 				</>
 			);
 		}
-		return upsellNudgeVariant;
-	};
+		return null;
+	}
 
 	return (
 		<WPCheckoutWrapper>
@@ -488,7 +486,7 @@ export default function WPCheckout( {
 								/>
 								{ hasCheckoutVersion( '2' ) && (
 									<CheckoutSidebarNudgeWrapper>
-										{ renderCheckoutSidebarNudge() }
+										<CheckoutSidebarNudge />
 									</CheckoutSidebarNudgeWrapper>
 								) }
 								<SecondaryCartPromotions

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -477,11 +477,7 @@ export default function WPCheckout( {
 									/>
 								) }
 
-								<WPCheckoutOrderSummary
-									siteId={ siteId }
-									onChangeSelection={ changeSelection }
-									nextDomainIsFree={ responseCart?.next_domain_is_free }
-								/>
+								<WPCheckoutOrderSummary siteId={ siteId } onChangeSelection={ changeSelection } />
 								<CheckoutSidebarNudge responseCart={ responseCart } />
 								<SecondaryCartPromotions
 									responseCart={ responseCart }


### PR DESCRIPTION
In a recent experiment we shown that the two year upsell nudge in checkout does positively encourage customers to upgrade to a two year plan - thus it will be included in the new checkout redesign.

Recently we also saw experiments that displayed other information content and I suggested we turn this sidebar section into a wrapper where any content can be displayed on a case by case basis depending on the cart's content.

Related to #

## Proposed Changes

* Create `CheckoutSidebarNudgeWrapper` to encapsulate a variety of upsell/nudge components
* Provide the render function `renderCheckoutSidebarNudge` where conditional logic can be set for specific cart contents

## Testing Instructions

**Test original behavior**
* Add a one year plan to your cart
* Go to checkout without any query parameter flags
* Look for the two year plan upsell in the sidebar

**Testing new behavior**
* Add the `?checkoutVersion=2` query parameter to the checkout URL, refresh page
* Look for the new upsell nudge as depicted in the checkout v2 design figma

**Further testing**
* On a local branch, edit the `renderCheckoutSidebarNudge` function in `wp-checkout.tsx` and add a new condition, set upsellNudgeVariant to whatever you like (text, component, etc)
* Check that the content is added to the sidebar nudge component area and that the wrapper component contains the inner context (i.e. no x-axis overflow)
