### PR TITLE
Launchpad: Migrate the `videopress` flow

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/index.ts
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Task, TaskId, TaskContext, TaskActionTable } from '../types';
+import { Task, TaskId, TaskContext, TaskAction } from '../types';
 import { actions as designActions } from './design';
 import { actions as domainActions } from './domain';
 import { actions as planActions } from './plan';
@@ -8,7 +8,7 @@ import { actions as setupActions } from './setup';
 import { actions as siteActions } from './site';
 import { actions as videoPressActions } from './videopress';
 
-const DEFINITIONS = {
+const DEFINITIONS: TaskAction = {
 	...setupActions,
 	...designActions,
 	...domainActions,
@@ -16,7 +16,7 @@ const DEFINITIONS = {
 	...siteActions,
 	...planActions,
 	...videoPressActions,
-} satisfies TaskActionTable;
+};
 
 export const NEW_TASK_DEFINITION_PARSER_FEATURE_FLAG = 'launchpad/new-task-definition-parser';
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/index.ts
@@ -6,6 +6,7 @@ import { actions as planActions } from './plan';
 import { actions as postActions } from './post';
 import { actions as setupActions } from './setup';
 import { actions as siteActions } from './site';
+import { actions as videoPressActions } from './videopress';
 
 const DEFINITIONS = {
 	...setupActions,
@@ -14,6 +15,7 @@ const DEFINITIONS = {
 	...postActions,
 	...siteActions,
 	...planActions,
+	...videoPressActions,
 } satisfies TaskActionTable;
 
 export const NEW_TASK_DEFINITION_PARSER_FEATURE_FLAG = 'launchpad/new-task-definition-parser';

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/index.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/index.ts
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Task, TaskId, TaskContext, TaskAction } from '../types';
+import { Task, TaskId, TaskContext, TaskActionTable } from '../types';
 import { actions as designActions } from './design';
 import { actions as domainActions } from './domain';
 import { actions as planActions } from './plan';
@@ -8,7 +8,7 @@ import { actions as setupActions } from './setup';
 import { actions as siteActions } from './site';
 import { actions as videoPressActions } from './videopress';
 
-const DEFINITIONS: TaskAction = {
+const DEFINITIONS: TaskActionTable = {
 	...setupActions,
 	...designActions,
 	...domainActions,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/setup/index.tsx
@@ -27,7 +27,19 @@ const getSetupBlog: TaskAction = ( task, flow, context ): Task => {
 	};
 };
 
+const getSetupVideoPressTask: TaskAction = ( task, flow, context ): Task => {
+	const { siteInfoQueryArgs } = context;
+
+	return {
+		...task,
+		actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
+		calypso_path: addQueryArgs( task.calypso_path, siteInfoQueryArgs ),
+		useCalypsoPath: true,
+	};
+};
+
 export const actions = {
 	setup_free: getSetupFreeTask,
 	setup_blog: getSetupBlog,
+	videopress_setup: getSetupVideoPressTask,
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/site/index.tsx
@@ -10,6 +10,7 @@ import {
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { goToCheckout } from 'calypso/landing/stepper/utils/checkout';
@@ -146,8 +147,38 @@ const getBlogLaunchedTask: TaskAction = ( task, flow, context ): Task => {
 		useCalypsoPath: false,
 	};
 };
+const getVideopressLaunchedTask: TaskAction = ( task, flow, context ): Task => {
+	const { site, submit, siteSlug } = context;
+
+	return {
+		...task,
+		isLaunchTask: true,
+		actionDispatch: () => {
+			if ( site?.ID ) {
+				const { setPendingAction, setProgressTitle } = dispatch( ONBOARD_STORE ) as OnboardActions;
+				const { launchSite } = dispatch( SITE_STORE ) as SiteActions;
+
+				setPendingAction( async () => {
+					setProgressTitle( __( 'Launching video site' ) );
+					await launchSite( site.ID );
+
+					// Waits for half a second so that the loading screen doesn't flash away too quickly
+					await new Promise( ( res ) => setTimeout( res, 500 ) );
+					window.location.replace(
+						addQueryArgs( `/home/${ siteSlug }`, {
+							forceLoadLaunchpadData: true,
+						} )
+					);
+				} );
+				recordTaskClickTracksEvent( task, flow, context );
+				submit?.();
+			}
+		},
+	};
+};
 
 export const actions = {
 	site_launched: getSiteLaunchedTask,
 	blog_launched: getBlogLaunchedTask,
+	videopress_launched: getVideopressLaunchedTask,
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/videopress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/videopress/index.tsx
@@ -1,0 +1,45 @@
+import { FEATURE_VIDEO_UPLOADS, planHasFeature } from '@automattic/calypso-products';
+import { isVideoPressFlow } from '@automattic/onboarding';
+import { addQueryArgs } from '@wordpress/url';
+import { recordTaskClickTracksEvent } from '../../tracking';
+import { TaskAction } from '../../types';
+
+const getVideoPressUploadTask: TaskAction = ( task, flow, context ) => {
+	const { site, siteSlug, tasks, planCartItem } = context;
+	const homePageId = site?.options?.page_on_front;
+	// send user to Home page editor, fallback to FSE if page id is not known
+	const productSlug = planCartItem?.product_slug ?? site?.plan?.product_slug;
+
+	const isVideoPressFlowWithUnsupportedPlan =
+		isVideoPressFlow( flow ) && ! planHasFeature( productSlug as string, FEATURE_VIDEO_UPLOADS );
+
+	const completedTasks: Record< string, boolean > = tasks.reduce(
+		( acc, cur ) => ( {
+			...acc,
+			[ cur.id ]: cur.completed,
+		} ),
+		{}
+	);
+	const videoPressUploadCompleted = completedTasks.video_uploaded;
+
+	const launchpadUploadVideoLink = homePageId
+		? `/page/${ siteSlug }/${ homePageId }`
+		: addQueryArgs( `/site-editor/${ siteSlug }`, {
+				canvas: 'edit',
+		  } );
+
+	return {
+		...task,
+		actionUrl: launchpadUploadVideoLink,
+		disabled: isVideoPressFlowWithUnsupportedPlan || videoPressUploadCompleted,
+		actionDispatch: () => {
+			recordTaskClickTracksEvent( task, flow, context );
+		},
+		returnUrl: launchpadUploadVideoLink,
+		useCalypsoPath: true,
+	};
+};
+
+export const actions = {
+	videopress_upload: getVideoPressUploadTask,
+};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -549,7 +549,7 @@ export function getEnhancedTasks( {
 					break;
 				}
 				case 'videopress_upload':
-					taskData = {
+					deprecatedData = {
 						actionUrl: launchpadUploadVideoLink,
 						disabled: isVideoPressFlowWithUnsupportedPlan || videoPressUploadCompleted,
 						actionDispatch: () => {
@@ -557,6 +557,8 @@ export function getEnhancedTasks( {
 							window.location.replace( launchpadUploadVideoLink );
 						},
 					};
+
+					taskData = getTaskDefinition( flow, task, context ) || deprecatedData;
 					break;
 				case 'videopress_launched':
 					taskData = {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -658,6 +658,9 @@ export function getEnhancedTasks( {
 						},
 					};
 					break;
+				case 'videopress_setup':
+					taskData = getTaskDefinition( flow, task, context ) || task;
+					break;
 			}
 			enhancedTaskList.push( { ...task, ...taskData } );
 		} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper.tsx
@@ -561,7 +561,7 @@ export function getEnhancedTasks( {
 					taskData = getTaskDefinition( flow, task, context ) || deprecatedData;
 					break;
 				case 'videopress_launched':
-					taskData = {
+					deprecatedData = {
 						isLaunchTask: true,
 						actionDispatch: () => {
 							if ( site?.ID ) {
@@ -587,6 +587,7 @@ export function getEnhancedTasks( {
 							}
 						},
 					};
+					taskData = getTaskDefinition( flow, task, context ) || deprecatedData;
 					break;
 				case 'domain_upsell':
 					deprecatedData = {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -19,20 +19,23 @@ export interface TranslatedLaunchpadStrings {
 	subtitle: string;
 }
 
+// TODO: Convert this type to enum, because union string doesnt protect from duplicates or typos;
+//
 export type TaskId =
 	| 'setup_free'
 	| 'setup_blog'
+	| 'videopress_setup'
 	| 'blog_launched'
+	| 'site_launched'
+	| 'videopress_launched'
 	| 'design_selected'
 	| 'design_completed'
 	| 'design_edited'
 	| 'domain_upsell'
 	| 'first_post_published'
 	| 'plan_selected'
-	| 'videopress_upload'
-	| 'videopress_setup'
 	| 'plan_completed'
-	| 'site_launched';
+	| 'videopress_upload';
 
 export interface TaskContext {
 	tasks: Task[];

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -30,6 +30,7 @@ export type TaskId =
 	| 'first_post_published'
 	| 'site_launched'
 	| 'plan_selected'
+	| 'videopress_upload'
 	| 'plan_completed'
 	| 'site_launched';
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/types.ts
@@ -28,9 +28,9 @@ export type TaskId =
 	| 'design_edited'
 	| 'domain_upsell'
 	| 'first_post_published'
-	| 'site_launched'
 	| 'plan_selected'
 	| 'videopress_upload'
+	| 'videopress_setup'
 	| 'plan_completed'
 	| 'site_launched';
 

--- a/config/development.json
+++ b/config/development.json
@@ -114,6 +114,7 @@
 		"launchpad/new-task-definition-parser/free": true,
 		"launchpad/new-task-definition-parser/start-writing": true,
 		"launchpad/new-task-definition-parser/design-first": true,
+		"launchpad/new-task-definition-parser/videopress": true,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,

--- a/config/production.json
+++ b/config/production.json
@@ -88,6 +88,7 @@
 		"launchpad/new-task-definition-parser/free": true,
 		"launchpad/new-task-definition-parser/start-writing": false,
 		"launchpad/new-task-definition-parser/design-first": true,
+		"launchpad/new-task-definition-parser/videopress": false,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -83,6 +83,7 @@
 		"launchpad/new-task-definition-parser/free": true,
 		"launchpad/new-task-definition-parser/start-writing": true,
 		"launchpad/new-task-definition-parser/design-first": true,
+		"launchpad/new-task-definition-parser/videopress": true,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,

--- a/config/test.json
+++ b/config/test.json
@@ -66,6 +66,7 @@
 		"launchpad/new-task-definition-parser/free": true,
 		"launchpad/new-task-definition-parser/start-writing": true,
 		"launchpad/new-task-definition-parser/design-first": true,
+		"launchpad/new-task-definition-parser/videopress": true,
 		"layout/app-banner": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, to avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86647

## Proposed Changes
*  Migrate all video press tasks to use the new structure

## List of tasks related to this flow
| TASK | MIGRATED? |
|--------|--------|
'videopress_setup'  | YES
'plan_selected' | Previously Migrated
'videopress_upload' | YES
'videopress_launched' | YES


### Expected State from feature flags
<img width="1019" alt="image" src="https://github.com/Automattic/wp-calypso/assets/38718/112c7ce3-d2db-4ff3-b40e-a4647d6c003a">



Use `yarn feature-search launchpad/new-task-definition-parser/videopress` to verify

Requires the feature flags:
* `launchpad/new-task-definition-parser`
* `launchpad/new-task-definition-parser/videopress`


`&flags=launchpad/new-task-definition-parser/videopress,launchpad/new-task-definition-parser` 

The flags can be enabled by appending the `?flags=` flag on the URL (Please always check if the flags= param is still on the URL when the system redirects back the user from some "no launchpad" page ).

## Testing Instructions
**NOTE:**
The current videopress flow is only showing the launchpad page if the feature flag `videomaker-trial` is disabled.

http://calypso.localhost:3000/setup/videopress/videomakerSetup?flags=-videomaker-trial

* Start the flow `/setup/videopress?flags=-videomaker-trial)` 
* Select a design
* Set a site name/description
* Select a domain
* Continue the flow until reach the page `/setup/videopress/launchpad?` 
* Turn on the feature flags and reload the page. NOTE: The `videomaker-trial` flag is not necessary here.
* Use all tasks
* Launch a site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?


