### PR TITLE
Render a list of developer features

### DIFF
--- a/client/me/developer/features/handle-click-link.tsx
+++ b/client/me/developer/features/handle-click-link.tsx
@@ -1,5 +1,13 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 
-export const handleClickLink = ( title: string ) => {
+export const handleClickLink = ( event: React.MouseEvent< HTMLAnchorElement > ) => {
+	const prefixToRemove = '/support';
+	const pathIndex = event.currentTarget.href.indexOf( prefixToRemove );
+
+	let title = event.currentTarget.href;
+	if ( pathIndex !== -1 ) {
+		title = title.substring( pathIndex + prefixToRemove.length );
+	}
+
 	recordTracksEvent( 'calypso_me_developer_learn_more', { feature: title } );
 };

--- a/client/me/developer/features/handle-click-link.tsx
+++ b/client/me/developer/features/handle-click-link.tsx
@@ -1,0 +1,5 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+
+export const handleClickLink = ( title: string ) => {
+	recordTracksEvent( 'calypso_me_developer_learn_more', { feature: title } );
+};

--- a/client/me/developer/features/handle-click-link.tsx
+++ b/client/me/developer/features/handle-click-link.tsx
@@ -1,13 +1,13 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 
 export const handleClickLink = ( event: React.MouseEvent< HTMLAnchorElement > ) => {
-	const prefixToRemove = '/support';
+	const prefixToRemove = '/support/';
 	const pathIndex = event.currentTarget.href.indexOf( prefixToRemove );
 
-	let title = event.currentTarget.href;
+	let featureSlug = event.currentTarget.href;
 	if ( pathIndex !== -1 ) {
-		title = title.substring( pathIndex + prefixToRemove.length );
+		featureSlug = featureSlug.substring( pathIndex + prefixToRemove.length );
 	}
 
-	recordTracksEvent( 'calypso_me_developer_learn_more', { feature: title } );
+	recordTracksEvent( 'calypso_me_developer_learn_more', { feature: featureSlug } );
 };

--- a/client/me/developer/features/index.tsx
+++ b/client/me/developer/features/index.tsx
@@ -12,8 +12,8 @@ export const DeveloperFeatures = () => {
 	return (
 		<>
 			<div className="developer-features-list">
-				{ features.map( ( { key, title, description, linkLearnMore } ) => (
-					<Card className="developer-features-list__item" key={ key }>
+				{ features.map( ( { id, title, description, linkLearnMore } ) => (
+					<Card className="developer-features-list__item" key={ id }>
 						<div className="developer-features-list__item-title">{ title }</div>
 						<div className="developer-features-list__item-description">{ description }</div>
 						{ linkLearnMore && (

--- a/client/me/developer/features/index.tsx
+++ b/client/me/developer/features/index.tsx
@@ -12,8 +12,8 @@ export const DeveloperFeatures = () => {
 	return (
 		<>
 			<div className="developer-features-list">
-				{ features.map( ( { title, description, linkLearnMore } ) => (
-					<Card className="developer-features-list__item">
+				{ features.map( ( { title, description, linkLearnMore }, index ) => (
+					<Card className="developer-features-list__item" key={ index }>
 						<div className="developer-features-list__item-title">{ title }</div>
 						<div className="developer-features-list__item-description">{ description }</div>
 						{ linkLearnMore && (

--- a/client/me/developer/features/index.tsx
+++ b/client/me/developer/features/index.tsx
@@ -9,11 +9,7 @@ export const DeveloperFeatures = () => {
 
 	return (
 		<>
-			<div className="developer-features__title">
-				{ translate(
-					'Explore all the developer-oriented features of WordPress.com and get early access'
-				) }
-			</div>
+			<div className="developer-features__title"></div>
 			<div className="developer-features-list">
 				{ features.map( ( { title, description, linkLearnMore } ) => (
 					<div className="developer-features-list__item">
@@ -21,7 +17,7 @@ export const DeveloperFeatures = () => {
 						<div className="developer-features-list__item-description">{ description }</div>
 						<div className="developer-features-list__item-learn-more">
 							<a href={ linkLearnMore } target="_blank" rel="noopener noreferrer">
-								Learn more
+								{ translate( 'Learn more' ) }
 							</a>
 						</div>
 					</div>

--- a/client/me/developer/features/index.tsx
+++ b/client/me/developer/features/index.tsx
@@ -1,4 +1,6 @@
+import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { handleClickLink } from './handle-click-link';
 import { useFeaturesList } from './use-features-list';
 
 import './style.scss';
@@ -10,16 +12,23 @@ export const DeveloperFeatures = () => {
 	return (
 		<>
 			<div className="developer-features-list">
-				{ features.map( ( { title, description, linkLearnMore } ) => (
-					<div className="developer-features-list__item">
+				{ features.map( ( { title, description, linkLearnMore, trackFeatureName } ) => (
+					<Card className="developer-features-list__item">
 						<div className="developer-features-list__item-title">{ title }</div>
 						<div className="developer-features-list__item-description">{ description }</div>
-						<div className="developer-features-list__item-learn-more">
-							<a href={ linkLearnMore } target="_blank" rel="noopener noreferrer">
-								{ translate( 'Learn more' ) }
-							</a>
-						</div>
-					</div>
+						{ linkLearnMore && (
+							<div className="developer-features-list__item-learn-more">
+								<a
+									href={ linkLearnMore }
+									target="_blank"
+									rel="noopener noreferrer"
+									onClick={ () => handleClickLink( trackFeatureName ) }
+								>
+									{ translate( 'Learn more' ) }
+								</a>
+							</div>
+						) }
+					</Card>
 				) ) }
 			</div>
 		</>

--- a/client/me/developer/features/index.tsx
+++ b/client/me/developer/features/index.tsx
@@ -1,0 +1,30 @@
+import { useTranslate } from 'i18n-calypso';
+import { useFeaturesList } from './use-features-list';
+
+import './style.scss';
+
+export const DeveloperFeatures = () => {
+	const translate = useTranslate();
+	const features = useFeaturesList();
+
+	return (
+		<>
+			<div className="developer-features__title">
+				{ translate(
+					'Explore all the developer-oriented features of WordPress.com and get early access'
+				) }
+			</div>
+			<div className="developer-features-list">
+				{ features.map( ( { title, description, linkLearnMore } ) => (
+					<div className="developer-features-list__item">
+						<div className="developer-features-list__item-title">{ title }</div>
+						<div className="developer-features-list__item-description">{ description }</div>
+						<div className="developer-features-list__item-learn-more">
+							<a href={ linkLearnMore }>Learn more</a>
+						</div>
+					</div>
+				) ) }
+			</div>
+		</>
+	);
+};

--- a/client/me/developer/features/index.tsx
+++ b/client/me/developer/features/index.tsx
@@ -12,7 +12,7 @@ export const DeveloperFeatures = () => {
 	return (
 		<>
 			<div className="developer-features-list">
-				{ features.map( ( { title, description, linkLearnMore, trackFeatureName } ) => (
+				{ features.map( ( { title, description, linkLearnMore } ) => (
 					<Card className="developer-features-list__item">
 						<div className="developer-features-list__item-title">{ title }</div>
 						<div className="developer-features-list__item-description">{ description }</div>
@@ -22,7 +22,7 @@ export const DeveloperFeatures = () => {
 									href={ linkLearnMore }
 									target="_blank"
 									rel="noopener noreferrer"
-									onClick={ () => handleClickLink( trackFeatureName ) }
+									onClick={ handleClickLink }
 								>
 									{ translate( 'Learn more' ) }
 								</a>

--- a/client/me/developer/features/index.tsx
+++ b/client/me/developer/features/index.tsx
@@ -20,7 +20,9 @@ export const DeveloperFeatures = () => {
 						<div className="developer-features-list__item-title">{ title }</div>
 						<div className="developer-features-list__item-description">{ description }</div>
 						<div className="developer-features-list__item-learn-more">
-							<a href={ linkLearnMore }>Learn more</a>
+							<a href={ linkLearnMore } target="_blank" rel="noopener noreferrer">
+								Learn more
+							</a>
 						</div>
 					</div>
 				) ) }

--- a/client/me/developer/features/index.tsx
+++ b/client/me/developer/features/index.tsx
@@ -12,8 +12,8 @@ export const DeveloperFeatures = () => {
 	return (
 		<>
 			<div className="developer-features-list">
-				{ features.map( ( { title, description, linkLearnMore }, index ) => (
-					<Card className="developer-features-list__item" key={ index }>
+				{ features.map( ( { key, title, description, linkLearnMore } ) => (
+					<Card className="developer-features-list__item" key={ key }>
 						<div className="developer-features-list__item-title">{ title }</div>
 						<div className="developer-features-list__item-description">{ description }</div>
 						{ linkLearnMore && (

--- a/client/me/developer/features/index.tsx
+++ b/client/me/developer/features/index.tsx
@@ -9,7 +9,6 @@ export const DeveloperFeatures = () => {
 
 	return (
 		<>
-			<div className="developer-features__title"></div>
 			<div className="developer-features-list">
 				{ features.map( ( { title, description, linkLearnMore } ) => (
 					<div className="developer-features-list__item">

--- a/client/me/developer/features/style.scss
+++ b/client/me/developer/features/style.scss
@@ -1,41 +1,42 @@
 @import "@automattic/typography/styles/variables";
 
-.developer-features__title {
-	font-size: $font-body-large;
-	text-align: center;
-	padding-bottom: 24px;
-}
-
 .developer-features-list {
 	display: grid;
 	grid-template-columns: repeat(3, 1fr);
-	grid-gap: 16px;
+	grid-gap: 24px;
 	padding-bottom: 24px;
+	font-family: "SF Pro Text", $sans;
 
 	.developer-features-list__item {
 		display: flex;
 		flex-direction: column;
-		padding: 14px 14px 0 14px;
-		border: 2px solid #aaa;
-		border-radius: 4px;
+		border-radius: 2px;
+		border: 1px solid #dcdcde;
 		background: #fff;
-		color: #111;
+		padding: 23px 23px 0 23px;
 
 		.developer-features-list__item-title {
-			font-size: $font-body;
-			padding-bottom: 10px;
+			padding-bottom: 8px;
+			font-weight: 500;
+			font-size: rem(16px);
+			letter-spacing: -0.32px;
+			line-height: 24px;
 		}
 		.developer-features-list__item-description {
-			font-size: $font-body-small;
-			opacity: 0.5;
+			padding-bottom: 8px;
+			font-size: rem(14px);
+			color: #757575;
+			line-height: 20px;
+			letter-spacing: -0.15px;
 		}
 		.developer-features-list__item-learn-more {
-			padding-bottom: 9px;
+			padding-bottom: 23px;
 			margin-top: auto;
 
 			a {
-				font-size: $font-body-small;
-				color: #3858e9;
+				line-height: 13px;
+				font-size: rem(13px);
+				color: #c9356e;
 			}
 		}
 	}

--- a/client/me/developer/features/style.scss
+++ b/client/me/developer/features/style.scss
@@ -27,13 +27,13 @@
 			line-height: 24px;
 		}
 		.developer-features-list__item-description {
-			padding-bottom: 8px;
 			font-size: rem(14px);
 			color: var(--color-text-subtle);
 			line-height: 20px;
 			letter-spacing: -0.15px;
 		}
 		.developer-features-list__item-learn-more {
+			padding-top: 8px;
 			margin-top: auto;
 		}
 	}
@@ -44,8 +44,8 @@
 		.developer-features-list__item {
 			margin: 0 32px 24px 32px;
 
-			.developer-features-list__item-description {
-				padding-bottom: 30px;
+			.developer-features-list__item-learn-more {
+				padding-top: 30px;
 			}
 		}
 	}

--- a/client/me/developer/features/style.scss
+++ b/client/me/developer/features/style.scss
@@ -1,12 +1,13 @@
 @import "@wordpress/base-styles/breakpoints.scss";
 @import "@automattic/typography/styles/variables";
+@import "@automattic/components/src/styles/typography";
 
 .developer-features-list {
 	display: grid;
 	grid-template-columns: repeat(3, 1fr);
 	grid-gap: 24px;
 	padding-bottom: 24px;
-	font-family: "SF Pro Text", $sans;
+	font-family: $font-sf-pro-text;
 
 	.developer-features-list__item {
 		display: flex;

--- a/client/me/developer/features/style.scss
+++ b/client/me/developer/features/style.scss
@@ -11,10 +11,12 @@
 	.developer-features-list__item {
 		display: flex;
 		flex-direction: column;
-		border-radius: 2px;
-		border: 1px solid #dcdcde;
-		background: #fff;
-		padding: 23px 23px 0 23px;
+		margin-bottom: 0;
+
+		a {
+			font-size: rem(13px);
+			color: #c9356e;
+		}
 
 		.developer-features-list__item-title {
 			padding-bottom: 8px;
@@ -31,18 +33,11 @@
 			letter-spacing: -0.15px;
 		}
 		.developer-features-list__item-learn-more {
-			padding-bottom: 23px;
 			margin-top: auto;
-
-			a {
-				line-height: 13px;
-				font-size: rem(13px);
-				color: #c9356e;
-			}
 		}
 	}
 
-	@media ( max-width: $break-medium ) {
+	@media ( max-width: $break-large ) {
 		display: block;
 
 		.developer-features-list__item {

--- a/client/me/developer/features/style.scss
+++ b/client/me/developer/features/style.scss
@@ -15,7 +15,7 @@
 
 		a {
 			font-size: rem(13px);
-			color: #c9356e;
+			color: var(--color-accent);
 		}
 
 		.developer-features-list__item-title {
@@ -28,7 +28,7 @@
 		.developer-features-list__item-description {
 			padding-bottom: 8px;
 			font-size: rem(14px);
-			color: #757575;
+			color: var(--color-text-subtle);
 			line-height: 20px;
 			letter-spacing: -0.15px;
 		}

--- a/client/me/developer/features/style.scss
+++ b/client/me/developer/features/style.scss
@@ -1,0 +1,42 @@
+@import "@automattic/typography/styles/variables";
+
+.developer-features__title {
+	font-size: $font-body-large;
+	text-align: center;
+	padding-bottom: 24px;
+}
+
+.developer-features-list {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	grid-gap: 16px;
+	padding-bottom: 24px;
+
+	.developer-features-list__item {
+		display: flex;
+		flex-direction: column;
+		padding: 14px 14px 0 14px;
+		border: 2px solid #aaa;
+		border-radius: 4px;
+		background: #fff;
+		color: #111;
+
+		.developer-features-list__item-title {
+			font-size: $font-body;
+			padding-bottom: 10px;
+		}
+		.developer-features-list__item-description {
+			font-size: $font-body-small;
+			opacity: 0.5;
+		}
+		.developer-features-list__item-learn-more {
+			padding-bottom: 9px;
+			margin-top: auto;
+
+			a {
+				font-size: $font-body-small;
+				color: #3858e9;
+			}
+		}
+	}
+}

--- a/client/me/developer/features/style.scss
+++ b/client/me/developer/features/style.scss
@@ -1,3 +1,4 @@
+@import "@wordpress/base-styles/breakpoints.scss";
 @import "@automattic/typography/styles/variables";
 
 .developer-features-list {
@@ -37,6 +38,18 @@
 				line-height: 13px;
 				font-size: rem(13px);
 				color: #c9356e;
+			}
+		}
+	}
+
+	@media ( max-width: $break-medium ) {
+		display: block;
+
+		.developer-features-list__item {
+			margin: 0 32px 24px 32px;
+
+			.developer-features-list__item-description {
+				padding-bottom: 30px;
 			}
 		}
 	}

--- a/client/me/developer/features/use-features-list.tsx
+++ b/client/me/developer/features/use-features-list.tsx
@@ -34,7 +34,7 @@ export const useFeaturesList = () => {
 				comment: 'Feature title for developers on WordPress.com',
 			} ),
 			description: translate(
-				'Build anything with full support and automatic updates for 50,000+ plugins and themes. Or start from scratch with your own custom code.',
+				'Build anything with support and automatic updates for 50,000+ plugins and themes. Or start from scratch with your own custom code.',
 				{
 					comment: 'Description of feature "Custom code" for developers on WordPress.com',
 				}

--- a/client/me/developer/features/use-features-list.tsx
+++ b/client/me/developer/features/use-features-list.tsx
@@ -6,45 +6,74 @@ export const useFeaturesList = () => {
 
 	return [
 		{
-			title: translate( 'SFTP, SSH, and WP-CLI' ),
+			title: translate( 'SFTP, SSH, and WP-CLI', {
+				comment: 'Feature title for developers on WordPress.com',
+			} ),
 			description: translate(
-				'Run WP-CLI commands, automate repetitive tasks, and troubleshoot your custom code with the tools you already use.'
+				'Run WP-CLI commands, automate repetitive tasks, and troubleshoot your custom code with the tools you already use.',
+				{
+					comment: 'Description of feature "SFTP, SSH, and WP-CLI" for developers on WordPress.com',
+				}
 			),
 			linkLearnMore: localizeUrl( '/support/connect-to-ssh-on-wordpress-com' ),
 		},
 		{
-			title: translate( 'Staging sites' ),
+			title: translate( 'Staging sites', {
+				comment: 'Feature title for developers on WordPress.com',
+			} ),
 			description: translate(
-				'Test changes on a WordPress.com staging site first, so you can identify and fix any vulnerabilities before they impact your live site.'
+				'Test changes on a WordPress.com staging site first, so you can identify and fix any vulnerabilities before they impact your live site.',
+				{
+					comment: 'Description of feature "Staging sites" for developers on WordPress.com',
+				}
 			),
 			linkLearnMore: localizeUrl( '/support/how-to-create-a-staging-site/' ),
 		},
 		{
-			title: translate( 'Custom code' ),
+			title: translate( 'Custom code', {
+				comment: 'Feature title for developers on WordPress.com',
+			} ),
 			description: translate(
-				'Build anything with full support and automatic updates for 50,000+ plugins and themes. Or start from scratch with your own custom code.'
+				'Build anything with full support and automatic updates for 50,000+ plugins and themes. Or start from scratch with your own custom code.',
+				{
+					comment: 'Description of feature "Custom code" for developers on WordPress.com',
+				}
 			),
 			linkLearnMore: localizeUrl( '/support/code' ),
 		},
 		{
-			title: translate( 'Free SSL certificates' ),
+			title: translate( 'Free SSL certificates', {
+				comment: 'Feature title for developers on WordPress.com',
+			} ),
 			description: translate(
-				'Take your site from HTTP to HTTPS at no additional cost. We encrypt every domain registered and connected to WordPress.com with a free SSL certificate.'
+				'Take your site from HTTP to HTTPS at no additional cost. We encrypt every domain registered and connected to WordPress.com with a free SSL certificate.',
+				{
+					comment: 'Description of feature "Free SSL certificates" for developers on WordPress.com',
+				}
 			),
 			linkLearnMore: localizeUrl( '/support/domains/https-ssl' ),
 		},
 		{
-			title: translate( '24/7 expert support' ),
+			title: translate( '24/7 expert support', {
+				comment: 'Feature title for developers on WordPress.com',
+			} ),
 			description: translate(
-				"Whenever you're stuck, whatever you're trying to make happen—our Happiness Engineers have the answers."
+				"Whenever you're stuck, whatever you're trying to make happen—our Happiness Engineers have the answers.",
+				{
+					comment: 'Description of feature "24/7 expert support" for developers on WordPress.com',
+				}
 			),
 			linkLearnMore: localizeUrl( '/support/help-support-options' ),
 		},
 		{
-			title: translate( 'Malware scanning and removal' ),
+			title: translate( 'Malware scanning and removal', {
+				comment: 'Feature title for developers on WordPress.com',
+			} ),
 			description: translate(
 				'Secure and maintain your site effortlessly with {{backupsLink}}real-time backups{{/backupsLink}}, advanced {{malwareScanningLink}}malware scanning and removal{{/malwareScanningLink}}, and continuous {{siteMonitoringLink}}site monitoring{{/siteMonitoringLink}}—ensuring peak performance and security at all times.',
 				{
+					comment:
+						'Description of feature "Malware scanning and removal" for developers on WordPress.com',
 					components: {
 						backupsLink: (
 							<a

--- a/client/me/developer/features/use-features-list.tsx
+++ b/client/me/developer/features/use-features-list.tsx
@@ -1,0 +1,50 @@
+import { useTranslate } from 'i18n-calypso';
+
+export const useFeaturesList = () => {
+	const translate = useTranslate();
+
+	return [
+		{
+			title: translate( 'SSH, WP-CLI, and GIT' ),
+			description: translate(
+				'Run WP-CLI commands, automate repetitive tasks and troubleshoot your custom code. All that with the tools you already use.'
+			),
+			linkLearnMore: '#',
+		},
+		{
+			title: translate( 'Staging sites' ),
+			description: translate(
+				'Test changes on a WordPress.com staging site first, so you can identify and fix any vulnerabilities before they impact your live site.'
+			),
+			linkLearnMore: '#',
+		},
+		{
+			title: translate( 'Real-time activity log' ),
+			description: translate(
+				'Stay on top of everything that happens on your site with our real-time activity log. If it happened, you’ll know about it. '
+			),
+			linkLearnMore: '#',
+		},
+		{
+			title: translate( 'DDOS and WAF protection' ),
+			description: translate(
+				'WordPress.com blocks millions of malicious requests daily so you can sleep through takeover and hacking attempts.'
+			),
+			linkLearnMore: '#',
+		},
+		{
+			title: translate( 'Free SSL certificates' ),
+			description: translate(
+				'Take your site from HTTP to HTTPS at no additional cost with a free SSL certificate.'
+			),
+			linkLearnMore: '#',
+		},
+		{
+			title: translate( 'Malware scanning and removal' ),
+			description: translate(
+				'Stay one step ahead of security threats with automated malware scanning and one-click fixes.'
+			),
+			linkLearnMore: '#',
+		},
+	];
+};

--- a/client/me/developer/features/use-features-list.tsx
+++ b/client/me/developer/features/use-features-list.tsx
@@ -7,73 +7,72 @@ export const useFeaturesList = () => {
 	return [
 		{
 			title: translate( 'SFTP, SSH, and WP-CLI', {
-				comment: 'Feature title for developers on WordPress.com',
+				comment: 'Feature title',
 			} ),
 			description: translate(
 				'Run WP-CLI commands, automate repetitive tasks, and troubleshoot your custom code with the tools you already use.',
 				{
-					comment: 'Description of feature "SFTP, SSH, and WP-CLI" for developers on WordPress.com',
+					comment: 'Feature description',
 				}
 			),
 			linkLearnMore: localizeUrl( '/support/connect-to-ssh-on-wordpress-com' ),
 		},
 		{
 			title: translate( 'Staging sites', {
-				comment: 'Feature title for developers on WordPress.com',
+				comment: 'Feature title',
 			} ),
 			description: translate(
 				'Test changes on a WordPress.com staging site first, so you can identify and fix any vulnerabilities before they impact your live site.',
 				{
-					comment: 'Description of feature "Staging sites" for developers on WordPress.com',
+					comment: 'Feature description',
 				}
 			),
 			linkLearnMore: localizeUrl( '/support/how-to-create-a-staging-site/' ),
 		},
 		{
 			title: translate( 'Custom code', {
-				comment: 'Feature title for developers on WordPress.com',
+				comment: 'Feature title',
 			} ),
 			description: translate(
 				'Build anything with support and automatic updates for 50,000+ plugins and themes. Or start from scratch with your own custom code.',
 				{
-					comment: 'Description of feature "Custom code" for developers on WordPress.com',
+					comment: 'Feature description',
 				}
 			),
 			linkLearnMore: localizeUrl( '/support/code' ),
 		},
 		{
 			title: translate( 'Free SSL certificates', {
-				comment: 'Feature title for developers on WordPress.com',
+				comment: 'Feature title',
 			} ),
 			description: translate(
 				'Take your site from HTTP to HTTPS at no additional cost. We encrypt every domain registered and connected to WordPress.com with a free SSL certificate.',
 				{
-					comment: 'Description of feature "Free SSL certificates" for developers on WordPress.com',
+					comment: 'Feature description',
 				}
 			),
 			linkLearnMore: localizeUrl( '/support/domains/https-ssl' ),
 		},
 		{
 			title: translate( '24/7 expert support', {
-				comment: 'Feature title for developers on WordPress.com',
+				comment: 'Feature title',
 			} ),
 			description: translate(
 				"Whenever you're stuck, whatever you're trying to make happen—our Happiness Engineers have the answers.",
 				{
-					comment: 'Description of feature "24/7 expert support" for developers on WordPress.com',
+					comment: 'Feature description',
 				}
 			),
 			linkLearnMore: localizeUrl( '/support/help-support-options' ),
 		},
 		{
 			title: translate( 'Malware scanning and removal', {
-				comment: 'Feature title for developers on WordPress.com',
+				comment: 'Feature title',
 			} ),
 			description: translate(
 				'Secure and maintain your site effortlessly with {{backupsLink}}real-time backups{{/backupsLink}}, advanced {{malwareScanningLink}}malware scanning and removal{{/malwareScanningLink}}, and continuous {{siteMonitoringLink}}site monitoring{{/siteMonitoringLink}}—ensuring peak performance and security at all times.',
 				{
-					comment:
-						'Description of feature "Malware scanning and removal" for developers on WordPress.com',
+					comment: 'Feature description',
 					components: {
 						backupsLink: (
 							<a

--- a/client/me/developer/features/use-features-list.tsx
+++ b/client/me/developer/features/use-features-list.tsx
@@ -1,11 +1,13 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
+import { handleClickLink } from './handle-click-link';
 
 export const useFeaturesList = () => {
 	const translate = useTranslate();
 
 	return [
 		{
+			trackFeatureName: 'SFTP, SSH, and WP-CLI',
 			title: translate( 'SFTP, SSH, and WP-CLI', {
 				comment: 'Feature title',
 			} ),
@@ -18,6 +20,7 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( '/support/connect-to-ssh-on-wordpress-com' ),
 		},
 		{
+			trackFeatureName: 'Staging sites',
 			title: translate( 'Staging sites', {
 				comment: 'Feature title',
 			} ),
@@ -30,6 +33,7 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( '/support/how-to-create-a-staging-site/' ),
 		},
 		{
+			trackFeatureName: 'Custom code',
 			title: translate( 'Custom code', {
 				comment: 'Feature title',
 			} ),
@@ -42,6 +46,7 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( '/support/code' ),
 		},
 		{
+			trackFeatureName: 'Free SSL certificates',
 			title: translate( 'Free SSL certificates', {
 				comment: 'Feature title',
 			} ),
@@ -54,11 +59,12 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( '/support/domains/https-ssl' ),
 		},
 		{
+			trackFeatureName: '24/7 expert support',
 			title: translate( '24/7 expert support', {
 				comment: 'Feature title',
 			} ),
 			description: translate(
-				"Whenever you're stuck, whatever you're trying to make happen—our Happiness Engineers have the answers.",
+				"Whenever you're stuck, whatever you're trying to make happen — our Happiness Engineers have the answers.",
 				{
 					comment: 'Feature description',
 				}
@@ -66,11 +72,12 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( '/support/help-support-options' ),
 		},
 		{
+			trackFeatureName: 'Malware scanning and removal',
 			title: translate( 'Malware scanning and removal', {
 				comment: 'Feature title',
 			} ),
 			description: translate(
-				'Secure and maintain your site effortlessly with {{backupsLink}}real-time backups{{/backupsLink}}, advanced {{malwareScanningLink}}malware scanning and removal{{/malwareScanningLink}}, and continuous {{siteMonitoringLink}}site monitoring{{/siteMonitoringLink}}—ensuring peak performance and security at all times.',
+				'Secure and maintain your site effortlessly with {{backupsLink}}real-time backups{{/backupsLink}}, advanced {{malwareScanningLink}}malware scanning and removal{{/malwareScanningLink}}, and continuous {{siteMonitoringLink}}site monitoring{{/siteMonitoringLink}} — ensuring peak performance and security at all times.',
 				{
 					comment: 'Feature description',
 					components: {
@@ -79,6 +86,7 @@ export const useFeaturesList = () => {
 								href={ localizeUrl( '/support/restore' ) }
 								target="_blank"
 								rel="noopener noreferrer"
+								onClick={ () => handleClickLink( 'Malware scanning and removal' ) }
 							/>
 						),
 						malwareScanningLink: (
@@ -86,6 +94,7 @@ export const useFeaturesList = () => {
 								href={ localizeUrl( '/support/malware-and-site-security' ) }
 								target="_blank"
 								rel="noopener noreferrer"
+								onClick={ () => handleClickLink( 'Malware scanning and removal' ) }
 							/>
 						),
 						siteMonitoringLink: (
@@ -93,12 +102,12 @@ export const useFeaturesList = () => {
 								href={ localizeUrl( '/support/site-monitoring' ) }
 								target="_blank"
 								rel="noopener noreferrer"
+								onClick={ () => handleClickLink( 'Malware scanning and removal' ) }
 							/>
 						),
 					},
 				}
 			),
-			linkLearnMore: '#',
 		},
 	];
 };

--- a/client/me/developer/features/use-features-list.tsx
+++ b/client/me/developer/features/use-features-list.tsx
@@ -7,6 +7,7 @@ export const useFeaturesList = () => {
 
 	return [
 		{
+			key: 'sftp-ssh-wp-cli',
 			title: translate( 'SFTP, SSH, and WP-CLI', {
 				comment: 'Feature title',
 			} ),
@@ -19,6 +20,7 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( '/support/connect-to-ssh-on-wordpress-com' ),
 		},
 		{
+			key: 'staging-sites',
 			title: translate( 'Staging sites', {
 				comment: 'Feature title',
 			} ),
@@ -31,6 +33,7 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( '/support/how-to-create-a-staging-site/' ),
 		},
 		{
+			key: 'custom-code',
 			title: translate( 'Custom code', {
 				comment: 'Feature title',
 			} ),
@@ -43,6 +46,7 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( '/support/code' ),
 		},
 		{
+			key: 'free-ssl-certificates',
 			title: translate( 'Free SSL certificates', {
 				comment: 'Feature title',
 			} ),
@@ -55,6 +59,7 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( '/support/domains/https-ssl' ),
 		},
 		{
+			key: 'expert-support',
 			title: translate( '24/7 expert support', {
 				comment: 'Feature title',
 			} ),
@@ -67,6 +72,7 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( '/support/help-support-options' ),
 		},
 		{
+			key: 'malware-scanning-removal',
 			title: translate( 'Malware scanning and removal', {
 				comment: 'Feature title',
 			} ),

--- a/client/me/developer/features/use-features-list.tsx
+++ b/client/me/developer/features/use-features-list.tsx
@@ -6,7 +6,7 @@ export const useFeaturesList = () => {
 
 	return [
 		{
-			title: translate( 'SSH, WP-CLI, and GIT' ),
+			title: translate( 'SFTP, SSH, and WP-CLI' ),
 			description: translate(
 				'Run WP-CLI commands, automate repetitive tasks, and troubleshoot your custom code with the tools you already use.'
 			),
@@ -22,7 +22,7 @@ export const useFeaturesList = () => {
 		{
 			title: translate( 'Custom code' ),
 			description: translate(
-				'Build anything with support and automatic updates for 50,000+ plugins and themes. Or start from scratch with your own custom code.'
+				'Build anything with full support and automatic updates for 50,000+ plugins and themes. Or start from scratch with your own custom code.'
 			),
 			linkLearnMore: localizeUrl( '/support/code' ),
 		},
@@ -36,7 +36,7 @@ export const useFeaturesList = () => {
 		{
 			title: translate( '24/7 expert support' ),
 			description: translate(
-				'Whenever you’re stuck, whatever you’re trying to make happen—our Happiness Engineers have the answers.'
+				"Whenever you're stuck, whatever you're trying to make happen—our Happiness Engineers have the answers."
 			),
 			linkLearnMore: localizeUrl( '/support/help-support-options' ),
 		},

--- a/client/me/developer/features/use-features-list.tsx
+++ b/client/me/developer/features/use-features-list.tsx
@@ -7,7 +7,6 @@ export const useFeaturesList = () => {
 
 	return [
 		{
-			trackFeatureName: 'SFTP, SSH, and WP-CLI',
 			title: translate( 'SFTP, SSH, and WP-CLI', {
 				comment: 'Feature title',
 			} ),
@@ -20,7 +19,6 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( '/support/connect-to-ssh-on-wordpress-com' ),
 		},
 		{
-			trackFeatureName: 'Staging sites',
 			title: translate( 'Staging sites', {
 				comment: 'Feature title',
 			} ),
@@ -33,7 +31,6 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( '/support/how-to-create-a-staging-site/' ),
 		},
 		{
-			trackFeatureName: 'Custom code',
 			title: translate( 'Custom code', {
 				comment: 'Feature title',
 			} ),
@@ -46,7 +43,6 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( '/support/code' ),
 		},
 		{
-			trackFeatureName: 'Free SSL certificates',
 			title: translate( 'Free SSL certificates', {
 				comment: 'Feature title',
 			} ),
@@ -59,7 +55,6 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( '/support/domains/https-ssl' ),
 		},
 		{
-			trackFeatureName: '24/7 expert support',
 			title: translate( '24/7 expert support', {
 				comment: 'Feature title',
 			} ),
@@ -72,7 +67,6 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( '/support/help-support-options' ),
 		},
 		{
-			trackFeatureName: 'Malware scanning and removal',
 			title: translate( 'Malware scanning and removal', {
 				comment: 'Feature title',
 			} ),
@@ -86,7 +80,7 @@ export const useFeaturesList = () => {
 								href={ localizeUrl( '/support/restore' ) }
 								target="_blank"
 								rel="noopener noreferrer"
-								onClick={ () => handleClickLink( 'Malware scanning and removal' ) }
+								onClick={ handleClickLink }
 							/>
 						),
 						malwareScanningLink: (
@@ -94,7 +88,7 @@ export const useFeaturesList = () => {
 								href={ localizeUrl( '/support/malware-and-site-security' ) }
 								target="_blank"
 								rel="noopener noreferrer"
-								onClick={ () => handleClickLink( 'Malware scanning and removal' ) }
+								onClick={ handleClickLink }
 							/>
 						),
 						siteMonitoringLink: (
@@ -102,7 +96,7 @@ export const useFeaturesList = () => {
 								href={ localizeUrl( '/support/site-monitoring' ) }
 								target="_blank"
 								rel="noopener noreferrer"
-								onClick={ () => handleClickLink( 'Malware scanning and removal' ) }
+								onClick={ handleClickLink }
 							/>
 						),
 					},

--- a/client/me/developer/features/use-features-list.tsx
+++ b/client/me/developer/features/use-features-list.tsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 
 export const useFeaturesList = () => {
@@ -7,42 +8,67 @@ export const useFeaturesList = () => {
 		{
 			title: translate( 'SSH, WP-CLI, and GIT' ),
 			description: translate(
-				'Run WP-CLI commands, automate repetitive tasks and troubleshoot your custom code. All that with the tools you already use.'
+				'Run WP-CLI commands, automate repetitive tasks, and troubleshoot your custom code with the tools you already use.'
 			),
-			linkLearnMore: '#',
+			linkLearnMore: localizeUrl( '/support/connect-to-ssh-on-wordpress-com' ),
 		},
 		{
 			title: translate( 'Staging sites' ),
 			description: translate(
 				'Test changes on a WordPress.com staging site first, so you can identify and fix any vulnerabilities before they impact your live site.'
 			),
-			linkLearnMore: '#',
+			linkLearnMore: localizeUrl( '/support/how-to-create-a-staging-site/' ),
 		},
 		{
-			title: translate( 'Real-time activity log' ),
+			title: translate( 'Custom code' ),
 			description: translate(
-				'Stay on top of everything that happens on your site with our real-time activity log. If it happened, you’ll know about it. '
+				'Build anything with support and automatic updates for 50,000+ plugins and themes. Or start from scratch with your own custom code.'
 			),
-			linkLearnMore: '#',
-		},
-		{
-			title: translate( 'DDOS and WAF protection' ),
-			description: translate(
-				'WordPress.com blocks millions of malicious requests daily so you can sleep through takeover and hacking attempts.'
-			),
-			linkLearnMore: '#',
+			linkLearnMore: localizeUrl( '/support/code' ),
 		},
 		{
 			title: translate( 'Free SSL certificates' ),
 			description: translate(
-				'Take your site from HTTP to HTTPS at no additional cost with a free SSL certificate.'
+				'Take your site from HTTP to HTTPS at no additional cost. We encrypt every domain registered and connected to WordPress.com with a free SSL certificate.'
 			),
-			linkLearnMore: '#',
+			linkLearnMore: localizeUrl( '/support/domains/https-ssl' ),
+		},
+		{
+			title: translate( '24/7 expert support' ),
+			description: translate(
+				'Whenever you’re stuck, whatever you’re trying to make happen—our Happiness Engineers have the answers.'
+			),
+			linkLearnMore: localizeUrl( '/support/help-support-options' ),
 		},
 		{
 			title: translate( 'Malware scanning and removal' ),
 			description: translate(
-				'Stay one step ahead of security threats with automated malware scanning and one-click fixes.'
+				'Secure and maintain your site effortlessly with {{backupsLink}}real-time backups{{/backupsLink}}, advanced {{malwareScanningLink}}malware scanning and removal{{/malwareScanningLink}}, and continuous {{siteMonitoringLink}}site monitoring{{/siteMonitoringLink}}—ensuring peak performance and security at all times.',
+				{
+					components: {
+						backupsLink: (
+							<a
+								href={ localizeUrl( '/support/restore' ) }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+						malwareScanningLink: (
+							<a
+								href={ localizeUrl( '/support/malware-and-site-security' ) }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+						siteMonitoringLink: (
+							<a
+								href={ localizeUrl( '/support/site-monitoring' ) }
+								target="_blank"
+								rel="noopener noreferrer"
+							/>
+						),
+					},
+				}
 			),
 			linkLearnMore: '#',
 		},

--- a/client/me/developer/features/use-features-list.tsx
+++ b/client/me/developer/features/use-features-list.tsx
@@ -64,7 +64,7 @@ export const useFeaturesList = () => {
 				comment: 'Feature title',
 			} ),
 			description: translate(
-				"Whenever you're stuck, whatever you're trying to make happen — our Happiness Engineers have the answers.",
+				"Whenever you're stuck, whatever you're trying to make happen—our Happiness Engineers have the answers.",
 				{
 					comment: 'Feature description',
 				}
@@ -77,7 +77,7 @@ export const useFeaturesList = () => {
 				comment: 'Feature title',
 			} ),
 			description: translate(
-				'Secure and maintain your site effortlessly with {{backupsLink}}real-time backups{{/backupsLink}}, advanced {{malwareScanningLink}}malware scanning and removal{{/malwareScanningLink}}, and continuous {{siteMonitoringLink}}site monitoring{{/siteMonitoringLink}} — ensuring peak performance and security at all times.',
+				'Secure and maintain your site effortlessly with {{backupsLink}}real-time backups{{/backupsLink}}, advanced {{malwareScanningLink}}malware scanning and removal{{/malwareScanningLink}}, and continuous {{siteMonitoringLink}}site monitoring{{/siteMonitoringLink}}—ensuring peak performance and security at all times.',
 				{
 					comment: 'Feature description',
 					components: {

--- a/client/me/developer/features/use-features-list.tsx
+++ b/client/me/developer/features/use-features-list.tsx
@@ -7,7 +7,7 @@ export const useFeaturesList = () => {
 
 	return [
 		{
-			key: 'sftp-ssh-wp-cli',
+			id: 'sftp-ssh-wp-cli',
 			title: translate( 'SFTP, SSH, and WP-CLI', {
 				comment: 'Feature title',
 			} ),
@@ -20,7 +20,7 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( '/support/connect-to-ssh-on-wordpress-com' ),
 		},
 		{
-			key: 'staging-sites',
+			id: 'staging-sites',
 			title: translate( 'Staging sites', {
 				comment: 'Feature title',
 			} ),
@@ -33,7 +33,7 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( '/support/how-to-create-a-staging-site/' ),
 		},
 		{
-			key: 'custom-code',
+			id: 'custom-code',
 			title: translate( 'Custom code', {
 				comment: 'Feature title',
 			} ),
@@ -46,7 +46,7 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( '/support/code' ),
 		},
 		{
-			key: 'free-ssl-certificates',
+			id: 'free-ssl-certificates',
 			title: translate( 'Free SSL certificates', {
 				comment: 'Feature title',
 			} ),
@@ -59,7 +59,7 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( '/support/domains/https-ssl' ),
 		},
 		{
-			key: 'expert-support',
+			id: 'expert-support',
 			title: translate( '24/7 expert support', {
 				comment: 'Feature title',
 			} ),
@@ -72,7 +72,7 @@ export const useFeaturesList = () => {
 			linkLearnMore: localizeUrl( '/support/help-support-options' ),
 		},
 		{
-			key: 'malware-scanning-removal',
+			id: 'malware-scanning-removal',
 			title: translate( 'Malware scanning and removal', {
 				comment: 'Feature title',
 			} ),

--- a/client/me/developer/main.jsx
+++ b/client/me/developer/main.jsx
@@ -1,5 +1,4 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { Card } from '@automattic/components';
 import { ToggleControl } from '@wordpress/components';
 import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -15,6 +14,7 @@ import withFormBase from 'calypso/me/form-base/with-form-base';
 import ReauthRequired from 'calypso/me/reauth-required';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
+import { DeveloperFeatures } from './features/index';
 import { getIAmDeveloperCopy } from './get-i-am-a-developer-copy';
 
 import './style.scss';
@@ -41,22 +41,22 @@ class Developer extends Component {
 					) }
 				/>
 
-				<Card className="developer__settings">
-					<form onChange={ this.props.submitForm }>
-						<FormFieldset
-							className={ classnames( {
-								'developer__is_dev_account-fieldset-is-loading': this.props.isFetchingUserSettings,
-							} ) }
-						>
-							<ToggleControl
-								disabled={ this.props.isFetchingUserSettings || this.props.isUpdatingUserSettings }
-								checked={ this.props.getSetting( 'is_dev_account' ) }
-								onChange={ this.toggleIsDevAccount }
-								label={ getIAmDeveloperCopy( this.props.translate ) }
-							/>
-						</FormFieldset>
-					</form>
-				</Card>
+				<DeveloperFeatures />
+
+				<form onChange={ this.props.submitForm }>
+					<FormFieldset
+						className={ classnames( {
+							'developer__is_dev_account-fieldset-is-loading': this.props.isFetchingUserSettings,
+						} ) }
+					>
+						<ToggleControl
+							disabled={ this.props.isFetchingUserSettings || this.props.isUpdatingUserSettings }
+							checked={ this.props.getSetting( 'is_dev_account' ) }
+							onChange={ this.toggleIsDevAccount }
+							label={ getIAmDeveloperCopy( this.props.translate ) }
+						/>
+					</FormFieldset>
+				</form>
 			</Main>
 		);
 	}

--- a/client/me/developer/main.jsx
+++ b/client/me/developer/main.jsx
@@ -30,7 +30,7 @@ class Developer extends Component {
 
 	render() {
 		return (
-			<Main className="developer">
+			<Main className="developer" wideLayout>
 				<PageViewTracker path="/me/developer" title="Me > Developer" />
 				<ReauthRequired twoStepAuthorization={ twoStepAuthorization } />
 				<NavigationHeader
@@ -39,14 +39,15 @@ class Developer extends Component {
 					subtitle={ this.props.translate(
 						'Take WordPress.com further with early access to new developer features.'
 					) }
+					className="developer__header"
 				/>
 
 				<DeveloperFeatures />
 
 				<form onChange={ this.props.submitForm }>
 					<FormFieldset
-						className={ classnames( {
-							'developer__is_dev_account-fieldset-is-loading': this.props.isFetchingUserSettings,
+						className={ classnames( 'developer__is_dev_account-fieldset', {
+							'is-loading': this.props.isFetchingUserSettings,
 						} ) }
 					>
 						<ToggleControl

--- a/client/me/developer/main.jsx
+++ b/client/me/developer/main.jsx
@@ -42,8 +42,6 @@ class Developer extends Component {
 					className="developer__header"
 				/>
 
-				<DeveloperFeatures />
-
 				<form onChange={ this.props.submitForm }>
 					<FormFieldset
 						className={ classnames( 'developer__is_dev_account-fieldset', {
@@ -58,6 +56,8 @@ class Developer extends Component {
 						/>
 					</FormFieldset>
 				</form>
+
+				<DeveloperFeatures />
 			</Main>
 		);
 	}

--- a/client/me/developer/style.scss
+++ b/client/me/developer/style.scss
@@ -4,7 +4,6 @@
 .navigation-header.developer__header {
 	.formatted-header__title {
 		font-family: $brand-serif;
-		color: #2c3338;
 		font-size: rem(44px);
 		line-height: 52px;
 		letter-spacing: 0.2px;
@@ -14,7 +13,6 @@
 
 	.formatted-header__subtitle {
 		font-family: "SF Pro Text", $sans;
-		color: #50575e;
 		font-size: rem(16px);
 		line-height: 24px;
 		letter-spacing: -0.32px;

--- a/client/me/developer/style.scss
+++ b/client/me/developer/style.scss
@@ -20,6 +20,14 @@
 		letter-spacing: -0.32px;
 		text-align: center;
 	}
+
+	@media ( max-width: $break-medium ) {
+		padding: 40px 32px 24px;
+
+		.formatted-header__subtitle {
+			display: block;
+		}
+	}
 }
 
 .form-fieldset.developer__is_dev_account-fieldset {
@@ -53,6 +61,16 @@
 				color: inherit;
 			}
 		}
+	}
+
+	@media ( max-width: $break-medium ) {
+		position: fixed;
+		left: 0;
+		bottom: 0;
+		width: 100%;
+		margin-bottom: 0;
+		text-align: left;
+		padding: 16px 32px;
 	}
 }
 

--- a/client/me/developer/style.scss
+++ b/client/me/developer/style.scss
@@ -1,33 +1,58 @@
 @import "@wordpress/base-styles/breakpoints.scss";
+@import "@automattic/typography/styles/variables";
 
-.developer__is_dev_account-fieldset-is-loading {
-	.components-form-toggle {
-		.components-form-toggle__thumb {
-			visibility: hidden;
-		}
-
-		.components-form-toggle__track {
-			border: none;
-			@include placeholder( --color-neutral-10 );
-		}
+.navigation-header.developer__header {
+	.formatted-header__title {
+		font-family: $brand-serif;
+		color: #2c3338;
+		font-size: rem(44px);
+		line-height: 52px;
+		letter-spacing: 0.2px;
+		text-align: center;
+		padding-bottom: 8px;
 	}
 
-	.components-toggle-control__label {
-		@include placeholder();
-		a {
-			color: inherit;
-		}
+	.formatted-header__subtitle {
+		font-family: "SF Pro Text", $sans;
+		color: #50575e;
+		font-size: rem(16px);
+		line-height: 24px;
+		letter-spacing: -0.32px;
+		text-align: center;
 	}
 }
 
-.developer__settings {
-	padding-bottom: 0;
+.form-fieldset.developer__is_dev_account-fieldset {
+	border-radius: 2px;
+	background: #e5f4ff;
+	padding: 16px;
+	text-align: center;
 
-	.components-base-control {
+	.components-toggle-control {
+		font-family: "SF Pro Text", $sans;
+		font-size: rem(14px);
+		display: inline-block;
 		margin-bottom: 0;
 	}
 
-	.form-fieldset {
-		margin-bottom: 24px;
+	&.is-loading {
+		.components-form-toggle {
+			.components-form-toggle__thumb {
+				visibility: hidden;
+			}
+
+			.components-form-toggle__track {
+				border: none;
+				@include placeholder( --color-neutral-10 );
+			}
+		}
+
+		.components-toggle-control__label {
+			@include placeholder();
+			a {
+				color: inherit;
+			}
+		}
 	}
 }
+

--- a/client/me/developer/style.scss
+++ b/client/me/developer/style.scss
@@ -23,8 +23,13 @@
 	@media ( max-width: $break-medium ) {
 		padding: 40px 32px 24px;
 
+		.formatted-header__title {
+			font-size: rem(32px);
+		}
+
 		.formatted-header__subtitle {
 			display: block;
+			font-size: rem(14px);
 		}
 	}
 }

--- a/client/me/developer/style.scss
+++ b/client/me/developer/style.scss
@@ -1,5 +1,6 @@
 @import "@wordpress/base-styles/breakpoints.scss";
 @import "@automattic/typography/styles/variables";
+@import "@automattic/components/src/styles/typography";
 
 .navigation-header.developer__header {
 	.formatted-header__title {
@@ -13,7 +14,7 @@
 	}
 
 	.formatted-header__subtitle {
-		font-family: "SF Pro Text", $sans;
+		font-family: $font-sf-pro-text;
 		font-size: rem(16px);
 		line-height: 24px;
 		letter-spacing: -0.32px;
@@ -41,7 +42,7 @@
 	text-align: center;
 
 	.components-toggle-control {
-		font-family: "SF Pro Text", $sans;
+		font-family: $font-sf-pro-text;
 		font-size: rem(14px);
 		display: inline-block;
 		margin-bottom: 0;

--- a/client/me/developer/style.scss
+++ b/client/me/developer/style.scss
@@ -40,6 +40,8 @@
 	background: var(--color-link-0);
 	padding: 16px;
 	text-align: center;
+	max-width: 750px;
+	margin: 0 auto 30px;
 
 	.components-toggle-control {
 		font-family: $font-sf-pro-text;
@@ -76,6 +78,7 @@
 		margin-bottom: 0;
 		text-align: left;
 		padding: 16px 32px;
+		z-index: 2;
 	}
 }
 

--- a/client/me/developer/style.scss
+++ b/client/me/developer/style.scss
@@ -9,6 +9,7 @@
 		letter-spacing: 0.2px;
 		text-align: center;
 		padding-bottom: 8px;
+		word-break: break-word;
 	}
 
 	.formatted-header__subtitle {

--- a/client/me/developer/style.scss
+++ b/client/me/developer/style.scss
@@ -37,7 +37,7 @@
 
 .form-fieldset.developer__is_dev_account-fieldset {
 	border-radius: 2px;
-	background: #e5f4ff;
+	background: var(--color-link-0);
 	padding: 16px;
 	text-align: center;
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/dotcom-forge/issues/5233

## Proposed Changes
We are moving "I am developer" checkbox from "Profile" to "Developer features" page - https://github.com/Automattic/wp-calypso/pull/86558.
Additionally we need to show the list of features which are available for developers, to provide the info of the checkbox "I am developer".
With this PR we are adding the list of that features to the page "Developer features".

## Testing Instructions
0) Checkout to the branch locally or open live branch
1) Open `http://calypso.localhost:3000/me/developer`
2) Assert that you see features and styles looks according to the design huXuof0X5yU9bqYvy6BPBW-fi-1970_1870
3) Assert that mobile version also looks goo according to the design huXuof0X5yU9bqYvy6BPBW-fi-1970_1870
4) Assert that loading-placeholder for "I am dev" checkbox looks also good: <br />![Screenshot 2024-01-23 at 12 43 09](https://github.com/Automattic/wp-calypso/assets/5598437/0625abb3-d9e4-478f-bd68-988c5e593d2f)


## The UI result (primarily for translators-team, to understand what it looks like)
![Screenshot 2024-01-23 at 12 48 55](https://github.com/Automattic/wp-calypso/assets/5598437/7e438699-d340-4e0d-bee6-8a550c45e8f0)