### PR TITLE
Fix the broken style tag HTML in iframe that renders a pattern

### DIFF
--- a/packages/global-styles/src/gutenberg-bridge/index.tsx
+++ b/packages/global-styles/src/gutenberg-bridge/index.tsx
@@ -33,14 +33,7 @@ const mergeBaseAndUserConfigs = ( base: GlobalStylesObject, user: GlobalStylesOb
 
 const withExperimentalBlockEditorProvider = createHigherOrderComponent(
 	< OuterProps extends object >( InnerComponent: React.ComponentType< OuterProps > ) => {
-		// Use fake assets to eliminate the compatStyles without the id.
-		// See https://github.com/WordPress/gutenberg/blob/f77958cfc13c02b0c0e6b9b697b43bbcad4ba40b/packages/block-editor/src/components/iframe/index.js#L127
-		const settings = {
-			__unstableResolvedAssets: {
-				styles: '<style id="" />',
-			},
-		};
-
+		const settings = {};
 		return ( props: OuterProps ) => (
 			<ExperimentalBlockEditorProvider settings={ settings }>
 				<InnerComponent { ...props } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/85489

## Proposed Changes

This PR fixes the broken style tag HTML in iframe that renders a pattern. 

| before | after |
|--------|--------|
| ![Image](https://github.com/Automattic/wp-calypso/assets/1881481/e48783f3-d90b-4bf6-93e1-0ec8ab22153e) | <img width="478" alt="Screenshot 2024-01-19 at 14 41 52" src="https://github.com/Automattic/wp-calypso/assets/5287479/7043c4c5-6444-4ef3-89bb-e5c73184a93e"> | 

<details><summary>Details</summary>
<p>

The font styles are safely injected.
<img width="498" alt="Screenshot 2024-01-19 at 14 59 12" src="https://github.com/Automattic/wp-calypso/assets/5287479/d3ea6576-a5f9-4399-8988-828ae6e017ff">

old version (`__unstableResolvedAssets.styles[n].id` was needed, as it's being used)
https://github.com/WordPress/gutenberg/blob/f77958cfc13c02b0c0e6b9b697b43bbcad4ba40b/packages/block-editor/src/components/iframe/index.js#L118

new version
https://github.com/WordPress/gutenberg/blob/33b6e64/packages/block-editor/src/components/iframe/index.js#L117

</p>
</details> 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live
* Go to the Assembler
* Click any pattern category
* Inspect the HTML in the iframe of a pattern

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?