### PR TITLE
POC: Dynamic theme tiers approach for Calypso

### DIFF
--- a/client/components/data/query-themes/index.jsx
+++ b/client/components/data/query-themes/index.jsx
@@ -1,7 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import PropTypes from 'prop-types';
 import { useEffect } from 'react';
-import { THEME_TIERS } from 'calypso/components/theme-tier/constants';
 import { useDispatch, useSelector } from 'calypso/state';
 import { requestThemes } from 'calypso/state/themes/actions';
 import { getThemesForQuery, isRequestingThemesForQuery } from 'calypso/state/themes/selectors';
@@ -34,7 +33,7 @@ QueryThemes.propTypes = {
 		search: PropTypes.string,
 		// The tier to look for -- 'free', 'premium', 'marketplace', or '' (for all themes)
 		tier: isEnabled( 'themes/tiers' )
-			? PropTypes.oneOf( [ '', ...Object.keys( THEME_TIERS ) ] )
+			? PropTypes.string
 			: PropTypes.oneOf( [ '', 'free', 'premium', 'marketplace' ] ),
 		// Comma-separated list of filters; see my-sites/themes/theme-filters
 		filter: PropTypes.string,

--- a/client/components/theme-tier/constants.js
+++ b/client/components/theme-tier/constants.js
@@ -17,6 +17,7 @@ import { translate } from 'i18n-calypso';
  * @property {string} label The translated label of the theme tier.
  * @property {string} minimumUpsellPlan The minimum plan required to activate a theme belonging to the tier. Used for upselling purposes.
  */
+// Once if the tier URL path thingy is resolved we could remove this file.
 export const THEME_TIERS = {
 	free: {
 		label: translate( 'Free' ),

--- a/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
+++ b/client/components/theme-tier/theme-tier-badge/theme-tier-upgrade-badge.js
@@ -4,7 +4,6 @@ import { Plans } from '@automattic/data-stores';
 import { createInterpolateElement } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import { useThemeTierForTheme } from 'calypso/state/themes/hooks/use-theme-tier-for-theme';
-import { THEME_TIERS } from '../constants';
 import ThemeTierBadgeCheckoutLink from './theme-tier-badge-checkout-link';
 import { useThemeTierBadgeContext } from './theme-tier-badge-context';
 import ThemeTierBadgeTracker from './theme-tier-badge-tracker';
@@ -15,7 +14,7 @@ export default function ThemeTierUpgradeBadge() {
 	const { themeId } = useThemeTierBadgeContext();
 	const themeTier = useThemeTierForTheme( themeId );
 
-	const tierMinimumUpsellPlan = THEME_TIERS[ themeTier?.slug ]?.minimumUpsellPlan;
+	const tierMinimumUpsellPlan = themeTier?.minimumUpsellPlan;
 	const mappedPlan = getPlan( tierMinimumUpsellPlan );
 	const planPathSlug = mappedPlan?.getPathSlug();
 

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -271,7 +271,7 @@ ThemesList.propTypes = {
 	] ),
 	siteId: PropTypes.number,
 	searchTerm: PropTypes.string,
-	tier: PropTypes.oneOf( [ '', 'free', 'premium', 'marketplace' ] ),
+	tier: PropTypes.string,
 	upsellCardDisplayed: PropTypes.func,
 	children: PropTypes.node,
 };

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -46,7 +46,6 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import PremiumGlobalStylesUpgradeModal from 'calypso/components/premium-global-styles-upgrade-modal';
 import SectionHeader from 'calypso/components/section-header';
-import { THEME_TIERS } from 'calypso/components/theme-tier/constants';
 import ThemeTierBadge from 'calypso/components/theme-tier/theme-tier-badge';
 import ThemeTypeBadge from 'calypso/components/theme-type-badge';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -204,7 +203,7 @@ const BannerUpsellTitle = ( {
 		);
 
 	if ( ! isThemeAllowed ) {
-		switch ( THEME_TIERS[ themeTier.slug ].minimumUpsellPlan ) {
+		switch ( themeTier.minimumUpsellPlan ) {
 			case PLAN_PERSONAL:
 				return translate(
 					'Access this theme for FREE with a %(personalPlanName)s, %(premiumPlanName)s, or %(businessPlanName)s plan!',
@@ -1371,7 +1370,7 @@ class ThemeSheet extends Component {
 			const redirectTo = `/theme/${ themeId }${ section ? '/' + section : '' }/${ siteSlug }`;
 			let plan;
 			if ( ! isThemeAllowed ) {
-				plan = THEME_TIERS[ themeTier.slug ].minimumUpsellPlan;
+				plan = themeTier.minimumUpsellPlan;
 			} else {
 				plan = isExternallyManagedTheme || isBundledSoftwareSet ? PLAN_BUSINESS : PLAN_PREMIUM;
 			}
@@ -1458,7 +1457,7 @@ class ThemeSheet extends Component {
 
 			let upsellNudgePlan;
 			if ( ! isThemeAllowed ) {
-				upsellNudgePlan = THEME_TIERS[ themeTier.slug ].minimumUpsellPlan;
+				upsellNudgePlan = themeTier.minimumUpsellPlan;
 			} else {
 				upsellNudgePlan =
 					isExternallyManagedTheme || isBundledSoftwareSet ? PLAN_BUSINESS : PLAN_PREMIUM;

--- a/client/my-sites/themes/helpers.js
+++ b/client/my-sites/themes/helpers.js
@@ -171,7 +171,9 @@ export function interlaceThemes( wpComThemes, wpOrgThemes, searchTerm, isLastPag
 
 export function getTierRouteParam() {
 	return isEnabled( 'themes/tiers' )
-		? `:tier(${ Object.keys( THEME_TIERS ).join( '|' ) })?`
+		? // We need to come up with some way to handle dynamic tiers. We could either change the route to tier/:tier or
+		  // fetch the tiers from the server and use them to build the route.
+		  `:tier(${ Object.keys( THEME_TIERS ).join( '|' ) })?`
 		: ':tier(free|premium|marketplace)?';
 }
 

--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -4,7 +4,6 @@ import { localize } from 'i18n-calypso';
 import { mapValues, pickBy, flowRight as compose } from 'lodash';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
-import { THEME_TIERS } from 'calypso/components/theme-tier/constants';
 import withIsFSEActive from 'calypso/data/themes/with-is-fse-active';
 import { localizeThemesPath } from 'calypso/my-sites/themes/helpers';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -60,7 +59,7 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 
 			const themeTier = options.themeTier;
 
-			const tierMinimumUpsellPlan = THEME_TIERS[ themeTier?.slug ]?.minimumUpsellPlan;
+			const tierMinimumUpsellPlan = themeTier?.minimumUpsellPlan;
 			const mappedPlan = getPlan( tierMinimumUpsellPlan );
 			const planPathSlug = mappedPlan?.getPathSlug();
 

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -1,6 +1,6 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import config from '@automattic/calypso-config';
-import { FEATURE_INSTALL_THEMES } from '@automattic/calypso-products';
+import { FEATURE_INSTALL_THEMES, getPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { isAssemblerSupported } from '@automattic/design-picker';
 import classNames from 'classnames';
@@ -16,7 +16,6 @@ import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QueryThemeFilters from 'calypso/components/data/query-theme-filters';
 import { SearchThemes, SearchThemesV2 } from 'calypso/components/search-themes';
 import SelectDropdown from 'calypso/components/select-dropdown';
-import { THEME_TIERS } from 'calypso/components/theme-tier/constants';
 import getSiteAssemblerUrl from 'calypso/components/themes-list/get-site-assembler-url';
 import { getOptionLabel } from 'calypso/landing/subscriptions/helpers';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -99,7 +98,7 @@ class ThemeShowcase extends Component {
 
 	static propTypes = {
 		tier: config.isEnabled( 'themes/tiers' )
-			? PropTypes.oneOf( [ '', ...Object.keys( THEME_TIERS ) ] )
+			? PropTypes.string
 			: PropTypes.oneOf( [ '', 'free', 'premium', 'marketplace' ] ),
 		search: PropTypes.string,
 		isCollectionView: PropTypes.bool,
@@ -205,7 +204,7 @@ class ThemeShowcase extends Component {
 				{ value: 'all', label: translate( 'All' ) },
 				...Object.keys( themeTiers ).map( ( tier ) => ( {
 					value: tier,
-					label: THEME_TIERS[ tier ]?.label || tier,
+					label: tier?.minimumUpsellPlan ? getPlan( tier.minimumUpsellPlan )?.getTitle() : tier,
 				} ) ),
 			];
 		}


### PR DESCRIPTION
## Proposed Changes
This POC is the FE/Calypso part. It aims to decouple Calypso from tiers so that it can accept any arbitrary tier and work without breaking or needing code changes.

* At the heart of this POC, all that we're doing is moving the `minimumUpsellPlan` responsibility to the API, which makes more sense from a maintenance point of view.
* We also needed to update some prop types since now they'll contain an unspecified list of strings (or could).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You need to apply the BE changes found here: D135893-code.
* Then just fire up the Calypso Live Link.
* Goto the Theme Showcase with `?flags=themes/tiers`
* Play around with the dropdown.
* Goto the Design Picker `?flags=themes/tiers`.
* Play around with it, make sure the upgrade modals work as expected, and checkout to the correct plan, etc.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?