### PR TITLE
Update: Site Monitoring styles in the Jetpack Mobile app

### DIFF
--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -1,5 +1,6 @@
 @use "sass:math";
 @import "uplot/dist/uPlot.min.css";
+@import "@automattic/typography/styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
@@ -41,6 +42,42 @@ $section-max-width: 1224px;
 			padding: 0;
 			margin-left: 16px;
 			margin-right: 16px;
+		}
+	}
+}
+
+.is-mobile-app-view {
+	.site-monitoring__formatted-header,
+	.site-monitoring-tab-panel {
+		display: none;
+	}
+
+	.site-monitoring-time-controls__title {
+		font-family: $sans;
+		font-size: $font-body-large;
+	}
+
+	&.is-section-site-monitoring .focus-content:not(.has-no-sidebar) .layout__content {
+		padding-top: 40px;
+	}
+
+	.site-monitoring__chart {
+		border: 0;
+		padding: 0;
+		margin: 0 -24px;
+		.site-monitoring__chart-header {
+			padding: 0 24px;
+		}
+	}
+
+	.site-monitoring-http-verbs-pie-chart .pie-chart__legend {
+		flex-direction: column;
+		justify-content: space-around;
+		gap: 4px;
+		align-items: center;
+
+		.legend-item {
+			align-items: center;
 		}
 	}
 }

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -56,6 +56,9 @@ $section-max-width: 1224px;
 		font-family: $sans;
 		font-size: $font-body-large;
 	}
+	.site-monitoring__chart-subtitle {
+		margin-bottom: 0;
+	}
 
 	&.is-section-site-monitoring .focus-content:not(.has-no-sidebar) .layout__content {
 		padding-top: 40px;
@@ -64,10 +67,15 @@ $section-max-width: 1224px;
 	.site-monitoring__chart {
 		border: 0;
 		padding: 0;
-		margin: 0 -24px;
+		margin: 0 -24px 24px -50px;
+
 		.site-monitoring__chart-header {
-			padding: 0 24px;
+			padding: 0 24px 0 50px;
 		}
+	}
+
+	.u-legend {
+		padding: 0 24px 0 50px;
 	}
 
 	.site-monitoring-http-verbs-pie-chart .pie-chart__legend {
@@ -80,6 +88,11 @@ $section-max-width: 1224px;
 			align-items: center;
 		}
 	}
+
+	.site-monitoring__chart-header {
+		margin-bottom: 12px;
+	}
+
 }
 
 .site-monitoring {


### PR DESCRIPTION
We are shipping the site monitoring tools inside the jetpack app. 

As part of this effort we are targeting the Jetpack app browser to display the site monitoring tools with removed UI. Since the app will have its own navigation between the different tabs. 

## Proposed Changes
Before:
<img src="https://github.com/Automattic/wp-calypso/assets/115071/becf9695-04c0-4365-96b0-f175b8acf22d" width="300" />

After:
<img src="https://github.com/Automattic/wp-calypso/assets/115071/f4d3cc8b-e1d2-4f73-8852-1a8c81fe5f28" width="300" />


## Testing Instructions
* Load up this PR.
* In developer console. Set the browser to prettend to be the jetpack app by setting the request header to 
```
Mozilla/5.0 (iPhone; CPU iPhone OS 14_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Mobile/15E148 wp-iphone
```
* Refresh the page. 
* Notice that the header section is now gone.
* Notice that the graphs have now full with. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?