### PR TITLE
Checkout: Fix style bleed for ToS foldable card

### DIFF
--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -53,14 +53,13 @@ const CheckoutTermsWrapper = styled.div< {
 	& .checkout__terms-foldable-card {
 		box-shadow: none;
 		padding: 0;
-		& .foldable-card__header {
+		&.is-compact .foldable-card__header {
 			font-size: 12px;
 			font-weight: 500;
 			line-height: 1.5;
 			padding: 0;
 		}
-		& .foldable-card.is-expanded,
-		.foldable-card__content {
+		&.is-expanded .foldable-card__content {
 			display: block;
 			padding: 0;
 			border-top: none;


### PR DESCRIPTION
As noted in Slack, p1706018153763499-slack-C0117V2PCAE, the ToS Foldable Card found in checkout has a padding left padding in some cases, but not others.

| Incorrect | Correct |
| ----- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/16580129/5705e75e-bf1c-42aa-ae7e-e9453e624e15) | <img width="630" alt="image" src="https://github.com/Automattic/wp-calypso/assets/16580129/fb059285-ea07-433b-9db7-5d77cb7b6f58"> |

It appears that the extra padding is only applied when accessing checkout from another page in Calypso. If you access Checkout directly the extra padding is not applied.

## Proposed Changes

* This PR changes the specificity of the selectors that remove the default padding for the foldable card in Checkout

## Testing Instructions

* Before applying this diff, go to the Calypso home screen (or any Calypso page) then access Checkout and observe the incorrect behavior of the ToS foldable card
* Apply diff, then repeat step one, the ToS card should no longer have left or right padding
* Open the card and ensure the content also has no left or right padding
