### PR TITLE
Different heading for continue as user in signup

### DIFF
--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, englishLocales } from '@automattic/i18n-utils';
 import { isNewsletterFlow, isHostingSignupFlow } from '@automattic/onboarding';
 import { isMobile } from '@automattic/viewport';
 import { Button } from '@wordpress/components';
@@ -466,10 +466,13 @@ export class UserStep extends Component {
 			wccomFrom,
 			isSocialFirst,
 			userLoggedIn,
+			locale,
 		} = this.props;
 
 		if ( userLoggedIn ) {
-			return translate( 'Is that you?' );
+			if ( englishLocales.includes( locale ) ) {
+				return translate( 'Is that you?' );
+			}
 		}
 
 		if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -458,7 +458,19 @@ export class UserStep extends Component {
 	}
 
 	getHeaderText() {
-		const { flowName, oauth2Client, translate, headerText, wccomFrom, isSocialFirst } = this.props;
+		const {
+			flowName,
+			oauth2Client,
+			translate,
+			headerText,
+			wccomFrom,
+			isSocialFirst,
+			userLoggedIn,
+		} = this.props;
+
+		if ( userLoggedIn ) {
+			return translate( 'Is that you?' );
+		}
 
 		if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {
 			return translate( 'Sign up for Crowdsignal' );

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -471,7 +471,7 @@ export class UserStep extends Component {
 
 		if ( userLoggedIn ) {
 			if ( englishLocales.includes( locale ) ) {
-				return translate( 'Is that you?' );
+				return translate( 'Is this you?' );
 			}
 		}
 


### PR DESCRIPTION
Context: pdt2If-15A-p2#comment-719

## What

If you try to signup while logged in, you see

![image](https://github.com/Automattic/wp-calypso/assets/52076348/049326c7-15a7-4e99-bbe8-f4d345cb10ae)

Buy you are already signed up, and this could be confusing.

## Solution

![image](https://github.com/Automattic/wp-calypso/assets/52076348/273f3b3a-9bd6-4669-8b46-0e7c25b6f81f)

## Testing 

1. Visit `[Live Link]/start/hosting/user-social?ref=developer-lp&flow=new-hosted-site`
2. Be sure to be logged in and check the heading
3. Check that the translation check works

Fixes https://github.com/Automattic/wp-calypso/issues/86806