### PR TITLE
State: Fix a couple of bad `useSelector` usages

### DIFF
--- a/client/login/wp-login/login-buttons.tsx
+++ b/client/login/wp-login/login-buttons.tsx
@@ -29,18 +29,10 @@ const LoginButtons = ( {
 	usernameOrEmail,
 }: LoginButtonsProps ) => {
 	const translate = useTranslate();
-
-	const { query, isJetpackWooCommerceFlow, currentRoute, isDisabled } = useSelector( ( state ) => {
-		const query = getCurrentQueryArguments( state );
-
-		return {
-			query,
-			wccomFrom: query?.[ 'wccom-from' ],
-			isJetpackWooCommerceFlow: 'woocommerce-onboarding' === query?.from,
-			currentRoute: getCurrentRoute( state ),
-			isDisabled: isFormDisabled( state ),
-		};
-	} );
+	const query = useSelector( getCurrentQueryArguments );
+	const isJetpackWooCommerceFlow = 'woocommerce-onboarding' === query?.from;
+	const currentRoute = useSelector( getCurrentRoute );
+	const isDisabled = useSelector( isFormDisabled );
 	const dispatch = useDispatch();
 
 	const getMagicLoginPageLink = () => {

--- a/client/my-sites/preview/main.jsx
+++ b/client/my-sites/preview/main.jsx
@@ -198,19 +198,26 @@ class PreviewMain extends Component {
 const ConnectedPreviewMain = ( props ) => {
 	const dispatch = useDispatch();
 	const selectedSiteId = useSelector( getSelectedSiteId );
-	const stateToProps = useSelector( ( state ) => {
-		const site = getSelectedSite( state );
-		const homePagePostId = get( site, [ 'options', 'page_on_front' ] );
+	const site = useSelector( getSelectedSite );
+	const homePagePostId = get( site, [ 'options', 'page_on_front' ] );
+	const isPreviewable = useSelector( ( state ) => isSitePreviewable( state, selectedSiteId ) );
+	const selectedSiteNonce =
+		useSelector( ( state ) => getSiteOption( state, selectedSiteId, 'frame_nonce' ) ) || '';
+	const canEditPages = useSelector( ( state ) =>
+		canCurrentUser( state, selectedSiteId, 'edit_pages' )
+	);
+	const editorURL = useSelector( ( state ) =>
+		getEditorUrl( state, selectedSiteId, homePagePostId, 'page' )
+	);
 
-		return {
-			isPreviewable: isSitePreviewable( state, selectedSiteId ),
-			selectedSiteNonce: getSiteOption( state, selectedSiteId, 'frame_nonce' ) || '',
-			site: site,
-			siteId: selectedSiteId,
-			canEditPages: canCurrentUser( state, selectedSiteId, 'edit_pages' ),
-			editorURL: getEditorUrl( state, selectedSiteId, homePagePostId, 'page' ),
-		};
-	} );
+	const stateToProps = {
+		isPreviewable,
+		selectedSiteNonce,
+		site,
+		siteId: selectedSiteId,
+		canEditPages,
+		editorURL,
+	};
 
 	const dispatchToProps = bindActionCreators(
 		{


### PR DESCRIPTION
## Proposed Changes

This PR fixes a couple of bad `useSelector()` usages in which we were needlessly returning a new object every time. 