### PR TITLE
BBE: design fixes in signup flow

### DIFF
--- a/client/signup/steps/design-picker/let-us-choose.tsx
+++ b/client/signup/steps/design-picker/let-us-choose.tsx
@@ -1,8 +1,8 @@
-import { translationExists } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { preventWidows } from 'calypso/lib/formatting';
 import type { Design } from '@automattic/design-picker';
 
 interface Props {
@@ -50,17 +50,13 @@ const LetUsChoose = ( { flowName, designs, onSelect }: Props ) => {
 		} );
 	}
 
-	const title = translationExists(
+	const title = translate(
 		"Can't decide? No problem, we can create the perfect design for your site!"
-	)
-		? translate( "Can't decide? No problem, we can create the perfect design for your site!" )
-		: translate(
-				"Can't decide? No problem, our experts can choose the perfect design for your site!"
-		  );
+	);
 
 	return (
 		<LetUsChooseContainer>
-			<div>{ title }</div>
+			<div>{ preventWidows( title ) }</div>
 			<LetUsChooseButton variant="secondary" onClick={ onClick }>
 				{ translate( 'Let us choose' ) }
 			</LetUsChooseButton>

--- a/client/signup/steps/social-profiles/style.scss
+++ b/client/signup/steps/social-profiles/style.scss
@@ -13,4 +13,10 @@
 			flex-basis: 50%;
 		}
 	}
+
+	.step-wrapper.is-horizontal-layout {
+		@include break-small {
+			margin-top: 15vh;
+		}
+	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->

Related to #

## Proposed Changes

* Fixes the top margin of the social profiles step to match the site options step.
* Removes a widow on the design picker step.

| Before | After |
|--------|--------|
| <video src="https://github.com/Automattic/wp-calypso/assets/5436027/c1a86b12-fdc4-4176-8e0b-55e0d584d854"></video> | <video src="https://github.com/Automattic/wp-calypso/assets/5436027/220fc2c1-4ca6-4e30-a09d-7f98c2a9913c"></video>|
|<img width="415" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/6c6f25a3-70ab-46b4-bcfe-4fe66cc0c87f">|<img width="336" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/60a026a6-e866-4641-93b1-dc333c8dc2f0"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me`.
* Confirm that the social profiles step has the same margin as the previous step.
* Confirm that the text on the design picker step does not have a widow.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?