### PR TITLE
wpcom-block-description-links: include and register HelpCenter store directly

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/inline-support-link.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/inline-support-link.tsx
@@ -1,10 +1,12 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { HELP_CENTER_STORE } from '@automattic/help-center/src/stores';
+import { HelpCenter } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Button, ExternalLink } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useState, JSXElementConstructor, ReactElement } from 'react';
+
+const HELP_CENTER_STORE = HelpCenter.register();
 
 interface Props {
 	children: string | ReactElement< string | JSXElementConstructor< any > >;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/inline-support-link.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/inline-support-link.tsx
@@ -1,12 +1,9 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-import { HelpCenter } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { Button, ExternalLink } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useState, JSXElementConstructor, ReactElement } from 'react';
-
-const HELP_CENTER_STORE = HelpCenter.register();
 
 interface Props {
 	children: string | ReactElement< string | JSXElementConstructor< any > >;
@@ -24,7 +21,7 @@ export default function DescriptionSupportLink( {
 	// This was cooked up to only apply the link in the BlockEditor sidebar.
 	// Since there was no identifier in the environment to differentiate.
 	const [ ref, setRef ] = useState< Element | null >();
-	const { setShowHelpCenter, setShowSupportDoc } = useDispatch( HELP_CENTER_STORE );
+	const { setShowHelpCenter, setShowSupportDoc } = useDispatch( 'automattic/help-center' );
 
 	if ( ref && ! ref?.closest( '.block-editor-block-inspector' ) ) {
 		return children as JSX.Element;


### PR DESCRIPTION
Fixes #86694, at least partially. Instead of including the Help Center store from the `help-center` package, which leads to also registering `User` and `Site` stores, just include and register the `HelpCenter` store directly from `data-stores`.

This reduces the size of the `wpcom-block-description-links` plugin script from 125kB to 70kB.

We could do even better by externalizing the `help-center` package with dependency extraction plugin, and by doing the same with dependencies like `i18n-calypso`. But that's not an one-liner like this PR.