### PR TITLE
Theme Tiers: Rename feature to "Premium themes"

### DIFF
--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -376,7 +376,6 @@ export const ThemeUpgradeModal = ( {
 
 	const getPersonalPlanFeatureList = () => {
 		return getPlanFeaturesObject( [
-			FEATURE_PERSONAL_THEMES,
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_AD_FREE_EXPERIENCE,
 			FEATURE_FAST_DNS,

--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -302,7 +302,6 @@ import {
 	FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	FEATURE_COMMISSION_FEE_STANDARD_FEATURES,
 	FEATURE_COMMISSION_FEE_WOO_FEATURES,
-	FEATURE_PERSONAL_THEMES,
 	FEATURE_STATS_PAID,
 } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
@@ -537,15 +536,6 @@ export const FEATURES_LIST: FeatureList = {
 						'Access to all of our advanced premium theme templates, including templates specifically tailored for businesses.'
 				  );
 		},
-	},
-
-	[ FEATURE_PERSONAL_THEMES ]: {
-		getSlug: () => FEATURE_PERSONAL_THEMES,
-		getTitle: () => i18n.translate( 'Unlimited starter themes' ),
-		getDescription: () =>
-			i18n.translate(
-				'Unlimited access to all of our starter themes, including designs specifically tailored for businesses.'
-			),
 	},
 
 	[ FEATURE_MONETISE ]: {
@@ -1958,15 +1948,8 @@ export const FEATURES_LIST: FeatureList = {
 	},
 	[ FEATURE_PREMIUM_THEMES_V2 ]: {
 		getSlug: () => FEATURE_PREMIUM_THEMES_V2,
-		getTitle: () => {
-			const shouldShowNewString =
-				isEnabled( 'themes/tiers' ) && i18n.hasTranslation( 'Explorer themes' );
-
-			return shouldShowNewString
-				? i18n.translate( 'Explorer themes' )
-				: i18n.translate( 'Premium themes' );
-		},
-		getIcon: () => <img src={ Theme2Image } alt={ i18n.translate( 'Explorer themes' ) } />,
+		getTitle: () => i18n.translate( 'Premium themes' ),
+		getIcon: () => <img src={ Theme2Image } alt={ i18n.translate( 'Premium themes' ) } />,
 		getCompareTitle: () => i18n.translate( 'A collection of premium design templates' ),
 		getDescription: () => i18n.translate( 'Switch between a collection of premium design themes.' ),
 	},


### PR DESCRIPTION
## Proposed Changes

Since we don't have yet good feature names that differentiate the themes that are available on the Starter plan from the ones on the Explorer plan, this PR:

- Renames the "Explorer themes" feature to "Premium themes"
- Removes the "Starter themes" feature

Screen | Screenshot
--- | ---
Plans grid | <img width="975" alt="Screenshot 2024-01-23 at 13 37 26" src="https://github.com/Automattic/wp-calypso/assets/1233880/b04d5a3d-a6da-468b-992e-c58f94d52a04"> | 
Unlock Starter tier theme | <img width="793" alt="Screenshot 2024-01-23 at 13 38 21" src="https://github.com/Automattic/wp-calypso/assets/1233880/034aeee8-1c0d-47ae-818a-bd1710c343f7">
Unlock Explorer tier theme | <img width="805" alt="Screenshot 2024-01-23 at 13 36 04" src="https://github.com/Automattic/wp-calypso/assets/1233880/25b574ef-6292-41d2-8b57-799fda727c22">


This means that the access to the Starter tier themes won't be highlighted in any features list for the time being. Once we came up with a good name (see paYJgx-4vW-p2) we can reintroduce it.

## Testing Instructions

- Use the Calypso live link below
- Go to `/plans/<FREE_SITE_DOMAIN>?flags=themes/tiers`
- Make sure the Starter plan does not highlight any themes feature
- Make sure the Explorer plan highlights the "Premium themes" feature
- Go to `/setup/site-setup/designSetup?siteSlug=<FREE_SITE_DOMAIN>&flags=themes/tiers&theme=kaze` 
- Click on the "Unlock theme" button
- Since Kaze is a Starter tier theme, you shouldn't see any themes feature listed under "Included in your Starter plan"
- Go to `/setup/site-setup/designSetup?siteSlug=<FREE_SITE_DOMAIN>&flags=themes/tiers&theme=podcasty` 
- Click on the "Unlock theme" button
- Since Podcasty is a Explorer tier theme, you should see "Premium themes" as a feature listed under "Included in your Explorer plan"