### PR TITLE
Hosting Command Palette: add right space in the banner command box

### DIFF
--- a/client/sites-dashboard/components/hosting-command-palette-banner.tsx
+++ b/client/sites-dashboard/components/hosting-command-palette-banner.tsx
@@ -79,6 +79,8 @@ const CommandBox = styled.div( {
 	letterSpacing: -0.15,
 	backgroundColor: 'var(--color-surface)',
 	boxShadow: '1px 1px 1px 0px #0000001F',
+	paddingRight: 10,
+	whiteSpace: 'nowrap',
 	'&.command-box__fadeIn': {
 		animation: `${ fadeIn } 1s ease-in-out`,
 		zIndex: 10,
@@ -171,7 +173,6 @@ const AnimatedCommand = () => {
 		if ( prefersReducedMotion ) {
 			return;
 		}
-
 		const interval = setInterval( () => {
 			setCurrentCommandIndex( ( prevIndex ) => ( prevIndex + 1 ) % commandNames.length );
 		}, 3000 );

--- a/client/sites-dashboard/components/hosting-command-palette-banner.tsx
+++ b/client/sites-dashboard/components/hosting-command-palette-banner.tsx
@@ -173,6 +173,7 @@ const AnimatedCommand = () => {
 		if ( prefersReducedMotion ) {
 			return;
 		}
+
 		const interval = setInterval( () => {
 			setCurrentCommandIndex( ( prevIndex ) => ( prevIndex + 1 ) % commandNames.length );
 		}, 3000 );

--- a/client/sites-dashboard/components/hosting-command-palette-banner.tsx
+++ b/client/sites-dashboard/components/hosting-command-palette-banner.tsx
@@ -88,6 +88,7 @@ const CommandBox = styled.div( {
 	'&.command-box__fadeOut': {
 		animation: `${ fadeOut } 1s ease-in-out`,
 		zIndex: 5,
+		opacity: 0,
 	},
 	svg: {
 		width: 24,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/wp-calypso/pull/85564
- Reported on p7DVsv-jIG-p2#comment-48943 

## Proposed Changes

* Add padding right to the banner command box to improve the UI for long command names.
* Fix intensity on box shadow opacity

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change your WPCOM preferred language to Spanish
* Access `/sites`
* Observe the command box inside the banner has enough space for all the commands.

**Before**

<img width="1354" alt="Screenshot 2024-01-19 at 11 41 22" src="https://github.com/Automattic/wp-calypso/assets/779993/d9e6dac1-6d4c-4217-9eaa-94dfb4266185">


**After**
<img width="1352" alt="Screenshot 2024-01-19 at 11 41 02" src="https://github.com/Automattic/wp-calypso/assets/779993/35b81c41-dd60-454f-ba06-c7d0d9ef8a55">

**Responsive**


https://github.com/Automattic/wp-calypso/assets/779993/6782563e-b9a5-4bba-b660-60efd85ae924






## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?