### PR TITLE
Podcasting: Remove podcast subtitle field

### DIFF
--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -317,10 +317,6 @@ class PodcastingDetails extends Component {
 						key: 'podcasting_title',
 						label: translate( 'Title' ),
 					} ) }
-					{ this.renderTextField( {
-						key: 'podcasting_subtitle',
-						label: translate( 'Subtitle' ),
-					} ) }
 				</div>
 				{ this.renderTopics() }
 				{ this.renderExplicitContent() }
@@ -331,7 +327,7 @@ class PodcastingDetails extends Component {
 				{ this.renderTextField( {
 					FormComponent: FormTextarea,
 					key: 'podcasting_summary',
-					label: translate( 'Summary' ),
+					label: translate( 'Summary/Description' ),
 				} ) }
 				{ this.renderTextField( {
 					key: 'podcasting_email',
@@ -388,11 +384,6 @@ class PodcastingDetails extends Component {
 			if ( ! fields.podcasting_title ) {
 				fieldsToUpdate.podcasting_title = settings.blogname;
 			}
-			// If we are newly enabling podcasting, and no podcast subtitle is set,
-			// use the site description.
-			if ( ! fields.podcasting_subtitle ) {
-				fieldsToUpdate.podcasting_subtitle = settings.blogdescription;
-			}
 		}
 
 		this.props.updateFields( fieldsToUpdate );
@@ -432,7 +423,6 @@ const getFormSettings = ( settings ) => {
 	return pick( settings, [
 		'podcasting_category_id',
 		'podcasting_title',
-		'podcasting_subtitle',
 		'podcasting_talent_name',
 		'podcasting_summary',
 		'podcasting_copyright',

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -317,17 +317,17 @@ class PodcastingDetails extends Component {
 						key: 'podcasting_title',
 						label: translate( 'Title' ),
 					} ) }
+					{ this.renderTextField( {
+						FormComponent: FormTextarea,
+						key: 'podcasting_summary',
+						label: translate( 'Summary/Description' ),
+					} ) }
 				</div>
 				{ this.renderTopics() }
 				{ this.renderExplicitContent() }
 				{ this.renderTextField( {
 					key: 'podcasting_talent_name',
 					label: translate( 'Hosts/Artist/Producer' ),
-				} ) }
-				{ this.renderTextField( {
-					FormComponent: FormTextarea,
-					key: 'podcasting_summary',
-					label: translate( 'Summary/Description' ),
 				} ) }
 				{ this.renderTextField( {
 					key: 'podcasting_email',

--- a/client/my-sites/site-settings/podcasting-details/index.jsx
+++ b/client/my-sites/site-settings/podcasting-details/index.jsx
@@ -340,14 +340,6 @@ class PodcastingDetails extends Component {
 					key: 'podcasting_copyright',
 					label: translate( 'Copyright' ),
 				} ) }
-				{ this.renderTextField( {
-					key: 'podcasting_keywords',
-					label: translate( 'Keywords' ),
-					explanation: translate(
-						'The keywords setting has been deprecated. This field is for reference only.'
-					),
-					isDisabled: true,
-				} ) }
 				{ isPodcastingEnabled && this.renderSaveButton( true ) }
 			</Fragment>
 		);
@@ -428,7 +420,6 @@ const getFormSettings = ( settings ) => {
 		'podcasting_copyright',
 		'podcasting_explicit',
 		'podcasting_image',
-		'podcasting_keywords',
 		'podcasting_category_1',
 		'podcasting_category_2',
 		'podcasting_category_3',

--- a/client/my-sites/site-settings/podcasting-details/style.scss
+++ b/client/my-sites/site-settings/podcasting-details/style.scss
@@ -60,7 +60,7 @@
 .podcasting-details__title-subtitle-wrapper {
 	@include breakpoint-deprecated( ">960px" ) {
 		float: left;
-		width: 75%;
+		width: 80%;
 	}
 }
 
@@ -71,7 +71,10 @@
 	}
 
 	.form-select {
+		margin-right: 12px;
+
 		@include breakpoint-deprecated( "<480px" ) {
+			margin-right: 0;
 			width: 100%;
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR removes the Podcast subtitle field.
* Changed the Summary field label from **Summary** to **Summary/Description** since this is being used to display on the `<description>` tag of the generated RSS feed.

### Before and after screen shots

| Before | After |
|--------|--------|
| <img width="724" alt="image" src="https://github.com/Automattic/wp-calypso/assets/24195829/8e979f10-f09e-4f87-9f81-e01792632ea4"> | <img width="722" alt="image" src="https://github.com/Automattic/wp-calypso/assets/24195829/2c2ccbd4-d2c3-4af4-878e-146078121a5e"> | 

### Related discussions:

- pbORJr-5u-p2#comment-214

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply this PR to your local.
- Go to http://calypso.localhost:3000/settings/podcasting/{site-slug} and check the fields.
- If visiting the feed URL for the Podcasting category, you should no longer see the `<itunes:subtitle>` tag in the feed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?