### PR TITLE
Site Settings: Translate `Next steps` notification button

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -77,7 +77,7 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 					( this.props.isJetpackSaveRequestSuccessful || ! this.props.siteIsJetpack )
 				) {
 					if ( ! this.state.isSiteTitleTaskCompleted && this.state.blogNameChanged ) {
-						noticeSettings.button = 'Next steps';
+						noticeSettings.button = this.props.translate( 'Next steps' );
 						noticeSettings.onClick = () => {
 							window.location.assign( `/home/${ this.props.siteSlug }` );
 						};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 716-gh-Automattic/i18n-issues

## Proposed Changes

* Wrap `Next steps` string in `translate()` call.

![Screenshot](https://github.com/Automattic/wp-calypso/assets/2722412/e622f17c-4b95-4723-a789-c172b0fd1ae9)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use calypso.live or boot locally.
* Switch UI to a Mag-16 language.
* Go to `/settings/general/`.
* Change the site title and save the form.
* Confirm the "Next steps" button is translated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
