### PR TITLE
Add tracks events to marketplace reviews

### DIFF
--- a/client/my-sites/marketplace/components/review-item/create-review-item.tsx
+++ b/client/my-sites/marketplace/components/review-item/create-review-item.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { isEnabled } from '@automattic/calypso-config';
 import { Button, ConfettiAnimation } from '@automattic/components';
 import Card from '@automattic/components/src/card';
@@ -48,6 +49,12 @@ export function MarketplaceCreateReviewItem( props: MarketplaceCreateReviewItemP
 
 	const createReviewMutation = useCreateMarketplaceReviewMutation( { productType, slug } );
 	const createReview = () => {
+		recordTracksEvent( 'calypso_marketplace_reviews_add_submit', {
+			product_type: productType,
+			slug: slug,
+			rating: Number( rating ),
+		} );
+
 		createReviewMutation.mutate(
 			{ productType, slug, content, rating },
 			{

--- a/client/my-sites/marketplace/components/review-item/index.tsx
+++ b/client/my-sites/marketplace/components/review-item/index.tsx
@@ -17,6 +17,7 @@ import {
 	EMPTY_PLACEHOLDER,
 } from 'calypso/data/marketplace/use-marketplace-reviews';
 import { getAvatarURL } from 'calypso/data/marketplace/utils';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { sanitizeSectionContent } from 'calypso/lib/plugins/sanitize-section-content';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import './style.scss';
@@ -71,6 +72,12 @@ export const MarketplaceReviewItem = ( props: MarketplaceReviewItemProps ) => {
 
 	const updateReviewMutation = useUpdateMarketplaceReviewMutation( { ...props } );
 	const updateReview = ( reviewId: number ) => {
+		recordTracksEvent( 'calypso_marketplace_reviews_update_submit', {
+			product_type: props.productType,
+			slug: props.slug,
+			rating: Number( editorRating ),
+		} );
+
 		updateReviewMutation.mutate(
 			{
 				reviewId: reviewId,

--- a/client/my-sites/marketplace/components/reviews-modal/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-modal/index.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { Dialog, Button } from '@automattic/components';
 import { getLocaleSlug, useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import Rating from 'calypso/components/rating';
 import { PluginPeriodVariations } from 'calypso/data/marketplace/types';
@@ -10,6 +10,7 @@ import {
 	useMarketplaceReviewsQuery,
 	useMarketplaceReviewsStatsQuery,
 } from 'calypso/data/marketplace/use-marketplace-reviews';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { getProductSlugByPeriodVariation } from 'calypso/lib/plugins/utils';
 import { MarketplaceReviewsList } from 'calypso/my-sites/marketplace/components/reviews-list';
 import './styles.scss';
@@ -39,6 +40,13 @@ export const ReviewsModal = ( props: Props ) => {
 		( state ) => productType === 'plugin' && isMarketplaceProduct( state, slug )
 	);
 	const [ editCompletedTimes, setEditCompletedTimes ] = useState( 0 );
+
+	useEffect( () => {
+		recordTracksEvent( 'calypso_marketplace_reviews_modal_open', {
+			product_type: productType,
+			slug: slug,
+		} );
+	}, [ productType, slug ] );
 
 	const { data: userReviews, isFetching: isFetchingUserReviews } = useMarketplaceReviewsQuery( {
 		productType,

--- a/client/my-sites/marketplace/components/reviews-modal/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-modal/index.tsx
@@ -87,6 +87,10 @@ export const ReviewsModal = ( props: Props ) => {
 			className="marketplace-reviews-modal"
 			isVisible={ isVisible }
 			onClose={ () => {
+				recordTracksEvent( 'calypso_marketplace_reviews_modal_close', {
+					product_type: productType,
+					slug: slug,
+				} );
 				onClose();
 				setEditCompletedTimes( 0 );
 			} }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/5269

## Proposed Changes

Add tracks events for:
- opening the reviews modal
- adding a new review
- updating a review
- closing the reviews modal

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this patch and navigate to a plugin in an environment with the following flags enabled: `marketplace-add-review` and `marketplace-reviews-show`
* Open developer tools and activate logging for track events running `localStorage.debug='calypso:analytics'`. Make sure you have logging level set to `Verbose` in dev tools. Keep the Console tab open
* Go to a plugin details that you are able to review, e.g. `/plugin/woocommerce-bookings`
* Open the reviews modal (by either clicking the number of reviews in the plugin header, or the `Read all reviews` link in the reviews section)
* Make sure you can see a tracks event logged named `calypso_marketplace_reviews_modal_open` with the `productType` as `plugin` and the plugin slug as `slug`
* Add a new review, and click the `Leave my review` button
* Make sure you can see a tracks event logged named `calypso_marketplace_reviews_add_submit` with the same parameters.
* Update your review
* Make sure you can see a tracks event logged named `calypso_marketplace_reviews_update_submit` with the same parameters.
* Dismiss the modal, clicking on the `X` or pressing `ESC` key
* Make sure you can see a tracks event logged named `calypso_marketplace_reviews_modal_close` with the same parameters.

![CleanShot 2024-01-22 at 12 47 19](https://github.com/Automattic/wp-calypso/assets/11555574/8308f9cb-2b70-465f-92ae-dbaa2a404629)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?