### PR TITLE
ESLint: Fix all `jsdoc/tag-lines` warnings

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/inline-social-logo.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/inline-social-logo.tsx
@@ -17,7 +17,6 @@ interface Props {
  * see https://github.com/w3c/svgwg/issues/707
  *
  * InlineSocialLogosSprite must be included on the page where this is used
- *
  * @returns A Social Logo SVG
  */
 function InlineSocialLogo( props: Assign< React.SVGProps< SVGSVGElement >, Props > ) {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/inline-social-logos-sprite.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/sharing-modal/inline-social-logos-sprite.tsx
@@ -2,7 +2,6 @@
  * A hidden inline svg sprite of social logos.
  *
  * Sprite was coppied from https://wordpress.com/calypso/images/social-logos-d55401f99bb02ebd6cf4.svg
- *
  * @returns see above.
  */
 const InlineSocialLogosSprite = () => {

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/get-editor-type.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/welcome-tour/get-editor-type.ts
@@ -8,7 +8,6 @@ import { select } from '@wordpress/data';
  * Navigation menu (Post Type: ‘nav_menu_item’)
  * Block templates (Post Type: ‘wp_template’)
  * Template parts (Post Type: ‘wp_template_part’)
- *
  * @see https://developer.wordpress.org/themes/basics/post-types/#default-post-types
  */
 
@@ -27,7 +26,6 @@ type EditorType = 'site' | PostType;
 export const getEditorType = (): EditorType | undefined => {
 	/**
 	 * Beware when using this method to figure out if we are in the site editor.
-	 *
 	 * @see https://github.com/WordPress/gutenberg/issues/46616#issuecomment-1355301090
 	 * @see https://github.com/Automattic/jetpack/blob/2e56d0d/projects/plugins/jetpack/extensions/shared/get-editor-type.js
 	 */

--- a/apps/notifications/src/panel/Notifications.jsx
+++ b/apps/notifications/src/panel/Notifications.jsx
@@ -79,7 +79,6 @@ export class Notifications extends PureComponent {
 		/**
 		 * Initialize store with actions that need to occur on
 		 * transitions from open to close or close to open
-		 *
 		 * @todo Pass this information directly into the Redux initial state
 		 */
 		store.dispatch( { type: SET_IS_SHOWING, isShowing } );

--- a/apps/notifications/src/panel/suggestions/index.jsx
+++ b/apps/notifications/src/panel/suggestions/index.jsx
@@ -14,7 +14,6 @@ const KEY_DOWN = 40;
  * This pattern looks for a any non-space-character
  * string prefixed with an `@` which either starts
  * at the beginning of a line or after a space
- *
  * @type {RegExp} matches @mentions
  */
 const suggestionMatcher = /(?:^|\s)@([^\s]*)$/i;
@@ -28,7 +27,6 @@ const reHasRegExpChars = RegExp( reRegExpChars.source );
 
 /**
  * This pattern looks for a query
- *
  * @type {RegExp} matches @query
  */
 const queryMatcher = ( query ) => new RegExp( `^${ query }| ${ query }`, 'i' ); // start of string, or preceded by a space

--- a/apps/notifications/src/panel/templates/block-user.jsx
+++ b/apps/notifications/src/panel/templates/block-user.jsx
@@ -29,15 +29,14 @@ export class UserBlock extends Component {
 	 * Specifically here for showing when a comment was made.
 	 *
 	 * If within the past five days, a relative time
-	 *   e.g. "23 sec. ago", "15 min. ago", "4 hrs. ago", "1 day ago"
+	 * e.g. "23 sec. ago", "15 min. ago", "4 hrs. ago", "1 day ago"
 	 *
 	 * If older than five days, absolute date
-	 *   e.g. "30 Apr 2015"
+	 * e.g. "30 Apr 2015"
 	 *
 	 * If anything goes wrong, ISO date
-	 *   e.g. "2020-12-20"
+	 * e.g. "2020-12-20"
 	 * Localized dates are always better, but ISO dates should be broadly recognizable.
-	 *
 	 * @param {string} timestamp - Timestamp in Date.parse()'able format
 	 * @returns {string} - Timestamp formatted for display or '' if input invalid
 	 */

--- a/apps/notifications/src/panel/templates/functions.jsx
+++ b/apps/notifications/src/panel/templates/functions.jsx
@@ -3,11 +3,11 @@ import { html as toHtml } from '../indices-to-html';
 /**
  * Adds markup to some common text patterns
  *
- *  - Bullet lists
- *  - Todo lists, WP style
- *  - Inline `code` snippets
- *  - Code fences
- *  - Header: description/explanation paragraphs
+ * - Bullet lists
+ * - Todo lists, WP style
+ * - Inline `code` snippets
+ * - Code fences
+ * - Header: description/explanation paragraphs
  *
  * Note: This code is only meant to serve until a
  * proper parser can be built up to convert the
@@ -16,7 +16,6 @@ import { html as toHtml } from '../indices-to-html';
  * and on every render this function will serve
  * sufficiently but it should not be looked upon
  * as good example code!
- *
  * @param {string} text input list of blocks as HTML string
  * @returns {string} marked-up text
  */

--- a/apps/notifications/src/panel/templates/index.jsx
+++ b/apps/notifications/src/panel/templates/index.jsx
@@ -39,7 +39,6 @@ const KEY_U = 85;
 /**
  * Returns the next index into a list of notes following
  * the index for the given sought-after notification id
- *
  * @param {!number} noteId id of note to search for
  * @param {!Array<Notification>} notes list of notes to search through
  * @returns {?number} index into note list of note following that given by noteId

--- a/apps/odyssey-stats/src/lib/create-odyssey-config.ts
+++ b/apps/odyssey-stats/src/lib/create-odyssey-config.ts
@@ -41,7 +41,6 @@ export class ConfigApi extends Function {
 	init( configKey = 'configData' ) {
 		/**
 		 * Manages config flags for various deployment builds
-		 *
 		 * @module config/index
 		 */
 		if ( 'undefined' === typeof window ) {

--- a/client/gutenberg/editor/calypsoify-iframe.tsx
+++ b/client/gutenberg/editor/calypsoify-iframe.tsx
@@ -205,7 +205,6 @@ class CalypsoifyIframe extends Component< ComponentProps, State > {
 	 * this.
 	 *
 	 * Some historical work which has been combined into this timer:
-	 *
 	 * @see https://github.com/Automattic/wp-calypso/pull/43248
 	 * @see https://github.com/Automattic/wp-calypso/pull/36977
 	 * @see https://github.com/Automattic/wp-calypso/pull/41006

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
@@ -7,7 +7,6 @@ import { isBulkDomainTransfer, isDomainOnly } from '../utils';
  * using the new component `<ThankYouV2>` instead of `<ThankYouLayout>`. The ultimate
  * goal is to refactor and migrate all thank you pages to use `<ThankYouV2>`, so that
  * consistent structure and styling are applied.
- *
  * @returns {boolean}
  */
 export const isRefactoredForThankYouV2 = ( props: CheckoutThankYouCombinedProps ) => {

--- a/packages/accessible-focus/src/index.ts
+++ b/packages/accessible-focus/src/index.ts
@@ -18,7 +18,6 @@ declare global {
 		/**
 		 * https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyIdentifier
 		 * Provides Safari support
-		 *
 		 * @deprecated
 		 */
 		keyIdentifier: string;
@@ -37,7 +36,6 @@ declare global {
  *
  * Therefore, we have two arrays of keycodes, one for the string APIs and one for the
  * older number based API.
- *
  * @param event The keyboard event to detect keyboard navigation against.
  */
 export function detectKeyboardNavigation( event: KeyboardEvent ): boolean {

--- a/packages/browser-data-collector/src/index.ts
+++ b/packages/browser-data-collector/src/index.ts
@@ -5,7 +5,6 @@ const inFlightReporters: Map< string, Promise< Report > > = new Map();
 
 /**
  * Starts a new report
- *
  * @param id id of the report, must be passed to `stop()` to stop it
  * @param obj Options
  * @param obj.fullPageLoad `true` if the report should start measuring from the load of the page, `false` to start measuring from now.
@@ -31,7 +30,6 @@ export const start = async (
 
 /**
  * Stops a report and sends it to the transporter.
- *
  * @param id id of the report to send, comes from `start()`
  * @param obj options
  * @param obj.collectors list of collectors to run

--- a/packages/calypso-analytics/src/tracks.ts
+++ b/packages/calypso-analytics/src/tracks.ts
@@ -126,7 +126,6 @@ export const analyticsEvents: EventEmitter = new EventEmitter();
 
 /**
  * Returns the anoymous id stored in the `tk_ai` cookie
- *
  * @returns The Tracks anonymous user id
  */
 export function getTracksAnonymousUserId(): string {

--- a/packages/calypso-analytics/src/utils/current-user.ts
+++ b/packages/calypso-analytics/src/utils/current-user.ts
@@ -26,7 +26,6 @@ export interface CurrentUser {
 
 /**
  * Gets current user.
- *
  * @returns Current user.
  */
 export function getCurrentUser(): CurrentUser {
@@ -35,7 +34,6 @@ export function getCurrentUser(): CurrentUser {
 
 /**
  * Sets current user, (stored in javascript memory).
- *
  * @param currentUser the user data for the current user
  * @returns Current user.
  */

--- a/packages/calypso-analytics/src/utils/do-not-track.ts
+++ b/packages/calypso-analytics/src/utils/do-not-track.ts
@@ -2,7 +2,6 @@ import debug from './debug';
 
 /**
  * Whether Do Not Track is enabled in the user's browser.
- *
  * @returns true if Do Not Track is enabled in the user's browser.
  */
 export default function getDoNotTrack(): boolean {

--- a/packages/calypso-analytics/src/utils/hash-pii.ts
+++ b/packages/calypso-analytics/src/utils/hash-pii.ts
@@ -2,7 +2,6 @@ import sha256 from 'hash.js/lib/hash/sha/256';
 
 /**
  * Hashes users' Personally Identifiable Information using SHA256
- *
  * @param data Data to be hashed
  * @returns SHA256 in hex string format
  */

--- a/packages/calypso-config/src/index.ts
+++ b/packages/calypso-config/src/index.ts
@@ -12,7 +12,6 @@ declare global {
 
 /**
  * Manages config flags for various deployment builds
- *
  * @module config/index
  */
 if ( 'undefined' === typeof window ) {

--- a/packages/calypso-products/src/get-difm-tiered-price-details.ts
+++ b/packages/calypso-products/src/get-difm-tiered-price-details.ts
@@ -10,7 +10,6 @@ export type DIFMPriceTierProduct = Pick< Product, 'price_tier_list' > & {
  * Returns null if this is not a DIFM purchase or the proper related price tier information is not available.
  * Returns just the price details if noOfPages is not passed.
  * Returns the price details alongwith calculated values of extraPageCount and extraPagesPrice is noOfPages is passed.
- *
  * @param { Product | any } product  product to get details from
  * @param { number } noOfPages  the number of pages required
  * @returns {Object} with the relevent tier details

--- a/packages/calypso-products/src/get-jetpack-item-term-variants.ts
+++ b/packages/calypso-products/src/get-jetpack-item-term-variants.ts
@@ -5,7 +5,6 @@ type termMap = { yearly: JetpackPurchasableItemSlug; monthly: JetpackPurchasable
 
 /**
  * Return the slugs of a Jetpack plan or product for all existing terms.
- *
  * @param itemSlug Slug of the Jetpack product or plan
  * @returns Object with term and product slug as key/value
  */

--- a/packages/calypso-products/src/get-jetpack-product-call-to-action.ts
+++ b/packages/calypso-products/src/get-jetpack-product-call-to-action.ts
@@ -4,7 +4,6 @@ import type { TranslateResult } from 'i18n-calypso';
 
 /**
  * Get Jetpack product call-to-action based on the product purchase object.
- *
  * @param {Product} product Product purchase object
  * @returns {TranslateResult} Product display name
  */

--- a/packages/calypso-products/src/get-plan-term-variant.ts
+++ b/packages/calypso-products/src/get-plan-term-variant.ts
@@ -4,7 +4,6 @@ import type { PlanSlug } from './types';
 
 /**
  * Return a (monthly/yealry/2yearly/etc) variant of a plan
- *
  * @param {PlanSlug} slug Slug/name of the plan to get the yearly variant from
  * @param {typeof TERMS_LIST[ number ]} planTerm The term to find a variant for
  * @returns {PlanSlug} Slug of the term-variant plan

--- a/packages/calypso-products/src/get-product-term-variants.ts
+++ b/packages/calypso-products/src/get-product-term-variants.ts
@@ -4,7 +4,6 @@ import type { ProductSlug } from './types';
 
 /**
  * Return a list of products that are similar to the product passed as argument, but with different terms.
- *
  * @param {ProductSlug} productSlug Slug of the product to get the term variants from
  * @returns {string[]} Slugs of the product variants
  */

--- a/packages/calypso-products/src/get-product-yearly-variant.ts
+++ b/packages/calypso-products/src/get-product-yearly-variant.ts
@@ -4,7 +4,6 @@ import type { ProductSlug } from './types';
 
 /**
  * Return the yearly variant of a product
- *
  * @param {ProductSlug} productSlug Slug of the product to get the yearly variant from
  * @returns {string} Slug of the yearly variant
  */

--- a/packages/calypso-products/src/has-marketplace-product.ts
+++ b/packages/calypso-products/src/has-marketplace-product.ts
@@ -1,6 +1,5 @@
 /**
  * Returns true if a list of products includes a product with a matching product or store product slug.
- *
  * @param {Object} productsList - List of products
  * @param {string} searchSlug - Either a product slug e.g. woocommerce-product-csv-import-suite or store product slug, e.g wc_product_csv_import_suite_yearly
  * @returns {boolean}

--- a/packages/calypso-products/src/is-google-workspace-product-slug.ts
+++ b/packages/calypso-products/src/is-google-workspace-product-slug.ts
@@ -5,7 +5,6 @@ import {
 
 /**
  * Determines whether the specified product slug is for Google Workspace Business Starter.
- *
  * @param {string} productSlug - slug of the product
  * @returns {boolean} true if the slug refers to Google Workspace Business Starter, false otherwise
  */

--- a/packages/calypso-products/src/is-gsuite-extra-license-product-slug.ts
+++ b/packages/calypso-products/src/is-gsuite-extra-license-product-slug.ts
@@ -2,7 +2,6 @@ import { GSUITE_EXTRA_LICENSE_SLUG } from './constants';
 
 /**
  * Determines whether the specified product slug is for a G Suite extra license.
- *
  * @param {string} productSlug - slug of the product
  * @returns {boolean} true if the slug refers to an extra license, false otherwise
  */

--- a/packages/calypso-products/src/is-gsuite-or-extra-license-product-slug.ts
+++ b/packages/calypso-products/src/is-gsuite-or-extra-license-product-slug.ts
@@ -3,7 +3,6 @@ import { isGSuiteProductSlug } from './is-gsuite-product-slug';
 
 /**
  * Determines whether the specified product slug refers to any type of G Suite product.
- *
  * @param {string} productSlug - slug of the product
  * @returns {boolean} true if the slug refers to any G Suite product, false otherwise
  */

--- a/packages/calypso-products/src/is-gsuite-or-google-workspace-product-slug.ts
+++ b/packages/calypso-products/src/is-gsuite-or-google-workspace-product-slug.ts
@@ -3,7 +3,6 @@ import { isGSuiteProductSlug } from './is-gsuite-product-slug';
 
 /**
  * Determines whether the specified product slug refers to either G Suite or Google Workspace.
- *
  * @param {string} productSlug - slug of the product
  * @returns {boolean} true if the slug refers to G Suite or Google Workspace, false otherwise
  */

--- a/packages/calypso-products/src/is-gsuite-product-slug.ts
+++ b/packages/calypso-products/src/is-gsuite-product-slug.ts
@@ -2,7 +2,6 @@ import { GSUITE_BASIC_SLUG, GSUITE_BUSINESS_SLUG } from './constants';
 
 /**
  * Determines whether the specified product slug is for G Suite Basic or Business.
- *
  * @param {string} productSlug - slug of the product
  * @returns {boolean} true if the slug refers to G Suite Basic or Business, false otherwise
  */

--- a/packages/calypso-products/src/is-superseding-jetpack-item.ts
+++ b/packages/calypso-products/src/is-superseding-jetpack-item.ts
@@ -7,7 +7,6 @@ import type { JetpackPurchasableItemSlug } from './types';
 
 /**
  * Check if a Jetpack item (product or plan) is superseding another one. Based on yearly variants.
- *
  * @param supersedingItem Item potentially superseding the other one
  * @param supersededItem Item potentially superseded by the other one
  * @returns True if the first item is superseding the second one

--- a/packages/calypso-products/src/is-tiered-volume-space-addon.ts
+++ b/packages/calypso-products/src/is-tiered-volume-space-addon.ts
@@ -5,7 +5,6 @@ import type { WithCamelCaseSlug, WithSnakeCaseSlug } from './types';
 /**
  * This deals with the tiered volume space addon. Also see ./is-space-upgrade.ts for other
  * storage products.
- *
  * @param product Product name
  * @returns boolean indicating whether the product is a space addon.
  */

--- a/packages/calypso-url/src/format.ts
+++ b/packages/calypso-url/src/format.ts
@@ -5,7 +5,6 @@ const BASE_URL = 'http://__domain__.invalid/';
 /**
  * Format a URL as a particular type.
  * Does not support formatting invalid or path-relative URLs.
- *
  * @param url The URL to format.
  * @param urlType The URL type into which to format. If not provided, defaults to the same type as `url`, which effectively results in the URL being normalized.
  * @returns The formatted URL.

--- a/packages/calypso-url/src/get-calypso-url.ts
+++ b/packages/calypso-url/src/get-calypso-url.ts
@@ -11,7 +11,6 @@ const ALLOWED_ORIGINS = [
 
 /**
  * Checks if the origin is allowed by checking against ALLOWED_ORIGINS and Calypso Live sites.
- *
  * @param origin string to check
  * @returns true if the origin is allowed
  */
@@ -21,7 +20,6 @@ function isAllowedOrigin( origin: string ) {
 
 /**
  * Checks if the origin is a Calypso Live site (e.g. https://busy-badger.calypso.live)
- *
  * @param origin string to check
  * @returns true if the origin is a Calypso Live site
  */
@@ -33,7 +31,6 @@ function isCalypsoLive( origin: string ) {
  * From wp-admin contexts: gets the Calypso origin from the `wpcom_origin` query arg
  * and compares it against a list of allowed wpcom origins. Helps to maintain consistent
  * interlinking in Calypso dev/testing contexts.
- *
  * @param path Optional path to append to the origin
  * @returns The origin if it's allowed, otherwise the default origin (wordpress.com)
  */

--- a/packages/calypso-url/src/safe-image-url/index.ts
+++ b/packages/calypso-url/src/safe-image-url/index.ts
@@ -32,7 +32,6 @@ const SIZE_PARAMS = [ 'w', 'h', 'resize', 'fit', 's' ];
  *
  * NOTE: This function will return `null` for external URLs with query strings,
  * because Photon itself does not support this!
- *
  * @param  url The URL to secure
  * @returns The secured URL, or `null` if we couldn't make it safe
  */

--- a/packages/calypso-url/src/url-parts.ts
+++ b/packages/calypso-url/src/url-parts.ts
@@ -63,7 +63,6 @@ function pickUrlParts(
 
 /**
  * Returns the various available URL parts.
- *
  * @param url the URL to analyze
  * @returns   the URL parts
  */
@@ -108,7 +107,6 @@ export function getUrlParts( url: string | URL ): UrlParts {
 
 /**
  * Returns a URL object built from the provided URL parts.
- *
  * @param parts the provided URL parts.
  * @returns the generated URL object.
  */

--- a/packages/calypso-url/src/url-type.ts
+++ b/packages/calypso-url/src/url-type.ts
@@ -23,7 +23,6 @@ const BASE_URL = `http://${ BASE_HOSTNAME }`;
 
 /**
  * Determine the type of a URL, with regards to its completeness.
- *
  * @param url the URL to analyze
  * @returns the type of the URL
  */

--- a/packages/components/src/gravatar/test/index.jsx
+++ b/packages/components/src/gravatar/test/index.jsx
@@ -9,7 +9,6 @@ describe( 'Gravatar', () => {
 	/**
 	 * Gravatar URLs use email hashes
 	 * Here we're hashing MyEmailAddress@example.com
-	 *
 	 * @see https://en.gravatar.com/site/implement/hash/
 	 */
 	const gravatarHash = 'f9879d71855b5ff21e4963273a886bfc';

--- a/packages/create-calypso-config/src/index.ts
+++ b/packages/create-calypso-config/src/index.ts
@@ -20,7 +20,6 @@ export type ConfigData = Record< string, any > & {
  * to the console instead of halting the execution thread.
  *
  * The config files are loaded in sequence: _shared.json, {env}.json, {env}.local.json
- *
  * @see server/config/parser.js
  * @param data Configurat data.
  * @throws {ReferenceError} when key not defined in the config (NODE_ENV=development only)
@@ -64,7 +63,6 @@ const config =
 
 /**
  * Checks whether a specific feature is enabled.
- *
  * @param data the json environment configuration to use for getting config values
  * @returns A function that takes a feature name and returns true when the feature is enabled.
  */
@@ -75,7 +73,6 @@ const isEnabled =
 
 /**
  * Gets a list of all enabled features.
- *
  * @param data A set of config data (Not used by general users, is pre-filled via currying).
  * @returns List of enabled features (strings).
  */
@@ -91,7 +88,6 @@ const enabledFeatures = ( data: ConfigData ) => (): string[] => {
 
 /**
  * Enables a specific feature.
- *
  * @param data the json environment configuration to use for getting config values
  */
 const enable = ( data: ConfigData ) => ( feature: string ) => {
@@ -102,7 +98,6 @@ const enable = ( data: ConfigData ) => ( feature: string ) => {
 
 /**
  * Disables a specific feature.
- *
  * @param data the json environment configuration to use for getting config values
  */
 

--- a/packages/data-stores/src/add-ons/use-add-on-checkout-link.ts
+++ b/packages/data-stores/src/add-ons/use-add-on-checkout-link.ts
@@ -4,7 +4,6 @@ import type { SiteDetails } from '../site/types';
 /**
  * Returns a function that will return a formatted checkout link for the given add-on and quantity.
  * E.g. https://wordpress.com/checkout/<siteSlug>/<addOnSlug>>:-q-<quantity>
- *
  * @returns {Function} A function returnig a formatted checkout link for the given add-on and quantity
  */
 

--- a/packages/data-stores/src/automated-transfer-eligibility/resolvers.ts
+++ b/packages/data-stores/src/automated-transfer-eligibility/resolvers.ts
@@ -3,7 +3,6 @@ import { TransferEligibility, Dispatch } from './types';
 
 /**
  * Requests the site's transfer eligibility from the WPCOM API.
- *
  * @param   {number} siteId The id of the site to retrieve
  */
 export const getAutomatedTransferEligibility =

--- a/packages/data-stores/src/domain-suggestions/selectors.ts
+++ b/packages/data-stores/src/domain-suggestions/selectors.ts
@@ -66,7 +66,6 @@ export const isLoadingDomainSuggestions = (
 
 /**
  * Do not use this selector. It is for internal use.
- *
  * @param state Store state
  * @param queryObject Normalized object representing the query
  * @returns suggestions

--- a/packages/data-stores/src/domain-suggestions/types.ts
+++ b/packages/data-stores/src/domain-suggestions/types.ts
@@ -5,7 +5,6 @@ import type { SelectFromMap } from '../mapped-types';
 export interface DomainSuggestionQuery {
 	/**
 	 * True to include .blog subdomain suggestions
-	 *
 	 * @example
 	 * example.photo.blog
 	 */
@@ -13,7 +12,6 @@ export interface DomainSuggestionQuery {
 
 	/**
 	 * True to include WordPress.com subdomain suggestions
-	 *
 	 * @example
 	 * example.wordpress.com
 	 */
@@ -31,7 +29,6 @@ export interface DomainSuggestionQuery {
 
 	/**
 	 * True to only provide a wordpress.com subdomain
-	 *
 	 * @example
 	 * example.wordpress.com
 	 */
@@ -75,35 +72,30 @@ export type DomainName = string;
 export interface DomainSuggestion {
 	/**
 	 * The domain name
-	 *
 	 * @example "example.com"
 	 */
 	domain_name: DomainName;
 
 	/**
 	 * Rendered formatted cost
-	 *
 	 * @example "Free" or "€15.00"
 	 */
 	cost: string;
 
 	/**
 	 * Raw price
-	 *
 	 * @example 40
 	 */
 	raw_price: number;
 
 	/**
 	 * Currency code
-	 *
 	 * @example USD
 	 */
 	currency_code: string;
 
 	/**
 	 * Relevance as a percent: 0 <= relevance <= 1
-	 *
 	 * @example 0.9
 	 */
 	relevance?: number;
@@ -120,7 +112,6 @@ export interface DomainSuggestion {
 
 	/**
 	 * Reasons for suggestion the domain
-	 *
 	 * @example [ "exact-match" ]
 	 */
 	match_reasons?: readonly string[];
@@ -209,7 +200,6 @@ export interface DomainAvailability {
 
 	/**
 	 * Rendered cost with currency
-	 *
 	 * @example "€15.00"
 	 */
 	cost?: string;

--- a/packages/data-stores/src/domain-suggestions/utils.ts
+++ b/packages/data-stores/src/domain-suggestions/utils.ts
@@ -4,7 +4,6 @@ import type { DomainSuggestionQuery, DomainSuggestionSelectorOptions } from './t
 
 /**
  * Stable transform to an object key for storage and access.
- *
  * @see client/state/domains/suggestions/utils.js
  */
 export const stringifyDomainQueryObject: ( q: DomainSuggestionQuery ) => string =
@@ -13,7 +12,6 @@ export const stringifyDomainQueryObject: ( q: DomainSuggestionQuery ) => string 
 /**
  * Formats the domain suggestion price according to 'format-currency' package rules
  * We use this for consistency in prices formats across plans and domains
- *
  * @param price the domain suggestion raw price
  * @param currencyCode the currency code to be used when formatting price
  */
@@ -28,7 +26,6 @@ export function getFormattedPrice( price: number, currencyCode: string ): string
  *
  * It's important to have a consistent, reproduceable representation of a domains query so that the result can be
  * stored and retrieved.
- *
  * @see client/state/domains/suggestions/utils.js
  * @see client/components/data/query-domains-suggestions/index.jsx
  * @param search       Domain search string

--- a/packages/data-stores/src/mapped-types.ts
+++ b/packages/data-stores/src/mapped-types.ts
@@ -8,7 +8,6 @@ import type { FunctionKeys } from 'utility-types';
  *
  * Mapped types can be thought of as functions in the type system, they accept some type
  * argument and transform it to another type.
- *
  * @see https://www.typescriptlang.org/docs/handbook/advanced-types.html#mapped-types
  */
 
@@ -20,7 +19,6 @@ type CastToFunction< T > = Cast< T, ( ...args: any[] ) => any >;
 
 /**
  * Maps a "raw" selector object to the selectors available when registered on the @wordpress/data store.
- *
  * @template S Selector map, usually from `import * as selectors from './my-store/selectors';`
  */
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -32,7 +30,6 @@ export type SelectFromMap< S extends object > = {
 
 /**
  * Maps a "raw" actionCreators object to the actions available when registered on the @wordpress/data store.
- *
  * @template A Selector map, usually from `import * as actions from './my-store/actions';`
  */
 export type DispatchFromMap< A extends Record< string, ( ...args: any[] ) => any > > = {

--- a/packages/data-stores/src/plans/resolvers.ts
+++ b/packages/data-stores/src/plans/resolvers.ts
@@ -27,7 +27,6 @@ const MONTHLY_PLAN_BILLING_PERIOD = 31;
 /**
  * Calculates the monthly price of a plan
  * Annual plans are only priced yearly
- *
  * @param plan the plan object
  */
 function getMonthlyPrice( plan: PricedAPIPlan ) {
@@ -36,7 +35,6 @@ function getMonthlyPrice( plan: PricedAPIPlan ) {
 
 /**
  * Calculates the yearly price of a monthly plan
- *
  * @param plan the plan object
  */
 function getAnnualPrice( plan: PricedAPIPlan ) {
@@ -46,7 +44,6 @@ function getAnnualPrice( plan: PricedAPIPlan ) {
 /**
  * Formats the plan price according to 'format-currency' package rules
  * We use this for consistency in prices formats across monthly and annual plans
- *
  * @param plan the plan object
  */
 function getFormattedPrice( plan: PricedAPIPlan ) {

--- a/packages/data-stores/src/site/resolvers.ts
+++ b/packages/data-stores/src/site/resolvers.ts
@@ -14,7 +14,6 @@ import type {
  * We are currently ignoring error messages and silently failing if we can't find a
  * site. This could be extended in the future by retrieving the `error` and
  * `message` strings returned by the API.
- *
  * @param siteId {number}	The site to look up
  */
 export const getSite =
@@ -35,7 +34,6 @@ export const getSite =
 
 /**
  * Get all site domains
- *
  * @param siteId {number} The site id
  */
 export const getSiteDomains =
@@ -50,7 +48,6 @@ export const getSiteDomains =
 
 /**
  * Get all site settings
- *
  * @param siteId {number} The site id
  */
 export const getSiteSettings =
@@ -66,7 +63,6 @@ export const getSiteSettings =
 
 /**
  * Get current site theme
- *
  * @param siteId {number} The site id
  */
 export const getSiteTheme =

--- a/packages/data-stores/src/wpcom-request-controls/index.ts
+++ b/packages/data-stores/src/wpcom-request-controls/index.ts
@@ -14,7 +14,6 @@ export const wpcomRequest = (
  * Action for performing a fetching using `window.fetch()` and parsing the response body.
  * It's different from `apiFetch()` from
  * `@wordpress/data-controls` in that it doesn't use any middleware to add extra parameters.
- *
  * @param resource the resource you wish to fetch
  * @param options request options
  */

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -78,7 +78,6 @@ interface TrackDesignViewProps {
  * that MUST be used as the `ref` prop on a `div` element.
  * The hook ensures that we generate theme display Tracks events when the user views
  * the underlying `div` element.
- *
  * @param { TrackDesignViewProps } designDetails Details around the design and current context.
  * @returns { Function } A callback ref that MUST be used on a div element for tracking.
  */

--- a/packages/design-picker/src/hooks/use-categorization.ts
+++ b/packages/design-picker/src/hooks/use-categorization.ts
@@ -89,7 +89,6 @@ export function useCategorizationFromApi(
 /**
  *	Check that the current selection still matches one of the category slugs,
  *	and if it doesn't reset the current selection to the default selection.
- *
  *	@param categories the list of available categories
  *	@param currentSelection the slug of the current selected category
  *	@returns whether the current selection should be set to the default selection
@@ -109,7 +108,6 @@ function shouldSetToDefaultSelection(
  * Chooses which category is the one that should be used by default.
  * If `defaultSelection` is a valid category slug then it'll be used, otherwise it'll be whichever
  * category appears first in the list.
- *
  * @param categories the categories from which the default will be selected
  * @param defaultSelection use this category as the default selection if possible
  * @returns the default category or null if none is available

--- a/packages/domain-picker/src/components/index.tsx
+++ b/packages/domain-picker/src/components/index.tsx
@@ -57,7 +57,6 @@ export interface Props {
 
 	/**
 	 * Callback that will be invoked when a domain is selected.
-	 *
 	 * @param domainSuggestion The selected domain.
 	 */
 	onDomainSelect: ( domainSuggestion: DomainSuggestion ) => void;

--- a/packages/domain-picker/src/constants.ts
+++ b/packages/domain-picker/src/constants.ts
@@ -9,7 +9,6 @@ export const DOMAIN_QUERY_MINIMUM_LENGTH = 2;
  *
  * Rapidly changing input generates excessive HTTP requests.
  * It also leads to jarring UI changes.
- *
  * @see https://stackoverflow.com/a/44755058/1432801
  */
 export const DOMAIN_SEARCH_DEBOUNCE_INTERVAL = 300;

--- a/packages/domain-picker/src/utils/index.ts
+++ b/packages/domain-picker/src/utils/index.ts
@@ -30,7 +30,6 @@ export function mockDomainSuggestion(
 
 /**
  * Get the suggestions vendor
- *
  * @param {Object} [options={}] Options to determine the suggestion vendor
  * @param {boolean} [options.isSignup=false] Flag to indicate that we're in a signup context
  * @param {boolean} [options.isDomainOnly=false] Flag to indicate that we're in a domain-only context

--- a/packages/explat-client-react-helpers/src/index.tsx
+++ b/packages/explat-client-react-helpers/src/index.tsx
@@ -20,7 +20,6 @@ export interface ExPlatClientReactHelpers {
 	 * An ExPlat useExperiment hook.
 	 *
 	 * NOTE: Doesn't obey ExperimentAssignment TTL in order to keep stable UX.
-	 *
 	 * @returns [isExperimentAssignmentLoading, ExperimentAssignment | null]
 	 */
 	useExperiment: (

--- a/packages/explat-client/src/create-explat-client.ts
+++ b/packages/explat-client/src/create-explat-client.ts
@@ -24,7 +24,6 @@ export interface ExPlatClient {
 	 *
 	 * Will never throw in production, it will return the default assignment.
 	 * It should not be run on the server but it won't crash anything.
-	 *
 	 * @param experimentName The experiment's name
 	 */
 	loadExperimentAssignment: ( experimentName: string ) => Promise< ExperimentAssignment >;
@@ -58,7 +57,6 @@ export class MissingExperimentAssignmentError extends Error {
 
 /**
  * Create an ExPlat Client
- *
  * @param config Configuration object
  */
 export function createExPlatClient( config: Config ): ExPlatClient {
@@ -70,8 +68,6 @@ export function createExPlatClient( config: Config ): ExPlatClient {
 	 * This bit of code is the heavy lifting behind loadExperimentAssignment, allowing it to be used intuitively.
 	 *
 	 * Using asyncOneAtATime, is how we ensure for each experiment that there is only ever one fetch process occuring.
-	 *
-	 *
 	 * @param experimentName The experiment's name
 	 */
 	const createWrappedExperimentAssignmentFetchAndStore = ( experimentName: string ) =>
@@ -222,7 +218,6 @@ export function createExPlatClient( config: Config ): ExPlatClient {
 
 /**
  * A dummy ExPlat client to sub in under SSR contexts
- *
  * @param config The config
  */
 export function createSsrSafeDummyExPlatClient( config: Config ): ExPlatClient {

--- a/packages/explat-client/src/internal/experiment-assignment-store.ts
+++ b/packages/explat-client/src/internal/experiment-assignment-store.ts
@@ -16,7 +16,6 @@ export const localStorageExperimentAssignmentKey = ( experimentName: string ): s
 
 /**
  * Store an ExperimentAssignment.
- *
  * @param experimentAssignment The ExperimentAssignment
  */
 export function storeExperimentAssignment( experimentAssignment: ExperimentAssignment ): void {
@@ -42,7 +41,6 @@ export function storeExperimentAssignment( experimentAssignment: ExperimentAssig
 
 /**
  * Retrieve an ExperimentAssignment.
- *
  * @param experimentName The experiment name.
  */
 export function retrieveExperimentAssignment(

--- a/packages/explat-client/src/internal/experiment-assignments.ts
+++ b/packages/explat-client/src/internal/experiment-assignments.ts
@@ -3,7 +3,6 @@ import type { ExperimentAssignment } from '../types';
 
 /**
  * Check if an ExperimentAssignment is still alive (as in the TTL).
- *
  * @param experimentAssignment The experiment assignment to check
  */
 export function isAlive( experimentAssignment: ExperimentAssignment ): boolean {
@@ -24,7 +23,6 @@ export const minimumTtl = 60;
 /**
  * A fallback ExperimentAssignment we return when we can't retrieve one.
  * As it is used in fallback situations, this function must never throw.
- *
  * @param experimentName The name of the experiment
  * @param ttl The time-to-live for the ExperimentAssignment, defaults to 60s
  */

--- a/packages/explat-client/src/internal/requests.ts
+++ b/packages/explat-client/src/internal/requests.ts
@@ -11,7 +11,6 @@ interface FetchExperimentAssignmentResponse {
 
 /**
  * Exported for testing only.
- *
  * @param response The response data
  */
 export function isFetchExperimentAssignmentResponse(
@@ -50,7 +49,6 @@ const lastAnonIdExpiryTimeMs = 24 * 60 * 60 * 1000; // 24 hours
  * - Otherwise, within the expiry time, returns the cached anonId
  *
  * Exported for testing.
- *
  * @param getAnonId The getAnonId function
  */
 export const localStorageCachedGetAnonId = async ( getAnonId: Config[ 'getAnonId' ] ) => {
@@ -76,7 +74,6 @@ export const localStorageCachedGetAnonId = async ( getAnonId: Config[ 'getAnonId
 
 /**
  * Fetch an ExperimentAssignment
- *
  * @param config The config object providing dependecy injection.
  * @param experimentName The experiment name to fetch
  */

--- a/packages/explat-client/src/internal/timing.ts
+++ b/packages/explat-client/src/internal/timing.ts
@@ -17,7 +17,6 @@ export function monotonicNow(): number {
 
 /**
  * Timeouts a promise. Returns timeoutValue in event of timeout.
- *
  * @param promise The promise to timeout
  * @param timeoutMilliseconds The timeout time in milliseconds
  */
@@ -40,7 +39,6 @@ export function timeoutPromise< T >(
  * Wraps an async function so that if it is called multiple times it will just return the same promise - until the promise is fulfilled.
  *
  * Once the promise has been fulfilled it will reset.
- *
  * @param f The function to wrap
  */
 export function asyncOneAtATime< T >( f: () => Promise< T > ): () => Promise< T > {

--- a/packages/explat-client/src/internal/validations.ts
+++ b/packages/explat-client/src/internal/validations.ts
@@ -6,7 +6,6 @@ export function isObject( x: unknown ): x is Record< string, unknown > {
 
 /**
  * Test if a piece of data is a valid name
- *
  * @param name The data to test
  */
 export function isName( name: unknown ): name is string {
@@ -15,7 +14,6 @@ export function isName( name: unknown ): name is string {
 
 /**
  * Test if a piece of data is a valid experimentAssignment
- *
  * @param experimentAssignment The data to test
  */
 export function isExperimentAssignment(
@@ -35,7 +33,6 @@ export function isExperimentAssignment(
 /**
  * Basic validation of ExperimentAssignment
  * Throws if invalid, returns the experimentAssignment if valid.
- *
  * @param experimentAssignment The data to validate
  */
 export function validateExperimentAssignment(

--- a/packages/help-center/src/data/use-site-analysis.ts
+++ b/packages/help-center/src/data/use-site-analysis.ts
@@ -38,7 +38,6 @@ function urlMatches( trustedURL: string, userInputUrl: string | undefined ) {
 
 /**
  * Analyses a site to determine whether its a WPCOM site, and if yes, it would fetch and return the site information (SiteDetails).
- *
  * @param userId the user ID
  * @param siteURL the site URL
  * @param enabled whether the query is enabled

--- a/packages/i18n-calypso/types/index.d.ts
+++ b/packages/i18n-calypso/types/index.d.ts
@@ -80,7 +80,6 @@ export type EventListener = ( ...payload: any ) => any;
 export interface I18N {
 	/**
 	 * Translate a string.
-	 *
 	 * @example translate( "Hello, %(name)s", { args: { name: "World" } } );
 	 * @param original The original string to translate.
 	 * @param options Options for the translation. Note that substutions must exist.

--- a/packages/i18n-utils/src/date-utils.ts
+++ b/packages/i18n-utils/src/date-utils.ts
@@ -5,7 +5,6 @@ const aDay = anHour * 24;
 
 /**
  * Get localized relative time string for past timestamp.
- *
  * @param options The parameters to be used.
  * @param options.timestamp Web timestamp (milliseconds since Epoch)
  * @param options.locale Locale slug
@@ -58,7 +57,6 @@ export const getRelativeTimeString = ( {
 
 /**
  * Get ISO date format for timestamp.
- *
  * @param {number} timestamp Web timestamp (milliseconds since Epoch)
  * @returns {string} Formatted ISO date, e.g. '2020-12-20'
  */
@@ -68,7 +66,6 @@ export const getISODateString = ( timestamp: number ) => {
 
 /**
  * Get localized short date format for timestamp.
- *
  * @param {number} timestamp Web timestamp (milliseconds since Epoch)
  * @param {string} locale Locale slug
  * @returns {string} Formatted localized date, e.g. 'Dec 20, 2021' for US English.
@@ -89,7 +86,6 @@ export const getShortDateString = ( timestamp: number, locale = 'en' ) => {
 
 /**
  * Get localized numeric date format for timestamp.
- *
  * @param {number} timestamp Web timestamp (milliseconds since Epoch)
  * @param {string} locale Locale slug
  * @returns {string} Formatted localized date, e.g. '12/20/2021' for US English

--- a/packages/i18n-utils/src/guess-timezone.ts
+++ b/packages/i18n-utils/src/guess-timezone.ts
@@ -62,7 +62,6 @@ const linkedTimezones = {
 /**
  * Potentially rewrite the timezone to what we have on the server-side.
  * See https://core.trac.wordpress.org/ticket/26656
- *
  * @param timezone A timezone string, like Asia/Calcutta.
  * @returns A potentially rewritten timezone string, like Asia/Kolkata.
  */

--- a/packages/i18n-utils/src/locale-context.tsx
+++ b/packages/i18n-utils/src/locale-context.tsx
@@ -18,7 +18,6 @@ export const LocaleProvider: React.FC< Props > = ( { children, localeSlug } ) =>
 
 /**
  * Returns locale slug
- *
  * @param {string} locale locale to be converted e.g. "en_US".
  * @returns locale string e.g. "en"
  */
@@ -49,7 +48,6 @@ function getWpI18nLocaleSlug(): string | undefined {
  * React hook providing the current locale slug. If `<LocaleProvider>` hasn't
  * been defined in the component tree then it will fall back to using the
  * data from `@wordpress/i18n` to determine the current locale slug.
- *
  * @example
  *
  * import { useLocale } from '@automattic/i18n-utils';
@@ -88,7 +86,6 @@ export function useLocale(): string {
 
 /**
  * HoC providing the current locale slug supplied to `<LocaleProvider>`.
- *
  * @param InnerComponent Component that will receive `locale` as a prop
  * @returns Component enhanced with locale
  * @example
@@ -112,7 +109,6 @@ export const withLocale = createHigherOrderComponent(
 
 /**
  * React hook providing whether the current locale slug belongs to English or not
- *
  * @example
  *
  * import { useIsEnglishLocale } from '@automattic/i18n-utils';

--- a/packages/i18n-utils/src/utils.ts
+++ b/packages/i18n-utils/src/utils.ts
@@ -25,7 +25,6 @@ export function getPathParts( path: string ) {
 
 /**
  * Checks if provided locale is a default one.
- *
  * @param {string} locale - locale slug (eg: 'fr')
  * @returns {boolean} true when the default locale is provided
  */
@@ -35,7 +34,6 @@ export function isDefaultLocale( locale: string | null ) {
 
 /**
  * Checks if provided locale has a parentLangSlug and is therefore a locale variant
- *
  * @param {string} locale - locale slug (eg: 'fr')
  * @returns {boolean} true when the locale has a parentLangSlug
  */
@@ -63,7 +61,6 @@ export function isLocaleRtl( locale: string ) {
  * Checks against a list of locales that don't have any GP translation sets
  * A 'translation set' refers to a collection of strings to be translated see:
  * https://glotpress.blog/the-manual/translation-sets/
- *
  * @param {string} locale - locale slug (eg: 'fr')
  * @returns {boolean} true when the locale is NOT a member of the exception list
  */
@@ -77,7 +74,6 @@ export function canBeTranslated( locale: string ) {
  *
  * Since the text is in English, this is always true in that case. Otherwise
  * We check whether a translation was provided for this text.
- *
  * @returns {boolean} true when a user would see text they can read.
  */
 export function translationExists( phrase: string ) {
@@ -87,7 +83,6 @@ export function translationExists( phrase: string ) {
 
 /**
  * Return a list of all supported language slugs
- *
  * @returns {Array} A list of all supported language slugs
  */
 export function getLanguageSlugs() {
@@ -96,7 +91,6 @@ export function getLanguageSlugs() {
 
 /**
  * Map provided language slug to supported slug if applicable.
- *
  * @param {string} langSlug Locale slug for the language
  * @returns {string} Mapped language slug
  */
@@ -111,7 +105,6 @@ export function getMappedLanguageSlug( langSlug: string | undefined ) {
 
 /**
  * Return a specifier for page.js/Express route param that enumerates all supported languages.
- *
  * @param {string} name of the parameter. By default it's `lang`, some routes use `locale`.
  * @param {boolean} optional whether to put the `?` character at the end, making the param optional
  * @returns {string} Router param specifier that looks like `:lang(cs|de|fr|pl)`
@@ -123,7 +116,6 @@ export function getLanguageRouteParam( name = 'lang', optional = true ) {
 /**
  * Return a specifier for a route param to match anything that looks like a language code, whether it is valid or not.
  * This is useful for routes that need to match any language, including unsupported ones.
- *
  * @returns {string} Router param specifier string
  */
 export function getAnyLanguageRouteParam() {
@@ -132,7 +124,6 @@ export function getAnyLanguageRouteParam() {
 
 /**
  * Matches and returns language from config.languages based on the given localeSlug
- *
  * @param   {string} langSlug locale slug of the language to match
  * @returns {Object | undefined} An object containing the locale data or undefined.
  */
@@ -150,7 +141,6 @@ export function getLanguage( langSlug: string | undefined ): Language | undefine
 
 /**
  * Assuming that locale is adding at the end of path, retrieves the locale if present.
- *
  * @param {string} path - original path
  * @returns {string|undefined} The locale slug if present or undefined
  */
@@ -165,7 +155,6 @@ export function getLocaleFromPath( path: string ) {
  * Adds a locale slug to the current path.
  *
  * Will replace existing locale slug, if present.
- *
  * @param path - original path
  * @param locale - locale slug (eg: 'fr')
  * @returns original path with new locale slug
@@ -180,7 +169,6 @@ export function addLocaleToPath( path: string, locale: string ) {
 /**
  * Removes the trailing locale slug from the path, if it is present.
  * '/start/en' => '/start', '/start' => '/start', '/start/flow/fr' => '/start/flow', '/start/flow' => '/start/flow'
- *
  * @param  path - original path
  * @returns original path minus locale slug
  */
@@ -199,7 +187,6 @@ export function removeLocaleFromPath( path: string ): string {
 
 /**
  * Filter out unexpected values from the given language revisions object.
- *
  * @param {Object} languageRevisions A candidate language revisions object for filtering.
  * @returns {Object} A valid language revisions object derived from the given one.
  */
@@ -223,7 +210,6 @@ export function filterLanguageRevisions( languageRevisions: Record< string, stri
 
 /**
  * Checks if provided locale is one of the magnificenet non-english locales.
- *
  * @param locale Locale slug
  * @returns true when provided magnificent non-english locale.
  */
@@ -233,7 +219,6 @@ export function isMagnificentLocale( locale: string ): boolean {
 
 /**
  * Checks if provided locale is translated incompletely (is missing essential translations).
- *
  * @param   {string}  locale Locale slug
  * @returns {boolean} Whether provided locale is flagged as translated incompletely.
  */
@@ -245,10 +230,8 @@ export function isTranslatedIncompletely( locale: string ) {
  * Adds a locale slug infront of the current path.
  *
  * Will replace existing locale slug, if present.
- *
  * @param path - original path
  * @param locale - the locale to add to the path (Optional)
- *
  * @returns original path with new locale slug
  */
 export function addLocaleToPathLocaleInFront( path: string, locale?: string ) {
@@ -266,7 +249,6 @@ export function addLocaleToPathLocaleInFront( path: string, locale?: string ) {
 /**
  * Removes the locale slug in the start of the path, if it is present.
  * '/en/themes' => '/themes', '/themes' => '/themes', '/fr/plugins' => '/plugins'
- *
  * @param  path - original path
  * @returns original path minus locale slug
  */
@@ -289,7 +271,6 @@ export function removeLocaleFromPathLocaleInFront( path: string ): string {
 /**
  * Retreive the locale slug in the start of the path, if it is present.
  * '/en/themes' => 'en', '/themes' => 'en', '/fr/plugins' => 'fr'
- *
  * @param  path - original path
  * @returns locale
  */

--- a/packages/jest-circus-allure-reporter/src/reporter.ts
+++ b/packages/jest-circus-allure-reporter/src/reporter.ts
@@ -27,7 +27,6 @@ export class AllureReporter {
 
 	/**
 	 * Construct an instance of the AllureReporter.
-	 *
 	 * @param options Key/pair parameters.
 	 * @param {AllureRuntime} options.allureRuntime Instance of Allure runtime exposed by allure-js-commons.
 	 * @param {Record<string, string>} [options.environmentInfo] Customized Jest environment variables.
@@ -77,7 +76,6 @@ export class AllureReporter {
 	 * A test file represents all top-level describe blocks in a spec file.
 	 *
 	 * This method calls the `startSuite` implementation.
-	 *
 	 * @param {string} fileName Name of the spec file.
 	 */
 	startTestFile( fileName?: string ): void {
@@ -96,7 +94,6 @@ export class AllureReporter {
 
 	/**
 	 * Starts a new suite in Allure.
-	 *
 	 * @param {string} [suiteName] Name of the suite.
 	 */
 	startSuite( suiteName?: string ): void {
@@ -108,7 +105,6 @@ export class AllureReporter {
 
 	/**
 	 * Ends the suite in Allure.
-	 *
 	 * @throws {Error} If this method is called without a running suite.
 	 */
 	endSuite(): void {
@@ -139,7 +135,6 @@ export class AllureReporter {
 	 * of the suite.
 	 *
 	 * If the hook is of the `afterXYZ` type, it is added at the end of the suite.
-	 *
 	 * @param {Circus.HookType} type Type of the hook being run.
 	 */
 	startHook( type: Circus.HookType ): void {
@@ -160,7 +155,6 @@ export class AllureReporter {
 	 * If this method is called outside of a hook, an error is thrown.
 	 *
 	 * Otherwise, the hook is marked as passed and finished.
-	 *
 	 * @param {Error} [error] Hook failures if any.
 	 * @throws {Error} If this method is called outside of a hook.
 	 */
@@ -185,7 +179,6 @@ export class AllureReporter {
 
 	/**
 	 * Starts the test case in Allure.
-	 *
 	 * @param {Circus.TestEntry} test Test step.
 	 * @param {Circus.State} state State of the test step.
 	 * @param {string} testPath Path to the test file.
@@ -239,7 +232,6 @@ export class AllureReporter {
 
 	/**
 	 * Mark the test case as pending/todo in Allure.
-	 *
 	 * @param {Circus.TestEntry} test Test step which is pending.
 	 * @throws {Error} If this method is called without a running suite.
 	 */
@@ -254,7 +246,6 @@ export class AllureReporter {
 
 	/**
 	 * Mark the test case as failed in Allure.
-	 *
 	 * @param {Error} error Error returned by Jest.
 	 * @throws {Error} If this method is called without a running suite.
 	 */
@@ -279,7 +270,6 @@ export class AllureReporter {
 
 	/**
 	 * Ends the test step in Allure.
-	 *
 	 * @throws {Error} If this method is called without a running suite.
 	 */
 	endTestStep() {
@@ -294,7 +284,6 @@ export class AllureReporter {
 
 	/**
 	 * Writes attachment in the specified file format.
-	 *
 	 * @param {Buffer|string} content Content of the attachement.
 	 * @param {ContentType|string|AttachmentOptions} type Type of attachment to write.
 	 * @returns {string}
@@ -316,7 +305,6 @@ export class AllureReporter {
 
 	/**
 	 * Push the test step onto the stack.
-	 *
 	 * @param {AllureStep} step Allure representation of the test step.
 	 */
 	pushStep( step: AllureStep ): void {
@@ -332,7 +320,6 @@ export class AllureReporter {
 
 	/**
 	 * Pushes the test onto the stack.
-	 *
 	 * @param {AllureTest} test Allure representation of the test.
 	 */
 	pushTest( test: AllureTest ): void {
@@ -348,7 +335,6 @@ export class AllureReporter {
 
 	/**
 	 * Pushes suite onto the stack.
-	 *
 	 * @param {AllureGroup} suite Group of tests representing a suite.
 	 */
 	pushSuite( suite: AllureGroup ): void {
@@ -364,7 +350,6 @@ export class AllureReporter {
 
 	/**
 	 * Adds the details of test failure into Allure.
-	 *
 	 * @param {Error} error Error returned by Jest.
 	 */
 	private handleError( error: Error | any ) {
@@ -411,7 +396,6 @@ export class AllureReporter {
 	}
 	/**
 	 * Extracts the test code.
-	 *
 	 * @param {string} serializedTestCode Test code.
 	 */
 	private extractCodeDetails( serializedTestCode: string ) {
@@ -425,7 +409,6 @@ export class AllureReporter {
 
 	/**
 	 * Extracts docblock from the test code.
-	 *
 	 * @param {string} contents Test code.
 	 */
 	private extractDocBlock( contents: string ): string {

--- a/packages/language-picker/src/language-picker.tsx
+++ b/packages/language-picker/src/language-picker.tsx
@@ -43,7 +43,6 @@ type Props< TLanguage extends Language > = {
  * Pick the first language group that includes the currently selected language.
  * If no language is currently selected then just use the default. Similarly,
  * if no language group can be found with the current language in it, use the default.
- *
  * @param selectedLanguage The currently selected language, if one exists.
  * @param languageGroups The language groups to choose from.
  * @param defaultLananguageGroupId The default language group to use when a language isn't picked or when the selected language isn't found in any of the groups.

--- a/packages/page-pattern-modal/src/utils/contains-missing-block.ts
+++ b/packages/page-pattern-modal/src/utils/contains-missing-block.ts
@@ -7,7 +7,6 @@ const MISSING_BLOCK_NAME = 'core/missing';
 /**
  * Determines whether the provided collection of Blocks contains any "missing"
  * blocks as determined by the presence of the `core/missing` block type.
- *
  * @param blocks the collection of block objects to check for "missing" block .
  * @returns whether the collection blocks contains any missing blocks.
  */

--- a/packages/page-pattern-modal/src/utils/group-utils.ts
+++ b/packages/page-pattern-modal/src/utils/group-utils.ts
@@ -1,7 +1,6 @@
 /**
  * Sorts the keys on the group object to have a preferred order.
  * If some groups exist without a preferred order, they will be included last
- *
  * @param preferredGroupOrder the order of group slugs that we want
  * @param groupsObject an object with all group information, with group names as keys
  */

--- a/packages/page-pattern-modal/src/utils/map-blocks-recursively.ts
+++ b/packages/page-pattern-modal/src/utils/map-blocks-recursively.ts
@@ -5,7 +5,6 @@ type Writeable< T > = { -readonly [ P in keyof T ]: T[ P ] };
 /**
  * Recursively maps over a collection of blocks calling the modifier function on
  * each to modify it and returning a collection of new block references.
- *
  * @param blocks an array of block objects
  * @param modifier a callback function used to modify the blocks
  */

--- a/packages/page-pattern-modal/src/utils/tracking.ts
+++ b/packages/page-pattern-modal/src/utils/tracking.ts
@@ -19,7 +19,6 @@ let tracksIdentity: Identity | null = null;
 /**
  * Populate `identity` on WPCOM and ATOMIC to enable tracking.
  * Always disabled for regular self-hosted installations.
- *
  * @param identity Info about identity.
  */
 export const initializeWithIdentity = ( identity: Identity ): void => {
@@ -29,7 +28,6 @@ export const initializeWithIdentity = ( identity: Identity ): void => {
 
 /**
  * Track a view of the layout selector.
- *
  * @param source Source triggering the view.
  */
 export const trackView = ( source: string ): void => {
@@ -64,7 +62,6 @@ export const trackDismiss = (): void => {
 
 /**
  * Track layout selection.
- *
  * @param pattern Pattern slug.
  */
 export const trackSelection = ( pattern: string ): void => {

--- a/packages/photon/src/index.ts
+++ b/packages/photon/src/index.ts
@@ -38,7 +38,6 @@ type PhotonOpts = {
  * Pass `secure: false` to get `http:`.
  *
  * Photon documentation: http://developer.wordpress.com/docs/photon/
- *
  * @param imageUrl - the URL of the image to run through Photon
  * @param [opts]   - optional options object with Photon options
  * @returns The generated Photon URL string
@@ -111,7 +110,6 @@ function isAlreadyPhotoned( host: string ) {
  * Statically hash the subdomain based on the URL, to optimize browser caches.
  * Only use i0 when using photon over https, based on the assumption that https
  * maps to http/2 (or later)
- *
  * @param  {string} pathname The pathname to use
  * @param  {boolean} isSecure Whether we're constructing a HTTPS URL or a HTTP one
  * @returns {string}          The hostname for the pathname

--- a/packages/plans-grid/src/plans-table/plan-item.tsx
+++ b/packages/plans-grid/src/plans-table/plan-item.tsx
@@ -26,7 +26,6 @@ const SPACE_BAR_KEYCODE = 32;
  * There are 6 possible cases of the domain message (the combinations of [hasDomain, isFreeDomain, isFreePlan]
  * Ifs and elses grew unclear. This is a simple state machine that covers all the states. To maintain it,
  * please look for the state you need (e.g: free_domain => paid_plan) and edit that branch.
- *
  * @param isFreePlan boolean determining whether the plan is free
  * @param domain the domain (can be undefined => NO_DOMAIN)
  * @param __ translate function

--- a/packages/search/src/utils.ts
+++ b/packages/search/src/utils.ts
@@ -5,7 +5,6 @@ import * as React from 'react';
  *
  * Source:
  * https://github.com/reakit/reakit/blob/HEAD/packages/reakit-utils/src/useUpdateEffect.ts
- *
  * @param effect The effect.
  * @param deps Dependencies of the effect.
  */

--- a/packages/state-utils/src/create-selector/index.ts
+++ b/packages/state-utils/src/create-selector/index.ts
@@ -21,7 +21,6 @@ type Dependant< TState, TProps extends any[], TDependency > = (
  * Default behavior for determining whether current state differs from previous
  * state, which is the basis upon which memoize cache is cleared. Should return
  * a value or array of values to be shallowly compared for strict equality.
- *
  * @param state Current state object
  * @returns Value(s) to be shallow compared
  */
@@ -55,7 +54,6 @@ const DEFAULT_GET_CACHE_KEY = ( () => {
 /**
  * Given an array of getDependants functions, returns a single function which,
  * when called, returns an array of mapped results from those functions.
- *
  * @param dependants Array of getDependants
  * @returns Function mapping getDependants results
  */
@@ -66,7 +64,6 @@ const makeSelectorFromArray =
 
 /**
  * Returns a memoized state selector for use with the global application state.
- *
  * @param selector      Function calculating cached result
  * @param getDependants Function(s) describing dependent
  *                                             state, or an array of dependent

--- a/packages/state-utils/src/extend-action/index.ts
+++ b/packages/state-utils/src/extend-action/index.ts
@@ -11,7 +11,6 @@ function isThunk( action: Action | AnyThunkAction ): action is AnyThunkAction {
 /**
  * Given an action object or thunk, returns an updated object or thunk which
  * will include additional data in the action (as provided) when dispatched.
- *
  * @see 'client/state/utils/with-enhancers' for a more advanced alternative
  * @param action Action object or thunk
  * @param data   Additional data to include in action

--- a/packages/tour-kit/src/hooks/use-focus-handler.ts
+++ b/packages/tour-kit/src/hooks/use-focus-handler.ts
@@ -5,7 +5,6 @@ import { useEffect, useCallback, useState } from '@wordpress/element';
 
 /**
  * A hook that returns true/false if ref node receives focus by either tabbing or clicking into any of its children.
- *
  * @param ref React.MutableRefObject< null | HTMLElement >
  */
 const useFocusHandler = ( ref: React.MutableRefObject< null | HTMLElement > ): boolean => {

--- a/packages/tour-kit/src/hooks/use-focus-trap.ts
+++ b/packages/tour-kit/src/hooks/use-focus-trap.ts
@@ -5,7 +5,6 @@ import { focus } from '@wordpress/dom';
 import { useEffect, useCallback, useState } from '@wordpress/element';
 /**
  * A hook that constraints tabbing/focus on focuable elements in the given element ref.
- *
  * @param ref React.MutableRefObject< null | HTMLElement >
  */
 const useFocusTrap = ( ref: React.MutableRefObject< null | HTMLElement > ): void => {

--- a/packages/tour-kit/src/utils/index.ts
+++ b/packages/tour-kit/src/utils/index.ts
@@ -2,7 +2,6 @@ import debugFactory from 'debug';
 
 /**
  * Helper to convert CSV of `classes` to an array.
- *
  * @param classes String or array of classes to format.
  * @returns Array of classes
  */

--- a/packages/tour-kit/src/utils/live-resize-modifier.tsx
+++ b/packages/tour-kit/src/utils/live-resize-modifier.tsx
@@ -37,7 +37,6 @@ type liveResizeModifierFactory = (
  *
  * The Popper modifier queues an asynchronous update on the Popper instance whenever either of the
  * Observers trigger its callback.
- *
  * @returns custom Popper modifier
  */
 export const liveResizeModifier: liveResizeModifierFactory = (

--- a/packages/tree-select/src/index.ts
+++ b/packages/tree-select/src/index.ts
@@ -33,7 +33,6 @@ export interface CachedSelector< S, A extends unknown[], R = unknown > {
 
 /**
  * Returns a selector that caches values.
- *
  * @param getDependents A Function describing the dependent(s) of the selector.
  *                      Must return an array which gets passed as the first arg to the selector.
  * @param selector      A standard selector for calculating cached result.

--- a/packages/viewport/src/index.ts
+++ b/packages/viewport/src/index.ts
@@ -129,7 +129,6 @@ export function getMediaQueryList( breakpoint: string ): undefined | QueryItem {
 
 /**
  * Returns whether the current window width matches a breakpoint.
- *
  * @param {string} breakpoint The breakpoint to consider.
  * @returns {boolean|undefined} Whether the provided breakpoint is matched.
  */
@@ -140,7 +139,6 @@ export function isWithinBreakpoint( breakpoint: string ): boolean | undefined {
 
 /**
  * Registers a listener to be notified of changes to breakpoint matching status.
- *
  * @param {string} breakpoint The breakpoint to consider.
  * @param {Function} listener The listener to be called on change.
  * @returns {Function} The function to be called when unsubscribing.
@@ -167,7 +165,6 @@ export function subscribeIsWithinBreakpoint(
 
 /**
  * Returns whether the current window width matches the mobile breakpoint.
- *
  * @returns {boolean|undefined} Whether the mobile breakpoint is matched.
  */
 export function isMobile(): boolean | undefined {
@@ -176,7 +173,6 @@ export function isMobile(): boolean | undefined {
 
 /**
  * Registers a listener to be notified of changes to mobile breakpoint matching status.
- *
  * @param {Function} listener The listener to be called on change.
  * @returns {Function} The registered subscription; undefined if none.
  */
@@ -186,7 +182,6 @@ export function subscribeIsMobile( listener: ListenerCallback ): UnsubcribeCallb
 
 /**
  * Returns whether the current window width matches the desktop breakpoint.
- *
  * @returns {boolean|undefined} Whether the desktop breakpoint is matched.
  */
 export function isDesktop(): boolean | undefined {
@@ -195,7 +190,6 @@ export function isDesktop(): boolean | undefined {
 
 /**
  * Registers a listener to be notified of changes to desktop breakpoint matching status.
- *
  * @param {Function} listener The listener to be called on change.
  * @returns {Function} The registered subscription; undefined if none.
  */
@@ -206,7 +200,6 @@ export function subscribeIsDesktop( listener: ListenerCallback ): UnsubcribeCall
 /**
  * Returns the current window width.
  * Avoid using this method, as it triggers a layout recalc.
- *
  * @returns {number} The current window width, in pixels.
  */
 export function getWindowInnerWidth(): number {

--- a/packages/wpcom-checkout/src/postal-code.ts
+++ b/packages/wpcom-checkout/src/postal-code.ts
@@ -91,7 +91,6 @@ function isCountryCodeDataWithFormatter(
 
 /**
  * Tries to convert given postal code based on the country code into a standardised format
- *
  * @param {string} postalCode user inputted postal code
  * @param {string|null|undefined} countryCode user selected country
  * @returns {string} formatted postal code

--- a/packages/wpcom-proxy-request/types/index.d.ts
+++ b/packages/wpcom-proxy-request/types/index.d.ts
@@ -1,6 +1,5 @@
 /**
  * TypeScript type definitions for wpcom-proxy-request
- *
  * @todo Migrate `src/index.js` to TypeScript, incorporate these type definitions.
  * (Needs changes to the build chain, see other packages in the monorepo
  * for inspiration, e.g. `@automattic/data-stores`.)


### PR DESCRIPTION
## Proposed Changes

Fixing all ESLint `jsdoc/tag-lines` warnings.

## Testing Instructions

Verify all checks are green