### PR TITLE
Jetpack Backup: Fix backup retention radio button style

### DIFF
--- a/client/components/backup-retention-management/style.scss
+++ b/client/components/backup-retention-management/style.scss
@@ -4,6 +4,7 @@
 .backup-retention-management {
 	box-sizing: border-box;
 	margin: auto;
+	margin-top: 1px;
 	max-width: 720px;
 	margin-left: -16px;
 	margin-right: -16px;
@@ -155,6 +156,10 @@
 				box-shadow: none;
 			}
 
+			&::before {
+				content: none;
+			}
+
 			&::after {
 				content: "";
 				display: block;
@@ -169,7 +174,8 @@
 					border: 3px solid #fff;
 				}
 
-				border-color: var(--color-accent);
+				border-color: var(--studio-jetpack-green-50);
+				background: var(--studio-jetpack-green-50);
 			}
 		}
 


### PR DESCRIPTION
## Proposed Changes
* Fix the style of the radio button in the backup retention setting

| Before | After |
|---|---|
| ![CleanShot 2024-01-24 at 21 07 07](https://github.com/Automattic/wp-calypso/assets/1488641/a546428c-6fa4-4cb3-9872-208cd3d5ce45) | ![CleanShot 2024-01-24 at 21 42 24](https://github.com/Automattic/wp-calypso/assets/1488641/5b62012d-5715-4042-8eb7-ae660237c7ad) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Calypso or Jetpack Cloud live branch
* Pick a site with a Jetpack VaultPress Backup plan (not an agency)
* Navigate to Jetpack Settings
* Ensure the styles looks as presented in the screenshot provided above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?