### PR TITLE
Clean up translation for upsell in plan selection screen.

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
+++ b/client/my-sites/plans-features-main/components/plan-upsell-modal/paid-plan-is-required-dialog.tsx
@@ -1,8 +1,6 @@
 import { LoadingPlaceholder } from '@automattic/components';
-import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { PlanButton } from '@automattic/plans-grid-next';
 import { useEffect, useState } from '@wordpress/element';
-import { hasTranslation } from '@wordpress/i18n';
 import { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import {
@@ -37,18 +35,9 @@ export default function PaidPlanIsRequiredDialog( {
 		onFreePlanSelected();
 	}
 
-	const isEnglish = useIsEnglishLocale();
-	const upsellDescription =
-		isEnglish ||
-		hasTranslation(
-			"Custom domains are only available with a paid plan. Choose annual billing and receive the domain's first year free."
-		)
-			? translate(
-					"Custom domains are only available with a paid plan. Choose annual billing and receive the domain's first year free."
-			  )
-			: translate(
-					'Custom domains are only available with a paid plan. And they are free for the first year with an annual paid plan.'
-			  );
+	const upsellDescription = translate(
+		"Custom domains are only available with a paid plan. Choose annual billing and receive the domain's first year free."
+	);
 
 	return (
 		<DialogContainer>


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/85929

## Proposed Changes

Recently we updated the text copy on the upsell plans to Custom domains are only available with a paid plan. `Choose annual billing and receive the domain's first year free.`,  https://github.com/Automattic/wp-calypso/pull/86359
Now, the translation is done for all languages and we are cleaning up the `hasTranslation` from the code.

## Testing Instructions

- Apply this PR and start the application. 
- In an incognito window, go to http://calypso.localhost:3000/start
- Create an account using an email.
- Select a paid domain (.com, for example).
- In the plan selection screen, select the Free plan.
- You will see the upsell popup with the new phrase.
<img width="701" alt="Screenshot 2023-12-18 at 11 39 07" src="https://github.com/Automattic/wp-calypso/assets/3832570/fc2de955-717a-4fa4-be74-19c3bf9cb6aa">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
