### PR TITLE
Checkout: add context to "Tax" translation strings

### DIFF
--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -50,7 +50,9 @@ export function getTaxLineItemFromCart( responseCart: ResponseCart ): LineItemTy
 		id: 'tax-line-item',
 		// translators: The label of the taxes line item in checkout
 		label: String(
-			translate( 'Tax', { context: "Shortened form of 'Sales Tax', not 'Business Tax'" } )
+			translate( 'Tax', {
+				context: "Shortened form of 'Sales Tax', not a country-specific tax name",
+			} )
 		),
 		type: 'tax',
 		formattedAmount: formatCurrency( responseCart.total_tax_integer, responseCart.currency, {
@@ -77,7 +79,9 @@ export function getTaxBreakdownLineItemsFromCart( responseCart: ResponseCart ): 
 			const label = taxBreakdownItem.label
 				? `${ taxBreakdownItem.label } (${ taxBreakdownItem.rate_display })`
 				: String(
-						translate( 'Tax', { context: "Shortened form of 'Sales Tax', not 'Business Tax'" } )
+						translate( 'Tax', {
+							context: "Shortened form of 'Sales Tax', not a country-specific tax name",
+						} )
 				  );
 			return {
 				id,

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -49,7 +49,9 @@ export function getTaxLineItemFromCart( responseCart: ResponseCart ): LineItemTy
 	return {
 		id: 'tax-line-item',
 		// translators: The label of the taxes line item in checkout
-		label: String( translate( 'Tax' ) ),
+		label: String(
+			translate( 'Tax', { context: "Shortened form of 'Sales Tax', not 'Business Tax'" } )
+		),
 		type: 'tax',
 		formattedAmount: formatCurrency( responseCart.total_tax_integer, responseCart.currency, {
 			isSmallestUnit: true,
@@ -74,7 +76,9 @@ export function getTaxBreakdownLineItemsFromCart( responseCart: ResponseCart ): 
 			const id = `tax-line-item-${ taxBreakdownItem.label ?? taxBreakdownItem.rate }`;
 			const label = taxBreakdownItem.label
 				? `${ taxBreakdownItem.label } (${ taxBreakdownItem.rate_display })`
-				: String( translate( 'Tax' ) );
+				: String(
+						translate( 'Tax', { context: "Shortened form of 'Sales Tax', not 'Business Tax'" } )
+				  );
 			return {
 				id,
 				label,


### PR DESCRIPTION
The word "tax" can be translated differently depending on the locale of the user/translator. For instance, for a French speaker in France, the more common use of "tax" is in the business tax/VAT context, so "Taxe sur la Valeur Ajoutée" (TVA). However for a French speaker in the US, where VAT isn't a thing, the more common use of "tax" would be in the sales tax context, so "Taxe sur la vente".

To guard against this mistranslation, this PR adds a translator context to the fallback for Checkout "tax" labels, specifying that it should be the more generic "Tax" translation. If an actual tax is being collected, the proper tax name will be returned by our tax partner when calculating taxes and shown to the user.

Similar has been done on the backend in D135669-code and the translation can be viewed here: https://translate.wordpress.com/projects/wpcom/fr/default/?filters%5Bstatus%5D=either&filters%5Boriginal_id%5D=912254&filters%5Btranslation_id%5D=15919682

Front-end changes to fix: https://github.com/Automattic/payments-shilling/issues/2361

**To Test:**
- set your user language to French
- add a product to your cart and visit Checkout
- use a tax location that _doesn't_ collect taxes (e.g. "US 04106")
- verify that any mentions of "Tax" read "Tax" (the context will prevent us from using any existing context-less translations)
- test the current VAT behavior by changing your billing information to "France 70123"
- verify that any mentions of tax read "TVA (20%)"