### PR TITLE
Checkout: Fix hiding of discounts in checkout footer

### DIFF
--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -9,6 +9,7 @@ import {
 	LineItemType,
 	getSubtotalWithoutDiscounts,
 	getTotalDiscountsWithoutCredits,
+	filterAndGroupCostOverridesForDisplay,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -90,6 +91,7 @@ export default function BeforeSubmitCheckoutHeader() {
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
 	const translate = useTranslate();
 
+	const costOverridesList = filterAndGroupCostOverridesForDisplay( responseCart, translate );
 	const totalDiscount = getTotalDiscountsWithoutCredits( responseCart, translate );
 	const discountLineItem: LineItemType = {
 		id: 'total-discount',
@@ -105,7 +107,10 @@ export default function BeforeSubmitCheckoutHeader() {
 	const subTotalLineItemWithoutCoupon: LineItemType = {
 		id: 'subtotal-without-coupon',
 		type: 'subtotal',
-		label: totalDiscount > 0 ? translate( 'Subtotal before discounts' ) : translate( 'Subtotal' ),
+		label:
+			costOverridesList.length > 0
+				? translate( 'Subtotal before discounts' )
+				: translate( 'Subtotal' ),
 		formattedAmount: formatCurrency( subtotalBeforeDiscounts, responseCart.currency, {
 			isSmallestUnit: true,
 			stripZeros: true,
@@ -124,7 +129,9 @@ export default function BeforeSubmitCheckoutHeader() {
 				<WPOrderReviewSection>
 					<NonTotalPrices>
 						<NonProductLineItem subtotal lineItem={ subTotalLineItemWithoutCoupon } />
-						{ totalDiscount > 0 && <NonProductLineItem subtotal lineItem={ discountLineItem } /> }
+						{ costOverridesList.length > 0 && (
+							<NonProductLineItem subtotal lineItem={ discountLineItem } />
+						) }
 						{ taxLineItems.map( ( taxLineItem ) => (
 							<NonProductLineItem key={ taxLineItem.id } tax lineItem={ taxLineItem } />
 						) ) }


### PR DESCRIPTION
## Proposed Changes

This is a follow-up to https://github.com/Automattic/wp-calypso/pull/86759 which accidentally always hid the "Discounts" line at the bottom of checkout.

Before             |  After
:-------------------------:|:-------------------------:
<img width="577" alt="Screenshot 2024-01-23 at 11 43 44 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/94ab8ba3-d6ef-4efc-860b-13c4f2de5b6a"> | <img width="582" alt="Screenshot 2024-01-23 at 11 43 30 AM" src="https://github.com/Automattic/wp-calypso/assets/2036909/59b7362a-a683-4f4a-b694-114cb7322d3d">

## Testing Instructions

- Add a product to your cart that has a discount.
- View the bottom of checkout and verify that it reads "Subtotal before discounts" and includes a "Discounts" line.
- Add a product to your cart without any discounts.
- View the bottom of checkout and verify that it reads "Subtotal" and does not include a "Discounts" line.