### PR TITLE
AI Logo Generator: Update UpgradeNudge to use checkout URL from hook

### DIFF
--- a/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-nudge.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-nudge.tsx
@@ -9,10 +9,10 @@ import { Icon, warning } from '@wordpress/icons';
  * Internal dependencies
  */
 import './upgrade-nudge.scss';
+import { useCheckout } from '../hooks/use-checkout';
 
 export const UpgradeNudge = () => {
 	const buttonText = __( 'Upgrade', 'jetpack' );
-	const checkoutUrl = 'https://wordpress.com/';
 	const upgradeMessage = createInterpolateElement(
 		__(
 			'You reached your plan request limit. <strong>Upgrade now to increase it.</strong>',
@@ -22,6 +22,8 @@ export const UpgradeNudge = () => {
 			strong: <strong />,
 		}
 	);
+
+	const { upgradeURL: checkoutUrl } = useCheckout();
 
 	return (
 		<div className="jetpack-upgrade-plan-banner">

--- a/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-nudge.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-nudge.tsx
@@ -23,7 +23,7 @@ export const UpgradeNudge = () => {
 		}
 	);
 
-	const { upgradeURL: checkoutUrl } = useCheckout();
+	const { nextTierCheckoutURL: checkoutUrl } = useCheckout();
 
 	return (
 		<div className="jetpack-upgrade-plan-banner">

--- a/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-checkout.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-checkout.ts
@@ -28,9 +28,9 @@ export const useCheckout = () => {
 	);
 	upgradeURL.searchParams.set( 'redirect_to', location.href );
 
-	debug( 'Upgrade URL: ', upgradeURL.toString() );
+	debug( 'Next tier checkout URL: ', upgradeURL.toString() );
 
 	return {
-		upgradeURL: upgradeURL.toString(),
+		nextTierCheckoutURL: upgradeURL.toString(),
 	};
 };

--- a/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-checkout.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-checkout.ts
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import debugFactory from 'debug';
+/**
+ * Internal dependencies
+ */
+import { STORE_NAME } from '../store';
+/**
+ * Types
+ */
+import type { Selectors } from '../store/types';
+
+const debug = debugFactory( 'jetpack-ai-calypso:use-checkout' );
+
+export const useCheckout = () => {
+	const { nextTier, siteDetails } = useSelect( ( select ) => {
+		const selectors: Selectors = select( STORE_NAME );
+		return {
+			nextTier: selectors.getAiAssistantFeature().nextTier,
+			siteDetails: selectors.getSiteDetails(),
+		};
+	}, [] );
+
+	const upgradeURL = new URL(
+		`${ location.origin }/checkout/${ siteDetails?.domain }/${ nextTier?.slug }`
+	);
+	upgradeURL.searchParams.set( 'redirect_to', location.href );
+
+	debug( 'Upgrade URL: ', upgradeURL.toString() );
+
+	return {
+		upgradeURL: upgradeURL.toString(),
+	};
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/issues/34720

## Proposed Changes

* Create the `useCheckout` hook to expose all things related to checkout, starting with the checkout URL for the next tier
* Update the `UpgradeNudge` component to start using the `useCheckout` hook

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test on a site with a tiered plan (you can buy it following the upgrade path on the site editor)
* Run this branch locally:
   * run `yarn start` on one terminal
   * run `yarn workspace @automattic/jetpack-ai-calypso run copy-assets` on another, and then `yarn workspace @automattic/jetpack-ai-calypso run watch` right after
* Sandbox the `public-api` endpoint on you machine
* Connect to your sandbox and add a filter to the `0-sandbox.php` file:

```
// set this number on the limit of your current tier to make the upgrade banner show up, my case was 200
add_filter( 'jetpack_ai_current_period_requests_count', function() { return 200; } );
```

* On your local calypso instance, go to "My Home" for the testing site
* Look for the "Create a logo with Jetpack AI" link and click it to launch the generator modal
* Confirm you are seeing the upgrade banner:

<img width="600" alt="Screenshot 2024-01-19 at 15 41 36" src="https://github.com/Automattic/wp-calypso/assets/6760046/e457ad25-d587-4e6b-b2cb-87a60a1a86b5">

* Confirm the URL for the upgrade button is a checkout URL:

```
http://calypso.localhost:3000/checkout/YOUR-SITE.wordpress.com/jetpack_ai_yearly:-q-500?redirect_to=[...]
```

* Confirm you can click the button and a checkout page will open up on a new tab, with the correct tier being sold (the next tier from your current plan)
   * My testing site was on the 200 requests tier, the checkout was showing the 500 requests tier, that is the next in this case

<img width="600" alt="Screenshot 2024-01-19 at 15 44 12" src="https://github.com/Automattic/wp-calypso/assets/6760046/06c58e60-e883-49bc-8a8e-c9a85cedc30d">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?