### PR TITLE
Checkout v2: Move included features list to wp-checkout

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -67,7 +67,6 @@ export function WPCheckoutOrderSummary( {
 		productId: number,
 		volume?: number
 	) => void;
-	nextDomainIsFree?: boolean;
 } ) {
 	const { formStatus } = useFormStatus();
 	const cartKey = useCartKey();
@@ -130,7 +129,7 @@ export function CheckoutSummaryFeaturedList( {
 				) : (
 					<CheckoutSummaryFeaturesWrapper
 						siteId={ siteId }
-						nextDomainIsFree={ responseCart?.next_domain_is_free }
+						nextDomainIsFree={ responseCart.next_domain_is_free }
 					/>
 				) }
 			</CheckoutSummaryFeatures>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -56,7 +56,7 @@ import type { TranslateResult } from 'i18n-calypso';
 // This will make converting to TS less noisy. The order of components can be reorganized later
 /* eslint-disable @typescript-eslint/no-use-before-define */
 
-export default function WPCheckoutOrderSummary( {
+export function WPCheckoutOrderSummary( {
 	siteId,
 	onChangeSelection,
 	nextDomainIsFree = false,
@@ -70,7 +70,6 @@ export default function WPCheckoutOrderSummary( {
 	) => void;
 	nextDomainIsFree?: boolean;
 } ) {
-	const translate = useTranslate();
 	const { formStatus } = useFormStatus();
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
@@ -91,21 +90,12 @@ export default function WPCheckoutOrderSummary( {
 			data-e2e-cart-is-loading={ isCartUpdating }
 		>
 			{ ! hasCheckoutVersion( '2' ) && (
-				<CheckoutSummaryFeatures>
-					<CheckoutSummaryFeaturesTitle>
-						{ responseCart.is_gift_purchase
-							? translate( 'WordPress.com Gift Subscription' )
-							: translate( 'Included with your purchase' ) }
-					</CheckoutSummaryFeaturesTitle>
-					{ isCartUpdating ? (
-						<LoadingCheckoutSummaryFeaturesList />
-					) : (
-						<CheckoutSummaryFeaturesWrapper
-							siteId={ siteId }
-							nextDomainIsFree={ nextDomainIsFree }
-						/>
-					) }
-				</CheckoutSummaryFeatures>
+				<CheckoutSummaryFeaturedList
+					responseCart={ responseCart }
+					siteId={ siteId }
+					nextDomainIsFree={ nextDomainIsFree }
+					isCartUpdating={ isCartUpdating }
+				/>
 			) }
 
 			{ ! isCartUpdating && ! hasRenewalInCart && ! isWcMobile && plan && hasMonthlyPlanInCart && (
@@ -115,7 +105,34 @@ export default function WPCheckoutOrderSummary( {
 		</CheckoutSummaryCard>
 	);
 }
+export function CheckoutSummaryFeaturedList( {
+	responseCart,
+	siteId,
+	nextDomainIsFree,
+	isCartUpdating,
+}: {
+	responseCart: ResponseCart;
+	siteId: number | undefined;
+	nextDomainIsFree: boolean;
+	isCartUpdating: boolean;
+} ) {
+	const translate = useTranslate();
 
+	return (
+		<CheckoutSummaryFeatures>
+			<CheckoutSummaryFeaturesTitle>
+				{ responseCart.is_gift_purchase
+					? translate( 'WordPress.com Gift Subscription' )
+					: translate( 'Included with your purchase' ) }
+			</CheckoutSummaryFeaturesTitle>
+			{ isCartUpdating ? (
+				<LoadingCheckoutSummaryFeaturesList />
+			) : (
+				<CheckoutSummaryFeaturesWrapper siteId={ siteId } nextDomainIsFree={ nextDomainIsFree } />
+			) }
+		</CheckoutSummaryFeatures>
+	);
+}
 function CheckoutSummaryPriceList() {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -466,11 +466,7 @@ export default function WPCheckout( {
 									/>
 								) }
 
-								<WPCheckoutOrderSummary
-									siteId={ siteId }
-									onChangeSelection={ changeSelection }
-									nextDomainIsFree={ responseCart?.next_domain_is_free }
-								/>
+								<WPCheckoutOrderSummary siteId={ siteId } onChangeSelection={ changeSelection } />
 								{ ! isWcMobile && ! isDIFMInCart && ! hasMonthlyProduct && (
 									<>
 										<CheckoutSidebarPlanUpsell />

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -481,8 +481,8 @@ export default function WPCheckout( {
 									<CheckoutSummaryFeaturedList
 										responseCart={ responseCart }
 										siteId={ siteId }
-										nextDomainIsFree={ responseCart?.next_domain_is_free }
 										isCartUpdating={ FormStatus.VALIDATING === formStatus }
+										onChangeSelection={ changeSelection }
 									/>
 								) }
 								<SecondaryCartPromotions

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -82,7 +82,7 @@ import JetpackAkismetCheckoutSidebarPlanUpsell from './jetpack-akismet-checkout-
 import BeforeSubmitCheckoutHeader from './payment-method-step';
 import SecondaryCartPromotions from './secondary-cart-promotions';
 import WPCheckoutOrderReview from './wp-checkout-order-review';
-import WPCheckoutOrderSummary from './wp-checkout-order-summary';
+import { CheckoutSummaryFeaturedList, WPCheckoutOrderSummary } from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
 import WPContactFormSummary from './wp-contact-form-summary';
 import type { OnChangeItemVariant } from './item-variation-picker';
@@ -476,6 +476,14 @@ export default function WPCheckout( {
 										<CheckoutSidebarPlanUpsell />
 										<JetpackAkismetCheckoutSidebarPlanUpsell />
 									</>
+								) }
+								{ hasCheckoutVersion( '2' ) && (
+									<CheckoutSummaryFeaturedList
+										responseCart={ responseCart }
+										siteId={ siteId }
+										nextDomainIsFree={ responseCart?.next_domain_is_free }
+										isCartUpdating={ FormStatus.VALIDATING === formStatus }
+									/>
 								) }
 								<SecondaryCartPromotions
 									responseCart={ responseCart }

--- a/client/my-sites/checkout/src/test/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/test/wp-checkout-order-summary.tsx
@@ -88,7 +88,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { useTranslate } from 'i18n-calypso';
 import React from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
-import WPCheckoutOrderSummary from '../components/wp-checkout-order-summary';
+import { WPCheckoutOrderSummary } from '../components/wp-checkout-order-summary';
 import getAkismetProductFeatures from '../lib/get-akismet-product-features';
 import getJetpackProductFeatures from '../lib/get-jetpack-product-features';
 import {


### PR DESCRIPTION
This PR moves the 'Included with your purchase' feature list to the bottom of the checkout v2 sidebar:

<img src='https://github.com/Automattic/wp-calypso/assets/16580129/6c701074-67a6-46dc-a623-996d1bdb7209' width='600px' />

This PR also move the 
Related to https://github.com/Automattic/payments-shilling/issues/1969

## Proposed Changes

* Abstracted the `CheckoutSummaryFeatures` component and `CheckoutSummaryAnnualUpsell` component into `CheckoutSummaryFeaturedList`
* This allows us to move the feature list outside of the `WPCheckoutOrderSummary` component and place it at the bottom of the checkout sidebar
* I think the `CheckoutSummaryAnnualUpsell` should be further abstracted into an upsell nudge which can be used with the sidebar nudge wrapper - https://github.com/Automattic/wp-calypso/pull/86620

## Testing Instructions

| Production | Version 2 |
| ----- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/16580129/598f29e0-6632-4b3d-ab33-303b1684a52c) | ![image](https://github.com/Automattic/wp-calypso/assets/16580129/f391a0a6-ff9c-4e47-9ff9-b16cd7094838) |

**Test production checkout**
* Add a monthly plan to your cart and go to checkout
* Ensure that it matches production

**Test version 2**
* Add `?checkoutVersion=2` to checkout URL and refresh the page
* Ensure that included features list is at the bottom of the sidebar
* Check for any visual or functional regressions
* Try changing to an annual plan, featured list should update accordingly
