### PR TITLE
Add check for Jetpack 'google-analytics' module to decide panel visibility

### DIFF
--- a/client/my-sites/site-settings/analytics/form-google-analytics.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics.jsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getFilteredAndSortedPlugins } from 'calypso/state/plugins/installed/selectors-ts';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
+import getJetpackModule from 'calypso/state/selectors/get-jetpack-module';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -31,6 +32,7 @@ export const GoogleAnalyticsForm = ( props ) => {
 		uniqueEventTracker,
 		path,
 		isAtomic,
+		isJetpackModuleAvailable,
 		isGoogleAnalyticsEligible,
 	} = props;
 	const [ isCodeValid, setIsCodeValid ] = useState( true );
@@ -85,6 +87,10 @@ export const GoogleAnalyticsForm = ( props ) => {
 		isAtomic,
 	};
 	if ( ( props.siteIsJetpack && ! isAtomic ) || ( isAtomic && isGoogleAnalyticsEligible ) ) {
+		// Google Analytics module is not available (important distinction from not active)
+		if ( ! isJetpackModuleAvailable ) {
+			return null;
+		}
 		return <GoogleAnalyticsJetpackForm { ...newProps } />;
 	}
 	return <GoogleAnalyticsSimpleForm { ...newProps } />;
@@ -94,6 +100,7 @@ const mapStateToProps = ( state ) => {
 	const site = getSelectedSite( state );
 	const siteId = getSelectedSiteId( state );
 	const isGoogleAnalyticsEligible = siteHasFeature( state, siteId, FEATURE_GOOGLE_ANALYTICS );
+	const isJetpackModuleAvailable = Boolean( getJetpackModule( state, siteId, 'google-analytics' ) );
 	const jetpackModuleActive = isJetpackModuleActive( state, siteId, 'google-analytics' );
 	const siteIsJetpack = isJetpackSite( state, siteId );
 	const googleAnalyticsEnabled = site && ( ! siteIsJetpack || jetpackModuleActive );
@@ -108,7 +115,7 @@ const mapStateToProps = ( state ) => {
 		siteId,
 		siteIsJetpack,
 		sitePlugins,
-		jetpackModuleActive,
+		isJetpackModuleAvailable,
 		isAtomic: isAtomicSite( state, siteId ),
 		isGoogleAnalyticsEligible,
 	};

--- a/client/my-sites/site-settings/test/form-google-analytics.jsx
+++ b/client/my-sites/site-settings/test/form-google-analytics.jsx
@@ -28,6 +28,7 @@ import {
 } from '@automattic/calypso-products';
 import { render, screen } from '@testing-library/react';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import { GoogleAnalyticsForm } from '../analytics/form-google-analytics';
 import GoogleAnalyticsJetpackForm from '../analytics/form-google-analytics-jetpack';
 import GoogleAnalyticsSimpleForm from '../analytics/form-google-analytics-simple';
 
@@ -57,6 +58,21 @@ describe( 'GoogleAnalyticsForm basic tests', () => {
 		} );
 	} );
 
+	test( 'base form should return null when ga module not available in a jetpack site', () => {
+		const gaFormProps = {
+			...props,
+			site: {
+				...props.site,
+				slug: 'test-site',
+			},
+			siteIsJetpack: true,
+			isAtomic: true,
+			isGoogleAnalyticsEligible: true,
+			isJetpackModuleAvailable: false,
+		};
+		render( <GoogleAnalyticsForm { ...gaFormProps } /> );
+		expect( screen.queryByRole( 'form', { name: /analytics/i } ) ).toBeNull();
+	} );
 	test( 'simple form should not blow up and have proper CSS class', () => {
 		render( <GoogleAnalyticsSimpleForm { ...props } /> );
 		expect( screen.queryByRole( 'form', { name: /analytics/i } ) ).toBeVisible();


### PR DESCRIPTION
Related to #69320
Closes #69320

## Proposed Changes

* Removes Google Analytics panel from `Tools > Marketing > Traffic` when a Jetpack site does not have the module available

## Testing Instructions

#### Testing creator plan (simple site)

1. Set up a site with `Creator` plan, **do not install any plugins or transfer to atomic**
2. Go to Tools > Marketing > Traffic
3. Observe that Google Analytics panel is visible
4. Click on the toggle
5. Observe the panel is expanded, per screenshot:

<img width="1072" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3747241/e29c2a4b-244b-42ad-a8a8-94ab40d3f655">

#### Testing creator plan (Atomic site)

1. In a creator plan site, install any plugin to transfer the site to Atomic if it's a simple site
2. Go to Tools > Marketing > Traffic
3. Observe that Google Analytics panel is visible
4. Click on the toggle
5. Observe that GA is enabled without expanding the expanded, per screenshot:

<img width="1072" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3747241/9b23ddc8-d933-4432-8f07-b9ef8e34a264">

#### Testing site without Jetpack's GA module

1. Use a site on Woo Express, free trial, or entrepreneur plan
2. Go to Tools > Marketing > Traffic
3. Observe that Google Analytics panel is NOT visible, per screenshot

<img width="1072" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3747241/5c09c8be-5eda-4be5-a9ae-3df7b6655d90">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
