### PR TITLE
Jetpack Manage: Ensure the product grid is rendered only when user products are fetched.

### DIFF
--- a/client/jetpack-cloud/sections/overview/primary/overview-products/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/overview-products/index.tsx
@@ -9,7 +9,7 @@ import getProductShortTitle from 'calypso/jetpack-cloud/sections/partner-portal/
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import useProductsQuery from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
-import { getProductsList } from 'calypso/state/products-list/selectors';
+import { getProductsList, isProductsListFetching } from 'calypso/state/products-list/selectors';
 
 import './style.scss';
 
@@ -18,6 +18,7 @@ export default function OverviewProducts() {
 	const dispatch = useDispatch();
 
 	const userProducts = useSelector( ( state ) => getProductsList( state ) );
+	const isFetchingUserProducts = useSelector( ( state ) => isProductsListFetching( state ) );
 	const { data: agencyProducts, isLoading: isLoadingProducts } = useProductsQuery();
 
 	// Track the View All click
@@ -46,7 +47,7 @@ export default function OverviewProducts() {
 		} );
 
 		return Object.values( jetpackProductsToShow );
-	}, [ agencyProducts ] );
+	}, [ agencyProducts, userProducts ] );
 
 	return (
 		<div className="overview-products">
@@ -69,7 +70,7 @@ export default function OverviewProducts() {
 				</Button>
 			</div>
 			<div className="overview-products__grid">
-				{ isLoadingProducts || userProducts === undefined ? (
+				{ isLoadingProducts || isFetchingUserProducts || userProducts === undefined ? (
 					<div className="overview-products__is-loading"></div>
 				) : (
 					<ProductGrid products={ products } />


### PR DESCRIPTION
At times, we face an issue where the product grid is shown on the Overview page while we have yet to fetch the complete product information. This causes some icons to not load properly which relies on the product slug. To fix this, the PR has implemented a solution where the product grid will only be displayed once we have fetched the product list.

<img width="709" alt="Screen Shot 2024-01-23 at 2 07 11 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/50252cb2-287b-4146-87ab-7b0b9a740191">


## Proposed Changes

* Add `isProductsListFetching` check in the Overview page before rendering the products grid.

## Testing Instructions
**Reproducing the issue**
 Note that you will need to run Jetpack cloud locally to easily reproduce the issue as it is slower to load and has bigger timeframe to catch the issue.
* Run a Jetpack cloud locally using the `trunk` branch.
* Go to the Overview page (`http://jetpack.cloud.localhost:3000/overview`)
* Keep refreshing the page until you reproduced the issue.
  <img width="709" alt="Screen Shot 2024-01-23 at 2 07 11 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/50252cb2-287b-4146-87ab-7b0b9a740191">

**Testing the fix**
* Checkout to `fix/jp-manage-overview-product-image-missing` branch and reload Jetpack cloud locally.
* Follow the steps above and confirm that the issue no longer occurs.

<img width="706" alt="Screen Shot 2024-01-23 at 2 19 32 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/3c9a9780-d4e6-4496-98f3-cd449f13a7b1">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?