### PR TITLE
Live Preview: Add the contenthash to the chunk file to resolve the cache issue

### DIFF
--- a/apps/wpcom-block-editor/webpack.config.js
+++ b/apps/wpcom-block-editor/webpack.config.js
@@ -27,6 +27,7 @@ const shouldEmitStats = process.env.EMIT_STATS && process.env.EMIT_STATS !== 'fa
  * @param   {Object}  argv.entry                    Entry point(s)
  * @param   {string}  argv.outputPath               Output path
  * @param   {string}  argv.outputFilename           Output filename pattern
+ * @param   {string}  argv.outputChunkFilename      Output chunk filename pattern
  * @returns {Object}                                webpack config
  */
 function getWebpackConfig(
@@ -41,10 +42,12 @@ function getWebpackConfig(
 		},
 		outputPath = path.join( __dirname, 'dist' ),
 		outputFilename = isDevelopment ? '[name].js' : '[name].min.js',
+		outputChunkFilename = isDevelopment ? '[name]-[contenthash].js' : '[name]-[contenthash].min.js',
 	}
 ) {
 	const webpackConfig = getBaseWebpackConfig( env, {
 		entry,
+		'output-chunk-filename': outputChunkFilename,
 		'output-filename': outputFilename,
 		'output-path': outputPath,
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1705634123164899-slack-C048CUFRGFQ

## Proposed Changes

* Add the `contenthash` (should we use `[hash]` to make sure it changes on every deploy?) to the chunk file to resolve the cache issue

| | Filename |
| - | - |
| Before | wpcom-live-preview-notice.js |
| After | wpcom-live-preview-notice-123c979e797142ab4bcf.js |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox `widgets.wp.com`
* Apply changes to your sandbox
* Go to Theme Showcase on your site
* Preview a theme
* Check the Network request
* Make sure the `wpcom-live-preview-notice.js` is loaded with the `contenthash`
  ![image](https://github.com/Automattic/wp-calypso/assets/13596067/3cada4dc-9fdc-4863-99ac-15ed00344e09)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?