### PR TITLE
Stats: Set the purchase notice status to postponed

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -106,7 +106,9 @@ const PersonalPurchase = ( {
 
 	const { mutateAsync: mutateNoticeVisbilityAsync } = useNoticeVisibilityMutation(
 		siteId,
-		'focus_jetpack_purchase'
+		'focus_jetpack_purchase',
+		'postponed',
+		4 * 7 * 24 * 3600 // four weeks
 	);
 
 	const handleClick = ( e: React.MouseEvent< HTMLAnchorElement, MouseEvent > ) =>

--- a/client/my-sites/stats/stats-reditect-flow/index.tsx
+++ b/client/my-sites/stats/stats-reditect-flow/index.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import { useDispatch } from 'react-redux'; //useSelector
 import { useNoticeVisibilityQuery } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import { useSelector } from 'calypso/state';
-import { isJetpackSite, getSiteOptions, getSiteSlug } from 'calypso/state/sites/selectors';
+import { isJetpackSite, getSiteOption, getSiteSlug } from 'calypso/state/sites/selectors';
 import {
 	requestStatNoticeSettings,
 	receiveStatNoticeSettings,
@@ -15,9 +15,11 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 const StatsRedirectFlow = () => {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
-	const siteCreatedTimeStamp = useSelector(
-		( state ) => getSiteOptions( state, siteId ?? 0 )?.created_at
-	);
+	const siteCreatedTimeStamp = useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'created_at' )
+	) as string;
+
+	const isCommercial = useSelector( ( state ) => getSiteOption( state, siteId, 'is_commercial' ) );
 
 	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
@@ -34,7 +36,7 @@ const StatsRedirectFlow = () => {
 		isSiteJetpackNotAtomic &&
 		purchaseRedirect &&
 		siteCreatedTimeStamp &&
-		new Date( siteCreatedTimeStamp ) > new Date( '2024-01-01' );
+		new Date( siteCreatedTimeStamp ) > new Date( '2024-01-15' );
 
 	const isRequesting = useSelector( ( state: object ) => isStatsNoticeSettingsFetching( state ) );
 	const dispatch = useDispatch();
@@ -55,7 +57,9 @@ const StatsRedirectFlow = () => {
 
 	// render purchase flow for Jetpack sites created after February 2024
 	if ( ! isRequesting && redirectToPurchase && siteSlug ) {
-		page.redirect( `/stats/purchase/${ siteSlug }?productType=commercial` );
+		page.redirect(
+			`/stats/purchase/${ siteSlug }?productType=${ isCommercial ? 'commercial' : 'personal' }`
+		);
 
 		return;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86723

## Proposed Changes

* instead of skipping the purchase page, postpone the time it shows up again
* use the blog type to display proper purchase page type

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* apply `stats/checkout-flows-v2` feature flag to the live branch
* create a JN site and navigate to its stats page on Calypso
* when you are redirected to the purchase page, verify that it's for PWYW type
* click on 'I will do it later' button and verify that the `notices` endpoint was triggered with `postponed` parameter instead of `dismissed`
* create another JN instance
* update its sticker to identify it as a commercial page
* navigate to the stats page on Calypso and verify that you are redirected to a commercial purchase page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?