### PR TITLE
Subscriber Stats: Only filter the site admin from being subscribers when determining showing the Launchpad

### DIFF
--- a/client/my-sites/stats/hooks/use-subscribers-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-query.tsx
@@ -54,8 +54,7 @@ function selectSubscribers( payload: SubscriberPayload ): SubscribersData {
 			return {
 				[ payload.fields[ 0 ] ]:
 					payload.unit !== 'week' ? dataSet[ 0 ] : dataSet[ 0 ].replaceAll( 'W', '-' ),
-				// Exclude the site owner count to align with the `Total subscribers` count from querySubscribersTotals.
-				[ payload.fields[ 1 ] ]: dataSet[ 1 ] > 0 ? dataSet[ 1 ] - 1 : dataSet[ 1 ],
+				[ payload.fields[ 1 ] ]: dataSet[ 1 ],
 				[ payload.fields[ 2 ] ]: dataSet[ 2 ],
 			};
 		} ),

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -24,11 +24,13 @@ const selectSubscribers = ( payload: {
 	total: number;
 	total_email: number;
 	total_wpcom: number;
+	is_owner_subscribing: boolean;
 } ) => {
 	return {
 		total: payload.total,
 		total_email: payload.total_email,
 		total_wpcom: payload.total_wpcom,
+		is_owner_subscribing: payload.is_owner_subscribing,
 	};
 };
 
@@ -81,6 +83,7 @@ function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boole
 					? queries[ 1 ].data.email_subscribers - queries[ 1 ].data.paid_subscribers
 					: null,
 			social_followers: queries[ 1 ]?.data?.social_followers,
+			is_owner_subscribing: queries[ 0 ]?.data?.is_owner_subscribing,
 		},
 		isLoading: queries.some( ( result ) => result.isLoading ),
 		isError: queries.some( ( result ) => result.isError ),

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -1,12 +1,15 @@
 import { useQueries } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 
-const querySubscribersTotals = ( siteId: number | null ): Promise< any > => {
+const querySubscribersTotals = ( siteId: number | null, filterAdmin?: boolean ): Promise< any > => {
 	return wpcom.req.get(
 		{
 			path: `/sites/${ siteId }/stats/followers`,
 		},
-		{ type: 'all' }
+		{
+			type: 'all',
+			filter_admin: filterAdmin ? true : false,
+		}
 	);
 };
 
@@ -44,12 +47,16 @@ const selectPaidSubscribers = ( payload: {
 	};
 };
 
-export default function useSubscribersTotalsQueries( siteId: number | null ) {
+export function useSubscribersTotalsWithoutAdminQueries( siteId: number | null ) {
+	return useSubscribersTotalsQueries( siteId, true );
+}
+
+function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boolean ) {
 	const queries = useQueries( {
 		queries: [
 			{
-				queryKey: [ 'stats', 'totals', 'subscribers', siteId ],
-				queryFn: () => querySubscribersTotals( siteId ),
+				queryKey: [ 'stats', 'totals', 'subscribers', siteId, filterAdmin ],
+				queryFn: () => querySubscribersTotals( siteId, filterAdmin ),
 				select: selectSubscribers,
 				staleTime: 1000 * 60 * 5, // 5 minutes
 			},
@@ -79,3 +86,5 @@ export default function useSubscribersTotalsQueries( siteId: number | null ) {
 		isError: queries.some( ( result ) => result.isError ),
 	};
 }
+
+export default useSubscribersTotalsQueries;

--- a/client/my-sites/stats/stats-subscribers/index.tsx
+++ b/client/my-sites/stats/stats-subscribers/index.tsx
@@ -20,6 +20,7 @@ import {
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useSubscribersTotalsWithoutAdminQueries } from '../hooks/use-subscribers-totals-query';
 import Followers from '../stats-followers';
+import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsModuleEmails from '../stats-module-emails';
 import PageViewTracker from '../stats-page-view-tracker';
 import Reach from '../stats-reach';
@@ -87,30 +88,32 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 					navigationItems={ [] }
 				></NavigationHeader>
 				<StatsNavigation selectedItem="subscribers" siteId={ siteId } slug={ siteSlug } />
-				{ showLaunchpad ? (
-					<SubscriberLaunchpad launchpadContext="subscriber-stats" />
-				) : (
-					<>
-						<SubscribersHighlightSection siteId={ siteId } />
-						{ isChartVisible && (
-							<>
-								<SubscribersChartSection
-									siteId={ siteId }
-									slug={ siteSlug }
-									period={ period.period }
-								/>
-								<SubscribersOverview siteId={ siteId } />
-							</>
-						) }
-						<div className={ statsModuleListClass }>
-							<Followers path="followers" />
-							<Reach />
-							{ ! isOdysseyStats && period && (
-								<StatsModuleEmails period={ period } query={ { period, date: today } } />
+				{ isLoading && <StatsModulePlaceholder className="is-subscriber-page" isLoading /> }
+				{ ! isLoading &&
+					( showLaunchpad ? (
+						<SubscriberLaunchpad launchpadContext="subscriber-stats" />
+					) : (
+						<>
+							<SubscribersHighlightSection siteId={ siteId } />
+							{ isChartVisible && (
+								<>
+									<SubscribersChartSection
+										siteId={ siteId }
+										slug={ siteSlug }
+										period={ period.period }
+									/>
+									<SubscribersOverview siteId={ siteId } />
+								</>
 							) }
-						</div>
-					</>
-				) }
+							<div className={ statsModuleListClass }>
+								<Followers path="followers" />
+								<Reach />
+								{ ! isOdysseyStats && period && (
+									<StatsModuleEmails period={ period } query={ { period, date: today } } />
+								) }
+							</div>
+						</>
+					) ) }
 				<JetpackColophon />
 			</div>
 		</Main>

--- a/client/my-sites/stats/stats-subscribers/index.tsx
+++ b/client/my-sites/stats/stats-subscribers/index.tsx
@@ -18,7 +18,7 @@ import {
 	isSimpleSite,
 } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import useSubscribersTotalsQueries from '../hooks/use-subscribers-totals-query';
+import { useSubscribersTotalsWithoutAdminQueries } from '../hooks/use-subscribers-totals-query';
 import Followers from '../stats-followers';
 import StatsModuleEmails from '../stats-module-emails';
 import PageViewTracker from '../stats-page-view-tracker';
@@ -65,7 +65,7 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 		'subscribers-page'
 	);
 
-	const { data: subscribersTotals, isLoading } = useSubscribersTotalsQueries( siteId );
+	const { data: subscribersTotals, isLoading } = useSubscribersTotalsWithoutAdminQueries( siteId );
 	const isSimple = useSelector( isSimpleSite );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 	const showLaunchpad = ! isLoading && ( isSimple || isAtomic ) && ! subscribersTotals?.total;

--- a/client/my-sites/stats/stats-subscribers/index.tsx
+++ b/client/my-sites/stats/stats-subscribers/index.tsx
@@ -66,6 +66,7 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 		'subscribers-page'
 	);
 
+	// TODO: Pass subscribersTotals as props to SubscribersHighlightSection to avoid duplicate queries.
 	const { data: subscribersTotals, isLoading } = useSubscribersTotalsQueries( siteId );
 	const isSimple = useSelector( isSimpleSite );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );

--- a/client/my-sites/stats/stats-subscribers/index.tsx
+++ b/client/my-sites/stats/stats-subscribers/index.tsx
@@ -18,7 +18,7 @@ import {
 	isSimpleSite,
 } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { useSubscribersTotalsWithoutAdminQueries } from '../hooks/use-subscribers-totals-query';
+import useSubscribersTotalsQueries from '../hooks/use-subscribers-totals-query';
 import Followers from '../stats-followers';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsModuleEmails from '../stats-module-emails';
@@ -66,10 +66,13 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 		'subscribers-page'
 	);
 
-	const { data: subscribersTotals, isLoading } = useSubscribersTotalsWithoutAdminQueries( siteId );
+	const { data: subscribersTotals, isLoading } = useSubscribersTotalsQueries( siteId );
 	const isSimple = useSelector( isSimpleSite );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
-	const showLaunchpad = ! isLoading && ( isSimple || isAtomic ) && ! subscribersTotals?.total;
+	const hasNoSubscriberOtherThanAdmin =
+		! subscribersTotals?.total ||
+		( subscribersTotals?.total === 1 && subscribersTotals?.is_owner_subscribing );
+	const showLaunchpad = ! isLoading && ( isSimple || isAtomic ) && hasNoSubscriberOtherThanAdmin;
 
 	// Track the last viewed tab.
 	// Necessary to properly configure the fixed navigation headers.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #85140

## Proposed Changes

* Introduce the param `filter_admin` to API `/stats/followers` to filter the site admin from being a subscriber.
* Add the loading placeholder before fetching the subscriber amount to show the Launchpad.
* Revert the manual decreasement of the Subscriber Stats highlights numbers.
https://github.com/Automattic/wp-calypso/pull/83901/files#diff-60329bd4d2d0f356511a8699ca30ea65ee0e532c63469a648650e779fd0d26b3R57-R58

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply the Diff: `D135598-code`.
* Sandbox API: `public-api.wordpress.com`.
* Navigate to the Subscriber Stats page for a new site: `/stats/subscribers/{site-slug}`.
* Ensure the Launchpad shows.
<img width="1012" alt="截圖 2024-01-23 下午11 29 37" src="https://github.com/Automattic/wp-calypso/assets/6869813/5a45708a-840c-491f-89ea-a2a47cbbe521">

* Navigate to the Subscriber Stats page for a site with subscribers: `/stats/subscribers/{site-slug}`.
* Ensure the Subscriber Stats numbers are all aligned, which includes the site admin count.
<img width="1301" alt="截圖 2024-01-23 下午11 30 02" src="https://github.com/Automattic/wp-calypso/assets/6869813/442833e4-63dc-4729-b594-3a323c45ca52">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?