### PR TITLE
Checkout: Move credits back below taxes in sidebar

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -61,13 +61,11 @@ export function CostOverridesList( {
 	currency,
 	removeCoupon,
 	couponCode,
-	creditsInteger,
 }: {
 	costOverridesList: Array< CostOverrideForDisplay >;
 	currency: string;
 	removeCoupon?: RemoveCouponFromCart;
 	couponCode: ResponseCart[ 'coupon' ];
-	creditsInteger: number;
 } ) {
 	const translate = useTranslate();
 	// Let's put the coupon code last because it will have its own "Remove" button.
@@ -93,14 +91,6 @@ export function CostOverridesList( {
 					</div>
 				);
 			} ) }
-			{ creditsInteger > 0 && (
-				<div className="cost-overrides-list-item" key="credits-override">
-					<span className="cost-overrides-list-item__reason">{ translate( 'Credits' ) }</span>
-					<span className="cost-overrides-list-item__discount">
-						{ formatCurrency( -creditsInteger, currency, { isSmallestUnit: true } ) }
-					</span>
-				</div>
-			) }
 			{ ! removeCoupon &&
 				couponOverrides.map( ( costOverride ) => {
 					return (

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -105,7 +105,7 @@ export default function BeforeSubmitCheckoutHeader() {
 	const subTotalLineItemWithoutCoupon: LineItemType = {
 		id: 'subtotal-without-coupon',
 		type: 'subtotal',
-		label: translate( 'Subtotal before discounts' ),
+		label: totalDiscount > 0 ? translate( 'Subtotal before discounts' ) : translate( 'Subtotal' ),
 		formattedAmount: formatCurrency( subtotalBeforeDiscounts, responseCart.currency, {
 			isSmallestUnit: true,
 			stripZeros: true,
@@ -124,7 +124,7 @@ export default function BeforeSubmitCheckoutHeader() {
 				<WPOrderReviewSection>
 					<NonTotalPrices>
 						<NonProductLineItem subtotal lineItem={ subTotalLineItemWithoutCoupon } />
-						<NonProductLineItem subtotal lineItem={ discountLineItem } />
+						{ totalDiscount > 0 && <NonProductLineItem subtotal lineItem={ discountLineItem } /> }
 						{ taxLineItems.map( ( taxLineItem ) => (
 							<NonProductLineItem key={ taxLineItem.id } tax lineItem={ taxLineItem } />
 						) ) }

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -129,7 +129,7 @@ function CheckoutSummaryPriceList() {
 
 	return (
 		<>
-			{ ! hasCheckoutVersion( '2' ) && (
+			{ ! hasCheckoutVersion( '2' ) && costOverridesList.length > 0 && (
 				<CheckoutFirstSubtotalLineItem key="checkout-summary-line-item-subtotal-one">
 					<span>{ translate( 'Subtotal before discounts' ) }</span>
 					<span>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -29,10 +29,9 @@ import {
 	getTaxBreakdownLineItemsFromCart,
 	getTotalLineItemFromCart,
 	hasCheckoutVersion,
-	getSubtotalWithCredits,
-	doesPurchaseHaveFullCredits,
 	getSubtotalWithoutDiscounts,
 	filterAndGroupCostOverridesForDisplay,
+	getCreditsLineItemFromCart,
 } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -120,16 +119,11 @@ export default function WPCheckoutOrderSummary( {
 function CheckoutSummaryPriceList() {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
+	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const taxLineItems = getTaxBreakdownLineItemsFromCart( responseCart );
 	const totalLineItem = getTotalLineItemFromCart( responseCart );
 	const translate = useTranslate();
-	const subtotalWithCredits = getSubtotalWithCredits( responseCart );
 	const costOverridesList = filterAndGroupCostOverridesForDisplay( responseCart, translate );
-	const isFullCredits = doesPurchaseHaveFullCredits( responseCart );
-	// Clamp the credits display value to the total
-	const creditsForDisplay = isFullCredits
-		? responseCart.sub_total_with_taxes_integer
-		: responseCart.credits_integer;
 
 	const subtotalBeforeDiscounts = getSubtotalWithoutDiscounts( responseCart );
 
@@ -151,14 +145,13 @@ function CheckoutSummaryPriceList() {
 					costOverridesList={ costOverridesList }
 					currency={ responseCart.currency }
 					couponCode={ responseCart.coupon }
-					creditsInteger={ creditsForDisplay }
 				/>
 			) }
 			<CheckoutSummaryAmountWrapper>
 				<CheckoutSummaryLineItem key="checkout-summary-line-item-subtotal">
 					<span>{ translate( 'Subtotal' ) }</span>
 					<span>
-						{ formatCurrency( subtotalWithCredits, responseCart.currency, {
+						{ formatCurrency( responseCart.sub_total_integer, responseCart.currency, {
 							isSmallestUnit: true,
 							stripZeros: true,
 						} ) }
@@ -170,6 +163,13 @@ function CheckoutSummaryPriceList() {
 						<span>{ taxLineItem.formattedAmount }</span>
 					</CheckoutSummaryLineItem>
 				) ) }
+				{ creditsLineItem && responseCart.sub_total_integer > 0 && (
+					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + creditsLineItem.id }>
+						<span>{ creditsLineItem.label }</span>
+						<span>{ creditsLineItem.formattedAmount }</span>
+					</CheckoutSummaryLineItem>
+				) }
+
 				<CheckoutSummaryTotal>
 					<span>{ translate( 'Total' ) }</span>
 					<span className="wp-checkout-order-summary__total-price">

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -17,7 +17,6 @@ import {
 	LineItem,
 	getPartnerCoupon,
 	hasCheckoutVersion,
-	doesPurchaseHaveFullCredits,
 	filterAndGroupCostOverridesForDisplay,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
@@ -149,11 +148,6 @@ export function WPOrderReviewLineItems( {
 	);
 
 	const costOverridesList = filterAndGroupCostOverridesForDisplay( responseCart, translate );
-	const isFullCredits = doesPurchaseHaveFullCredits( responseCart );
-	// Clamp the credits display value to the total
-	const creditsForDisplay = isFullCredits
-		? responseCart.sub_total_with_taxes_integer
-		: responseCart.credits_integer;
 
 	const changeAkismetPro500CartQuantity = useCallback< OnChangeAkProQuantity >(
 		( uuid, productSlug, productId, prevQuantity, newQuantity ) => {
@@ -236,7 +230,6 @@ export function WPOrderReviewLineItems( {
 					currency={ responseCart.currency }
 					removeCoupon={ removeCoupon }
 					couponCode={ responseCart.coupon }
-					creditsInteger={ creditsForDisplay }
 				/>
 			) }
 		</WPOrderReviewList>

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -188,17 +188,6 @@ function getCreditsUsedByCart( responseCart: ResponseCart ): number {
 	return isFullCredits ? responseCart.sub_total_with_taxes_integer : responseCart.credits_integer;
 }
 
-/*
- * Coupon discounts are applied (or not, as appropriate) to each line item's
- * total, so the cart's subtotal includes them. However, because it's nice to
- * be able to display the coupon discount as a discount separately from the
- * subtotal, this function returns the cart's subtotal with the coupon savings
- * removed.
- */
-export function getSubtotalWithoutCoupon( responseCart: ResponseCart ): number {
-	return responseCart.sub_total_integer + responseCart.coupon_savings_total_integer;
-}
-
 export function getSubtotalWithoutDiscounts( responseCart: ResponseCart ): number {
 	return responseCart.products.reduce( ( total, product ) => {
 		return product.item_original_subtotal_integer + total;
@@ -214,18 +203,6 @@ export function getTotalDiscountsWithoutCredits(
 		total = total + override.discountAmount;
 		return total;
 	}, 0 );
-}
-
-/**
- * Credits are the only type of cart discount that is applied to the cart as a
- * whole and not to individual line items. The subtotal is only a subtotal of
- * line items and does not have credits applied. Therefore, if we want to
- * display credits as a discount along with other discounts before the
- * subtotal, we probably want to display the subtotal as having credits already
- * applied, which this function returns.
- */
-export function getSubtotalWithCredits( responseCart: ResponseCart ): number {
-	return responseCart.sub_total_integer - getCreditsUsedByCart( responseCart );
 }
 
 export function doesPurchaseHaveFullCredits( cart: ResponseCart ): boolean {


### PR DESCRIPTION
## Proposed Changes

In https://github.com/Automattic/wp-calypso/pull/86360/, we modified the checkout sidebar to show a list of discounts applied to the cart. Because credits are sort of a discount, they were moved from their original location after taxes to be included in this list. However, this was a mistake because they are not a discount and are applied after taxes. If the cart was a full credits cart with taxes, they made the math very confusing. Since they are not a discount they also caused issues like credits being hidden entirely when there were no other discounts.

In this PR we restore the original position of the credits line in the sidebar.

This PR also hides "Subtotal before discounts" and "Discounts" lines if there are no discounts.

Before             |  After
:-------------------------:|:-------------------------:
<img width="321" alt="Screenshot 2024-01-23 at 9 24 06 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/6cf663e8-9f59-425a-b25d-4799763421e2"> | <img width="314" alt="Screenshot 2024-01-23 at 9 33 55 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/1569c01f-7a8b-4c87-81d7-28542407023f">
<img width="305" alt="Screenshot 2024-01-23 at 9 47 59 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/86d29d5f-da5b-47a6-930d-dca4095c763b"> | <img width="326" alt="Screenshot 2024-01-23 at 9 47 44 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/5f5d0361-7379-4552-9b4b-1884ab189a5e">
<img width="566" alt="Screenshot 2024-01-23 at 9 48 47 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/b0e6886e-ca74-423e-aa7c-e6a8ced41c42"> | <img width="570" alt="Screenshot 2024-01-23 at 9 49 13 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/fbff4d24-e132-4516-bea4-6517bf5d91d3">

## Testing Instructions

- Add enough credits to your cart to cover the entire cart.
- Add a product to your cart which has discounts (or add a coupon) and visit checkout.
- Make sure that your address in checkout is a taxable location.
- Verify that the math in the sidebar makes sense.
- Verify that the math at the bottom of checkout also makes sense.
- Repeat the above with a cart that has no discounts.