### PR TITLE
Reuse existing type 'PlanFeaturesForGridPlan'

### DIFF
--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -32,12 +32,7 @@ export interface GridPlan {
 	planSlug: PlanSlug;
 	freeTrialPlanSlug?: PlanSlug;
 	isVisible: boolean;
-	features: {
-		wpcomFeatures: TransformedFeatureObject[];
-		jetpackFeatures: TransformedFeatureObject[];
-		storageOptions: StorageOption[];
-		conditionalFeatures?: FeatureObject[];
-	};
+	features: PlanFeaturesForGridPlan;
 	tagline: TranslateResult;
 	planTitle: TranslateResult;
 	availableForPurchase: boolean;


### PR DESCRIPTION
Discussed in https://github.com/Automattic/wp-calypso/pull/86624#discussion_r1462656458

## Proposed Changes

Minor cleanup to reuse the existing `PlanFeaturesForGridPlan` type.

## Testing Instructions

No functional changes. Verify that there are no build errors.
