### PR TITLE
Live Preview: fix wrapping in narrow screens

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.scss
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.scss
@@ -1,14 +1,18 @@
 @import "./upgrade-modal";
 
-.components-editor-notices__pinned .components-notice__content {
-	display: flex;
-	margin-right: 0;
+.components-notice:has(.wpcom-live-preview-action) {
+	.components-notice__content {
+		display: flex;
+		align-items: center;
+		margin-right: 0;
 
-	.components-notice__actions {
-		margin-left: auto;
+		.components-notice__actions {
+			margin-left: auto;
 
-		.components-notice__action {
-			margin-top: 0;
+			.components-notice__action {
+				margin-top: 0;
+				white-space: nowrap;
+			}
 		}
 	}
 }

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/live-preview-notice-plugin.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/live-preview-notice-plugin.tsx
@@ -42,6 +42,7 @@ const LivePreviewNotice: FC< {
 						label: __( 'Back to themes', 'wpcom-live-preview' ),
 						url: dashboardLink,
 						variant: 'secondary',
+						className: 'wpcom-live-preview-action',
 					},
 				],
 			}

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/upgrade-notice.tsx
@@ -44,6 +44,7 @@ export const LivePreviewUpgradeNotice: FC< {
 								label: __( 'Back to themes', 'wpcom-live-preview' ),
 								url: dashboardLink,
 								variant: 'secondary',
+								className: 'wpcom-live-preview-action',
 							},
 					  ]
 					: [] ),


### PR DESCRIPTION
## Proposed Changes

- Adds `white-space: nowrap` and `align-items: center` so that the action button (link) wraps nicely when the screen is narrow.
- Improves the CSS selector so that it selects Live Preview's notice by doing some CSS `:has()` magic (previously it selected any pinned notice).
   - Note that this magic is required because there is no way to pass a class name to `createInfoNotice()`.

|Before|After|
|-|-|
|<img width="686" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/fe0542dd-b563-4f4b-b3c7-26044e87e69a">|<img width="686" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/3847e0eb-3a11-4c42-8b13-1429507634b7">|
|<img width="685" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/43ff5e4e-21a3-4c89-b576-d44f3a571eb6">|<img width="686" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/38f767b5-66e1-4017-996a-30a573dfcc26">|

## Testing Instructions

1. Patch this to your sandbox
2. Prepare a free site
3. Live-preview a free theme on narrow screen; verify that the banner wraps nicely as above
3. Live-preview a premium theme on narrow screen; verify that the banner wraps nicely as above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?