### PR TITLE
[WordAds]: Add CMP activation option to settings

### DIFF
--- a/client/my-sites/earn/ads/form-settings.tsx
+++ b/client/my-sites/earn/ads/form-settings.tsx
@@ -413,7 +413,7 @@ const AdsFormSettings = () => {
 				<FormFieldset>
 					{ /* <SupportInfo
 						text={ translate(
-							'Activates GDPR Consent Banner for EU Compliance. Let site visitors easily provide consent for personalized ads.'
+							'Enables the CMP Banner to ensure GDPR compliance for EU visitors. Let site visitors easily provide consent for personalized ads.'
 						) }
 						link={ localizeUrl(
 							'https://wordpress.com/support/us-privacy-laws-and-your-wordpress-com-site/'
@@ -423,13 +423,13 @@ const AdsFormSettings = () => {
 						checked={ !! settings.cmp_enabled }
 						disabled={ isDisabled }
 						onChange={ () => handleCompactToggle( 'cmp_enabled' ) }
-						label={ translate( 'Enable GDPR Consent banner for EU visitors' ) }
+						label={ translate( 'Enable GDPR Consent banner' ) }
 					/>
 
 					<div className="ads__child-settings">
 						<FormSettingExplanation>
 							{ translate(
-								'Activates GDPR Consent Banner for EU Compliance. Let site visitors easily provide consent for personalized ads.'
+								'Enables the CMP Banner to ensure GDPR compliance for EU visitors. Lets EU site visitors provide consent for personalized ads.'
 							) }
 						</FormSettingExplanation>
 					</div>

--- a/client/my-sites/earn/ads/form-settings.tsx
+++ b/client/my-sites/earn/ads/form-settings.tsx
@@ -46,6 +46,7 @@ type Settings = {
 	custom_adstxt_enabled?: boolean;
 	custom_adstxt?: string;
 	jetpack_module_enabled?: boolean;
+	cmp_enabled?: boolean;
 };
 
 const AdsFormSettings = () => {
@@ -135,6 +136,7 @@ const AdsFormSettings = () => {
 			custom_adstxt_enabled: false,
 			custom_adstxt: '',
 			jetpack_module_enabled: false,
+			cmp_enabled: false,
 		};
 	}
 
@@ -150,6 +152,7 @@ const AdsFormSettings = () => {
 			custom_adstxt_enabled: settings.custom_adstxt_enabled,
 			custom_adstxt: settings.custom_adstxt,
 			jetpack_module_enabled: settings.jetpack_module_enabled,
+			cmp_enabled: settings.cmp_enabled,
 		};
 	}
 
@@ -407,6 +410,30 @@ const AdsFormSettings = () => {
 						</FormFieldset>
 					</div>
 				) }
+				<FormFieldset>
+					{ /* <SupportInfo
+						text={ translate(
+							'Activates GDPR Consent Banner for EU Compliance. Let site visitors easily provide consent for personalized ads.'
+						) }
+						link={ localizeUrl(
+							'https://wordpress.com/support/us-privacy-laws-and-your-wordpress-com-site/'
+						) }
+					/> */ }
+					<ToggleControl
+						checked={ !! settings.cmp_enabled }
+						disabled={ isDisabled }
+						onChange={ () => handleCompactToggle( 'cmp_enabled' ) }
+						label={ translate( 'Enable GDPR Consent banner for EU visitors' ) }
+					/>
+
+					<div className="ads__child-settings">
+						<FormSettingExplanation>
+							{ translate(
+								'Activates GDPR Consent Banner for EU Compliance. Let site visitors easily provide consent for personalized ads.'
+							) }
+						</FormSettingExplanation>
+					</div>
+				</FormFieldset>
 			</div>
 		);
 	}

--- a/client/my-sites/earn/ads/form-settings.tsx
+++ b/client/my-sites/earn/ads/form-settings.tsx
@@ -411,14 +411,6 @@ const AdsFormSettings = () => {
 					</div>
 				) }
 				<FormFieldset>
-					{ /* <SupportInfo
-						text={ translate(
-							'Enables the CMP Banner to ensure GDPR compliance for EU visitors. Let site visitors easily provide consent for personalized ads.'
-						) }
-						link={ localizeUrl(
-							'https://wordpress.com/support/us-privacy-laws-and-your-wordpress-com-site/'
-						) }
-					/> */ }
 					<ToggleControl
 						checked={ !! settings.cmp_enabled }
 						disabled={ isDisabled }

--- a/client/my-sites/earn/ads/form-settings.tsx
+++ b/client/my-sites/earn/ads/form-settings.tsx
@@ -410,22 +410,25 @@ const AdsFormSettings = () => {
 						</FormFieldset>
 					</div>
 				) }
-				<FormFieldset>
-					<ToggleControl
-						checked={ !! settings.cmp_enabled }
-						disabled={ isDisabled }
-						onChange={ () => handleCompactToggle( 'cmp_enabled' ) }
-						label={ translate( 'Enable GDPR Consent Banner' ) }
-					/>
 
-					<div className="ads__child-settings">
-						<FormSettingExplanation>
-							{ translate(
-								'Show a cookie banner to all EU and UK site visitors prompting them to consent to their personal data being used to personalize the ads they see. Without proper consents EU/UK visitors will only see lower paying non-personalized ads.'
-							) }
-						</FormSettingExplanation>
-					</div>
-				</FormFieldset>
+				{ siteIsJetpack && (
+					<FormFieldset>
+						<ToggleControl
+							checked={ !! settings.cmp_enabled }
+							disabled={ isDisabled }
+							onChange={ () => handleCompactToggle( 'cmp_enabled' ) }
+							label={ translate( 'Enable GDPR Consent Banner' ) }
+						/>
+
+						<div className="ads__child-settings">
+							<FormSettingExplanation>
+								{ translate(
+									'Show a cookie banner to all EU and UK site visitors prompting them to consent to their personal data being used to personalize the ads they see. Without proper consents EU/UK visitors will only see lower paying non-personalized ads.'
+								) }
+							</FormSettingExplanation>
+						</div>
+					</FormFieldset>
+				) }
 			</div>
 		);
 	}

--- a/client/my-sites/earn/ads/form-settings.tsx
+++ b/client/my-sites/earn/ads/form-settings.tsx
@@ -421,7 +421,7 @@ const AdsFormSettings = () => {
 					<div className="ads__child-settings">
 						<FormSettingExplanation>
 							{ translate(
-								'Enable the GDPR Banner to ensure compliance with EU laws by allowing EU site visitors provide consent for personalized ads.'
+								'Show a cookie banner to all EU and UK site visitors prompting them to consent to their personal data being used to personalize the ads they see. Without proper consents EU/UK visitors will only see lower paying non-personalized ads.'
 							) }
 						</FormSettingExplanation>
 					</div>

--- a/client/my-sites/earn/ads/form-settings.tsx
+++ b/client/my-sites/earn/ads/form-settings.tsx
@@ -429,7 +429,7 @@ const AdsFormSettings = () => {
 					<div className="ads__child-settings">
 						<FormSettingExplanation>
 							{ translate(
-								'Enables the CMP Banner to ensure GDPR compliance for EU visitors. Lets EU site visitors provide consent for personalized ads.'
+								'Enable the GDPR Banner to ensure compliance with EU laws by allowing EU site visitors provide consent for personalized ads.'
 							) }
 						</FormSettingExplanation>
 					</div>

--- a/client/my-sites/earn/ads/form-settings.tsx
+++ b/client/my-sites/earn/ads/form-settings.tsx
@@ -415,7 +415,7 @@ const AdsFormSettings = () => {
 						checked={ !! settings.cmp_enabled }
 						disabled={ isDisabled }
 						onChange={ () => handleCompactToggle( 'cmp_enabled' ) }
-						label={ translate( 'Enable GDPR Consent banner' ) }
+						label={ translate( 'Enable GDPR Consent Banner' ) }
 					/>
 
 					<div className="ads__child-settings">

--- a/client/my-sites/earn/ads/payments.tsx
+++ b/client/my-sites/earn/ads/payments.tsx
@@ -38,6 +38,7 @@ type WordAdSettings = {
 	};
 	ccpa_enabled: boolean;
 	ccpa_privacy_policy_url: string;
+	cmp_enabled: boolean;
 };
 
 const WordAdsPayments = () => {

--- a/client/state/data-layer/wpcom/wordads/settings/index.js
+++ b/client/state/data-layer/wpcom/wordads/settings/index.js
@@ -74,6 +74,7 @@ export const saveWordadsSettings = ( action ) => ( dispatch, getState ) => {
 				wordads_ccpa_privacy_policy_url: settings.ccpa_privacy_policy_url,
 				wordads_custom_adstxt_enabled: settings.custom_adstxt_enabled,
 				wordads_custom_adstxt: settings.custom_adstxt,
+				wordads_cmp_enabled: settings.cmp_enabled,
 			};
 		}
 		dispatch( saveJetpackSettings( siteId, jetpackSettings ) );

--- a/client/state/selectors/get-wordads-settings.js
+++ b/client/state/selectors/get-wordads-settings.js
@@ -42,6 +42,7 @@ export const getWordadsSettings = createSelector(
 				ccpa_privacy_policy_url: siteSettings.wordads_ccpa_privacy_policy_url,
 				custom_adstxt_enabled: siteSettings.wordads_custom_adstxt_enabled,
 				custom_adstxt: siteSettings.wordads_custom_adstxt,
+				cmp_enabled: siteSettings.wordads_cmp_enabled,
 			};
 		}
 

--- a/client/state/selectors/test/get-wordads-settings.js
+++ b/client/state/selectors/test/get-wordads-settings.js
@@ -94,6 +94,7 @@ describe( 'getWordadsSettings()', () => {
 						wordads_ccpa_privacy_policy_url: 'wordads_ccpa_privacy_policy_url-test',
 						wordads_custom_adstxt_enabled: 'wordads_custom_adstxt_enabled-test',
 						wordads_custom_adstxt: 'wordads_custom_adstxt-test',
+						wordads_cmp_enabled: 'wordads_cmp_enabled-test',
 					},
 				},
 			},
@@ -126,5 +127,6 @@ describe( 'getWordadsSettings()', () => {
 			'wordads_custom_adstxt_enabled-test'
 		);
 		expect( output ).toHaveProperty( 'custom_adstxt', 'wordads_custom_adstxt-test' );
+		expect( output ).toHaveProperty( 'cmp_enabled', 'wordads_cmp_enabled-test' );
 	} );
 } );


### PR DESCRIPTION
## Proposed Changes

*   Now that we are making A8C CMP available on Jetpack, we want to include the option for WordAds site owners to toggle the CMP banner on/off for EU visitors via the settings page on Calyspo.

## Testing Instructions

* Visit your WordAds-enabled Jetpack site's dashboard
* Go to Tools ->  Earn -> Ads
* Scroll to the Ad settings, you should see the toggle option titled `Enable GDPR Consent Banner`
* Toggle the option and click "Save settings". Your settings should save correctly.

<img width="1728" alt="settings" src="https://github.com/Automattic/wp-calypso/assets/9039613/f833bfb3-d2e2-45f0-9aaa-f16f8fec48d8">

- Repeat the same steps above for a non-Jetpack site with WordAds enabled, and the `Enable GDPR Consent Banner` option should NOT be visible

<img width="1727" alt="option absent" src="https://github.com/Automattic/wp-calypso/assets/9039613/c4fe7baf-debb-4817-9d6e-36684dcfee42">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?