### PR TITLE
Enable the social first registration on the paid media flow

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -177,7 +177,7 @@ export function generateFlows( {
 		},
 		{
 			name: 'onboarding-pm',
-			steps: [ 'user', 'domains', 'plans' ],
+			steps: [ userSocialStep, 'domains', 'plans' ],
 			destination: getSignupDestination,
 			description:
 				'Paid media version of the onboarding flow. Read more in https://wp.me/pau2Xa-4Kk.',

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -7,14 +7,13 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { isEmpty, omit, get } from 'lodash';
 import PropTypes from 'prop-types';
-import { Component, useEffect, useState } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import SignupForm from 'calypso/blocks/signup-form';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import WooCommerceConnectCartHeader from 'calypso/components/woocommerce-connect-cart-header';
 import { initGoogleRecaptcha, recordGoogleRecaptchaAction } from 'calypso/lib/analytics/recaptcha';
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
-import { useExperiment } from 'calypso/lib/explat';
 import { getSocialServiceFromClientId } from 'calypso/lib/login';
 import {
 	isCrowdsignalOAuth2Client,
@@ -731,54 +730,4 @@ const ConnectedUser = connect(
 	}
 )( localize( UserStep ) );
 
-const ExperimentWrappedUser = ( props ) => {
-	const [ isLayoutSwitchComplete, setIsLayoutSwitchComplete ] = useState(
-		props.flowName !== 'onboarding-pm'
-	);
-	const [ isLoading, experimentAssignment ] = useExperiment(
-		'calypso_gf_signup_onboardingpm_passwordless_registration',
-		{
-			isEligible: props.flowName === 'onboarding-pm',
-		}
-	);
-	useEffect( () => {
-		if ( ! isLoading && props.flowName === 'onboarding-pm' ) {
-			const [ globalDiv ] = document.getElementsByClassName( 'signup__step is-user' );
-			const variationName = experimentAssignment?.variationName;
-			if ( typeof globalDiv === 'object' ) {
-				if ( variationName === 'treatment' ) {
-					globalDiv.classList.add( 'is-passwordless-experiment' );
-				} else if ( variationName === null || variationName === 'control' ) {
-					globalDiv.classList.remove( 'is-passwordless-experiment' );
-				}
-			}
-
-			setIsLayoutSwitchComplete( true );
-		}
-		return () => {
-			if ( props.flowName === 'onboarding-pm' ) {
-				const [ globalDiv ] = document.getElementsByClassName( 'signup__step is-user' );
-				if ( typeof globalDiv === 'object' ) {
-					globalDiv.classList.remove( 'is-passwordless-experiment' );
-				}
-			}
-		};
-	}, [
-		experimentAssignment?.variationName,
-		isLoading,
-		props.flowName,
-		setIsLayoutSwitchComplete,
-	] );
-
-	if ( ! isLayoutSwitchComplete ) {
-		return null;
-	}
-	return (
-		<ConnectedUser
-			{ ...props }
-			isSocialFirst={ experimentAssignment?.variationName === 'treatment' || props.isSocialFirst }
-		/>
-	);
-};
-
-export default ExperimentWrappedUser;
+export default ConnectedUser;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/growth-foundations#268 and fixes Automattic/growth-foundations#274

## Proposed Changes

This PR launches the social-first(a.k.a. the passwordless registration) user step to the paid media flow per conclusion we've agreed on peP6yB-1Wh-p2.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visiting `/start/onboarding-pm`, confirm that the social-first user step shows and works as expected.
* Spot-checking several other existing flows, confirm that they all work as expected, e.g. /start, /setup/newsletter .

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
