### PR TITLE
Assembler v2: Show wp_block patterns from dotcompatterns

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -1,9 +1,4 @@
-import { isEnabled } from '@automattic/calypso-config';
-
-export const getPatternSourceSiteID = () =>
-	isEnabled( 'pattern-assembler/v2' )
-		? '226765597' // assemblerv2patterns
-		: '174455321'; // dotcompatterns
+export const getPatternSourceSiteID = () => '174455321'; // dotcompatterns
 
 export const PUBLIC_API_URL = 'https://public-api.wordpress.com';
 export const SITE_TAGLINE = 'Site Tagline';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Use Dotcompatterns for `wp_block` patterns

>[!Note]
>Featured patterns are shown initially and the rest are in "Show more patterns".
>They are shown in a different order because the order is by publish date.

### Assembler categories 
|Horizon Before|Horizon After|
|-|-|
|From in Assemblerv2patterns|From Dotcompatterns|
|<img width="1350" alt="Screenshot 2567-01-25 at 19 36 52" src="https://github.com/Automattic/wp-calypso/assets/1881481/f6aac8d3-84ce-4a04-8b48-0f7fd894590c">|<img width="1353" alt="Screenshot 2567-01-25 at 19 35 33" src="https://github.com/Automattic/wp-calypso/assets/1881481/08b77b9b-450f-4b91-9b5d-e8709e45b583">|

### Pages Screen

|Horizon Before|Horizon After|
|-|-|
|Featured pages from in Assemblerv2patterns|Featured pages from Dotcompatterns|
|<img width="1699" alt="Screenshot 2567-01-25 at 19 58 00" src="https://github.com/Automattic/wp-calypso/assets/1881481/9bb2716b-9222-47e5-b8e8-1e21e451e1a0">|<img width="1697" alt="Screenshot 2567-01-25 at 20 06 03" src="https://github.com/Automattic/wp-calypso/assets/1881481/c7270fbf-e349-4f3e-97f9-7052ce25a217">|


You can count the patterns in the valid categories to confirm they all are there:

|Patterns in Assemblerv2patterns|Patterns in Dotcompatterns|
|-|-|
|<img width="240" alt="Screenshot 2567-01-25 at 19 32 01" src="https://github.com/Automattic/wp-calypso/assets/1881481/aa62f1dd-40ca-4a93-b02c-0ed6d0394944">|<img width="242" alt="Screenshot 2567-01-25 at 19 31 34" src="https://github.com/Automattic/wp-calypso/assets/1881481/0aacf7f7-046e-4328-8f58-7105bcde1a49">|

Not moving the patterns in the categories:
- `Link in Bio` 
 because we should migrate there the 19 LIB Virtual themes patterns from this query https://dotcompatterns.wordpress.com/wp-admin/edit.php?s&post_status=publish&post_type=post&cat=208842493
- `Virtual Themes`
 because this category is not required. We are not changing virtual themes as part of this migration.
- `_AssemblerHidden`
 because this feature has to be discussed and implemented first.
- `Page Title`
 because this pattern seems to be a test?

There are the two FAQs patterns in the category `_AssemblerHidden` that are not moved for now:

<img width="962" alt="Screenshot 2567-01-25 at 19 50 12" src="https://github.com/Automattic/wp-calypso/assets/1881481/93db2011-1b31-4ad4-8f2f-39ba1b2f0249">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler with the param `flags=pattern-assembler/v2`
* Verify you see the same patterns as in horizon.wordpress.com

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?