### PR TITLE
Only show review stats with at least 3 reviews

### DIFF
--- a/client/my-sites/marketplace/components/reviews-summary/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-summary/index.tsx
@@ -68,7 +68,7 @@ export const ReviewsSummary = ( { slug, productName, productType }: Props ) => {
 				productType={ productType }
 			/>
 			<div className="reviews-summary__container">
-				{ numberOfReviews !== null && (
+				{ numberOfReviews !== null && numberOfReviews >= 3 && (
 					<div>
 						{ averageRating !== null && <Rating rating={ averageRating } /> }
 						<Button borderless className="reviews-summary__number-reviews-link is-link">

--- a/client/my-sites/marketplace/components/reviews-summary/index.tsx
+++ b/client/my-sites/marketplace/components/reviews-summary/index.tsx
@@ -68,6 +68,7 @@ export const ReviewsSummary = ( { slug, productName, productType }: Props ) => {
 				productType={ productType }
 			/>
 			<div className="reviews-summary__container">
+				{ /* Only show stats if we have a minimum sample size to reduce outliers unfairly impacting the score */ }
 				{ numberOfReviews !== null && numberOfReviews >= 3 && (
 					<div>
 						{ averageRating !== null && <Rating rating={ averageRating } /> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pekYwv-3Eb-p2

## Proposed Changes

* Add condition to only show number of ratings and average ratings for themes if there are at least 3 reviews

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to a theme that has 3 or more reviews, eg. `/theme/spiel`
* Check that the stats are shown
![CleanShot 2024-01-23 at 11 37 50@2x](https://github.com/Automattic/wp-calypso/assets/11555574/45064307-8d1c-4764-95d9-7cd92f84b227)
* Go to a theme that doesn't have 3 reviews, eg. `/theme/organic-stax`
* Check that the stats aren't shown
![CleanShot 2024-01-23 at 11 38 47@2x](https://github.com/Automattic/wp-calypso/assets/11555574/189f9b56-1c2a-404e-8fdd-90222b715a70)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?