### PR TITLE
Theme Tiers: Added theme tiers to the events recorded by the design picker

### DIFF
--- a/client/landing/stepper/constants.ts
+++ b/client/landing/stepper/constants.ts
@@ -6,6 +6,7 @@ export const WRITE_INTENT_DEFAULT_DESIGN: Design = {
 	is_premium: false,
 	categories: [],
 	theme: 'hey',
+	design_tier: null,
 };
 
 export const SITE_PICKER_FILTER_CONFIG = [ 'wpcom', 'atomic' ];

--- a/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
+++ b/client/landing/stepper/declarative-flow/internals/analytics/record-design.ts
@@ -112,6 +112,7 @@ export function getDesignEventProps( {
 		theme: design.recipe?.stylesheet,
 		theme_style: design.recipe?.stylesheet + variationSlugSuffix,
 		design_type: design.design_type,
+		...( design?.design_tier && { design_tier: design.design_tier } ),
 		is_premium: design.is_premium,
 		is_externally_managed: design?.is_externally_managed,
 		is_bundled_with_woo: design?.is_bundled_with_woo,

--- a/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-designs-query.ts
@@ -27,6 +27,12 @@ interface StarterDesignsResponse {
 	static: { designs: StarterDesign[] };
 }
 
+export type ThemeTier = {
+	slug: string;
+	feature: string;
+	platform: string;
+};
+
 interface StarterDesign {
 	slug: string;
 	title: string;
@@ -41,6 +47,7 @@ interface StarterDesign {
 	design_type?: DesignType;
 	theme_type?: string;
 	screenshot?: string;
+	theme_tier: ThemeTier;
 }
 
 export function useStarterDesignsQuery(
@@ -89,6 +96,7 @@ function apiStarterDesignsToDesign( design: StarterDesign ): Design {
 		preview_data,
 		design_type,
 		screenshot,
+		theme_tier,
 	} = design;
 	const is_premium =
 		( design.recipe.stylesheet && design.recipe.stylesheet.startsWith( 'premium/' ) ) || false;
@@ -115,5 +123,6 @@ function apiStarterDesignsToDesign( design: StarterDesign ): Design {
 		...( preview_data && { preview_data } ),
 		theme: '',
 		screenshot,
+		design_tier: theme_tier?.slug,
 	};
 }

--- a/packages/design-picker/src/components/unified-design-picker.tsx
+++ b/packages/design-picker/src/components/unified-design-picker.tsx
@@ -121,6 +121,7 @@ const useTrackDesignView = ( {
 				recordTracksEvent( 'calypso_design_picker_design_display', {
 					category: trackingCategory,
 					design_type: design.design_type,
+					...( design?.design_tier && { design_tier: design.design_tier } ),
 					is_premium: design.is_premium,
 					is_premium_available: isPremiumThemeAvailable,
 					slug: design.slug,

--- a/packages/design-picker/src/hooks/use-theme-designs-query.ts
+++ b/packages/design-picker/src/hooks/use-theme-designs-query.ts
@@ -47,7 +47,7 @@ export function useThemeDesignsQuery(
 	} );
 }
 
-function apiThemeToDesign( { id, name, taxonomies, stylesheet, price }: any ): Design {
+function apiThemeToDesign( { id, name, taxonomies, stylesheet, price, theme_tier }: any ): Design {
 	// Designs use a "featured" term in the theme_picks taxonomy. For example: Blank Canvas
 	const isFeaturedPicks = !! taxonomies?.theme_picks?.find(
 		( { slug }: any ) => slug === 'featured'
@@ -67,6 +67,7 @@ function apiThemeToDesign( { id, name, taxonomies, stylesheet, price }: any ): D
 		showFirst: isFeaturedPicks,
 		...( STATIC_PREVIEWS.includes( id ) && { preview: 'static' } ),
 		design_type: is_premium ? 'premium' : 'standard',
+		design_tier: theme_tier?.slug,
 		price,
 
 		// Deprecated; used for /start flow

--- a/packages/design-picker/src/types.ts
+++ b/packages/design-picker/src/types.ts
@@ -94,6 +94,7 @@ export interface Design {
 	showFirst?: boolean; // Whether this design will appear at the top, regardless of category
 	preview?: 'static';
 	design_type?: DesignType;
+	design_tier: string | null;
 	style_variations?: StyleVariation[];
 	price?: string;
 	software_sets?: SoftwareSet[];


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/5201

## Proposed Changes

* Added the themes tier property to the internal DTOs used by the Design Picker.
* Now the property gets mapped from the input DTO to the domain DTO.
* The event recorder maps from the domain DTO to the event DTO.

I'll be posting a P2 on Marvel, we need to figure out how we want to move forward when we cleanup after the tiers project. Right now the existing `design_type` property has only two values, it's either `Standard` or `Premium`. Premium includes all non-free themes.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the live link.
* Go to the Design Picker.
* Open Chrome's network inspector and filter by t.gif
* With the theme/tiers flag enabled...
* hover over themes on the list
* click on style variations
* click on a theme
* You should see that the events that include the `design_type` also include a `design_tier` property.
* Repeat the process with the flag disabled.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?