### PR TITLE
Marketplace Reviews: Add track event when displaying Add Review button

### DIFF
--- a/client/my-sites/marketplace/components/reviews-summary/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-summary/index.tsx
@@ -2,7 +2,7 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 import Rating from 'calypso/components/rating';
 import {
 	useMarketplaceReviewsStatsQuery,
@@ -15,6 +15,14 @@ import './styles.scss';
 
 type Props = ProductProps & {
 	productName: string;
+};
+
+const TrackedButton = ( { onClick, children }: { onClick: () => void; children: ReactNode } ) => {
+	// useEffect used to avoid calling recordTracksEvent on every render
+	useEffect( () => {
+		recordTracksEvent( 'calypso_marketplace_reviews_add_button_displayed' );
+	}, [] );
+	return <Button onClick={ onClick }>{ children }</Button>;
 };
 
 export const ReviewsSummary = ( { slug, productName, productType }: Props ) => {
@@ -74,7 +82,9 @@ export const ReviewsSummary = ( { slug, productName, productType }: Props ) => {
 					</div>
 				) }
 				{ userCanPublishReviews && (
-					<Button onClick={ handleAddReviewClick }>{ translate( 'Add Review' ) }</Button>
+					<TrackedButton onClick={ handleAddReviewClick }>
+						{ translate( 'Add Review' ) }
+					</TrackedButton>
 				) }
 			</div>
 		</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/dotcom-forge/issues/5144

Include an event that will make the Funnel more specific to reviews

## Proposed Changes

* Add a new tracks event triggered when the `Add Review` button is displayed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable the logging of track events executing this in the Developer Console: `localStorage.debug='calypso:analytics'` and make sure you've got Debug level to `Verbose`
* In an environment with the following flags enabled: `marketplace-add-review`,`marketplace-reviews-show`
* Navigate to a theme that you can review, e.g. `/themes/spiel` if you have a activated `Spiel` before. 
* Open the Developer Console, and make sure you can see a tracks event named `calypso_marketplace_reviews_add_button_displayed`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?