### PR TITLE
DeveloperMe: show developer survey notification

### DIFF
--- a/client/me/developer/main.jsx
+++ b/client/me/developer/main.jsx
@@ -13,7 +13,6 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import withFormBase from 'calypso/me/form-base/with-form-base';
 import ReauthRequired from 'calypso/me/reauth-required';
-import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { successNotice, removeNotice } from 'calypso/state/notices/actions';
 import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
@@ -100,7 +99,7 @@ class Developer extends Component {
 			this.props.removeNotice( this.developerSurveyNoticeId );
 		}
 
-		setTimeout( () => this.props.removeNotice( 'save-user-settings' ), 5000 );
+		setTimeout( () => this.props.removeNotice( 'save-user-settings' ), 3000 );
 	};
 
 	componentDidMount() {
@@ -166,7 +165,6 @@ export default compose(
 			currentUser: getCurrentUser( state ),
 		} ),
 		{
-			recordGoogleEvent,
 			successNotice,
 			removeNotice,
 		}

--- a/client/me/developer/main.jsx
+++ b/client/me/developer/main.jsx
@@ -29,12 +29,13 @@ class Developer extends Component {
 		} );
 	};
 
-	shouldShowDevSurveyNotice = () => {
+	shouldShowDevSurveyNotice = ( isDevAccount ) => {
 		const cookies = cookie.parse( document.cookie );
 
+		const isDevAccountEnabled = isDevAccount ?? this.props.getSetting( 'is_dev_account' );
+
 		return (
-			this.props.getSetting( 'is_dev_account' ) &&
-			! [ 'completed', 'dismissed' ].includes( cookies.developer_survey )
+			isDevAccountEnabled && ! [ 'completed', 'dismissed' ].includes( cookies.developer_survey )
 		);
 	};
 
@@ -84,9 +85,11 @@ class Developer extends Component {
 			enabled: isDevAccount ? 1 : 0,
 		} );
 
-		if ( this.shouldShowDevSurveyNotice() ) {
+		if ( this.shouldShowDevSurveyNotice( isDevAccount ) ) {
 			this.showDevSurveyNotice();
 		}
+
+		setTimeout( () => this.props.removeNotice( 'save-user-settings' ), 5000 );
 	};
 
 	componentDidMount() {
@@ -124,8 +127,6 @@ class Developer extends Component {
 					className="developer__header"
 				/>
 
-				<DeveloperFeatures />
-
 				<form onChange={ this.props.submitForm }>
 					<FormFieldset
 						className={ classnames( 'developer__is_dev_account-fieldset', {
@@ -135,11 +136,13 @@ class Developer extends Component {
 						<ToggleControl
 							disabled={ this.props.isFetchingUserSettings || this.props.isUpdatingUserSettings }
 							checked={ this.props.getSetting( 'is_dev_account' ) }
-							onChange={ () => this.handleToggleIsDevAccount() }
+							onChange={ this.handleToggleIsDevAccount }
 							label={ getIAmDeveloperCopy( this.props.translate ) }
 						/>
 					</FormFieldset>
 				</form>
+
+				<DeveloperFeatures />
 			</Main>
 		);
 	}

--- a/client/me/developer/main.jsx
+++ b/client/me/developer/main.jsx
@@ -23,6 +23,8 @@ import { getIAmDeveloperCopy } from './get-i-am-a-developer-copy';
 import './style.scss';
 
 class Developer extends Component {
+	developerSurveyNoticeId = 'developer-survey';
+
 	getSurveyHref = () => {
 		return 'handle_me';
 	};
@@ -48,8 +50,6 @@ class Developer extends Component {
 	};
 
 	showDevSurveyNotice = () => {
-		const noticeId = 'developer-survey';
-
 		const noticeMessage = this.props.translate(
 			"Hey developer! How do {{i}}you{{/i}} use WordPress.com? Spare a moment? We'd love to hear what you think in a {{surveyLink}}quick survey{{/surveyLink}}.",
 			{
@@ -63,7 +63,7 @@ class Developer extends Component {
 							onClick={ () => {
 								recordTracksEvent( 'calypso_me_developer_survey_clicked' );
 
-								this.props.removeNotice( noticeId );
+								this.props.removeNotice( this.developerSurveyNoticeId );
 							} }
 						/>
 					),
@@ -72,18 +72,19 @@ class Developer extends Component {
 		);
 
 		const noticeProps = {
-			id: noticeId,
+			id: this.developerSurveyNoticeId,
 			isPersistent: true,
 			onDismissClick: () => {
 				recordTracksEvent( 'calypso_me_developer_survey_dismissed' );
 
 				this.setDeveloperSurveyCookie( 'dismissed', 24 * 60 * 60 ); // 1 day
 
-				this.props.removeNotice( noticeId );
+				this.props.removeNotice( this.developerSurveyNoticeId );
 			},
 		};
 
 		this.props.successNotice( noticeMessage, noticeProps );
+		recordTracksEvent( 'calypso_me_developer_survey_impression' );
 	};
 
 	handleToggleIsDevAccount = ( isDevAccount ) => {
@@ -95,6 +96,8 @@ class Developer extends Component {
 
 		if ( this.shouldShowDevSurveyNotice( isDevAccount ) ) {
 			this.showDevSurveyNotice();
+		} else {
+			this.props.removeNotice( this.developerSurveyNoticeId );
 		}
 
 		setTimeout( () => this.props.removeNotice( 'save-user-settings' ), 5000 );

--- a/client/me/developer/main.jsx
+++ b/client/me/developer/main.jsx
@@ -14,6 +14,7 @@ import twoStepAuthorization from 'calypso/lib/two-step-authorization';
 import withFormBase from 'calypso/me/form-base/with-form-base';
 import ReauthRequired from 'calypso/me/reauth-required';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { successNotice, removeNotice } from 'calypso/state/notices/actions';
 import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
 import { DeveloperFeatures } from './features/index';
@@ -22,6 +23,10 @@ import { getIAmDeveloperCopy } from './get-i-am-a-developer-copy';
 import './style.scss';
 
 class Developer extends Component {
+	getSurveyHref = () => {
+		return 'handle_me';
+	};
+
 	setDeveloperSurveyCookie = ( value, maxAge ) => {
 		document.cookie = cookie.serialize( 'developer_survey', value, {
 			path: '/',
@@ -33,9 +38,12 @@ class Developer extends Component {
 		const cookies = cookie.parse( document.cookie );
 
 		const isDevAccountEnabled = isDevAccount ?? this.props.getSetting( 'is_dev_account' );
+		const isEN = this.props.currentUser.localeSlug === 'en';
 
 		return (
-			isDevAccountEnabled && ! [ 'completed', 'dismissed' ].includes( cookies.developer_survey )
+			isEN &&
+			isDevAccountEnabled &&
+			! [ 'completed', 'dismissed' ].includes( cookies.developer_survey )
 		);
 	};
 
@@ -49,7 +57,7 @@ class Developer extends Component {
 					i: <i />,
 					surveyLink: (
 						<a
-							href="handle_me"
+							href={ this.getSurveyHref() }
 							target="_blank"
 							rel="noopener noreferrer"
 							onClick={ () => {
@@ -152,6 +160,7 @@ export default compose(
 	connect(
 		( state ) => ( {
 			isFetchingUserSettings: isFetchingUserSettings( state ),
+			currentUser: getCurrentUser( state ),
 		} ),
 		{
 			recordGoogleEvent,

--- a/client/me/developer/main.jsx
+++ b/client/me/developer/main.jsx
@@ -25,7 +25,7 @@ class Developer extends Component {
 	developerSurveyNoticeId = 'developer-survey';
 
 	getSurveyHref = () => {
-		return 'handle_me';
+		return 'https://wordpressdotcom.survey.fm/developer-survey';
 	};
 
 	setDeveloperSurveyCookie = ( value, maxAge ) => {


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/5290

## Proposed Changes
We'll be creating a survey using [crowdsignal](https://app.crowdsignal.com/dashboard) to collect data and gauge developer interests.

With this PR we are implementing a notice that shows up when users turn on the “I am a developer” toggle in the Developer Features Page.

![Screenshot 2024-01-25 at 14 31 56](https://github.com/Automattic/wp-calypso/assets/5598437/1c8c51df-fc12-4687-876d-3c3f353ec408)


## Testing Instructions
### Simple flow
0. Checkout to this branch
1. Open `http://calypso.localhost:3000/me/developer`
2. Turn off `I am a developer`
3. Assert that you see notification `Settings saved successfully!`
4. Turn on `I am a developer`
5. Assert that you see notification `Settings saved successfully!`
6. Assert that you see notification `Hey developer! How do you use WordPress.com? Spare a moment? We'd love to hear what you think in a quick survey.`
7. Click on `X` (Dismiss) button in the survey notice
8. Assert that track event fired - `calypso_me_developer_survey_dismissed`
9. Assert that `developer_survey=dismissed` cookie is set for 1 day
10. Assert that notice disappeared
11. Turn off and then turn on `I am a developer`
12. Assert that you don't see "Developer survey" notice
13. Let's emulate case when the cookie  `developer_survey=expired` - open browser dev tools and remove it
11. Turn off and then turn on `I am a developer`
12. Assert that you don't see "Developer survey" notice again
13. Now let's click on survey link
14. Assert that the new page `/handle_me` is opened in the new browser's tab
15. Assert that notice disappeared
16. Assert that track event fired - `calypso_me_developer_survey_clicked`
17. Now let's emulate case when the  the survey is filled out - open this page with this query `http://calypso.localhost:3000/me/developer?survey=completed`
18. Assert that you got cookie `developer_survey=completed` with maxAge as 1 year
19. Assert that you see `Thank you for your feedback!` notice.
11. Turn off and then turn on `I am a developer`
12. Assert that you don't see "Developer survey" notice

### Extra flow
1. Turn on "I am developer"
2. Make sure that you don't have `developer_survey` cookie
3. Reload page
4. Assert that you see `Hey developer! How do you use WordPress.com? Spare a moment? We'd love to hear what you think in a quick survey.`
5. Dismiss the notice
3. Reload page
4. Assert that you don't see the notice