### PR TITLE
`Theme`: Render screenshot `alt` text only once the image is loaded

### DIFF
--- a/client/components/theme/index.jsx
+++ b/client/components/theme/index.jsx
@@ -104,6 +104,14 @@ export class Theme extends Component {
 		active: false,
 	};
 
+	constructor( props ) {
+		super( props );
+
+		this.state = {
+			isScreenshotLoaded: false,
+		};
+	}
+
 	prevThemeThumbnailRef = createRef( null );
 	themeThumbnailRef = createRef( null );
 
@@ -154,6 +162,7 @@ export class Theme extends Component {
 	renderScreenshot() {
 		const { isExternallyManagedTheme, selectedStyleVariation, theme, siteSlug, translate } =
 			this.props;
+		const { isScreenshotLoaded } = this.state;
 		const { description, screenshot } = theme;
 
 		if ( theme.isCustomGeneratedTheme ) {
@@ -201,10 +210,13 @@ export class Theme extends Component {
 
 		return (
 			<img
-				alt={ decodeEntities( description ) }
+				alt={ isScreenshotLoaded ? decodeEntities( description ) : '' }
 				className="theme__img"
 				src={ themeImgSrc }
 				srcSet={ `${ themeImgSrcDoubleDpi } 2x` }
+				onLoad={ () => {
+					this.setState( { isScreenshotLoaded: true } );
+				} }
 			/>
 		);
 	}

--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -22,6 +22,7 @@ exports[`Theme rendering with default display buttonContents should match snapsh
           Info
         </div>
         <img
+          alt=""
           class="theme__img"
           src="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360"
           srcset="https://i0.wp.com/s0.wp.com/wp-content/themes/pub/twentyseventeen/screenshot.png?fit=479%2C360&zoom=2 2x"


### PR DESCRIPTION
Fixes #83008

There's a buggy behavior on Firefox, where you get to see the `alt` text while the image is loading. See video on p1697222238957639-slack-C03N25JPCE4 or this image:

![image](https://github.com/Automattic/wp-calypso/assets/545779/8d00690f-2480-43d3-bcc2-98ea6d33b03a)

## Proposed Changes

Keep the screenshot loading state on the component's state, and render the screenshot's `alt` text only once the image is loaded.

## Testing Instructions

- Open the live preview **with Firefox**
- Go to `/themes`
- Check that you don't see the `alt` text while loading

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?