### PR TITLE
Expose Hosting Trial: Add free trial CTA to plugins page upsell nudge and allow starting the trial

### DIFF
--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -111,7 +111,7 @@ const PluginsDiscoveryPage = ( props ) => {
 		setIsTrialAcknowledgeModalOpen( true );
 	};
 
-	const secondaryCallToAction = isEligibleForHostingTrial ? __( 'Start for free' ) : null;
+	const secondaryCallToAction = isEligibleForHostingTrial ? __( 'Try for free' ) : null;
 
 	return (
 		<>

--- a/client/my-sites/plugins/plugins-discovery-page/index.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/index.jsx
@@ -1,4 +1,8 @@
+import { useI18n } from '@wordpress/react-i18n';
 import { useSelector } from 'react-redux';
+import HostingActivateStatus from 'calypso/my-sites/hosting/hosting-activate-status';
+import { TrialAcknowledgeModal } from 'calypso/my-sites/plans/trials/trial-acknowledge/acknowlege-modal';
+import { WithOnclickTrialRequest } from 'calypso/my-sites/plans/trials/trial-acknowledge/with-onclick-trial-request';
 import { isCompatiblePlugin } from 'calypso/my-sites/plugins/plugin-compatibility';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import EducationFooter from '../education-footer';
@@ -6,9 +10,9 @@ import CollectionListView from '../plugins-browser/collection-list-view';
 import SingleListView, { SHORT_LIST_LENGTH } from '../plugins-browser/single-list-view';
 import usePlugins from '../use-plugins';
 import InPageCTASection from './in-page-cta-section';
-import './style.scss';
 import UpgradeNudge from './upgrade-nudge';
-
+import { useTrialHelpers } from './use-trial-helpers';
+import './style.scss';
 /**
  * Module variables
  */
@@ -86,10 +90,47 @@ const PluginsDiscoveryPage = ( props ) => {
 	} );
 
 	const isLoggedIn = useSelector( isUserLoggedIn );
+	const { __ } = useI18n();
+
+	const {
+		isTrialAcknowledgeModalOpen,
+		setIsTrialAcknowledgeModalOpen,
+		isTransferring,
+		hasRequestedTrial,
+		trialRequested,
+		requestUpdatedSiteData,
+		setOpenModal,
+		isEligibleForHostingTrial,
+		isAtomic,
+	} = useTrialHelpers( props );
+
+	const onStartTrialUpsellClick = () => {
+		if ( ! isEligibleForHostingTrial ) {
+			return;
+		}
+		setIsTrialAcknowledgeModalOpen( true );
+	};
+
+	const secondaryCallToAction = isEligibleForHostingTrial ? __( 'Start for free' ) : null;
 
 	return (
 		<>
-			<UpgradeNudge { ...props } paidPlugins={ true } />
+			{ ! isTransferring && ! hasRequestedTrial && (
+				<UpgradeNudge
+					{ ...props }
+					secondaryCallToAction={ secondaryCallToAction }
+					secondaryOnClick={ onStartTrialUpsellClick }
+					paidPlugins={ true }
+				/>
+			) }
+			{ ! isTrialAcknowledgeModalOpen && ! isAtomic && (
+				<HostingActivateStatus
+					context="plugin"
+					onTick={ requestUpdatedSiteData }
+					keepAlive={ hasRequestedTrial && ! isAtomic }
+				/>
+			) }
+
 			<PaidPluginsSection { ...props } />
 			<CollectionListView category="monetization" { ...props } />
 			<EducationFooter />
@@ -102,8 +143,11 @@ const PluginsDiscoveryPage = ( props ) => {
 			<CollectionListView category="business" { ...props } />
 			<PopularPluginsSection { ...props } pluginsByCategoryFeatured={ pluginsByCategoryFeatured } />
 			<CollectionListView category="ecommerce" { ...props } />
+			{ isEligibleForHostingTrial && isTrialAcknowledgeModalOpen && (
+				<TrialAcknowledgeModal setOpenModal={ setOpenModal } trialRequested={ trialRequested } />
+			) }
 		</>
 	);
 };
 
-export default PluginsDiscoveryPage;
+export default WithOnclickTrialRequest( PluginsDiscoveryPage );

--- a/client/my-sites/plugins/plugins-discovery-page/style.scss
+++ b/client/my-sites/plugins/plugins-discovery-page/style.scss
@@ -1,3 +1,6 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .plugins-discovery-page__upsell.card.banner.upsell-nudge {
 	background-color: #f0f7fc;
 	border: none;
@@ -15,6 +18,12 @@
 		background-color: #0675c4;
 	}
 
+	.banner__action {
+		@include break-mobile {
+			display: flex;
+		}
+	}
+
 	.banner__action .button {
 		background-color: #0675c4;
 		font-weight: 400;
@@ -22,5 +31,16 @@
 		padding: 8px 14px;
 		font-size: 0.875rem;
 		line-height: 22px;
+	}
+
+	.banner__action .button:not(:first-child) {
+		margin-top: 15px;
+		background-color: var(--color-surface);
+		border: 1px solid var(--color-neutral-10);
+
+		@include break-mobile {
+			margin-left: 12px;
+			margin-top: 0;
+		}
 	}
 }

--- a/client/my-sites/plugins/plugins-discovery-page/style.scss
+++ b/client/my-sites/plugins/plugins-discovery-page/style.scss
@@ -26,18 +26,25 @@
 		font-size: 0.875rem;
 		line-height: 22px;
 		white-space: nowrap;
+		width: 100%;
+
+		@include break-wide {
+			width: auto;
+		}
 	}
 
 	.banner__action .button:not(:first-child) {
 		background-color: var(--color-surface);
 		border: 1px solid var(--color-neutral-10);
-		margin-left: 12px;
-		margin-top: 0;
 
-		@include breakpoint-deprecated( "<480px" ) {
-			width: 100%;
-			margin-top: 12px;
-			margin-left: 0;
+		width: 100%;
+		margin-top: 12px;
+		margin-left: 0;
+
+		@include break-wide {
+			width: auto;
+			margin-left: 12px;
+			margin-top: 0;
 		}
 	}
 }

--- a/client/my-sites/plugins/plugins-discovery-page/style.scss
+++ b/client/my-sites/plugins/plugins-discovery-page/style.scss
@@ -18,12 +18,6 @@
 		background-color: #0675c4;
 	}
 
-	.banner__action {
-		@include break-mobile {
-			display: flex;
-		}
-	}
-
 	.banner__action .button {
 		background-color: #0675c4;
 		font-weight: 400;
@@ -31,16 +25,19 @@
 		padding: 8px 14px;
 		font-size: 0.875rem;
 		line-height: 22px;
+		white-space: nowrap;
 	}
 
 	.banner__action .button:not(:first-child) {
-		margin-top: 15px;
 		background-color: var(--color-surface);
 		border: 1px solid var(--color-neutral-10);
+		margin-left: 12px;
+		margin-top: 0;
 
-		@include break-mobile {
-			margin-left: 12px;
-			margin-top: 0;
+		@include breakpoint-deprecated( "<480px" ) {
+			width: 100%;
+			margin-top: 12px;
+			margin-left: 0;
 		}
 	}
 }

--- a/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
+++ b/client/my-sites/plugins/plugins-discovery-page/upgrade-nudge.jsx
@@ -19,7 +19,14 @@ import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getSitePlan, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
-const UpgradeNudge = ( { siteSlug, paidPlugins, handleUpsellNudgeClick } ) => {
+const UpgradeNudge = ( {
+	siteSlug,
+	paidPlugins,
+	handleUpsellNudgeClick,
+	secondaryCallToAction,
+	secondaryOnClick,
+	secondaryEvent,
+} ) => {
 	const selectedSite = useSelector( getSelectedSite );
 	const sitePlan = useSelector( ( state ) => getSitePlan( state, selectedSite?.ID ) );
 
@@ -139,6 +146,9 @@ const UpgradeNudge = ( { siteSlug, paidPlugins, handleUpsellNudgeClick } ) => {
 			icon="notice-outline"
 			showIcon={ true }
 			onClick={ handleUpsellNudgeClick }
+			secondaryCallToAction={ secondaryCallToAction }
+			secondaryOnClick={ secondaryOnClick }
+			secondaryEvent={ secondaryEvent }
 			feature={ FEATURE_INSTALL_PLUGINS }
 			plan={ plan }
 			title={ title }

--- a/client/my-sites/plugins/plugins-discovery-page/use-trial-helpers.tsx
+++ b/client/my-sites/plugins/plugins-discovery-page/use-trial-helpers.tsx
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { isHostingTrialSite } from 'calypso/sites-dashboard/utils';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
+import { AppState } from 'calypso/types';
+
+export const useTrialHelpers = ( { ...props } ) => {
+	const [ isTrialAcknowledgeModalOpen, setIsTrialAcknowledgeModalOpen ] = useState( false );
+	const [ trialTransferStates, setTrialTransferStates ] = useState( {
+		isTransferring: false,
+		hasRequestedTrial: false,
+	} );
+
+	const isEligibleForTrial = useSelector( isUserEligibleForFreeHostingTrial );
+	const site = props.selectedSite;
+	const isFreeSite = site?.plan?.is_free;
+	const isTrialSite = isHostingTrialSite( site );
+
+	const isLoggedIn = useSelector( isUserLoggedIn );
+	const isEligibleForHostingTrial = isEligibleForTrial && isFreeSite && isLoggedIn;
+	const isAtomic = useSelector( ( state: AppState ) => isSiteWpcomAtomic( state, site?.ID ) );
+
+	const setOpenModal = ( isOpen: boolean ) => {
+		setIsTrialAcknowledgeModalOpen( isOpen );
+	};
+
+	useEffect( () => {
+		if ( isTrialSite && ! isAtomic ) {
+			setTrialTransferStates( {
+				isTransferring: true,
+				hasRequestedTrial: true,
+			} );
+		}
+	}, [] );
+
+	const trialRequested = () => {
+		setTrialTransferStates( {
+			isTransferring: true,
+			hasRequestedTrial: true,
+		} );
+	};
+
+	const requestUpdatedSiteData = useCallback(
+		( isTransferring: boolean, wasTransferring: boolean, isTransferCompleted: boolean ) => {
+			if ( ! isTransferring && wasTransferring && isTransferCompleted ) {
+				props.fetchUpdatedData();
+				setTrialTransferStates( {
+					isTransferring: false,
+					hasRequestedTrial: true,
+				} );
+			}
+		},
+		[]
+	);
+
+	return {
+		isTrialAcknowledgeModalOpen,
+		setIsTrialAcknowledgeModalOpen,
+		isAtomic,
+		...trialTransferStates,
+		trialRequested,
+		requestUpdatedSiteData,
+		setOpenModal,
+		isEligibleForHostingTrial,
+	};
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5097

## Proposed Changes

This PR shows free trial CTA on the upsell banner if the user is eligible and allow starting the trial without leaving the page.

* Show modal to allow starting trial
* Transition to atomic without leaving the page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to` /plugins/simple_site`
* Verify there is a "Start for free" CTA
* Verify you are able to start your trial without leaving the page.

![image](https://github.com/Automattic/wp-calypso/assets/47489215/e247c7f9-f966-40d7-9062-6e4b543b5a37)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?