### PR TITLE
State: Use shorter version of `useSelector` when no args

### DIFF
--- a/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
@@ -16,7 +16,7 @@ import type { RawPurchase } from 'calypso/lib/purchases/types';
  * Update site products in the Redux store by fetching purchases via API for Odyssey Stats.
  */
 const useOdysseyQuerySitePurchases = ( siteId: number | null ) => {
-	const isRequesting = useSelector( ( state ) => isFetchingSitePurchases( state ) );
+	const isRequesting = useSelector( isFetchingSitePurchases );
 	const reduxDispatch = useDispatch();
 
 	useEffect( () => {

--- a/client/blocks/announcement-modal/docs/example.jsx
+++ b/client/blocks/announcement-modal/docs/example.jsx
@@ -8,7 +8,7 @@ import { setPreference } from 'calypso/state/preferences/actions';
 
 const AnnouncementModalExample = () => {
 	const dispatch = useDispatch();
-	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
+	const userId = useSelector( getCurrentUserId );
 	const announcementId = 'example';
 	const dismissPreference = `announcement-modal-${ announcementId }-${ userId }`;
 

--- a/client/blocks/announcement-modal/index.jsx
+++ b/client/blocks/announcement-modal/index.jsx
@@ -36,7 +36,7 @@ const Page = ( { headline, heading, content, image, cta, handleClick } ) => {
 
 const Modal = ( { announcementId, pages, finishButtonText } ) => {
 	const dispatch = useDispatch();
-	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
+	const userId = useSelector( getCurrentUserId );
 	const hasPreferences = useSelector( hasReceivedRemotePreferences );
 	const dismissPreference = `announcement-modal-${ announcementId }-${ userId }`;
 	const isDismissed = useSelector( ( state ) => getPreference( state, dismissPreference ) );

--- a/client/blocks/cookie-banner/index.tsx
+++ b/client/blocks/cookie-banner/index.tsx
@@ -21,7 +21,7 @@ const noop = () => undefined;
 const CookieBannerInner = ( { onClose }: { onClose: () => void } ) => {
 	const content = useCookieBannerContent();
 	const dispatch = useDispatch();
-	const isLoggedIn = useSelector( ( state ) => isUserLoggedIn( state ) );
+	const isLoggedIn = useSelector( isUserLoggedIn );
 	const { setUserAdvertisingOptOut } = useDoNotSell();
 
 	const handleAccept = useCallback< CookieBannerProps[ 'onAccept' ] >(

--- a/client/blocks/importer/hooks/use-site-can-migrate.ts
+++ b/client/blocks/importer/hooks/use-site-can-migrate.ts
@@ -17,7 +17,7 @@ export function useSiteMigrateInfo(
 		status,
 	} = useMigrationEnabledInfoQuery( targetSiteId, sourceSiteSlug, fetchMigrationEnabledOnMount );
 
-	const isRequestingAllSites = useSelector( ( state ) => isRequestingSites( state ) );
+	const isRequestingAllSites = useSelector( isRequestingSites );
 	const sourceSite = useSelector( ( state ) => getSite( state, data?.source_blog_id ) );
 	const dispatch = useDispatch();
 	const [ isInitFetchingDone, setIsInitFetchingDone ] = useState( false );

--- a/client/blocks/importer/wordpress/index.tsx
+++ b/client/blocks/importer/wordpress/index.tsx
@@ -61,7 +61,7 @@ export const WordpressImporter: React.FunctionComponent< Props > = ( props ) => 
 	);
 	const isSiteAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 	const isSiteJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
-	const hasAllSitesFetched = useSelector( ( state ) => hasAllSitesList( state ) );
+	const hasAllSitesFetched = useSelector( hasAllSitesList );
 	const fromSiteAnalyzedData = useSelector( getUrlData );
 	const { setIsMigrateFromWp } = useDispatch( ONBOARD_STORE );
 	const isMigrateFromWp = useSelect(

--- a/client/blocks/jetpack-review-prompt/index.tsx
+++ b/client/blocks/jetpack-review-prompt/index.tsx
@@ -21,9 +21,7 @@ const JetpackReviewPrompt: FunctionComponent< Props > = ( { align = 'center', ty
 	const dispatch = useDispatch();
 
 	// dismiss count is stored in a preference, make sure we have that before rendering
-	const hasReceivedRemotePreferences = useSelector( ( state ) =>
-		getHasReceivedRemotePreferences( state )
-	);
+	const hasReceivedRemotePreferences = useSelector( getHasReceivedRemotePreferences );
 
 	const isDismissed = useSelector( ( state ) => getIsDismissed( state, type ) );
 	const validFrom = useSelector( ( state ) => getValidFromDate( state, type ) );

--- a/client/blocks/promo-card-block/index.jsx
+++ b/client/blocks/promo-card-block/index.jsx
@@ -21,7 +21,7 @@ const PromoCardBlock = ( {
 	impressionEvent,
 	productSlug,
 } ) => {
-	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 	const selectedPlugin = useSelector( ( state ) =>
 		getPluginOnSite( state, selectedSiteId, productSlug )
 	);

--- a/client/blocks/subscriptions-module-banner/index.tsx
+++ b/client/blocks/subscriptions-module-banner/index.tsx
@@ -23,7 +23,7 @@ export default function SubscriptionsModuleBanner() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 	const siteId = site?.ID;
 	const siteJetpackSettings = useSelector( ( state ) => {
 		if ( ! siteId ) {

--- a/client/components/command-palette/use-current-site-rank-top.ts
+++ b/client/components/command-palette/use-current-site-rank-top.ts
@@ -5,7 +5,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export function useCurrentSiteRankTop() {
 	let currentSiteId = useSelector( getSelectedSiteId );
-	const currentPath = useSelector( ( state ) => getCurrentRoute( state ) );
+	const currentPath = useSelector( getCurrentRoute );
 	const siteFragment = getSiteFragment( currentPath );
 	if ( ! siteFragment ) {
 		currentSiteId = null;

--- a/client/components/data/query-reader-followed-tags/index.jsx
+++ b/client/components/data/query-reader-followed-tags/index.jsx
@@ -8,7 +8,7 @@ import { requestTags } from 'calypso/state/reader/tags/items/actions';
  *  users tags to the state tree.
  */
 const QueryReaderFollowedTags = () => {
-	const locale = useSelector( ( state ) => getCurrentUserLocale( state ) );
+	const locale = useSelector( getCurrentUserLocale );
 	const dispatch = useDispatch();
 
 	useEffect( () => {

--- a/client/components/data/query-reader-tag/index.jsx
+++ b/client/components/data/query-reader-tag/index.jsx
@@ -5,7 +5,7 @@ import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { requestTags } from 'calypso/state/reader/tags/items/actions';
 
 const QueryReaderTag = ( { tag } ) => {
-	const locale = useSelector( ( state ) => getCurrentUserLocale( state ) );
+	const locale = useSelector( getCurrentUserLocale );
 	const dispatch = useDispatch();
 
 	useEffect( () => {

--- a/client/components/data/query-site-purchases/index.jsx
+++ b/client/components/data/query-site-purchases/index.jsx
@@ -8,7 +8,7 @@ import { isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
 const debug = debugFactory( 'calypso:query-site-purchases' );
 
 export const useQuerySitePurchases = ( siteId ) => {
-	const isRequesting = useSelector( ( state ) => isFetchingSitePurchases( state ) );
+	const isRequesting = useSelector( isFetchingSitePurchases );
 	const reduxDispatch = useDispatch();
 	const previousSiteId = useRef();
 

--- a/client/components/data/query-user-purchases/index.jsx
+++ b/client/components/data/query-user-purchases/index.jsx
@@ -30,7 +30,7 @@ function QueryUserPurchases() {
 }
 
 export const useQueryUserPurchases = ( enabled = true ) => {
-	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
+	const userId = useSelector( getCurrentUserId );
 	const isRequesting = useSelector( ( state ) => state.purchases.isFetchingUserPurchases );
 	const hasLoaded = useSelector( ( state ) => state.purchases.hasLoadedUserPurchasesFromServer );
 	const reduxDispatch = useDispatch();

--- a/client/components/data/query-user-settings/README.md
+++ b/client/components/data/query-user-settings/README.md
@@ -12,7 +12,7 @@ import { useSelector } from 'calypso/state';
 import { default as getUserSettings } from 'calypso/state/selectors/get-user-settings';
 
 export default function CurrentUser() {
-	const userSettings = useSelector( ( state ) => getUserSettings( state ) );
+	const userSettings = useSelector( getUserSettings );
 	const loginName = userSettings?.login_name;
 
 	return (

--- a/client/components/domains/domain-upsell-callout/index.jsx
+++ b/client/components/domains/domain-upsell-callout/index.jsx
@@ -19,12 +19,12 @@ import './style.scss';
 
 const DomainUpsellCallout = ( { trackEvent } ) => {
 	const dispatch = useDispatch();
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 	const trackEventView = `calypso_${ trackEvent }_view`;
 	const trackEventClick = `calypso_${ trackEvent }_click`;
 	const trackEventDismiss = `calypso_${ trackEvent }_dismiss`;
 	const dismissPreference = `${ trackEvent }-${ site?.ID }`;
-	const isEmailVerified = useSelector( ( state ) => isCurrentUserEmailVerified( state ) );
+	const isEmailVerified = useSelector( isCurrentUserEmailVerified );
 	const siteDomains = useSelector( ( state ) => getDomainsBySiteId( state, site?.ID ) );
 	const siteDomainsLength = useMemo(
 		() => siteDomains.filter( ( domain ) => ! domain.isWPCOMDomain ).length,

--- a/client/components/language-picker/site-language-picker.jsx
+++ b/client/components/language-picker/site-language-picker.jsx
@@ -23,8 +23,8 @@ import LanguagePicker from './index';
  * Some of the languages we add may not be supported by calypso.
  */
 const SiteLanguagePicker = ( { languages: origLanguages, ...restProps } ) => {
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) ) || -1;
-	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
+	const siteId = useSelector( getSelectedSiteId ) || -1;
+	const selectedSite = useSelector( getSelectedSite );
 	const siteIsJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const wpVersion = selectedSite?.options?.software_version;
 

--- a/client/data/marketplace/use-can-publish-plugin-reviews.ts
+++ b/client/data/marketplace/use-can-publish-plugin-reviews.ts
@@ -12,7 +12,7 @@ export function useCanPublishPluginReview( plugin = { isMarketplaceProduct: fals
 	const { isMarketplaceProduct } = plugin;
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
-	const purchases = useSelector( ( state ) => getUserPurchases( state ) );
+	const purchases = useSelector( getUserPurchases );
 	const purchasedPlugin = getPluginPurchased( plugin, purchases || [] );
 	const hasActiveSubscription = !! purchasedPlugin;
 

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -58,7 +58,7 @@ const JetpackCloudSidebar = ( {
 	backButtonProps,
 }: Props ) => {
 	const isAgency = useSelector( isAgencyUser );
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteId = useSelector( getSelectedSiteId );
 	const jetpackAdminUrl = useSelector( ( state ) =>
 		siteId ? getJetpackAdminUrl( state, siteId ) : null
 	);

--- a/client/jetpack-cloud/sections/overview/primary/overview-products/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/overview-products/index.tsx
@@ -17,8 +17,8 @@ export default function OverviewProducts() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
-	const userProducts = useSelector( ( state ) => getProductsList( state ) );
-	const isFetchingUserProducts = useSelector( ( state ) => isProductsListFetching( state ) );
+	const userProducts = useSelector( getProductsList );
+	const isFetchingUserProducts = useSelector( isProductsListFetching );
 	const { data: agencyProducts, isLoading: isLoadingProducts } = useProductsQuery();
 
 	// Track the View All click

--- a/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/index.tsx
@@ -23,7 +23,7 @@ export default function ProductPriceWithDiscount( {
 }: Props ) {
 	const translate = useTranslate();
 
-	const userProducts = useSelector( ( state ) => getProductsList( state ) );
+	const userProducts = useSelector( getProductsList );
 	const isDailyPricing = product.price_interval === 'day';
 
 	const isBundle = quantity > 1;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -61,7 +61,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		const runImportInitially = useInitialQueryRun( siteId );
 		const canImport = useSelector( ( state ) => canCurrentUser( state, siteId, 'manage_options' ) );
 		const siteImports = useSelector( ( state ) => getImporterStatusForSiteId( state, siteId ) );
-		const hasAllSitesFetched = useSelector( ( state ) => hasAllSitesList( state ) );
+		const hasAllSitesFetched = useSelector( hasAllSitesList );
 		const isImporterStatusHydrated = useSelector( isImporterStatusHydratedSelector );
 		const isMigrateFromWp = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIsMigrateFromWp(),

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-creation-step/index.tsx
@@ -79,7 +79,7 @@ const SiteCreationStep: Step = function SiteCreationStep( { navigation, flow, da
 			[]
 		);
 
-	const username = useSelector( ( state ) => getCurrentUserName( state ) );
+	const username = useSelector( getCurrentUserName );
 
 	const { setPendingAction } = useDispatch( ONBOARD_STORE );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sites-checker/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sites-checker/index.tsx
@@ -18,8 +18,8 @@ import './styles.scss';
 const SitesChecker: Step = function SitePicker( { navigation, flow } ) {
 	const { __ } = useI18n();
 	const { submit } = navigation;
-	const hasAllSitesFetched = useSelector( ( state ) => hasAllSitesList( state ) );
-	const allSites = useSelector( ( state ) => getSites( state ) );
+	const hasAllSitesFetched = useSelector( hasAllSitesList );
+	const allSites = useSelector( getSites );
 	const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
 
 	useEffect( () => {

--- a/client/landing/stepper/hooks/use-is-eligible-subscriber-importer.ts
+++ b/client/landing/stepper/hooks/use-is-eligible-subscriber-importer.ts
@@ -2,5 +2,5 @@ import { useSelector } from 'calypso/state';
 import isEligibleForSubscriberImporter from 'calypso/state/selectors/is-eligible-for-subscriber-importer';
 
 export function useIsEligibleSubscriberImporter() {
-	return useSelector( ( state ) => isEligibleForSubscriberImporter( state ) );
+	return useSelector( isEligibleForSubscriberImporter );
 }

--- a/client/landing/stepper/hooks/use-site-copy.tsx
+++ b/client/landing/stepper/hooks/use-site-copy.tsx
@@ -59,7 +59,7 @@ export const useSiteCopy = (
 	site: Pick< SiteExcerptData, 'ID' | 'site_owner' | 'plan' > | undefined,
 	options: SiteCopyOptions = { enabled: true }
 ) => {
-	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
+	const userId = useSelector( getCurrentUserId );
 	const hasCopySiteFeature = useSafeSiteHasFeature(
 		site?.ID,
 		WPCOM_FEATURES_COPY_SITE,
@@ -82,7 +82,7 @@ export const useSiteCopy = (
 		( state ) => isFetchingUserPurchases( state ) || ! hasLoadedUserPurchasesFromServer( state )
 	);
 
-	const purchases = useSelector( ( state ) => getUserPurchases( state ) );
+	const purchases = useSelector( getUserPurchases );
 
 	const { setPlanCartItem, setProductCartItems, resetOnboardStore } = useDispatch( ONBOARD_STORE );
 

--- a/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
+++ b/client/login/magic-login/handle-emailed-link-form-jetpack-connect.tsx
@@ -35,19 +35,15 @@ const HandleEmailedLinkFormJetpackConnect: FC< Props > = ( { emailAddress, token
 	const [ hasSubmitted, setHasSubmitted ] = useState( false );
 
 	const redirectToOriginal = useSelector( ( state ) => getRedirectToOriginal( state ) || '' );
-	const redirectToSanitized = useSelector( ( state ) => getRedirectToSanitized( state ) );
-	const authError = useSelector( ( state ) => getMagicLoginRequestAuthError( state ) );
-	const isAuthenticated = useSelector( ( state ) =>
-		getMagicLoginRequestedAuthSuccessfully( state )
-	);
+	const redirectToSanitized = useSelector( getRedirectToSanitized );
+	const authError = useSelector( getMagicLoginRequestAuthError );
+	const isAuthenticated = useSelector( getMagicLoginRequestedAuthSuccessfully );
 	const isExpired = useSelector(
 		( state ) => getMagicLoginCurrentView( state ) === LINK_EXPIRED_PAGE
 	);
-	const isFetching = useSelector( ( state ) => isFetchingMagicLoginAuth( state ) );
-	const twoFactorEnabled = useSelector( ( state ) => isTwoFactorEnabled( state ) );
-	const twoFactorNotificationSent = useSelector( ( state ) =>
-		getTwoFactorNotificationSent( state )
-	);
+	const isFetching = useSelector( isFetchingMagicLoginAuth );
+	const twoFactorEnabled = useSelector( isTwoFactorEnabled );
+	const twoFactorNotificationSent = useSelector( getTwoFactorNotificationSent );
 
 	useEffect( () => {
 		if ( ! emailAddress || ! token ) {

--- a/client/me/account/toggle-sites-as-landing-page.tsx
+++ b/client/me/account/toggle-sites-as-landing-page.tsx
@@ -12,7 +12,7 @@ function ToggleSitesAsLandingPage() {
 	const useSitesAsLandingPage = useSelector(
 		( state ) => getPreference( state, 'sites-landing-page' )?.useSitesAsLandingPage
 	);
-	const isSaving = useSelector( ( state ) => isSavingPreference( state ) );
+	const isSaving = useSelector( isSavingPreference );
 
 	async function handleToggle( isChecked: boolean ) {
 		const preference = { useSitesAsLandingPage: isChecked, updatedAt: Date.now() };

--- a/client/my-sites/backup/banners/enable-restores-banner.tsx
+++ b/client/my-sites/backup/banners/enable-restores-banner.tsx
@@ -11,7 +11,7 @@ import '../style.scss';
 const EnableRestoresBanner: FunctionComponent = () => {
 	const translate = useTranslate();
 
-	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
+	const siteSlug = useSelector( getSelectedSiteSlug ) || '';
 
 	return (
 		<Banner

--- a/client/my-sites/backup/clone-flow/index.tsx
+++ b/client/my-sites/backup/clone-flow/index.tsx
@@ -65,7 +65,7 @@ const BackupCloneFlow: FunctionComponent< Props > = ( { siteId } ) => {
 	const gmtOffset = useSelector( ( state ) => getSiteGmtOffset( state, siteId ) );
 	const timezone = useSelector( ( state ) => getSiteTimezoneValue( state, siteId ) );
 	const siteUrl = useSelector( ( state ) => ( siteId && getSiteUrl( state, siteId ) ) || '' );
-	const previousPath = useSelector( ( state ) => getPreviousRoute( state ) );
+	const previousPath = useSelector( getPreviousRoute );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
 	const [ rewindConfig, setRewindConfig ] = useState< RewindConfig >( defaultRewindConfig );

--- a/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
+++ b/client/my-sites/checkout/cart/upcoming-renewals-reminder.tsx
@@ -125,8 +125,8 @@ const UpcomingRenewalsReminder: FunctionComponent< Props > = ( { cart, addItemTo
 		setUpcomingRenewalsDialogVisible( false );
 	}, [ setUpcomingRenewalsDialogVisible ] );
 
-	const arePurchasesLoaded = useSelector( ( state ) => hasLoadedUserPurchasesFromServer( state ) );
-	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
+	const arePurchasesLoaded = useSelector( hasLoadedUserPurchasesFromServer );
+	const userId = useSelector( getCurrentUserId );
 
 	if ( ! userId || ! selectedSite ) {
 		return null;

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation-completed.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation-completed.tsx
@@ -31,7 +31,7 @@ const LicensingActivationThankYouCompleted: FC< Props > = ( {
 		hasProductInfo ? getProductName( state, productSlug ) : null
 	);
 
-	const isProductListFetching = useSelector( ( state ) => getIsProductListFetching( state ) );
+	const isProductListFetching = useSelector( getIsProductListFetching );
 
 	// In the siteless-checkout flow, the subscription is transferred from temporary-site to the user's target site.
 	const subscriptionTransferSucceeded = destinationSiteId > 0;

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
@@ -66,7 +66,7 @@ const LicensingActivationThankYou: FC< Props > = ( {
 		hasProductInfo ? getProductName( state, productSlug ) : null
 	);
 	const productsList: ProductsList = useSelector( getProductsList );
-	const isProductListFetching = useSelector( ( state ) => getIsProductListFetching( state ) );
+	const isProductListFetching = useSelector( getIsProductListFetching );
 	const userName = useSelector( getCurrentUserName );
 	const jetpackSites = useSelector( getJetpackSites ) as JetpackSite[];
 

--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-license-key.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-manual-activation-license-key.tsx
@@ -25,7 +25,7 @@ const LicensingActivationInstructions: FC< JetpackLicenseKeyProps > = ( {
 		hasProductInfo ? getProductName( state, productSlug ) : null
 	);
 
-	const isProductListFetching = useSelector( ( state ) => getIsProductListFetching( state ) );
+	const isProductListFetching = useSelector( getIsProductListFetching );
 
 	return (
 		<>

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/marketplace-thank-you-theme-section.tsx
@@ -130,7 +130,7 @@ export const ThankYouThemeSection = ( {
 		getCustomizeUrl( state, theme.id, siteId, isFSEActive )
 	);
 	const siteUrl = useSelector( ( state ) => getSiteUrl( state, siteId ) ) ?? undefined;
-	const themeOptions = useSelector( ( state ) => getThemePreviewThemeOptions( state ) );
+	const themeOptions = useSelector( getThemePreviewThemeOptions );
 
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 

--- a/client/my-sites/checkout/src/hooks/use-get-thank-you-url/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-get-thank-you-url/index.tsx
@@ -40,7 +40,7 @@ export default function useGetThankYouUrl( {
 	adminUrl: wpAdminUrl,
 	fromSiteSlug,
 }: GetThankYouUrlProps ): GetThankYouUrl {
-	const selectedSiteData = useSelector( ( state ) => getSelectedSite( state ) );
+	const selectedSiteData = useSelector( getSelectedSite );
 
 	const adminUrl = selectedSiteData?.options?.admin_url || wpAdminUrl;
 

--- a/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
+++ b/client/my-sites/checkout/src/hooks/use-tos-foldable-card.tsx
@@ -6,7 +6,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 export function useToSFoldableCard(): boolean {
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteId = useSelector( getSelectedSiteId );
 	const isJetpackNotAtomic = useSelector(
 		( state ) => isJetpackSite( state, siteId ) && ! isSiteAutomatedTransfer( state, siteId )
 	);

--- a/client/my-sites/customer-home/cards/actions/quick-links-for-hosted-sites/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links-for-hosted-sites/index.jsx
@@ -20,7 +20,7 @@ import '../quick-links/style.scss';
 const QuickLinksForHostedSites = ( props ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
-	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
+	const siteSlug = useSelector( getSelectedSiteSlug );
 	const isAtomic = useSelector( ( state ) => isSiteAtomic( state, siteId ) );
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 	const canManageSite = useSelector( ( state ) =>

--- a/client/my-sites/customer-home/cards/tasks/marketplace/index.jsx
+++ b/client/my-sites/customer-home/cards/tasks/marketplace/index.jsx
@@ -7,7 +7,7 @@ import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const Marketplace = () => {
 	const translate = useTranslate();
-	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
+	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	return (
 		<Task

--- a/client/my-sites/domains/domain-management/settings/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/index.tsx
@@ -103,7 +103,7 @@ const Settings = ( {
 		}
 	}, [ contactInformation, requestWhois, selectedDomainName ] );
 
-	const hasConnectableSites = useSelector( ( state ) => canAnySiteConnectDomains( state ) );
+	const hasConnectableSites = useSelector( canAnySiteConnectDomains );
 
 	const renderHeader = () => {
 		const previousPath = domainManagementList(

--- a/client/my-sites/earn/ads/form-settings.tsx
+++ b/client/my-sites/earn/ads/form-settings.tsx
@@ -55,8 +55,8 @@ const AdsFormSettings = () => {
 	const [ settings, setSettings ] = useState< Settings >( {} );
 	const [ isChanged, setIsChanged ] = useState( false );
 
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const site = useSelector( getSelectedSite );
+	const siteId = useSelector( getSelectedSiteId );
 	const siteUrl = useSelector( ( state ) => getSiteUrl( state, siteId ?? 0 ) );
 	const siteIsJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ?? 0 ) );
 	const isSavingSettings = useSelector( ( state ) =>

--- a/client/my-sites/earn/ads/payments.tsx
+++ b/client/my-sites/earn/ads/payments.tsx
@@ -42,7 +42,7 @@ type WordAdSettings = {
 
 const WordAdsPayments = () => {
 	const translate = useTranslate();
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteId = useSelector( getSelectedSiteId );
 	const payments: Payments = useSelector( ( state ) => getWordAdsPayments( state, siteId ?? 0 ) );
 	const wordAdsSettings: WordAdSettings = useSelector( ( state ) =>
 		getWordadsSettings( state, siteId )

--- a/client/my-sites/earn/ads/wrapper.tsx
+++ b/client/my-sites/earn/ads/wrapper.tsx
@@ -45,8 +45,8 @@ type AdsWrapperProps = {
 const AdsWrapper = ( { section, children }: AdsWrapperProps ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
-	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
+	const site = useSelector( getSelectedSite );
+	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	const canAccessAds = useSelector( ( state ) => canAccessWordAds( state, site?.ID ) );
 	const wordAdsStatus = useSelector( ( state ) => getSiteWordadsStatus( state, site?.ID ) );

--- a/client/my-sites/earn/components/add-edit-coupon-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-coupon-modal/index.tsx
@@ -73,7 +73,7 @@ const RecurringPaymentsCouponAddEditModal = ( {
 	const dispatch = useDispatch();
 
 	/** Currency */
-	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 	const connectedAccountDefaultCurrency = useSelector( ( state ) =>
 		getconnectedAccountDefaultCurrencyForSiteId( state, selectedSiteId )
 	);

--- a/client/my-sites/earn/components/add-edit-coupon-modal/products-selector.tsx
+++ b/client/my-sites/earn/components/add-edit-coupon-modal/products-selector.tsx
@@ -26,7 +26,7 @@ const ProductsSelector = ( {
 }: ProductsSelectorProps ) => {
 	const [ selectedPlanIds, setSelectedPlanIds ] = useState( initialSelectedList ?? [] );
 
-	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 
 	const products: Product[] = useSelector( ( state ) =>
 		getProductsForSiteId( state, selectedSiteId )

--- a/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
+++ b/client/my-sites/earn/components/add-edit-plan-modal/index.tsx
@@ -81,7 +81,7 @@ const RecurringPaymentsPlanAddEditModal = ( {
 }: RecurringPaymentsPlanAddEditModalProps ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 	const connectedAccountDefaultCurrency = useSelector( ( state ) =>
 		getconnectedAccountDefaultCurrencyForSiteId( state, siteId ?? selectedSiteId )
 	);

--- a/client/my-sites/earn/components/stats/index.tsx
+++ b/client/my-sites/earn/components/stats/index.tsx
@@ -12,7 +12,7 @@ import CommissionFees from '../commission-fees';
 function StatsSection() {
 	const translate = useTranslate();
 
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 
 	const {
 		commission,

--- a/client/my-sites/earn/customers/cancel-dialog.tsx
+++ b/client/my-sites/earn/customers/cancel-dialog.tsx
@@ -14,7 +14,7 @@ type CancelDialogProps = {
 function CancelDialog( { subscriberToCancel, setSubscriberToCancel }: CancelDialogProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 
 	function onCloseCancelSubscription( reason: string | undefined ) {
 		if ( reason === 'cancel' ) {

--- a/client/my-sites/earn/customers/index.tsx
+++ b/client/my-sites/earn/customers/index.tsx
@@ -37,7 +37,7 @@ function CustomerSection() {
 	const moment = useLocalizedMoment();
 	const subscriberId = new URLSearchParams( window.location.search ).get( 'subscriber' );
 	const [ subscriberToCancel, setSubscriberToCancel ] = useState< Subscriber | null >( null );
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 
 	const subscribers = useSelector(
 		( state ) => getOwnershipsForSiteId( state, site?.ID ),

--- a/client/my-sites/earn/home.tsx
+++ b/client/my-sites/earn/home.tsx
@@ -47,7 +47,7 @@ const Home = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const [ peerReferralLink, setPeerReferralLink ] = useState( '' );
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 	const sitePlanSlug = useSelector( ( state ) => getSitePlanSlug( state, site?.ID ?? 0 ) );
 	const hasWordAdsFeature = useSelector( ( state ) => siteHasWordAds( state, site?.ID ?? null ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, site?.ID ) );

--- a/client/my-sites/earn/hooks/use-earn-launchpad-tasks.ts
+++ b/client/my-sites/earn/hooks/use-earn-launchpad-tasks.ts
@@ -7,7 +7,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 export const useEarnLaunchpadTasks = () => {
 	const checklistSlug = 'earn';
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 	const products = useSelector( ( state ) => getProductsForSiteId( state, site?.ID ) );
 	const connectedAccountId = useSelector( ( state ) =>
 		getConnectedAccountIdForSiteId( state, site?.ID )

--- a/client/my-sites/earn/launchpad/index.tsx
+++ b/client/my-sites/earn/launchpad/index.tsx
@@ -17,7 +17,7 @@ type EarnLaunchpadProps = {
 const EarnLaunchpad = ( { launchpad }: EarnLaunchpadProps ) => {
 	const { checklistSlug, taskFilter, numberOfSteps, completedSteps } = launchpad;
 	const translate = useTranslate();
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 	const isNewsletter = 'newsletter' === site?.options?.site_intent;
 
 	return (

--- a/client/my-sites/earn/main.tsx
+++ b/client/my-sites/earn/main.tsx
@@ -36,7 +36,7 @@ type Tab = {
 
 const EarningsMain = ( { section, query, path }: EarningsMainProps ) => {
 	const translate = useTranslate();
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 	const canAccessAds = useSelector( ( state ) => canAccessWordAds( state, site?.ID ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, site?.ID ) );
 	const adsProgramName = isJetpack ? 'Ads' : 'WordAds';

--- a/client/my-sites/earn/memberships/coupons-list.tsx
+++ b/client/my-sites/earn/memberships/coupons-list.tsx
@@ -42,7 +42,7 @@ function CouponsList() {
 	const [ showAddEditDialog, setShowAddEditDialog ] = useState( false );
 	const [ showDeleteDialog, setShowDeleteDialog ] = useState( false );
 	const [ coupon, setCoupon ] = useState< Product | null >( null );
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 	const features = useSelector( ( state ) => getFeaturesBySiteId( state, site?.ID ) );
 	const hasLoadedFeatures = features?.active.length > 0;
 	const coupons: Coupon[] = useSelector( ( state ) => getCouponsForSiteId( state, site?.ID ) );

--- a/client/my-sites/earn/memberships/delete-coupon-modal.tsx
+++ b/client/my-sites/earn/memberships/delete-coupon-modal.tsx
@@ -15,7 +15,7 @@ const RecurringPaymentsCouponDeleteModal = ( {
 	coupon,
 }: RecurringPaymentsCouponDeleteModalProps ) => {
 	const translate = useTranslate();
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteId = useSelector( getSelectedSiteId );
 	const dispatch = useDispatch();
 
 	const onClose = ( action?: string ) => {

--- a/client/my-sites/earn/memberships/delete-plan-modal.tsx
+++ b/client/my-sites/earn/memberships/delete-plan-modal.tsx
@@ -17,7 +17,7 @@ const RecurringPaymentsPlanDeleteModal = ( {
 	annualProduct,
 }: RecurringPaymentsPlanDeleteModalProps ) => {
 	const translate = useTranslate();
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteId = useSelector( getSelectedSiteId );
 	const dispatch = useDispatch();
 
 	const onClose = ( action?: string ) => {

--- a/client/my-sites/earn/memberships/products-list.tsx
+++ b/client/my-sites/earn/memberships/products-list.tsx
@@ -41,7 +41,7 @@ function ProductsList() {
 	const [ showDeleteDialog, setShowDeleteDialog ] = useState( false );
 	const [ product, setProduct ] = useState< Product | null >( null );
 	const [ annualProduct, setAnnualProduct ] = useState< Product | null >( null );
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 	const features = useSelector( ( state ) => getFeaturesBySiteId( state, site?.ID ) );
 	const hasLoadedFeatures = features?.active.length > 0;
 	const products: Product[] = useSelector( ( state ) => getProductsForSiteId( state, site?.ID ) );

--- a/client/my-sites/earn/memberships/section.tsx
+++ b/client/my-sites/earn/memberships/section.tsx
@@ -41,7 +41,7 @@ function MembershipsSection( { query }: MembershipsSectionProps ) {
 	const source = getSource();
 	const [ disconnectedConnectedAccountId, setDisconnectedConnectedAccountId ] = useState( null );
 
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 
 	const connectedAccountId = useSelector( ( state ) =>
 		getConnectedAccountIdForSiteId( state, site?.ID )

--- a/client/my-sites/earn/refer-a-friend/index.tsx
+++ b/client/my-sites/earn/refer-a-friend/index.tsx
@@ -19,7 +19,7 @@ import './style.scss';
 const ReferAFriendSection = () => {
 	const translate = useTranslate();
 	const [ peerReferralLink, setPeerReferralLink ] = useState( '' );
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, site?.ID ) );
 	const isAtomicSite = useSelector( ( state ) => isSiteAutomatedTransfer( state, site?.ID ) );
 

--- a/client/my-sites/email/email-management/email-home.tsx
+++ b/client/my-sites/email/email-management/email-home.tsx
@@ -95,7 +95,7 @@ const EmailHome = ( props: EmailManagementHomeProps ) => {
 		}
 		return canCurrentUser( state, selectedSite.ID, 'manage_options' );
 	} );
-	const hasSitesLoaded = useSelector( ( state ) => hasLoadedSites( state ) );
+	const hasSitesLoaded = useSelector( hasLoadedSites );
 
 	const addEmailForwardMutationActive = useAddEmailForwardMutationIsLoading();
 

--- a/client/my-sites/hosting/site-admin-interface-card/use-select-interface-mutation.ts
+++ b/client/my-sites/hosting/site-admin-interface-card/use-select-interface-mutation.ts
@@ -38,7 +38,7 @@ export const useSiteInterfaceMutation = (
 ) => {
 	const dispatch = useDispatch();
 	const site = useSelector( ( state ) => getRawSite( state, siteId ) );
-	const isRequestingMenu = useSelector( ( state ) => getIsRequestingAdminMenu( state ) );
+	const isRequestingMenu = useSelector( getIsRequestingAdminMenu );
 	const [ hasSuccessfullyFinished, setHasSuccessfullyFinished ] = useState( false );
 	useEffect( () => {
 		if ( hasSuccessfullyFinished && ! isRequestingMenu ) {

--- a/client/my-sites/hosting/staging-site-card/card-content/staging-site-sync-loading-bar-card-content.tsx
+++ b/client/my-sites/hosting/staging-site-card/card-content/staging-site-sync-loading-bar-card-content.tsx
@@ -20,7 +20,7 @@ export const StagingSiteSyncLoadingBarCardContent = ( {
 }: CardContentProps ) => {
 	const translate = useTranslate();
 	const siteOwnerId = useSelector( ( state ) => getSelectedSite( state )?.site_owner );
-	const currentUserId = useSelector( ( state ) => getCurrentUserId( state ) );
+	const currentUserId = useSelector( getCurrentUserId );
 	const isOwner = siteOwnerId === currentUserId;
 
 	const message = isOwner

--- a/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
+++ b/client/my-sites/marketplace/pages/marketplace-product-install/index.tsx
@@ -100,7 +100,7 @@ const MarketplaceProductInstall = ( {
 		getStatusForPlugin( state, siteId, pluginSlug )
 	);
 
-	const productsList = useSelector( ( state ) => getProductsList( state ) );
+	const productsList = useSelector( getProductsList );
 	const isProductListFetched = Object.values( productsList ).length > 0;
 	const isMarketplaceProduct = useSelector( ( state ) =>
 		isMarketplaceProductSelector( state, pluginSlug )

--- a/client/my-sites/people/people-section-nav-compact/index.tsx
+++ b/client/my-sites/people/people-section-nav-compact/index.tsx
@@ -13,7 +13,7 @@ interface Props {
 function PeopleSectionNavCompact( props: Props ) {
 	const translate = useTranslate();
 	const { selectedFilter, searchTerm, filterCount } = props;
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 	const searchPlaceholder =
 		selectedFilter === 'subscribers' ? translate( 'Search by email…' ) : undefined;
 

--- a/client/my-sites/people/subscriber-details/index.tsx
+++ b/client/my-sites/people/subscriber-details/index.tsx
@@ -29,7 +29,7 @@ export default function SubscriberDetails( props: Props ) {
 	const dispatch = useDispatch();
 	const { removeFollower, isSuccess: isRemoveFollowerSuccess } = useRemoveFollowerMutation();
 
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 	const { subscriberId, subscriberType } = props;
 	const [ templateState, setTemplateState ] = useState( 'loading' );
 	const { data: subscriber, isLoading } = useFollowerQuery(

--- a/client/my-sites/people/subscribers-team/index.tsx
+++ b/client/my-sites/people/subscribers-team/index.tsx
@@ -27,7 +27,7 @@ interface Props {
 function SubscribersTeam( props: Props ) {
 	const translate = useTranslate();
 	const { filter, search } = props;
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, site?.ID ) );
 	const isPossibleJetpackConnectionProblem = useIsJetpackConnectionProblem( site?.ID as number );
 	const pendingInvites = useSelector( ( state ) =>

--- a/client/my-sites/people/subscribers/index.tsx
+++ b/client/my-sites/people/subscribers/index.tsx
@@ -27,7 +27,7 @@ function Subscribers( props: Props ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const { search, followersQuery } = props;
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 
 	const listKey = [ 'subscribers', site?.ID, 'all', search ].join( '-' );
 	const { data, fetchNextPage, isLoading, isFetchingNextPage, hasNextPage, refetch } =

--- a/client/my-sites/people/team-invite/index.tsx
+++ b/client/my-sites/people/team-invite/index.tsx
@@ -33,7 +33,7 @@ function TeamInvite( props: Props ) {
 	const siteId = site.ID;
 	const [ hasPermission, setHasPermission ] = useState( false );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
-	const needsVerification = useSelector( ( state ) => isCurrentUserEmailVerified( state ) );
+	const needsVerification = useSelector( isCurrentUserEmailVerified );
 	const isSiteForTeams = useSelector( ( state ) => isSiteWPForTeams( state, siteId ) );
 	const showSSONotice = useSsoNotice( siteId );
 

--- a/client/my-sites/people/team-invite/invite-form.tsx
+++ b/client/my-sites/people/team-invite/invite-form.tsx
@@ -41,7 +41,7 @@ function InviteForm( props: Props ) {
 	];
 	const defaultEmailControlPlaceholder = translate( 'Add another email or username' );
 
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 	const siteId = site?.ID as number;
 	const defaultUserRole = useInitialRole( siteId );
 	const isAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );

--- a/client/my-sites/people/team-invites/index.tsx
+++ b/client/my-sites/people/team-invites/index.tsx
@@ -17,7 +17,7 @@ interface Props {
 function TeamInvites( props: Props ) {
 	const translate = useTranslate();
 	const { singleInviteView } = props;
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 	const siteId = site?.ID as number;
 	const pendingInvites = useSelector( ( state ) => getPendingInvitesForSite( state, siteId ) );
 	const addTeamMemberLink = `/people/new/${ site?.slug }`;

--- a/client/my-sites/people/team-members/index.tsx
+++ b/client/my-sites/people/team-members/index.tsx
@@ -19,7 +19,7 @@ interface Props {
 function TeamMembers( props: Props ) {
 	const translate = useTranslate();
 	const { search, usersQuery, showAddTeamMembersBtn = true } = props;
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 
 	const listKey = [ 'team-members', site?.ID, search ].join( '-' );
 	const { data, fetchNextPage, isLoading, isFetchingNextPage, hasNextPage } = usersQuery;

--- a/client/my-sites/people/viewer-details/index.tsx
+++ b/client/my-sites/people/viewer-details/index.tsx
@@ -30,7 +30,7 @@ export default function ViewerDetails( props: Props ) {
 	const dispatch = useDispatch();
 
 	const { userId } = props;
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 	const acceptedInvites = useSelector( ( state ) =>
 		getAcceptedInvitesForSite( state, site?.ID as number )
 	);

--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -86,7 +86,7 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 		discountInformation &&
 		getDiscountByName( discountInformation.withDiscount, discountInformation.discountEndDate );
 	const planUpgradeCreditsApplicable = usePlanUpgradeCreditsApplicable( siteId, visiblePlans );
-	const currencyCode = useSelector( ( state ) => getCurrentUserCurrencyCode( state ) );
+	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 
 	switch ( noticeType ) {
 		case NO_NOTICE:

--- a/client/my-sites/plans/current-plan/trials/business-trial-included.tsx
+++ b/client/my-sites/plans/current-plan/trials/business-trial-included.tsx
@@ -16,8 +16,8 @@ interface Props {
 const BusinessTrialIncluded: FunctionComponent< Props > = ( props ) => {
 	const { displayAll = true, displayOnlyActionableItems = false, tracksContext } = props;
 
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) ) || -1;
-	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
+	const siteId = useSelector( getSelectedSiteId ) || -1;
+	const siteSlug = useSelector( getSelectedSiteSlug ) || '';
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 
 	const allIncludedFeatures = useBusinessTrialIncludedFeatures( siteSlug, siteAdminUrl || '' );

--- a/client/my-sites/plans/current-plan/trials/trial-current-plan.tsx
+++ b/client/my-sites/plans/current-plan/trials/trial-current-plan.tsx
@@ -23,7 +23,7 @@ import EcommerceTrialNotIncluded from './ecommerce-trial-not-included';
 import './trial-current-plan.scss';
 
 const TrialCurrentPlan = () => {
-	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
+	const selectedSite = useSelector( getSelectedSite );
 
 	const translate = useTranslate();
 

--- a/client/my-sites/plans/jetpack-plans/plans-header.tsx
+++ b/client/my-sites/plans/jetpack-plans/plans-header.tsx
@@ -60,7 +60,7 @@ const ConnectFlowPlansHeader = () => (
 );
 
 const PlansHeader = ( { context, shouldShowPlanRecommendation }: HeaderProps ) => {
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteId = useSelector( getSelectedSiteId );
 	// Site plan
 	const currentPlan =
 		useSelector( ( state ) => getSitePlan( state, siteId ) )?.product_slug || null;

--- a/client/my-sites/plans/jetpack-plans/selector.tsx
+++ b/client/my-sites/plans/jetpack-plans/selector.tsx
@@ -49,8 +49,8 @@ const SelectorPage: React.FC< SelectorPageProps > = ( {
 }: SelectorPageProps ) => {
 	const dispatch = useDispatch();
 
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const siteSlugState = useSelector( ( state ) => getSelectedSiteSlug( state ) ) || '';
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlugState = useSelector( getSelectedSiteSlug ) || '';
 	const siteSlug = siteSlugProp || siteSlugState;
 	const [ currentDuration, setDuration ] = useState< Duration >( defaultDuration );
 	const viewTrackerPath = getViewTrackerPath( rootUrl, siteSlugProp );

--- a/client/my-sites/plans/jetpack-plans/storage-pricing/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/storage-pricing/index.tsx
@@ -35,7 +35,7 @@ export const StoragePricing: React.FC< Props > = ( {
 	locale,
 } ) => {
 	const [ duration, setDuration ] = useState< Duration >( defaultDuration );
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteId = useSelector( getSelectedSiteId );
 	const showAnnualPlansOnly = config.isEnabled( 'jetpack/pricing-page-annual-only' );
 
 	const filterBar = React.useMemo(

--- a/client/my-sites/plans/jetpack-plans/storage-tier-upgrade/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/storage-tier-upgrade/index.tsx
@@ -21,8 +21,8 @@ export const StorageTierUpgrade: React.FC< Props > = ( {
 	siteSlug: siteSlugProp,
 	locale,
 } ) => {
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const siteSlugState = useSelector( ( state ) => getSelectedSiteSlug( state ) );
+	const siteId = useSelector( getSelectedSiteId );
+	const siteSlugState = useSelector( getSelectedSiteSlug );
 	const siteSlug = siteSlugProp || siteSlugState || '';
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 

--- a/client/my-sites/plans/jetpack-plans/upsell/index.tsx
+++ b/client/my-sites/plans/jetpack-plans/upsell/index.tsx
@@ -52,7 +52,7 @@ const JetpackUpsellPage: React.FC< Props > = ( {
 		'calypso_jetpack_upsell_page_2022_06'
 	);
 
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteId = useSelector( getSelectedSiteId );
 	const currencyCode = useSelector( getCurrentUserCurrencyCode );
 	const isFetchingPurchases = useSelector( isFetchingSitePurchases );
 	const purchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );

--- a/client/my-sites/plans/trials/trial-banner/index.tsx
+++ b/client/my-sites/plans/trials/trial-banner/index.tsx
@@ -20,7 +20,7 @@ interface TrialBannerProps {
 
 const TrialBanner = ( props: TrialBannerProps ) => {
 	const { callToAction, isEcommerceTrial } = props;
-	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) ) || -1;
+	const selectedSiteId = useSelector( getSelectedSiteId ) || -1;
 
 	const currentPlan = useSelector( ( state ) => getCurrentPlan( state, selectedSiteId ) );
 	const trialDaysLeft = useSelector( ( state ) =>

--- a/client/my-sites/plugins/plugin-custom-domain-dialog/index.tsx
+++ b/client/my-sites/plugins/plugin-custom-domain-dialog/index.tsx
@@ -24,7 +24,7 @@ export const PluginCustomDomainDialog = ( {
 	const translate = useTranslate();
 	const localizeUrl = useLocalizeUrl();
 
-	const selectedSiteUrl = useSelector( ( state ) => getSelectedSiteSlug( state ) );
+	const selectedSiteUrl = useSelector( getSelectedSiteSlug );
 
 	const hasNonPrimaryCustomDomain = domains.some(
 		( { isPrimary, isSubdomain } ) => ! isPrimary && ! isSubdomain

--- a/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/CTA-button.jsx
@@ -69,7 +69,7 @@ export default function CTAButton( { plugin, hasEligibilityMessages, disabled } 
 		! isJetpackSelfHosted;
 
 	// Keep me updated
-	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
+	const userId = useSelector( getCurrentUserId );
 	const keepMeUpdatedPreferenceId = `jetpack-self-hosted-keep-updated-${ userId }`;
 	const keepMeUpdatedPreference = useSelector( ( state ) =>
 		getPreference( state, keepMeUpdatedPreferenceId )

--- a/client/my-sites/plugins/plugin-details-CTA/staging-site-notice.jsx
+++ b/client/my-sites/plugins/plugin-details-CTA/staging-site-notice.jsx
@@ -8,7 +8,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 export default function StagingSiteNotice( { plugin } ) {
 	const translate = useTranslate();
 
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteId = useSelector( getSelectedSiteId );
 	const productionSite = useSelector( ( state ) =>
 		getProductionSiteForWpcomStaging( state, siteId )
 	);

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -92,7 +92,7 @@ function PluginDetails( props ) {
 	const siteIds = [ ...new Set( siteObjectsToSiteIds( sites ) ) ];
 	const selectedOrAllSites = useSelector( getSelectedOrAllSites );
 	const isRequestingSites = useSelector( checkRequestingSites );
-	const requestingPluginsForSites = useSelector( ( state ) => isRequestingForAllSites( state ) );
+	const requestingPluginsForSites = useSelector( isRequestingForAllSites );
 	const analyticsPath = selectedSite ? '/plugins/:plugin/:site' : '/plugins/:plugin';
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	const { localizePath } = useLocalizedPlugins();
@@ -139,7 +139,7 @@ function PluginDetails( props ) {
 	const isWide = useBreakpoint( '>960px' );
 
 	// Determine if the plugin is WPcom or WPorg hosted
-	const productsList = useSelector( ( state ) => getProductsList( state ) );
+	const productsList = useSelector( getProductsList );
 	const isProductListFetched = Object.values( productsList ).length > 0;
 
 	const isMarketplaceProduct = useSelector( ( state ) =>

--- a/client/my-sites/plugins/plugins-announcement-modal/index.jsx
+++ b/client/my-sites/plugins/plugins-announcement-modal/index.jsx
@@ -9,7 +9,7 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 const PluginsAnnouncementModal = () => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
-	const selectedSiteUrl = useSelector( ( state ) => getSelectedSiteSlug( state ) );
+	const selectedSiteUrl = useSelector( getSelectedSiteSlug );
 	const jetpackNonAtomic = useSelector(
 		( state ) => isJetpackSite( state, siteId ) && ! isAtomicSite( state, siteId )
 	);

--- a/client/my-sites/plugins/plugins-browser-item/index.jsx
+++ b/client/my-sites/plugins/plugins-browser-item/index.jsx
@@ -258,7 +258,7 @@ function InstalledInOrPricing( {
 	currentSites,
 } ) {
 	const translate = useTranslate();
-	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 	const isMarketplaceProduct = useSelector( ( state ) =>
 		isMarketplaceProductSelector( state, plugin.slug )
 	);

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -197,7 +197,7 @@ class PreviewMain extends Component {
 
 const ConnectedPreviewMain = ( props ) => {
 	const dispatch = useDispatch();
-	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 	const stateToProps = useSelector( ( state ) => {
 		const site = getSelectedSite( state );
 		const homePagePostId = get( site, [ 'options', 'page_on_front' ] );

--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -52,7 +52,7 @@ function useLogBillingHistoryError( message: string ) {
 }
 
 export function BillingHistory( { siteSlug }: { siteSlug: string } ) {
-	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 	const translate = useTranslate();
 	const logBillingHistoryError = useLogBillingHistoryError(
 		'site level billing history load error'

--- a/client/my-sites/purchases/billing-history/use-redirect-to-history-page-on-wrong-site-for-transaction.tsx
+++ b/client/my-sites/purchases/billing-history/use-redirect-to-history-page-on-wrong-site-for-transaction.tsx
@@ -10,7 +10,7 @@ export default function useRedirectToHistoryPageOnWrongSiteForTransaction(
 	receiptId: number,
 	transaction: BillingTransaction | undefined | null
 ): boolean {
-	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 	const reduxDispatch = useDispatch();
 	const didRedirect = useRef( false );
 	const doesTransactionExist = !! transaction;

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -28,7 +28,7 @@ const useSiteMenuItems = () => {
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSiteId ) );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, selectedSiteId ) );
 	const locale = useLocale();
-	const currentRoute = useSelector( ( state ) => getCurrentRoute( state ) );
+	const currentRoute = useSelector( getCurrentRoute );
 	const isAllDomainsView = '/domains/manage' === currentRoute;
 
 	useEffect( () => {

--- a/client/my-sites/site-settings/cloudflare.js
+++ b/client/my-sites/site-settings/cloudflare.js
@@ -21,7 +21,7 @@ const Cloudflare = () => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const showCloudflare = config.isEnabled( 'cloudflare' );
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) ) || 0;
+	const siteId = useSelector( getSelectedSiteId ) || 0;
 	const hasCloudflareCDN = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_CLOUDFLARE_CDN )
 	);

--- a/client/my-sites/site-settings/jetpack-credentials-banner/index.tsx
+++ b/client/my-sites/site-settings/jetpack-credentials-banner/index.tsx
@@ -16,7 +16,7 @@ interface Props {
 const JetpackCredentialsBanner = ( { siteSlug }: Props ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const preference: Preference[] = useSelector( ( state ) => getPreference( state ) );
+	const preference: Preference[] = useSelector( getPreference );
 
 	const savePreferenceType = useCallback(
 		( type: PreferenceType ) => {

--- a/client/my-sites/site-settings/settings-reading/main.tsx
+++ b/client/my-sites/site-settings/settings-reading/main.tsx
@@ -157,7 +157,7 @@ const ReadingSettingsForm = wrapSettingsForm( getFormSettings )(
 
 const ReadingSettings = () => {
 	const translate = useTranslate();
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteId = useSelector( getSelectedSiteId );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const isPossibleJetpackConnectionProblem = useIsJetpackConnectionProblem( siteId as number );
 

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
@@ -44,7 +44,7 @@ const SiteTransferComplete = () => {
 
 const SiteOwnerTransfer = () => {
 	useQueryUserPurchases();
-	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
+	const selectedSite = useSelector( getSelectedSite );
 	const [ newSiteOwner, setNewSiteOwner ] = useState< User | null >( null );
 	const [ transferSiteSuccess, setSiteTransferSuccess ] = useState( false );
 

--- a/client/my-sites/site-settings/widgets.jsx
+++ b/client/my-sites/site-settings/widgets.jsx
@@ -1,4 +1,5 @@
 import { Card } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -9,7 +10,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 function Widgets( { isSavingSettings, isRequestingSettings, isAtomic, translate } ) {
 	const isFormPending = isRequestingSettings || isSavingSettings;
-	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 
 	return (
 		<>
@@ -40,7 +41,7 @@ function Widgets( { isSavingSettings, isRequestingSettings, isAtomic, translate 
 						) }
 						link={
 							isAtomic
-								? 'https://wordpress.com/support/widgets/#widget-visibility'
+								? localizeUrl( 'https://wordpress.com/support/widgets/#widget-visibility' )
 								: 'https://jetpack.com/support/widget-visibility'
 						}
 						privacyLink={ ! isAtomic }

--- a/client/my-sites/stats/jetpack-upsell-section/index.tsx
+++ b/client/my-sites/stats/jetpack-upsell-section/index.tsx
@@ -24,7 +24,7 @@ const QUERY_VALUES = {
 };
 
 export default function JetpackUpsellSection() {
-	const siteSlug = useSelector( ( state ) => getSelectedSiteSlug( state ) );
+	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	// NOTE: This will only work within Odyssey Stats.
 	const { purchasedProducts } = usePurchasedProducts();

--- a/client/my-sites/stats/mini-carousel/index.jsx
+++ b/client/my-sites/stats/mini-carousel/index.jsx
@@ -36,7 +36,7 @@ const EVENT_GOOGLE_ANALYTICS_BANNER_CLICK = 'calypso_stats_google_analytics_bann
 const EVENT_GOOGLE_ANALYTICS_BANNER_DISMISS = 'calypso_stats_google_analytics_banner_dismiss';
 
 const MiniCarousel = ( { slug, isSitePrivate } ) => {
-	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 
 	const { data: hasNeverPublishedPost, isLoading: isHasNeverPublishedPostLoading } =
 		useHasNeverPublishedPost( selectedSiteId ?? null, true, {

--- a/client/my-sites/stats/promo-cards/index.jsx
+++ b/client/my-sites/stats/promo-cards/index.jsx
@@ -28,7 +28,7 @@ export default function PromoCards( { isOdysseyStats, slug, pageSlug } ) {
 	// TODO: Figure out an approach that doesn't require replicating state value from DotPager.
 	const [ dotPagerIndex, setDotPagerIndex ] = useState( 0 );
 
-	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 	const jetpackNonAtomic = useSelector(
 		( state ) => isJetpackSite( state, selectedSiteId ) && ! isAtomicSite( state, selectedSiteId )
 	);

--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -110,7 +110,7 @@ const NewStatsNotices = ( { siteId, isOdysseyStats, statsPurchaseSuccess }: Stat
 	const { isLoading, isError, data: serverNoticesVisibility } = useNoticesVisibilityQuery( siteId );
 
 	// TODO: Integrate checking purchases and plans loaded state into `hasSiteProductJetpackStatsPaid`.
-	const hasLoadedPurchases = useSelector( ( state ) => hasLoadedSitePurchasesFromServer( state ) );
+	const hasLoadedPurchases = useSelector( hasLoadedSitePurchasesFromServer );
 	// Only check plans loaded state for supporting Stats on WPCOM.
 	const hasLoadedPlans =
 		useSelector( ( state ) => hasLoadedSitePlansFromServer( state, siteId ) ) || isOdysseyStats;

--- a/client/my-sites/stats/stats-purchase/index.tsx
+++ b/client/my-sites/stats/stats-purchase/index.tsx
@@ -45,7 +45,7 @@ const StatsPurchasePage = ( {
 	const isTypeDetectionEnabled = config.isEnabled( 'stats/type-detection' );
 	const isTierUpgradeSliderEnabled = config.isEnabled( 'stats/tier-upgrade-slider' );
 
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )

--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -100,7 +100,7 @@ function StatsCommercialUpgradeSlider( {
 	// 5. Nofiying the parent component when the slider changes.
 
 	const translate = useTranslate();
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteId = useSelector( getSelectedSiteId );
 	const tiers = useAvailableUpgradeTiers( siteId );
 	const uiStrings = useTranslatedStrings();
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-svg.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-svg.tsx
@@ -23,7 +23,7 @@ const StatsPurchaseSVG = ( {
 	const message = translate( 'Thanks for being one of our biggest supporters!' );
 	const isOdyssey = configApi.isEnabled( 'is_running_in_jetpack_site' );
 
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteId = useSelector( getSelectedSiteId );
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
 	// For Odyssey Stats, the SVG is loaded separately from the sprite located in `widgets.wp.com/odyssey-stats/common/` for CORS reasons.
 	let purchaseGraphSVG = isWPCOMSite ? calypsoStatsPurchaseGraphSVG : statsPurchaseGraphSVG;

--- a/client/my-sites/stats/stats-reditect-flow/index.tsx
+++ b/client/my-sites/stats/stats-reditect-flow/index.tsx
@@ -13,7 +13,7 @@ import { isStatsNoticeSettingsFetching } from 'calypso/state/stats/notices/selec
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const StatsRedirectFlow = () => {
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const siteCreatedTimeStamp = useSelector( ( state ) =>
 		getSiteOption( state, siteId, 'created_at' )

--- a/client/my-sites/stats/stats-subscribers/index.tsx
+++ b/client/my-sites/stats/stats-subscribers/index.tsx
@@ -41,7 +41,7 @@ interface StatsSubscribersPageProps {
 const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 	const translate = useTranslate();
 	// Use hooks for Redux pulls.
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	// Run-time configuration.

--- a/client/my-sites/stats/stats-upsell-modal/index.tsx
+++ b/client/my-sites/stats/stats-upsell-modal/index.tsx
@@ -23,7 +23,7 @@ export default function StatsUpsellModal( { siteId }: { siteId: number } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const plan = useSelector( ( state ) => getPlanBySlug( state, PLAN_PREMIUM ) );
-	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const selectedSiteId = useSelector( getSelectedSiteId );
 	const planMonthly = Plans.usePricingMetaForGridPlans( {
 		planSlugs: [ PLAN_PREMIUM ],
 		selectedSiteId,

--- a/client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx
+++ b/client/my-sites/subscribers/components/subscriber-launchpad/subscriber-launchpad.tsx
@@ -14,7 +14,7 @@ const SubscriberLaunchpad = ( {
 	const { checklistSlug, taskFilter, numberOfSteps, completedSteps } =
 		useSubscriberLaunchpadTasks();
 	const translate = useTranslate();
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 
 	return (
 		<div className="subscriber-launchpad">

--- a/client/my-sites/subscribers/components/subscriber-popover/subscriber-popover.tsx
+++ b/client/my-sites/subscribers/components/subscriber-popover/subscriber-popover.tsx
@@ -30,7 +30,7 @@ const SubscriberPopover = ( {
 	const [ isVisible, setIsVisible ] = useState( false );
 	const onToggle = useCallback( () => setIsVisible( ( visible ) => ! visible ), [] );
 	const buttonRef = useRef< HTMLButtonElement >( null );
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 	const couponsAndGiftsEnabled = useSelector( ( state ) =>
 		getCouponsAndGiftsEnabledForSiteId( state, site?.ID )
 	);

--- a/client/my-sites/subscribers/hooks/use-subscriber-launchpad-tasks.ts
+++ b/client/my-sites/subscribers/hooks/use-subscriber-launchpad-tasks.ts
@@ -5,7 +5,7 @@ import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 const useSubscriberLaunchpadTasks = () => {
 	const checklistSlug = 'subscribers';
-	const site = useSelector( ( state ) => getSelectedSite( state ) );
+	const site = useSelector( getSelectedSite );
 
 	const {
 		data: { checklist },

--- a/client/reader/follow-button/index.jsx
+++ b/client/reader/follow-button/index.jsx
@@ -17,7 +17,7 @@ function ReaderFollowButton( props ) {
 	const { onFollowToggle, railcar, followSource, hasButtonStyle, isButtonOnly, siteUrl, iconSize } =
 		props;
 
-	const isLoggedIn = useSelector( ( state ) => isUserLoggedIn( state ) );
+	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	function recordFollowToggle( isFollowing ) {
 		if ( isLoggedIn ) {

--- a/client/reader/recommended-sites/recommended-sites.tsx
+++ b/client/reader/recommended-sites/recommended-sites.tsx
@@ -61,7 +61,7 @@ const RecommendedSites = () => {
 	);
 
 	const offset = useSelector( ( state ) => getReaderRecommendedSitesPagingOffset( state, seed ) );
-	const blockedSites = useSelector( ( state ) => getBlockedSites( state ) );
+	const blockedSites = useSelector( getBlockedSites );
 
 	const filteredRecommendedSites = useMemo( () => {
 		if ( ! Array.isArray( recommendedSites ) || ! recommendedSites.length ) {

--- a/client/reader/stream/reader-list-followed-sites/item.jsx
+++ b/client/reader/stream/reader-list-followed-sites/item.jsx
@@ -19,7 +19,7 @@ const ReaderListFollowingItem = ( props ) => {
 	const { site, path, isUnseen, feed, follow, siteId } = props;
 	const moment = useLocalizedMoment();
 	const dispatch = useDispatch();
-	const isLoggedIn = useSelector( ( state ) => isUserLoggedIn( state ) );
+	const isLoggedIn = useSelector( isUserLoggedIn );
 	const siteIcon = site ? site.site_icon ?? get( site, 'icon.img' ) : null;
 	let feedIcon = get( follow, 'site_icon' );
 

--- a/client/reader/stream/reader-tag-sidebar/index.jsx
+++ b/client/reader/stream/reader-tag-sidebar/index.jsx
@@ -26,13 +26,13 @@ const ReaderTagSidebar = ( {
 	showFollow,
 	registerLastActionRequiresLogin: registerLastActionRequiresLoginProp,
 } ) => {
-	const primarySiteId = useSelector( ( state ) => getPrimarySiteId( state ) );
+	const primarySiteId = useSelector( getPrimarySiteId );
 	const translate = useTranslate();
 	const relatedMetaByTag = useRelatedMetaByTag( tag );
 	const tagStats = useTagStats( tag );
 	const dispatch = useDispatch();
 	const isFollowing = useSelector( ( state ) => getReaderTagBySlug( state, tag )?.isFollowing );
-	const isLoggedIn = useSelector( ( state ) => isUserLoggedIn( state ) );
+	const isLoggedIn = useSelector( isUserLoggedIn );
 
 	const today = moment().subtract( 10, 'd' ).format( '--MM-DD' );
 	const { data: prompts } = useBloggingPrompts( primarySiteId, today, 10 );

--- a/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
+++ b/client/signup/steps/woocommerce-install/hooks/use-woop-handling/index.ts
@@ -69,8 +69,8 @@ export default function useEligibility( siteId: number ): EligibilityHook {
 	);
 
 	// Get email verification data.
-	const currentUserEmail = useSelector( ( state ) => getCurrentUserEmail( state ) );
-	const isEmailVerified = useSelector( ( state ) => isCurrentUserEmailVerified( state ) );
+	const currentUserEmail = useSelector( getCurrentUserEmail );
+	const isEmailVerified = useSelector( isCurrentUserEmailVerified );
 
 	/*
 	 * Inspect transfer to detect blockers.

--- a/client/sites-dashboard/components/sites-display-mode-switcher.tsx
+++ b/client/sites-dashboard/components/sites-display-mode-switcher.tsx
@@ -15,7 +15,7 @@ const container = css( {
 export type SitesDisplayMode = 'tile' | 'list';
 
 export const useSitesDisplayMode = () => {
-	const siteCount = useSelector( ( state ) => getCurrentUserSiteCount( state ) );
+	const siteCount = useSelector( getCurrentUserSiteCount );
 	return useAsyncPreference< SitesDisplayMode >( {
 		defaultValue: siteCount && siteCount > 6 ? 'list' : 'tile',
 		preferenceName: 'sites-management-dashboard-display-mode',

--- a/client/sites-dashboard/components/sites-grid-action-renew.tsx
+++ b/client/sites-dashboard/components/sites-grid-action-renew.tsx
@@ -39,7 +39,7 @@ const RenewLink = styled.a( {
 
 export function SitesGridActionRenew( { site, isUpgradeable }: SitesGridActionRenewProps ) {
 	const { __ } = useI18n();
-	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
+	const userId = useSelector( getCurrentUserId );
 	const isSiteOwner = site.site_owner === userId;
 	const productSlug = site.plan?.product_slug;
 

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -147,7 +147,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 	const { __ } = useI18n();
 	const translatedStatus = useSiteLaunchStatusLabel( site );
 	const { ref, inView } = useInView( { triggerOnce: true } );
-	const userId = useSelector( ( state ) => getCurrentUserId( state ) );
+	const userId = useSelector( getCurrentUserId );
 
 	const isP2Site = site.options?.is_wpforteams_site;
 	const isWpcomStagingSite = isStagingSite( site );

--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -60,7 +60,7 @@ interface useCommandsArrayWpcomOptions {
 
 function useCommandNavigation() {
 	const dispatch = useDispatch();
-	const currentRoute = useSelector( ( state ) => getCurrentRoutePattern( state ) );
+	const currentRoute = useSelector( getCurrentRoutePattern );
 	// Callback to navigate to a command's destination
 	// used on command callback or siteFunctions onClick
 	const commandNavigation = useCallback(

--- a/client/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js
+++ b/client/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js
@@ -68,7 +68,7 @@ export const useIsJetpackConnectionProblem = ( siteId ) => {
  * React HOC to check if the current site has possible Jetpack connection problem.
  */
 export const withJetpackConnectionProblem = ( Wrapped ) => ( props ) => {
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteId = useSelector( getSelectedSiteId );
 	const isPossibleConnectionProblem = useIsJetpackConnectionProblem( siteId );
 	return (
 		<Wrapped { ...props } isPossibleJetpackConnectionProblem={ isPossibleConnectionProblem } />

--- a/client/state/sites/hooks/use-sites-sorting.ts
+++ b/client/state/sites/hooks/use-sites-sorting.ts
@@ -34,7 +34,7 @@ export const stringifySitesSorting = ( sorting: Required< SitesSortOptions > ): 
 };
 
 export const useSitesSorting = () => {
-	const siteCount = useSelector( ( state ) => getCurrentUserSiteCount( state ) );
+	const siteCount = useSelector( getCurrentUserSiteCount );
 
 	const [ sitesSorting, onSitesSortingChange ] = useAsyncPreference< SitesSorting >( {
 		defaultValue: stringifySitesSorting(

--- a/client/state/themes/hooks/use-theme-tier-for-theme.ts
+++ b/client/state/themes/hooks/use-theme-tier-for-theme.ts
@@ -6,7 +6,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 export function useThemeTierForTheme( themeId: string ) {
 	const themeTier = useSelector( ( state ) => getThemeTierForTheme( state, themeId ) );
 
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteId = useSelector( getSelectedSiteId );
 	const retainedBenefits = useTierRetainedBenefitsQuery( siteId as number, themeId );
 	return retainedBenefits?.is_eligible ? retainedBenefits.tier : themeTier;
 }

--- a/packages/help-center/src/components/help-center-launchpad.tsx
+++ b/packages/help-center/src/components/help-center-launchpad.tsx
@@ -31,7 +31,7 @@ const getEnvironmentHostname = () => {
 export const HelpCenterLaunchpad = () => {
 	const { __ } = useI18n();
 
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteId = useSelector( getSelectedSiteId );
 	const site = useSelect(
 		( select ) => {
 			if ( siteId ) {
@@ -54,7 +54,7 @@ export const HelpCenterLaunchpad = () => {
 		data?.checklist?.filter( ( checklistItem ) => checklistItem.completed ).length || 1;
 
 	const launchpadURL = `${ getEnvironmentHostname() }/setup/${ siteIntent }/launchpad?siteSlug=${ siteSlug }`;
-	const sectionName = useSelector( ( state ) => getSectionName( state ) );
+	const sectionName = useSelector( getSectionName );
 	const handleLaunchpadHelpLinkClick = () => {
 		recordTracksEvent( 'calypso_help_launchpad_click', {
 			link: launchpadURL,

--- a/packages/help-center/src/components/help-center-search.tsx
+++ b/packages/help-center/src/components/help-center-search.tsx
@@ -46,7 +46,7 @@ export const HelpCenterSearch = ( { onSearchChange, currentRoute }: HelpCenterSe
 		[ setSubject, setMessage, onSearchChange ]
 	);
 
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteId = useSelector( getSelectedSiteId );
 	const site = useSelect(
 		( select ) => siteId && ( select( SITE_STORE ) as SiteSelect ).getSite( siteId ),
 		[ siteId ]

--- a/packages/help-center/src/components/help-center.tsx
+++ b/packages/help-center/src/components/help-center.tsx
@@ -85,8 +85,8 @@ const HelpCenter: React.FC< Container > = ( {
 	}, [] );
 	const { setSite } = useDispatch( HELP_CENTER_STORE );
 
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const primarySiteId = useSelector( ( state ) => getPrimarySiteId( state ) );
+	const siteId = useSelector( getSelectedSiteId );
+	const primarySiteId = useSelector( getPrimarySiteId );
 
 	useSelect( ( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(), [] );
 


### PR DESCRIPTION
## Proposed Changes

Currently, we have plenty of places where we call 

`useSelector( ( state ) => selectorName( state ) )`

where we can use the shorter version:

`useSelector( selectorName )`

This PR updates all of these instances to the short version.

## Testing Instructions

Verify all checks are green.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?