### PR TITLE
Jetpack Manage: Fix onboarding JS error for missing product icon

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-store/utils/get-product-icon.ts
+++ b/client/my-sites/plans/jetpack-plans/product-store/utils/get-product-icon.ts
@@ -121,8 +121,7 @@ const PRODUCT_ICON_MAP: Record< string, IconResource > = {
 
 const getProductIcon = ( { productSlug, light }: productIconProps ): string => {
 	const iconResource = PRODUCT_ICON_MAP[ productSlug ];
-
-	return light ? iconResource.light : iconResource.regular;
+	return light ? iconResource?.light : iconResource?.regular;
 };
 
 export default getProductIcon;


### PR DESCRIPTION
## Proposed Changes

Newly signed-up users of Manage will land on the `/onboarding` page, but due to a missing product icon, a JS error was thrown.

## Testing Instructions

- Create a new agency user
- Verify that the onboarding page loads fine on the initial load

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?