### PR TITLE
Related Posts: Update the settings section display

### DIFF
--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -82,13 +82,15 @@ const SiteSettingsTraffic = ( {
 					placeholder={ null }
 				/>
 			) }
-			<Banner
-				showIcon={ false }
-				href={ `/settings/reading/${ siteSlug }` }
-				title={ translate(
-					'Looking for the Related Posts settings? We have moved them to the Reading settings section'
-				) }
-			/>
+			{ isAdmin && (
+				<Banner
+					showIcon={ false }
+					href={ `/settings/reading/${ siteSlug }` }
+					title={ translate(
+						'Looking for the Related Posts settings? We have moved them to the Reading settings section'
+					) }
+				/>
+			) }
 			{ ! isJetpack && isAdmin && config.isEnabled( 'cloudflare' ) && (
 				<CloudflareAnalyticsSettings />
 			) }

--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -6,6 +6,7 @@ import { connect } from 'react-redux';
 import blazeIllustration from 'calypso/assets/images/customer-home/illustration--blaze.svg';
 import PromoCardBlock from 'calypso/blocks/promo-card-block';
 import AsyncLoad from 'calypso/components/async-load';
+import Banner from 'calypso/components/banner';
 import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -81,6 +82,13 @@ const SiteSettingsTraffic = ( {
 					placeholder={ null }
 				/>
 			) }
+			<Banner
+				showIcon={ false }
+				href={ `/settings/reading/${ siteSlug }` }
+				title={ translate(
+					'Looking for the Related Posts settings? We have moved them to the Reading settings section'
+				) }
+			/>
 			{ ! isJetpack && isAdmin && config.isEnabled( 'cloudflare' ) && (
 				<CloudflareAnalyticsSettings />
 			) }

--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -1,4 +1,5 @@
 import config from '@automattic/calypso-config';
+import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { pick } from 'lodash';
 import { useEffect } from 'react';
@@ -6,7 +7,6 @@ import { connect } from 'react-redux';
 import blazeIllustration from 'calypso/assets/images/customer-home/illustration--blaze.svg';
 import PromoCardBlock from 'calypso/blocks/promo-card-block';
 import AsyncLoad from 'calypso/components/async-load';
-import Banner from 'calypso/components/banner';
 import EmptyContent from 'calypso/components/empty-content';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
@@ -16,6 +16,7 @@ import JetpackDevModeNotice from 'calypso/my-sites/site-settings/jetpack-dev-mod
 import JetpackSiteStats from 'calypso/my-sites/site-settings/jetpack-site-stats';
 import SeoSettingsHelpCard from 'calypso/my-sites/site-settings/seo-settings/help';
 import SiteVerification from 'calypso/my-sites/site-settings/seo-settings/site-verification';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import Shortlinks from 'calypso/my-sites/site-settings/shortlinks';
 import Sitemaps from 'calypso/my-sites/site-settings/sitemaps';
 import wrapSettingsForm from 'calypso/my-sites/site-settings/wrap-settings-form';
@@ -83,13 +84,24 @@ const SiteSettingsTraffic = ( {
 				/>
 			) }
 			{ isAdmin && (
-				<Banner
-					showIcon={ false }
-					href={ `/settings/reading/${ siteSlug }#related-posts-settings` }
-					title={ translate(
-						'Looking for the Related Posts settings? We have moved them to the Reading settings section'
-					) }
-				/>
+				<>
+					<SettingsSectionHeader
+						id="related-posts-settings"
+						title={ translate( 'Related posts' ) }
+					/>
+					<Card className="site-settings__card">
+						<em>
+							{ translate(
+								'Related posts configuration has moved to the {{a}}Settings > Reading{{/a}}.',
+								{
+									components: {
+										a: <a href={ `/settings/reading/${ siteSlug }#related-posts-settings` } />,
+									},
+								}
+							) }
+						</em>
+					</Card>
+				</>
 			) }
 			{ ! isJetpack && isAdmin && config.isEnabled( 'cloudflare' ) && (
 				<CloudflareAnalyticsSettings />

--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -85,7 +85,7 @@ const SiteSettingsTraffic = ( {
 			{ isAdmin && (
 				<Banner
 					showIcon={ false }
-					href={ `/settings/reading/${ siteSlug }` }
+					href={ `/settings/reading/${ siteSlug }#related-posts-settings` }
 					title={ translate(
 						'Looking for the Related Posts settings? We have moved them to the Reading settings section'
 					) }

--- a/client/my-sites/marketing/traffic/index.js
+++ b/client/my-sites/marketing/traffic/index.js
@@ -13,7 +13,6 @@ import CloudflareAnalyticsSettings from 'calypso/my-sites/site-settings/analytic
 import AnalyticsSettings from 'calypso/my-sites/site-settings/analytics/form-google-analytics';
 import JetpackDevModeNotice from 'calypso/my-sites/site-settings/jetpack-dev-mode-notice';
 import JetpackSiteStats from 'calypso/my-sites/site-settings/jetpack-site-stats';
-import RelatedPosts from 'calypso/my-sites/site-settings/related-posts';
 import SeoSettingsHelpCard from 'calypso/my-sites/site-settings/seo-settings/help';
 import SiteVerification from 'calypso/my-sites/site-settings/seo-settings/site-verification';
 import Shortlinks from 'calypso/my-sites/site-settings/shortlinks';
@@ -82,15 +81,6 @@ const SiteSettingsTraffic = ( {
 					placeholder={ null }
 				/>
 			) }
-			{ isAdmin && (
-				<RelatedPosts
-					onSubmitForm={ handleSubmitForm }
-					handleToggle={ handleAutosavingToggle }
-					isSavingSettings={ isSavingSettings }
-					isRequestingSettings={ isRequestingSettings }
-					fields={ fields }
-				/>
-			) }
 			{ ! isJetpack && isAdmin && config.isEnabled( 'cloudflare' ) && (
 				<CloudflareAnalyticsSettings />
 			) }
@@ -146,20 +136,7 @@ const connectComponent = connect( ( state ) => {
 } );
 
 const getFormSettings = ( settings ) =>
-	pick( settings, [
-		'stats',
-		'admin_bar',
-		'hide_smile',
-		'count_roles',
-		'roles',
-		'jetpack_relatedposts_allowed',
-		'jetpack_relatedposts_enabled',
-		'jetpack_relatedposts_show_context',
-		'jetpack_relatedposts_show_date',
-		'jetpack_relatedposts_show_headline',
-		'jetpack_relatedposts_show_thumbnails',
-		'blog_public',
-	] );
+	pick( settings, [ 'stats', 'admin_bar', 'hide_smile', 'count_roles', 'roles', 'blog_public' ] );
 
 export default connectComponent(
 	localize( wrapSettingsForm( getFormSettings )( SiteSettingsTraffic ) )

--- a/client/my-sites/site-settings/reading-site-settings/RelatedPostsSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/RelatedPostsSetting.tsx
@@ -28,7 +28,7 @@ export const RelatedPostsSetting = ( {
 	const translate = useTranslate();
 	return (
 		<>
-			<FormLabel>{ translate( 'Related Posts' ) }</FormLabel>
+			<FormLabel id="related-posts-settings">{ translate( 'Related Posts' ) }</FormLabel>
 			<RelatedPostsFormFieldset
 				fields={ fields }
 				handleToggle={ handleToggle }

--- a/client/my-sites/site-settings/reading-site-settings/RelatedPostsSetting.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/RelatedPostsSetting.tsx
@@ -15,6 +15,7 @@ type RelatedPostsSettingProps = {
 	handleToggle?: ( field: string ) => ( ( isChecked: boolean ) => void ) | undefined;
 	isRequestingSettings?: boolean;
 	isSavingSettings?: boolean;
+	isJetpackSelfHosted?: boolean | null;
 };
 
 export const RelatedPostsSetting = ( {
@@ -22,6 +23,7 @@ export const RelatedPostsSetting = ( {
 	handleToggle,
 	isRequestingSettings,
 	isSavingSettings,
+	isJetpackSelfHosted,
 }: RelatedPostsSettingProps ) => {
 	const translate = useTranslate();
 	return (
@@ -32,6 +34,7 @@ export const RelatedPostsSetting = ( {
 				handleToggle={ handleToggle }
 				isRequestingSettings={ isRequestingSettings }
 				isSavingSettings={ isSavingSettings }
+				isJetpackSelfHosted={ isJetpackSelfHosted }
 			/>
 		</>
 	);

--- a/client/my-sites/site-settings/reading-site-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/index.tsx
@@ -1,7 +1,9 @@
 import { Card } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
 import SupportInfo from 'calypso/components/support-info';
+import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { useSelector } from 'calypso/state';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -51,6 +53,10 @@ export const SiteSettingsSection = ( {
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
 	const isJetpackSelfHosted = isJetpack && ! isAtomic;
 
+	useEffect( () => {
+		setTimeout( () => scrollToAnchor( { offset: 15 } ) );
+	}, [] );
+
 	return (
 		<>
 			{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }
@@ -77,7 +83,7 @@ export const SiteSettingsSection = ( {
 					disabled={ disabled }
 				/>
 			</Card>
-			<Card className="site-settings__card" id="related-posts-settings">
+			<Card className="site-settings__card">
 				<SupportInfo
 					text={ translate(
 						'The feature helps visitors find more of your content by displaying related posts at the bottom of each post.'

--- a/client/my-sites/site-settings/reading-site-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/index.tsx
@@ -98,6 +98,7 @@ export const SiteSettingsSection = ( {
 					handleToggle={ handleToggle }
 					isRequestingSettings={ isRequestingSettings }
 					isSavingSettings={ isSavingSettings }
+					isJetpackSelfHosted={ isJetpackSelfHosted }
 				/>
 			</Card>
 		</>

--- a/client/my-sites/site-settings/reading-site-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/index.tsx
@@ -1,6 +1,12 @@
 import { Card } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
+import SupportInfo from 'calypso/components/support-info';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import { useSelector } from 'calypso/state';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite as isJetpackSiteSelector } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { BlogPagesSetting, BLOG_PAGES_OPTION } from './BlogPagesSetting';
 import { RelatedPostsSetting } from './RelatedPostsSetting';
 import YourHomepageDisplaysSetting from './YourHomepageDisplaysSetting';
@@ -40,6 +46,10 @@ export const SiteSettingsSection = ( {
 }: SiteSettingsSectionProps ) => {
 	const translate = useTranslate();
 	const { page_for_posts, page_on_front, posts_per_page, show_on_front } = fields;
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) ) || 0;
+	const isJetpack = useSelector( ( state ) => isJetpackSiteSelector( state, siteId ) );
+	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
+	const isJetpackSelfHosted = isJetpack && ! isAtomic;
 
 	return (
 		<>
@@ -68,6 +78,21 @@ export const SiteSettingsSection = ( {
 				/>
 			</Card>
 			<Card className="site-settings__card">
+				<SupportInfo
+					text={ translate(
+						'The feature helps visitors find more of your content by displaying related posts at the bottom of each post.'
+					) }
+					link={
+						isJetpackSelfHosted
+							? localizeUrl( 'https://jetpack.com/support/related-posts/' )
+							: localizeUrl(
+									'https://wordpress.com/support/related-posts/#related-posts-classic-themes'
+							  )
+					}
+					privacyLink={
+						isJetpackSelfHosted ? true : localizeUrl( 'https://automattic.com/privacy/' )
+					}
+				/>
 				<RelatedPostsSetting
 					fields={ fields }
 					handleToggle={ handleToggle }

--- a/client/my-sites/site-settings/reading-site-settings/index.tsx
+++ b/client/my-sites/site-settings/reading-site-settings/index.tsx
@@ -77,7 +77,7 @@ export const SiteSettingsSection = ( {
 					disabled={ disabled }
 				/>
 			</Card>
-			<Card className="site-settings__card">
+			<Card className="site-settings__card" id="related-posts-settings">
 				<SupportInfo
 					text={ translate(
 						'The feature helps visitors find more of your content by displaying related posts at the bottom of each post.'

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -5,7 +5,6 @@ import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
-import SupportInfo from 'calypso/components/support-info';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import { useSelector } from 'calypso/state';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -29,22 +28,6 @@ export const RelatedPostsSetting = ( {
 
 	return (
 		<FormFieldset>
-			<SupportInfo
-				text={ translate(
-					'The feature helps visitors find more of your content by displaying related posts at the bottom of each post.'
-				) }
-				link={
-					isJetpackSelfHosted
-						? localizeUrl( 'https://jetpack.com/support/related-posts/' )
-						: localizeUrl(
-								'https://wordpress.com/support/related-posts/#related-posts-classic-themes'
-						  )
-				}
-				privacyLink={
-					isJetpackSelfHosted ? true : localizeUrl( 'https://automattic.com/privacy/' )
-				}
-			/>
-
 			<ToggleControl
 				checked={ !! fields.jetpack_relatedposts_enabled }
 				disabled={ isRequestingSettings || isSavingSettings }

--- a/client/my-sites/site-settings/related-posts/index.jsx
+++ b/client/my-sites/site-settings/related-posts/index.jsx
@@ -6,10 +6,6 @@ import PropTypes from 'prop-types';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
-import { useSelector } from 'calypso/state';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
-import { isJetpackSite as isJetpackSiteSelector } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import RelatedContentPreview from './related-content-preview';
 
 import './style.scss';
@@ -19,12 +15,9 @@ export const RelatedPostsSetting = ( {
 	handleToggle,
 	isRequestingSettings,
 	isSavingSettings,
+	isJetpackSelfHosted,
 } ) => {
 	const translate = useTranslate();
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) ) || 0;
-	const isJetpack = useSelector( ( state ) => isJetpackSiteSelector( state, siteId ) );
-	const isAtomic = useSelector( ( state ) => isAtomicSite( state, siteId ) );
-	const isJetpackSelfHosted = isJetpack && ! isAtomic;
 
 	return (
 		<FormFieldset>


### PR DESCRIPTION
> [!WARNING]
> Please **do not** merge this PR until we agree on the banner / copy that hasn't been translated yet. (https://github.com/Automattic/wp-calypso/pull/86851#issuecomment-1910434959)

---

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/72720, https://github.com/Automattic/wp-calypso/issues/81903 and https://github.com/Automattic/wp-calypso/issues/84029.

## Proposed Changes

The proposed changes realize steps discussed in https://github.com/Automattic/wp-calypso/issues/72720#issuecomment-1906198915:

* remove "Related Posts" settings section from the `marketing/traffic` page and replace it with `<Card>` that directs users to the `/settings/reading` page - the new home for the "Related Posts" settings
* move `<SupportInfo>` component up to the Reading settings Card to align it with the "Related Posts" heading

https://github.com/Automattic/wp-calypso/assets/25105483/d764f38e-82aa-49a0-9f5c-87db407996ea

Card:

![Markup on 2024-01-26 at 12:10:16](https://github.com/Automattic/wp-calypso/assets/25105483/c4fc1736-6d0e-4b35-b513-69fb40933938)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build it.
2. Navigate to `http://calypso.localhost:3000/marketing/traffic/[site-slug]`.
3. When you scroll down, instead of the Related Posts settings section, you should see there a banner directing users to the Reading settings page.
4. Click the banner. You should be redirected to the Reading settings page.
5. Once on the Reading settings page, try to adjust the settings and save them; consider testing with all three site types (Simple, WoA and self-hosted Jetpack).
6. The ℹ️ icon on the side should be aligned with the "Related Posts" heading and should be working as expected.
7. Check for unexpected JS errors / warnings

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?