### PR TITLE
Plans 2023: Remove hardcoded feature flags for flows with hidden plan type selector

### DIFF
--- a/client/jetpack-app/plans/main.tsx
+++ b/client/jetpack-app/plans/main.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { getPlan, PLAN_FREE } from '@automattic/calypso-products';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
@@ -119,13 +118,6 @@ const JetpackAppPlans: React.FC< JetpackAppPlansProps > = ( { paidDomainName, or
 						hidePlanTypeSelector
 						hidePlansFeatureComparison
 						setSiteUrlAsFreeDomainSuggestion={ setSiteUrlAsFreeDomainSuggestion }
-						showPlanTypeSelectorDropdown={
-							/**
-							 *	Override the default feature flag to prevent this feature from rendering in untested locations
-							 *  The hardcoded 'false' short curicuit should be removed once the feature is fully tested in the given context
-							 */
-							config.isEnabled( 'onboarding/interval-dropdown' ) && false
-						}
 					/>
 				</>
 			) : (

--- a/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
+++ b/client/my-sites/plans/ecommerce-trial/wooexpress-plans/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	PLAN_FREE,
 	PLAN_WOOEXPRESS_MEDIUM,
@@ -133,13 +132,6 @@ export function WooExpressPlans( props: WooExpressPlansProps ) {
 					hidePlanTypeSelector={ true }
 					hideUnavailableFeatures={ true }
 					intent="plans-woocommerce"
-					showPlanTypeSelectorDropdown={
-						/**
-						 *	Override the default feature flag to prevent this feature from rendering in untested locations
-						 *  The hardcoded 'false' short curicuit should be removed once the feature is fully tested in the given context
-						 */
-						config.isEnabled( 'onboarding/interval-dropdown' ) && false
-					}
 				/>
 			</div>
 

--- a/client/my-sites/plans/p2-plans-main.jsx
+++ b/client/my-sites/plans/p2-plans-main.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -23,13 +22,6 @@ export class P2PlansMain extends Component {
 					hidePlanTypeSelector={ true }
 					intent="plans-p2"
 					isInSignup={ false }
-					showPlanTypeSelectorDropdown={
-						/**
-						 *	Override the default feature flag to prevent this feature from rendering in untested locations
-						 *  The hardcoded 'false' short curicuit should be removed once the feature is fully tested in the given context
-						 */
-						config.isEnabled( 'onboarding/interval-dropdown' ) && false
-					}
 				/>
 			</>
 		);

--- a/client/my-sites/plans/trials/business-trial-plans/index.tsx
+++ b/client/my-sites/plans/trials/business-trial-plans/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	PLAN_FREE,
 	PRODUCT_1GB_SPACE,
@@ -52,13 +51,6 @@ export function BusinessTrialPlans( props: BusinessTrialPlansProps ) {
 				hideUnavailableFeatures={ true }
 				hidePlansFeatureComparison={ true }
 				intent="plans-business-trial"
-				showPlanTypeSelectorDropdown={
-					/**
-					 *	Override the default feature flag to prevent this feature from rendering in untested locations
-					 *  The hardcoded 'false' short curicuit should be removed once the feature is fully tested in the given context
-					 */
-					config.isEnabled( 'onboarding/interval-dropdown' ) && false
-				}
 			/>
 		</div>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/growth-foundations/issues/305

## Proposed Changes

* The new plan type selector dropdown was disabled for all others flows except for signup flows. The flags, however, are unnecessary for flows that hide the plan type selector anyway ( as evidenced by the `hidePlanTypeSelector` prop passed to each of the plans grids note below )

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### WooExpress flow plans page
* Visit `WordPress.com/setup/wooexpress`
* Wait for the site to generate
* Navigate to `/plans`
* Smoke test the plans grid. Note that the WooExpress plans page renders its own custom plan type selector with a monthly / 1 year toggle. It should still behave as it does in production.

#### P2 flow plans page
* Visit `/start/p2`
* Generate a p2 workspace
* Navigate to `/plans/{new_p2_workspace_site_slug}`
* Smoke test the plans grid. Everything should behave as it currently does in production.

#### Jetpack App flow
* Follow testing instructions noted in this PR https://github.com/Automattic/wp-calypso/pull/82135
* Visit `WordPress.com/jetpack-app/plans`
* Desktop view is broken, but I believe that is expected? This view is meant primarily for a mobile experience
* Verify that the plans grid in the mobile view continues to behave as expected

#### Business Trial Plans Page
* All trial pages share a single UI view, which can be tested following the instructions in this PR https://github.com/Automattic/wp-calypso/pull/80095
  * Create a jurassic.ninja site
  * Install Move to WordPress.com plugin
  * Click on Migrate site to WordPress.com CTA
  * Migrate site to WordPress.com
  * Visit the upgrades > plans page for the newly created WordPress.com site
  * Smoke test the plans grid. Everything should behave as it currently does in production.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?