### PR TITLE
Fixes the Blaze Campaign page E2E test

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts
@@ -43,14 +43,14 @@ export class BlazeCampaignPage {
 	 * @param {TestFile} path TestFile object.
 	 */
 	async uploadImage( path: TestFile ) {
-		await this.page.getByRole( 'region', { name: 'Appearance' } ).waitFor( { timeout: 15 * 1000 } );
+		const fileChooserPromise = this.page.waitForEvent( 'filechooser', { timeout: 15_000 } );
 
-		const fileChooserPromiser = this.page.waitForEvent( 'filechooser' );
 		await this.page
 			.getByRole( 'region', { name: 'Appearance' } )
 			.getByRole( 'button', { name: 'Upload' } )
 			.click();
-		const fileChooser = await fileChooserPromiser;
+
+		const fileChooser = await fileChooserPromise;
 		await fileChooser.setFiles( path.fullpath );
 
 		await this.page.getByRole( 'region', { name: 'Appearance' } ).locator( 'img' ).waitFor();

--- a/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts
@@ -43,8 +43,9 @@ export class BlazeCampaignPage {
 	 * @param {TestFile} path TestFile object.
 	 */
 	async uploadImage( path: TestFile ) {
-		// Waiting for 15 seconds here because the normal Blaze flow fetches for AI suggestions that can take between 5 to 10 seconds.
-		const fileChooserPromiser = this.page.waitForEvent( 'filechooser', { timeout: 15000 } );
+		await this.page.getByRole( 'region', { name: 'Appearance' } ).waitFor( { timeout: 15 * 1000 } );
+
+		const fileChooserPromiser = this.page.waitForEvent( 'filechooser' );
 		await this.page
 			.getByRole( 'region', { name: 'Appearance' } )
 			.getByRole( 'button', { name: 'Upload' } )

--- a/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts
@@ -43,7 +43,8 @@ export class BlazeCampaignPage {
 	 * @param {TestFile} path TestFile object.
 	 */
 	async uploadImage( path: TestFile ) {
-		const fileChooserPromiser = this.page.waitForEvent( 'filechooser' );
+		// Waiting for 15 seconds here because the normal Blaze flow fetches for AI suggestions that can take between 5 to 10 seconds.
+		const fileChooserPromiser = this.page.waitForEvent( 'filechooser', { timeout: 15000 } );
 		await this.page
 			.getByRole( 'region', { name: 'Appearance' } )
 			.getByRole( 'button', { name: 'Upload' } )


### PR DESCRIPTION
The E2E test for Blaze (/advertising page) is flaky. Sometimes, the step `Upload image` takes more than 10 seconds, and it timeouts.

<img width="704" alt="Screenshot 2024-01-19 at 14 38 09" src="https://github.com/Automattic/wp-calypso/assets/1258162/eb983fec-ea76-4b98-914d-a641716e4385">

This is not normal, but also between the expected time for that functionality. The explanation is that After the user clicks the Getting Starting button, the Blaze widget starts an initial flow and fetches the DSP API multiple times to get the site's and post's information. 

We incorporated a functionality into Blaze that uses AI to autogenerate better Campaign snippets and titles. This new task can take some time (usually around 5 seconds) but can handle nearly 9 seconds for some edge cases. And if we include the rest of the calls in the entire process, the total amount of time can get past 10 seconds.

## Proposed Changes

* Increase the timeout for the step `Upload image` to 15 seconds, to give a bit more time to the test to run correctly.

## Testing Instructions

* Setup your local environment to run E2E tests: [Readme file](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e#readme)
* Execute this in the console and verify that the test finished correctly
```
yarn workspace wp-e2e-tests build && TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/tools/advertising__promote.ts
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

The PR author and reviewer are responsible for completing the checklist.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?