### PR TITLE
Assembler: add default header and footer on first load

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -22,9 +22,11 @@ export const NAVIGATOR_PATHS = {
 	PAGES: '/pages',
 };
 
-export const INITIAL_PATH = NAVIGATOR_PATHS.MAIN_HEADER;
+export const INITIAL_PATH = NAVIGATOR_PATHS.MAIN;
 
 export const INITIAL_SCREEN = 'main';
+
+export const INITIAL_CATEGORY = 'intro';
 
 /* Category list of the patterns fetched via PTK API from Dotcompatterns
  *

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -649,6 +649,8 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 				<NavigatorScreen path={ NAVIGATOR_PATHS.MAIN } partialMatch>
 					<ScreenMain
 						onMainItemSelect={ onMainItemSelect }
+						onSetHeader={ setHeader }
+						onSetFooter={ setFooter }
 						hasHeader={ !! header }
 						hasFooter={ !! footer }
 						sections={ sections }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -365,6 +365,17 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 		}
 	};
 
+	const onPreselectPattern = ( type: PatternType, selectedPattern: Pattern ) => {
+		injectCategoryToPattern( selectedPattern, categories, type );
+
+		if ( 'header' === type ) {
+			setHeader( selectedPattern );
+		}
+		if ( 'footer' === type ) {
+			setFooter( selectedPattern );
+		}
+	};
+
 	const onSubmit = () => {
 		const design = getDesign() as Design;
 		const stylesheet = design.recipe?.stylesheet ?? '';
@@ -649,8 +660,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 				<NavigatorScreen path={ NAVIGATOR_PATHS.MAIN } partialMatch>
 					<ScreenMain
 						onMainItemSelect={ onMainItemSelect }
-						onSetHeader={ setHeader }
-						onSetFooter={ setFooter }
+						onPreselectPattern={ onPreselectPattern }
 						hasHeader={ !! header }
 						hasFooter={ !! footer }
 						sections={ sections }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -29,6 +29,11 @@
 	overflow: auto;
 	background: var(--pattern-large-preview-background);
 
+	&--has-placeholder {
+		display: flex;
+		flex-direction: column;
+	}
+
 	/**
 	 * Hides the scrollbar to avoid the layout keeps changes forever
 	 * See https://github.com/Automattic/wp-calypso/issues/78357.
@@ -77,9 +82,11 @@
 .pattern-large-preview__placeholder {
 	display: flex;
 	flex-direction: column;
+	flex-grow: 1;
 	align-items: center;
 	justify-content: center;
 	width: 100%;
+	padding: 20px;
 	color: var(--studio-gray-60);
 	background: #f8f8f8;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.scss
@@ -86,7 +86,7 @@
 	align-items: center;
 	justify-content: center;
 	width: 100%;
-	padding: 20px;
+	padding: 40px;
 	color: var(--studio-gray-60);
 	background: #f8f8f8;
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -201,6 +201,39 @@ const PatternLargePreview = ( {
 		);
 	};
 
+	const renderPlaceholder = () => {
+		return (
+			<li className="pattern-large-preview__placeholder">
+				<h2>{ translate( 'Welcome to your homepage.' ) }</h2>
+				<ul>
+					<li>{ translate( 'Select patterns for your homepage.' ) }</li>
+					<li>{ translate( 'Choose your colors and fonts.' ) }</li>
+					<li>{ translate( 'Pick additional site pages.' ) }</li>
+					<li>{ translate( 'Add your own content in the Editor.' ) }</li>
+				</ul>
+			</li>
+		);
+	};
+
+	const renderPatterns = () => {
+		const hasPlaceholder = sections.length === 0;
+		return (
+			<ul
+				className={ classnames( 'pattern-large-preview__patterns', {
+					'pattern-large-preview__patterns--has-placeholder': hasPlaceholder,
+				} ) }
+				style={ patternLargePreviewStyle }
+				ref={ listRef }
+			>
+				{ header && renderPattern( 'header', header ) }
+				{ hasPlaceholder
+					? renderPlaceholder()
+					: sections.map( ( pattern, i ) => renderPattern( 'section', pattern, i ) ) }
+				{ footer && renderPattern( 'footer', footer ) }
+			</ul>
+		);
+	};
+
 	const updateViewportHeight = ( height?: number ) => {
 		// Required for 100vh patterns
 		setViewportHeight( height );
@@ -292,27 +325,7 @@ const PatternLargePreview = ( {
 			onViewportChange={ updateViewportHeight }
 			onZoomOutScaleChange={ handleZoomOutScale }
 		>
-			{ hasSelectedPattern ? (
-				<ul
-					className="pattern-large-preview__patterns"
-					style={ patternLargePreviewStyle }
-					ref={ listRef }
-				>
-					{ header && renderPattern( 'header', header ) }
-					{ sections.map( ( pattern, i ) => renderPattern( 'section', pattern, i ) ) }
-					{ footer && renderPattern( 'footer', footer ) }
-				</ul>
-			) : (
-				<div className="pattern-large-preview__placeholder">
-					<h2>{ translate( 'Welcome to your homepage.' ) }</h2>
-					<ul>
-						<li>{ translate( 'Select patterns for your homepage.' ) }</li>
-						<li>{ translate( 'Choose your colors and fonts.' ) }</li>
-						<li>{ translate( 'Pick additional site pages.' ) }</li>
-						<li>{ translate( 'Add your own content in the Editor.' ) }</li>
-					</ul>
-				</div>
-			) }
+			{ renderPatterns() }
 			{ activeElement && (
 				<PatternTooltipDeadClick targetRef={ frameRef } isVisible={ shouldShowTooltip } />
 			) }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -17,8 +17,7 @@ import { Category, Pattern, PatternType } from './types';
 
 interface Props {
 	onMainItemSelect: ( name: string ) => void;
-	onSetHeader: ( pattern: Pattern | null ) => void;
-	onSetFooter: ( pattern: Pattern | null ) => void;
+	onPreselectPattern: ( type: PatternType, selectedPattern: Pattern ) => void;
 	hasHeader: boolean;
 	hasFooter: boolean;
 	sections: Pattern[];
@@ -30,8 +29,7 @@ interface Props {
 
 const ScreenMain = ( {
 	onMainItemSelect,
-	onSetHeader,
-	onSetFooter,
+	onPreselectPattern,
 	hasHeader,
 	hasFooter,
 	sections,
@@ -47,6 +45,10 @@ const ScreenMain = ( {
 	const selectedCategory = params.categorySlug as string;
 	const totalPatternCount = Number( hasHeader ) + sections.length + Number( hasFooter );
 	const isButtonDisabled = totalPatternCount === 0;
+
+	const handlePreselectCategory = ( category: string ) => {
+		goTo( `${ NAVIGATOR_PATHS.MAIN }/${ category }`, { replace: true } );
+	};
 
 	const handleSelectCategory = ( category: string, type: PatternType = 'section' ) => {
 		const basePath = NAVIGATOR_PATHS.MAIN;
@@ -73,13 +75,13 @@ const ScreenMain = ( {
 	useEffect( () => {
 		if ( ! selectedCategory ) {
 			if ( ! hasHeader && patternsMapByCategory.header?.length > 0 ) {
-				onSetHeader( patternsMapByCategory.header[ 0 ] );
+				onPreselectPattern( 'header', patternsMapByCategory.header[ 0 ] );
 			}
 			if ( ! hasFooter && patternsMapByCategory.footer?.length > 0 ) {
-				onSetFooter( patternsMapByCategory.footer[ 0 ] );
+				onPreselectPattern( 'footer', patternsMapByCategory.footer[ 0 ] );
 			}
 			if ( hasHeader && hasFooter ) {
-				handleSelectCategory( INITIAL_CATEGORY );
+				handlePreselectCategory( INITIAL_CATEGORY );
 			}
 		}
 	}, [

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/screen-main.tsx
@@ -6,7 +6,8 @@ import {
 } from '@wordpress/components';
 import { header, footer } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { NAVIGATOR_PATHS } from './constants';
+import { useEffect } from 'react';
+import { INITIAL_CATEGORY, NAVIGATOR_PATHS } from './constants';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import { useScreen, usePatternCountMapByCategory } from './hooks';
 import NavigatorTitle from './navigator-title';
@@ -16,6 +17,8 @@ import { Category, Pattern, PatternType } from './types';
 
 interface Props {
 	onMainItemSelect: ( name: string ) => void;
+	onSetHeader: ( pattern: Pattern | null ) => void;
+	onSetFooter: ( pattern: Pattern | null ) => void;
 	hasHeader: boolean;
 	hasFooter: boolean;
 	sections: Pattern[];
@@ -27,6 +30,8 @@ interface Props {
 
 const ScreenMain = ( {
 	onMainItemSelect,
+	onSetHeader,
+	onSetFooter,
 	hasHeader,
 	hasFooter,
 	sections,
@@ -59,6 +64,30 @@ const ScreenMain = ( {
 			}
 		}
 	};
+
+	// On the first Assembler flow load, instead of starting with a blank page,
+	// we insert a default header pattern and footer pattern, and then pre-select the first pattern category.
+	//
+	// This is done by doing all the above in a React effect when there is no selected pattern category,
+	// which happens on the first load of the Assembler flow.
+	useEffect( () => {
+		if ( ! selectedCategory ) {
+			if ( ! hasHeader && patternsMapByCategory.header?.length > 0 ) {
+				onSetHeader( patternsMapByCategory.header[ 0 ] );
+			}
+			if ( ! hasFooter && patternsMapByCategory.footer?.length > 0 ) {
+				onSetFooter( patternsMapByCategory.footer[ 0 ] );
+			}
+			if ( hasHeader && hasFooter ) {
+				handleSelectCategory( INITIAL_CATEGORY );
+			}
+		}
+	}, [
+		hasHeader,
+		hasFooter,
+		patternsMapByCategory.header?.length,
+		patternsMapByCategory.footer?.length,
+	] );
 
 	return (
 		<>

--- a/test/e2e/specs/onboarding/onboarding__site-assembler.ts
+++ b/test/e2e/specs/onboarding/onboarding__site-assembler.ts
@@ -100,27 +100,31 @@ describe( 'Onboarding: Site Assembler', () => {
 			siteAssemblerFlow = new SiteAssemblerFlow( page );
 		} );
 
-		it( 'Select a Header pattern', async function () {
-			// The pane is now open by default.
-			// @see https://github.com/Automattic/wp-calypso/pull/80924
+		it( 'Select a pattern in the default category', async function () {
 			await siteAssemblerFlow.selectLayoutComponent( { index: 0 } );
 
-			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 1 );
+			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 3 );
 		} );
 
-		// Skip section patterns while the Assembler v2 is being developed.
-		it.skip( 'Select a Quote pattern', async function () {
-			await siteAssemblerFlow.clickLayoutComponentType( 'Quotes' );
+		it( 'Select a Testimonials pattern', async function () {
+			await siteAssemblerFlow.clickLayoutComponentType( 'Testimonials' );
 			await siteAssemblerFlow.selectLayoutComponent( { index: 0 } );
 
-			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 2 );
+			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 4 );
 		} );
 
-		it( 'Select a Footer pattern', async function () {
+		it( 'Select another Header pattern', async function () {
+			await siteAssemblerFlow.clickLayoutComponentType( 'Header' );
+			await siteAssemblerFlow.selectLayoutComponent( { index: 1 } );
+
+			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 4 );
+		} );
+
+		it( 'Select another Footer pattern', async function () {
 			await siteAssemblerFlow.clickLayoutComponentType( 'Footer' );
-			await siteAssemblerFlow.selectLayoutComponent( { index: 0 } );
+			await siteAssemblerFlow.selectLayoutComponent( { index: 1 } );
 
-			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 2 );
+			expect( await siteAssemblerFlow.getAssembledComponentsCount() ).toBe( 4 );
 		} );
 
 		it( 'Pick default style', async function () {


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/wp-calypso/issues/86689

## Proposed Changes

We want to increase the "wow" factor when a user first go to the Assembler flow is first initiated.

In this PR, when the Assembler flow is first loaded, we:

- Insert the first Header pattern and the first Footer pattern.
- Set the category to Intro (previously Header).

---

### Implementation details

I changed the initial path from `/main/header` to `/main`. In this way, the `selectedCategory` is `undefined`. I use this condition inside a `useEffect()` to initialize the default Header and Footer patterns and then set the category to Intro.

### About the default Header and Footer patterns

In v2, the default Header and Footer patterns can be changed by tagging the patterns with the `Featured` tag. For the sake of demo of this PR, I just picked a random simple Header and Footer pattern :)

---

### Assembler v1

Before

<img width="1904" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/40bcd96a-0a7f-4db3-a8d4-56edc8b38d9a">

After

<img width="1904" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/d2b121d1-7493-4378-8682-d5033e8a989e">

### Assembler v2

Before

<img width="1904" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/279cba1d-4cbe-4eca-bb0d-3b8519bf3044">


After

<img width="1904" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/3c664ce1-c9a3-4108-a2cf-d32b1fcc592b">


## Testing Instructions

1. Go to `/setup/assembler-first` then select "Start a new site"
   - (you can also use any other Assembler entry point)
2. Verify that you can see the Header and Footer patterns, and the initial category is Intro.
3. Verify that you can still remove and/or replace the Header and Footer patterns as usual.
4. Verify that you can add/remove/replace section patterns as usual.
5. Verify that the flow can be completed as usual.
6. Repeat the testing with `flags=pattern-assembler/v2`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?