### PR TITLE
Stats: Fix drawing of background image on purchase pages

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -177,11 +177,13 @@ const StatsSingleItemPagePurchaseFrame = ( {
 					<div className={ `${ COMPONENT_CLASS_NAME }__card-inner--right` }>
 						{ useNewPreviewImage && <StatsPurchasePreviewImage /> }
 						{ ! useNewPreviewImage && (
-							<StatsPurchaseSVG isFree={ isFree } hasHighlight={ false } extraMessage={ false } />
+							<>
+								<StatsPurchaseSVG isFree={ isFree } hasHighlight={ false } extraMessage={ false } />
+								<div className={ `${ COMPONENT_CLASS_NAME }__card-inner--right-background` }>
+									<img src={ statsPurchaseBackgroundSVG } alt="Blurred background" />
+								</div>
+							</>
 						) }
-						<div className={ `${ COMPONENT_CLASS_NAME }__card-inner--right-background` }>
-							<img src={ statsPurchaseBackgroundSVG } alt="Blurred background" />
-						</div>
 					</div>
 				</div>
 			</Card>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86129.

## Proposed Changes

Disables the background SVG image in the new flow. Should only be shown in the old flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit the Calypso Live link.
* Visit the Stats page.
* Enable the feature flag: `stats/checkout-flows-v2`
* Confirm the new image is visible and the source is the new PNG data.
* Confirm via the dev tools that the background SVB is no longer present. Look inside the `stats-purchase-wizard__card-inner--right` DIV to confirm.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?