### PR TITLE
Update components package version to 2.1.0

### DIFF
--- a/packages/calypso-url/CHANGELOG.md
+++ b/packages/calypso-url/CHANGELOG.md
@@ -1,7 +1,8 @@
+## 1.1.0
+
+- added `getCalypsoUrl` helper
+
 ## 1.0.0
 
 - Initial release
 
-## 1.1.0
-
-- added `getCalypsoUrl` helper

--- a/packages/components/CHANGELOG.md
+++ b/packages/components/CHANGELOG.md
@@ -1,6 +1,7 @@
-## next
+## 2.1.0
 
 - Update social-logos to ^2.5.2 (#72876)
+- Remove the `HappinessEngineersTray` component and the dependencies on `@automattic/data-stores`, `@automattic/search` and `wpcom-proxy-request`
 
 ## 2.0.1
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/components",
-	"version": "2.0.2",
+	"version": "2.1.0",
 	"description": "Automattic Components.",
 	"homepage": "https://github.com/Automattic/wp-calypso",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
Update the package's version and changelog. Commits the changes I had only locally when I publised the `calypso-url@1.1.0` and `components@2.1.0` on Wednesday.