### PR TITLE
Jetpack Manage pricing page: Add React hook to new public pricing endpoint

### DIFF
--- a/client/state/partner-portal/licenses/hooks/use-products-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-products-query.ts
@@ -51,6 +51,10 @@ function queryProducts( isPublicFacing: boolean ): Promise< APIProductFamily[] >
 		} );
 }
 
+export function usePublicProductsQuery(): UseQueryResult< APIProductFamilyProduct[], unknown > {
+	return useProductsQuery( true );
+}
+
 export default function useProductsQuery(
 	isPublicFacing = false
 ): UseQueryResult< APIProductFamilyProduct[], unknown > {

--- a/client/state/partner-portal/licenses/hooks/use-products-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-products-query.ts
@@ -2,17 +2,21 @@ import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import selectAlphabeticallySortedProductOptions from 'calypso/jetpack-cloud/sections/partner-portal/lib/select-alphabetically-sorted-product-options';
-import { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
+import wpcom, { wpcomJetpackLicensing as wpcomJpl } from 'calypso/lib/wp';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getIsPartnerOAuthTokenLoaded } from 'calypso/state/partner-portal/partner/selectors';
 import { APIProductFamily, APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { errorNotice } from '../../../notices/actions';
 
-function queryProducts(): Promise< APIProductFamily[] > {
-	return wpcomJpl.req
+function queryProducts( isPublicFacing: boolean ): Promise< APIProductFamily[] > {
+	const productsPath = isPublicFacing
+		? '/jetpack-licensing/public/manage-pricing'
+		: '/jetpack-licensing/partner/product-families';
+	const requestObject = isPublicFacing ? wpcom.req : wpcomJpl.req;
+	return requestObject
 		.get( {
 			apiNamespace: 'wpcom/v2',
-			path: '/jetpack-licensing/partner/product-families',
+			path: productsPath,
 		} )
 		.then( ( data: APIProductFamily[] ) => {
 			const exclude = [
@@ -47,14 +51,16 @@ function queryProducts(): Promise< APIProductFamily[] > {
 		} );
 }
 
-export default function useProductsQuery(): UseQueryResult< APIProductFamilyProduct[], unknown > {
+export default function useProductsQuery(
+	isPublicFacing = false
+): UseQueryResult< APIProductFamilyProduct[], unknown > {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const isPartnerOAuthTokenLoaded = useSelector( getIsPartnerOAuthTokenLoaded );
 
 	const query = useQuery( {
-		queryKey: [ 'partner-portal', 'licenses', 'products' ],
-		queryFn: queryProducts,
+		queryKey: [ 'partner-portal', 'licenses', 'products', isPublicFacing ],
+		queryFn: () => queryProducts( isPublicFacing ),
 		select: selectAlphabeticallySortedProductOptions,
 		enabled: isPartnerOAuthTokenLoaded,
 		refetchOnWindowFocus: false,

--- a/client/state/partner-portal/licenses/hooks/use-products-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-products-query.ts
@@ -62,7 +62,7 @@ export default function useProductsQuery(
 		queryKey: [ 'partner-portal', 'licenses', 'products', isPublicFacing ],
 		queryFn: () => queryProducts( isPublicFacing ),
 		select: selectAlphabeticallySortedProductOptions,
-		enabled: isPartnerOAuthTokenLoaded,
+		enabled: isPublicFacing || isPartnerOAuthTokenLoaded,
 		refetchOnWindowFocus: false,
 	} );
 

--- a/client/state/partner-portal/licenses/hooks/use-products-query.ts
+++ b/client/state/partner-portal/licenses/hooks/use-products-query.ts
@@ -9,14 +9,14 @@ import { APIProductFamily, APIProductFamilyProduct } from 'calypso/state/partner
 import { errorNotice } from '../../../notices/actions';
 
 function queryProducts( isPublicFacing: boolean ): Promise< APIProductFamily[] > {
-	const productsPath = isPublicFacing
+	const productsAPIPath = isPublicFacing
 		? '/jetpack-licensing/public/manage-pricing'
 		: '/jetpack-licensing/partner/product-families';
 	const requestObject = isPublicFacing ? wpcom.req : wpcomJpl.req;
 	return requestObject
 		.get( {
 			apiNamespace: 'wpcom/v2',
-			path: productsPath,
+			path: productsAPIPath,
 		} )
 		.then( ( data: APIProductFamily[] ) => {
 			const exclude = [

--- a/client/state/partner-portal/licenses/test/hooks.js
+++ b/client/state/partner-portal/licenses/test/hooks.js
@@ -69,208 +69,226 @@ describe( 'useRefreshLicenseList', () => {
 } );
 
 describe( 'useProductsQuery', () => {
+	const unexpected = [
+		{
+			name: 'Jetpack Backup',
+			slug: 'jetpack-backup',
+			products: [
+				{
+					name: 'Jetpack Backup (Daily)',
+					product_id: 2100,
+					slug: 'jetpack-backup-daily',
+				},
+				{
+					name: 'Jetpack Backup (Real-time)',
+					product_id: 2102,
+					slug: 'jetpack-backup-realtime',
+				},
+				{
+					name: 'Jetpack Backup (1GB)',
+					product_id: 2120,
+					slug: 'jetpack-backup-t0',
+				},
+			],
+		},
+		{
+			name: 'Jetpack Plans',
+			slug: 'jetpack-plans',
+			products: [
+				{
+					name: 'Jetpack Personal',
+					product_id: 2005,
+					slug: 'personal',
+				},
+				{
+					name: 'Jetpack Premium',
+					product_id: 2000,
+					slug: 'premium',
+				},
+				{
+					name: 'Jetpack Professional',
+					product_id: 2001,
+					slug: 'professional',
+				},
+			],
+		},
+		{
+			name: 'Jetpack Packs',
+			slug: 'jetpack-packs',
+			products: [
+				{
+					name: 'Jetpack Security Daily',
+					product_id: 2010,
+					slug: 'jetpack-security-daily',
+				},
+				{
+					name: 'Jetpack Security Real-time',
+					product_id: 2012,
+					slug: 'jetpack-security-realtime',
+				},
+			],
+		},
+	];
+	const expected = [
+		{
+			name: 'Jetpack Scan',
+			slug: 'jetpack-scan',
+			products: [
+				{
+					family_slug: 'jetpack-scan',
+					name: 'Jetpack Scan Daily',
+					product_id: 2106,
+					slug: 'jetpack-scan',
+				},
+			],
+		},
+		{
+			name: 'Jetpack Backup',
+			slug: 'jetpack-backup',
+			products: [
+				{
+					family_slug: 'jetpack-backup',
+					name: 'Jetpack Backup (10GB)',
+					product_id: 2112,
+					slug: 'jetpack-backup-t1',
+				},
+				{
+					family_slug: 'jetpack-backup',
+					name: 'Jetpack Backup (1TB)',
+					product_id: 2114,
+					slug: 'jetpack-backup-t2',
+				},
+			],
+		},
+		{
+			name: 'Jetpack Anti Spam',
+			slug: 'jetpack-anti-spam',
+			products: [
+				{
+					family_slug: 'jetpack-anti-spam',
+					name: 'Jetpack Anti-Spam',
+					product_id: 2110,
+					slug: 'jetpack-anti-spam',
+				},
+			],
+		},
+		{
+			name: 'Jetpack Videopress',
+			slug: 'jetpack-videopress',
+			products: [
+				{
+					family_slug: 'jetpack-videopress',
+					name: 'Jetpack VideoPress',
+					product_id: 2116,
+					slug: 'jetpack-videopress',
+				},
+			],
+		},
+		{
+			name: 'Jetpack Packs',
+			slug: 'jetpack-packs',
+			products: [
+				{
+					family_slug: 'jetpack-packs',
+					name: 'Jetpack Complete',
+					product_id: 2014,
+					slug: 'jetpack-complete',
+				},
+				{
+					family_slug: 'jetpack-packs',
+					name: 'Jetpack Security (10GB)',
+					product_id: 2016,
+					slug: 'jetpack-security-t1',
+				},
+				{
+					family_slug: 'jetpack-packs',
+					name: 'Jetpack Security (1TB)',
+					product_id: 2019,
+					slug: 'jetpack-security-t2',
+				},
+			],
+		},
+	];
+
+	const expectedResults = [
+		{
+			family_slug: 'jetpack-anti-spam',
+			name: 'Jetpack Anti-Spam',
+			product_id: 2110,
+			slug: 'jetpack-anti-spam',
+		},
+		{
+			family_slug: 'jetpack-backup',
+			name: 'Jetpack Backup (10GB)',
+			product_id: 2112,
+			slug: 'jetpack-backup-t1',
+		},
+		{
+			family_slug: 'jetpack-backup',
+			name: 'Jetpack Backup (1TB)',
+			product_id: 2114,
+			slug: 'jetpack-backup-t2',
+		},
+		{
+			family_slug: 'jetpack-packs',
+			name: 'Jetpack Complete',
+			product_id: 2014,
+			slug: 'jetpack-complete',
+		},
+		{
+			family_slug: 'jetpack-scan',
+			name: 'Jetpack Scan Daily',
+			product_id: 2106,
+			slug: 'jetpack-scan',
+		},
+		{
+			family_slug: 'jetpack-packs',
+			name: 'Jetpack Security (10GB)',
+			product_id: 2016,
+			slug: 'jetpack-security-t1',
+		},
+		{
+			family_slug: 'jetpack-packs',
+			name: 'Jetpack Security (1TB)',
+			product_id: 2019,
+			slug: 'jetpack-security-t2',
+		},
+		{
+			family_slug: 'jetpack-videopress',
+			name: 'Jetpack VideoPress',
+			product_id: 2116,
+			slug: 'jetpack-videopress',
+		},
+	];
+
 	it( 'returns filtered list of products', async () => {
 		const queryClient = new QueryClient();
 		const wrapper = ( { children } ) => (
 			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
 		);
-		const unexpected = [
-			{
-				name: 'Jetpack Backup',
-				slug: 'jetpack-backup',
-				products: [
-					{
-						name: 'Jetpack Backup (Daily)',
-						product_id: 2100,
-						slug: 'jetpack-backup-daily',
-					},
-					{
-						name: 'Jetpack Backup (Real-time)',
-						product_id: 2102,
-						slug: 'jetpack-backup-realtime',
-					},
-					{
-						name: 'Jetpack Backup (1GB)',
-						product_id: 2120,
-						slug: 'jetpack-backup-t0',
-					},
-				],
-			},
-			{
-				name: 'Jetpack Plans',
-				slug: 'jetpack-plans',
-				products: [
-					{
-						name: 'Jetpack Personal',
-						product_id: 2005,
-						slug: 'personal',
-					},
-					{
-						name: 'Jetpack Premium',
-						product_id: 2000,
-						slug: 'premium',
-					},
-					{
-						name: 'Jetpack Professional',
-						product_id: 2001,
-						slug: 'professional',
-					},
-				],
-			},
-			{
-				name: 'Jetpack Packs',
-				slug: 'jetpack-packs',
-				products: [
-					{
-						name: 'Jetpack Security Daily',
-						product_id: 2010,
-						slug: 'jetpack-security-daily',
-					},
-					{
-						name: 'Jetpack Security Real-time',
-						product_id: 2012,
-						slug: 'jetpack-security-realtime',
-					},
-				],
-			},
-		];
-		const expected = [
-			{
-				name: 'Jetpack Scan',
-				slug: 'jetpack-scan',
-				products: [
-					{
-						family_slug: 'jetpack-scan',
-						name: 'Jetpack Scan Daily',
-						product_id: 2106,
-						slug: 'jetpack-scan',
-					},
-				],
-			},
-			{
-				name: 'Jetpack Backup',
-				slug: 'jetpack-backup',
-				products: [
-					{
-						family_slug: 'jetpack-backup',
-						name: 'Jetpack Backup (10GB)',
-						product_id: 2112,
-						slug: 'jetpack-backup-t1',
-					},
-					{
-						family_slug: 'jetpack-backup',
-						name: 'Jetpack Backup (1TB)',
-						product_id: 2114,
-						slug: 'jetpack-backup-t2',
-					},
-				],
-			},
-			{
-				name: 'Jetpack Anti Spam',
-				slug: 'jetpack-anti-spam',
-				products: [
-					{
-						family_slug: 'jetpack-anti-spam',
-						name: 'Jetpack Anti-Spam',
-						product_id: 2110,
-						slug: 'jetpack-anti-spam',
-					},
-				],
-			},
-			{
-				name: 'Jetpack Videopress',
-				slug: 'jetpack-videopress',
-				products: [
-					{
-						family_slug: 'jetpack-videopress',
-						name: 'Jetpack VideoPress',
-						product_id: 2116,
-						slug: 'jetpack-videopress',
-					},
-				],
-			},
-			{
-				name: 'Jetpack Packs',
-				slug: 'jetpack-packs',
-				products: [
-					{
-						family_slug: 'jetpack-packs',
-						name: 'Jetpack Complete',
-						product_id: 2014,
-						slug: 'jetpack-complete',
-					},
-					{
-						family_slug: 'jetpack-packs',
-						name: 'Jetpack Security (10GB)',
-						product_id: 2016,
-						slug: 'jetpack-security-t1',
-					},
-					{
-						family_slug: 'jetpack-packs',
-						name: 'Jetpack Security (1TB)',
-						product_id: 2019,
-						slug: 'jetpack-security-t2',
-					},
-				],
-			},
-		];
-
-		const expectedResults = [
-			{
-				family_slug: 'jetpack-anti-spam',
-				name: 'Jetpack Anti-Spam',
-				product_id: 2110,
-				slug: 'jetpack-anti-spam',
-			},
-			{
-				family_slug: 'jetpack-backup',
-				name: 'Jetpack Backup (10GB)',
-				product_id: 2112,
-				slug: 'jetpack-backup-t1',
-			},
-			{
-				family_slug: 'jetpack-backup',
-				name: 'Jetpack Backup (1TB)',
-				product_id: 2114,
-				slug: 'jetpack-backup-t2',
-			},
-			{
-				family_slug: 'jetpack-packs',
-				name: 'Jetpack Complete',
-				product_id: 2014,
-				slug: 'jetpack-complete',
-			},
-			{
-				family_slug: 'jetpack-scan',
-				name: 'Jetpack Scan Daily',
-				product_id: 2106,
-				slug: 'jetpack-scan',
-			},
-			{
-				family_slug: 'jetpack-packs',
-				name: 'Jetpack Security (10GB)',
-				product_id: 2016,
-				slug: 'jetpack-security-t1',
-			},
-			{
-				family_slug: 'jetpack-packs',
-				name: 'Jetpack Security (1TB)',
-				product_id: 2019,
-				slug: 'jetpack-security-t2',
-			},
-			{
-				family_slug: 'jetpack-videopress',
-				name: 'Jetpack VideoPress',
-				product_id: 2116,
-				slug: 'jetpack-videopress',
-			},
-		];
-
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/wpcom/v2/jetpack-licensing/partner/product-families' )
 			.reply( 200, [ ...unexpected, ...expected ] );
 
 		const { result } = renderHook( () => useProductsQuery(), {
+			wrapper,
+		} );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( result.current.data ).toEqual( expectedResults );
+	} );
+
+	it( 'returns filtered the public facing list of products', async () => {
+		const queryClient = new QueryClient();
+		const wrapper = ( { children } ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/wpcom/v2/jetpack-licensing/public/manage-pricing' )
+			.reply( 200, [ ...unexpected, ...expected ] );
+
+		const { result } = renderHook( () => useProductsQuery( true ), {
 			wrapper,
 		} );
 


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/260

## Proposed Changes

* This PR modifies `useProductsQuery` adding a parameter to call the public facing endpoint, which does not need authentication.

## Testing Instructions

* Run the tests (`yarn run test-client client/state/partner-portal/licenses/test/hooks`)
* Add the `true` parameter to any usage of `useProductsQuery` (e.g. to the overview page, `client/jetpack-cloud/sections/overview/primary/overview-products/index.tsx`) and check the Network tab of your browser to ensure the correct endpoint is being called (`/wpcom/v2/jetpack-licensing/public/manage-pricing`) and it works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?