### PR TITLE
QuerySites when atomic transfer is complete

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -14,6 +14,7 @@ import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
 import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
 import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
 import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
+import QuerySites from 'calypso/components/data/query-sites';
 import FeatureExample from 'calypso/components/feature-example';
 import Layout from 'calypso/components/layout';
 import Column from 'calypso/components/layout/column';
@@ -250,6 +251,7 @@ const Hosting = ( props ) => {
 
 		return (
 			<>
+				{ isSiteAtomic && <QuerySites siteId={ siteId } /> }
 				{ isJetpack && <QueryJetpackModules siteId={ siteId } /> }
 				{ isGithubIntegrationEnabled && (
 					<>

--- a/client/my-sites/hosting/test/index.js
+++ b/client/my-sites/hosting/test/index.js
@@ -34,7 +34,8 @@ import {
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import { Provider } from 'react-redux';
-import { createStore } from 'redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
 import wp from 'calypso/lib/wp';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import Hosting from '../main';
@@ -69,7 +70,10 @@ const createTestStore = ( {
 	transferStatus,
 } ) => {
 	const TEST_SITE_ID = 1;
-	return createStore( ( state ) => state, {
+	const middlewares = [ thunk ];
+
+	const mockStore = configureStore( middlewares );
+	const store = mockStore( {
 		atomicHosting: {
 			[ TEST_SITE_ID ]: {
 				isLoadingSftpUsers: false,
@@ -119,8 +123,12 @@ const createTestStore = ( {
 					],
 				},
 			},
+			requesting: {
+				[ TEST_SITE_ID ]: true,
+			},
 		},
 	} );
+	return store;
 };
 
 const renderComponentWithStoreAndQueryClient = ( store ) => {


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5311

## Proposed Changes

* Add QuerySites in /hosting-config to have the most **fresh data** upon atomic transfer is complete

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start with a simple site that has never been reverted from atomic
* Transfer the site to atomic by activating it at `/host-config/:site`
* Upon completion, the Admin interface style card should look like 👇 (no need to refresh the page)
![classic](https://github.com/Automattic/wp-calypso/assets/6586048/e5a406fe-e7bb-44e9-9d1e-76e7260b194a)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?