### PR TITLE
 Jetpack Manage: Hide the 'Assign License' stepper when the site is selected in the 'Issue License' and 'Add Payment Method' flow.

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/assign-license-step-progress/index.tsx
@@ -49,6 +49,7 @@ interface Props {
 	currentStep: StepKey;
 	selectedSite?: SiteDetails | null;
 	showDownloadStep?: boolean;
+	showAssignLicenseStep?: boolean;
 	isBundleLicensing?: boolean;
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/controller.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/controller.tsx
@@ -155,7 +155,7 @@ export const paymentMethodAddContext: Callback = ( context, next ) => {
 	const sites = getSites( state );
 	const selectedSite = siteId ? sites?.find( ( site ) => site?.ID === parseInt( siteId ) ) : null;
 	context.primary = isNewCardAdditionEnabled ? (
-		<PaymentMethodAddV2 />
+		<PaymentMethodAddV2 withAssignLicense={ ! selectedSite } />
 	) : (
 		<PaymentMethodAdd selectedSite={ selectedSite } />
 	);

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -160,7 +160,11 @@ export default function IssueLicense( { selectedSite, suggestedProduct }: Assign
 				sidebarNavigation={ <PartnerPortalSidebarNavigation /> }
 			>
 				<LayoutTop>
-					<AssignLicenseStepProgress currentStep={ currentStep } isBundleLicensing />
+					<AssignLicenseStepProgress
+						currentStep={ currentStep }
+						selectedSite={ selectedSite }
+						isBundleLicensing
+					/>
 
 					<LayoutHeader showStickyContent={ showStickyContent }>
 						<Title>{ translate( 'Issue product licenses' ) } </Title>

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/hooks/use-payment-method-stepper.ts
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/hooks/use-payment-method-stepper.ts
@@ -2,7 +2,7 @@ import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 
-export function usePaymentMethodStepper() {
+export function usePaymentMethodStepper( { withAssignLicense }: { withAssignLicense?: boolean } ) {
 	const translate = useTranslate();
 
 	const products = ( getQueryArg( window.location.href, 'products' ) ?? '' ).toString();
@@ -14,13 +14,18 @@ export function usePaymentMethodStepper() {
 
 	return useMemo( () => {
 		if ( isIssueLicenseFlow ) {
+			const steps = [
+				translate( 'Select licenses' ),
+				translate( 'Review selections' ),
+				translate( 'Add Payment Method' ),
+			];
+
+			if ( withAssignLicense ) {
+				steps.push( translate( 'Assign licenses' ) );
+			}
+
 			return {
-				steps: [
-					translate( 'Select licenses' ),
-					translate( 'Review selections' ),
-					translate( 'Add Payment Method' ),
-					translate( 'Assign licenses' ),
-				],
+				steps,
 				current: 2,
 			};
 		}
@@ -37,5 +42,5 @@ export function usePaymentMethodStepper() {
 		}
 
 		return null;
-	}, [ isIssueLicenseFlow, isSiteCreationFlow, translate ] );
+	}, [ isIssueLicenseFlow, isSiteCreationFlow, translate, withAssignLicense ] );
 }

--- a/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/index.tsx
@@ -16,13 +16,17 @@ import { usePaymentMethodStepper } from './hooks/use-payment-method-stepper';
 
 import './style.scss';
 
-export default function PaymentMethodListV2() {
+export default function PaymentMethodListV2( {
+	withAssignLicense,
+}: {
+	withAssignLicense: boolean;
+} ) {
 	const translate = useTranslate();
 
 	const title = translate( 'Add new card' );
 	const subtitle = translate( 'You will only be charged for paid licenses you issue.' );
 
-	const stepper = usePaymentMethodStepper();
+	const stepper = usePaymentMethodStepper( { withAssignLicense } );
 
 	return (
 		<Layout


### PR DESCRIPTION
When initiating the "Issue License" flow with a site selected, we currently display an unnecessary "Assign License" step in the process, even though we skip this step and automatically assign the issued license. This pull request aims to fix this issue by hiding the "Assign License" step when a site has already been selected.

Closes https://github.com/Automattic/jetpack-manage/issues/256

## Proposed Changes

* Update the Issue license page to pass the `selectedSite` prop to the `AssignLicenseStepProgress` component, which, in effect, hides the **'Assign License'** step.
* Add a new `withAssignLicense` prop in the `PaymentMethodStepper` hook to consider skipping this step with the Selected Site flow.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Site Selected flow**
* Clear any Payment methods on the Payment method page (`/partner-portal/payment-methods`)
* Use the Jetpack cloud live link below and Go to the Dashboard page (`/dashboard`)
* Issue License to any site by clicking the **'Add'** and **'Issue License'** buttons. This will trigger an Issue License flow with the Site selected.
   <img width="862" alt="Screenshot 2024-01-25 at 5 24 53 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/05eb6bef-bc11-42bd-872f-e01481bf9a70">
* In the Issue License page, confirm that the **'Assign License'** stepper is not visible.
    <img width="1361" alt="Screenshot 2024-01-25 at 5 25 52 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/13f75dc9-689c-4f84-bac2-dcfcc084ff25">
* Proceed to click the **'Review license'** button, and once the Review modal is displayed, click the **'Issue Licenses'** button.
   <img width="1614" alt="Screenshot 2024-01-25 at 5 29 21 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/ec8f2502-156d-4671-8c56-d60cf98c896f">
* In the **'Add Payment Method'** page, confirm that the **'Assign License'** stepper is not visible.
    <img width="1233" alt="Screenshot 2024-01-25 at 5 28 45 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/16397acb-9814-4e21-9e1a-f135c003c563">

**Non-Site Selected flow**
* Directly go to the Issue License page (`/partner-portal/issue-license`)
* Confirm that the **'Assign License'** stepper is visible.
     <img width="1262" alt="Screenshot 2024-01-25 at 5 32 45 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/b23e5136-b656-4d33-ba75-2280b2ae2fbf">
* Proceed to review and issue any licenses.
* In the 'Add Payment Method' page, confirm that the **'Assign License'** stepper is visible.
     <img width="1189" alt="Screenshot 2024-01-25 at 5 33 24 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/fa0ef80e-5a88-4638-b642-e87d03b003f2">


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?