### PR TITLE
Marketplace Reviews: Update plugin banner wording

### DIFF
--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -406,7 +406,7 @@ function PluginDetails( props ) {
 						className="plugin-details__reviews-banner"
 						title={ translate( 'Review this plugin!' ) }
 						description={ translate(
-							'Please help other users sharing your experience with this plugin.'
+							'Please help other users by sharing your experience with this plugin.'
 						) }
 						onClick={ () => setIsReviewsModalVisible( true ) }
 						disableHref


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/wp-calypso/pull/86598/

## Proposed Changes

* Update the Banner wording from "Please help other users sharing your experience with this plugin." to "Please help other users **by** sharing your experience with this plugin."

|Before | After|
|-------|------|
| ![CleanShot 2024-01-23 at 16 39 18@2x](https://github.com/Automattic/wp-calypso/assets/3519124/0c487650-b5a2-4794-b23c-baaab1b56dcf) | ![CleanShot 2024-01-23 at 16 39 04@2x](https://github.com/Automattic/wp-calypso/assets/3519124/742b0a37-a389-459d-99cc-2886a3cd2680) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to a plugin you can review, e.g. `/plugins/woocommerce-subscriptions`
* Check the wording banner corresponds to the description

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?