### PR TITLE
Woo Express: Don't show the storage upgrade link for Performance plan users

### DIFF
--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -3,6 +3,7 @@ import {
 	planHasFeature,
 	isBusinessPlan,
 	isEcommercePlan,
+	isWooExpressMediumPlan,
 	PLAN_FREE,
 	PLAN_WPCOM_PRO,
 	PLAN_WPCOM_FLEXIBLE,
@@ -74,7 +75,10 @@ export function PlanStorage( { children, className, siteId } ) {
 	}
 
 	const planHasTopStorageSpace =
-		isBusinessPlan( sitePlanSlug ) || isEcommercePlan( sitePlanSlug ) || isProPlan( sitePlanSlug );
+		isBusinessPlan( sitePlanSlug ) ||
+		isEcommercePlan( sitePlanSlug ) ||
+		isProPlan( sitePlanSlug ) ||
+		isWooExpressMediumPlan( sitePlanSlug );
 
 	const displayUpgradeLink = canUserUpgrade && ! planHasTopStorageSpace && ! isStagingSite;
 	const isSharedQuota = isStagingSite || hasStagingSite;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #83326

## Proposed Changes

This adds the Woo Express Performance plan to the list of plans that we _don't_ show a storage upgrade for in the media library.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to production https://wordpress.com/setup/wooexpress and create a new Woo Express trial site.
* Upgrade the site to the Performance plan.
* Go to `https://wordpress.com/media/:siteSlug`.
* You should see an "Upgrade" link next to the amount of storage used.
![image](https://github.com/Automattic/wp-calypso/assets/917632/bf673133-db81-46d9-873a-f4673cfb63a9)
* Now go to `/media/:siteSlug` either using the calypso.live url or by running this branch in Calypso locally.
* You should no longer see the "Upgrade" link.
![image](https://github.com/Automattic/wp-calypso/assets/917632/e902d90d-4fa8-4ca3-8a6d-78fad1868bea)
* Create a new Woo Express trial site and upgrade it to the Essential plan.
* You should still see the "Upgrade" link in the media library.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
