### PR TITLE
Fix sub management when some site has no URL

### DIFF
--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -120,8 +120,8 @@ const useSiteSubscriptionsQuery = ( {
 			}
 
 			return (
-				item.name.toLowerCase().includes( searchTermLowerCase ) ||
-				item.URL.toLowerCase().includes( searchTermLowerCase )
+				item?.name?.toLowerCase().includes( searchTermLowerCase ) ||
+				item?.URL?.toLowerCase().includes( searchTermLowerCase )
 			);
 		};
 		const sort = getSortFunction( sortTerm );

--- a/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
+++ b/packages/data-stores/src/reader/queries/use-site-subscriptions-query.ts
@@ -120,8 +120,8 @@ const useSiteSubscriptionsQuery = ( {
 			}
 
 			return (
-				item?.name?.toLowerCase().includes( searchTermLowerCase ) ||
-				item?.URL?.toLowerCase().includes( searchTermLowerCase )
+				item?.name?.toLowerCase?.().includes( searchTermLowerCase ) ||
+				item?.URL?.toLowerCase?.().includes( searchTermLowerCase )
 			);
 		};
 		const sort = getSortFunction( sortTerm );


### PR DESCRIPTION
It's probably very very rare, but it can happen that the subscription endpoint will return sites without a URL value. This guards against that. 

See: p1706024532007979-slack-C03N25JPCE4
