### PR TITLE
Marketplace Reviews: Show a placeholder according the number of stars given

### DIFF
--- a/client/my-sites/marketplace/components/review-item/create-review-item.tsx
+++ b/client/my-sites/marketplace/components/review-item/create-review-item.tsx
@@ -4,7 +4,7 @@ import Card from '@automattic/components/src/card';
 import { CheckboxControl, TextareaControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import moment from 'moment';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import Gravatar from 'calypso/components/gravatar';
 import ReviewsRatingsStars from 'calypso/components/reviews-rating-stars/reviews-ratings-stars';
@@ -30,6 +30,7 @@ export function MarketplaceCreateReviewItem( props: MarketplaceCreateReviewItemP
 	const [ errorMessage, setErrorMessage ] = useState( '' );
 	const [ showThankYouSection, setShowThankYouSection ] = useState( false );
 	const [ showContentArea, setShowContentArea ] = useState( false );
+	const [ contentPlaceholder, setContentPlaceholder ] = useState( '' );
 
 	const { data: userReviews, isFetching: isFetchingUserReviews } = useMarketplaceReviewsQuery( {
 		productType,
@@ -66,6 +67,45 @@ export function MarketplaceCreateReviewItem( props: MarketplaceCreateReviewItemP
 		setRating( value );
 		setShowContentArea( true );
 	};
+
+	useEffect( () => {
+		switch ( rating ) {
+			case 1:
+				return setContentPlaceholder(
+					translate(
+						"We're sorry to hear about your experience. Could you share what went wrong or how we can improve?"
+					)
+				);
+			case 2:
+				return setContentPlaceholder(
+					translate(
+						"It looks like things didn't go as expected. Can you tell us what could have been better?"
+					)
+				);
+			case 3:
+				return setContentPlaceholder(
+					translate(
+						'Thanks for your feedback! What did you like, and how can we make your experience even better?'
+					)
+				);
+			case 4:
+				return setContentPlaceholder(
+					translate(
+						'Great to know you had a good experience! What did you enjoy, and how can we make it excellent?'
+					)
+				);
+			case 5:
+				return setContentPlaceholder(
+					translate( 'Thrilled to see you had a fantastic experience! What did you love the most?' )
+				);
+			// Fallback that shouldn't really be seen
+			// as the field is only shown once a rating is selected
+			default:
+				return setContentPlaceholder(
+					translate( 'Please write your review to help other users.' )
+				);
+		}
+	}, [ rating, translate ] );
 
 	// Hide the Thank You section if user removed their review
 	if ( ! userReviews?.length && ! isFetchingUserReviews && showThankYouSection ) {
@@ -118,6 +158,7 @@ export function MarketplaceCreateReviewItem( props: MarketplaceCreateReviewItemP
 								rows={ 4 }
 								cols={ 40 }
 								className="marketplace-review-item__editor"
+								placeholder={ contentPlaceholder }
 								name="content"
 								value={ content }
 								onChange={ setContent }


### PR DESCRIPTION


## Proposed Changes

Update the placeholder of the content field according the rating the user is giving.

![CleanShot 2024-01-19 at 13 39 27](https://github.com/Automattic/wp-calypso/assets/5039531/b38b3f21-8918-4ac1-abca-0471651ea8cb)


## Testing Instructions
* Go to the plugin details page of a plugin where you haven't left a review yet. Ex: `/plugins/woocommerce-subscriptions/:site`
* Purchase it if you don't have an active subscription yet.
* Open the reviews modal
* Click on the number of stars to write a review
* Check if the message is appropriate
* Change the number of stars and check if the placeholder is changing.

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?