### PR TITLE
Assembler: fix issue when sometimes pattern order is reversed

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-category-patterns-map.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-category-patterns-map.ts
@@ -35,7 +35,7 @@ const useCategoryPatternsMap = ( patterns: Pattern[] ) => {
 			}
 		};
 
-		patterns.reverse().forEach( ( pattern ) => {
+		[ ...patterns ].reverse().forEach( ( pattern ) => {
 			Object.keys( pattern.categories ).forEach( ( category ) => {
 				const isPage = isPagePattern( pattern );
 


### PR DESCRIPTION
## Proposed Changes

Sometimes, I noticed that the order of patterns in each category suddenly got reversed. This is not easily reproducible, but the issue is real.

This is because we call `patterns.reverse()`, which modifies the original array. Cloning the original array before reversing should fix the issue.

## Testing Instructions

Smoke test Assembler; verify that there is no issue.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?