### PR TITLE
Add confirmRazorpayOrder

### DIFF
--- a/client/lib/store-transactions/index.js
+++ b/client/lib/store-transactions/index.js
@@ -74,3 +74,9 @@ export async function getRazorpayConfiguration( requestArgs ) {
 	debug( 'RazorPay configuration', config );
 	return config;
 }
+
+export async function confirmRazorpayOrder( requestArgs ) {
+	const response = await wp.req.post( '/me/razorpay-confirm-payment', requestArgs );
+	debug( 'Razorpay order confirmation response', response );
+	return response;
+}


### PR DESCRIPTION
## Proposed Changes

* WPCOM has a new endpoint for confirming razorpay transaction; this patch adds a helper function to access it.

## Testing Instructions

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
