### PR TITLE
Jetpack Manage: URL only connection scaffolding

### DIFF
--- a/client/components/jetpack/add-new-site-button/index.tsx
+++ b/client/components/jetpack/add-new-site-button/index.tsx
@@ -1,4 +1,5 @@
-import { WordPressLogo } from '@automattic/components';
+import { isEnabled } from '@automattic/calypso-config';
+import { Gridicon, WordPressLogo } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
@@ -13,6 +14,7 @@ type Props = {
 	onClickAddNewSite?: () => void;
 	onClickWpcomMenuItem?: () => void;
 	onClickJetpackMenuItem?: () => void;
+	onClickUrlMenuItem?: () => void;
 };
 
 const AddNewSiteButton = ( {
@@ -23,6 +25,7 @@ const AddNewSiteButton = ( {
 	onClickAddNewSite,
 	onClickWpcomMenuItem,
 	onClickJetpackMenuItem,
+	onClickUrlMenuItem,
 }: Props ): JSX.Element => {
 	const translate = useTranslate();
 
@@ -49,6 +52,13 @@ const AddNewSiteButton = ( {
 				<JetpackLogo className="gridicon" size={ 18 } />
 				<span>{ translate( 'Connect a site to Jetpack' ) }</span>
 			</PopoverMenuItem>
+
+			{ isEnabled( 'jetpack/url-only-connection' ) && (
+				<PopoverMenuItem onClick={ onClickUrlMenuItem } href="/dashboard/connect-url">
+					<Gridicon icon="domains" size={ 18 } />
+					<span>{ translate( 'Add sites by URL' ) }</span>
+				</PopoverMenuItem>
+			) }
 		</SplitButton>
 	);
 };

--- a/client/jetpack-cloud/sections/agency-dashboard/connect-url/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/connect-url/index.tsx
@@ -1,0 +1,45 @@
+import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import SitesInput from './sites-input';
+import ValidateSites from './validate-sites';
+import './style.scss';
+
+export default function ConnectUrl() {
+	const translate = useTranslate();
+
+	const [ detectedSites, setDetectedSites ] = useState( [] );
+	const [ detectedFilename, setDetectedFilename ] = useState( '' );
+	const [ validating, setValidating ] = useState( false );
+
+	const handleValidate = () => {
+		setValidating( true );
+	};
+
+	const pageTitle = validating ? translate( 'Adding sites' ) : translate( 'Add sites by URL' );
+	const pageSubtitle = validating
+		? translate( 'Please wait while we add all sites to your account.' )
+		: translate( 'Add one or multiple sites at once by entering their address below.' );
+
+	return (
+		<div className="connect-url">
+			<h2 className="connect-url__page-title">{ pageTitle }</h2>
+			<div className="connect-url__page-subtitle">{ pageSubtitle }</div>
+			<Card>
+				{ ! validating ? (
+					<SitesInput
+						{ ...{
+							detectedSites,
+							setDetectedSites,
+							detectedFilename,
+							setDetectedFilename,
+							handleValidate,
+						} }
+					/>
+				) : (
+					<ValidateSites { ...{ detectedSites } } />
+				) }
+			</Card>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/connect-url/sites-input.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/connect-url/sites-input.tsx
@@ -1,0 +1,98 @@
+import { Button, FormLabel } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { Dispatch, SetStateAction } from 'react';
+import FilePicker from 'calypso/components/file-picker';
+import FormTextarea from 'calypso/components/forms/form-textarea';
+
+export default function SitesInput( {
+	detectedSites,
+	setDetectedSites,
+	detectedFilename,
+	setDetectedFilename,
+	handleValidate,
+}: {
+	detectedSites: string[];
+	setDetectedSites: Dispatch< SetStateAction< string[] > >;
+	detectedFilename: string;
+	setDetectedFilename: Dispatch< SetStateAction< string > >;
+	handleValidate: () => void;
+} ) {
+	const translate = useTranslate();
+
+	let fileReader: any;
+
+	const handleFileRead = () => {
+		const sites: string[] = [];
+		const content = fileReader.result;
+		const lines = content.split( /\r\n|\n/ );
+		lines.forEach( ( line: string ) => {
+			const fields = line.split( ',' );
+			sites.push( fields[ 0 ] );
+		} );
+
+		setDetectedSites( sites.filter( ( url ) => url.trim() !== 'url' ) );
+	};
+
+	const onFilePick = ( files: File[] ) => {
+		fileReader = new FileReader();
+		fileReader.onloadend = handleFileRead;
+		fileReader.readAsText( files[ 0 ] );
+		setDetectedFilename( files[ 0 ].name );
+	};
+
+	const onTextareaChange = ( event: any ) =>
+		setDetectedSites(
+			0 === event.target.value.length
+				? []
+				: event.target.value
+						.split( /,|\n/ )
+						.filter( ( url: string ) => url.trim() !== '' )
+						.map( ( url: string ) => url.trim() )
+		);
+
+	const filePicker = (
+		<>
+			<div className="connect-url__file-picker-text">{ translate( 'Drop file to upload' ) }</div>
+			<div className="connect-url__file-picker-text">{ translate( 'or' ) }</div>
+			<div className="connect-url__file-picker-text">
+				<Button className="connect-url__file-picker-button">{ translate( 'Select file' ) }</Button>
+			</div>
+		</>
+	);
+
+	const uploadResults = (
+		<>
+			<FormLabel>{ detectedFilename }</FormLabel>
+			<div className="connect-url__file-picker-url-count">
+				{ translate( '%(num)d sites detected', { args: { num: detectedSites.length } } ) }
+			</div>
+		</>
+	);
+
+	return (
+		<>
+			<FormLabel>{ translate( 'Enter site URLs:' ) }</FormLabel>
+			<FormTextarea
+				className="connect-url__site-urls-field"
+				placeholder={ translate( 'E.g.: www.totoros.blog, www.totoro.org' ) }
+				onChange={ onTextareaChange }
+			></FormTextarea>
+			<div className="connect-url__form-instruction">
+				{ translate( 'Separate each site with a comma' ) }
+			</div>
+			<FormLabel>{ translate( 'Or upload a CSV file:' ) }</FormLabel>
+
+			<div className="connect-url__file-picker">
+				<FilePicker accept=".csv,.txt" onPick={ onFilePick }>
+					{ '' === detectedFilename ? filePicker : uploadResults }
+				</FilePicker>
+			</div>
+
+			<Button primary disabled={ 0 === detectedSites.length } onClick={ handleValidate }>
+				{ 0 === detectedSites.length
+					? translate( 'Add sites' )
+					: translate( 'Add %(num)d sites', { args: { num: detectedSites.length } } ) }
+			</Button>
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/connect-url/spinner.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/connect-url/spinner.tsx
@@ -1,0 +1,16 @@
+export default function Spinner() {
+	return (
+		<svg
+			className="connect-url__validate-sites-spinner"
+			width="24"
+			height="24"
+			viewBox="0 0 24 24"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<path
+				className="connect-url__validate-sites-spinner-animation"
+				d="M2,12A10.94,10.94,0,0,1,5,4.65c-.21-.19-.42-.36-.62-.55h0A11,11,0,0,0,12,23c.34,0,.67,0,1-.05C6,23,2,17.74,2,12Z"
+			/>
+		</svg>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/connect-url/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/connect-url/style.scss
@@ -1,0 +1,62 @@
+.connect-url__page-title {
+	margin-bottom: 0.5rem;
+}
+
+.connect-url__page-subtitle {
+	margin-bottom: 2rem;
+}
+
+.connect-url__file-picker {
+	display: block;
+	width: 100%;
+	border: 1px dashed #ccc;
+	padding: 2rem 0;
+	margin-bottom: 1rem;
+}
+
+.connect-url__file-picker-text {
+	display: block;
+	width: 100%;
+	text-align: center;
+}
+
+.connect-url__form-instruction {
+	font-size: 0.875rem;
+	color: var(--color-accent-40);
+	margin-bottom: 1.5rem;
+	font-style: italic;
+}
+
+.connect-url__file-picker .form-label,
+.connect-url__file-picker-url-count {
+	text-align: center;
+	margin-bottom: 0;
+}
+
+.connect-url__file-picker-url-count {
+	font-size: 0.75rem;
+}
+
+.connect-url__validate-sites-spinner {
+	margin-right: 1rem;
+	margin-bottom: 1rem;
+}
+
+.connect-url__validate-sites-spinner-animation {
+	transform-origin: center;
+	animation: spinner 0.6s linear infinite;
+}
+
+@keyframes spinner {
+	100% {
+		transform: rotate(360deg);
+	}
+}
+
+.connect-url__validate-sites-quantity {
+	margin-bottom: 1rem;
+}
+
+.connect-url__validate-sites-row {
+	display: flex;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/connect-url/validate-sites.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/connect-url/validate-sites.tsx
@@ -1,0 +1,27 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import Spinner from './spinner';
+
+export default function ValidateSites( { detectedSites }: { detectedSites: string[] } ) {
+	const translate = useTranslate();
+
+	const domainList = detectedSites.map( ( site: string ) => (
+		<div className="connect-url__validate-sites-row">
+			<Spinner />
+			<div>{ site }</div>
+		</div>
+	) );
+
+	return (
+		<div className="connect-url__validate-sites">
+			<div className="connect-url__validate-sites-quantity">
+				{ translate( 'Adding {{strong}}%(num)d sites{{/strong}}', {
+					args: { num: detectedSites.length },
+					components: { strong: <strong /> },
+				} ) }
+			</div>
+			<div>{ domainList }</div>
+			<Button disabled={ true }>{ translate( 'Adding sites' ) }</Button>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
@@ -4,6 +4,7 @@ import page, { type Callback } from '@automattic/calypso-router';
 import JetpackManageSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/jetpack-manage';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import { setAllSitesSelected } from 'calypso/state/ui/actions';
+import ConnectUrl from './connect-url';
 import DashboardOverview from './dashboard-overview';
 import Header from './header';
 
@@ -52,5 +53,12 @@ export const agencyDashboardContext: Callback = ( context, next ) => {
 	// By definition, Sites Management does not select any one specific site
 	context.store.dispatch( setAllSitesSelected() );
 
+	next();
+};
+
+export const connectUrlContext: Callback = ( context, next ) => {
+	context.header = <Header />;
+	context.secondary = <JetpackManageSidebar path={ context.path } />;
+	context.primary = <ConnectUrl />;
 	next();
 };

--- a/client/jetpack-cloud/sections/agency-dashboard/index.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/index.ts
@@ -1,7 +1,12 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller/index.web';
-import { agencyDashboardContext } from './controller';
+import { agencyDashboardContext, connectUrlContext } from './controller';
 
 export default function (): void {
 	page( '/dashboard/:filter(favorites)?', agencyDashboardContext, makeLayout, clientRender );
+
+	if ( isEnabled( 'jetpack/url-only-connection' ) ) {
+		page( '/dashboard/connect-url', connectUrlContext, makeLayout, clientRender );
+	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
@@ -71,6 +71,13 @@ export default function SiteTopHeaderButtons() {
 								)
 							)
 						}
+						onClickUrlMenuItem={ () =>
+							dispatch(
+								recordTracksEvent(
+									'calypso_jetpack_agency_dashboard_sites_overview_connect_url_click'
+								)
+							)
+						}
 					/>
 					<WPCOMHostingPopover
 						context={ buttonRef.current }

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -60,6 +60,7 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/card-addition-improvements": true,
+		"jetpack/url-only-connection": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -56,6 +56,7 @@
 		"jetpack/simplify-pricing-structure": false,
 		"jetpack/standalone-plugin-onboarding-update-v1": true,
 		"jetpack/card-addition-improvements": true,
+		"jetpack/url-only-connection": true,
 		"layout/app-banner": false,
 		"layout/guided-tours": false,
 		"layout/query-selected-editor": false,


### PR DESCRIPTION
## Proposed Changes

* TBD

## Testing Instructions

* TBD

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?