### PR TITLE
Membership Coupons: Adjust character limit for coupons, add error for out of limit entries

### DIFF
--- a/client/my-sites/earn/components/add-edit-coupon-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-coupon-modal/index.tsx
@@ -440,7 +440,7 @@ const RecurringPaymentsCouponAddEditModal = ( {
 						action="Random"
 						onChange={ onCouponCodeChange }
 						onAction={ onCouponCodeRandomize }
-						onCharacterLimitReached={ handleCharacterLimitReached }
+						onCharacterMinReached={ handleCharacterLimitReached }
 						isError={ ! isFormValid( 'coupon_code' ) }
 						isValid={ isFormValid( 'coupon_code' ) }
 						minLength="3"
@@ -448,7 +448,9 @@ const RecurringPaymentsCouponAddEditModal = ( {
 						onBlur={ () => setFocusedCouponCode( true ) }
 					/>
 					<FormSettingExplanation>
-						{ translate( 'Choose a unique coupon code for the discount. Not case-sensitive.' ) }
+						{ translate(
+							'Choose a unique coupon code between 3 and 20 characters for the discount. Not case-sensitive.'
+						) }
 					</FormSettingExplanation>
 					{ ! isFormValid( 'coupon_code' ) && ! isCharacterLimitExceeded && focusedCouponCode && (
 						<FormInputValidation isError text={ translate( 'Please input a coupon code.' ) } />
@@ -456,7 +458,7 @@ const RecurringPaymentsCouponAddEditModal = ( {
 					{ isCharacterLimitExceeded && (
 						<FormInputValidation
 							isError
-							text={ translate( 'Coupon codes must be between 3 and 20 characters' ) }
+							text={ translate( 'Coupon codes must be at least 3 characters' ) }
 						/>
 					) }
 				</FormFieldset>

--- a/client/my-sites/earn/components/add-edit-coupon-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-coupon-modal/index.tsx
@@ -163,7 +163,8 @@ const RecurringPaymentsCouponAddEditModal = ( {
 	const [ focusedDiscountValue, setFocusedDiscountValue ] = useState( false );
 	const [ focusedLimitPerUser, setFocusedLimitPerUser ] = useState( false );
 	const [ focusedEmailAllowList, setFocusedEmailAllowList ] = useState( false );
-	const [ isCharacterLimitExceeded, setIsCharacterLimitExceeded ] = useState( false );
+	const [ isCharacterMinReached, setisCharacterMinReached ] = useState( false );
+	const [ isCharacterMaxReached, setisCharacterMaxReached ] = useState( false );
 
 	/** Coupon functions */
 	const generateRandomCouponCode = (): string => {
@@ -194,8 +195,11 @@ const RecurringPaymentsCouponAddEditModal = ( {
 		const newValue = event.target.value;
 		setEditedCouponCode( newValue );
 	}, [] );
-	const handleCharacterLimitReached = useCallback( ( isExceeded ) => {
-		setIsCharacterLimitExceeded( isExceeded );
+	const handleCharacterMinLimitReached = useCallback( ( isMet ) => {
+		setisCharacterMinReached( isMet );
+	}, [] );
+	const handleCharacterMaxLimitReached = useCallback( ( isMet ) => {
+		setisCharacterMaxReached( isMet );
 	}, [] );
 	const onCouponCodeRandomize = () => {
 		const code = generateRandomCouponCode();
@@ -265,7 +269,7 @@ const RecurringPaymentsCouponAddEditModal = ( {
 	/** Form validation */
 	const isFormValid = ( field?: string ) => {
 		if ( field === 'coupon_code' || ! field ) {
-			if ( isCharacterLimitExceeded ) {
+			if ( isCharacterMinReached ) {
 				return false;
 			}
 
@@ -440,7 +444,8 @@ const RecurringPaymentsCouponAddEditModal = ( {
 						action="Random"
 						onChange={ onCouponCodeChange }
 						onAction={ onCouponCodeRandomize }
-						onCharacterMinReached={ handleCharacterLimitReached }
+						onCharacterMinReached={ handleCharacterMinLimitReached }
+						onCharacterMaxReached={ handleCharacterMaxLimitReached }
 						isError={ ! isFormValid( 'coupon_code' ) }
 						isValid={ isFormValid( 'coupon_code' ) }
 						minLength="3"
@@ -448,17 +453,23 @@ const RecurringPaymentsCouponAddEditModal = ( {
 						onBlur={ () => setFocusedCouponCode( true ) }
 					/>
 					<FormSettingExplanation>
-						{ translate(
-							'Choose a unique coupon code between 3 and 20 characters for the discount. Not case-sensitive.'
-						) }
+						{ translate( 'Choose a unique coupon code for the discount. Not case-sensitive.' ) }
 					</FormSettingExplanation>
-					{ ! isFormValid( 'coupon_code' ) && ! isCharacterLimitExceeded && focusedCouponCode && (
+					{ ! isFormValid( 'coupon_code' ) && ! isCharacterMinReached && focusedCouponCode && (
 						<FormInputValidation isError text={ translate( 'Please input a coupon code.' ) } />
 					) }
-					{ isCharacterLimitExceeded && (
+					{ isCharacterMinReached && (
 						<FormInputValidation
 							isError
 							text={ translate( 'Coupon codes must be at least 3 characters' ) }
+						/>
+					) }
+					{ isCharacterMaxReached && (
+						<FormInputValidation
+							isError
+							text={ translate(
+								'The coupon code maximum length of 20 characters has been reached'
+							) }
 						/>
 					) }
 				</FormFieldset>

--- a/client/my-sites/earn/components/add-edit-coupon-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-coupon-modal/index.tsx
@@ -466,7 +466,7 @@ const RecurringPaymentsCouponAddEditModal = ( {
 					) }
 					{ isCharacterMaxReached && (
 						<FormInputValidation
-							isValid
+							isWarning
 							text={ translate(
 								'The coupon code maximum length of 20 characters has been reached'
 							) }

--- a/client/my-sites/earn/components/add-edit-coupon-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-coupon-modal/index.tsx
@@ -466,6 +466,7 @@ const RecurringPaymentsCouponAddEditModal = ( {
 					) }
 					{ isCharacterMaxReached && (
 						<FormInputValidation
+							isError={ false }
 							isWarning
 							text={ translate(
 								'The coupon code maximum length of 20 characters has been reached'

--- a/client/my-sites/earn/components/add-edit-coupon-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-coupon-modal/index.tsx
@@ -191,14 +191,14 @@ const RecurringPaymentsCouponAddEditModal = ( {
 		/^[\w.\-+*]+@(?:(?:[\w\-*]+(?:\.[\w\-*]+)+)+|(?:[\w\-*]*\*[\w\-*]*)+)+$/.test( email );
 
 	/** Form event handlers */
-	const onCouponCodeChange = useCallback( ( event ) => {
+	const onCouponCodeChange = useCallback( ( event: ChangeEvent< HTMLInputElement > ) => {
 		const newValue = event.target.value;
 		setEditedCouponCode( newValue );
 	}, [] );
-	const handleCharacterMinLimitReached = useCallback( ( isMet ) => {
+	const handleCharacterMinLimitReached = useCallback( ( isMet: boolean ) => {
 		setisCharacterMinReached( isMet );
 	}, [] );
-	const handleCharacterMaxLimitReached = useCallback( ( isMet ) => {
+	const handleCharacterMaxLimitReached = useCallback( ( isMet: boolean ) => {
 		setisCharacterMaxReached( isMet );
 	}, [] );
 	const onCouponCodeRandomize = () => {
@@ -466,7 +466,7 @@ const RecurringPaymentsCouponAddEditModal = ( {
 					) }
 					{ isCharacterMaxReached && (
 						<FormInputValidation
-							isError
+							isValid
 							text={ translate(
 								'The coupon code maximum length of 20 characters has been reached'
 							) }

--- a/client/my-sites/earn/components/form-text-input-with-value-generation/index.tsx
+++ b/client/my-sites/earn/components/form-text-input-with-value-generation/index.tsx
@@ -16,6 +16,7 @@ type FormTextInputWithValueGenerationProps = {
 	onBlur?: ( event: FocusEvent< HTMLInputElement > ) => void;
 	onChange?: ( event: ChangeEvent< HTMLInputElement > ) => void;
 	onCharacterMinReached?: () => void;
+	onCharacterMaxReached?: () => void;
 	disabled?: boolean;
 	isError?: boolean;
 	isValid?: boolean;
@@ -28,8 +29,8 @@ const FormTextInputWithValueGeneration = ( {
 	value,
 	onAction = noop,
 	onChange = noop,
-	onCharacterMinReached = noop,
-	onCharacterMaxReached = noop,
+	onCharacterMinReached = false,
+	onCharacterMaxReached = false,
 	onFocus = noop,
 	onBlur = noop,
 	disabled = false,

--- a/client/my-sites/earn/components/form-text-input-with-value-generation/index.tsx
+++ b/client/my-sites/earn/components/form-text-input-with-value-generation/index.tsx
@@ -15,6 +15,7 @@ type FormTextInputWithValueGenerationProps = {
 	onFocus?: ( event: FocusEvent< HTMLInputElement > ) => void;
 	onBlur?: ( event: FocusEvent< HTMLInputElement > ) => void;
 	onChange?: ( event: ChangeEvent< HTMLInputElement > ) => void;
+	onCharacterLimitReached?: () => void;
 	disabled?: boolean;
 	isError?: boolean;
 	isValid?: boolean;
@@ -27,15 +28,36 @@ const FormTextInputWithValueGeneration = ( {
 	value,
 	onAction = noop,
 	onChange = noop,
+	onCharacterLimitReached = noop,
 	onFocus = noop,
 	onBlur = noop,
 	disabled = false,
 	isError = false,
 	isValid = false,
-	maxLength = '10',
+	minLength = '3',
+	maxLength = '20',
 	...props
 }: FormTextInputWithValueGenerationProps ) => {
 	const [ focused, setFocused ] = useState( false );
+
+	const handleChange = useCallback(
+		( event: ChangeEvent< HTMLInputElement > ) => {
+			onChange( event );
+			const valueLength = event.target.value.length;
+
+			if ( valueLength < parseInt( minLength, 10 ) ) {
+				onCharacterLimitReached( true );
+			} else if (
+				valueLength === parseInt( maxLength, 10 ) &&
+				event.nativeEvent.inputType === 'insertText'
+			) {
+				onCharacterLimitReached( true );
+			} else {
+				onCharacterLimitReached( false );
+			}
+		},
+		[ onChange, minLength, maxLength, onCharacterLimitReached ]
+	);
 
 	const handleFocus = useCallback(
 		( event: FocusEvent< HTMLInputElement > ) => {
@@ -69,7 +91,7 @@ const FormTextInputWithValueGeneration = ( {
 				disabled={ disabled }
 				onFocus={ handleFocus }
 				onBlur={ handleBlur }
-				onChange={ onChange }
+				onChange={ handleChange }
 				value={ value }
 				maxLength={ maxLength }
 			/>

--- a/client/my-sites/earn/components/form-text-input-with-value-generation/index.tsx
+++ b/client/my-sites/earn/components/form-text-input-with-value-generation/index.tsx
@@ -15,7 +15,7 @@ type FormTextInputWithValueGenerationProps = {
 	onFocus?: ( event: FocusEvent< HTMLInputElement > ) => void;
 	onBlur?: ( event: FocusEvent< HTMLInputElement > ) => void;
 	onChange?: ( event: ChangeEvent< HTMLInputElement > ) => void;
-	onCharacterLimitReached?: () => void;
+	onCharacterMinReached?: () => void;
 	disabled?: boolean;
 	isError?: boolean;
 	isValid?: boolean;
@@ -28,7 +28,7 @@ const FormTextInputWithValueGeneration = ( {
 	value,
 	onAction = noop,
 	onChange = noop,
-	onCharacterLimitReached = noop,
+	onCharacterMinReached = noop,
 	onFocus = noop,
 	onBlur = noop,
 	disabled = false,
@@ -46,17 +46,12 @@ const FormTextInputWithValueGeneration = ( {
 			const valueLength = event.target.value.length;
 
 			if ( valueLength < parseInt( minLength, 10 ) ) {
-				onCharacterLimitReached( true );
-			} else if (
-				valueLength === parseInt( maxLength, 10 ) &&
-				event.nativeEvent.inputType === 'insertText'
-			) {
-				onCharacterLimitReached( true );
+				onCharacterMinReached( true );
 			} else {
-				onCharacterLimitReached( false );
+				onCharacterMinReached( false );
 			}
 		},
-		[ onChange, minLength, maxLength, onCharacterLimitReached ]
+		[ onChange, minLength, onCharacterMinReached ]
 	);
 
 	const handleFocus = useCallback(

--- a/client/my-sites/earn/components/form-text-input-with-value-generation/index.tsx
+++ b/client/my-sites/earn/components/form-text-input-with-value-generation/index.tsx
@@ -29,6 +29,7 @@ const FormTextInputWithValueGeneration = ( {
 	onAction = noop,
 	onChange = noop,
 	onCharacterMinReached = noop,
+	onCharacterMaxReached = noop,
 	onFocus = noop,
 	onBlur = noop,
 	disabled = false,
@@ -50,8 +51,14 @@ const FormTextInputWithValueGeneration = ( {
 			} else {
 				onCharacterMinReached( false );
 			}
+
+			if ( valueLength >= parseInt( maxLength, 10 ) ) {
+				onCharacterMaxReached( true );
+			} else {
+				onCharacterMaxReached( false );
+			}
 		},
-		[ onChange, minLength, onCharacterMinReached ]
+		[ onChange, minLength, maxLength, onCharacterMinReached, onCharacterMaxReached ]
 	);
 
 	const handleFocus = useCallback(

--- a/client/my-sites/earn/components/form-text-input-with-value-generation/index.tsx
+++ b/client/my-sites/earn/components/form-text-input-with-value-generation/index.tsx
@@ -15,8 +15,8 @@ type FormTextInputWithValueGenerationProps = {
 	onFocus?: ( event: FocusEvent< HTMLInputElement > ) => void;
 	onBlur?: ( event: FocusEvent< HTMLInputElement > ) => void;
 	onChange?: ( event: ChangeEvent< HTMLInputElement > ) => void;
-	onCharacterMinLimitReached?: ( isMinReached: boolean ) => void;
-	onCharacterMaxLimitReached?: ( isMaxReached: boolean ) => void;
+	onCharacterMinReached?: ( isMinReached: boolean ) => void;
+	onCharacterMaxReached?: ( isMaxReached: boolean ) => void;
 	disabled?: boolean;
 	isError?: boolean;
 	isValid?: boolean;

--- a/client/my-sites/earn/components/form-text-input-with-value-generation/index.tsx
+++ b/client/my-sites/earn/components/form-text-input-with-value-generation/index.tsx
@@ -15,11 +15,12 @@ type FormTextInputWithValueGenerationProps = {
 	onFocus?: ( event: FocusEvent< HTMLInputElement > ) => void;
 	onBlur?: ( event: FocusEvent< HTMLInputElement > ) => void;
 	onChange?: ( event: ChangeEvent< HTMLInputElement > ) => void;
-	onCharacterMinReached?: () => void;
-	onCharacterMaxReached?: () => void;
+	onCharacterMinLimitReached?: ( isMinReached: boolean ) => void;
+	onCharacterMaxLimitReached?: ( isMaxReached: boolean ) => void;
 	disabled?: boolean;
 	isError?: boolean;
 	isValid?: boolean;
+	minLength?: string;
 	maxLength?: string;
 };
 
@@ -29,8 +30,8 @@ const FormTextInputWithValueGeneration = ( {
 	value,
 	onAction = noop,
 	onChange = noop,
-	onCharacterMinReached = false,
-	onCharacterMaxReached = false,
+	onCharacterMinReached = noop,
+	onCharacterMaxReached = noop,
 	onFocus = noop,
 	onBlur = noop,
 	disabled = false,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/gold/issues/292

## Proposed Changes

This patch should increase the memberships coupon length from 10 to 20 characters. It also adjusts the validation so that a message noting the valid range of the coupon is shown, as well as prevents form submission outside of that range.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. First, patch D135376-code to your sandbox.
2. Patch this diff or use the Calypso Live link.
3. Navigate to `/earn/payments/SITE_URL`
4. Attempt to add a coupon. Note that when entering text in the coupon code field, an entry less than 3 characters or attempting to enter more than 20 will result in a message "Coupon codes must be between 3 and 20 characters".
5. Enter two characters, and click into the Amount box and enter a number. The Save button should remain inactive.
6. Enter between 3 and 20 characters, and the Save button should be active. Try saving the coupon; it should successfully save.
7. You can also try reverting D135376-code and attempting the above steps; anything over 10 characters should trigger a 400 error.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?