### PR TITLE
Upsell Nudge: Add event tracking for impression

### DIFF
--- a/client/blocks/post-share/nudges.jsx
+++ b/client/blocks/post-share/nudges.jsx
@@ -47,6 +47,7 @@ export const UpgradeToPremiumNudgePure = ( props ) => {
 					args: { planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '' },
 				} )
 			}
+			event="post_share_plan_upgrade_nudge"
 		/>
 	);
 };

--- a/client/blocks/upsell-nudge/index.tsx
+++ b/client/blocks/upsell-nudge/index.tsx
@@ -293,11 +293,15 @@ const ConnectedUpsellNudge = connect( ( state: IAppState, ownProps: OwnProps ) =
 } )( UpsellNudge );
 
 export default function Wrapper( props: OwnProps ) {
-	return (
-		<AsyncLoad
-			require="../../my-sites/checkout/purchase-modal/is-eligible-for-one-click-checkout-wrapper"
-			component={ ConnectedUpsellNudge }
-			componentProps={ props }
-		/>
-	);
+	const { isOneClickCheckoutEnabled = true, plan } = props;
+	if ( isOneClickCheckoutEnabled && plan ) {
+		return (
+			<AsyncLoad
+				require="../../my-sites/checkout/purchase-modal/is-eligible-for-one-click-checkout-wrapper"
+				component={ ConnectedUpsellNudge }
+				componentProps={ props }
+			/>
+		);
+	}
+	return <ConnectedUpsellNudge { ...props } />;
 }

--- a/client/blocks/upsell-nudge/index.tsx
+++ b/client/blocks/upsell-nudge/index.tsx
@@ -96,7 +96,7 @@ type OwnProps = {
 
 type Props = OwnProps & ConnectedProps;
 
-const UpsellNudge = ( {
+export const UpsellNudge = ( {
 	callToAction,
 	secondaryCallToAction,
 	canManageSite,

--- a/client/blocks/upsell-nudge/index.tsx
+++ b/client/blocks/upsell-nudge/index.tsx
@@ -16,17 +16,14 @@ import { useState } from 'react';
 import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import Banner from 'calypso/components/banner';
+import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { addQueryArgs } from 'calypso/lib/url';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import {
-	getCurrentPlan,
-	isSiteOnECommerceTrial,
-	isSiteOnWooExpress,
-} from 'calypso/state/sites/plans/selectors';
+import { isSiteOnECommerceTrial, isSiteOnWooExpress } from 'calypso/state/sites/plans/selectors';
 import { getSite, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import type { SiteDetails } from '@automattic/data-stores';
@@ -39,68 +36,70 @@ import './style.scss';
 
 const debug = debugFactory( 'calypso:upsell-nudge' );
 
-type Props = Partial< {
-	callToAction: TranslateResult;
-	secondaryCallToAction: TranslateResult;
+type ConnectedProps = {
+	site: SiteDetails | null | undefined;
+	selectedSiteHasFeature: boolean;
 	canManageSite: boolean;
-	canUserUpgrade: boolean;
-	className?: string;
-	compact: boolean;
-	compactButton: boolean;
-	customerType: string;
-	description: TranslateResult;
-	disableHref: boolean;
-	dismissPreferenceName: string;
-	dismissTemporary: boolean;
-	event: string;
-	secondaryEvent: string;
-	feature: string;
-	forceDisplay: boolean;
-	forceHref: boolean;
-	horizontal: boolean;
-	href: string;
-	secondaryHref: string;
-	isJetpackDevDocs: boolean;
 	isJetpack: boolean;
 	isAtomic: boolean;
 	isVip: boolean;
-	siteIsWPForTeams: boolean;
-	list: TranslateResult[] | unknown[];
-	renderListItem: ( arg: any ) => void;
-	onClick: () => void;
-	secondaryOnClick: () => void;
-	onDismissClick: () => void;
-	plan: string;
-	price: number[];
-	primaryButton: boolean;
-	selectedSiteHasFeature: boolean;
-	showIcon: boolean;
-	icon: string;
-	site: SiteDetails | null | undefined;
-	siteSlug: SiteSlug | null;
-	target: string;
-	title: TranslateResult;
-	tracksClickName: string;
-	tracksClickProperties: Record< string, unknown >;
-	tracksDismissName: string;
-	tracksDismissProperties: Record< string, unknown >;
-	tracksImpressionName: string;
-	tracksImpressionProperties: Record< string, unknown >;
-	displayAsLink: boolean;
 	isSiteWooExpressOrEcomFreeTrial: boolean;
-	isBusy: boolean;
-	isEligibleForOneClickCheckout: IsEligibleForOneClickCheckoutReturnValue;
-	isOneClickCheckoutEnabled: boolean;
-} >;
+	siteSlug: SiteSlug | null;
+	siteIsWPForTeams: boolean;
+};
 
-/**
- * @param {any} props Props declared as `any` to prevent errors in TSX files that use this component.
- */
-export const UpsellNudge = ( {
+type OwnProps = {
+	callToAction?: TranslateResult;
+	className?: string;
+	compact?: boolean;
+	compactButton?: boolean;
+	customerType?: string;
+	description?: TranslateResult;
+	disableCircle?: boolean;
+	disableHref?: boolean;
+	dismissPreferenceName?: string;
+	dismissTemporary?: boolean;
+	displayAsLink?: boolean;
+	event: string;
+	feature?: string;
+	forceDisplay?: boolean;
+	forceHref?: boolean;
+	horizontal?: boolean;
+	href?: string;
+	icon?: string;
+	iconPath?: string;
+	isBusy?: boolean;
+	isEligibleForOneClickCheckout?: IsEligibleForOneClickCheckoutReturnValue;
+	isJetpackDevDocs?: boolean;
+	isOneClickCheckoutEnabled?: boolean;
+	list?: TranslateResult[] | unknown[];
+	onClick?: () => void;
+	onDismissClick?: () => void;
+	plan?: string;
+	price?: number[];
+	primaryButton?: boolean;
+	renderListItem?: ( arg: any ) => void;
+	secondaryCallToAction?: TranslateResult;
+	secondaryEvent?: string;
+	secondaryHref?: string;
+	secondaryOnClick?: () => void;
+	showIcon?: boolean;
+	target?: string;
+	title?: TranslateResult;
+	tracksClickName?: string;
+	tracksClickProperties?: Record< string, unknown >;
+	tracksDismissName?: string;
+	tracksDismissProperties?: Record< string, unknown >;
+	tracksImpressionName?: string;
+	tracksImpressionProperties?: Record< string, unknown >;
+};
+
+type Props = OwnProps & ConnectedProps;
+
+const UpsellNudge = ( {
 	callToAction,
 	secondaryCallToAction,
 	canManageSite,
-	canUserUpgrade,
 	className,
 	compact,
 	compactButton = true,
@@ -133,6 +132,8 @@ export const UpsellNudge = ( {
 	selectedSiteHasFeature,
 	showIcon = false,
 	icon = 'star',
+	iconPath,
+	disableCircle,
 	site,
 	siteSlug,
 	target,
@@ -171,7 +172,7 @@ export const UpsellNudge = ( {
 		return null;
 	}
 
-	if ( ! href && siteSlug && canUserUpgrade ) {
+	if ( ! href && siteSlug && canManageSite ) {
 		href = addQueryArgs( { feature, plan }, `/plans/${ siteSlug }` );
 		if ( customerType ) {
 			href = `/plans/${ siteSlug }?customerType=${ customerType }`;
@@ -203,7 +204,7 @@ export const UpsellNudge = ( {
 			isEligibleForOneClickCheckout?.result === true &&
 			plan &&
 			siteSlug &&
-			canUserUpgrade
+			canManageSite
 		) {
 			e.preventDefault();
 			setShowPurchaseModal( true );
@@ -219,6 +220,16 @@ export const UpsellNudge = ( {
 					plan={ plan }
 					siteSlug={ siteSlug }
 					setShowPurchaseModal={ setShowPurchaseModal }
+				/>
+			) }
+			{ ! isEligibleForOneClickCheckout?.isLoading && (
+				<TrackComponentView
+					eventName="calypso_upsell_nudge_impression"
+					eventProperties={ {
+						is_eligible_for_one_click_checkout: !! isEligibleForOneClickCheckout?.result,
+						plan: plan,
+						event,
+					} }
 				/>
 			) }
 			<Banner
@@ -239,6 +250,8 @@ export const UpsellNudge = ( {
 				href={ href }
 				secondaryHref={ secondaryHref }
 				icon={ icon }
+				iconPath={ iconPath }
+				disableCircle={ disableCircle }
 				jetpack={ isJetpack || isJetpackDevDocs } //Force show Jetpack example in Devdocs
 				isAtomic={ isAtomic }
 				list={ list }
@@ -267,7 +280,7 @@ export const UpsellNudge = ( {
 	);
 };
 
-const ConnectedUpsellNudge = connect( ( state: IAppState, ownProps: Props ) => {
+const ConnectedUpsellNudge = connect( ( state: IAppState, ownProps: OwnProps ) => {
 	const siteId = getSelectedSiteId( state );
 
 	return {
@@ -280,22 +293,17 @@ const ConnectedUpsellNudge = connect( ( state: IAppState, ownProps: Props ) => {
 		isSiteWooExpressOrEcomFreeTrial: siteId
 			? isSiteOnECommerceTrial( state, siteId ) || isSiteOnWooExpress( state, siteId )
 			: false,
-		currentPlan: getCurrentPlan( state, siteId ),
 		siteSlug: ownProps.disableHref ? null : getSelectedSiteSlug( state ),
-		canUserUpgrade: canCurrentUser( state, getSelectedSiteId( state ), 'manage_options' ),
 		siteIsWPForTeams: isSiteWPForTeams( state, getSelectedSiteId( state ) ) || false,
 	};
 } )( UpsellNudge );
 
-export default function Wrapper( props: Props ) {
-	if ( props.isOneClickCheckoutEnabled ) {
-		return (
-			<AsyncLoad
-				require="../../my-sites/checkout/purchase-modal/is-eligible-for-one-click-checkout-wrapper"
-				component={ ConnectedUpsellNudge }
-				componentProps={ props }
-			/>
-		);
-	}
-	return <ConnectedUpsellNudge { ...props } />;
+export default function Wrapper( props: OwnProps ) {
+	return (
+		<AsyncLoad
+			require="../../my-sites/checkout/purchase-modal/is-eligible-for-one-click-checkout-wrapper"
+			component={ ConnectedUpsellNudge }
+			componentProps={ props }
+		/>
+	);
 }

--- a/client/blocks/upsell-nudge/index.tsx
+++ b/client/blocks/upsell-nudge/index.tsx
@@ -55,7 +55,6 @@ type OwnProps = {
 	compactButton?: boolean;
 	customerType?: string;
 	description?: TranslateResult;
-	disableCircle?: boolean;
 	disableHref?: boolean;
 	dismissPreferenceName?: string;
 	dismissTemporary?: boolean;
@@ -67,7 +66,6 @@ type OwnProps = {
 	horizontal?: boolean;
 	href?: string;
 	icon?: string;
-	iconPath?: string;
 	isBusy?: boolean;
 	isEligibleForOneClickCheckout?: IsEligibleForOneClickCheckoutReturnValue;
 	isJetpackDevDocs?: boolean;
@@ -132,8 +130,6 @@ export const UpsellNudge = ( {
 	selectedSiteHasFeature,
 	showIcon = false,
 	icon = 'star',
-	iconPath,
-	disableCircle,
 	site,
 	siteSlug,
 	target,
@@ -250,8 +246,6 @@ export const UpsellNudge = ( {
 				href={ href }
 				secondaryHref={ secondaryHref }
 				icon={ icon }
-				iconPath={ iconPath }
-				disableCircle={ disableCircle }
 				jetpack={ isJetpack || isJetpackDevDocs } //Force show Jetpack example in Devdocs
 				isAtomic={ isAtomic }
 				list={ list }

--- a/client/components/domains/transfer-domain-step/index.jsx
+++ b/client/components/domains/transfer-domain-step/index.jsx
@@ -427,6 +427,7 @@ class TransferDomainStep extends Component {
 							} )
 						}
 						showIcon={ true }
+						event="domains_transfer_plan_required"
 					/>
 					{ content }
 				</div>

--- a/client/my-sites/site-settings/built-by-upsell-banner.tsx
+++ b/client/my-sites/site-settings/built-by-upsell-banner.tsx
@@ -1,7 +1,7 @@
 import { SiteDetails } from '@automattic/data-stores';
 import { useI18n } from '@wordpress/react-i18n';
 import builtByLogo from 'calypso/assets/images/illustrations/built-by-wp-vert-blue.png';
-import { Banner } from 'calypso/components/banner';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
 import { addQueryArgs } from 'calypso/lib/url';
 
 type Props = {
@@ -35,7 +35,7 @@ export function BuiltByUpsell( { site, isUnlaunchedSite, urlRef }: Props ) {
 		'https://wordpress.com/website-design-service/'
 	);
 	return (
-		<Banner
+		<UpsellNudge
 			className="site-settings__built-by-upsell"
 			title={ __( 'We’ll build your site for you' ) }
 			description={ __(
@@ -46,6 +46,7 @@ export function BuiltByUpsell( { site, isUnlaunchedSite, urlRef }: Props ) {
 			target="_blank"
 			iconPath={ builtByLogo }
 			disableCircle={ true }
+			showIcon={ true }
 			event="settings_bb_upsell"
 			tracksImpressionName="calypso_settings_bb_upsell_impression"
 			tracksClickName="calypso_settings_bb_upsell_cta_click"

--- a/client/my-sites/site-settings/built-by-upsell-banner.tsx
+++ b/client/my-sites/site-settings/built-by-upsell-banner.tsx
@@ -1,7 +1,7 @@
 import { SiteDetails } from '@automattic/data-stores';
 import { useI18n } from '@wordpress/react-i18n';
 import builtByLogo from 'calypso/assets/images/illustrations/built-by-wp-vert-blue.png';
-import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import { Banner } from 'calypso/components/banner';
 import { addQueryArgs } from 'calypso/lib/url';
 
 type Props = {
@@ -35,7 +35,7 @@ export function BuiltByUpsell( { site, isUnlaunchedSite, urlRef }: Props ) {
 		'https://wordpress.com/website-design-service/'
 	);
 	return (
-		<UpsellNudge
+		<Banner
 			className="site-settings__built-by-upsell"
 			title={ __( 'We’ll build your site for you' ) }
 			description={ __(
@@ -46,7 +46,6 @@ export function BuiltByUpsell( { site, isUnlaunchedSite, urlRef }: Props ) {
 			target="_blank"
 			iconPath={ builtByLogo }
 			disableCircle={ true }
-			showIcon={ true }
 			event="settings_bb_upsell"
 			tracksImpressionName="calypso_settings_bb_upsell_impression"
 			tracksClickName="calypso_settings_bb_upsell_cta_click"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Adds a new Tracks event to track impressions of the `<UpsellNudge/>` component, `calypso_upsell_nudge_impression`. While the underlying `<Banner/>` does track impressions, the exact event can be overridden by consumers, leading to a scenario where it is not possible to measure impressions with one event.
* The event properties are `is_eligible_for_one_click_checkout`, `plan` and `event`. Since `event` is a required prop for this component, this PR also adds it to `client/blocks/post-share/nudges.jsx` and `client/components/domains/transfer-domain-step/index.jsx` which are the only two usages where this prop was absent.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the browser dev console.
* Go to `/plugins/<site slug>` for a site on a free plan.
* In the Network tab, look for the requests to `t.gif` and confirm that a request with the `en` property as `calypso_upsell_nudge_impression` is present. The `is_eligible_for_one_click_checkout`, `plan` and `event` properties should also be present.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?