### PR TITLE
AI Logo Generator: Add event tracking on the upgrade banner button

### DIFF
--- a/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-nudge.tsx
+++ b/packages/jetpack-ai-calypso/src/logo-generator/components/upgrade-nudge.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -9,6 +10,7 @@ import { Icon, warning } from '@wordpress/icons';
  * Internal dependencies
  */
 import './upgrade-nudge.scss';
+import { EVENT_PLACEMENT_UPGRADE_PROMPT, EVENT_UPGRADE } from '../../constants';
 
 export const UpgradeNudge = () => {
 	const buttonText = __( 'Upgrade', 'jetpack' );
@@ -23,6 +25,10 @@ export const UpgradeNudge = () => {
 		}
 	);
 
+	const handleUpgradeClick = () => {
+		recordTracksEvent( EVENT_UPGRADE, { placement: EVENT_PLACEMENT_UPGRADE_PROMPT } );
+	};
+
 	return (
 		<div className="jetpack-upgrade-plan-banner">
 			<div className="jetpack-upgrade-plan-banner__wrapper">
@@ -32,7 +38,12 @@ export const UpgradeNudge = () => {
 						{ upgradeMessage }
 					</span>
 				</div>
-				<Button href={ checkoutUrl } target="_blank" className="is-primary">
+				<Button
+					href={ checkoutUrl }
+					target="_blank"
+					className="is-primary"
+					onClick={ handleUpgradeClick }
+				>
 					{ buttonText }
 				</Button>
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/issues/34720

## Proposed Changes

* Start tracking the `jetpack_ai_logo_modal_upgrade` event on the upgrade button from the upgrade banner
* Set the placement as `upgrade_prompt`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test on a site with a tiered plan (you can buy it following the upgrade path on the site editor)
* Run this branch locally:
* Sandbox the `public-api` endpoint on you machine
* Connect to your sandbox and add a filter to the `0-sandbox.php` file:

```
// set this number on the limit of your current tier to make the upgrade banner show up
add_filter( 'jetpack_ai_current_period_requests_count', function() { return 200; } );
```

* Go to "My Home" for the testing site
* Look for the "Create a logo with Jetpack AI" link and click it to launch the generator modal
* Confirm you see the upgrade banner
* Click the "Upgrade" button on the upgrade banner
* Wait for some time and then confirm the event shows up on the events dashboard

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?