### PR TITLE
Notifications app: rename main file to .jsx and use JSX there

### DIFF
--- a/apps/notifications/src/standalone/index.jsx
+++ b/apps/notifications/src/standalone/index.jsx
@@ -1,5 +1,4 @@
 import '@automattic/calypso-polyfills';
-import { createElement } from 'react';
 import ReactDOM from 'react-dom';
 import Notifications, { refreshNotes } from '../panel/Notifications';
 import { createClient } from './client';
@@ -75,16 +74,16 @@ const render = ( wpcom ) => {
 	document.body.classList.add( 'font-smoothing-antialiased' );
 
 	ReactDOM.render(
-		createElement( Notifications, {
-			customEnhancer,
-			customMiddleware,
-			isShowing,
-			isVisible,
-			locale,
-			receiveMessage: sendMessage,
-			redirectPath: '/',
-			wpcom,
-		} ),
+		<Notifications
+			customEnhancer={ customEnhancer }
+			customMiddleware={ customMiddleware }
+			isShowing={ isShowing }
+			isVisible={ isVisible }
+			locale={ locale }
+			receiveMessage={ sendMessage }
+			redirectPath="/"
+			wpcom={ wpcom }
+		/>,
 		document.getElementsByClassName( 'wpnc__main' )[ 0 ]
 	);
 };


### PR DESCRIPTION
Landing a very janitorial part of #86402 separately: rename the Notification app's main file to .jsx and use JSX markup there instead of `createElement`.