### PR TITLE
`ThemeTierBadge`: Return `null` when there is no badge

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/index.js
+++ b/client/components/theme-tier/theme-tier-badge/index.js
@@ -53,6 +53,12 @@ export default function ThemeTierBadge( {
 		return <ThemeTierUpgradeBadge />;
 	};
 
+	const badge = getBadge();
+
+	if ( ! badge ) {
+		return null;
+	}
+
 	return (
 		<div className={ classNames( 'theme-tier-badge', className ) }>
 			<ThemeTierBadgeContextProvider
@@ -60,7 +66,7 @@ export default function ThemeTierBadge( {
 				showUpgradeBadge={ showUpgradeBadge }
 				themeId={ themeId }
 			>
-				{ getBadge() }
+				{ badge }
 			</ThemeTierBadgeContextProvider>
 		</div>
 	);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/style.scss
@@ -583,10 +583,6 @@ $design-button-primary-color: rgb(17, 122, 201);
 
 		.design-picker-design-title__theme-tier-badge {
 			gap: 8px;
-
-			&:empty {
-				display: none;
-			}
 		}
 
 		.step-container__navigation {


### PR DESCRIPTION
On https://github.com/Automattic/wp-calypso/pull/86582 it was discussed (see https://github.com/Automattic/wp-calypso/pull/86582/files#r1457641120) that `ThemeTierBadge` should return `null` when there is no badge to show, in order to prevent having to use CSS hacks to handle an empty `div`.

## Proposed Changes

Return `null` when there's no badge instead of the full `div.theme-tier-badge`.

## Testing Instructions

### Theme showcase

1. Go to `/themes` with a free domain and add `?flags=themes/tiers` to the URL
2. Check that the layout looks as usual in both themes with and without a badge below the title

### Design picker

1. Go to `/start`, create a free domain, get to the design picker page, and add `?flags=themes/tiers` to the URL
2. Check that the layout looks as usual in both themes with and without a badge below the title
3. Click on a theme with a badge, and check that the content on both columns is correctly aligned
4. Repeat the previous step with a theme that has no badge

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?