### PR TITLE
Update thank you destination for domain-only purchases

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only.tsx
@@ -34,7 +34,11 @@ function UpsellActions( { domainNames, receiptId }: { domainNames: string[]; rec
 			) : null }
 
 			<Button
-				href={ getProfessionalEmailCheckoutUpsellPath( siteSlug, selectedDomainName, receiptId ) }
+				href={ getProfessionalEmailCheckoutUpsellPath(
+					siteSlug ?? selectedDomainName,
+					selectedDomainName,
+					receiptId
+				) }
 				onClick={ () =>
 					recordTracksEvent( 'calypso_domain_only_thank_you_professional_email_click' )
 				}

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -723,7 +723,6 @@ function getProfessionalEmailUpsellUrl( {
 	cart,
 	siteSlug,
 	domains,
-	isDomainOnly,
 }: {
 	receiptId: ReceiptId | ReceiptIdPlaceholder;
 	cart: ResponseCart | undefined;
@@ -744,7 +743,6 @@ function getProfessionalEmailUpsellUrl( {
 	}
 
 	if (
-		! isDomainOnly &&
 		! hasBloggerPlan( cart ) &&
 		! hasPersonalPlan( cart ) &&
 		! hasBusinessPlan( cart ) &&
@@ -774,7 +772,7 @@ function getProfessionalEmailUpsellUrl( {
 		return;
 	}
 
-	return getProfessionalEmailCheckoutUpsellPath( siteSlug, domainName, receiptId );
+	return getProfessionalEmailCheckoutUpsellPath( siteSlug ?? domainName, domainName, receiptId );
 }
 
 function getNoticeType(

--- a/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/test/get-thank-you-page-url.ts
@@ -1307,9 +1307,7 @@ describe( 'getThankYouPageUrl', () => {
 				receiptId: samplePurchaseId,
 			} );
 
-			expect( url ).toBe(
-				`/checkout/offer-professional-email/foo.bar/${ samplePurchaseId }/no-site`
-			);
+			expect( url ).toBe( `/checkout/thank-you/no-site/${ samplePurchaseId }` );
 		} );
 
 		it( 'Is not displayed if cart is missing', () => {

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -7,6 +7,7 @@ import {
 } from 'calypso/controller';
 import { recordSiftScienceUser } from 'calypso/lib/siftscience';
 import { loggedInSiteSelection, noSite, siteSelection } from 'calypso/my-sites/controller';
+import { getProfessionalEmailCheckoutUpsellPath } from 'calypso/my-sites/email/paths';
 import {
 	checkout,
 	checkoutAkismetSiteless,
@@ -274,18 +275,8 @@ export default function () {
 		clientRender
 	);
 
-	// Use `noSite` instead of the `siteSelection` middleware for the no-site route.
 	page(
-		'/checkout/offer-professional-email/:domain/:receiptId/no-site',
-		redirectLoggedOut,
-		noSite,
-		checkoutThankYou,
-		makeLayout,
-		clientRender
-	);
-
-	page(
-		'/checkout/offer-professional-email/:domain/:receiptId/:site?',
+		getProfessionalEmailCheckoutUpsellPath( ':site?', ':domain', ':receiptId' ),
 		redirectLoggedOut,
 		siteSelection,
 		upsellNudge,

--- a/client/my-sites/checkout/index.js
+++ b/client/my-sites/checkout/index.js
@@ -276,7 +276,7 @@ export default function () {
 	);
 
 	page(
-		getProfessionalEmailCheckoutUpsellPath( ':site?', ':domain', ':receiptId' ),
+		getProfessionalEmailCheckoutUpsellPath( ':site', ':domain', ':receiptId' ),
 		redirectLoggedOut,
 		siteSelection,
 		upsellNudge,

--- a/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
+++ b/client/my-sites/checkout/upsell-nudge/professional-email-upsell/index.tsx
@@ -20,6 +20,7 @@ import {
 	FIELD_PASSWORD_RESET_EMAIL,
 } from 'calypso/my-sites/email/form/mailboxes/constants';
 import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
+import { getProfessionalEmailCheckoutUpsellPath } from 'calypso/my-sites/email/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
@@ -114,7 +115,7 @@ const ProfessionalEmailUpsell = ( {
 	return (
 		<>
 			<PageViewTracker
-				path="/checkout/offer-professional-email/:domain/:receiptId/:site"
+				path={ getProfessionalEmailCheckoutUpsellPath( ':site', ':domain', ':receiptId' ) }
 				title="Post Checkout - Professional Email Upsell"
 			/>
 

--- a/client/my-sites/email/paths.ts
+++ b/client/my-sites/email/paths.ts
@@ -186,10 +186,10 @@ export const getEmailInDepthComparisonPath = (
 	} );
 
 export const getProfessionalEmailCheckoutUpsellPath = (
-	siteName: string | null | undefined,
+	siteName: string,
 	domainName: string,
 	receiptId: number | string
-) => `/checkout/offer-professional-email/${ domainName }/${ receiptId }/${ siteName ?? 'no-site' }`;
+) => `/checkout/offer-professional-email/${ domainName }/${ receiptId }/${ siteName }`;
 
 export const getMailboxesPath = ( siteName?: string | null ) =>
 	siteName ? `/mailboxes/${ siteName }` : `/mailboxes`;

--- a/client/my-sites/email/test/paths.ts
+++ b/client/my-sites/email/test/paths.ts
@@ -193,8 +193,8 @@ describe( 'path helper functions', () => {
 		expect( getProfessionalEmailCheckoutUpsellPath( siteName, domainName, 1234 ) ).toEqual(
 			`/checkout/offer-professional-email/${ domainName }/1234/${ siteName }`
 		);
-		expect( getProfessionalEmailCheckoutUpsellPath( ':site?', ':domain', ':receiptId' ) ).toEqual(
-			'/checkout/offer-professional-email/:domain/:receiptId/:site?'
+		expect( getProfessionalEmailCheckoutUpsellPath( ':site', ':domain', ':receiptId' ) ).toEqual(
+			'/checkout/offer-professional-email/:domain/:receiptId/:site'
 		);
 	} );
 

--- a/client/my-sites/email/test/paths.ts
+++ b/client/my-sites/email/test/paths.ts
@@ -193,8 +193,8 @@ describe( 'path helper functions', () => {
 		expect( getProfessionalEmailCheckoutUpsellPath( siteName, domainName, 1234 ) ).toEqual(
 			`/checkout/offer-professional-email/${ domainName }/1234/${ siteName }`
 		);
-		expect( getProfessionalEmailCheckoutUpsellPath( undefined, domainName, 1234 ) ).toEqual(
-			`/checkout/offer-professional-email/${ domainName }/1234/no-site`
+		expect( getProfessionalEmailCheckoutUpsellPath( ':site?', ':domain', ':receiptId' ) ).toEqual(
+			'/checkout/offer-professional-email/:domain/:receiptId/:site?'
 		);
 	} );
 

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -112,7 +112,7 @@ function getDomainSignupFlowDestination( { domainItem, cartItem, siteId, designT
 		return `/checkout/thank-you/${ siteSlug }`;
 	}
 
-	return getThankYouNoSiteDestination();
+	return '/checkout/thank-you/no-site/:receiptId';
 }
 
 function getEmailSignupFlowDestination( { siteId, siteSlug } ) {
@@ -120,10 +120,6 @@ function getEmailSignupFlowDestination( { siteId, siteSlug } ) {
 		{ siteId },
 		`/checkout/thank-you/features/email-license/${ siteSlug }/:receiptId`
 	);
-}
-
-function getThankYouNoSiteDestination() {
-	return `/checkout/thank-you/no-site`;
 }
 
 function getChecklistThemeDestination( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5163

## Proposed Changes

The domain-only flow will currently take users to a redesigned thank you page after checkout. The current implementation (#83657) isn't "powered by" the URL router, though, but a slug that was previously used for the post-checkout Professional Email upsell page was recycled to render the thank you page instead.

This isn't ideal, so this PR addresses this in two ways:
1. Make the domain-only flow still land on a redesigned thank you page, but have it be powered by the URL router instead.
2. Make the Professional Email upsell banner on that thank you page link to a functional version of the post-checkout Professional Email upsell page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/domains/manage`
2. Click `Add a domain > Register a new domain`
3. Add a domain and proceed to checkout
4. Ensure that you are navigated to `/checkout/thank-you/no-site/:receiptId`
5. Ensure that clicking on `Add email` takes you to the post-checkout Professional Email upsell page
6. On the post-checkout Professional Email upsell page, fill out the input fields and click `Add Professional Email`
7. Ensure that the one-click checkout modal displays correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?