### PR TITLE
Monitor: use american english term instead of British english

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/test/toggle-activate-monitoring.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/toggle-activate-monitoring/test/toggle-activate-monitoring.tsx
@@ -115,7 +115,7 @@ describe( 'ToggleActivateMonitoring', () => {
 			userEvent.hover( button );
 		} );
 		waitFor( () => {
-			expect( screen.getByText( 'Maximise uptime' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Maximize uptime' ) ).toBeInTheDocument();
 		} );
 	} );
 

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-badge/test/upgrade-badge.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-badge/test/upgrade-badge.tsx
@@ -36,7 +36,7 @@ describe( 'UpgradeBadge', () => {
 			userEvent.hover( badgeWrapper );
 		} );
 		waitFor( () => {
-			expect( screen.getByText( 'Maximise uptime' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Maximize uptime' ) ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/index.tsx
@@ -84,7 +84,7 @@ export default function UpgradePopover( {
 			showDelay={ 300 }
 			onShow={ handleOnShow }
 		>
-			<h2 className="upgrade-popover__heading">{ translate( 'Maximise uptime' ) }</h2>
+			<h2 className="upgrade-popover__heading">{ translate( 'Maximize uptime' ) }</h2>
 			{ dismissibleWithPreference && (
 				<Button
 					borderless

--- a/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/test/upgrade-popover.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/downtime-monitoring/upgrade-popover/test/upgrade-popover.tsx
@@ -35,7 +35,7 @@ describe( 'UpgradePopover', () => {
 	it( 'renders the component when the popover is visible and not dismissible', () => {
 		render( <UpgradePopover { ...defaultProps } />, { wrapper: Wrapper } );
 
-		expect( screen.getByText( 'Maximise uptime' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Maximize uptime' ) ).toBeInTheDocument();
 		expect( screen.getByText( '1 minute monitoring interval' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'SMS Notifications' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Multiple email recipients' ) ).toBeInTheDocument();
@@ -64,7 +64,7 @@ describe( 'UpgradePopover', () => {
 
 	it( 'renders an empty component when the popover is not visible', () => {
 		render( <UpgradePopover { ...defaultProps } isVisible={ false } />, { wrapper: Wrapper } );
-		expect( screen.queryByText( 'Maximise uptime' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Maximize uptime' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the component when the popover is dismissible and show close button', () => {
@@ -73,7 +73,7 @@ describe( 'UpgradePopover', () => {
 			wrapper: Wrapper,
 		} );
 
-		expect( screen.getByText( 'Maximise uptime' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Maximize uptime' ) ).toBeInTheDocument();
 		const closeButton = screen.getByRole( 'button', { name: 'Close' } );
 		expect( closeButton ).toBeInTheDocument();
 		fireEvent.click( closeButton );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-downtime-monitoring-upgrade-banner/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-downtime-monitoring-upgrade-banner/index.tsx
@@ -68,7 +68,7 @@ export default function SiteDowntimeMonitoringUpgradeBanner() {
 			className="site-downtime-monitoring-upgrade-banner"
 			title={ translate( 'Your uptime, our priority: enhanced Downtime Monitoring' ) }
 			description={ translate(
-				'Maximise uptime with our swift 1-minute interval alerts, now supporting multi-emails and SMS notifications.'
+				'Maximize uptime with our swift 1-minute interval alerts, now supporting multi-emails and SMS notifications.'
 			) }
 			disableCircle
 			horizontal


### PR DESCRIPTION
## Proposed Changes

* Update wording from "maximise" to "maximize" in Monitor messaging. We try to use american english by default, and British english becomes available as a language pack.

## Testing Instructions

* Go to https://cloud.jetpack.com/dashboard
* Ensure "maximise" is now "maximize" in Monitor prompts.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
