### PR TITLE
Global Styles: Reduce the banner height by inlining the action buttons

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
@@ -17,6 +17,30 @@
 	}
 }
 
+.components-notice:has(.wpcom-global-styles-action-is-upgrade):not(:has(.wpcom-global-styles-action-is-support)) {
+	.components-notice__content {
+		display: flex;
+		flex-wrap: wrap;
+		margin-right: 0;
+		line-height: 36px;
+
+		.components-notice__actions {
+			margin-left: auto;
+
+			.components-notice__action {
+				margin-top: 0;
+			}
+		}
+	}
+
+	// Hack: this notice is intentionally set to be dismissible (but we hide the close icon),
+	// so that it is guaranteed to be displayed after the non-dismissible notices,
+	// such as the Block Theme Preview notice.
+	.components-notice__dismiss {
+		display: none;
+	}
+}
+
 .components-notice-list .components-notice__action.components-button.wpcom-global-styles-action-has-icon {
 	display: flex;
 	&::after,

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
@@ -22,7 +22,7 @@
 		display: flex;
 		flex-wrap: wrap;
 		margin-right: 0;
-		line-height: 36px;
+		align-items: center;
 
 		.components-notice__actions {
 			margin-left: auto;

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notice.scss
@@ -17,27 +17,30 @@
 	}
 }
 
-.components-notice:has(.wpcom-global-styles-action-is-upgrade):not(:has(.wpcom-global-styles-action-is-support)) {
-	.components-notice__content {
-		display: flex;
-		flex-wrap: wrap;
-		margin-right: 0;
-		align-items: center;
+// Inline the action buttons when there is another pinned notice,
+// such as the Live Preview notice.
+.components-notice-list:has(.components-notice) ~ .components-notice-list {
+	.components-notice:has(.wpcom-global-styles-action-is-upgrade) {
+		.components-notice__content {
+			display: flex;
+			flex-wrap: wrap;
+			margin-right: 0;
+			align-items: center;
 
-		.components-notice__actions {
-			margin-left: auto;
+			.components-notice__actions {
+				margin-left: auto;
 
-			.components-notice__action {
-				margin-top: 0;
+				.components-notice__action {
+					margin-top: 0;
+				}
 			}
 		}
-	}
 
-	// Hack: this notice is intentionally set to be dismissible (but we hide the close icon),
-	// so that it is guaranteed to be displayed after the non-dismissible notices,
-	// such as the Block Theme Preview notice.
-	.components-notice__dismiss {
-		display: none;
+		// Hack: this notice is intentionally set to be dismissible (but we hide the close icon),
+		// so that it is guaranteed to be displayed after the pinned notices.
+		.components-notice__dismiss {
+			display: none;
+		}
 	}
 }
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
@@ -12,6 +12,7 @@ import {
 	useState,
 } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import classnames from 'classnames';
 import { useCanvas } from './use-canvas';
 import { useGlobalStylesConfig } from './use-global-styles-config';
 import { usePreview } from './use-preview';
@@ -147,8 +148,11 @@ function GlobalStylesEditNotice() {
 				onClick: upgradePlan,
 				variant: 'primary',
 				noDefaultClasses: true,
-				className:
-					'wpcom-global-styles-action-is-upgrade wpcom-global-styles-action-has-icon wpcom-global-styles-action-is-external',
+				className: classnames(
+					'wpcom-global-styles-action-is-upgrade',
+					'wpcom-global-styles-action-has-icon',
+					'wpcom-global-styles-action-is-external'
+				),
 			},
 		];
 

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-global-styles/notices.js
@@ -147,7 +147,8 @@ function GlobalStylesEditNotice() {
 				onClick: upgradePlan,
 				variant: 'primary',
 				noDefaultClasses: true,
-				className: 'wpcom-global-styles-action-has-icon wpcom-global-styles-action-is-external',
+				className:
+					'wpcom-global-styles-action-is-upgrade wpcom-global-styles-action-has-icon wpcom-global-styles-action-is-external',
 			},
 		];
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

- https://github.com/Automattic/wp-calypso/issues/85538

## Proposed Changes

After time-boxing this for 2 days, I came into conclusion that combining the Global Styles and Live Preview notices is a futile attempt unless we move both of them to a shared location (e.g. `jetpack-mu-wpcom`).

Currently, GS code lives in `editing-toolkit-plugin`, whereas LP code lives in `wpcom-block-editor`, so to share some logic, we must be duplicating some code from one location from another if we keep both of them in their existing location.

Refactoring GS and LP code to a shared location requires a non-trivial dev effort, and we have other priorities right now. So for now, I implemented a minimum solution which is to modify the CSS of the GS banner so that its height is reduced.

Some design considerations:

- I keep the GS banner to be a "warning" banner to distinguish it with the LP banner (which is now an "info" banner).
- I am hesitant to reorder the action buttons in the GS banner, because I'm afraid I will be affecting the revenue if we move the Upgrade button to the right as per the proposed new design. So, for now I keep it in the left.
- I made this banner non-dismissible as per the proposed new design (it was dismissible).
- I keep the banner in the Post Editor unchanged, because it contains 3 action buttons, and the layout will be broken on narrow screen.

cc: @matt-west. Does this PR (along with the considerations above) make sense?

### In Site Editor (with Live Preview)

Before

<img width="1432" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/8b0a18d2-cc80-4ca9-a4f7-28fb0eeed6c7">

After

<img width="1433" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/18b93ebd-6c8f-45fe-8d88-a7fee7e16ee7">

### In Site Editor (without Live Preview)

Before & After (no changes)

<img width="1430" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/0e43f2af-9725-4817-b9f5-9b3258ee77aa">


### In Post Editor

Before & After (no changes)

<img width="1094" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/d5de4522-4ed3-44b6-9e26-8503ad61b960">


## Testing Instructions

1. Sandbox your site.
2. Patch this to your sandbox (`install-plugins.sh etk global-styles-reduce-height`)
3. Verify that the GS banner is updated under all scenarios described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?