### PR TITLE
Stats: Update layout of commercial opt-out form

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -195,7 +195,7 @@ const PersonalPurchase = ( {
 			) }
 
 			{ subscriptionValue === 0 && (
-				<div className={ `${ COMPONENT_CLASS_NAME }__persnal-checklist` }>
+				<div className={ `${ COMPONENT_CLASS_NAME }__personal-checklist` }>
 					<p>
 						<strong>
 							{ translate( 'Please confirm non-commercial usage by checking each box:' ) }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -191,10 +191,23 @@ const StatsSingleItemPagePurchaseFrame = ( {
 	);
 };
 
+const StatsSingleItemCard = ( { children }: { children: React.ReactNode } ) => {
+	return (
+		<div className={ classNames( COMPONENT_CLASS_NAME, `${ COMPONENT_CLASS_NAME }--single` ) }>
+			<Card className={ `${ COMPONENT_CLASS_NAME }__card-parent` }>
+				<div className={ `${ COMPONENT_CLASS_NAME }__card` }>
+					<div className={ `${ COMPONENT_CLASS_NAME }__card-inner--left` }>{ children }</div>
+				</div>
+			</Card>
+		</div>
+	);
+};
+
 export {
 	StatsCommercialPriceDisplay,
 	StatsBenefitsCommercial,
 	StatsBenefitsPersonal,
 	StatsBenefitsFree,
 	StatsSingleItemPagePurchaseFrame,
+	StatsSingleItemCard,
 };

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -310,20 +310,20 @@ const StatsSingleItemPagePurchase = ( {
 function StatsCommercialFlowOptOutForm( { isCommercial, siteSlug } ) {
 	const translate = useTranslate();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+
 	// Checkbox state
 	const [ isAdsChecked, setAdsChecked ] = useState( false );
 	const [ isSellingChecked, setSellingChecked ] = useState( false );
 	const [ isBusinessChecked, setBusinessChecked ] = useState( false );
 	const [ isDonationChecked, setDonationChecked ] = useState( false );
-	// Form handlers
+
 	const handleSwitchToPersonalClick = ( event: React.MouseEvent, isOdysseyStats: boolean ) => {
-		// event.preventDefault(); // Not necessary?
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 		recordTracksEvent( `${ event_from }_stats_purchase_commercial_switch_to_personal_clicked` );
 		setTimeout( () => page( `/stats/purchase/${ siteSlug }?productType=personal` ), 250 );
 	};
+
 	const handleRequestUpdateClick = ( event: React.MouseEvent, isOdysseyStats: boolean ) => {
-		// event.preventDefault(); // Not a real form so probably not necessary?
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 		recordTracksEvent( `${ event_from }_stats_purchase_commercial_update_classification_clicked` );
 
@@ -350,7 +350,7 @@ Thanks\n\n`;
 				'If you think we misidentified your site as commercial, confirm the information below and we’ll take a look.'
 		  )
 		: translate( 'To use a non-commercial license you must agree to the following:' );
-	// Form output
+
 	return (
 		<>
 			<h1>{ translate( 'Continue with a non-commercial license' ) }</h1>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -310,7 +310,7 @@ const StatsSingleItemPagePurchase = ( {
 			</StatsSingleItemPagePurchaseFrame>
 			<StatsSingleItemCard>
 				<h1>Hello from the new card</h1>
-				<StatsCommercialFlowPanel
+				<StatsCommercialFlowCardInsert
 					isCommercial={ isCommercial }
 					isOdysseyStats={ false }
 					siteSlug={ siteSlug }
@@ -334,6 +334,16 @@ function StatsCommercialFlowPanel( { isCommercial, isOdysseyStats, siteSlug } ) 
 				</PanelBody>
 			</Panel>
 		</div>
+	);
+}
+
+function StatsCommercialFlowCardInsert( { isCommercial, isOdysseyStats, siteSlug } ) {
+	return (
+		<StatsCommercialFlowOptOutForm
+			isCommercial={ isCommercial }
+			isOdysseyStats={ isOdysseyStats }
+			siteSlug={ siteSlug }
+		/>
 	);
 }
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -317,13 +317,13 @@ function StatsCommercialFlowOptOutForm( { isCommercial, siteSlug } ) {
 	const [ isBusinessChecked, setBusinessChecked ] = useState( false );
 	const [ isDonationChecked, setDonationChecked ] = useState( false );
 
-	const handleSwitchToPersonalClick = ( event: React.MouseEvent, isOdysseyStats: boolean ) => {
+	const handleSwitchToPersonalClick = () => {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 		recordTracksEvent( `${ event_from }_stats_purchase_commercial_switch_to_personal_clicked` );
 		setTimeout( () => page( `/stats/purchase/${ siteSlug }?productType=personal` ), 250 );
 	};
 
-	const handleRequestUpdateClick = ( event: React.MouseEvent, isOdysseyStats: boolean ) => {
+	const handleRequestUpdateClick = () => {
 		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
 		recordTracksEvent( `${ event_from }_stats_purchase_commercial_update_classification_clicked` );
 
@@ -345,11 +345,17 @@ Thanks\n\n`;
 		setTimeout( () => ( window.location.href = emailHref ), 250 );
 	};
 
+	const isFormSubmissionDisabled = () => {
+		return ! isAdsChecked || ! isSellingChecked || ! isBusinessChecked || ! isDonationChecked;
+	};
+
 	const formMessage = isCommercial
 		? translate(
 				'If you think we misidentified your site as commercial, confirm the information below and we’ll take a look.'
 		  )
 		: translate( 'To use a non-commercial license you must agree to the following:' );
+	const formButton = isCommercial ? translate( 'Request update' ) : translate( 'Continue' );
+	const formHandler = isCommercial ? handleRequestUpdateClick : handleSwitchToPersonalClick;
 
 	return (
 		<>
@@ -400,28 +406,9 @@ Thanks\n\n`;
 				</ul>
 			</div>
 			<div className={ `${ COMPONENT_CLASS_NAME }__personal-checklist-button` }>
-				{ isCommercial ? (
-					<Button
-						variant="secondary"
-						disabled={
-							! isAdsChecked || ! isSellingChecked || ! isBusinessChecked || ! isDonationChecked
-						}
-						onClick={ ( e: React.MouseEvent ) => handleRequestUpdateClick( e, isOdysseyStats ) }
-					>
-						{ translate( 'Request update' ) }
-					</Button>
-				) : (
-					// Otherwise if the site is personal or not identified yet, we should allow products switch.
-					<Button
-						variant="secondary"
-						disabled={
-							! isAdsChecked || ! isSellingChecked || ! isBusinessChecked || ! isDonationChecked
-						}
-						onClick={ ( e: React.MouseEvent ) => handleSwitchToPersonalClick( e, isOdysseyStats ) }
-					>
-						{ translate( 'Choose a non-commercial license' ) }
-					</Button>
-				) }
+				<Button variant="secondary" disabled={ isFormSubmissionDisabled() } onClick={ formHandler }>
+					{ formButton }
+				</Button>
 			</div>
 		</>
 	);

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -185,7 +185,7 @@ const StatsCommercialPurchase = ( {
 			) }
 			{ /** Hide the section for upgrades */ }
 			{ ! isCommercialOwned && (
-				<StatsCommercialFlowOptOutForm
+				<StatsCommercialFlowPanel
 					isCommercial={ isCommercial }
 					isOdysseyStats={ isOdysseyStats }
 					siteSlug={ siteSlug }
@@ -310,7 +310,7 @@ const StatsSingleItemPagePurchase = ( {
 			</StatsSingleItemPagePurchaseFrame>
 			<StatsSingleItemCard>
 				<h1>Hello from the new card</h1>
-				<StatsCommercialFlowOptOutForm
+				<StatsCommercialFlowPanel
 					isCommercial={ isCommercial }
 					isOdysseyStats={ false }
 					siteSlug={ siteSlug }
@@ -319,6 +319,23 @@ const StatsSingleItemPagePurchase = ( {
 		</>
 	);
 };
+
+function StatsCommercialFlowPanel( { isCommercial, isOdysseyStats, siteSlug } ) {
+	const translate = useTranslate();
+	return (
+		<div className={ `${ COMPONENT_CLASS_NAME }__additional-card-panel` }>
+			<Panel className={ `${ COMPONENT_CLASS_NAME }__card-panel` }>
+				<PanelBody title={ translate( 'This is not a commercial site' ) } initialOpen={ false }>
+					<StatsCommercialFlowOptOutForm
+						isCommercial={ isCommercial }
+						isOdysseyStats={ isOdysseyStats }
+						siteSlug={ siteSlug }
+					/>
+				</PanelBody>
+			</Panel>
+		</div>
+	);
+}
 
 function StatsCommercialFlowOptOutForm( { isCommercial, isOdysseyStats, siteSlug } ) {
 	const translate = useTranslate();
@@ -359,97 +376,85 @@ Thanks\n\n`;
 
 	// Form output
 	return (
-		<div className={ `${ COMPONENT_CLASS_NAME }__additional-card-panel` }>
-			<Panel className={ `${ COMPONENT_CLASS_NAME }__card-panel` }>
-				<PanelBody title={ translate( 'This is not a commercial site' ) } initialOpen={ false }>
-					<p>
-						{ translate(
-							'If you think we misidentified your site as commercial, confirm the information below, and we’ll take a look.'
-						) }
-					</p>
-					<div className={ `${ COMPONENT_CLASS_NAME }__persnal-checklist` }>
-						<ul>
-							<li>
-								<CheckboxControl
-									className={ `${ COMPONENT_CLASS_NAME }__control--checkbox` }
-									checked={ isAdsChecked }
-									label={ translate( `I don't have ads on my site` ) }
-									onChange={ ( value: boolean ) => {
-										setAdsChecked( value );
-									} }
-								/>
-							</li>
-							<li>
-								<CheckboxControl
-									className={ `${ COMPONENT_CLASS_NAME }__control--checkbox` }
-									checked={ isSellingChecked }
-									label={ translate( `I don't sell products/services on my site` ) }
-									onChange={ ( value: boolean ) => {
-										setSellingChecked( value );
-									} }
-								/>
-							</li>
-							<li>
-								<CheckboxControl
-									className={ `${ COMPONENT_CLASS_NAME }__control--checkbox` }
-									checked={ isBusinessChecked }
-									label={ translate( `I don't promote a business on my site` ) }
-									onChange={ ( value: boolean ) => {
-										setBusinessChecked( value );
-									} }
-								/>
-							</li>
-							<li>
-								<CheckboxControl
-									className={ `${ COMPONENT_CLASS_NAME }__control--checkbox` }
-									checked={ isDonationChecked }
-									label={ translate( `I don't solicit donations or sponsorships on my site` ) }
-									onChange={ ( value ) => {
-										setDonationChecked( value );
-									} }
-								/>
-							</li>
-						</ul>
-						{ isAdsChecked &&
-							isSellingChecked &&
-							isBusinessChecked &&
-							isDonationChecked &&
-							( isCommercial ? (
-								<Button
-									variant="secondary"
-									disabled={
-										! isAdsChecked ||
-										! isSellingChecked ||
-										! isBusinessChecked ||
-										! isDonationChecked
-									}
-									onClick={ ( e: React.MouseEvent ) =>
-										handleRequestUpdateClick( e, isOdysseyStats )
-									}
-								>
-									{ translate( 'Request update' ) }
-								</Button>
-							) : (
-								// Otherwise if the site is personal or not identified yet, we should allow products switch.
-								<Button
-									variant="secondary"
-									disabled={
-										! isAdsChecked ||
-										! isSellingChecked ||
-										! isBusinessChecked ||
-										! isDonationChecked
-									}
-									onClick={ ( e: React.MouseEvent ) =>
-										handleSwitchToPersonalClick( e, isOdysseyStats )
-									}
-								>
-									{ translate( 'Choose a non-commercial license' ) }
-								</Button>
-							) ) }
-					</div>
-				</PanelBody>
-			</Panel>
-		</div>
+		<>
+			<p>
+				{ translate(
+					'If you think we misidentified your site as commercial, confirm the information below, and we’ll take a look.'
+				) }
+			</p>
+			<div className={ `${ COMPONENT_CLASS_NAME }__persnal-checklist` }>
+				<ul>
+					<li>
+						<CheckboxControl
+							className={ `${ COMPONENT_CLASS_NAME }__control--checkbox` }
+							checked={ isAdsChecked }
+							label={ translate( `I don't have ads on my site` ) }
+							onChange={ ( value: boolean ) => {
+								setAdsChecked( value );
+							} }
+						/>
+					</li>
+					<li>
+						<CheckboxControl
+							className={ `${ COMPONENT_CLASS_NAME }__control--checkbox` }
+							checked={ isSellingChecked }
+							label={ translate( `I don't sell products/services on my site` ) }
+							onChange={ ( value: boolean ) => {
+								setSellingChecked( value );
+							} }
+						/>
+					</li>
+					<li>
+						<CheckboxControl
+							className={ `${ COMPONENT_CLASS_NAME }__control--checkbox` }
+							checked={ isBusinessChecked }
+							label={ translate( `I don't promote a business on my site` ) }
+							onChange={ ( value: boolean ) => {
+								setBusinessChecked( value );
+							} }
+						/>
+					</li>
+					<li>
+						<CheckboxControl
+							className={ `${ COMPONENT_CLASS_NAME }__control--checkbox` }
+							checked={ isDonationChecked }
+							label={ translate( `I don't solicit donations or sponsorships on my site` ) }
+							onChange={ ( value ) => {
+								setDonationChecked( value );
+							} }
+						/>
+					</li>
+				</ul>
+				{ isAdsChecked &&
+					isSellingChecked &&
+					isBusinessChecked &&
+					isDonationChecked &&
+					( isCommercial ? (
+						<Button
+							variant="secondary"
+							disabled={
+								! isAdsChecked || ! isSellingChecked || ! isBusinessChecked || ! isDonationChecked
+							}
+							onClick={ ( e: React.MouseEvent ) => handleRequestUpdateClick( e, isOdysseyStats ) }
+						>
+							{ translate( 'Request update' ) }
+						</Button>
+					) : (
+						// Otherwise if the site is personal or not identified yet, we should allow products switch.
+						<Button
+							variant="secondary"
+							disabled={
+								! isAdsChecked || ! isSellingChecked || ! isBusinessChecked || ! isDonationChecked
+							}
+							onClick={ ( e: React.MouseEvent ) =>
+								handleSwitchToPersonalClick( e, isOdysseyStats )
+							}
+						>
+							{ translate( 'Choose a non-commercial license' ) }
+						</Button>
+					) ) }
+			</div>
+		</>
 	);
 }
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -301,29 +301,16 @@ const StatsSingleItemPagePurchase = ( {
 			{ ! isCommercialOwned && (
 				<StatsSingleItemCard>
 					<h1>Hello from the new card</h1>
-					<StatsCommercialFlowCardInsert
-						isCommercial={ isCommercial }
-						isOdysseyStats={ false }
-						siteSlug={ siteSlug }
-					/>
+					<StatsCommercialFlowOptOutForm isCommercial={ isCommercial } siteSlug={ siteSlug } />
 				</StatsSingleItemCard>
 			) }
 		</>
 	);
 };
 
-function StatsCommercialFlowCardInsert( { isCommercial, isOdysseyStats, siteSlug } ) {
-	return (
-		<StatsCommercialFlowOptOutForm
-			isCommercial={ isCommercial }
-			isOdysseyStats={ isOdysseyStats }
-			siteSlug={ siteSlug }
-		/>
-	);
-}
-
-function StatsCommercialFlowOptOutForm( { isCommercial, isOdysseyStats, siteSlug } ) {
+function StatsCommercialFlowOptOutForm( { isCommercial, siteSlug } ) {
 	const translate = useTranslate();
+	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 	// Checkbox state
 	const [ isAdsChecked, setAdsChecked ] = useState( false );
 	const [ isSellingChecked, setSellingChecked ] = useState( false );

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -310,6 +310,11 @@ const StatsSingleItemPagePurchase = ( {
 			</StatsSingleItemPagePurchaseFrame>
 			<StatsSingleItemCard>
 				<h1>Hello from the new card</h1>
+				<StatsCommercialFlowOptOutForm
+					isCommercial={ isCommercial }
+					isOdysseyStats={ false }
+					siteSlug={ siteSlug }
+				/>
 			</StatsSingleItemCard>
 		</>
 	);

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -398,34 +398,30 @@ Thanks\n\n`;
 						/>
 					</li>
 				</ul>
-				{ isAdsChecked &&
-					isSellingChecked &&
-					isBusinessChecked &&
-					isDonationChecked &&
-					( isCommercial ? (
-						<Button
-							variant="secondary"
-							disabled={
-								! isAdsChecked || ! isSellingChecked || ! isBusinessChecked || ! isDonationChecked
-							}
-							onClick={ ( e: React.MouseEvent ) => handleRequestUpdateClick( e, isOdysseyStats ) }
-						>
-							{ translate( 'Request update' ) }
-						</Button>
-					) : (
-						// Otherwise if the site is personal or not identified yet, we should allow products switch.
-						<Button
-							variant="secondary"
-							disabled={
-								! isAdsChecked || ! isSellingChecked || ! isBusinessChecked || ! isDonationChecked
-							}
-							onClick={ ( e: React.MouseEvent ) =>
-								handleSwitchToPersonalClick( e, isOdysseyStats )
-							}
-						>
-							{ translate( 'Choose a non-commercial license' ) }
-						</Button>
-					) ) }
+			</div>
+			<div className={ `${ COMPONENT_CLASS_NAME }__personal-checklist-button` }>
+				{ isCommercial ? (
+					<Button
+						variant="secondary"
+						disabled={
+							! isAdsChecked || ! isSellingChecked || ! isBusinessChecked || ! isDonationChecked
+						}
+						onClick={ ( e: React.MouseEvent ) => handleRequestUpdateClick( e, isOdysseyStats ) }
+					>
+						{ translate( 'Request update' ) }
+					</Button>
+				) : (
+					// Otherwise if the site is personal or not identified yet, we should allow products switch.
+					<Button
+						variant="secondary"
+						disabled={
+							! isAdsChecked || ! isSellingChecked || ! isBusinessChecked || ! isDonationChecked
+						}
+						onClick={ ( e: React.MouseEvent ) => handleSwitchToPersonalClick( e, isOdysseyStats ) }
+					>
+						{ translate( 'Choose a non-commercial license' ) }
+					</Button>
+				) }
 			</div>
 		</>
 	);

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -129,6 +129,8 @@ const StatsCommercialPurchase = ( {
 		? translate( 'Upgrade and continue' )
 		: translate( 'Purchase' );
 
+	// TODO: Remove isTierUpgradeSliderEnabled code paths.
+
 	return (
 		<>
 			<h1>{ pageTitle }</h1>
@@ -349,6 +351,7 @@ Thanks\n\n`;
 		return ! isAdsChecked || ! isSellingChecked || ! isBusinessChecked || ! isDonationChecked;
 	};
 
+	// Message, button text, and handler differ based on isCommercial flag.
 	const formMessage = isCommercial
 		? translate(
 				'If you think we misidentified your site as commercial, confirm the information below and we’ll take a look.'

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -345,15 +345,16 @@ Thanks\n\n`;
 		setTimeout( () => ( window.location.href = emailHref ), 250 );
 	};
 
+	const formMessage = isCommercial
+		? translate(
+				'If you think we misidentified your site as commercial, confirm the information below and we’ll take a look.'
+		  )
+		: translate( 'To use a non-commercial license you must agree to the following:' );
 	// Form output
 	return (
 		<>
-			<h1>Hello from the new card</h1>
-			<p>
-				{ translate(
-					'If you think we misidentified your site as commercial, confirm the information below, and we’ll take a look.'
-				) }
-			</p>
+			<h1>{ translate( 'Continue with a non-commercial license' ) }</h1>
+			<p>{ formMessage }</p>
 			<div className={ `${ COMPONENT_CLASS_NAME }__personal-checklist` }>
 				<ul>
 					<li>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -293,6 +293,7 @@ const StatsSingleItemPagePurchase = ( {
 	isCommercial,
 }: StatsSingleItemPagePurchaseProps ) => {
 	const adminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
+	const { isCommercialOwned } = useStatsPurchases( siteId );
 
 	return (
 		<>
@@ -308,14 +309,16 @@ const StatsSingleItemPagePurchase = ( {
 					isCommercial={ isCommercial }
 				/>
 			</StatsSingleItemPagePurchaseFrame>
-			<StatsSingleItemCard>
-				<h1>Hello from the new card</h1>
-				<StatsCommercialFlowCardInsert
-					isCommercial={ isCommercial }
-					isOdysseyStats={ false }
-					siteSlug={ siteSlug }
-				/>
-			</StatsSingleItemCard>
+			{ ! isCommercialOwned && (
+				<StatsSingleItemCard>
+					<h1>Hello from the new card</h1>
+					<StatsCommercialFlowCardInsert
+						isCommercial={ isCommercial }
+						isOdysseyStats={ false }
+						siteSlug={ siteSlug }
+					/>
+				</StatsSingleItemCard>
+			) }
 		</>
 	);
 };

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -74,6 +74,11 @@ interface StatsPersonalPurchaseProps {
 	disableFreeProduct: boolean;
 }
 
+interface StatsCommercialFlowOptOutFormProps {
+	siteSlug: string;
+	isCommercial: boolean | null;
+}
+
 const COMPONENT_CLASS_NAME = 'stats-purchase-single';
 const FLAGS_CHECKOUT_FLOWS_V2 = 'stats/checkout-flows-v2';
 
@@ -309,7 +314,10 @@ const StatsSingleItemPagePurchase = ( {
 	);
 };
 
-function StatsCommercialFlowOptOutForm( { isCommercial, siteSlug } ) {
+function StatsCommercialFlowOptOutForm( {
+	isCommercial,
+	siteSlug,
+}: StatsCommercialFlowOptOutFormProps ) {
 	const translate = useTranslate();
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button as CalypsoButton } from '@automattic/components';
-import { Button, Panel, PanelBody, CheckboxControl } from '@wordpress/components';
+import { Button, CheckboxControl } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState, useCallback } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -35,7 +35,6 @@ interface StatsCommercialPurchaseProps {
 	adminUrl: string;
 	redirectUri: string;
 	from: string;
-	isCommercial?: boolean | null;
 }
 
 interface StatsSingleItemPagePurchaseProps {
@@ -104,7 +103,6 @@ const StatsCommercialPurchase = ( {
 	from,
 	adminUrl,
 	redirectUri,
-	isCommercial = true,
 }: StatsCommercialPurchaseProps ) => {
 	const translate = useTranslate();
 	const isWPCOMSite = useSelector( ( state ) => siteId && getIsSiteWPCOM( state, siteId ) );
@@ -182,14 +180,6 @@ const StatsCommercialPurchase = ( {
 						{ continueButtonText }
 					</ButtonComponent>
 				</>
-			) }
-			{ /** Hide the section for upgrades */ }
-			{ ! isCommercialOwned && (
-				<StatsCommercialFlowPanel
-					isCommercial={ isCommercial }
-					isOdysseyStats={ isOdysseyStats }
-					siteSlug={ siteSlug }
-				/>
 			) }
 		</>
 	);
@@ -306,7 +296,6 @@ const StatsSingleItemPagePurchase = ( {
 					adminUrl={ adminUrl || '' }
 					redirectUri={ redirectUri }
 					from={ from }
-					isCommercial={ isCommercial }
 				/>
 			</StatsSingleItemPagePurchaseFrame>
 			{ ! isCommercialOwned && (
@@ -322,23 +311,6 @@ const StatsSingleItemPagePurchase = ( {
 		</>
 	);
 };
-
-function StatsCommercialFlowPanel( { isCommercial, isOdysseyStats, siteSlug } ) {
-	const translate = useTranslate();
-	return (
-		<div className={ `${ COMPONENT_CLASS_NAME }__additional-card-panel` }>
-			<Panel className={ `${ COMPONENT_CLASS_NAME }__card-panel` }>
-				<PanelBody title={ translate( 'This is not a commercial site' ) } initialOpen={ false }>
-					<StatsCommercialFlowOptOutForm
-						isCommercial={ isCommercial }
-						isOdysseyStats={ isOdysseyStats }
-						siteSlug={ siteSlug }
-					/>
-				</PanelBody>
-			</Panel>
-		</div>
-	);
-}
 
 function StatsCommercialFlowCardInsert( { isCommercial, isOdysseyStats, siteSlug } ) {
 	return (

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -300,7 +300,6 @@ const StatsSingleItemPagePurchase = ( {
 			</StatsSingleItemPagePurchaseFrame>
 			{ ! isCommercialOwned && (
 				<StatsSingleItemCard>
-					<h1>Hello from the new card</h1>
 					<StatsCommercialFlowOptOutForm isCommercial={ isCommercial } siteSlug={ siteSlug } />
 				</StatsSingleItemCard>
 			) }
@@ -349,6 +348,7 @@ Thanks\n\n`;
 	// Form output
 	return (
 		<>
+			<h1>Hello from the new card</h1>
 			<p>
 				{ translate(
 					'If you think we misidentified your site as commercial, confirm the information below, and we’ll take a look.'

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -16,6 +16,7 @@ import {
 	StatsCommercialPriceDisplay,
 	StatsBenefitsCommercial,
 	StatsSingleItemPagePurchaseFrame,
+	StatsSingleItemCard,
 } from './stats-purchase-shared';
 import {
 	MIN_STEP_SPLITS,
@@ -415,18 +416,23 @@ const StatsSingleItemPagePurchase = ( {
 	const adminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 
 	return (
-		<StatsSingleItemPagePurchaseFrame>
-			<StatsCommercialPurchase
-				siteId={ siteId }
-				siteSlug={ siteSlug }
-				planValue={ planValue }
-				currencyCode={ currencyCode }
-				adminUrl={ adminUrl || '' }
-				redirectUri={ redirectUri }
-				from={ from }
-				isCommercial={ isCommercial }
-			/>
-		</StatsSingleItemPagePurchaseFrame>
+		<>
+			<StatsSingleItemPagePurchaseFrame>
+				<StatsCommercialPurchase
+					siteId={ siteId }
+					siteSlug={ siteSlug }
+					planValue={ planValue }
+					currencyCode={ currencyCode }
+					adminUrl={ adminUrl || '' }
+					redirectUri={ redirectUri }
+					from={ from }
+					isCommercial={ isCommercial }
+				/>
+			</StatsSingleItemPagePurchaseFrame>
+			<StatsSingleItemCard>
+				<h1>Hello from the new card</h1>
+			</StatsSingleItemCard>
+		</>
 	);
 };
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -354,7 +354,7 @@ Thanks\n\n`;
 					'If you think we misidentified your site as commercial, confirm the information below, and we’ll take a look.'
 				) }
 			</p>
-			<div className={ `${ COMPONENT_CLASS_NAME }__persnal-checklist` }>
+			<div className={ `${ COMPONENT_CLASS_NAME }__personal-checklist` }>
 				<ul>
 					<li>
 						<CheckboxControl

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -548,3 +548,15 @@ $button-padding: 8px 32px;
 		margin: 0;
 	}
 }
+
+.stats-purchase-single__personal-checklist-button {
+	.components-button {
+		&.is-secondary {
+			&[disabled],
+			&:disabled,
+			&.disabled {
+				box-shadow: inset 0 0 0 1px var(--color-neutral-5);
+			}
+		}
+	}
+}

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -15,7 +15,7 @@ $button-padding: 8px 32px;
 
 	// Apply Jetpack dedicated styling upon the Calypso theme base.
 	&:not(.stats-purchase-page--is-wpcom) {
-		.stats-purchase-wizard__persnal-checklist {
+		.stats-purchase-wizard__personal-checklist {
 			.components-checkbox-control__input[type="checkbox"] {
 				&:checked {
 					background-color: var(--studio-jetpack-green-50);
@@ -28,7 +28,7 @@ $button-padding: 8px 32px;
 			}
 		}
 
-		.stats-purchase-single__persnal-checklist {
+		.stats-purchase-single__personal-checklist {
 			.components-checkbox-control__input[type="checkbox"] {
 				&:checked {
 					background-color: var(--studio-jetpack-green-50);
@@ -250,7 +250,7 @@ $button-padding: 8px 32px;
 		background-image: url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyNCIgaGVpZ2h0PSIyNCIgZmlsbD0ibm9uZSI+PG1hc2sgaWQ9ImEiIHdpZHRoPSIxNSIgaGVpZ2h0PSIxNCIgeD0iNCIgeT0iNSIgbWFza1VuaXRzPSJ1c2VyU3BhY2VPblVzZSIgc3R5bGU9Im1hc2stdHlwZTpsdW1pbmFuY2UiPjxwYXRoIGZpbGw9IiNmZmYiIGQ9Ik0xOC45MDcgNi40MSAxNy41MDQgNWwtNS41NjMgNS41OUw2LjM4IDUgNC45NzUgNi40MSAxMC41MzggMTJsLTUuNTYzIDUuNTlMNi4zOCAxOWw1LjU2Mi01LjU5TDE3LjUwNCAxOWwxLjQwMy0xLjQxTDEzLjM0NCAxMmw1LjU2My01LjU5WiIvPjwvbWFzaz48ZyBtYXNrPSJ1cmwoI2EpIj48cGF0aCBmaWxsPSIjRDYzNjM4IiBkPSJNMCAwaDIzLjg4MnYyNEgweiIvPjwvZz48L3N2Zz4=);
 	}
 
-	.stats-purchase-wizard__persnal-checklist {
+	.stats-purchase-wizard__personal-checklist {
 		margin-bottom: 24px;
 	}
 

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -520,6 +520,8 @@ $button-padding: 8px 32px;
 }
 
 .stats-purchase-wizard--single {
+	margin-bottom: 24px;
+
 	h1 {
 		font-family: $font-sf-pro-display;
 		font-size: $font-headline-small;

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -29,6 +29,8 @@ $button-padding: 8px 32px;
 		}
 
 		.stats-purchase-single__personal-checklist {
+			margin-bottom: 24px;
+
 			.components-checkbox-control__input[type="checkbox"] {
 				&:checked {
 					background-color: var(--studio-jetpack-green-50);

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -551,6 +551,7 @@ $button-padding: 8px 32px;
 
 .stats-purchase-single__personal-checklist-button {
 	.components-button {
+		box-shadow: inset 0 0 0 1px #1a1a1a;
 		&.is-secondary {
 			&[disabled],
 			&:disabled,

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -533,59 +533,6 @@ $button-padding: 8px 32px;
 	}
 }
 
-.stats-purchase-single__additional-card-panel {
-	margin-top: 32px;
-	width: var(--stats-purchase-left-min-width); // avoid jumping when tab content is added to the document
-
-	.stats-purchase-single__card-panel {
-		border-radius: 4px;
-	}
-
-	.components-panel__arrow {
-		display: block;
-	}
-
-	.components-panel__body {
-		padding: 0;
-
-		&.is-opened {
-			padding: 12px 16px 12px 24px;
-
-			.components-panel__body-title {
-				.components-panel__body-toggle {
-					padding: 16px; // default to the original padding due to negative margins from an opened panel
-				}
-			}
-		}
-	}
-
-	.components-panel__body-title {
-		.components-panel__body-toggle {
-			padding: 12px 16px 12px 24px;
-			font-size: var(--font-body);
-			line-height: 24px;
-			color: var(--jp-black);
-		}
-	}
-
-	p {
-		color: var(--gray-gray-50);
-		font-size: var(--font-body);
-		font-weight: 400;
-		line-height: 24px;
-	}
-
-	ul {
-		margin-bottom: 24px;
-
-		label {
-			font-size: var(--font-body);
-			line-height: 24px;
-			color: var(--jp-black);
-		}
-	}
-}
-
 .stats-purchase-wizard__actions {
 	display: flex;
 	flex-wrap: wrap;

--- a/client/my-sites/stats/stats-purchase/styles.scss
+++ b/client/my-sites/stats/stats-purchase/styles.scss
@@ -39,6 +39,14 @@ $button-padding: 8px 32px;
 					box-shadow: 0 0 0 var(--wp-admin-border-width-focus) #fff, 0 0 0 calc(2 * var(--wp-admin-border-width-focus)) var(--studio-jetpack-green-50);
 				}
 			}
+
+			.stats-purchase-single__control--checkbox {
+				.components-checkbox-control__label {
+					font-size: var(--font-body);
+					line-height: 24px;
+					color: var(--jp-black);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86834

## Proposed Changes

Moves the opt-out UI from the Panel interface into a new secondary Card interface. Always visible unless the site already has a paid commercial license.

### Before with opt-out inside a Panel control
<img width="585" alt="SCR-20240125-tgbr" src="https://github.com/Automattic/wp-calypso/assets/40267301/081fc115-f43a-4f65-800e-543a6efff6dc">

### After with opt-out inside a Card interface
<img width="582" alt="SCR-20240125-tgie" src="https://github.com/Automattic/wp-calypso/assets/40267301/3ab91eb5-2fe3-4113-bb64-647c11556132">

### Variant for sites already classified as "commercial"
<img width="471" alt="SCR-20240125-thle" src="https://github.com/Automattic/wp-calypso/assets/40267301/ca775d4e-e167-4b23-9a20-27d49b2c314e">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch the Calypso Live link.
* Navigate to the Stats page and click the upgrade banner.
* If you are shown the PWYW UI, click the link to switch to a commercial license.
* Enable the flag as needed: `stats/checkout-flows-v2`
* Confirm the UI matches the above screenshot. No Panel dropdown control, new card UI, button is visible even if checkboxes are unchecked.
* Check all checkboxes and confirm button is enabled.
* Click the button to jump to the PWYW interface.

**Note:** If your site has already been classified as commercial, you'll be prompted to open your email client with a prefilled email title/body provided. In this scenario, the info text and button text will be different (see variant screenshot).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?