### PR TITLE
Marketplace Reviews: Use Marketplace rating average from Marketplace plugins

### DIFF
--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -3,7 +3,10 @@ import { Badge, Button } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'react-redux';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
-import { useMarketplaceReviewsQuery } from 'calypso/data/marketplace/use-marketplace-reviews';
+import {
+	useMarketplaceReviewsQuery,
+	useMarketplaceReviewsStatsQuery,
+} from 'calypso/data/marketplace/use-marketplace-reviews';
 import { formatNumberMetric } from 'calypso/lib/format-number-compact';
 import { preventWidows } from 'calypso/lib/formatting';
 import PluginIcon from 'calypso/my-sites/plugins/plugin-icon/plugin-icon';
@@ -19,6 +22,7 @@ const PluginDetailsHeader = ( {
 	isPlaceholder,
 	isJetpackCloud,
 	onReviewsClick = () => {},
+	isMarketplaceProduct,
 } ) => {
 	const moment = useLocalizedMoment();
 	const translate = useTranslate();
@@ -28,11 +32,21 @@ const PluginDetailsHeader = ( {
 
 	const { currentVersionsRange } = usePluginVersionInfo( plugin, selectedSite?.ID );
 
+	const { data: reviewsStats } = useMarketplaceReviewsStatsQuery( {
+		productType: 'plugin',
+		slug: plugin.slug,
+	} );
+
 	const { data: marketplaceReviews } = useMarketplaceReviewsQuery( {
 		productType: 'plugin',
 		slug: plugin.slug,
 	} );
 	const numberOfReviews = marketplaceReviews?.length || 0;
+
+	// Rating can be a valid number, 0 or null, discard undefined for easier comparison
+	const rating = isMarketplaceProduct
+		? ( reviewsStats?.ratings_average * 100 ) / 5 ?? 0
+		: plugin.rating ?? null;
 
 	if ( isPlaceholder ) {
 		return <PluginDetailsHeaderPlaceholder />;
@@ -75,23 +89,26 @@ const PluginDetailsHeader = ( {
 				{ preventWidows( plugin.short_description || plugin.description ) }
 			</div>
 			<div className="plugin-details-header__additional-info">
-				{ !! plugin.rating && (
+				{ /* We want to accept rating 0, which means no rating for Marketplace products */ }
+				{ rating !== null && (
 					<div className="plugin-details-header__info">
 						<div className="plugin-details-header__info-title">{ translate( 'Ratings' ) }</div>
 						<div className="plugin-details-header__info-value">
-							<PluginRatings rating={ plugin.rating } />
-							{ isEnabled( 'marketplace-reviews-show' ) && numberOfReviews > 0 && (
+							<PluginRatings rating={ rating } />
+							{ isEnabled( 'marketplace-reviews-show' ) && (
 								<Button
 									borderless
 									className="plugin-details-header__number-reviews-link is-link"
 									onClick={ onReviewsClick }
 								>
-									{ translate( '%(numberOfReviews)d review', '%(numberOfReviews)d reviews', {
-										count: numberOfReviews,
-										args: {
-											numberOfReviews,
-										},
-									} ) }
+									{ numberOfReviews > 0 &&
+										translate( '%(numberOfReviews)d review', '%(numberOfReviews)d reviews', {
+											count: numberOfReviews,
+											args: {
+												numberOfReviews,
+											},
+										} ) }
+									{ isMarketplaceProduct && numberOfReviews === 0 && translate( 'Write a review' ) }
 								</Button>
 							) }
 						</div>

--- a/client/my-sites/plugins/plugin-details-header/test/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/test/index.jsx
@@ -25,6 +25,7 @@ jest.mock( '../../plugin-management-v2/hooks/use-plugin-version-info', () => {
 
 jest.mock( 'calypso/data/marketplace/use-marketplace-reviews', () => ( {
 	useMarketplaceReviewsQuery: () => ( { data: [] } ),
+	useMarketplaceReviewsStatsQuery: () => ( { data: [] } ),
 } ) );
 
 jest.mock( '@automattic/calypso-config', () => {

--- a/client/my-sites/plugins/plugin-details.jsx
+++ b/client/my-sites/plugins/plugin-details.jsx
@@ -420,6 +420,7 @@ function PluginDetails( props ) {
 							plugin={ fullPlugin }
 							isPlaceholder={ showPlaceholder }
 							onReviewsClick={ () => setIsReviewsModalVisible( true ) }
+							isMarketplaceProduct={ isMarketplaceProduct }
 						/>
 					</div>
 					<div className="plugin-details__content">

--- a/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/plugin-details-v2/index.tsx
@@ -93,6 +93,7 @@ export default function PluginDetailsV2( {
 								isJetpackCloud
 								plugin={ fullPlugin }
 								isPlaceholder={ showPlaceholder }
+								isMarketplaceProduct={ isMarketplaceProduct }
 							/>
 						</div>
 					</div>

--- a/client/my-sites/plugins/plugin-ratings/index.jsx
+++ b/client/my-sites/plugins/plugin-ratings/index.jsx
@@ -104,10 +104,6 @@ class PluginRatings extends Component {
 			return this.renderPlaceholder();
 		}
 
-		if ( ! rating ) {
-			return null;
-		}
-
 		const tierViews = ratings && ratingTiers.map( this.renderRatingTier );
 		return (
 			<div className="plugin-ratings">
@@ -122,7 +118,9 @@ class PluginRatings extends Component {
 							)
 						</span>
 					) }
-					{ ! hideRatingNumber && <span className="plugin-ratings__number">{ rating / 20 }</span> }
+					{ ! hideRatingNumber && rating > 0 && (
+						<span className="plugin-ratings__number">{ rating / 20 }</span>
+					) }
 				</div>
 				{ ! inlineNumRatings && numRatings && (
 					<div className="plugin-ratings__rating-text">


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Solves #https://github.com/Automattic/dotcom-forge/issues/5243

## Proposed Changes

* Use the Marketplace rating for Marketplace plugins
* Include the link `Write a review` when there are no exiting reviews. The link will open the Reviews modal

The following screenshots are a comparison of the scenario of No Reviews:

|Before | After|
|-------|------|
| ![CleanShot 2024-01-24 at 20 00 00@2x](https://github.com/Automattic/wp-calypso/assets/3519124/23f840a3-9250-4897-be33-a06941759222) |  ![CleanShot 2024-01-24 at 19 59 13@2x](https://github.com/Automattic/wp-calypso/assets/3519124/4eaf295b-5b44-4d61-879f-c647f680830f) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In an environment with the flags enabled `marketplace-add-review` and `marketplace-reviews-show`, e.g. `wpcalypso`
* Navigate to a Marketplace plugin with reviews in both Woo and WP.com, e.g. `woocommerce-bookiings`, `/plugins/woocommerce-bookings/:siteId`
* Make sure the rating average of the header in the plugin page and the reviews modal is the same (look at the linked issue https://github.com/Automattic/dotcom-forge/issues/5243 for a gif)
- Navigate to a `.org` plugin with reviews, e.g. `wordpress-seo`, `/plugins/wordpress-seo/:siteId`
- Make sure you can see the reviews rating as expected
* Navigate to a Marketplace plugin without reviews, e.g. `wordpress-subscriptions`, `/plugins/woocommerce-subscriptions`
* Make sure that you can see a link with the text `Write a review` that opens the review modal

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?