### PR TITLE
Refine types for calypso-razorpay

### DIFF
--- a/packages/calypso-razorpay/README.md
+++ b/packages/calypso-razorpay/README.md
@@ -13,7 +13,8 @@ You'll need to wrap this context provider around any component that wishes to us
 
 A React hook that allows access to Razorpay.js. This returns an object with the following properties:
 
-- `razorpay: Razorpay` The instance of the razorpay library.
-- `razorpayConfiguration: null | RazorpayConfiguration` The object containing the data returned by the wpcom razorpay configuration endpoint.
-- `isRazorpayLoading: boolean` A boolean that is true if razorpay is currently being loaded.
-- `razorpayLoadingError: undefined | null | Error` An optional object that will be set if there is an error loading razorpay.
+- `razorpayConfiguration: null | RazorpayConfiguration` The object containing the data returned by the wpcom razorpay configuration endpoint. Consumers can use this to instantiate a Razorpay object.
+- `isRazorpayLoading: boolean` A boolean that is true if the razorpay configuration is currently being loaded.
+- `razorpayLoadingError: undefined | null | Error` An optional object that will be set if there is an error loading the razorpay configuration.
+
+The hook does not provide an instantiated Razorpay object because doing so properly requires an Order ID, the existence of which is negotiated during the order flow. That is, we first initiate a transaction, returning a razorpay order ID negotiated between the backend and Razorpay, and then on the frontend initialize the Razorpay object which handles opening the modal with that order ID.

--- a/packages/calypso-razorpay/src/index.tsx
+++ b/packages/calypso-razorpay/src/index.tsx
@@ -21,7 +21,7 @@ export interface RazorpayOptions {
 export interface RazorpayConfirmationRequestArgs {
 	razorpay_payment_id: string;
 	razorpay_signature: string;
-	order_id: string; // This is a BD order ID.
+	bd_order_id: string;
 }
 
 export declare class Razorpay {

--- a/packages/calypso-razorpay/src/index.tsx
+++ b/packages/calypso-razorpay/src/index.tsx
@@ -22,7 +22,6 @@ declare global {
 export type RazorpayLoadingError = Error | null | undefined;
 
 export interface RazorpayData {
-	razorpay: Razorpay | null;
 	razorpayConfiguration: RazorpayConfiguration | null;
 	isRazorpayLoading: boolean;
 	razorpayLoadingError: RazorpayLoadingError;
@@ -31,7 +30,6 @@ export interface RazorpayData {
 const RazorpayContext = createContext< RazorpayData | undefined >( undefined );
 
 export interface UseRazorpayJs {
-	razorpay: Razorpay | null;
 	isRazorpayLoading: boolean;
 	razorpayLoadingError: RazorpayLoadingError;
 }
@@ -58,7 +56,6 @@ function useRazorpayJs(
 	razorpayConfigurationError: Error | undefined
 ): UseRazorpayJs {
 	const [ state, setState ] = useState< UseRazorpayJs >( {
-		razorpay: null,
 		isRazorpayLoading: true,
 		razorpayLoadingError: undefined,
 	} );
@@ -88,12 +85,8 @@ function useRazorpayJs(
 					);
 				}
 
-				// We've checked that it exists before getting here.
-				const razorpay = new window.Razorpay( razorpayConfiguration.options );
-
 				if ( isSubscribed ) {
 					setState( {
-						razorpay,
 						isRazorpayLoading: false,
 						razorpayLoadingError: undefined,
 					} );
@@ -106,7 +99,6 @@ function useRazorpayJs(
 			debug( 'Error while loading Razorpay!' );
 			if ( isSubscribed ) {
 				setState( {
-					razorpay: null,
 					isRazorpayLoading: false,
 					razorpayLoadingError: error,
 				} );
@@ -198,13 +190,12 @@ export function RazorpayHookProvider( {
 		configurationArgs
 	);
 
-	const { razorpay, isRazorpayLoading, razorpayLoadingError } = useRazorpayJs(
+	const { isRazorpayLoading, razorpayLoadingError } = useRazorpayJs(
 		razorpayConfiguration,
 		razorpayConfigurationError
 	);
 
 	const razorpayData = {
-		razorpay,
 		razorpayConfiguration,
 		isRazorpayLoading,
 		razorpayLoadingError,
@@ -222,7 +213,6 @@ export function RazorpayHookProvider( {
  *
  * This returns an object with the following properties:
  *
- * - razorpay: the instance of the razorpay library
  * - razorpayConfiguration: the object containing the data returned by the wpcom razorpay configuration endpoint
  * - isRazorpayLoading: a boolean that is true if razorpay is currently being loaded
  * - razorpayLoadingError: an optional object that will be set if there is an error loading razorpay

--- a/packages/calypso-razorpay/src/index.tsx
+++ b/packages/calypso-razorpay/src/index.tsx
@@ -5,7 +5,23 @@ const debug = debugFactory( 'calypso-razorpay' );
 
 export interface RazorpayConfiguration {
 	js_url: string;
-	options: { key: string };
+	options: RazorpayOptions;
+}
+
+export interface RazorpayOptions {
+	key: string;
+	order_id?: string; // This is a razorpay order ID; the name is constrained by a 3rd party library.
+	handler?: ( response: {
+		razorpay_payment_id: string;
+		razorpay_order_id: string;
+		razorpay_signature: string;
+	} ) => void;
+}
+
+export interface RazorpayConfirmationRequestArgs {
+	razorpay_payment_id: string;
+	razorpay_signature: string;
+	order_id: string; // This is a BD order ID.
 }
 
 export declare class Razorpay {


### PR DESCRIPTION
## Proposed Changes

#85846 added the calypso-razorpay package. That patch makes two important changes.

- Rather than supplying a Razorpay object directly in the hook, we supply just the configuration and let clients instantiate the library at the point of use. The reason for this is that proper initialization depends on information that doesn't exist until the order flow has started (specifically, the razorpay order ID).
- Exports types representing the important bits of the options object used to initialize the razorpay library as well as the request parameters for confirming the order.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
