### PR TITLE
Plans Next: Untangle Features Grid from media queries, up reuse and default responsiveness

### DIFF
--- a/.vscode/settings-sample.jsonc
+++ b/.vscode/settings-sample.jsonc
@@ -12,10 +12,10 @@
 	// Editor settings
 	"editor.formatOnSave": false,
 	"editor.codeActionsOnSave": {
-		"source.fixAll": true,
-		"source.fixAll.eslint": true,
-		"source.fixAll.tslint": true,
-		"source.fixAll.stylelint": true
+		"source.fixAll": "explicit",
+		"source.fixAll.eslint": "explicit",
+		"source.fixAll.tslint": "explicit",
+		"source.fixAll.stylelint": "explicit"
 	},
 	// Use prettier for formatting JS/TS
 	"[javascript][javascriptreact][typescript][typescriptreact]": {

--- a/client/jetpack-app/plans/style.scss
+++ b/client/jetpack-app/plans/style.scss
@@ -1,4 +1,3 @@
-@import "@automattic/plans-grid-next/src/media-queries";
 @import "@wordpress/base-styles/variables";
 @import "@automattic/typography/styles/fonts";
 
@@ -7,8 +6,6 @@ body {
 }
 
 .jetpack-app__plans {
-	@include plan-features-layout-switcher;
-
 	.jetpack-app__plans-header {
 		display: block;
 		overflow: auto;

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -890,6 +890,7 @@ const PlansFeaturesMain = ( {
 									generatedWPComSubdomain={ resolvedSubdomainName }
 									isCustomDomainAllowedOnFreePlan={ isCustomDomainAllowedOnFreePlan }
 									isInSignup={ isInSignup }
+									isInAdmin={ ! isInSignup }
 									isLaunchPage={ isLaunchPage }
 									onUpgradeClick={ handleUpgradeClick }
 									selectedFeature={ selectedFeature }
@@ -951,6 +952,7 @@ const PlansFeaturesMain = ( {
 											<ComparisonGrid
 												gridPlans={ gridPlansForComparisonGrid }
 												isInSignup={ isInSignup }
+												isInAdmin={ ! isInSignup }
 												isLaunchPage={ isLaunchPage }
 												onUpgradeClick={ handleUpgradeClick }
 												selectedFeature={ selectedFeature }

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -28,19 +28,6 @@
 		width: auto;
 	}
 
-	// .is-section-stepper &,
-	// .is-section-signup & {
-	// 	@include plan-features-layout-switcher;
-	// }
-
-	// .is-section-plans:not(.is-sidebar-collapsed) & {
-	// 	@include plan-features-layout-switcher-with-sidebar;
-	// }
-
-	// .is-section-plans.is-sidebar-collapsed & {
-	// 	@include plan-features-layout-switcher;
-	// }
-
 	.signup__steps .plans-features-main__group.is-scrollable & {
 		max-width: 100%;
 	}
@@ -53,22 +40,6 @@
 		@include plans-2023-break-small {
 			padding-top: 35px; // enough to cover `plans-grid__popular-badge` repositioning (top: -35px)
 		}
-
-		// @include plans-2023-break-medium {
-		// 	margin: 0 20px;
-		// }
-
-		// @include plans-section-break-medium {
-		// 	margin: 0;
-		// }
-
-		// @include plans-2023-break-medium {
-		// 	margin: 0 20px;
-		// }
-
-		// @include plans-section-break-medium {
-		// 	margin: 0;
-		// }
 	}
 }
 

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -28,18 +28,18 @@
 		width: auto;
 	}
 
-	.is-section-stepper &,
-	.is-section-signup & {
-		@include plan-features-layout-switcher;
-	}
+	// .is-section-stepper &,
+	// .is-section-signup & {
+	// 	@include plan-features-layout-switcher;
+	// }
 
-	.is-section-plans:not(.is-sidebar-collapsed) & {
-		@include plan-features-layout-switcher-with-sidebar;
-	}
+	// .is-section-plans:not(.is-sidebar-collapsed) & {
+	// 	@include plan-features-layout-switcher-with-sidebar;
+	// }
 
-	.is-section-plans.is-sidebar-collapsed & {
-		@include plan-features-layout-switcher;
-	}
+	// .is-section-plans.is-sidebar-collapsed & {
+	// 	@include plan-features-layout-switcher;
+	// }
 
 	.signup__steps .plans-features-main__group.is-scrollable & {
 		max-width: 100%;
@@ -52,24 +52,23 @@
 
 		@include plans-2023-break-small {
 			padding-top: 35px; // enough to cover `plans-grid__popular-badge` repositioning (top: -35px)
-			margin: 0;
 		}
 
-		@include plans-2023-break-medium {
-			margin: 0 20px;
-		}
+		// @include plans-2023-break-medium {
+		// 	margin: 0 20px;
+		// }
 
-		@include plans-section-break-medium {
-			margin: 0;
-		}
+		// @include plans-section-break-medium {
+		// 	margin: 0;
+		// }
 
-		@include plans-2023-break-medium {
-			margin: 0 20px;
-		}
+		// @include plans-2023-break-medium {
+		// 	margin: 0 20px;
+		// }
 
-		@include plans-section-break-medium {
-			margin: 0;
-		}
+		// @include plans-section-break-medium {
+		// 	margin: 0;
+		// }
 	}
 }
 

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -39,10 +39,6 @@
 		max-width: 1480px;
 	}
 
-	.is-onboarding-2023-pricing-grid &.is-wide-layout {
-		@include pricing-grid-breakpoints;
-	}
-
 	.formatted-header.is-without-subhead {
 		margin-bottom: 15px;
 	}
@@ -50,10 +46,6 @@
 	.step-wrapper {
 		&.is-wide-layout {
 			max-width: 1200px;
-		}
-
-		.is-onboarding-2023-pricing-grid .signup__step &.is-wide-layout {
-			@include pricing-grid-breakpoints;
 		}
 	}
 }

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -799,29 +799,6 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 		}
 	}
 
-	/* TODO: Remove the following when the 2023 pricig grid is live to all users */
-	.signup:not(.is-onboarding-2023-pricing-grid) .signup__step .plans.plans-step {
-		.formatted-header {
-			.formatted-header__title {
-				font-size: 2.25rem;
-				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-				line-height: 2.5rem;
-				font-weight: 500;
-
-				@include break-mobile {
-					font-size: 2.75rem;
-					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-					line-height: 3rem;
-				}
-			}
-
-			.formatted-header__subtitle button.is-borderless {
-				font-weight: 500;
-				color: var(--studio-gray-90);
-			}
-		}
-	}
-
 	.signup__step.is-mailbox-domain,
 	.signup__step.is-emails,
 	.signup__step.is-mailbox,

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -470,16 +470,6 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 		}
 	}
 
-	.signup.is-onboarding-2023-pricing-grid .step-wrapper:not(.is-horizontal-layout) {
-		.step-wrapper__header {
-			margin: 24px 20px 38px;
-
-			@media (min-width: 880px) {
-				margin: 24px 20px;
-			}
-		}
-	}
-
 	.step-wrapper__header-button {
 		@include breakpoint-deprecated("<660px") {
 			margin-top: 16px;
@@ -828,23 +818,6 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 			.formatted-header__subtitle button.is-borderless {
 				font-weight: 500;
 				color: var(--studio-gray-90);
-			}
-		}
-	}
-
-	.signup.is-onboarding-2023-pricing-grid .signup__step .plans.plans-step {
-		.formatted-header {
-			.formatted-header__title {
-				font-size: 2.25rem;
-				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-				line-height: 2.5rem;
-				font-weight: 400;
-
-				@media (min-width: 880px) {
-					font-size: 2.75rem;
-					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
-					line-height: 3rem;
-				}
 			}
 		}
 	}

--- a/client/signup/style.scss
+++ b/client/signup/style.scss
@@ -799,6 +799,29 @@ body.is-section-signup.is-white-signup .layout:not(.dops):not(.is-wccom-oauth-fl
 		}
 	}
 
+	/* TODO: Remove the following when the 2023 pricig grid is live to all users */
+	.signup .signup__step .plans.plans-step {
+		.formatted-header {
+			.formatted-header__title {
+				font-size: 2.25rem;
+				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+				line-height: 2.5rem;
+				font-weight: 500;
+
+				@include break-mobile {
+					font-size: 2.75rem;
+					/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+					line-height: 3rem;
+				}
+			}
+
+			.formatted-header__subtitle button.is-borderless {
+				font-weight: 500;
+				color: var(--studio-gray-90);
+			}
+		}
+	}
+
 	.signup__step.is-mailbox-domain,
 	.signup__step.is-emails,
 	.signup__step.is-mailbox,

--- a/packages/plans-grid-next/src/_media-queries.scss
+++ b/packages/plans-grid-next/src/_media-queries.scss
@@ -10,7 +10,7 @@ $plans-2023-medium-breakpoint: 1350px;
 $minWidthToGridWidthMap: (
 	780px: "668px",
 	1024px: "860px",
-	1350px: "100%",
+	1200px: "100%",
 );
 
 // Plan Comparison Grid Breakpoints

--- a/packages/plans-grid-next/src/_media-queries.scss
+++ b/packages/plans-grid-next/src/_media-queries.scss
@@ -73,90 +73,9 @@ $planComparisonMinWidthToGridWidthWithSidebarMap: (
 }
 
 /**
- * Show/hide desktop/tablet/mobile layouts based on the screen width.
- * Desktop layout: width > $plans-2023-medium-breakpoint
- * Tablet layout:  $plans-2023-small-breakpoint < width < $plans-2023-medium-breakpoint
- * Mobile layout:  width < $plans-2023-small-breakpoint
+ * @deprecated
+ * TODO clk Used in comparison grid
  */
-@mixin plan-features-layout-switcher {
-	.plan-features-2023-grid__desktop-view {
-		display: none;
-
-		@media ( min-width: $plans-2023-medium-breakpoint ) {
-			display: block;
-		}
-	}
-
-	.plan-features-2023-grid__tablet-view {
-		display: none;
-
-		@media ( min-width: $plans-2023-small-breakpoint ) {
-			display: block;
-		}
-
-		@media ( min-width: $plans-2023-medium-breakpoint ) {
-			display: none;
-		}
-	}
-
-	.plan-features-2023-grid__mobile-view {
-		display: flex;
-
-		@media ( min-width: $plans-2023-small-breakpoint ) {
-			display: none;
-		}
-	}
-
-	.plan-features-2023-grid__plan-spotlight {
-		display: none;
-
-		@media ( min-width: $plans-2023-small-breakpoint ) {
-			display: block;
-		}
-	}
-}
-
-/**
- * Same as `plan-features-layout-switcher`, except that we add the sidebar width to the breakpoints.
- */
-@mixin plan-features-layout-switcher-with-sidebar {
-	.plan-features-2023-grid__desktop-view {
-		display: none;
-
-		@media ( min-width: ( $plans-2023-medium-breakpoint + $plan-features-sidebar-width ) ) {
-			display: block;
-		}
-	}
-
-	.plan-features-2023-grid__tablet-view {
-		display: none;
-
-		@media ( min-width: ( $plans-2023-small-breakpoint + $plan-features-sidebar-width ) ) {
-			display: block;
-		}
-
-		@media ( min-width: ( $plans-2023-medium-breakpoint + $plan-features-sidebar-width ) ) {
-			display: none;
-		}
-	}
-
-	.plan-features-2023-grid__mobile-view {
-		display: flex;
-
-		@media ( min-width: ( $plans-2023-small-breakpoint + $plan-features-sidebar-width ) ) {
-			display: none;
-		}
-	}
-
-	.plan-features-2023-grid__plan-spotlight {
-		display: none;
-
-		@media ( min-width: $plans-2023-small-breakpoint + $plan-features-sidebar-width ) {
-			display: block;
-		}
-	}
-}
-
 @mixin plans-2023-break-small() {
 	body.is-section-stepper &,
 	body.is-section-signup.is-white-signup & {
@@ -178,6 +97,10 @@ $planComparisonMinWidthToGridWidthWithSidebarMap: (
 	}
 }
 
+/**
+ * @deprecated
+ * TODO clk Used in comparison grid
+ */
 @mixin plans-2023-break-medium() {
 	body.is-section-stepper &,
 	body.is-section-signup.is-white-signup & {
@@ -199,26 +122,14 @@ $planComparisonMinWidthToGridWidthWithSidebarMap: (
 	}
 }
 
-@mixin plans-section-break-medium() {
-	.is-section-plans:not(.is-sidebar-collapsed) & {
-		@media ( min-width: $plans-2023-medium-breakpoint + $plan-features-sidebar-width ) {
-			@content;
-		}
-	}
-
-	.is-section-plans.is-sidebar-collapsed & {
-		@media ( min-width: $plans-2023-medium-breakpoint ) {
-			@content;
-		}
-	}
-}
-
 /**
  * @see client/my-sites/plans/modernized-layout.tsx
  * This file introduces padding for the header on the plans page
  * at a custom mobile breakpoint.
  *
  * This mixin can be use to target that particular breakpoint.
+ *
+ * TODO clk used in plans-features-main / should migrate there
  */
 @mixin plans-section-custom-mobile-breakpoint() {
 	.is-section-plans & {
@@ -231,6 +142,8 @@ $planComparisonMinWidthToGridWidthWithSidebarMap: (
 /**
  * @see @automattic/plans-grid-next/src/components/plan-type-selector/style.scss
  * This introduces mobile only sticky behavior for the plan type selector.
+ *
+ * TODO clk need to update to use GridSize / container breakpoints
  *
  */
 @mixin plan-type-selector-custom-mobile-breakpoint() {

--- a/packages/plans-grid-next/src/_mixins.scss
+++ b/packages/plans-grid-next/src/_mixins.scss
@@ -1,0 +1,12 @@
+@mixin plans-grid-large() {
+	.plans-grid-next.is-large & {
+		@content;
+	}
+}
+
+@mixin plans-grid-medium-large() {
+	.plans-grid-next.is-medium &,
+	.plans-grid-next.is-large & {
+		@content;
+	}
+}

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -10,7 +10,7 @@ import {
 import { Gridicon, JetpackLogo } from '@automattic/components';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useMemo } from '@wordpress/element';
+import { useRef, useMemo } from '@wordpress/element';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import {
@@ -24,6 +24,7 @@ import {
 } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { usePlansGridContext } from '../../grid-context';
+import useGridSize from '../../hooks/use-grid-size';
 import useHighlightAdjacencyMatrix from '../../hooks/use-highlight-adjacency-matrix';
 import { useManageTooltipToggle } from '../../hooks/use-manage-tooltip-toggle';
 import filterUnusedFeaturesObject from '../../lib/filter-unused-features-object';

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -10,7 +10,7 @@ import {
 import { Gridicon, JetpackLogo } from '@automattic/components';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
-import { useRef, useMemo } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import {
@@ -24,7 +24,6 @@ import {
 } from 'react';
 import { useInView } from 'react-intersection-observer';
 import { usePlansGridContext } from '../../grid-context';
-import useGridSize from '../../hooks/use-grid-size';
 import useHighlightAdjacencyMatrix from '../../hooks/use-highlight-adjacency-matrix';
 import { useManageTooltipToggle } from '../../hooks/use-manage-tooltip-toggle';
 import filterUnusedFeaturesObject from '../../lib/filter-unused-features-object';

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -907,7 +907,7 @@ const FeaturesGrid = ( {
 
 	return (
 		<>
-			<SpotlightPlan { ...spotlightPlanProps } />
+			{ 'small' !== gridSize && <SpotlightPlan { ...spotlightPlanProps } /> }
 			<div className="plan-features">
 				<div className="plan-features-2023-grid__content">
 					<div>

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -880,6 +880,7 @@ const FeaturesGrid = ( {
 	selectedFeature,
 	generatedWPComSubdomain,
 	isCustomDomainAllowedOnFreePlan,
+	gridSize,
 }: FeaturesGridProps ) => {
 	const spotlightPlanProps = {
 		currentSitePlanSlug,
@@ -910,15 +911,21 @@ const FeaturesGrid = ( {
 			<div className="plan-features">
 				<div className="plan-features-2023-grid__content">
 					<div>
-						<div className="plan-features-2023-grid__desktop-view">
-							<Table { ...planFeaturesProps } stickyRowOffset={ stickyRowOffset } />
-						</div>
-						<div className="plan-features-2023-grid__tablet-view">
-							<TabletView { ...planFeaturesProps } stickyRowOffset={ stickyRowOffset } />
-						</div>
-						<div className="plan-features-2023-grid__mobile-view">
-							<MobileView { ...planFeaturesProps } />
-						</div>
+						{ 'large' === gridSize && (
+							<div className="plan-features-2023-grid__desktop-view">
+								<Table { ...planFeaturesProps } stickyRowOffset={ stickyRowOffset } />
+							</div>
+						) }
+						{ 'medium' === gridSize && (
+							<div className="plan-features-2023-grid__tablet-view">
+								<TabletView { ...planFeaturesProps } stickyRowOffset={ stickyRowOffset } />
+							</div>
+						) }
+						{ 'small' === gridSize && (
+							<div className="plan-features-2023-grid__mobile-view">
+								<MobileView { ...planFeaturesProps } />
+							</div>
+						) }
 					</div>
 				</div>
 			</div>

--- a/packages/plans-grid-next/src/hooks/use-grid-size.ts
+++ b/packages/plans-grid-next/src/hooks/use-grid-size.ts
@@ -42,7 +42,7 @@ const useGridSize = ( { containerRef, containerBreakpoints }: Props ) => {
 		return () => {
 			window.removeEventListener( 'resize', handleResize );
 		};
-	}, [ containerRef, gridSize, setGridSize ] );
+	}, [ containerBreakpoints, containerRef, gridSize, setGridSize ] );
 
 	return gridSize;
 };

--- a/packages/plans-grid-next/src/hooks/use-grid-size.ts
+++ b/packages/plans-grid-next/src/hooks/use-grid-size.ts
@@ -1,85 +1,21 @@
 import { useLayoutEffect, useState } from '@wordpress/element';
-import type { GridSize } from '../types';
 
-const useGridSizex = ( {
-	containerRef,
-	leftOffset = 0,
-	columnMinWidth = 222,
-	columnsInRow = { medium: 3, large: 4 },
-}: {
+interface Props {
 	containerRef: React.MutableRefObject< HTMLDivElement | null >;
-	leftOffset?: number;
-	columnMinWidth: number;
-	columnsInRow: { medium: number; large: number };
-} ) => {
-	const breakpoints = {
-		small: 780,
-		large: 1600,
-	};
-
-	const largeFit = columnsInRow.large * columnMinWidth;
-	const mediumFit = columnsInRow.medium * columnMinWidth;
-
-	const [ gridSize, setGridSize ] = useState< GridSize >( 'large' );
-
-	useLayoutEffect( () => {
-		const handleResize = () => {
-			const offsetWidth = containerRef.current?.offsetWidth;
-
-			if ( offsetWidth ) {
-				const width = offsetWidth + leftOffset;
-
-				if ( width <= breakpoints.small ) {
-					if ( gridSize !== 'small' ) {
-						console.log( width, offsetWidth );
-						setGridSize( 'small' );
-					}
-				} else if ( width >= breakpoints.large ) {
-					if ( gridSize !== 'large' ) {
-						console.log( width, offsetWidth );
-						setGridSize( 'large' );
-					}
-				} else if ( gridSize !== 'medium' ) {
-					console.log( width, offsetWidth );
-					setGridSize( 'medium' );
-				}
-			}
-		};
-
-		window.addEventListener( 'resize', handleResize );
-		handleResize();
-
-		return () => {
-			window.removeEventListener( 'resize', handleResize );
-		};
-	}, [ containerRef, gridSize, largeFit, leftOffset, mediumFit, setGridSize ] );
-
-	return gridSize;
-};
+	/**
+	 * Labelled breakpoints a la "container query".
+	 * These are currently observed manually (i.e. we do not use container queries),
+	 * but they could be used in the future in a containment context.
+	 * The keys are the labels, the values are the minimum widths.
+	 */
+	containerBreakpoints: Map< string, number >;
+}
 
 /**
- * Labelled breakpoints a la "container query".
- * These are currently observed manually (i.e. we do not use container queries),
- * but they could be used in the future in a containment context.
+ * useGridSize returns the current grid size based on the width of the container
+ * and the breakpoints passed through as props.
  */
-const containerBreakpoints = new Map( [
-	[ 'small', 0 ],
-	[ 'medium', 740 ],
-	[ 'large', 1320 ], // 1320 to fit enterpreneur plan, 1180 to work in admin
-] );
-
-const useGridSize = ( {
-	containerRef,
-	averageColumnMinWidth = 222,
-	columnsInRow = { medium: 3, large: 4 },
-}: {
-	containerRef: React.MutableRefObject< HTMLDivElement | null >;
-	averageColumnMinWidth: number;
-	columnsInRow: { medium: number; large: number };
-} ) => {
-	const largeFit = columnsInRow.large * averageColumnMinWidth;
-	const mediumFit = columnsInRow.medium * averageColumnMinWidth;
-
+const useGridSize = ( { containerRef, containerBreakpoints }: Props ) => {
 	const [ gridSize, setGridSize ] = useState< string | null >( null );
 
 	useLayoutEffect( () => {
@@ -90,32 +26,13 @@ const useGridSize = ( {
 				const width = offsetWidth;
 
 				for ( const [ key, value ] of [ ...containerBreakpoints ].reverse() ) {
-					console.log( key, value, width, offsetWidth );
 					if ( width >= value ) {
 						if ( gridSize !== key ) {
-							console.log( key, width, offsetWidth );
 							setGridSize( key );
 						}
 						break;
 					}
 				}
-
-				// if ( width < containerBreakpoints.small ) {
-				// 	if ( gridSize !== 'small' ) {
-				// 		console.log( 'small', width, offsetWidth );
-				// 		setGridSize( 'small' );
-				// 	}
-				// } else if ( width >= containerBreakpoints.small && width < containerBreakpoints.large ) {
-				// 	// else if ( width >= largeFit ) {
-				// 	if ( gridSize !== 'medium' ) {
-				// 		console.log( 'medium', width, offsetWidth );
-				// 		setGridSize( 'medium' );
-				// 	}
-				// } else if ( gridSize !== 'large' ) {
-				// 	// else if ( width >= mediumFit ) {
-				// 	console.log( 'large', width, offsetWidth );
-				// 	setGridSize( 'large' );
-				// }
 			}
 		};
 
@@ -125,7 +42,7 @@ const useGridSize = ( {
 		return () => {
 			window.removeEventListener( 'resize', handleResize );
 		};
-	}, [ containerRef, gridSize, largeFit, mediumFit, setGridSize ] );
+	}, [ containerRef, gridSize, setGridSize ] );
 
 	return gridSize;
 };

--- a/packages/plans-grid-next/src/hooks/use-grid-size.ts
+++ b/packages/plans-grid-next/src/hooks/use-grid-size.ts
@@ -64,7 +64,7 @@ const useGridSizex = ( {
  */
 const containerBreakpoints = new Map( [
 	[ 'small', 0 ],
-	[ 'medium', 725 ],
+	[ 'medium', 740 ],
 	[ 'large', 1320 ], // 1320 to fit enterpreneur plan, 1180 to work in admin
 ] );
 

--- a/packages/plans-grid-next/src/hooks/use-grid-size.ts
+++ b/packages/plans-grid-next/src/hooks/use-grid-size.ts
@@ -1,0 +1,133 @@
+import { useLayoutEffect, useState } from '@wordpress/element';
+import type { GridSize } from '../types';
+
+const useGridSizex = ( {
+	containerRef,
+	leftOffset = 0,
+	columnMinWidth = 222,
+	columnsInRow = { medium: 3, large: 4 },
+}: {
+	containerRef: React.MutableRefObject< HTMLDivElement | null >;
+	leftOffset?: number;
+	columnMinWidth: number;
+	columnsInRow: { medium: number; large: number };
+} ) => {
+	const breakpoints = {
+		small: 780,
+		large: 1600,
+	};
+
+	const largeFit = columnsInRow.large * columnMinWidth;
+	const mediumFit = columnsInRow.medium * columnMinWidth;
+
+	const [ gridSize, setGridSize ] = useState< GridSize >( 'large' );
+
+	useLayoutEffect( () => {
+		const handleResize = () => {
+			const offsetWidth = containerRef.current?.offsetWidth;
+
+			if ( offsetWidth ) {
+				const width = offsetWidth + leftOffset;
+
+				if ( width <= breakpoints.small ) {
+					if ( gridSize !== 'small' ) {
+						console.log( width, offsetWidth );
+						setGridSize( 'small' );
+					}
+				} else if ( width >= breakpoints.large ) {
+					if ( gridSize !== 'large' ) {
+						console.log( width, offsetWidth );
+						setGridSize( 'large' );
+					}
+				} else if ( gridSize !== 'medium' ) {
+					console.log( width, offsetWidth );
+					setGridSize( 'medium' );
+				}
+			}
+		};
+
+		window.addEventListener( 'resize', handleResize );
+		handleResize();
+
+		return () => {
+			window.removeEventListener( 'resize', handleResize );
+		};
+	}, [ containerRef, gridSize, largeFit, leftOffset, mediumFit, setGridSize ] );
+
+	return gridSize;
+};
+
+/**
+ * Labelled breakpoints a la "container query".
+ * These are currently observed manually (i.e. we do not use container queries),
+ * but they could be used in the future in a containment context.
+ */
+const containerBreakpoints = new Map( [
+	[ 'small', 0 ],
+	[ 'medium', 725 ],
+	[ 'large', 1320 ], // 1320 to fit enterpreneur plan, 1180 to work in admin
+] );
+
+const useGridSize = ( {
+	containerRef,
+	averageColumnMinWidth = 222,
+	columnsInRow = { medium: 3, large: 4 },
+}: {
+	containerRef: React.MutableRefObject< HTMLDivElement | null >;
+	averageColumnMinWidth: number;
+	columnsInRow: { medium: number; large: number };
+} ) => {
+	const largeFit = columnsInRow.large * averageColumnMinWidth;
+	const mediumFit = columnsInRow.medium * averageColumnMinWidth;
+
+	const [ gridSize, setGridSize ] = useState< string | null >( null );
+
+	useLayoutEffect( () => {
+		const handleResize = () => {
+			const offsetWidth = containerRef.current?.getBoundingClientRect().width;
+
+			if ( offsetWidth ) {
+				const width = offsetWidth;
+
+				for ( const [ key, value ] of [ ...containerBreakpoints ].reverse() ) {
+					console.log( key, value, width, offsetWidth );
+					if ( width >= value ) {
+						if ( gridSize !== key ) {
+							console.log( key, width, offsetWidth );
+							setGridSize( key );
+						}
+						break;
+					}
+				}
+
+				// if ( width < containerBreakpoints.small ) {
+				// 	if ( gridSize !== 'small' ) {
+				// 		console.log( 'small', width, offsetWidth );
+				// 		setGridSize( 'small' );
+				// 	}
+				// } else if ( width >= containerBreakpoints.small && width < containerBreakpoints.large ) {
+				// 	// else if ( width >= largeFit ) {
+				// 	if ( gridSize !== 'medium' ) {
+				// 		console.log( 'medium', width, offsetWidth );
+				// 		setGridSize( 'medium' );
+				// 	}
+				// } else if ( gridSize !== 'large' ) {
+				// 	// else if ( width >= mediumFit ) {
+				// 	console.log( 'large', width, offsetWidth );
+				// 	setGridSize( 'large' );
+				// }
+			}
+		};
+
+		window.addEventListener( 'resize', handleResize );
+		handleResize();
+
+		return () => {
+			window.removeEventListener( 'resize', handleResize );
+		};
+	}, [ containerRef, gridSize, largeFit, mediumFit, setGridSize ] );
+
+	return gridSize;
+};
+
+export default useGridSize;

--- a/packages/plans-grid-next/src/index.tsx
+++ b/packages/plans-grid-next/src/index.tsx
@@ -78,22 +78,21 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		allFeaturesList,
 		onUpgradeClick,
 		coupon,
+		isInAdmin,
 	} = props;
-
 	const handleUpgradeClick = useUpgradeClickHandler( {
 		gridPlans,
 		onUpgradeClick,
 	} );
 
-	const gridPlansWithoutSpotlight = ! props.gridPlanForSpotlight
-		? gridPlans
-		: gridPlans.filter( ( { planSlug } ) => props.gridPlanForSpotlight?.planSlug !== planSlug );
-	const columnsInRowForMedium = 4 === gridPlansWithoutSpotlight.length ? 2 : 3;
 	const gridContainerRef = useRef< HTMLDivElement | null >( null );
 	const gridSize = useGridSize( {
 		containerRef: gridContainerRef,
-		averageColumnMinWidth: 222,
-		columnsInRow: { medium: columnsInRowForMedium, large: gridPlansWithoutSpotlight.length },
+		containerBreakpoints: new Map( [
+			[ 'small', 0 ],
+			[ 'medium', 740 ],
+			[ 'large', isInAdmin ? 1180 : 1320 ], // 1320 to fit Enterpreneur plan, 1180 to work in admin
+		] ),
 	} );
 
 	const classNames = classnames( 'plans-grid-next__features-grid', {
@@ -102,8 +101,6 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		'is-large': 'large' === gridSize,
 		'is-visible': gridSize,
 	} );
-
-	console.log( 1234, gridSize, gridContainerRef );
 
 	return (
 		<div ref={ gridContainerRef } className={ classNames }>

--- a/packages/plans-grid-next/src/index.tsx
+++ b/packages/plans-grid-next/src/index.tsx
@@ -1,3 +1,5 @@
+import { useRef } from '@wordpress/element';
+import classnames from 'classnames';
 import ComparisonGrid from './components/comparison-grid';
 import FeaturesGrid from './components/features-grid';
 import PlanButton from './components/plan-button';
@@ -7,6 +9,7 @@ import PlansGridContextProvider from './grid-context';
 import useGridPlans from './hooks/data-store/use-grid-plans';
 import usePlanFeaturesForGridPlans from './hooks/data-store/use-plan-features-for-grid-plans';
 import useRestructuredPlanFeaturesForComparisonGrid from './hooks/data-store/use-restructured-plan-features-for-comparison-grid';
+import useGridSize from './hooks/use-grid-size';
 import { useManageTooltipToggle } from './hooks/use-manage-tooltip-toggle';
 import useUpgradeClickHandler from './hooks/use-upgrade-click-handler';
 import type { ComparisonGridExternalProps, FeaturesGridExternalProps } from './types';
@@ -82,18 +85,44 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		onUpgradeClick,
 	} );
 
+	const gridPlansWithoutSpotlight = ! props.gridPlanForSpotlight
+		? gridPlans
+		: gridPlans.filter( ( { planSlug } ) => props.gridPlanForSpotlight?.planSlug !== planSlug );
+	const columnsInRowForMedium = 4 === gridPlansWithoutSpotlight.length ? 2 : 3;
+	const gridContainerRef = useRef< HTMLDivElement | null >( null );
+	const gridSize = useGridSize( {
+		containerRef: gridContainerRef,
+		averageColumnMinWidth: 222,
+		columnsInRow: { medium: columnsInRowForMedium, large: gridPlansWithoutSpotlight.length },
+	} );
+
+	const classNames = classnames( 'plans-grid-next__features-grid', {
+		'is-small': 'small' === gridSize,
+		'is-medium': 'medium' === gridSize,
+		'is-large': 'large' === gridSize,
+		'is-visible': gridSize,
+	} );
+
+	console.log( 123, gridSize );
+
 	return (
-		<PlansGridContextProvider
-			intent={ intent }
-			selectedSiteId={ selectedSiteId }
-			gridPlans={ gridPlans }
-			coupon={ coupon }
-			useCheckPlanAvailabilityForPurchase={ useCheckPlanAvailabilityForPurchase }
-			recordTracksEvent={ recordTracksEvent }
-			allFeaturesList={ allFeaturesList }
-		>
-			<FeaturesGrid { ...props } onUpgradeClick={ handleUpgradeClick } />
-		</PlansGridContextProvider>
+		<div ref={ gridContainerRef } className={ classNames }>
+			<PlansGridContextProvider
+				intent={ intent }
+				selectedSiteId={ selectedSiteId }
+				gridPlans={ gridPlans }
+				coupon={ coupon }
+				useCheckPlanAvailabilityForPurchase={ useCheckPlanAvailabilityForPurchase }
+				recordTracksEvent={ recordTracksEvent }
+				allFeaturesList={ allFeaturesList }
+			>
+				<FeaturesGrid
+					{ ...props }
+					onUpgradeClick={ handleUpgradeClick }
+					gridSize={ gridSize ?? undefined }
+				/>
+			</PlansGridContextProvider>
+		</div>
 	);
 };
 

--- a/packages/plans-grid-next/src/index.tsx
+++ b/packages/plans-grid-next/src/index.tsx
@@ -103,7 +103,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		'is-visible': gridSize,
 	} );
 
-	console.log( 123, gridSize );
+	console.log( 1234, gridSize, gridContainerRef );
 
 	return (
 		<div ref={ gridContainerRef } className={ classNames }>

--- a/packages/plans-grid-next/src/index.tsx
+++ b/packages/plans-grid-next/src/index.tsx
@@ -40,31 +40,35 @@ const WrappedComparisonGrid = ( {
 		onUpgradeClick,
 	} );
 
+	const classNames = classnames( 'plans-grid-next', 'plans-grid-next__comparison-grid' );
+
 	return (
-		<PlansGridContextProvider
-			intent={ intent }
-			selectedSiteId={ selectedSiteId }
-			gridPlans={ gridPlans }
-			useCheckPlanAvailabilityForPurchase={ useCheckPlanAvailabilityForPurchase }
-			recordTracksEvent={ recordTracksEvent }
-			allFeaturesList={ allFeaturesList }
-			coupon={ coupon }
-		>
-			<ComparisonGrid
-				intervalType={ intervalType }
-				isInSignup={ isInSignup }
-				isLaunchPage={ isLaunchPage }
-				currentSitePlanSlug={ currentSitePlanSlug }
-				onUpgradeClick={ handleUpgradeClick }
+		<div className={ classNames }>
+			<PlansGridContextProvider
+				intent={ intent }
 				selectedSiteId={ selectedSiteId }
-				selectedPlan={ selectedPlan }
-				selectedFeature={ selectedFeature }
-				showUpgradeableStorage={ showUpgradeableStorage }
-				stickyRowOffset={ stickyRowOffset }
-				onStorageAddOnClick={ onStorageAddOnClick }
-				{ ...otherProps }
-			/>
-		</PlansGridContextProvider>
+				gridPlans={ gridPlans }
+				useCheckPlanAvailabilityForPurchase={ useCheckPlanAvailabilityForPurchase }
+				recordTracksEvent={ recordTracksEvent }
+				allFeaturesList={ allFeaturesList }
+				coupon={ coupon }
+			>
+				<ComparisonGrid
+					intervalType={ intervalType }
+					isInSignup={ isInSignup }
+					isLaunchPage={ isLaunchPage }
+					currentSitePlanSlug={ currentSitePlanSlug }
+					onUpgradeClick={ handleUpgradeClick }
+					selectedSiteId={ selectedSiteId }
+					selectedPlan={ selectedPlan }
+					selectedFeature={ selectedFeature }
+					showUpgradeableStorage={ showUpgradeableStorage }
+					stickyRowOffset={ stickyRowOffset }
+					onStorageAddOnClick={ onStorageAddOnClick }
+					{ ...otherProps }
+				/>
+			</PlansGridContextProvider>
+		</div>
 	);
 };
 
@@ -95,7 +99,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		] ),
 	} );
 
-	const classNames = classnames( 'plans-grid-next__features-grid', {
+	const classNames = classnames( 'plans-grid-next', 'plans-grid-next__features-grid', {
 		'is-small': 'small' === gridSize,
 		'is-medium': 'medium' === gridSize,
 		'is-large': 'large' === gridSize,

--- a/packages/plans-grid-next/src/index.tsx
+++ b/packages/plans-grid-next/src/index.tsx
@@ -103,7 +103,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		'is-small': 'small' === gridSize,
 		'is-medium': 'medium' === gridSize,
 		'is-large': 'large' === gridSize,
-		'is-visible': gridSize,
+		'is-visible': true,
 	} );
 
 	return (

--- a/packages/plans-grid-next/src/media-queries.tsx
+++ b/packages/plans-grid-next/src/media-queries.tsx
@@ -3,12 +3,12 @@ import type { SerializedStyles } from '@emotion/react';
 
 const sidebarWidth = 272; //in px
 const plans2023SmallBreakpoint = '780px';
-const plans2023MediumBreakpoint = '1350px';
-const plans2023LargeBreakpoint = '1600px';
 const plans2023SmallWithSidebarBreakpoint = `${ 780 + sidebarWidth }px`;
-const plans2023MediumWithSidebarBreakpoint = `${ 1350 + sidebarWidth }px`;
-const plans2023LargeWithSidebarBreakpoint = `${ 1600 + sidebarWidth }px`;
 
+/**
+ * @deprecated
+ * TODO clk Used in comparison-grid-toggle and plans-features-main
+ */
 export const plansBreakSmall = ( styles: SerializedStyles ) => css`
 	body.is-section-signup.is-white-signup &,
 	body.is-section-stepper & {
@@ -25,48 +25,6 @@ export const plansBreakSmall = ( styles: SerializedStyles ) => css`
 
 	.is-section-plans.is-sidebar-collapsed & {
 		@media ( min-width: ${ plans2023SmallBreakpoint } ) {
-			${ styles }
-		}
-	}
-`;
-
-export const plansBreakMedium = ( styles: SerializedStyles ) => css`
-	body.is-section-signup.is-white-signup &,
-	body.is-section-stepper & {
-		@media ( min-width: ${ plans2023MediumBreakpoint } ) {
-			${ styles }
-		}
-	}
-
-	.is-section-plans:not( .is-sidebar-collapsed ) & {
-		@media ( min-width: ${ plans2023MediumWithSidebarBreakpoint } ) {
-			${ styles }
-		}
-	}
-
-	.is-section-plans.is-sidebar-collapsed & {
-		@media ( min-width: ${ plans2023MediumBreakpoint } ) {
-			${ styles }
-		}
-	}
-`;
-
-export const plansBreakLarge = ( styles: SerializedStyles ) => css`
-	body.is-section-signup.is-white-signup &,
-	body.is-section-stepper & {
-		@media ( min-width: ${ plans2023LargeBreakpoint } ) {
-			${ styles }
-		}
-	}
-
-	.is-section-plans:not( .is-sidebar-collapsed ) & {
-		@media ( min-width: ${ plans2023LargeWithSidebarBreakpoint } ) {
-			${ styles }
-		}
-	}
-
-	.is-section-plans.is-sidebar-collapsed & {
-		@media ( min-width: ${ plans2023LargeBreakpoint } ) {
 			${ styles }
 		}
 	}

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -8,17 +8,17 @@ $mobile-card-max-width: 440px;
 	margin-top: 300px;
 }
 
-.plans-grid-next__features-grid {
-	display: none;
+// .plans-grid-next__features-grid {
+// 	display: none;
 
-	&.is-visible {
-		display: block;
-	}
-}
+// 	&.is-visible {
+// 		display: block;
+// 	}
+// }
 
 .plan-features-2023-grid__header {
-	position: relative;
 	display: flex;
+	position: relative;
 	align-items: flex-start;
 	padding-inline: 20px 0;
 	padding-block: 0 8px;
@@ -30,15 +30,18 @@ $mobile-card-max-width: 440px;
 .plan-features-2023-grid__header-logo {
 	padding-left: 20px;
 
-	@include plans-2023-break-small {
+	.plans-grid-next__features-grid.is-medium &,
+	.plans-grid-next__features-grid.is-large & {
 		margin-top: 36px;
+	}
 
-		.plan-features-2023-grid__table-top & {
+	.plan-features-2023-grid__table-top & {
+		.plans-grid-next__features-grid.is-medium & {
 			margin-top: 62px;
 		}
 	}
 
-	@include plans-2023-break-medium {
+	.plans-grid-next__features-grid.is-large & {
 		margin-top: 36px;
 	}
 }
@@ -62,6 +65,7 @@ $mobile-card-max-width: 440px;
 }
 
 .plan-features-2023-grid__mobile-view {
+	display: flex;
 	flex-direction: column;
 	align-items: stretch;
 	gap: 20px;
@@ -75,9 +79,16 @@ $mobile-card-max-width: 440px;
 		border-radius: 5px;
 		padding: 38px 0 20px 0;
 
-		@include plans-section-custom-mobile-breakpoint {
-			margin-left: 0;
-			margin-right: 0;
+		/*
+		 * TODO: Remove/refactor this once we have a better way to handle.
+		 * .is-section-plans refers to external context.
+		 */
+		.plans-grid-next__features-grid.is-medium &,
+		.plans-grid-next__features-grid.is-large & {
+			.is-section-plans & {
+				margin-left: 0;
+				margin-right: 0;
+			}
 		}
 
 		&:first-of-type {
@@ -225,12 +236,13 @@ $mobile-card-max-width: 440px;
 	font-weight: 400;
 	padding: 0 20px 24px 20px;
 
-	@include plans-2023-break-small {
+	.plans-grid-next__features-grid.is-medium &,
+	.plans-grid-next__features-grid.is-large & {
 		font-size: $font-body-small;
 		line-height: 20px;
 	}
 
-	@include plans-2023-break-medium {
+	.plans-grid-next__features-grid.is-large & {
 		font-size: 0.813rem; /* stylelint-disable-line */
 		line-height: 16px;
 		padding-bottom: 8px;
@@ -259,13 +271,15 @@ $mobile-card-max-width: 440px;
 
 	&.is-top-buttons {
 		padding: 0 20px;
-		@include plans-2023-break-small {
+		.plans-grid-next__features-grid.is-medium &,
+		.plans-grid-next__features-grid.is-large & {
 			padding-top: 16px;
 			padding-bottom: 16px;
 		}
 	}
 
-	@include plans-2023-break-small {
+	.plans-grid-next__features-grid.is-medium &,
+	.plans-grid-next__features-grid.is-large & {
 		// The .plan-features-2023-grid__table-item is used to render the plan spotlight which doesn't
 		// use a table layout, but borders are only appropriate in table layout.
 		&:is(td) {
@@ -300,7 +314,9 @@ $mobile-card-max-width: 440px;
 
 		&.plan-features-2023-grid__header-billing-info {
 			padding-bottom: 16px;
-			@include plans-2023-break-small {
+
+			.plans-grid-next__features-grid.is-medium &,
+			.plans-grid-next__features-grid.is-large & {
 				padding-bottom: 16px;
 			}
 		}
@@ -361,7 +377,8 @@ $mobile-card-max-width: 440px;
 			font-weight: 600;
 		}
 
-		@include plans-2023-break-small {
+		.plans-grid-next__features-grid.is-medium &,
+		.plans-grid-next__features-grid.is-large & {
 			font-size: $font-body-extra-small;
 			line-height: 16px;
 		}
@@ -414,7 +431,8 @@ $mobile-card-max-width: 440px;
 		position: relative;
 		margin: 32px 0 0;
 
-		@include plans-2023-break-small {
+		.plans-grid-next__features-grid.is-medium &,
+		.plans-grid-next__features-grid.is-large & {
 			margin: 0;
 			top: 14px;
 		}
@@ -477,6 +495,91 @@ $mobile-card-max-width: 440px;
 	}
 }
 
+
+/* stylelint-disable-next-line no-duplicate-selectors */
+.plan-features-2023-grid__table-item {
+	.plan-features-2023-grid__common-title {
+		.plans-grid-next__features-grid.is-medium &,
+		.plans-grid-next__features-grid.is-large & {
+			.is-section-stepper &,
+			body.is-section-signup.is-white-signup &,
+			.is-2023-pricing-grid & {
+				margin-top: 20px;
+				font-size: $font-body-extra-small;
+			}
+		}
+	}
+
+	&.plan-features-2023-grid__header-billing-info {
+		.plans-grid-next__features-grid.is-medium &,
+		.plans-grid-next__features-grid.is-large & {
+			.is-section-stepper &,
+			body.is-section-signup.is-white-signup &,
+			.is-2023-pricing-grid & {
+				padding-bottom: 0;
+			}
+		}
+
+		.plans-grid-next__billing-timeframe-vip-price {
+			.plans-grid-next__features-grid.is-medium &,
+			.plans-grid-next__features-grid.is-large & {
+				.is-section-stepper &,
+				body.is-section-signup.is-white-signup &,
+				.is-2023-pricing-grid & {
+					font-size: $font-body-small;
+					line-height: 20px;
+				}
+			}
+
+			.plans-grid-next__features-grid.is-large & {
+				.is-section-stepper &,
+				body.is-section-signup.is-white-signup &,
+				.is-2023-pricing-grid & {
+					font-size: $font-body-extra-small;
+					line-height: 16px;
+				}
+			}
+		}
+	}
+
+	&.popular-plan-parent-class {
+		.plan-features-2023-grid__popular-badge {
+			.plans-grid-next__features-grid.is-medium &,
+			.plans-grid-next__features-grid.is-large & {
+				.is-section-stepper &,
+				body.is-section-signup.is-white-signup &,
+				.is-2023-pricing-grid & {
+					position: absolute;
+					top: -35px; // at -35px this covers the top border of the table, including its top-right radius, as intended
+					right: -1px;
+					border-color: #e0e0e0;
+					border-width: 1px 1px 0 1px;
+					/* stylelint-disable-next-line scales/radii */
+					border-radius: 5px 5px 0 0;
+					border-style: solid;
+					padding-top: 20px;
+					margin-bottom: 0;
+
+					.plans-grid__plan-pill {
+						transform: translate(20px, 0);
+					}
+				}
+			}
+		}
+	}
+}
+
+.step-wrapper__header {
+	.plans-grid-next__features-grid.is-medium &,
+	.plans-grid-next__features-grid.is-large & {
+		.is-section-stepper &,
+		body.is-section-signup.is-white-signup &,
+		.is-2023-pricing-grid & {
+			margin: 24px 20px;
+		}
+	}
+}
+
 body.is-section-stepper,
 body.is-section-signup.is-white-signup,
 .is-2023-pricing-grid {
@@ -497,25 +600,11 @@ body.is-section-signup.is-white-signup,
 			font-size: $font-body-extra-small;
 			padding: 0 19px 24px 20px;
 
-			@include plans-2023-break-small {
-				padding-bottom: 0;
-			}
-
 			.plans-grid-next__billing-timeframe-vip-price {
 				font-size: $font-body;
 				line-height: 24px;
 				font-weight: 400;
 				color: var(--studio-gray-80);
-
-				@include plans-2023-break-small {
-					font-size: $font-body-small;
-					line-height: 20px;
-				}
-
-				@include plans-2023-break-medium {
-					font-size: $font-body-extra-small;
-					line-height: 16px;
-				}
 			}
 		}
 
@@ -528,19 +617,6 @@ body.is-section-signup.is-white-signup,
 				background: #fff;
 				color: #fff;
 				padding: 0 0 17px;
-
-				@include plans-2023-break-small {
-					position: absolute;
-					top: -35px; // at -35px this covers the top border of the table, including its top-right radius, as intended
-					right: -1px;
-					border-color: #e0e0e0;
-					border-width: 1px 1px 0 1px;
-					/* stylelint-disable-next-line scales/radii */
-					border-radius: 5px 5px 0 0;
-					border-style: solid;
-					padding-top: 20px;
-					margin-bottom: 0;
-				}
 
 				.plans-grid__plan-pill {
 					font-family: Inter, $sans;
@@ -559,9 +635,6 @@ body.is-section-signup.is-white-signup,
 					background-color: var(--studio-gray-80);
 					transform: translate(20px, -50px);
 					text-transform: unset;
-					@include plans-2023-break-small {
-						transform: translate(20px, 0);
-					}
 				}
 
 				&:not(.with-plan-logo) {
@@ -633,11 +706,6 @@ body.is-section-signup.is-white-signup,
 			padding: 0 20px;
 			margin-bottom: 12px;
 
-			@include plans-2023-break-small {
-				margin-top: 20px;
-				font-size: $font-body-extra-small;
-			}
-
 			&.is-personal-plan {
 				color: var(--studio-blue-60);
 			}
@@ -684,10 +752,6 @@ body.is-section-signup.is-white-signup,
 
 	.step-wrapper__header {
 		margin: 24px 20px 38px;
-
-		@include plans-2023-break-small {
-			margin: 24px 20px;
-		}
 	}
 }
 

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -36,13 +36,9 @@ $mobile-card-max-width: 440px;
 	}
 
 	.plan-features-2023-grid__table-top & {
-		@include plans-grid-medium {
+		@include plans-grid-large {
 			margin-top: 62px;
 		}
-	}
-
-	@include plans-grid-medium-large {
-		margin-top: 36px;
 	}
 }
 

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -501,43 +501,27 @@ $mobile-card-max-width: 440px;
 	.plan-features-2023-grid__common-title {
 		.plans-grid-next__features-grid.is-medium &,
 		.plans-grid-next__features-grid.is-large & {
-			.is-section-stepper &,
-			body.is-section-signup.is-white-signup &,
-			.is-2023-pricing-grid & {
-				margin-top: 20px;
-				font-size: $font-body-extra-small;
-			}
+			margin-top: 20px;
+			font-size: $font-body-extra-small;
 		}
 	}
 
 	&.plan-features-2023-grid__header-billing-info {
 		.plans-grid-next__features-grid.is-medium &,
 		.plans-grid-next__features-grid.is-large & {
-			.is-section-stepper &,
-			body.is-section-signup.is-white-signup &,
-			.is-2023-pricing-grid & {
-				padding-bottom: 0;
-			}
+			padding-bottom: 0;
 		}
 
 		.plans-grid-next__billing-timeframe-vip-price {
 			.plans-grid-next__features-grid.is-medium &,
 			.plans-grid-next__features-grid.is-large & {
-				.is-section-stepper &,
-				body.is-section-signup.is-white-signup &,
-				.is-2023-pricing-grid & {
-					font-size: $font-body-small;
-					line-height: 20px;
-				}
+				font-size: $font-body-small;
+				line-height: 20px;
 			}
 
 			.plans-grid-next__features-grid.is-large & {
-				.is-section-stepper &,
-				body.is-section-signup.is-white-signup &,
-				.is-2023-pricing-grid & {
-					font-size: $font-body-extra-small;
-					line-height: 16px;
-				}
+				font-size: $font-body-extra-small;
+				line-height: 16px;
 			}
 		}
 	}
@@ -546,44 +530,29 @@ $mobile-card-max-width: 440px;
 		.plan-features-2023-grid__popular-badge {
 			.plans-grid-next__features-grid.is-medium &,
 			.plans-grid-next__features-grid.is-large & {
-				.is-section-stepper &,
-				body.is-section-signup.is-white-signup &,
-				.is-2023-pricing-grid & {
-					position: absolute;
-					top: -35px; // at -35px this covers the top border of the table, including its top-right radius, as intended
-					right: -1px;
-					border-color: #e0e0e0;
-					border-width: 1px 1px 0 1px;
-					/* stylelint-disable-next-line scales/radii */
-					border-radius: 5px 5px 0 0;
-					border-style: solid;
-					padding-top: 20px;
-					margin-bottom: 0;
+				position: absolute;
+				top: -35px; // at -35px this covers the top border of the table, including its top-right radius, as intended
+				right: -1px;
+				border-color: #e0e0e0;
+				border-width: 1px 1px 0 1px;
+				/* stylelint-disable-next-line scales/radii */
+				border-radius: 5px 5px 0 0;
+				border-style: solid;
+				padding-top: 20px;
+				margin-bottom: 0;
 
-					.plans-grid__plan-pill {
-						transform: translate(20px, 0);
-					}
+				.plans-grid__plan-pill {
+					transform: translate(20px, 0);
 				}
 			}
 		}
 	}
 }
 
-.step-wrapper__header {
-	.plans-grid-next__features-grid.is-medium &,
-	.plans-grid-next__features-grid.is-large & {
-		.is-section-stepper &,
-		body.is-section-signup.is-white-signup &,
-		.is-2023-pricing-grid & {
-			margin: 24px 20px;
-		}
-	}
-}
-
-body.is-section-stepper,
-body.is-section-signup.is-white-signup,
-.is-2023-pricing-grid {
-
+/**
+ * TODO clk consolidate with the rest above
+ */
+.plans-grid-next {
 	.plan-features-2023-grid__table-item {
 		border-right: none;
 		background-color: transparent;
@@ -749,10 +718,26 @@ body.is-section-signup.is-white-signup,
 			color: var(--studio-orange-40);
 		}
 	}
+}
 
+/**
+ * TODO clk migrate out of plans-grid-next
+ */
+body.is-section-stepper,
+body.is-section-signup.is-white-signup {
 	.step-wrapper__header {
 		margin: 24px 20px 38px;
+		@include plans-2023-break-small {
+			margin: 24px 20px;
+		}
 	}
+}
+
+/**
+ * TODO clk migrate out of plans-grid-next
+ */
+.formatted-header {
+	margin-bottom: 0;
 }
 
 .plans-features-main__comparison-grid-container {
@@ -1066,10 +1051,6 @@ body.is-section-signup.is-white-signup,
 			}
 		}
 	}
-}
-
-.formatted-header {
-	margin-bottom: 0;
 }
 
 

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -1,4 +1,5 @@
 @import "@automattic/onboarding/styles/mixins";
+@import "./mixins";
 @import "./media-queries";
 
 $table-cell-max-width: 344px;
@@ -30,18 +31,17 @@ $mobile-card-max-width: 440px;
 .plan-features-2023-grid__header-logo {
 	padding-left: 20px;
 
-	.plans-grid-next__features-grid.is-medium &,
-	.plans-grid-next__features-grid.is-large & {
+	@include plans-grid-medium-large {
 		margin-top: 36px;
 	}
 
 	.plan-features-2023-grid__table-top & {
-		.plans-grid-next__features-grid.is-medium & {
+		@include plans-grid-medium {
 			margin-top: 62px;
 		}
 	}
 
-	.plans-grid-next__features-grid.is-large & {
+	@include plans-grid-medium-large {
 		margin-top: 36px;
 	}
 }
@@ -83,8 +83,7 @@ $mobile-card-max-width: 440px;
 		 * TODO: Remove/refactor this once we have a better way to handle.
 		 * .is-section-plans refers to external context.
 		 */
-		.plans-grid-next__features-grid.is-medium &,
-		.plans-grid-next__features-grid.is-large & {
+		@include plans-grid-medium-large {
 			.is-section-plans & {
 				margin-left: 0;
 				margin-right: 0;
@@ -236,13 +235,12 @@ $mobile-card-max-width: 440px;
 	font-weight: 400;
 	padding: 0 20px 24px 20px;
 
-	.plans-grid-next__features-grid.is-medium &,
-	.plans-grid-next__features-grid.is-large & {
+	@include plans-grid-medium-large {
 		font-size: $font-body-small;
 		line-height: 20px;
 	}
 
-	.plans-grid-next__features-grid.is-large & {
+	@include plans-grid-large {
 		font-size: 0.813rem; /* stylelint-disable-line */
 		line-height: 16px;
 		padding-bottom: 8px;
@@ -271,15 +269,13 @@ $mobile-card-max-width: 440px;
 
 	&.is-top-buttons {
 		padding: 0 20px;
-		.plans-grid-next__features-grid.is-medium &,
-		.plans-grid-next__features-grid.is-large & {
+		@include plans-grid-medium-large {
 			padding-top: 16px;
 			padding-bottom: 16px;
 		}
 	}
 
-	.plans-grid-next__features-grid.is-medium &,
-	.plans-grid-next__features-grid.is-large & {
+	@include plans-grid-medium-large {
 		// The .plan-features-2023-grid__table-item is used to render the plan spotlight which doesn't
 		// use a table layout, but borders are only appropriate in table layout.
 		&:is(td) {
@@ -315,8 +311,7 @@ $mobile-card-max-width: 440px;
 		&.plan-features-2023-grid__header-billing-info {
 			padding-bottom: 16px;
 
-			.plans-grid-next__features-grid.is-medium &,
-			.plans-grid-next__features-grid.is-large & {
+			@include plans-grid-medium-large {
 				padding-bottom: 16px;
 			}
 		}
@@ -377,8 +372,7 @@ $mobile-card-max-width: 440px;
 			font-weight: 600;
 		}
 
-		.plans-grid-next__features-grid.is-medium &,
-		.plans-grid-next__features-grid.is-large & {
+		@include plans-grid-medium-large {
 			font-size: $font-body-extra-small;
 			line-height: 16px;
 		}
@@ -431,8 +425,7 @@ $mobile-card-max-width: 440px;
 		position: relative;
 		margin: 32px 0 0;
 
-		.plans-grid-next__features-grid.is-medium &,
-		.plans-grid-next__features-grid.is-large & {
+		@include plans-grid-medium-large {
 			margin: 0;
 			top: 14px;
 		}
@@ -499,27 +492,24 @@ $mobile-card-max-width: 440px;
 /* stylelint-disable-next-line no-duplicate-selectors */
 .plan-features-2023-grid__table-item {
 	.plan-features-2023-grid__common-title {
-		.plans-grid-next__features-grid.is-medium &,
-		.plans-grid-next__features-grid.is-large & {
+		@include plans-grid-medium-large {
 			margin-top: 20px;
 			font-size: $font-body-extra-small;
 		}
 	}
 
 	&.plan-features-2023-grid__header-billing-info {
-		.plans-grid-next__features-grid.is-medium &,
-		.plans-grid-next__features-grid.is-large & {
+		@include plans-grid-medium-large {
 			padding-bottom: 0;
 		}
 
 		.plans-grid-next__billing-timeframe-vip-price {
-			.plans-grid-next__features-grid.is-medium &,
-			.plans-grid-next__features-grid.is-large & {
+			@include plans-grid-medium-large {
 				font-size: $font-body-small;
 				line-height: 20px;
 			}
 
-			.plans-grid-next__features-grid.is-large & {
+			@include plans-grid-large {
 				font-size: $font-body-extra-small;
 				line-height: 16px;
 			}
@@ -528,8 +518,7 @@ $mobile-card-max-width: 440px;
 
 	&.popular-plan-parent-class {
 		.plan-features-2023-grid__popular-badge {
-			.plans-grid-next__features-grid.is-medium &,
-			.plans-grid-next__features-grid.is-large & {
+			@include plans-grid-medium-large {
 				position: absolute;
 				top: -35px; // at -35px this covers the top border of the table, including its top-right radius, as intended
 				right: -1px;

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -8,13 +8,13 @@ $mobile-card-max-width: 440px;
 	margin-top: 300px;
 }
 
-// .plans-grid-next__features-grid {
-// 	display: none;
+.plans-grid-next__features-grid {
+	display: none;
 
-// 	&.is-visible {
-// 		display: block;
-// 	}
-// }
+	&.is-visible {
+		display: block;
+	}
+}
 
 .plan-features-2023-grid__header {
 	display: flex;

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -8,6 +8,14 @@ $mobile-card-max-width: 440px;
 	margin-top: 300px;
 }
 
+.plans-grid-next__features-grid {
+	display: none;
+
+	&.is-visible {
+		display: block;
+	}
+}
+
 .plan-features-2023-grid__header {
 	position: relative;
 	display: flex;

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -57,6 +57,8 @@ export interface GridPlan {
  * Grid Component Types:
  ***********************/
 
+export type GridSize = 'small' | 'medium' | 'large';
+
 export type PlansIntent =
 	| 'plans-blog-onboarding'
 	| 'plans-newsletter'
@@ -120,6 +122,8 @@ export interface CommonGridProps {
 	planTypeSelectorProps?: PlanTypeSelectorProps;
 	onUpgradeClick: ( planSlug: PlanSlug ) => void;
 	planUpgradeCreditsApplicable?: number | null;
+	gridContainerRef?: React.MutableRefObject< HTMLDivElement | null >;
+	gridSize?: string;
 }
 
 export interface FeaturesGridProps extends CommonGridProps {

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -57,6 +57,8 @@ export interface GridPlan {
  * Grid Component Types:
  ***********************/
 
+export type GridSize = 'small' | 'medium' | 'large';
+
 export type PlansIntent =
 	| 'plans-blog-onboarding'
 	| 'plans-newsletter'
@@ -121,6 +123,8 @@ export interface CommonGridProps {
 	planTypeSelectorProps?: PlanTypeSelectorProps;
 	onUpgradeClick: ( planSlug: PlanSlug ) => void;
 	planUpgradeCreditsApplicable?: number | null;
+	gridContainerRef?: React.MutableRefObject< HTMLDivElement | null >;
+	gridSize?: string;
 }
 
 export interface FeaturesGridProps extends CommonGridProps {
@@ -150,7 +154,7 @@ export type GridContextProps = {
 };
 
 export type ComparisonGridExternalProps = Omit< GridContextProps, 'children' > &
-	Omit< ComparisonGridProps, 'onUpgradeClick' > & {
+	Omit< ComparisonGridProps, 'onUpgradeClick' | 'gridContainerRef' | 'gridSize' > & {
 		onUpgradeClick?: (
 			cartItems?: MinimalRequestCartProduct[] | null,
 			clickedPlanSlug?: PlanSlug
@@ -158,7 +162,10 @@ export type ComparisonGridExternalProps = Omit< GridContextProps, 'children' > &
 	};
 
 export type FeaturesGridExternalProps = Omit< GridContextProps, 'children' > &
-	Omit< FeaturesGridProps, 'onUpgradeClick' | 'isLargeCurrency' | 'translate' > & {
+	Omit<
+		FeaturesGridProps,
+		'onUpgradeClick' | 'isLargeCurrency' | 'translate' | 'gridContainerRef' | 'gridSize'
+	> & {
 		onUpgradeClick?: (
 			cartItems?: MinimalRequestCartProduct[] | null,
 			clickedPlanSlug?: PlanSlug

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -57,8 +57,6 @@ export interface GridPlan {
  * Grid Component Types:
  ***********************/
 
-export type GridSize = 'small' | 'medium' | 'large';
-
 export type PlansIntent =
 	| 'plans-blog-onboarding'
 	| 'plans-newsletter'
@@ -123,8 +121,6 @@ export interface CommonGridProps {
 	planTypeSelectorProps?: PlanTypeSelectorProps;
 	onUpgradeClick: ( planSlug: PlanSlug ) => void;
 	planUpgradeCreditsApplicable?: number | null;
-	gridContainerRef?: React.MutableRefObject< HTMLDivElement | null >;
-	gridSize?: string;
 }
 
 export interface FeaturesGridProps extends CommonGridProps {

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -105,6 +105,7 @@ export interface CommonGridProps {
 	 */
 	selectedSiteId?: number | null;
 	isInSignup: boolean;
+	isInAdmin: boolean;
 	isLaunchPage?: boolean | null;
 	isReskinned?: boolean;
 	onStorageAddOnClick?: ( addOnSlug: WPComStorageAddOnSlug ) => void;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79010

## Proposed Changes

This is part of a series of PRs for untangling the pricing grids/components from screen/media queries and any Calypso-dependent CSS context (such as sidebar width). The end goal is to (1) make the components responsive and reusable in any context, and (2) to be able to render the grids anywhere on a page (in a modal, sidebar, a half-page column, etc.). So pdgrnI-2uQ-p2 becomes relevant and this work should set the foundations for it.

In this PR:
- we untangle the Features Grid from media queries
- we do not rewrite the Features Grid implementation (it's an old-fashioned table, and there's a separate component hierarchy for mobile views - all the stuff we "flagged" in https://github.com/Automattic/wp-calypso/issues/72910), but rather hack our way through the existing setup
- the approach is akin to "container queries", which we may consider surfacing down the line (assuming support is not an issue)
- also introduces `isInAdmin` property - on several occasions, this has been the exception we should have been conditioning on, and not `isInSignup` (since logged-out will behave similarly to signup)

This also fixes `/jetpack-app/plans`, which looks awfully broken now on anything other than mobile (but that might be the intention I guess)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try several flows along with `/plans[ site ]` and main `/start/plans`
* Confirm the grid resizes properly and gives the various views (mobile, tablet, desktop)
    * The above may not be as precise as previously, but they should be rendering the grid without any overflows of text, like the plan titles/names. So if the grid fits, then we should be good
* Confirm margins and the rest of the layout are correct in `/setup` and `/start` across the various views (mobile, tablet, desktop)
* Confirm text sizes are correct across the various views (mobile, tablet, desktop)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?