### PR TITLE
Stop firing Parsely Pageview on script load

### DIFF
--- a/client/lib/analytics/ad-tracking/parsely.ts
+++ b/client/lib/analytics/ad-tracking/parsely.ts
@@ -8,6 +8,7 @@ import { PARSLEY_SCRIPT_URL } from './constants';
 declare global {
 	interface Window {
 		PARSELY: {
+			autotrack: boolean;
 			conversions: {
 				trackPurchase: ( label: string ) => void;
 			};
@@ -25,7 +26,7 @@ export const loadParselyTracker = async (): Promise< void > => {
 	if ( ! mayWeTrackByTracker( 'parsely' ) ) {
 		throw new Error( 'Tracking is not allowed' );
 	}
-
+	window.PARSELY = { ...window.PARSELY, autotrack: false };
 	// Load the Parsely Tracker script
 	await loadScript( PARSLEY_SCRIPT_URL );
 };


### PR DESCRIPTION
Related to # https://github.com/orgs/Automattic/projects/388/views/1?pane=issue&itemId=50854127

## Proposed Changes

Set autotrack to false to disable Parsely [onload](https://docs.parse.ly/dynamic-tracking/#h-disabling-on-load-tracking) page view event. 

## Testing Instructions

1. Check out branch
2. Set the ad-tracking feature to true
3. Sandbox public api 
4. Enable USE_STORE_SANDBOX 
5. Open Chrome
6. Login to Calypso and navigate to add ons and make a purchase 
7. Navigate to the Chrome Network Tab
8. Filter requests by `parsely` 
9. You should only see `conversion` or `heartbeat` events being fired for Parsely. No Parsely `page view` event should be fired.

![parsely network tab](https://github.com/Automattic/wp-calypso/assets/25906001/3d6a19fb-9fe0-4183-8548-56844596d012)

