### PR TITLE
Remove the credit applied label and the strikeout prices for the plan upgrade credit.

### DIFF
--- a/client/my-sites/plans-features-main/components/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/plan-notice.tsx
@@ -137,7 +137,7 @@ export default function PlanNotice( props: PlanNoticeProps ) {
 					isReskinned={ true }
 				>
 					{ translate(
-						'We’ve applied the {{b}}%(amountInCurrency)s{{/b}} {{a}}upgrade credit{{/a}} from your current plan as a deduction to your new plan, below. This remaining credit will be applied at checkout if you upgrade today!',
+						'You have {{b}}%(amountInCurrency)s{{/b}} in {{a}}upgrade credits{{/a}} available from your current plan. This credit will be applied to the pricing below at checkout if you upgrade today!',
 						{
 							args: {
 								amountInCurrency: formatCurrency(

--- a/client/my-sites/plans-features-main/components/test/plan-notice.tsx
+++ b/client/my-sites/plans-features-main/components/test/plan-notice.tsx
@@ -152,7 +152,7 @@ describe( '<PlanNotice /> Tests', () => {
 			/>
 		);
 		expect( screen.getByRole( 'status' ).textContent ).toBe(
-			'We’ve applied the $100.00 upgrade credit from your current plan as a deduction to your new plan, below. This remaining credit will be applied at checkout if you upgrade today!'
+			'You have $100.00 in upgrade credits available from your current plan. This credit will be applied to the pricing below at checkout if you upgrade today!'
 		);
 	} );
 

--- a/packages/plans-grid-next/src/components/header-price.tsx
+++ b/packages/plans-grid-next/src/components/header-price.tsx
@@ -144,10 +144,16 @@ const PlanFeatures2023GridHeaderPrice = ( {
 	} = gridPlansIndex[ planSlug ];
 	const isPricedPlan = null !== originalPrice.monthly;
 
-	const isGridPlanDiscounted = Boolean( discountedPrice.monthly );
-	const isAnyVisibleGridPlanDiscounted = visibleGridPlans.some(
-		( { pricing } ) => pricing.discountedPrice.monthly
-	);
+	/**
+	 * If this discount is related to a `Plan upgrade credit`
+	 * then we do not show any discount messaging as per Automattic/martech#1927
+	 * We currently only support the `One time discount` in some currencies
+	 */
+	const isGridPlanOneTimeDiscounted =
+		Boolean( discountedPrice.monthly ) && ! planUpgradeCreditsApplicable;
+	const isAnyVisibleGridPlanOneTimeDiscounted =
+		visibleGridPlans.some( ( { pricing } ) => pricing.discountedPrice.monthly ) &&
+		! planUpgradeCreditsApplicable;
 
 	const isGridPlanOnIntroOffer = introOffer && ! introOffer.isOfferComplete;
 	const isAnyVisibleGridPlanOnIntroOffer = visibleGridPlans.some(
@@ -206,13 +212,11 @@ const PlanFeatures2023GridHeaderPrice = ( {
 		);
 	}
 
-	if ( isGridPlanDiscounted ) {
+	if ( isGridPlanOneTimeDiscounted ) {
 		return (
 			<HeaderPriceContainer>
 				<Badge className="plan-features-2023-grid__badge">
-					{ planUpgradeCreditsApplicable
-						? translate( 'Credit applied' )
-						: translate( 'One time discount' ) }
+					{ translate( 'One time discount' ) }
 				</Badge>
 				<PricesGroup isLargeCurrency={ isLargeCurrency }>
 					<PlanPrice
@@ -238,7 +242,7 @@ const PlanFeatures2023GridHeaderPrice = ( {
 		);
 	}
 
-	if ( isAnyVisibleGridPlanDiscounted || isAnyVisibleGridPlanOnIntroOffer ) {
+	if ( isAnyVisibleGridPlanOneTimeDiscounted || isAnyVisibleGridPlanOnIntroOffer ) {
 		return (
 			<HeaderPriceContainer>
 				<Badge className="plan-features-2023-grid__badge" isHidden={ true }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

- Fixes  Automattic/martech#1927
## Proposed Changes

* As title describes

 | Before | After |
 | - | - |
 | <img width="1075" alt="image" src="https://github.com/Automattic/martech/assets/3422709/e0a0cf52-30ab-4a19-a8c5-5e61bfaefef5"> |  <img width="1075" alt="image" src="https://github.com/Automattic/martech/assets/3422709/01fcda4b-64b4-4756-aa52-04a2bc8d5f72"> |
| <img width="1543" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/9bcb9471-cee9-4b69-a760-e9ca7774508c"> | <img width="1543" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/d7f358d6-1eba-40ce-89bb-e3277a64c479"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase a plan smaller than ecommerce, Go to the `/plans` page and make sure the plan upgrade credit banner on top is visible. But the strikeout pricing and Credits Applied batch isn't.
* Change currency to INR and try to create a new site, in the plans page make sure the one time discount is visible.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?