### PR TITLE
Subscribers Page: Fix subscribers empty view

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -50,11 +50,11 @@ const SubscriberListContainer = ( {
 		if ( ! isLoading && subscribers.length === 0 && page > 1 ) {
 			pageChangeCallback( pages ?? 0 );
 		}
-	}, [ isLoading, subscribers, page, pageChangeCallback ] );
+	}, [ isLoading, subscribers, page, pageChangeCallback, pages ] );
 
 	return (
 		<section className="subscriber-list-container">
-			{ ! isLoading && ( Boolean( grandTotal ) || searchTerm ) && (
+			{ Boolean( grandTotal ) && (
 				<>
 					<div className="subscriber-list-container__header">
 						<span className="subscriber-list-container__title">

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -7,11 +7,16 @@ import { useDebounce } from 'use-debounce';
 import { usePagination } from 'calypso/my-sites/subscribers/hooks';
 import { Subscriber } from 'calypso/my-sites/subscribers/types';
 import { useSelector } from 'calypso/state';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { SubscribersFilterBy, SubscribersSortBy } from '../../constants';
 import useManySubsSite from '../../hooks/use-many-subs-site';
-import { useSubscriberCountQuery, useSubscribersQuery } from '../../queries';
+import {
+	useSubscriberCountQuery,
+	useSubscriberDetailsQuery,
+	useSubscribersQuery,
+} from '../../queries';
 import { migrateSubscribers } from './migrate-subscribers-query';
 
 type SubscribersPageProviderProps = {
@@ -114,11 +119,15 @@ export const SubscribersPageProvider = ( {
 	} );
 	const pages = subscribersQueryResult.data?.pages || 0;
 
+	// Current user is not included in the subscribers list, so we need to remove from the total
 	const { data: subscribersTotals } = useSubscriberCountQuery( siteId );
-	const grandTotal = subscribersTotals?.email_subscribers
-		? // Remove the site owner from the count
-		  subscribersTotals.email_subscribers - 1
-		: 0;
+	const userId = useSelector( getCurrentUserId ) ?? undefined;
+	const { data: isCurrentUserSubscribed } = useSubscriberDetailsQuery( siteId, undefined, userId );
+
+	const grandTotal =
+		isCurrentUserSubscribed && subscribersTotals?.email_subscribers
+			? subscribersTotals.email_subscribers - 1
+			: 0;
 
 	const { pageChangeCallback } = usePagination(
 		pageNumber,

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -11,7 +11,7 @@ import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { SubscribersFilterBy, SubscribersSortBy } from '../../constants';
 import useManySubsSite from '../../hooks/use-many-subs-site';
-import { useSubscribersQuery } from '../../queries';
+import { useSubscriberCountQuery, useSubscribersQuery } from '../../queries';
 import { migrateSubscribers } from './migrate-subscribers-query';
 
 type SubscribersPageProviderProps = {
@@ -112,8 +112,13 @@ export const SubscribersPageProvider = ( {
 		sortTerm,
 		filterOption: subscriberType,
 	} );
-	const grandTotal = subscribersQueryResult.data?.total || 0;
 	const pages = subscribersQueryResult.data?.pages || 0;
+
+	const { data: subscribersTotals } = useSubscriberCountQuery( siteId );
+	const grandTotal = subscribersTotals?.email_subscribers
+		? // Remove the site owner from the count
+		  subscribersTotals.email_subscribers - 1
+		: 0;
 
 	const { pageChangeCallback } = usePagination(
 		pageNumber,

--- a/client/my-sites/subscribers/helpers/index.ts
+++ b/client/my-sites/subscribers/helpers/index.ts
@@ -6,7 +6,8 @@ const getSubscribersCacheKey = (
 	perPage?: number,
 	search?: string,
 	sortTerm?: string,
-	filterOption?: string
+	filterOption?: string,
+	hasManySubscribers?: boolean
 ) => {
 	const cacheKey = [ 'subscribers', siteId ];
 	if ( currentPage ) {
@@ -23,6 +24,9 @@ const getSubscribersCacheKey = (
 	}
 	if ( filterOption ) {
 		cacheKey.push( 'filter-option', filterOption );
+	}
+	if ( hasManySubscribers ) {
+		cacheKey.push( 'many-subscribers' );
 	}
 	return cacheKey;
 };

--- a/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
+++ b/client/my-sites/subscribers/hooks/use-unsubscribe-modal.ts
@@ -8,7 +8,7 @@ import { useRecordRemoveModal } from '../tracks';
 import { Subscriber, SubscriberListArgs } from '../types';
 
 const useUnsubscribeModal = (
-	siteId: number | undefined | null,
+	siteId: number | null,
 	args: SubscriberListArgs,
 	detailsView = false,
 	onSuccess?: () => void

--- a/client/my-sites/subscribers/main.tsx
+++ b/client/my-sites/subscribers/main.tsx
@@ -151,7 +151,7 @@ const SubscribersPage = ( {
 	}, [ siteId ] );
 
 	const { currentSubscriber, onClickUnsubscribe, onConfirmModal, resetSubscriber } =
-		useUnsubscribeModal( selectedSite?.ID, pageArgs );
+		useUnsubscribeModal( selectedSite?.ID ?? null, pageArgs );
 	const onClickView = ( { subscription_id, user_id }: Subscriber ) => {
 		page.show( getSubscriberDetailsUrl( selectedSite?.slug, subscription_id, user_id, pageArgs ) );
 	};

--- a/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
+++ b/client/my-sites/subscribers/mutations/use-subscriber-remove-mutation.ts
@@ -6,24 +6,27 @@ import {
 	getSubscriberDetailsType,
 	getSubscribersCacheKey,
 } from '../helpers';
+import useManySubsSite from '../hooks/use-many-subs-site';
 import { useRecordSubscriberRemoved } from '../tracks';
 import type { SubscriberEndpointResponse, Subscriber, SubscriberListArgs } from '../types';
 
 const useSubscriberRemoveMutation = (
-	siteId: number | undefined | null,
+	siteId: number | null,
 	args: SubscriberListArgs,
 	invalidateDetailsCache = false
 ) => {
 	const { currentPage, perPage = DEFAULT_PER_PAGE, filterOption, searchTerm, sortTerm } = args;
 	const queryClient = useQueryClient();
 	const recordSubscriberRemoved = useRecordSubscriberRemoved();
+	const { hasManySubscribers } = useManySubsSite( siteId );
 	const subscribersCacheKey = getSubscribersCacheKey(
 		siteId,
 		currentPage,
 		perPage,
 		searchTerm,
 		sortTerm,
-		filterOption
+		filterOption,
+		hasManySubscribers
 	);
 
 	return useMutation( {
@@ -94,9 +97,10 @@ const useSubscriberRemoveMutation = (
 								siteId,
 								page + 1,
 								perPage,
-								filterOption,
 								searchTerm,
-								sortTerm
+								sortTerm,
+								filterOption,
+								hasManySubscribers
 							)
 						);
 						if ( nextPageQueryData && nextPageQueryData.subscribers.length ) {
@@ -139,7 +143,15 @@ const useSubscriberRemoveMutation = (
 			if ( context?.previousPages ) {
 				context.previousPages?.forEach( ( previousSubscribers, page ) => {
 					queryClient.setQueryData(
-						getSubscribersCacheKey( siteId, page, perPage, filterOption, searchTerm, sortTerm ),
+						getSubscribersCacheKey(
+							siteId,
+							page,
+							perPage,
+							searchTerm,
+							sortTerm,
+							filterOption,
+							hasManySubscribers
+						),
 						previousSubscribers
 					);
 				} );

--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -26,7 +26,15 @@ const useSubscribersQuery = ( {
 	const shouldFetch = ! isLoading;
 
 	return useQuery< SubscriberEndpointResponse >( {
-		queryKey: getSubscribersCacheKey( siteId, page, perPage, search, sortTerm, filterOption ),
+		queryKey: getSubscribersCacheKey(
+			siteId,
+			page,
+			perPage,
+			search,
+			sortTerm,
+			filterOption,
+			hasManySubscribers
+		),
 		queryFn: () => {
 			// This is a temporary solution until we have a better way to handle this.
 			const pathRoute = hasManySubscribers ? 'subscribers_by_user_type' : 'subscribers';


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/85667

## Proposed Changes

* Change `grandTotal` to use `useSubscriberCountQuery`
  * Check if the current user is subscribed to remove from the count (as the GET /subscribers endpoint always excludes the current user)
* Fix cache key to include `hasManySubscribers`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR to your local
* Go to http://calypso.localhost:3000/subscribers/{site-slug}
* Open a site with no subscribers
* You should see the Subscribers Launchpad
* Open a site with subscribers and search for a non-existent subscriber
* You should see an empty search view
* Perform regression tests on the Subscribers list

<img width="1087" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/584f9e39-5904-4fb9-966d-78062a9462c6">

<img width="1113" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3113712/61c3eb21-300e-4643-b7f6-5a95098c559f">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?