### PR TITLE
Add Bundle Analyzer to wpcom-block-editor

### DIFF
--- a/apps/wpcom-block-editor/package.json
+++ b/apps/wpcom-block-editor/package.json
@@ -60,6 +60,7 @@
 		"@wordpress/dependency-extraction-webpack-plugin": "^5.0.0",
 		"npm-run-all": "^4.1.5",
 		"postcss": "^8.4.5",
-		"webpack": "^5.89.0"
+		"webpack": "^5.89.0",
+		"webpack-bundle-analyzer": "^4.10.1"
 	}
 }

--- a/apps/wpcom-block-editor/webpack.config.js
+++ b/apps/wpcom-block-editor/webpack.config.js
@@ -6,11 +6,13 @@ const path = require( 'path' );
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
 const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 const webpack = require( 'webpack' );
+const { BundleAnalyzerPlugin } = require( 'webpack-bundle-analyzer' );
 
 /**
  * Internal variables
  */
 const isDevelopment = process.env.NODE_ENV !== 'production';
+const shouldEmitStats = process.env.EMIT_STATS && process.env.EMIT_STATS !== 'false';
 
 /**
  * Return a webpack config object
@@ -78,6 +80,17 @@ function getWebpackConfig(
 					}
 				},
 			} ),
+			shouldEmitStats &&
+				new BundleAnalyzerPlugin( {
+					analyzerMode: 'server',
+					statsOptions: {
+						source: false,
+						reasons: false,
+						optimizationBailout: false,
+						chunkOrigins: false,
+						chunkGroups: true,
+					},
+				} ),
 		],
 	};
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2001,6 +2001,7 @@ __metadata:
     redux: "npm:^4.2.1"
     tinymce: "npm:^5.0.0"
     webpack: "npm:^5.89.0"
+    webpack-bundle-analyzer: "npm:^4.10.1"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1705629726572469-slack-CRWCHQGUB

## Proposed Changes

This PR introduces [Bundle Analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer) to wpcom-block-editor to make it easy to identify the bottleneck in our build size. 

<img width="1430" alt="Screenshot 2024-01-19 at 16 35 59" src="https://github.com/Automattic/wp-calypso/assets/5287479/13335df0-9f32-4580-a3eb-1805847fa5b6">

<img width="1400" alt="Screenshot 2024-01-19 at 16 36 23" src="https://github.com/Automattic/wp-calypso/assets/5287479/86b82ced-247a-4b71-8ef7-5124df2019e6">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* cd apps/wpcom-block-editor/
* EMIT_STATS=true yarn build:wpcom-block-editor
* Your browser opens http://127.0.0.1:8888/

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?