### PR TITLE
Update error notice for card errors

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/payment-method-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-form/index.tsx
@@ -140,8 +140,14 @@ function PaymentMethodForm() {
 
 	const handleChangeError = useCallback(
 		( { transactionError }: { transactionError: string | null } ) => {
-			if ( !! transactionError && transactionError.includes( 'CVC' ) ) {
-				transactionError = translate( 'Your CVC code or card expiration is invalid.' );
+			if (
+				!! transactionError &&
+				( transactionError.toLowerCase().includes( 'cvc' ) ||
+					transactionError.toLowerCase().includes( 'code' ) )
+			) {
+				transactionError = translate(
+					'Your payment method cvc code or expiration date is invalid.'
+				);
 			}
 			reduxDispatch(
 				errorNotice(

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-form/index.tsx
@@ -143,7 +143,7 @@ function PaymentMethodForm() {
 			if (
 				transactionError &&
 				( transactionError.toLowerCase().includes( 'cvc' ) ||
-					transactionError.toLowerCase().includes( 'code' ) )
+					transactionError.toLowerCase().includes( 'security code' ) )
 			) {
 				transactionError = translate(
 					'Your payment method cvc code or expiration date is invalid.'

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-form/index.tsx
@@ -141,7 +141,7 @@ function PaymentMethodForm() {
 	const handleChangeError = useCallback(
 		( { transactionError }: { transactionError: string | null } ) => {
 			if ( !! transactionError && transactionError.includes( 'CVC' ) ) {
-				( 'Your CVC code or card expiration is invalid.' );
+				transactionError = translate( 'Your CVC code or card expiration is invalid.' );
 			}
 			reduxDispatch(
 				errorNotice(

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-form/index.tsx
@@ -141,7 +141,7 @@ function PaymentMethodForm() {
 	const handleChangeError = useCallback(
 		( { transactionError }: { transactionError: string | null } ) => {
 			if (
-				!! transactionError &&
+				transactionError &&
 				( transactionError.toLowerCase().includes( 'cvc' ) ||
 					transactionError.toLowerCase().includes( 'code' ) )
 			) {

--- a/client/jetpack-cloud/sections/partner-portal/payment-method-form/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/payment-method-form/index.tsx
@@ -140,6 +140,9 @@ function PaymentMethodForm() {
 
 	const handleChangeError = useCallback(
 		( { transactionError }: { transactionError: string | null } ) => {
+			if ( !! transactionError && transactionError.includes( 'CVC' ) ) {
+				( 'Your CVC code or card expiration is invalid.' );
+			}
 			reduxDispatch(
 				errorNotice(
 					transactionError ||


### PR DESCRIPTION
Update the error handling to account for a cvc error response potentially being an invalid card expiration.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Update the error notice in the card additions page to indicate when a received CVC error may actually be for an incorrect expiration date and account for both in the erro messages.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Jetpack Cloud Live link below to access the payments add page at `partner-portal/payment-methods/add`
* Enter in a card number with an incorrect CVC. Ensure that the new error message is displayed. 
* Enter in a card number with a correct CVC but incorrect expiration date. Ensure that an appropriate error is displayed. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
