### PR TITLE
Site Monitoring: Add SelectDownItem label

### DIFF
--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
@@ -153,12 +153,10 @@ export const SiteLogsToolbar = ( {
 								<SelectDropdown.Item
 									key={ option.value }
 									onClick={ () => onSeverityChange( option.value ) }
-									value={ option.label }
 									ariaLabel={ option.label }
+									selected={ option.value === severity }
 								>
-									<span>
-										<strong>{ option.label }</strong>
-									</span>
+									{ option.label }
 								</SelectDropdown.Item>
 							) ) }
 						</SelectDropdown>
@@ -178,12 +176,10 @@ export const SiteLogsToolbar = ( {
 									<SelectDropdown.Item
 										key={ option.value }
 										onClick={ () => onRequestTypeChange( option.value ) }
-										value={ option.label }
 										ariaLabel={ option.label }
+										selected={ option.value === requestType }
 									>
-										<span>
-											<strong>{ option.label }</strong>
-										</span>
+										{ option.label }
 									</SelectDropdown.Item>
 								) ) }
 							</SelectDropdown>
@@ -200,12 +196,10 @@ export const SiteLogsToolbar = ( {
 									<SelectDropdown.Item
 										key={ option.value }
 										onClick={ () => onRequestStatusChange( option.value ) }
-										value={ option.label }
 										ariaLabel={ option.label }
+										selected={ option.value === requestStatus }
 									>
-										<span>
-											<strong>{ option.label }</strong>
-										</span>
+										{ option.label }
 									</SelectDropdown.Item>
 								) ) }
 							</SelectDropdown>

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
@@ -153,6 +153,8 @@ export const SiteLogsToolbar = ( {
 								<SelectDropdown.Item
 									key={ option.value }
 									onClick={ () => onSeverityChange( option.value ) }
+									value={ option.label }
+									ariaLabel={ option.label }
 								>
 									<span>
 										<strong>{ option.label }</strong>
@@ -176,6 +178,8 @@ export const SiteLogsToolbar = ( {
 									<SelectDropdown.Item
 										key={ option.value }
 										onClick={ () => onRequestTypeChange( option.value ) }
+										value={ option.label }
+										ariaLabel={ option.label }
 									>
 										<span>
 											<strong>{ option.label }</strong>
@@ -196,6 +200,8 @@ export const SiteLogsToolbar = ( {
 									<SelectDropdown.Item
 										key={ option.value }
 										onClick={ () => onRequestStatusChange( option.value ) }
+										value={ option.label }
+										ariaLabel={ option.label }
 									>
 										<span>
 											<strong>{ option.label }</strong>

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/style.scss
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/style.scss
@@ -34,18 +34,6 @@
 		}
 	}
 
-	.site-logs-toolbar-filter-severity {
-		width: 140px;
-	}
-
-	.site-logs-toolbar-filter-request-type {
-		width: 110px;
-	}
-
-	.site-logs-toolbar-filter-request-status {
-		width: 90px;
-	}
-
 	@media screen and ( max-width: 600px ) {
 		.site-logs-toolbar__top-row {
 			flex-direction: column;


### PR DESCRIPTION
Fixes issue in safari (MacOS) where the dropdown in not visible. 

See
<img width="400" alt="Screenshot 2024-01-24 at 4 42 49 PM" src="https://github.com/Automattic/wp-calypso/assets/115071/3abaf272-8d4d-4c4e-a1c8-ffe27ffdaab7" />

<img width="400" alt="Screenshot 2024-01-24 at 4 42 44 PM" src="https://github.com/Automattic/wp-calypso/assets/115071/40acbd3a-628a-4044-88f2-36398749c97d">


## Proposed Changes

This PR fixes it by passing in the correct labels and and values to the <SelectDropdown.Item component.
Previously the values for the aria-label attributes were set to [Object Object]

See

<img width="1736" alt="Screenshot 2024-01-24 at 4 54 55 PM" src="https://github.com/Automattic/wp-calypso/assets/115071/bf891a4d-e36e-4bb1-b335-b3d7513ecc7c">

## Testing Instructions

* Does it work as expected in Safari. 
(if you are having truble logging in login on wordpress.com and then add ?flags=oauth to the url that you are testing) 
* Does it work as expected in Chrome or Firefox?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?