### PR TITLE
Site selector: add missing section translations

### DIFF
--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -155,6 +155,23 @@ class Sites extends Component {
 				break;
 			case 'github-deployments':
 				path = translate( 'GitHub Deployments' );
+			case 'earn':
+				path = translate( 'Monetize' );
+				break;
+			case 'subscribers':
+				path = translate( 'Subscribers' );
+				break;
+			case 'themes':
+				path = translate( 'Themes' );
+				break;
+			case 'marketing':
+				path = translate( 'Marketing' );
+				break;
+			case 'import':
+				path = translate( 'Import' );
+				break;
+			case 'export':
+				path = translate( 'Export' );
 				break;
 		}
 

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -173,6 +173,12 @@ class Sites extends Component {
 			case 'export':
 				path = translate( 'Export' );
 				break;
+			case 'email':
+				path = translate( 'Emails' );
+				break;
+			case 'purchases':
+				path = translate( 'Purchases' );
+				break;
 		}
 
 		return translate( 'Select a site to open {{strong}}%(path)s{{/strong}}', {

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -179,6 +179,24 @@ class Sites extends Component {
 			case 'purchases':
 				path = translate( 'Purchases' );
 				break;
+			case 'customize':
+				path = translate( 'Customizer' );
+				break;
+			case 'google-my-business':
+				path = translate( 'Google Business Profile' );
+				break;
+			case 'view':
+				path = translate( 'Preview' );
+				break;
+			case 'woocommerce-installation':
+				path = 'WooCommerce';
+				break;
+			case 'store':
+				path = translate( 'Store' );
+				break;
+			case 'add-ons':
+				path = translate( 'Add-ons' );
+				break;
 		}
 
 		return translate( 'Select a site to open {{strong}}%(path)s{{/strong}}', {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Looks like we use the `path` as part of translated string, but those are _always_ English so it doesn't look right.

Added few missing translations, but there could be more.

Would probably be better if we'd just use "section name" from configs, as that's transalted?

## Proposed Changes

* Add missing site selector translations for few sections 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open `/import`, `/marketing`, `/earn`, etc while using e.g. Spanish language.

Before

<img width="399" alt="Screenshot 2024-01-19 at 11 43 11" src="https://github.com/Automattic/wp-calypso/assets/87168/ef0583e4-8318-4ba2-9c5e-bb4f440c1cea">


After

<img width="430" alt="Screenshot 2024-01-19 at 11 43 06" src="https://github.com/Automattic/wp-calypso/assets/87168/8777b150-085f-42fa-a371-f6af69103763">

Few others:

<img width="412" alt="Screenshot 2024-01-19 at 11 41 41" src="https://github.com/Automattic/wp-calypso/assets/87168/9f202240-20b1-42a4-a6a3-c71d9dc7b095">
<img width="417" alt="Screenshot 2024-01-19 at 11 36 03" src="https://github.com/Automattic/wp-calypso/assets/87168/c98ecee6-23c5-4970-abd1-0cdadeb72771">
<img width="473" alt="Screenshot 2024-01-19 at 11 34 29" src="https://github.com/Automattic/wp-calypso/assets/87168/9b3d9ed4-483d-4939-96f3-46b1d97e0a7c">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?