### PR TITLE
Jetpack Manage: Require an Agency account to access the Overview page.

### DIFF
--- a/client/jetpack-cloud/sections/overview/controller.tsx
+++ b/client/jetpack-cloud/sections/overview/controller.tsx
@@ -1,11 +1,22 @@
-import { type Callback, type Context } from '@automattic/calypso-router';
+import page, { type Callback, type Context } from '@automattic/calypso-router';
 import ContentSidebar from 'calypso/jetpack-cloud/components/content-sidebar';
 import Overview from 'calypso/jetpack-cloud/sections/overview/primary/overview';
 import OverviewSidebar from 'calypso/jetpack-cloud/sections/overview/primary/sidebar';
 import JetpackManageSidebar from 'calypso/jetpack-cloud/sections/sidebar-navigation/jetpack-manage';
+import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 
 const setSidebar = ( context: Context ): void => {
 	context.secondary = <JetpackManageSidebar path={ context.path } />;
+};
+
+export const requireAccessContext: Callback = ( context, next ) => {
+	const state = context.store.getState();
+	const isAgency = isAgencyUser( state );
+	if ( ! isAgency ) {
+		return page.redirect( '/' );
+	}
+
+	next();
 };
 
 export const overviewContext: Callback = ( context, next ) => {

--- a/client/jetpack-cloud/sections/overview/index.ts
+++ b/client/jetpack-cloud/sections/overview/index.ts
@@ -5,5 +5,12 @@ import { navigation } from 'calypso/my-sites/controller';
 import * as controller from './controller';
 
 export default function () {
-	page( overviewPath(), navigation, controller.overviewContext, makeLayout, clientRender );
+	page(
+		overviewPath(),
+		navigation,
+		controller.requireAccessContext,
+		controller.overviewContext,
+		makeLayout,
+		clientRender
+	);
 }


### PR DESCRIPTION
The Jetpack Manage overview page doesn't verify if the logged-in user is an agency account or not. This means that non-agency users can access the page, but most of the links on the page won't work, as they are meant for agency users only. This PR prevents non-agency users to access this page.

## Proposed Changes

* Add `requireAccessContext` in the Overview page route that checks if the current user is an agency account. Page will now redirect to the landing page if the user is non-agency.

## Testing Instructions
* Spin up Jetpack cloud locally using the command `yarn start-jetpack-cloud`.
* Open an Incognito tab in your browser, and go to the Overview page (`http://jetpack.cloud.localhost:3000/overview`)
* Once the page prompts to log in to a WP account. Create a new WP account. **Note that this account is just a regular Jetpack user, not an agency user.**
* After creating the new account, confirm that the page is redirected to the Landing page.
   <img width="781" alt="Screenshot 2024-01-24 at 2 33 26 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/a10d5e88-6127-4691-8f9e-03afca8e03df">
* While your session is active, confirm that every time you access the Overview page, you get redirected to a Landing page.
* Finally, test that the Overview page is accessible with an Agency account.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?