### PR TITLE
Adding new UI to promote button

### DIFF
--- a/client/my-sites/promote-post-i2/components/post-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/post-item/index.tsx
@@ -113,7 +113,7 @@ export default function PostItem( { post }: { post: BlazablePost } ) {
 							{ __( 'View' ) }
 						</a>
 						<Button
-							variant="primary"
+							variant="secondary"
 							isBusy={ false }
 							disabled={ false }
 							onClick={ onClickPromote }
@@ -137,7 +137,7 @@ export default function PostItem( { post }: { post: BlazablePost } ) {
 			</td>
 			<td className="post-item__post-promote">
 				<Button
-					variant="primary"
+					variant="secondary"
 					isBusy={ false }
 					disabled={ false }
 					onClick={ onClickPromote }

--- a/client/my-sites/promote-post-i2/components/post-item/style.scss
+++ b/client/my-sites/promote-post-i2/components/post-item/style.scss
@@ -113,6 +113,8 @@ body.is-section-promote-post-i2 {
 
 		&__post-promote-button {
 			border-radius: 4px;
+			color: #3858ea;
+			box-shadow: inset 0 0 0 1px rgba(56, 88, 234, 0.5);
 		}
 	}
 

--- a/client/my-sites/promote-post-i2/components/post-item/style.scss
+++ b/client/my-sites/promote-post-i2/components/post-item/style.scss
@@ -113,9 +113,9 @@ body.is-section-promote-post-i2 {
 
 		&__post-promote-button {
 			border-radius: 4px;
-			border: 1.5px solid var(--color-accent) !important;
-			color: var(--color-accent) !important;
-			background-color: var(--color-surface) !important;
+			border: 1.5px solid var(--color-accent);
+			color: var(--color-accent);
+			background-color: var(--color-surface);
 		}
 	}
 

--- a/client/my-sites/promote-post-i2/components/post-item/style.scss
+++ b/client/my-sites/promote-post-i2/components/post-item/style.scss
@@ -113,8 +113,9 @@ body.is-section-promote-post-i2 {
 
 		&__post-promote-button {
 			border-radius: 4px;
-			color: #3858ea;
-			box-shadow: inset 0 0 0 1px rgba(56, 88, 234, 0.5);
+			border: 1.5px solid var(--color-accent) !important;
+			color: var(--color-accent) !important;
+			background-color: var(--color-surface) !important;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* New UI proposed for the promote button. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- [ ] Open calypso and navigate to any blog
- [ ] Click on Tools > Advertising
- [ ] Watch the list and look for the promote button. It should have the same UI as the one shown in this figma ss.

![Screenshot 2024-01-23 at 6 39 44 p m](https://github.com/Automattic/wp-calypso/assets/5014402/03c226b2-ad1c-4a31-8f34-b0754048476f)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
