### PR TITLE
Notification settings: Rename Block emails to Pause emails

### DIFF
--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -224,10 +224,10 @@ class NotificationSubscriptions extends Component {
 								<span>
 									{ locale === 'en' ||
 									i18n.hasTranslation(
-										'Pause all email updates from blogs you’re following on WordPress.com'
+										'Pause all email updates from sites you’re following on WordPress.com'
 									)
 										? this.props.translate(
-												'Pause all email updates from blogs you’re following on WordPress.com'
+												'Pause all email updates from sites you’re following on WordPress.com'
 										  )
 										: this.props.translate(
 												'Block all email updates from blogs you’re following on WordPress.com'

--- a/client/me/notification-settings/reader-subscriptions/index.jsx
+++ b/client/me/notification-settings/reader-subscriptions/index.jsx
@@ -1,5 +1,5 @@
 import { Card } from '@automattic/components';
-import { localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import { flowRight as compose } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -56,6 +56,8 @@ class NotificationSubscriptions extends Component {
 	}
 
 	render() {
+		const { locale } = this.props;
+
 		return (
 			<Main wideLayout className="reader-subscriptions__notifications-settings">
 				<PageViewTracker
@@ -205,7 +207,11 @@ class NotificationSubscriptions extends Component {
 						</FormFieldset>
 
 						<FormFieldset>
-							<FormLegend>{ this.props.translate( 'Block emails' ) }</FormLegend>
+							<FormLegend>
+								{ locale === 'en' || i18n.hasTranslation( 'Pause emails' )
+									? this.props.translate( 'Pause emails' )
+									: this.props.translate( 'Block emails' ) }
+							</FormLegend>
 							<FormLabel>
 								<FormCheckbox
 									checked={ this.props.getSetting( 'subscription_delivery_email_blocked' ) }
@@ -216,9 +222,16 @@ class NotificationSubscriptions extends Component {
 									onClick={ this.handleCheckboxEvent( 'Block All Notification Emails' ) }
 								/>
 								<span>
-									{ this.props.translate(
-										'Block all email updates from blogs you’re following on WordPress.com'
-									) }
+									{ locale === 'en' ||
+									i18n.hasTranslation(
+										'Pause all email updates from blogs you’re following on WordPress.com'
+									)
+										? this.props.translate(
+												'Pause all email updates from blogs you’re following on WordPress.com'
+										  )
+										: this.props.translate(
+												'Block all email updates from blogs you’re following on WordPress.com'
+										  ) }
 								</span>
 							</FormLabel>
 						</FormFieldset>


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/79068

## Proposed Changes

* Changes the label and description of the "Block emails" section to "Pause emails"

| Before | After |
|-|-|
|  ![CleanShot 2024-01-24 at 09 08 19@2x](https://github.com/Automattic/wp-calypso/assets/528287/f341fc5d-fb46-4e1e-9f28-4653591714c6) | ![CleanShot 2024-01-24 at 09 08 27@2x](https://github.com/Automattic/wp-calypso/assets/528287/818c2e45-2674-45db-8ef9-02cdf538d305) |



## Testing Instructions

1. Apply this PR
2. Navigate to http://calypso.localhost:3000/me/notifications/subscriptions
3. Confirm that the label has changes

When testing with non-EN locales, please notice that "Pause emails" has already been translated, and the description has not.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?