### PR TITLE
Strip zero width space chars from dns records

### DIFF
--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -245,7 +245,6 @@ class DnsAddNew extends React.Component {
 
 	onChange = ( event ) => {
 		const { name, value } = event.target;
-
 		const skipNormalization = name === 'data' && this.state.type === 'TXT';
 		// Strip zero width spaces from the value
 		const filteredValue = value.replace( /\u200B/g, '' );

--- a/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
+++ b/client/my-sites/domains/domain-management/dns/dns-add-new.jsx
@@ -245,11 +245,14 @@ class DnsAddNew extends React.Component {
 
 	onChange = ( event ) => {
 		const { name, value } = event.target;
+
 		const skipNormalization = name === 'data' && this.state.type === 'TXT';
+		// Strip zero width spaces from the value
+		const filteredValue = value.replace( /\u200B/g, '' );
 
 		this.formStateController.handleFieldChange( {
 			name,
-			value: skipNormalization ? value : value.trim().toLowerCase(),
+			value: skipNormalization ? filteredValue : filteredValue.trim().toLowerCase(),
 		} );
 	};
 

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -89,7 +89,8 @@ function isValidData( data, type ) {
 
 function getNormalizedData( record, selectedDomainName ) {
 	const normalizedRecord = Object.assign( {}, record );
-	normalizedRecord.data = getFieldWithDot( record.data );
+	normalizedRecord.data = stripZeroWidthSpace( getFieldWithDot( record.data ) );
+
 	normalizedRecord.name = getNormalizedName( record.name, record.type, selectedDomainName );
 	if ( record.target ) {
 		normalizedRecord.target = getFieldWithDot( record.target );
@@ -110,6 +111,10 @@ function getNormalizedName( name, type, selectedDomainName ) {
 	}
 
 	return name;
+}
+
+function stripZeroWidthSpace( data ) {
+	return data.replace( /&#8203;/g, '' );
 }
 
 function isRootDomain( name, domainName ) {

--- a/client/state/domains/dns/utils.js
+++ b/client/state/domains/dns/utils.js
@@ -89,8 +89,7 @@ function isValidData( data, type ) {
 
 function getNormalizedData( record, selectedDomainName ) {
 	const normalizedRecord = Object.assign( {}, record );
-	normalizedRecord.data = stripZeroWidthSpace( getFieldWithDot( record.data ) );
-
+	normalizedRecord.data = getFieldWithDot( record.data );
 	normalizedRecord.name = getNormalizedName( record.name, record.type, selectedDomainName );
 	if ( record.target ) {
 		normalizedRecord.target = getFieldWithDot( record.target );
@@ -111,10 +110,6 @@ function getNormalizedName( name, type, selectedDomainName ) {
 	}
 
 	return name;
-}
-
-function stripZeroWidthSpace( data ) {
-	return data.replace( /&#8203;/g, '' );
 }
 
 function isRootDomain( name, domainName ) {


### PR DESCRIPTION
## Proposed Changes

We recently sent out an email with instructions to insert an spf txt record. Unfortunately, there was an error in the code to copy, which included a zero width space html character (`&#8203;`)

This is a quick fix that strips these characters out from the record before submitting data.

## Testing Instructions

Adds a new txt record with this format:
`v=spf1 include:_spf.&#8203;wpcloud.&#8203;com ~all`

and check that `&#8203;` are removed before sbumitting.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?