### PR TITLE
Comments: Allow Filtering Replied Comments 

### DIFF
--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -198,6 +198,7 @@ export class CommentList extends Component {
 							<Comment
 								commentId={ commentId }
 								commentsListQuery={ commentsListQuery }
+								filterUnreplied={ filterUnreplied }
 								isBulkMode={ isBulkMode }
 								isPostView={ isPostView }
 								isSelected={ this.isCommentSelected( commentId ) }

--- a/client/my-sites/comments/comment-list/index.jsx
+++ b/client/my-sites/comments/comment-list/index.jsx
@@ -28,9 +28,11 @@ export class CommentList extends Component {
 		comments: PropTypes.array,
 		commentsCount: PropTypes.number,
 		counts: PropTypes.object,
+		filterUnreplied: PropTypes.bool,
 		order: PropTypes.string,
 		recordChangePage: PropTypes.func,
 		replyComment: PropTypes.func,
+		setFilterUnreplied: PropTypes.func,
 		setOrder: PropTypes.func,
 		siteId: PropTypes.number,
 		status: PropTypes.string,
@@ -130,11 +132,13 @@ export class CommentList extends Component {
 			comments,
 			commentsCount,
 			counts,
+			filterUnreplied,
 			isLoading,
 			isPostView,
 			order,
 			page,
 			postId,
+			setFilterUnreplied,
 			setOrder,
 			siteId,
 			siteFragment,
@@ -172,12 +176,14 @@ export class CommentList extends Component {
 					commentsListQuery={ commentsListQuery }
 					commentsPage={ comments }
 					counts={ counts }
+					filterUnreplied={ filterUnreplied }
 					isBulkMode={ isBulkMode }
 					isPostView={ isPostView }
 					isSelectedAll={ this.isSelectedAll() }
 					order={ order }
 					postId={ postId }
 					selectedComments={ selectedComments }
+					setFilterUnreplied={ setFilterUnreplied }
 					setOrder={ setOrder }
 					siteId={ siteId }
 					siteFragment={ siteFragment }
@@ -233,8 +239,14 @@ export class CommentList extends Component {
 	}
 }
 
-const mapStateToProps = ( state, { order, page, postId, siteId, status } ) => {
-	const comments = getCommentsPage( state, siteId, { order, page, postId, status } );
+const mapStateToProps = ( state, { filterUnreplied, order, page, postId, siteId, status } ) => {
+	const comments = getCommentsPage( state, siteId, {
+		filterUnreplied,
+		order,
+		page,
+		postId,
+		status,
+	} );
 	const counts = getSiteCommentCounts( state, siteId, postId );
 	const commentsCount = get( counts, 'unapproved' === status ? 'pending' : status );
 	const isLoading = typeof comments === 'undefined';

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -380,7 +380,7 @@ export class CommentNavigation extends Component {
 											checked={ filterUnreplied }
 											onChange={ setFilterUnreplied( ! filterUnreplied ) }
 										/>
-										<span>{ translate( 'Only display unreplied comments' ) }</span>
+										<span>{ translate( 'Collapse replied comments' ) }</span>
 									</FormLabel>
 								</FormFieldset>
 							</Popover>

--- a/client/my-sites/comments/comment-navigation/index.jsx
+++ b/client/my-sites/comments/comment-navigation/index.jsx
@@ -1,10 +1,12 @@
-import { Button, Count, Gridicon, SegmentedControl } from '@automattic/components';
+import { Button, Count, Gridicon, Popover, SegmentedControl } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { get, includes, isEqual, map } from 'lodash';
-import { Component } from 'react';
+import { createRef, Component } from 'react';
 import { connect } from 'react-redux';
 import ButtonGroup from 'calypso/components/button-group';
 import FormCheckbox from 'calypso/components/forms/form-checkbox';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormLabel from 'calypso/components/forms/form-label';
 import Search from 'calypso/components/search';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
@@ -45,7 +47,12 @@ export class CommentNavigation extends Component {
 		order: NEWEST_FIRST,
 	};
 
-	shouldComponentUpdate = ( nextProps ) => ! isEqual( this.props, nextProps );
+	state = {
+		showPopover: false,
+	};
+
+	shouldComponentUpdate = ( nextProps, nextState ) =>
+		! isEqual( this.props, nextProps ) || ! isEqual( this.state, nextState );
 
 	componentDidUpdate = ( prevProps ) => {
 		const { commentsListQuery, hasPendingBulkAction, refreshPage } = this.props;
@@ -187,9 +194,20 @@ export class CommentNavigation extends Component {
 		return this.props.toggleSelectAll( this.props.visibleComments );
 	};
 
+	popoverButtonRef = createRef();
+
+	showPopover = () => {
+		this.setState( { showPopover: true } );
+	};
+
+	closePopover = () => {
+		this.setState( { showPopover: false } );
+	};
+
 	render() {
 		const {
 			doSearch,
+			filterUnreplied,
 			hasSearch,
 			hasComments,
 			isBulkMode,
@@ -197,6 +215,7 @@ export class CommentNavigation extends Component {
 			isSelectedAll,
 			query,
 			selectedComments,
+			setFilterUnreplied,
 			setOrder,
 			order,
 			status: queryStatus,
@@ -334,6 +353,37 @@ export class CommentNavigation extends Component {
 										: translate( 'Empty trash' ) }
 								</Button>
 							) }
+						</>
+					) }
+
+					{ hasComments && (
+						<>
+							<Button
+								title={ translate( 'Settings' ) }
+								compact
+								borderless
+								onClick={ this.showPopover }
+								ref={ this.popoverButtonRef }
+								aria-haspopup
+							>
+								<Gridicon icon="cog" />
+							</Button>
+							<Popover
+								onClose={ this.closePopover }
+								context={ this.popoverButtonRef.current }
+								isVisible={ this.state.showPopover }
+								position="top left"
+							>
+								<FormFieldset className="comment-navigation__unreplied-comments">
+									<FormLabel>
+										<FormCheckbox
+											checked={ filterUnreplied }
+											onChange={ setFilterUnreplied( ! filterUnreplied ) }
+										/>
+										<span>{ translate( 'Only display unreplied comments' ) }</span>
+									</FormLabel>
+								</FormFieldset>
+							</Popover>
 						</>
 					) }
 				</CommentNavigationTab>

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -1,6 +1,7 @@
-import { Card } from '@automattic/components';
+import { Card, FoldableCard } from '@automattic/components';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import classNames from 'classnames';
+import { localize } from 'i18n-calypso';
 import { debounce, get, isEqual } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
@@ -15,6 +16,7 @@ import CommentHeader from 'calypso/my-sites/comments/comment/comment-header';
 import CommentReply from 'calypso/my-sites/comments/comment/comment-reply';
 import { getMinimumComment } from 'calypso/my-sites/comments/comment/utils';
 import { getSiteComment } from 'calypso/state/comments/selectors';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -134,45 +136,28 @@ export class Comment extends Component {
 
 	toggleSelected = () => this.props.toggleSelected( this.props.minimumComment );
 
-	render() {
+	renderComment() {
 		const {
 			siteId,
 			postId,
 			commentId,
-			commentIsPending,
 			commentsListQuery,
-			isAtMaxDepth,
 			isBulkMode,
 			isLoading,
 			isPostView,
 			isSelected,
+			isSingularEditMode,
 			redirect,
 			refreshCommentData,
 			updateLastUndo,
-			isSingularEditMode,
 		} = this.props;
 
 		const { isReplyVisible } = this.state;
 
 		const isEditMode = isSingularEditMode && ! isBulkMode;
 
-		const classes = classNames( 'comment', {
-			'is-at-max-depth': isAtMaxDepth,
-			'is-bulk-mode': isBulkMode,
-			'is-edit-mode': isEditMode,
-			'is-placeholder': isLoading,
-			'is-pending': commentIsPending,
-			'is-reply-visible': isReplyVisible,
-		} );
-
 		return (
-			<Card
-				className={ classes }
-				id={ `comment-${ commentId }` }
-				onClick={ isBulkMode ? this.toggleSelected : undefined }
-				onKeyDown={ this.keyDownHandler }
-				ref={ this.storeCardRef }
-			>
+			<>
 				{ refreshCommentData && (
 					<QueryComment commentId={ commentId } siteId={ siteId } forceWpcom />
 				) }
@@ -201,6 +186,66 @@ export class Comment extends Component {
 				{ isEditMode && ! isLoading && (
 					<CommentEdit { ...{ commentId } } toggleEditMode={ this.toggleEditMode } />
 				) }
+			</>
+		);
+	}
+
+	render() {
+		const {
+			commentId,
+			commentIsPending,
+			isAtMaxDepth,
+			isBulkMode,
+			isLoading,
+			isSingularEditMode,
+			isOwnComment,
+			filterUnreplied,
+			hasRepliedToComment,
+			translate,
+		} = this.props;
+
+		const { isReplyVisible } = this.state;
+
+		const isEditMode = isSingularEditMode && ! isBulkMode;
+
+		const classes = classNames( 'comment', {
+			'is-at-max-depth': isAtMaxDepth,
+			'is-bulk-mode': isBulkMode,
+			'is-edit-mode': isEditMode,
+			'is-placeholder': isLoading,
+			'is-pending': commentIsPending,
+			'is-reply-visible': isReplyVisible,
+		} );
+
+		if ( filterUnreplied && ! isBulkMode && ( ! hasRepliedToComment || isOwnComment ) ) {
+			return (
+				<FoldableCard
+					className={ classes }
+					compact
+					header={
+						isOwnComment
+							? translate( 'This is your own comment' )
+							: translate( "You've already replied to this comment" )
+					}
+					id={ `comment-${ commentId }` }
+					onClick={ isBulkMode ? this.toggleSelected : undefined }
+					onKeyDown={ this.keyDownHandler }
+					ref={ this.storeCardRef }
+				>
+					{ this.renderComment() }
+				</FoldableCard>
+			);
+		}
+
+		return (
+			<Card
+				className={ classes }
+				id={ `comment-${ commentId }` }
+				onClick={ isBulkMode ? this.toggleSelected : undefined }
+				onKeyDown={ this.keyDownHandler }
+				ref={ this.storeCardRef }
+			>
+				{ this.renderComment() }
 			</Card>
 		);
 	}
@@ -210,13 +255,16 @@ const mapStateToProps = ( state, { commentId } ) => {
 	const siteId = getSelectedSiteId( state );
 	const comment = getSiteComment( state, siteId, commentId );
 	const commentStatus = get( comment, 'status' );
+	const currentUserId = getCurrentUserId( state );
 	return {
 		siteId,
 		postId: get( comment, 'post.ID' ),
 		commentIsPending: 'unapproved' === commentStatus,
+		hasRepliedToComment: ! get( comment, 'i_replied' ),
 		isLoading: typeof comment === 'undefined',
+		isOwnComment: get( comment, 'author.ID' ) === currentUserId,
 		minimumComment: getMinimumComment( comment ),
 	};
 };
 
-export default connect( mapStateToProps )( Comment );
+export default connect( mapStateToProps )( localize( Comment ) );

--- a/client/my-sites/comments/comment/index.jsx
+++ b/client/my-sites/comments/comment/index.jsx
@@ -192,6 +192,7 @@ export class Comment extends Component {
 
 	render() {
 		const {
+			commentHasNoReply,
 			commentId,
 			commentIsPending,
 			isAtMaxDepth,
@@ -200,7 +201,6 @@ export class Comment extends Component {
 			isSingularEditMode,
 			isOwnComment,
 			filterUnreplied,
-			hasRepliedToComment,
 			translate,
 		} = this.props;
 
@@ -217,7 +217,7 @@ export class Comment extends Component {
 			'is-reply-visible': isReplyVisible,
 		} );
 
-		if ( filterUnreplied && ! isBulkMode && ( ! hasRepliedToComment || isOwnComment ) ) {
+		if ( filterUnreplied && ! isBulkMode && ( ! commentHasNoReply || isOwnComment ) ) {
 			return (
 				<FoldableCard
 					className={ classes }
@@ -260,7 +260,7 @@ const mapStateToProps = ( state, { commentId } ) => {
 		siteId,
 		postId: get( comment, 'post.ID' ),
 		commentIsPending: 'unapproved' === commentStatus,
-		hasRepliedToComment: ! get( comment, 'i_replied' ),
+		commentHasNoReply: ! get( comment, 'i_replied' ),
 		isLoading: typeof comment === 'undefined',
 		isOwnComment: get( comment, 'author.ID' ) === currentUserId,
 		minimumComment: getMinimumComment( comment ),

--- a/client/my-sites/comments/comment/style.scss
+++ b/client/my-sites/comments/comment/style.scss
@@ -35,6 +35,19 @@
 	transition: margin 0.15s linear;
 }
 
+// Collapsed Comment
+
+.comment.foldable-card {
+	.foldable-card__main {
+		color: var(--color-text-subtle);
+		font-size: $font-body-extra-small;
+	}
+
+	&.is-expanded .foldable-card__content {
+		padding: 0;
+	}
+}
+
 // Comment Header Block
 
 .comment__header {

--- a/client/my-sites/comments/constants.js
+++ b/client/my-sites/comments/constants.js
@@ -6,3 +6,4 @@ export const COMMENTS_PER_PAGE = 20;
 // and relying on the fact that more recent comments have higher ID values.
 export const NEWEST_FIRST = 'desc';
 export const OLDEST_FIRST = 'asc';
+

--- a/client/my-sites/comments/constants.js
+++ b/client/my-sites/comments/constants.js
@@ -6,4 +6,3 @@ export const COMMENTS_PER_PAGE = 20;
 // and relying on the fact that more recent comments have higher ID values.
 export const NEWEST_FIRST = 'desc';
 export const OLDEST_FIRST = 'asc';
-

--- a/client/my-sites/comments/main.jsx
+++ b/client/my-sites/comments/main.jsx
@@ -41,9 +41,12 @@ export class CommentsManagement extends Component {
 
 	state = {
 		order: NEWEST_FIRST,
+		filterUnreplied: false,
 	};
 
 	setOrder = ( order ) => () => this.setState( { order } );
+
+	setFilterUnreplied = ( filterUnreplied ) => () => this.setState( { filterUnreplied } );
 
 	render() {
 		const {
@@ -61,7 +64,7 @@ export class CommentsManagement extends Component {
 			translate,
 			hideModerationTips,
 		} = this.props;
-		const { order } = this.state;
+		const { filterUnreplied, order } = this.state;
 
 		return (
 			<Main className="comments" wideLayout>
@@ -102,9 +105,11 @@ export class CommentsManagement extends Component {
 						<CommentList
 							key={ `${ siteId }-${ status }` }
 							changePage={ changePage }
+							filterUnreplied={ filterUnreplied }
 							order={ order }
 							page={ page }
 							postId={ postId }
+							setFilterUnreplied={ this.setFilterUnreplied }
 							setOrder={ this.setOrder }
 							siteId={ siteId }
 							siteFragment={ siteFragment }

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -9,10 +9,8 @@
 		}
 
 		.comment-navigation__open-bulk {
-			padding-top: 9px;
-			position: absolute;
-			right: 0;
-			top: 0;
+			justify-content: center;
+			padding-top: 0;
 		}
 	}
 }

--- a/client/my-sites/comments/style.scss
+++ b/client/my-sites/comments/style.scss
@@ -74,6 +74,14 @@
 	}
 }
 
+.comment-navigation__unreplied-comments.form-fieldset {
+	margin: 12px;
+
+	.form-label {
+		margin: 0;
+	}
+}
+
 .button.comment-navigation__button-empty {
 	margin-left: 8px;
 }


### PR DESCRIPTION
Fixes #2082

## Proposed Changes

The idea here is to make it easier for bloggers to engage with their audience - it's often quite difficult to keep track of who you've already replied to. 

This is mostly a proof-of-concept, and I was initially a little sceptical of this approach. However, I've been trying it for a few days, and I actually really like it. :) I've even missed a few comments that I didn't realise until now! 

## Testing Instructions

1. Write some comments on your account and anonymously
2. Reply to a couple
3. Head to My Sites > Comments
4. Click the Settings button in the top right and "Collapse replied comments"
5. ...does it work? 

<img width="1153" alt="Screenshot 2024-01-25 at 22 24 40" src="https://github.com/Automattic/wp-calypso/assets/43215253/2445b63e-0cbd-4694-9b04-c4326ae592e5">

Although we could just filter out unreplied comments and not show them at all, that a) risks being confusing for the user since "Unreplied" isn't really a status per se and b) breaks pagination. For that, you'd need to change the endpoint, and there's two issues with that:

1. It's not open-source so I can't do so 😁 
2. Even if it were, there is no in-built way within WordPress to gather unreplied comments. It'd probably be a heavy custom function that would have to do multiple loops until it fills the number required for pagination. 

I'm really not sure who to ping for this - it doesn't look like this section of Calypso has been updated for a while. @tyxla Sorry to default to you (!!), but would you mind helping me to get the ball rolling on this? :) 

@supernovia Hi Velda! 👋 If you get a minute, I'd love your thoughts. I've found this quite helpful when testing - do you think others might? 