### PR TITLE
Track disabling of Jetpack SSO

### DIFF
--- a/client/my-sites/site-settings/jetpack-module-toggle.jsx
+++ b/client/my-sites/site-settings/jetpack-module-toggle.jsx
@@ -47,11 +47,18 @@ class JetpackModuleToggle extends Component {
 	};
 
 	recordTracksEvent = ( name, status ) => {
+		const { moduleSlug, path } = this.props;
+
 		const tracksProps = {
-			module: this.props.moduleSlug,
-			path: this.props.path,
+			module: moduleSlug,
+			path,
 			toggled: status,
 		};
+
+		this.props.recordTracksEvent(
+			`calypso_jetpack_module_toggle_${ moduleSlug }_${ status }`,
+			tracksProps
+		);
 
 		this.props.recordTracksEvent( name, tracksProps );
 	};


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/86746

We currently track `calypso_jetpack_module_toggle` with parameters `module` ( we are interested in `sso` here) and `toggled` (that can be on and off).

It is difficult to see trends filtering by both properties.

This PR introduces a 	`calypso_jetpack_module_toggle_${ moduleSlug }_${ status }` event.
We will be interested in tracking `calypso_jetpack_module_toggle_sso_off`, but this is more generic and can help in the future to track other modules as well.

## Testing
1. Live link
2. Go to [Live link]/settings/security/[Site slug]
3. Turn on and off Jetpack SSO and check that the event is fired.

## How to see events in real time
1. Open Console in chrome
2. localStorage.setItem( 'debug', 'calypso:analytics*' );
3. Refresh
4. Enable all items in the filters 
5. filter for events with the word “recording.” This removes unnecessary noise.