### PR TITLE
Marketplace: Remove wp-staging plugin from the list of incompatible plugins

### DIFF
--- a/client/my-sites/plugins/plugin-compatibility.js
+++ b/client/my-sites/plugins/plugin-compatibility.js
@@ -118,7 +118,6 @@ const incompatiblePlugins = new Set( [
 
 	// cloning/staging
 	'flo-launch',
-	'wp-staging',
 
 	// misc
 	'adult-mass-photos-downloader',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/dotcom-forge/issues/5143

## Proposed Changes

* Remove `wp-staging` plugin from the list incompatible plugins

| Before  | After |
| ------------- | ------------- |
| ![CleanShot 2024-01-19 at 10 10 05@2x](https://github.com/Automattic/wp-calypso/assets/86406124/5eef860a-9605-4855-b559-8548a91b699d) | ![CleanShot 2024-01-19 at 10 10 47@2x](https://github.com/Automattic/wp-calypso/assets/86406124/f80bcdc2-b1d9-4ab1-9b30-10e6c2cf9ca0)  |


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `plugins/wp-staging/[:site]`
* Make sure `Incompatible plugin: This plugin is not supported on WordPress.com.` warning isn't shown. 
* Also make sure 'Install & Activate' button is enabled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?