### PR TITLE
Checkout: Add CheckoutSummaryFeaturedList to wp-checkout

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -82,7 +82,7 @@ import JetpackAkismetCheckoutSidebarPlanUpsell from './jetpack-akismet-checkout-
 import BeforeSubmitCheckoutHeader from './payment-method-step';
 import SecondaryCartPromotions from './secondary-cart-promotions';
 import WPCheckoutOrderReview from './wp-checkout-order-review';
-import { WPCheckoutOrderSummary } from './wp-checkout-order-summary';
+import { CheckoutSummaryFeaturedList, WPCheckoutOrderSummary } from './wp-checkout-order-summary';
 import WPContactForm from './wp-contact-form';
 import WPContactFormSummary from './wp-contact-form-summary';
 import type { OnChangeItemVariant } from './item-variation-picker';
@@ -478,6 +478,14 @@ export default function WPCheckout( {
 								) }
 
 								<WPCheckoutOrderSummary siteId={ siteId } onChangeSelection={ changeSelection } />
+								{ hasCheckoutVersion( '2' ) && (
+									<CheckoutSummaryFeaturedList
+										responseCart={ responseCart }
+										siteId={ siteId }
+										isCartUpdating={ FormStatus.VALIDATING === formStatus }
+										onChangeSelection={ changeSelection }
+									/>
+								) }
 								<CheckoutSidebarNudge responseCart={ responseCart } />
 								<SecondaryCartPromotions
 									responseCart={ responseCart }

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -478,6 +478,7 @@ export default function WPCheckout( {
 								) }
 
 								<WPCheckoutOrderSummary siteId={ siteId } onChangeSelection={ changeSelection } />
+								<CheckoutSidebarNudge responseCart={ responseCart } />
 								{ hasCheckoutVersion( '2' ) && (
 									<CheckoutSummaryFeaturedList
 										responseCart={ responseCart }
@@ -486,7 +487,6 @@ export default function WPCheckout( {
 										onChangeSelection={ changeSelection }
 									/>
 								) }
-								<CheckoutSidebarNudge responseCart={ responseCart } />
 								<SecondaryCartPromotions
 									responseCart={ responseCart }
 									addItemToCart={ addItemToCart }


### PR DESCRIPTION
It looks like the recent implementation #86675 of the Included Features List in checkout v2 was removed by accident when the upsell nudge code was deployed (probably missed a rebase) #86620. Fortunately, this only affected the featured list found behind the checkout v2 feature flag, and not production.

## Proposed Changes

* This PR adds the `<CheckoutSummaryFeaturedList>` back to `wp-checkout` 

## Testing Instructions

* Go to Checkout and ensure that the "Included with your purchase" feature list still shows at the top of the sidebar
* Go to `?checkoutVersion=2` in Checkout and ensure the featured list shows at the bottom of the sidebar below the upsell nudge
