### PR TITLE
Woo Express: Add Padding to Free Trial Expired Page

### DIFF
--- a/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/style.scss
+++ b/client/my-sites/plans/ecommerce-trial/ecommerce-trial-expired/style.scss
@@ -54,7 +54,7 @@ body.is-section-plans.is-expired-ecommerce-trial-plan {
 		justify-content: center;
 		margin: auto;
 		max-width: 800px;
-		padding-top: 1.5em;
+		padding: 1.5em;
 
 		@media ( min-width: $break-small ) {
 			flex-direction: row;


### PR DESCRIPTION
Fixes #86417

## Proposed Changes

* Adds some bottom padding to the "Free Trial expired" page for Woo Express 

## Testing Instructions

At `/plans/my-plan/trial-expired/site`, compare the padding at the bottom of the page - or just check these screenshots!

**Before:**
<img width="869" alt="Screenshot 2024-01-26 at 08 16 44" src="https://github.com/Automattic/wp-calypso/assets/43215253/674a7ffc-74e8-4068-a4b0-3be19d02a4e2">

**After:**
<img width="844" alt="Screenshot 2024-01-26 at 08 16 30" src="https://github.com/Automattic/wp-calypso/assets/43215253/499ccc8a-859f-4601-9919-8553ccf4b7af">

Grey background is so that it's easy to see on GitHub - not actually part of the changes.

cc @daledupreez  @markbiek