### PR TITLE
Stats E2E: adapt to subscriber launch pad changes

### DIFF
--- a/test/e2e/specs/stats/stats.ts
+++ b/test/e2e/specs/stats/stats.ts
@@ -97,10 +97,6 @@ describe( DataHelper.createSuiteTitle( 'Stats' ), function () {
 		it( 'Click on Subscribers tab', async function () {
 			await statsPage.clickTab( 'Subscribers' );
 		} );
-
-		it( 'Click link to see all annual insights', async function () {
-			await statsPage.selectSubscriberType( 'Email' );
-		} );
 	} );
 
 	// The Store tab is not present unless Business or higher plan is on the site and the


### PR DESCRIPTION
per discussion: p1705484914883879-slack-C82FZ5T4G

## Proposed Changes

* Removed test on Subscriber stats page, because the subscriber launchpad is showing by default if there's no subscribers other than the owner.
* We might want to come back and add more tests when we resolved the discrepancy issue: pejTkB-14x-p2

## Testing Instructions


* Ensure all stats E2E tests are passing

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?