### PR TITLE
Add razorpay cases to payment method name translator

### DIFF
--- a/client/my-sites/checkout/src/lib/translate-payment-method-names.ts
+++ b/client/my-sites/checkout/src/lib/translate-payment-method-names.ts
@@ -44,6 +44,8 @@ export function translateWpcomPaymentMethodToCheckoutPaymentMethod(
 			return 'web-pay';
 		case 'WPCOM_Billing_MoneyPress_Stored':
 			return 'existingCard';
+		case 'WPCOM_Billing_Razorpay':
+			return 'razorpay';
 	}
 	throw new Error( `Unknown payment method '${ paymentMethod }'` );
 }
@@ -92,6 +94,8 @@ export function translateCheckoutPaymentMethodToWpcomPaymentMethod(
 			return 'WPCOM_Billing_Web_Payment';
 		case 'free-purchase':
 			return 'WPCOM_Billing_WPCOM';
+		case 'razorpay':
+			return 'WPCOM_Billing_Razorpay';
 	}
 	return null;
 }
@@ -115,6 +119,7 @@ export function readWPCOMPaymentMethodClass( slug: string ): WPCOMPaymentMethod 
 		case 'WPCOM_Billing_Stripe_Source_Three_D_Secure':
 		case 'WPCOM_Billing_Stripe_Source_Wechat':
 		case 'WPCOM_Billing_Web_Payment':
+		case 'WPCOM_Billing_Razorpay':
 			return slug;
 	}
 	return null;
@@ -146,6 +151,7 @@ export function readCheckoutPaymentMethodSlug( slug: string ): CheckoutPaymentMe
 		case 'wechat':
 		case 'web-pay':
 		case 'free-purchase':
+		case 'razorpay':
 			return slug;
 		case 'apple-pay':
 		case 'google-pay':


### PR DESCRIPTION
## Proposed Changes

* #86320 updates the payment method enum type in the wpcom-checkout package to include Razorpay. This patch adds these cases to the payment method translation helper functions.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
