### PR TITLE
Memberships: Add state tests for Coupons UI

### DIFF
--- a/client/state/memberships/coupon-list/schema.js
+++ b/client/state/memberships/coupon-list/schema.js
@@ -31,7 +31,7 @@ const couponSchema = {
 const couponListSchema = {
 	type: 'object',
 	patternProperties: {
-		'\\d+$': {
+		'^\\d+$': {
 			type: 'array',
 			items: couponSchema,
 		},

--- a/client/state/memberships/coupon-list/selectors.js
+++ b/client/state/memberships/coupon-list/selectors.js
@@ -1,5 +1,7 @@
 import 'calypso/state/memberships/init';
 
+const EMPTY_LIST = [];
+
 export function getCouponsForSiteId( state, siteId ) {
-	return state.memberships?.couponList.items[ siteId ] ?? [];
+	return state.memberships?.couponList.items[ siteId ] ?? EMPTY_LIST;
 }

--- a/client/state/memberships/coupon-list/test/actions.js
+++ b/client/state/memberships/coupon-list/test/actions.js
@@ -3,7 +3,33 @@ import {
 	MEMBERSHIPS_COUPON_RECEIVE,
 	MEMBERSHIPS_COUPON_DELETE,
 } from 'calypso/state/action-types';
-import { requestCoupons, receiveUpdateCoupon, receiveDeleteCoupon } from '../actions';
+import {
+	COUPON_DISCOUNT_TYPE_PERCENTAGE,
+	COUPON_DURATION_FOREVER,
+} from '../../../../my-sites/earn/memberships/constants';
+import {
+	requestCoupons,
+	receiveUpdateCoupon,
+	receiveDeleteCoupon,
+	requestAddCoupon,
+	requestUpdateCoupon,
+	requestDeleteCoupon,
+} from '../actions';
+
+const mockCoupon = {
+	coupon_code: 'COUPON4',
+	discount_type: COUPON_DISCOUNT_TYPE_PERCENTAGE,
+	discount_value: 50,
+	discount_percentage: 50,
+	start_date: '2023-12-20',
+	end_date: undefined,
+	plan_ids_allow_list: [],
+	cannot_be_combined: true,
+	can_be_combined: false, //TODO: remove when backend switches to cannot_be_combined
+	first_time_purchase_only: false,
+	duration: COUPON_DURATION_FOREVER,
+	email_allow_list: [],
+}
 
 describe( 'actions', () => {
 	describe( 'requestCoupons()', () => {
@@ -32,6 +58,195 @@ describe( 'actions', () => {
 				siteId: 123,
 				type: MEMBERSHIPS_COUPON_DELETE,
 			} );
+		} );
+	} );
+
+	describe( 'requestAddCoupon()', () => {
+		test( 'should dispatch add coupon failure and error notice on failure', async () => {
+			const siteId = 1;
+			const coupon = mockCoupon;
+			nock( 'https://public-api.wordpress.com' )
+				.post( '/wpcom/v2/sites/1/memberships/coupons' )
+				.replyWithError( { code: 'validation_error', message: 'Coupon code is already used' } );
+			const noticeText = 'Added coupon';
+			const dispatchedActions = [];
+
+			const dispatch = ( obj ) => dispatchedActions.push( obj );
+			await requestAddCoupon( siteId, coupon, noticeText )( dispatch );
+
+			const [ addAction, addFailureAction, noticeCreateAction ] = dispatchedActions;
+			expect( addAction ).toHaveProperty( 'coupon' );
+			expect( addAction ).toHaveProperty( 'siteId' );
+			expect( addAction ).toHaveProperty( 'type' );
+			expect( addFailureAction ).toHaveProperty( 'error' );
+			expect( addFailureAction ).toHaveProperty( 'siteId' );
+			expect( addFailureAction ).toHaveProperty( 'type' );
+			expect( noticeCreateAction ).toHaveProperty( 'notice' );
+			expect( noticeCreateAction ).toHaveProperty( 'type' );
+		} );
+
+		test( 'should dispatch an http request to the add coupon endpoint and associated actions', async () => {
+			const siteId = 1;
+			const couponId = '123';
+			const coupon = mockCoupon;
+			nock( 'https://public-api.wordpress.com' )
+				.post( '/wpcom/v2/sites/1/memberships/coupons' )
+				.reply( 200, { id: couponId, ...coupon } );
+			const noticeText = 'Added coupon';
+			const dispatchedActions = [];
+			const dispatch = ( obj ) => dispatchedActions.push( obj );
+
+			await requestAddCoupon( siteId, coupon, noticeText )( dispatch );
+
+			const [ addAction, receiveAction, noticeCreateAction ] = dispatchedActions;
+			expect( addAction ).toHaveProperty( 'coupon' );
+			expect( addAction ).toHaveProperty( 'siteId' );
+			expect( addAction ).toHaveProperty( 'type' );
+			expect( receiveAction ).toHaveProperty( 'coupon' );
+			expect( receiveAction.coupon ).toHaveProperty( 'ID' );
+			expect( receiveAction ).toHaveProperty( 'siteId' );
+			expect( receiveAction ).toHaveProperty( 'type' );
+			expect( noticeCreateAction ).toHaveProperty( 'notice' );
+			expect( noticeCreateAction ).toHaveProperty( 'type' );
+		} );
+	} );
+
+	describe( 'requestUpdateCoupon()', () => {
+		test( 'should dispatch update coupon failure and error notice on failure', async () => {
+			const siteId = 1;
+			const couponId = '123';
+			const coupon = {
+				...mockCoupon,
+				discount_value: 5,
+				discount_percentage: 0,
+				start_date: '2023-12-20',
+				end_date: '2024-04-12',
+				first_time_purchase_only: true,
+				email_allow_list: [ '*@*.edu' ],
+			};
+			const couponContainingId = { ID: parseInt( couponId ), ...coupon };
+			nock( 'https://public-api.wordpress.com' )
+				.put( '/wpcom/v2/sites/1/memberships/coupon/123' )
+				.replyWithError( {
+					code: 'other_error',
+					message: 'Something went wrong updating this coupon.',
+				} );
+			const noticeText = 'Updated coupon';
+			const dispatchedActions = [];
+
+			const dispatch = ( obj ) => dispatchedActions.push( obj );
+			await requestUpdateCoupon( siteId, couponContainingId, noticeText )( dispatch );
+
+			const [ updateAction, updateFailureAction, noticeCreateAction ] = dispatchedActions;
+			expect( updateAction ).toHaveProperty( 'coupon' );
+			expect( updateAction ).toHaveProperty( 'siteId' );
+			expect( updateAction ).toHaveProperty( 'type' );
+			expect( updateFailureAction ).toHaveProperty( 'error' );
+			expect( updateFailureAction ).toHaveProperty( 'siteId' );
+			expect( updateFailureAction ).toHaveProperty( 'type' );
+			expect( noticeCreateAction ).toHaveProperty( 'notice' );
+			expect( noticeCreateAction ).toHaveProperty( 'type' );
+		} );
+
+		test( 'should dispatch an http request to the update coupon endpoint and associated actions', async () => {
+			const siteId = 1;
+			const couponId = '123';
+			const coupon = {
+				...mockCoupon,
+				discount_value: 5,
+				discount_percentage: 0,
+				start_date: '2023-12-20',
+				end_date: '2024-04-12',
+				first_time_purchase_only: true,
+				email_allow_list: [ '*@*.edu' ],
+			};
+			const couponContainingId = { ID: parseInt( couponId ), ...coupon };
+			nock( 'https://public-api.wordpress.com' )
+				.put( '/wpcom/v2/sites/1/memberships/coupon/123' )
+				.reply( 200, { id: couponId, ...coupon } );
+			const noticeText = 'Updated coupon';
+			const dispatchedActions = [];
+			const dispatch = ( obj ) => dispatchedActions.push( obj );
+			await requestUpdateCoupon( siteId, couponContainingId, noticeText )( dispatch );
+
+			const [ updateAction, receiveAction, noticeCreateAction ] = dispatchedActions;
+			expect( updateAction ).toHaveProperty( 'coupon' );
+			expect( updateAction ).toHaveProperty( 'siteId' );
+			expect( updateAction ).toHaveProperty( 'type' );
+			expect( receiveAction ).toHaveProperty( 'coupon' );
+			expect( receiveAction ).toHaveProperty( 'siteId' );
+			expect( receiveAction ).toHaveProperty( 'type' );
+			expect( noticeCreateAction ).toHaveProperty( 'notice' );
+			expect( noticeCreateAction ).toHaveProperty( 'type' );
+		} );
+	} );
+
+	describe( 'requestDeleteCoupon()', () => {
+		test( 'should dispatch delete coupon failure and error notice on failure', async () => {
+			const siteId = 1;
+			const couponId = '123';
+			const coupon = {
+				...mockCoupon,
+				discount_value: 5,
+				discount_percentage: 0,
+				start_date: '2023-12-20',
+				end_date: '2024-04-12',
+				first_time_purchase_only: true,
+				email_allow_list: [ '*@*.edu' ],
+			};
+			const couponContainingId = { ID: parseInt( couponId ), ...coupon };
+			const noticeText = 'Coupon deleted';
+			const dispatchedActions = [];
+
+			nock( 'https://public-api.wordpress.com' )
+				.delete( '/wpcom/v2/sites/1/memberships/coupon/123' )
+				.replyWithError( {
+					code: 'other_error',
+					message: 'Something went wrong when deleting this coupon.',
+				} );
+
+			const dispatch = ( obj ) => dispatchedActions.push( obj );
+			await requestDeleteCoupon( siteId, couponContainingId, noticeText )( dispatch );
+
+			const [ deleteAction, deleteFailureAction, noticeCreateAction ] = dispatchedActions;
+			expect( deleteAction ).toHaveProperty( 'coupon' );
+			expect( deleteAction ).toHaveProperty( 'siteId' );
+			expect( deleteAction ).toHaveProperty( 'type' );
+			expect( deleteFailureAction ).toHaveProperty( 'error' );
+			expect( deleteFailureAction ).toHaveProperty( 'siteId' );
+			expect( deleteFailureAction ).toHaveProperty( 'type' );
+			expect( noticeCreateAction ).toHaveProperty( 'notice' );
+			expect( noticeCreateAction ).toHaveProperty( 'type' );
+		} );
+
+		test( 'should dispatch an http request to the delete coupon endpoint and associated actions', async () => {
+			const siteId = 1;
+			const couponId = '123';
+			const coupon = {
+				...mockCoupon,
+				discount_value: 5,
+				discount_percentage: 0,
+				start_date: '2023-12-20',
+				end_date: '2024-04-12',
+				first_time_purchase_only: true,
+				email_allow_list: [ '*@*.edu' ],
+			};
+			const couponContainingId = { ID: parseInt( couponId ), ...coupon };
+			const noticeText = 'Coupon deleted';
+			const dispatchedActions = [];
+			const dispatch = ( obj ) => dispatchedActions.push( obj );
+			nock( 'https://public-api.wordpress.com' )
+				.delete( '/wpcom/v2/sites/1/memberships/coupon/123' )
+				.reply( 200 );
+
+			await requestDeleteCoupon( siteId, couponContainingId, noticeText )( dispatch );
+
+			const [ deleteAction, noticeCreateAction ] = dispatchedActions;
+			expect( deleteAction ).toHaveProperty( 'coupon' );
+			expect( deleteAction ).toHaveProperty( 'siteId' );
+			expect( deleteAction ).toHaveProperty( 'type' );
+			expect( noticeCreateAction ).toHaveProperty( 'notice' );
+			expect( noticeCreateAction ).toHaveProperty( 'type' );
 		} );
 	} );
 } );

--- a/client/state/memberships/coupon-list/test/actions.js
+++ b/client/state/memberships/coupon-list/test/actions.js
@@ -1,3 +1,4 @@
+import nock from 'nock';
 import {
 	MEMBERSHIPS_COUPONS_LIST,
 	MEMBERSHIPS_COUPON_RECEIVE,
@@ -29,7 +30,7 @@ const mockCoupon = {
 	first_time_purchase_only: false,
 	duration: COUPON_DURATION_FOREVER,
 	email_allow_list: [],
-}
+};
 
 describe( 'actions', () => {
 	describe( 'requestCoupons()', () => {

--- a/client/state/memberships/coupon-list/test/reducer.js
+++ b/client/state/memberships/coupon-list/test/reducer.js
@@ -1,0 +1,58 @@
+import deepFreeze from 'deep-freeze';
+import {
+	MEMBERSHIPS_COUPONS_RECEIVE,
+	MEMBERSHIPS_COUPON_RECEIVE,
+	MEMBERSHIPS_COUPON_DELETE,
+} from '../../../action-types';
+import { items } from '../reducer';
+
+describe( 'reducer', () => {
+	test( 'items() should default to an empty object', () => {
+		expect( items( undefined, {} ) ).toEqual( {} );
+	} );
+
+	test( 'MEMBERSHIPS_COUPONS_RECEIVE should properly add existing coupons for site', () => {
+		const coupons = [ { ID: 1 }, { ID: 2 } ];
+		const siteId = 1;
+		const expectation = { 1: coupons };
+
+		expect( items( {}, { type: MEMBERSHIPS_COUPONS_RECEIVE, siteId, coupons } ) ).toEqual(
+			expectation
+		);
+	} );
+
+	describe( 'MEMBERSHIPS_COUPON_RECEIVE', () => {
+		test( 'should properly add a new coupon for site', () => {
+			const existingCoupons = [ { ID: 1 }, { ID: 2 } ];
+			const existingState = deepFreeze( { 1: existingCoupons } );
+			const newCoupon = { ID: 3 };
+			const siteId = '1';
+			const expectation = { 1: [ newCoupon, ...existingCoupons ] };
+			expect(
+				items( existingState, { type: MEMBERSHIPS_COUPON_RECEIVE, siteId, coupon: newCoupon } )
+			).toEqual( expectation );
+		} );
+
+		test( 'should properly add a new coupon for a different site', () => {
+			const existingCouponsForSite1 = [ { ID: 1 }, { ID: 2 }, { ID: 3 } ];
+			const existingState = deepFreeze( { 1: existingCouponsForSite1 } );
+			const newCoupon = { ID: 4 };
+			const siteId = '2';
+			const expectation = { 1: existingCouponsForSite1, 2: [ newCoupon ] };
+			expect(
+				items( existingState, { type: MEMBERSHIPS_COUPON_RECEIVE, siteId, coupon: newCoupon } )
+			).toEqual( expectation );
+		} );
+	} );
+
+	test( 'MEMBERSHIPS_COUPON_DELETE should properly delete coupons for specified site', () => {
+		const existingCoupons = [ { ID: 1 }, { ID: 2 }, { ID: 3 } ];
+		const existingState = { 1: existingCoupons };
+		const couponToDelete = { ID: 3 };
+		const siteId = '1';
+		const expectation = { 1: [ { ID: 1 }, { ID: 2 } ] };
+		expect(
+			items( existingState, { type: MEMBERSHIPS_COUPON_DELETE, siteId, coupon: couponToDelete } )
+		).toEqual( expectation );
+	} );
+} );

--- a/client/state/memberships/coupon-list/test/selectors.js
+++ b/client/state/memberships/coupon-list/test/selectors.js
@@ -1,0 +1,31 @@
+import { getCouponsForSiteId } from '../selectors';
+
+describe( 'selectors', () => {
+	describe( 'getCouponsForSiteId()', () => {
+		test( 'should return an array of coupons when coupons exist for that site', () => {
+			const existingCoupons = [ { ID: 1 }, { ID: 2 } ];
+			const existingState = { memberships: { couponList: { items: { 1: existingCoupons } } } };
+			const siteId = '1';
+
+			expect( getCouponsForSiteId( existingState, siteId ) ).toEqual( existingCoupons );
+		} );
+
+		test( 'should return an empty array of coupons when no coupons exist for that site', () => {
+			const existingState = {
+				memberships: { couponList: { items: { 1: [], 2: [ { ID: 1 }, { ID: 2 } ] } } },
+			};
+			const siteId = '1';
+
+			expect( getCouponsForSiteId( existingState, siteId ) ).toEqual( [] );
+		} );
+
+		test( 'should return an empty array of coupons when site does not exist', () => {
+			const existingState = {
+				memberships: { couponList: { items: { 1: [], 2: [ { ID: 1 }, { ID: 2 } ] } } },
+			};
+			const siteId = '3';
+
+			expect( getCouponsForSiteId( existingState, siteId ) ).toEqual( [] );
+		} );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85869

## Proposed Changes

* Add tests for `client/state/memberships/coupon-list`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Automated tests included.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?