### PR TITLE
Fix package references for new jetpack ai package

### DIFF
--- a/.github/workflows/icfy-stats.yml
+++ b/.github/workflows/icfy-stats.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Fetch git history
         run: git fetch --prune --unshallow
       - name: Install dependencies
-        run: yarn install --inline-builds
+        run: SKIP_TSC=true yarn install --inline-builds
       - name: Build ICFY stats
         env:
           NODE_ENV: production

--- a/.github/workflows/icfy-stats.yml
+++ b/.github/workflows/icfy-stats.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Fetch git history
         run: git fetch --prune --unshallow
       - name: Install dependencies
-        run: SKIP_TSC=true yarn install --inline-builds
+        run: yarn install --inline-builds
       - name: Build ICFY stats
         env:
           NODE_ENV: production

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -28,7 +28,6 @@
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
 		"prepack": "yarn run clean && yarn run build",
-		"prepare": "yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {

--- a/packages/data-stores/package.json
+++ b/packages/data-stores/package.json
@@ -28,6 +28,7 @@
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
 		"prepack": "yarn run clean && yarn run build",
+		"prepare": "yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},
 	"dependencies": {

--- a/packages/data-stores/tsconfig.json
+++ b/packages/data-stores/tsconfig.json
@@ -10,6 +10,7 @@
 	"references": [
 		{ "path": "../calypso-analytics" },
 		{ "path": "../calypso-products" },
+		{ "path": "../calypso-config" },
 		{ "path": "../i18n-utils" },
 		{ "path": "../shopping-cart" },
 		{ "path": "../format-currency" },

--- a/packages/jetpack-ai-calypso/package.json
+++ b/packages/jetpack-ai-calypso/package.json
@@ -38,6 +38,7 @@
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
+		"prepare": "yarn run build",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/jetpack-ai-calypso/package.json
+++ b/packages/jetpack-ai-calypso/package.json
@@ -38,7 +38,6 @@
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
-		"prepare": "yarn run build",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/jetpack-ai-calypso/package.json
+++ b/packages/jetpack-ai-calypso/package.json
@@ -55,6 +55,7 @@
 	},
 	"peerDependencies": {
 		"@babel/runtime": "^7.23.7",
+		"@wordpress/data": "^9.19.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0"
 	},
@@ -65,6 +66,7 @@
 	},
 	"dependencies": {
 		"@automattic/calypso-analytics": "workspace:^",
+		"@automattic/data-stores": "workspace:^",
 		"classnames": "^2.3.2",
 		"debug": "^4.3.4"
 	}

--- a/packages/jetpack-ai-calypso/package.json
+++ b/packages/jetpack-ai-calypso/package.json
@@ -38,7 +38,7 @@
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
-		"prepare": "yarn run clean && yarn run build",
+		"prepare": "yarn run build",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/jetpack-ai-calypso/package.json
+++ b/packages/jetpack-ai-calypso/package.json
@@ -38,7 +38,7 @@
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
-		"prepare": "yarn run build",
+		"prepare": "yarn run clean && yarn run build",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/jetpack-ai-calypso/tsconfig.json
+++ b/packages/jetpack-ai-calypso/tsconfig.json
@@ -7,5 +7,5 @@
 		"rootDir": "src"
 	},
 	"files": [ "./global.d.ts" ],
-	"references": [ { "path": "../data-stores" } ]
+	"references": [ { "path": "../calypso-analytics" }, { "path": "../data-stores" } ]
 }

--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -29,7 +29,7 @@
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
-		"prepare": "yarn run build",
+		"prepare": "yarn run clean && yarn run build",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/plans-grid-next/package.json
+++ b/packages/plans-grid-next/package.json
@@ -29,7 +29,7 @@
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
-		"prepare": "yarn run clean && yarn run build",
+		"prepare": "yarn run build",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -35,7 +35,7 @@
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
-		"prepare": "yarn run clean && yarn run build",
+		"prepare": "yarn run build",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/social-previews/package.json
+++ b/packages/social-previews/package.json
@@ -35,7 +35,7 @@
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
-		"prepare": "yarn run build",
+		"prepare": "yarn run clean && yarn run build",
 		"prepack": "yarn run clean && yarn run build",
 		"watch": "tsc --build ./tsconfig.json --watch"
 	},

--- a/packages/tsconfig.json
+++ b/packages/tsconfig.json
@@ -32,6 +32,7 @@
 		{ "path": "./help-center" },
 		{ "path": "./i18n-utils" },
 		{ "path": "./jest-circus-allure-reporter" },
+		{ "path": "./jetpack-ai-calypso" },
 		{ "path": "./js-utils" },
 		{ "path": "./language-picker" },
 		{ "path": "./languages" },

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -22,7 +22,7 @@
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/viewport#readme",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"prepare": " yarn run build",
+		"prepare": "yarn run clean && yarn run build",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
 		"prepack": "yarn run clean && yarn run build"
 	},

--- a/packages/viewport/package.json
+++ b/packages/viewport/package.json
@@ -22,7 +22,7 @@
 	"homepage": "https://github.com/Automattic/wp-calypso/tree/HEAD/packages/viewport#readme",
 	"scripts": {
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
-		"prepare": "yarn run clean && yarn run build",
+		"prepare": " yarn run build",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json",
 		"prepack": "yarn run clean && yarn run build"
 	},

--- a/yarn.lock
+++ b/yarn.lock
@@ -1044,6 +1044,7 @@ __metadata:
     "@automattic/calypso-analytics": "workspace:^"
     "@automattic/calypso-build": "workspace:^"
     "@automattic/calypso-typescript-config": "workspace:^"
+    "@automattic/data-stores": "workspace:^"
     "@testing-library/jest-dom": "npm:^6.2.0"
     "@testing-library/react": "npm:^14.1.2"
     classnames: "npm:^2.3.2"
@@ -1055,6 +1056,7 @@ __metadata:
     webpack: "npm:^5.89.0"
   peerDependencies:
     "@babel/runtime": ^7.23.7
+    "@wordpress/data": ^9.19.0
     react: ^18.2.0
     react-dom: ^18.2.0
   peerDependenciesMeta:


### PR DESCRIPTION
Attempts to fix the ICFY `yarn install` failure due to a tsc issue. (I left the commit history kind of messy so that you can see what errors different commits caused.)

- Adds SKIP_TSC to icfy workflow. While this doesn't fix the issue, it does improve performance by 45s to 60s. We use this for yarn install in TeamCity to avoid doing type checks when we don't need them.
- Change a handful of `yarn prepare` instances to remove clean. It's possible for a package to clean up types that other packages are depending on during the build. I don't know the exact mechanics, but if we add this back, we get these failures: https://github.com/Automattic/wp-calypso/actions/runs/7649365973/job/20843657397. My theory is that cleaning the local tsconfig project might also clean the _referenced_ tsconfig projects.
- Add correct dependencies and references for new jetpack AI package.
- Make sure that jetpack AI is part of the global packages tsconfig.
- For the data-stores package, add a missing reference to calypso-config.

So the two big things:
1. Running `yarn clean` as part of the build. if we truly need to clean, it should be done in whole before starting the build. `yarn prepare` runs as a postinstall script.
2. A number of missing references and dependencies. Any time an internal workspace TS package is used, it needs to be in both `package.json` (as a workspace package) and in `tsconfig.json` (as a reference.) But we don't have anything enforcing this.
