### PR TITLE
Marketplace Reviews: Update display logic of the reviews banner

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -397,18 +397,22 @@ function PluginDetails( props ) {
 			/>
 			<PluginDetailsNotices selectedSite={ selectedSite } plugin={ fullPlugin } />
 
-			{ userReviews.length === 0 && canPublishReview && (
-				<Banner
-					className="plugin-details__reviews-banner"
-					title={ translate( 'Review this plugin!' ) }
-					description={ translate(
-						'Please help other users sharing your experience with this plugin.'
-					) }
-					onClick={ () => setIsReviewsModalVisible( true ) }
-					disableHref
-					event="calypso_marketplace_reviews_plugin_banner"
-				/>
-			) }
+			{ isEnabled( 'marketplace-reviews-show' ) &&
+				userReviews.length === 0 &&
+				canPublishReview &&
+				isMarketplaceProduct &&
+				! showPlaceholder && (
+					<Banner
+						className="plugin-details__reviews-banner"
+						title={ translate( 'Review this plugin!' ) }
+						description={ translate(
+							'Please help other users sharing your experience with this plugin.'
+						) }
+						onClick={ () => setIsReviewsModalVisible( true ) }
+						disableHref
+						event="calypso_marketplace_reviews_plugin_banner"
+					/>
+				) }
 			<div className="plugin-details__page">
 				<div className={ classnames( 'plugin-details__layout', { 'is-logged-in': isLoggedIn } ) }>
 					<div className="plugin-details__header">


### PR DESCRIPTION
## Proposed Changes

The banner should be shown only when:
- The flag `marketplace-reviews-show` is enabled
- User hasn't submitted a review yet
- the user can publish a review (has an active subscription
- The plugin is a Marketplace plugin
- The plugin data is already loaded

## Testing Instructions

Check the banner is only displayed according the cases above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?