### PR TITLE
Related Posts: Fix user-facing doc links to match the site type

### DIFF
--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -95,7 +95,7 @@ export const RelatedPostsSetting = ( {
 								<a
 									href={
 										isJetpack && ! isAtomic
-											? 'https://jetpack.com/support/jetpack-blocks/related-posts-block/'
+											? 'https://jetpack.com/support/related-posts/'
 											: localizeUrl(
 													'https://wordpress.com/support/related-posts/#add-a-related-posts-block'
 											  )

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -1,4 +1,5 @@
 import { Card } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { ToggleControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -6,6 +7,10 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import SupportInfo from 'calypso/components/support-info';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { useSelector } from 'calypso/state';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite as isJetpackSiteSelector } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import RelatedContentPreview from './related-content-preview';
 
 import './style.scss';
@@ -17,13 +22,26 @@ export const RelatedPostsSetting = ( {
 	isSavingSettings,
 } ) => {
 	const translate = useTranslate();
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) ) || 0;
+	const isJetpack = useSelector( ( state ) => isJetpackSiteSelector( state, siteId ) );
+	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
+
 	return (
 		<FormFieldset>
 			<SupportInfo
 				text={ translate(
 					'The feature helps visitors find more of your content by displaying related posts at the bottom of each post.'
 				) }
-				link="https://jetpack.com/support/related-posts/"
+				link={
+					isJetpack && ! isAtomic
+						? 'https://jetpack.com/support/related-posts/'
+						: localizeUrl(
+								'https://wordpress.com/support/related-posts/#related-posts-classic-themes'
+						  )
+				}
+				privacyLink={
+					isJetpack && ! isAtomic ? true : localizeUrl( 'https://automattic.com/privacy/' )
+				}
 			/>
 
 			<ToggleControl
@@ -75,7 +93,13 @@ export const RelatedPostsSetting = ( {
 						components: {
 							a: (
 								<a
-									href="https://jetpack.com/support/jetpack-blocks/related-posts-block/"
+									href={
+										isJetpack && ! isAtomic
+											? 'https://jetpack.com/support/jetpack-blocks/related-posts-block/'
+											: localizeUrl(
+													'https://wordpress.com/support/related-posts/#add-a-related-posts-block'
+											  )
+									}
 									target="_blank"
 									rel="noopener noreferrer"
 								/>

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -25,6 +25,7 @@ export const RelatedPostsSetting = ( {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) ) || 0;
 	const isJetpack = useSelector( ( state ) => isJetpackSiteSelector( state, siteId ) );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
+	const isJetpackSelfHosted = isJetpack && ! isAtomic;
 
 	return (
 		<FormFieldset>
@@ -33,14 +34,14 @@ export const RelatedPostsSetting = ( {
 					'The feature helps visitors find more of your content by displaying related posts at the bottom of each post.'
 				) }
 				link={
-					isJetpack && ! isAtomic
+					isJetpackSelfHosted
 						? 'https://jetpack.com/support/related-posts/'
 						: localizeUrl(
 								'https://wordpress.com/support/related-posts/#related-posts-classic-themes'
 						  )
 				}
 				privacyLink={
-					isJetpack && ! isAtomic ? true : localizeUrl( 'https://automattic.com/privacy/' )
+					isJetpackSelfHosted ? true : localizeUrl( 'https://automattic.com/privacy/' )
 				}
 			/>
 
@@ -94,7 +95,7 @@ export const RelatedPostsSetting = ( {
 							a: (
 								<a
 									href={
-										isJetpack && ! isAtomic
+										isJetpackSelfHosted
 											? 'https://jetpack.com/support/related-posts/'
 											: localizeUrl(
 													'https://wordpress.com/support/related-posts/#add-a-related-posts-block'

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -35,7 +35,7 @@ export const RelatedPostsSetting = ( {
 				) }
 				link={
 					isJetpackSelfHosted
-						? 'https://jetpack.com/support/related-posts/'
+						? localizeUrl( 'https://jetpack.com/support/related-posts/' )
 						: localizeUrl(
 								'https://wordpress.com/support/related-posts/#related-posts-classic-themes'
 						  )
@@ -96,7 +96,7 @@ export const RelatedPostsSetting = ( {
 								<a
 									href={
 										isJetpackSelfHosted
-											? 'https://jetpack.com/support/related-posts/'
+											? localizeUrl( 'https://jetpack.com/support/related-posts/' )
 											: localizeUrl(
 													'https://wordpress.com/support/related-posts/#add-a-related-posts-block'
 											  )


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/71619.

> [!WARNING]
> Please do not merge until we hear from the privacy team (p1706008296144499-slack-CAK10PA07).

## Proposed Changes

* update the user-facing documentation links related to the Related posts feature
  * the link should be different depending on whether the site is Simple or WoA vs Jetpack self-hosted
  * use localized URL when possible
* update the privacy URL based on the site type as well

**Proposed links:**

| Link type | Simple and WoA | self-hosted Jetpack |
|--------|--------|--------|
| 1. Learn more | https://wordpress.com/support/related-posts/#related-posts-classic-themes | https://jetpack.com/support/related-posts/ |
| 2. Related Posts block info | https://wordpress.com/support/related-posts/#add-a-related-posts-block | https://jetpack.com/support/related-posts/ | 
| 3. Privacy information | https://automattic.com/privacy/ | https://jetpack.com/support/related-posts/#privacy | 

![Markup on 2024-01-23 at 12:02:02](https://github.com/Automattic/wp-calypso/assets/25105483/ef29518d-09fb-4efb-920e-91dd9b5cca00)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out and build the PR branch.
2. Navigate to `/marketing/traffic/` or `/settings/reading/` and review all three links present in the Related Posts section. They should point to relevant documentation and privacy pages.
3. Check the links with Simple, WoA and self-hosted Jetpack sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?