### PR TITLE
Fix stats date control format

### DIFF
--- a/client/components/stats-date-control/index.tsx
+++ b/client/components/stats-date-control/index.tsx
@@ -118,8 +118,8 @@ const StatsDateControl = ( {
 			return shortcut.label;
 		}
 		// Generate a full date range for the label.
-		const startDate = moment( dateRange.chartStart ).format( 'MMMM Do, YYYY' );
-		const endDate = moment( dateRange.chartEnd ).format( 'MMMM Do, YYYY' );
+		const startDate = moment( dateRange.chartStart ).format( 'LL' );
+		const endDate = moment( dateRange.chartEnd ).format( 'LL' );
 		return `${ startDate } - ${ endDate }`;
 	};
 

--- a/client/components/stats-date-control/stats-date-control-picker-date.tsx
+++ b/client/components/stats-date-control/stats-date-control-picker-date.tsx
@@ -34,11 +34,11 @@ const DateControlPickerDate = ( {
 			</h2>
 			<div className={ `${ BASE_CLASS_NAME }s__inputs` }>
 				<div className={ `${ BASE_CLASS_NAME }s__inputs-input-group` }>
-					<label htmlFor="startDate">From</label>
+					<label htmlFor="startDate">{ translate( 'From', { context: 'from date' } ) }</label>
 					<DateInput id="startDate" value={ startDate } onChange={ onStartChange } />
 				</div>
 				<div className={ `${ BASE_CLASS_NAME }s__inputs-input-group` }>
-					<label htmlFor="endDate">To</label>
+					<label htmlFor="endDate">{ translate( 'To', { context: 'to date' } ) }</label>
 					<DateInput id="endDate" value={ endDate } onChange={ onEndChange } />
 				</div>
 			</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 719-gh-Automattic/i18n-issues

## Proposed Changes

* Wrap the `From` and `To` labels in Stats DateControlPickerDate in translate calls, with additional context to indicate that it refers to dates.
* Update the formatting of selected dates range to use the localized format, instead of `Month Day, Year`.

English and German before:
<img width="933" alt="Screenshot 2024-01-21 at 01 30 16 1" src="https://github.com/Automattic/wp-calypso/assets/7847633/f503ecfe-80c9-41e0-a99e-1366318c78d4">
<img width="942" alt="Screenshot 2024-01-21 at 01 35 56" src="https://github.com/Automattic/wp-calypso/assets/7847633/60f2389c-e66b-4fd6-8de0-e53cdad4cd26">

English and German after:
<img width="942" alt="Screenshot 2024-01-21 at 01 32 15" src="https://github.com/Automattic/wp-calypso/assets/7847633/62a33d98-1439-4769-9e69-e69972a5b8b0">
<img width="942" alt="Screenshot 2024-01-21 at 01 35 20" src="https://github.com/Automattic/wp-calypso/assets/7847633/3bb5772b-582b-4b2b-8b4b-01423d94c87a">


## Testing Instructions

* Code review
* Using local Calypso instance or calypso.live, switch to English, navigate to /stats and check the date picker and the date ranges view.
* Repeat with a Mag-16 locale

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
