### PR TITLE
Assembler v2: Use the "Show more patterns" feature

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
@@ -99,7 +99,7 @@ const usePatternPages = (
 		.filter( Boolean ) as Pattern[];
 
 	pagesToShow = pageCategoriesInOrder
-		.map( ( category: Category ) => {
+		?.map( ( category: Category ) => {
 			const { name = '' } = category;
 			const page = getFeaturedPageOrFirstInCategory( name );
 			if ( page ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-pattern-pages.ts
@@ -99,7 +99,7 @@ const usePatternPages = (
 		.filter( Boolean ) as Pattern[];
 
 	pagesToShow = pageCategoriesInOrder
-		?.map( ( category: Category ) => {
+		.map( ( category: Category ) => {
 			const { name = '' } = category;
 			const page = getFeaturedPageOrFirstInCategory( name );
 			if ( page ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-panel.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@wordpress/components';
 import { chevronDown } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
@@ -38,9 +37,7 @@ const PatternListPanel = ( {
 	isNewSite,
 }: PatternListPanelProps ) => {
 	const translate = useTranslate();
-	const [ isShowMorePatterns, setIsShowMorePatterns ] = useState(
-		isEnabled( 'pattern-assembler/v2' )
-	);
+	const [ isShowMorePatterns, setIsShowMorePatterns ] = useState( false );
 	const categoryPatterns = selectedCategory ? patternsMapByCategory[ selectedCategory ] : [];
 	const category = useMemo(
 		() => selectedCategory && categories.find( ( { name } ) => name === selectedCategory ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/86283

## Proposed Changes

* Revert changes to continue using the "Show more patterns" feature on Assembler v2

|BEFORE|AFTER|
|-|-|
|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/3c421a65-ca85-4aea-87e6-ef91f31a55e9">|<video src="https://github.com/Automattic/wp-calypso/assets/1881481/bc735b53-db9f-44f1-897d-0171ce806810">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access assembler with the param `flags=pattern-assembler/v2`
* Verify you see the button "Show more patterns" and works as expected


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?