### PR TITLE
Plans 2023: Add monthly interval to onboarding pm flow if no custom domain selected

### DIFF
--- a/client/my-sites/plans-features-main/hooks/use-filtered-displayed-intervals.ts
+++ b/client/my-sites/plans-features-main/hooks/use-filtered-displayed-intervals.ts
@@ -40,6 +40,9 @@ const useFilteredDisplayedIntervals = ( {
 		}
 
 		if ( intent === 'plans-paid-media' ) {
+			// Monetizing free domain users is hard. From experience, users who choose a free domain
+			// have very low intent to purchase something during signup. We show a cheaper and flexible
+			// monthly option for this specific segment, but hide it if a custom domain is selected.
 			if ( paidDomainName ) {
 				filteredIntervals = [ 'yearly', '2yearly', '3yearly' ];
 			}

--- a/client/my-sites/plans-features-main/hooks/use-filtered-displayed-intervals.ts
+++ b/client/my-sites/plans-features-main/hooks/use-filtered-displayed-intervals.ts
@@ -40,10 +40,8 @@ const useFilteredDisplayedIntervals = ( {
 		}
 
 		if ( intent === 'plans-paid-media' ) {
-			filteredIntervals = [ 'yearly', '2yearly', '3yearly' ];
-
-			if ( ! paidDomainName ) {
-				filteredIntervals = [ 'yearly', '2yearly', '3yearly', 'monthly' ];
+			if ( paidDomainName ) {
+				filteredIntervals = [ 'yearly', '2yearly', '3yearly' ];
 			}
 		}
 

--- a/client/my-sites/plans-features-main/hooks/use-filtered-displayed-intervals.ts
+++ b/client/my-sites/plans-features-main/hooks/use-filtered-displayed-intervals.ts
@@ -1,0 +1,50 @@
+import {
+	getPlan,
+	getBillingMonthsForTerm,
+	isFreePlan,
+	URL_FRIENDLY_TERMS_MAPPING,
+	UrlFriendlyTermType,
+} from '@automattic/calypso-products';
+import { PlansIntent } from '@automattic/plans-grid-next';
+import { useMemo } from 'react';
+
+interface Props {
+	intent?: PlansIntent;
+	displayedIntervals: UrlFriendlyTermType[];
+	paidDomainName?: string;
+	productSlug?: string;
+}
+
+const useFilteredDisplayedIntervals = ( {
+	intent,
+	displayedIntervals,
+	paidDomainName,
+	productSlug,
+}: Props ) => {
+	return useMemo( () => {
+		let filteredIntervals = displayedIntervals;
+
+		// Hide interval terms that are less than the current plan's term in months
+		if ( productSlug && ! isFreePlan( productSlug ) ) {
+			const currentPlanIntervalInMonths = getBillingMonthsForTerm(
+				getPlan( productSlug )?.term || ''
+			);
+
+			filteredIntervals = displayedIntervals.filter( ( intervalType ) => {
+				const intervalInMonths = getBillingMonthsForTerm(
+					URL_FRIENDLY_TERMS_MAPPING[ intervalType ] || ''
+				);
+
+				return intervalInMonths >= currentPlanIntervalInMonths;
+			} );
+		}
+
+		if ( intent === 'plans-paid-media' && ! paidDomainName ) {
+			filteredIntervals = [ ...filteredIntervals, 'monthly' ];
+		}
+
+		return filteredIntervals;
+	}, [ productSlug, displayedIntervals, intent, paidDomainName ] );
+};
+
+export default useFilteredDisplayedIntervals;

--- a/client/my-sites/plans-features-main/hooks/use-filtered-displayed-intervals.ts
+++ b/client/my-sites/plans-features-main/hooks/use-filtered-displayed-intervals.ts
@@ -39,8 +39,12 @@ const useFilteredDisplayedIntervals = ( {
 			} );
 		}
 
-		if ( intent === 'plans-paid-media' && ! paidDomainName ) {
-			filteredIntervals = [ ...filteredIntervals, 'monthly' ];
+		if ( intent === 'plans-paid-media' ) {
+			filteredIntervals = [ 'yearly', '2yearly', '3yearly' ];
+
+			if ( ! paidDomainName ) {
+				filteredIntervals = [ 'yearly', '2yearly', '3yearly', 'monthly' ];
+			}
 		}
 
 		return filteredIntervals;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -15,8 +15,6 @@ import {
 	isWpcomEnterpriseGridPlan,
 	type PlanSlug,
 	UrlFriendlyTermType,
-	getBillingMonthsForTerm,
-	URL_FRIENDLY_TERMS_MAPPING,
 } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button, Spinner } from '@automattic/components';
@@ -79,6 +77,7 @@ import { useModalResolutionCallback } from './components/plan-upsell-modal/hooks
 import useCheckPlanAvailabilityForPurchase from './hooks/use-check-plan-availability-for-purchase';
 import useCurrentPlanManageHref from './hooks/use-current-plan-manage-href';
 import useFilterPlansForPlanFeatures from './hooks/use-filter-plans-for-plan-features';
+import useFilteredDisplayedIntervals from './hooks/use-filtered-displayed-intervals';
 import usePlanBillingPeriod from './hooks/use-plan-billing-period';
 import usePlanFromUpsells from './hooks/use-plan-from-upsells';
 import usePlanIntentFromSiteMeta from './hooks/use-plan-intent-from-site-meta';
@@ -528,19 +527,12 @@ const PlansFeaturesMain = ( {
 		_customerType = 'business';
 	}
 
-	let filteredDisplayedIntervals = displayedIntervals;
-	// Hide interval terms that are less than the current plan's term in months
-	if ( currentPlan?.productSlug && ! isFreePlan( currentPlan.productSlug ) ) {
-		const currentPlanIntervalTypeBillingMonths = getBillingMonthsForTerm(
-			getPlan( currentPlan.productSlug )?.term || ''
-		);
-		filteredDisplayedIntervals = displayedIntervals.filter( ( intervalType ) => {
-			const intervalTypeInMonths = getBillingMonthsForTerm(
-				URL_FRIENDLY_TERMS_MAPPING[ intervalType ] || ''
-			);
-			return intervalTypeInMonths >= currentPlanIntervalTypeBillingMonths;
-		} );
-	}
+	const filteredDisplayedIntervals = useFilteredDisplayedIntervals( {
+		productSlug: currentPlan?.productSlug,
+		displayedIntervals,
+		intent,
+		paidDomainName,
+	} );
 
 	const planTypeSelectorProps = useMemo( () => {
 		const props = {

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -188,7 +188,6 @@ export function generateFlows( {
 			optionalDependenciesInQuery: [ 'coupon' ],
 			props: {
 				plans: {
-					displayedIntervals: [ 'yearly', '2yearly', '3yearly' ],
 					/**
 					 * This intent is geared towards customizations related to the paid media flow
 					 * Current customizations are as follows


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Related to https://github.com/Automattic/growth-foundations/issues/302
- "we also need to show monthly plans on the drop-down menu of onboarding-pm flow when free domain/skip domain selected" p1705653191840109-slack-C059R8S4ALT
- peP6yB-1OY-p2

## Proposed Changes

* When no custom domain is selected for the onboarding-pm flow, include the "monthly" plan type selector interval for selection.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out branch
* Navigate to `start/onboarding-pm`
* Select a custom domain and continue
* Verify that no monthly interval is available for selection in the plan type selector dropdown
* Return to the domains screen of `start/onboarding-pm`
* Select no domain or a free domain and continue
* Verify that a monthly interval is available for selection

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?