### PR TITLE
Refactor/decouple plan actions data into a hook

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-plan-actions.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-actions.ts
@@ -23,6 +23,14 @@ function getSignupPlanActions(
 		pricing: { currencyCode, originalPrice, discountedPrice },
 	}: GridPlan ): PlanAction => {
 		const planTitle = getPlan( planSlug )?.getTitle() || '';
+		const priceString = formatCurrency(
+			( discountedPrice.monthly || originalPrice.monthly ) ?? 0,
+			currencyCode || 'USD',
+			{
+				stripZeros: true,
+				isSmallestUnit: true,
+			}
+		);
 
 		// const postButtonText = isBusinessPlan( planSlug ); // && planActionOverrides?.trialAlreadyUsed?.postButtonText;
 
@@ -33,14 +41,6 @@ function getSignupPlanActions(
 		} );
 
 		const onClick = () => handleUpgradeButtonClick( hasFreeTrialPlan );
-		const priceString = formatCurrency(
-			( discountedPrice.monthly || originalPrice.monthly ) ?? 0,
-			currencyCode || 'USD',
-			{
-				stripZeros: true,
-				isSmallestUnit: true,
-			}
-		);
 
 		if ( isFreePlan( planSlug ) ) {
 			btnText = translate( 'Start with Free' );
@@ -114,11 +114,61 @@ function getSignupPlanActions(
 	};
 }
 
-function getLaunchPagePlanActions( translate: TranslateFunc ): PlanActionGetter {}
+function getLaunchPagePlanActions(
+	translate: TranslateFunc,
+	handleUpgradeButtonClick: ( isFreeTrialPlan?: boolean ) => void,
+	isStuck: boolean,
+	isLargeCurrency?: boolean
+): PlanActionGetter {
+	return ( {
+		planSlug,
+		pricing: { currencyCode, originalPrice, discountedPrice },
+	}: GridPlan ): PlanAction => {
+		const planTitle = getPlan( planSlug )?.getTitle() || '';
+		const priceString = formatCurrency(
+			( discountedPrice.monthly || originalPrice.monthly ) ?? 0,
+			currencyCode || 'USD',
+			{
+				stripZeros: true,
+				isSmallestUnit: true,
+			}
+		);
+
+		let buttonText = translate( 'Select %(plan)s', {
+			args: {
+				plan: planTitle,
+			},
+			context: 'Button to select a paid plan by plan name, e.g., "Select Personal"',
+			comment:
+				'A button to select a new paid plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
+		} );
+
+		if ( isFreePlan( planSlug ) ) {
+			buttonText = translate( 'Keep this plan', {
+				comment:
+					'A selection to keep the current plan. Check screenshot - https://cloudup.com/cb_9FMG_R01',
+			} );
+		} else if ( isStuck && ! isLargeCurrency ) {
+			buttonText = translate( 'Select %(plan)s – %(priceString)s', {
+				args: {
+					plan: planTitle,
+					priceString: priceString ?? '',
+				},
+				comment:
+					'%(plan)s is the name of the plan and %(priceString)s is the full price including the currency. Eg: Select Premium - $10',
+			} );
+		}
+
+		return {
+			text: buttonText,
+			onClick: handleUpgradeButtonClick,
+		};
+	};
+}
 
 function getLoggedInPlanActions( translate: TranslateFunc ): PlanActionGetter {}
 
-function usePlanActions( isLaunchPage: boolean, isInSignup: boolean ): GetPlanActionFunc {
+function usePlanActions( isLaunchPage: boolean, isInSignup: boolean ): PlanActionGetter {
 	const translate = useTranslate();
 
 	if ( isLaunchPage ) {

--- a/client/my-sites/plans-features-main/hooks/use-plan-actions.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-actions.ts
@@ -1,0 +1,98 @@
+import { TranslateResult, useTranslate } from 'i18n-calypso';
+import type { PlanSlug, StorageOption } from '@automattic/calypso-products';
+
+type UsePlanActionsParams = {
+	availableForPurchase: boolean;
+	currentSitePlanSlug?: string | null;
+	isPopular?: boolean;
+	isInSignup?: boolean;
+	isLaunchPage?: boolean | null;
+	isMonthlyPlan?: boolean;
+	onUpgradeClick: ( overridePlanSlug?: PlanSlug ) => void;
+	planSlug: PlanSlug;
+	buttonText?: string;
+	showMonthlyPrice: boolean;
+	isStuck: boolean;
+	isLargeCurrency?: boolean;
+	storageOptions?: StorageOption[];
+};
+
+type InnerParams = Omit< UsePlanActionsParams, 'isInSignup' | 'isLaunchPage' >;
+
+type PlanActions = {
+	[ planSlug in PlanSlug ]: {
+		text: TranslateResult;
+		onClick: () => void;
+		busy?: boolean;
+	};
+};
+
+type TranslateFunc = ReturnType< typeof useTranslate >;
+
+function getLaunchPagePlanActions(
+	{
+		availableForPurchase,
+		currentSitePlanSlug,
+		isPopular,
+		isMonthlyPlan,
+		onUpgradeClick,
+		planSlug,
+		buttonText,
+		showMonthlyPrice,
+		isStuck,
+		isLargeCurrency,
+		storageOptions,
+	}: InnerParams,
+	translate: TranslateFunc
+): PlanActions {}
+
+function getSignupPlanActions(
+	{
+		availableForPurchase,
+		currentSitePlanSlug,
+		isPopular,
+		isMonthlyPlan,
+		onUpgradeClick,
+		planSlug,
+		buttonText,
+		showMonthlyPrice,
+		isStuck,
+		isLargeCurrency,
+		storageOptions,
+	}: InnerParams,
+	translate: TranslateFunc
+): PlanActions {}
+
+function getLoggedInPlanActions(
+	{
+		availableForPurchase,
+		currentSitePlanSlug,
+		isPopular,
+		isMonthlyPlan,
+		onUpgradeClick,
+		planSlug,
+		buttonText,
+		showMonthlyPrice,
+		isStuck,
+		isLargeCurrency,
+		storageOptions,
+	}: InnerParams,
+	translate: TranslateFunc
+): PlanActions {}
+
+function usePlanActions( params: UsePlanActionsParams ): PlanActions {
+	const translate = useTranslate();
+	const { isLaunchPage, isInSignup } = params;
+
+	if ( isLaunchPage ) {
+		return getLaunchPagePlanActions( params, translate );
+	}
+
+	if ( isInSignup ) {
+		return getSignupPlanActions( params, translate );
+	}
+
+	return getLoggedInPlanActions( params, translate );
+}
+
+export default usePlanActions;

--- a/client/my-sites/plans-features-main/hooks/use-plan-actions.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-actions.ts
@@ -1,5 +1,6 @@
 import { TranslateResult, useTranslate } from 'i18n-calypso';
 import type { PlanSlug, StorageOption } from '@automattic/calypso-products';
+import type { PlanActionGetter, GridPlan } from '@automattic/plans-grid-next';
 
 type UsePlanActionsParams = {
 	availableForPurchase: boolean;
@@ -17,82 +18,34 @@ type UsePlanActionsParams = {
 	storageOptions?: StorageOption[];
 };
 
-type InnerParams = Omit< UsePlanActionsParams, 'isInSignup' | 'isLaunchPage' >;
-
-type PlanActions = {
-	[ planSlug in PlanSlug ]: {
-		text: TranslateResult;
-		onClick: () => void;
-		busy?: boolean;
-	};
-};
-
 type TranslateFunc = ReturnType< typeof useTranslate >;
 
 function getLaunchPagePlanActions(
-	{
-		availableForPurchase,
-		currentSitePlanSlug,
-		isPopular,
-		isMonthlyPlan,
-		onUpgradeClick,
-		planSlug,
-		buttonText,
-		showMonthlyPrice,
-		isStuck,
-		isLargeCurrency,
-		storageOptions,
-	}: InnerParams,
 	translate: TranslateFunc
-): PlanActions {}
+): PlanActionGetter {}
 
 function getSignupPlanActions(
-	{
-		availableForPurchase,
-		currentSitePlanSlug,
-		isPopular,
-		isMonthlyPlan,
-		onUpgradeClick,
-		planSlug,
-		buttonText,
-		showMonthlyPrice,
-		isStuck,
-		isLargeCurrency,
-		storageOptions,
-	}: InnerParams,
 	translate: TranslateFunc
-): PlanActions {}
+): PlanActionGetter {
+
+}
 
 function getLoggedInPlanActions(
-	{
-		availableForPurchase,
-		currentSitePlanSlug,
-		isPopular,
-		isMonthlyPlan,
-		onUpgradeClick,
-		planSlug,
-		buttonText,
-		showMonthlyPrice,
-		isStuck,
-		isLargeCurrency,
-		storageOptions,
-	}: InnerParams,
-	translate: TranslateFunc
-): PlanActions {}
+	translate: TranslateFunc,
+): PlanActionGetter {}
 
-function usePlanActions( params: UsePlanActionsParams ): PlanActions {
+function usePlanActions( isLaunchPage: boolean, isInSignup: boolean ): GetPlanActionFunc {
 	const translate = useTranslate();
-	const { isLaunchPage, isInSignup } = params;
 
 	if ( isLaunchPage ) {
-		return getLaunchPagePlanActions( params, translate );
+		return getLaunchPagePlanActions( translate );
 	}
 
 	if ( isInSignup ) {
-		return getSignupPlanActions( params, translate );
+		return getSignupPlanActions( translate );
 	}
 
-	return getLoggedInPlanActions( params, translate );
+	return getLoggedInPlanActions( translate );
 }
 
 export default usePlanActions;

--- a/client/my-sites/plans-features-main/hooks/use-plan-actions.ts
+++ b/client/my-sites/plans-features-main/hooks/use-plan-actions.ts
@@ -1,38 +1,122 @@
 import { TranslateResult, useTranslate } from 'i18n-calypso';
-import type { PlanSlug, StorageOption } from '@automattic/calypso-products';
-import type { PlanActionGetter, GridPlan } from '@automattic/plans-grid-next';
-
-type UsePlanActionsParams = {
-	availableForPurchase: boolean;
-	currentSitePlanSlug?: string | null;
-	isPopular?: boolean;
-	isInSignup?: boolean;
-	isLaunchPage?: boolean | null;
-	isMonthlyPlan?: boolean;
-	onUpgradeClick: ( overridePlanSlug?: PlanSlug ) => void;
-	planSlug: PlanSlug;
-	buttonText?: string;
-	showMonthlyPrice: boolean;
-	isStuck: boolean;
-	isLargeCurrency?: boolean;
-	storageOptions?: StorageOption[];
-};
+import {
+	getPlan,
+	isBusinessPlan,
+	isFreePlan,
+	type PlanSlug,
+	type StorageOption,
+} from '@automattic/calypso-products';
+import { formatCurrency } from '@automattic/format-currency';
+import type { PlanAction, PlanActionGetter, GridPlan } from '@automattic/plans-grid-next';
 
 type TranslateFunc = ReturnType< typeof useTranslate >;
 
-function getLaunchPagePlanActions(
-	translate: TranslateFunc
-): PlanActionGetter {}
-
 function getSignupPlanActions(
-	translate: TranslateFunc
+	translate: TranslateFunc,
+	handleUpgradeButtonClick: ( isFreeTrialPlan?: boolean ) => void,
+	isStuck: boolean,
+	hasFreeTrialPlan?: boolean,
+	isLargeCurrency?: boolean
 ): PlanActionGetter {
+	return ( {
+		planSlug,
+		pricing: { currencyCode, originalPrice, discountedPrice },
+	}: GridPlan ): PlanAction => {
+		const planTitle = getPlan( planSlug )?.getTitle() || '';
 
+		// const postButtonText = isBusinessPlan( planSlug ); // && planActionOverrides?.trialAlreadyUsed?.postButtonText;
+
+		let btnText = translate( 'Get %(plan)s', {
+			args: {
+				plan: planTitle,
+			},
+		} );
+
+		const onClick = () => handleUpgradeButtonClick( hasFreeTrialPlan );
+		const priceString = formatCurrency(
+			( discountedPrice.monthly || originalPrice.monthly ) ?? 0,
+			currencyCode || 'USD',
+			{
+				stripZeros: true,
+				isSmallestUnit: true,
+			}
+		);
+
+		if ( isFreePlan( planSlug ) ) {
+			btnText = translate( 'Start with Free' );
+		} else if ( isStuck && ! isLargeCurrency ) {
+			btnText = translate( 'Get %(plan)s – %(priceString)s', {
+				args: {
+					plan: planTitle,
+					priceString: priceString ?? '',
+				},
+				comment:
+					'%(plan)s is the name of the plan and %(priceString)s is the full price including the currency. Eg: Get Premium - $10',
+			} );
+		} else if ( isStuck && isLargeCurrency ) {
+			btnText = translate( 'Get %(plan)s {{span}}%(priceString)s{{/span}}', {
+				args: {
+					plan: planTitle,
+					priceString: priceString ?? '',
+				},
+				comment:
+					'%(plan)s is the name of the plan and %(priceString)s is the full price including the currency. Eg: Get Premium - $10',
+				// TODO: update the file into tsx
+				// components: {
+				// 	span: <span className="plan-features-2023-grid__actions-signup-plan-text" />,
+				// },
+			} );
+		}
+
+		if ( hasFreeTrialPlan ) {
+			return {
+				text: translate( 'Try for free' ),
+				onClick,
+			};
+			/* TODO: needs to handle this special case ...
+			return (
+				<div className="plan-features-2023-grid__multiple-actions-container">
+					<PlanButton planSlug={ planSlug } onClick={ onClick } busy={ busy }>
+						{ translate( 'Try for free' ) }
+					</PlanButton>
+					{ ! isStuck && ( // along side with the free trial CTA, we also provide an option for purchasing the plan directly here
+						<PlanButton
+							planSlug={ planSlug }
+							onClick={ () => handleUpgradeButtonClick( false ) }
+							borderless
+						>
+							{ btnText }
+						</PlanButton>
+					) }
+				</div>
+			);
+			*/
+		}
+		return {
+			text: btnText,
+			onClick,
+		};
+
+		/* TODO: need to handle the post button thing
+		return (
+			<>
+				<PlanButton planSlug={ planSlug } onClick={ onClick } busy={ busy }>
+					{ btnText }
+				</PlanButton>
+				{ postButtonText && (
+					<span className="plan-features-2023-grid__actions-post-button-text">
+						{ postButtonText }
+					</span>
+				) }
+			</>
+		);
+		*/
+	};
 }
 
-function getLoggedInPlanActions(
-	translate: TranslateFunc,
-): PlanActionGetter {}
+function getLaunchPagePlanActions( translate: TranslateFunc ): PlanActionGetter {}
+
+function getLoggedInPlanActions( translate: TranslateFunc ): PlanActionGetter {}
 
 function usePlanActions( isLaunchPage: boolean, isInSignup: boolean ): GetPlanActionFunc {
 	const translate = useTranslate();

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -89,6 +89,14 @@ export interface PlanActionOverrides {
 	};
 }
 
+export type PlanAction = {
+	text: TranslateResult;
+	onClick: () => void;
+	busy?: boolean;
+};
+
+export type PlanActionGetter = ( gridPlan: GridPlan ) => PlanAction;
+
 // A generic type representing the response of an async request.
 // It's probably generic enough to be put outside of the pricing grid package,
 // but at the moment it's located here to reduce its scope of influence.

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -89,10 +89,12 @@ export interface PlanActionOverrides {
 	};
 }
 
+// TODO: consolidate it with the props of PlanButton
 export type PlanAction = {
 	text: TranslateResult;
 	onClick: () => void;
 	busy?: boolean;
+	borderless?: boolean;
 };
 
 export type PlanActionGetter = ( gridPlan: GridPlan ) => PlanAction;

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -92,12 +92,17 @@ export interface PlanActionOverrides {
 // TODO: consolidate it with the props of PlanButton
 export type PlanAction = {
 	text: TranslateResult;
-	onClick: () => void;
+	onClick?: () => void;
 	busy?: boolean;
 	borderless?: boolean;
+	current?: boolean;
+	disabled?: boolean;
+	classes?: string;
+	href?: string;
+	tooltip?: TranslateResult;
 };
 
-export type PlanActionGetter = ( gridPlan: GridPlan ) => PlanAction;
+export type PlanActionGetter = ( gridPlan: GridPlan ) => PlanAction | null;
 
 // A generic type representing the response of an async request.
 // It's probably generic enough to be put outside of the pricing grid package,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#1458

## Proposed Changes

WIP

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
