### PR TITLE
Stats: Include purchase info in redirect logic

### DIFF
--- a/client/my-sites/stats/hooks/use-notice-visibility-mutation.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-mutation.ts
@@ -28,7 +28,7 @@ export default function useNoticeVisibilityMutation(
 	postponedFor = 0
 ) {
 	return useMutation( {
-		mutationKey: [ 'stats', 'notices-visibility', siteId, noticeId ],
+		mutationKey: [ 'stats', 'notices-visibility', 'raw', siteId ],
 		mutationFn: () => dismissNotice( siteId, noticeId, status, postponedFor ),
 		retry: 1,
 		retryDelay: 3 * 1000, // 3 seconds

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -33,7 +33,6 @@ const CONFLICT_NOTICE_ID_GROUPS: Record< string, Array< NoticeIdType > > = {
 		'commercial_site_upgrade',
 		'tier_upgrade',
 	],
-	excluded: [ 'focus_jetpack_purchase' ],
 };
 
 /**

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -66,33 +66,23 @@ const queryNotices = async function ( siteId: number | null ): Promise< Notices 
 
 const useNoticesVisibilityQueryRaw = function < T >(
 	siteId: number | null,
-	select?: ( payload: Notices ) => T,
-	staleTime?: number
+	select?: ( payload: Notices ) => T
 ) {
 	return useQuery( {
 		queryKey: [ 'stats', 'notices-visibility', 'raw', siteId ],
 		queryFn: () => queryNotices( siteId ),
 		select,
-		staleTime: staleTime !== undefined ? staleTime : 1000 * 30, // custom or 30 seconds
 		retry: 1,
 		retryDelay: 3 * 1000, // 3 seconds,
 	} );
 };
 
-export function useNoticeVisibilityQuery(
-	siteId: number | null,
-	noticeId: NoticeIdType,
-	staleTime?: number
-) {
+export function useNoticeVisibilityQuery( siteId: number | null, noticeId: NoticeIdType ) {
 	const selectVisibilityForSingleNotice = ( payload: Notices ) => {
 		payload = processConflictNotices( payload );
 		return !! payload?.[ noticeId ];
 	};
-	return useNoticesVisibilityQueryRaw< boolean >(
-		siteId,
-		selectVisibilityForSingleNotice,
-		staleTime
-	);
+	return useNoticesVisibilityQueryRaw< boolean >( siteId, selectVisibilityForSingleNotice );
 }
 
 export function useNoticesVisibilityQuery( siteId: number | null ) {

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -72,6 +72,7 @@ const useNoticesVisibilityQueryRaw = function < T >(
 		queryKey: [ 'stats', 'notices-visibility', 'raw', siteId ],
 		queryFn: () => queryNotices( siteId ),
 		select,
+		staleTime: 1000 * 30, // 30 seconds
 		retry: 1,
 		retryDelay: 3 * 1000, // 3 seconds,
 	} );

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -33,6 +33,7 @@ const CONFLICT_NOTICE_ID_GROUPS: Record< string, Array< NoticeIdType > > = {
 		'commercial_site_upgrade',
 		'tier_upgrade',
 	],
+	excluded: [ 'focus_jetpack_purchase' ],
 };
 
 /**
@@ -65,24 +66,33 @@ const queryNotices = async function ( siteId: number | null ): Promise< Notices 
 
 const useNoticesVisibilityQueryRaw = function < T >(
 	siteId: number | null,
-	select?: ( payload: Notices ) => T
+	select?: ( payload: Notices ) => T,
+	staleTime?: number
 ) {
 	return useQuery( {
 		queryKey: [ 'stats', 'notices-visibility', 'raw', siteId ],
 		queryFn: () => queryNotices( siteId ),
 		select,
-		staleTime: 1000 * 30, // 30 seconds
+		staleTime: staleTime !== undefined ? staleTime : 1000 * 30, // custom or 30 seconds
 		retry: 1,
 		retryDelay: 3 * 1000, // 3 seconds,
 	} );
 };
 
-export function useNoticeVisibilityQuery( siteId: number | null, noticeId: NoticeIdType ) {
+export function useNoticeVisibilityQuery(
+	siteId: number | null,
+	noticeId: NoticeIdType,
+	staleTime?: number
+) {
 	const selectVisibilityForSingleNotice = ( payload: Notices ) => {
 		payload = processConflictNotices( payload );
 		return !! payload?.[ noticeId ];
 	};
-	return useNoticesVisibilityQueryRaw< boolean >( siteId, selectVisibilityForSingleNotice );
+	return useNoticesVisibilityQueryRaw< boolean >(
+		siteId,
+		selectVisibilityForSingleNotice,
+		staleTime
+	);
 }
 
 export function useNoticesVisibilityQuery( siteId: number | null ) {

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -11,6 +11,7 @@ import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import useNoticeVisibilityMutation from 'calypso/my-sites/stats/hooks/use-notice-visibility-mutation';
+import { useNoticeVisibilityQuery } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
 import gotoCheckoutPage from './stats-purchase-checkout-redirect';
@@ -103,7 +104,7 @@ const PersonalPurchase = ( {
 	if ( isNewPurchaseFlowEnabled ) {
 		continueButtonText = translate( 'Contribute and continue' );
 	}
-
+	const { refetch: refetchNotices } = useNoticeVisibilityQuery( siteId, 'focus_jetpack_purchase' );
 	const { mutateAsync: mutateNoticeVisbilityAsync } = useNoticeVisibilityMutation(
 		siteId,
 		'focus_jetpack_purchase',
@@ -133,14 +134,16 @@ const PersonalPurchase = ( {
 	};
 
 	const handleCheckoutPostponed = () => {
-		mutateNoticeVisbilityAsync().finally( () => {
-			// publish event
-			const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
-			recordTracksEvent( `${ event_from }_stats_purchase_flow_skip_button_clicked` );
+		mutateNoticeVisbilityAsync()
+			.then( refetchNotices )
+			.finally( () => {
+				// publish event
+				const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
+				recordTracksEvent( `${ event_from }_stats_purchase_flow_skip_button_clicked` );
 
-			// redirect to the Traffic page
-			setTimeout( () => page( `/stats/day/${ siteSlug }` ), 250 );
-		} );
+				// redirect to the Traffic page
+				setTimeout( () => page( `/stats/day/${ siteSlug }` ), 250 );
+			} );
 	};
 
 	return (

--- a/client/my-sites/stats/stats-reditect-flow/index.tsx
+++ b/client/my-sites/stats/stats-reditect-flow/index.tsx
@@ -20,7 +20,8 @@ const StatsRedirectFlow = () => {
 		getSiteOption( state, siteId, 'created_at' )
 	) as string;
 
-	const { isFreeOwned, isPWYWOwned, isCommercialOwned } = useStatsPurchases( siteId );
+	const { isFreeOwned, isPWYWOwned, isCommercialOwned, supportCommercialUse } =
+		useStatsPurchases( siteId );
 
 	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
@@ -31,7 +32,7 @@ const StatsRedirectFlow = () => {
 		'focus_jetpack_purchase'
 	);
 
-	const hasPlan = isFreeOwned || isPWYWOwned || isCommercialOwned;
+	const hasPlan = isFreeOwned || isPWYWOwned || isCommercialOwned || supportCommercialUse;
 	// TODO: update the date to the release date when the feature is ready.
 	const qualifiedUser =
 		siteCreatedTimeStamp && new Date( siteCreatedTimeStamp ) > new Date( '2024-01-15' );

--- a/client/my-sites/stats/stats-reditect-flow/index.tsx
+++ b/client/my-sites/stats/stats-reditect-flow/index.tsx
@@ -28,8 +28,7 @@ const StatsRedirectFlow = () => {
 
 	const { isFetching, data: purchaseNotPosponed } = useNoticeVisibilityQuery(
 		siteId,
-		'focus_jetpack_purchase',
-		0
+		'focus_jetpack_purchase'
 	);
 
 	const hasPlan = isFreeOwned || isPWYWOwned || isCommercialOwned;

--- a/client/my-sites/stats/stats-reditect-flow/index.tsx
+++ b/client/my-sites/stats/stats-reditect-flow/index.tsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { useEffect } from 'react';
-import { useDispatch } from 'react-redux'; //useSelector
+import { useDispatch } from 'react-redux';
 import { useNoticeVisibilityQuery } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import { useSelector } from 'calypso/state';
 import { isJetpackSite, getSiteOption, getSiteSlug } from 'calypso/state/sites/selectors';
@@ -11,6 +11,7 @@ import {
 } from 'calypso/state/stats/notices/actions';
 import { isStatsNoticeSettingsFetching } from 'calypso/state/stats/notices/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import useStatsPurchases from '../hooks/use-stats-purchases';
 
 const StatsRedirectFlow = () => {
 	const siteId = useSelector( getSelectedSiteId );
@@ -19,29 +20,34 @@ const StatsRedirectFlow = () => {
 		getSiteOption( state, siteId, 'created_at' )
 	) as string;
 
-	const isCommercial = useSelector( ( state ) => getSiteOption( state, siteId, 'is_commercial' ) );
+	const { isFreeOwned, isPWYWOwned, isCommercialOwned } = useStatsPurchases( siteId );
 
 	const isSiteJetpackNotAtomic = useSelector( ( state ) =>
 		isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } )
 	);
 
-	const { isFetching, data: purchaseRedirect } = useNoticeVisibilityQuery(
+	const { isFetching, data: purchaseNotPosponed } = useNoticeVisibilityQuery(
 		siteId,
-		'focus_jetpack_purchase'
+		'focus_jetpack_purchase',
+		0
 	);
 
+	const hasPlan = isFreeOwned || isPWYWOwned || isCommercialOwned;
 	// TODO: update the date to the release date when the feature is ready.
+	const qualifiedUser =
+		siteCreatedTimeStamp && new Date( siteCreatedTimeStamp ) > new Date( '2024-01-15' );
+
+	// to redirect the user can't have a plan purached and can't have the flag true, if either is true the user either has a plan or is postponing
 	const redirectToPurchase =
 		config.isEnabled( 'stats/checkout-flows-v2' ) &&
 		isSiteJetpackNotAtomic &&
-		purchaseRedirect &&
-		siteCreatedTimeStamp &&
-		new Date( siteCreatedTimeStamp ) > new Date( '2024-01-15' );
+		! hasPlan &&
+		purchaseNotPosponed &&
+		qualifiedUser;
 
 	const isRequesting = useSelector( ( state: object ) => isStatsNoticeSettingsFetching( state ) );
 	const dispatch = useDispatch();
 
-	// Only runs on mount.
 	useEffect( () => {
 		if ( isFetching ) {
 			// when react-query is fetching data
@@ -49,17 +55,15 @@ const StatsRedirectFlow = () => {
 		} else {
 			dispatch(
 				receiveStatNoticeSettings( siteId, {
-					focus_jetpack_purchase: purchaseRedirect,
+					focus_jetpack_purchase: purchaseNotPosponed,
 				} )
 			);
 		}
-	}, [ dispatch, redirectToPurchase, siteId, isFetching, purchaseRedirect ] );
+	}, [ dispatch, redirectToPurchase, siteId, isFetching, purchaseNotPosponed ] );
 
 	// render purchase flow for Jetpack sites created after February 2024
-	if ( ! isRequesting && redirectToPurchase && siteSlug ) {
-		page.redirect(
-			`/stats/purchase/${ siteSlug }?productType=${ isCommercial ? 'commercial' : 'personal' }`
-		);
+	if ( ! isFetching && ! isRequesting && redirectToPurchase && siteSlug ) {
+		page.redirect( `/stats/purchase/${ siteSlug }?productType=commercial` );
 
 		return;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86140

## Proposed Changes

* Include information about owned products to prevent unnecessary redirecting after making a purchase
* Fix a condition after redirecting users clicking on a "skip" button (previously, they were incorrectly redirected to the purchase page again)
* Restoring the type of the page users are redirected to

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* create a JN and connect it
* navigate to the live branch and apply `stats/checkout-flows-v2` feature flag
* navigate to the stats page and verify that you are redirected to the purchase page
* select the conditions at the bottom of the page and navigate to the PWYW page
* click `I will do it later` button (note, there will be a delay that will use a loader in the future)
* verify that you are redirected to the Traffic page
* create another JN page
* with feature flag applied to the Traffic page
* after redirecting, purchase a plan
* verify that you are redirected to the traffic page (I'm not sure if you will be redirected to the live branch, so check the URL)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?