### PR TITLE
ExPlat: Fix and clean-up A/A tests

### DIFF
--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -135,9 +135,7 @@ class PagesMain extends Component {
 				 * Assumes users have a somewhat working clock but shouldn't be a problem if they don't.
 				 */ }
 				<Experiment
-					name={ `explat_test_aa_weekly_calypso_${ moment.utc().format( 'GGGG' ) }_week_${ moment
-						.utc()
-						.format( 'WW' ) }` }
+					name={ `explat_test_aa_weekly_calypso_${ moment.utc().format( 'GGGG' ) }_week_${ moment.utc().week() }` }
 					defaultExperience={ null }
 					treatmentExperience={ null }
 					loadingExperience={ null }

--- a/client/my-sites/pages/main.jsx
+++ b/client/my-sites/pages/main.jsx
@@ -142,12 +142,6 @@ class PagesMain extends Component {
 					treatmentExperience={ null }
 					loadingExperience={ null }
 				/>
-				<Experiment
-					name="explat_test_aaaaa_2021_08_26_18_59"
-					defaultExperience={ null }
-					treatmentExperience={ null }
-					loadingExperience={ null }
-				/>
 			</Main>
 		);
 	}


### PR DESCRIPTION
Cleans up the A/A tests for Calypso:

- Adjusts the week to be single digit (matches the auto-generated profiles, ie. `_week_3` vs `_week_03`).
- Remove old experiment created and disabled in 2021.

<img width="1247" alt="Screenshot" src="https://github.com/Automattic/wp-calypso/assets/4505888/09fc58c8-32de-4b33-9298-dac2de060711">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?