### PR TITLE
Impact Affiliate i2: Redirect to the stats/day page if the home is not enabled

### DIFF
--- a/client/my-sites/stats/stats-reditect-flow/index.tsx
+++ b/client/my-sites/stats/stats-reditect-flow/index.tsx
@@ -63,7 +63,16 @@ const StatsRedirectFlow = () => {
 
 	// render purchase flow for Jetpack sites created after February 2024
 	if ( ! isFetching && ! isRequesting && redirectToPurchase && siteSlug ) {
-		page.redirect( `/stats/purchase/${ siteSlug }?productType=commercial` );
+		// We need to ensure we pass the irclick id for impact affiliate tracking if its set.
+		const currentParams = new URLSearchParams( window.location.search );
+		const queryParams = new URLSearchParams();
+
+		queryParams.set( 'productType', 'commercial' );
+		if ( currentParams.has( 'irclickid' ) ) {
+			queryParams.set( 'irclickid', currentParams.get( 'irclickid' ) || '' );
+		}
+
+		page.redirect( `/stats/purchase/${ siteSlug }?${ queryParams.toString() }` );
 
 		return;
 	}

--- a/client/root.js
+++ b/client/root.js
@@ -98,5 +98,5 @@ async function getLoggedInLandingPage( { dispatch, getState } ) {
 		return `/home/${ primarySiteSlug }`;
 	}
 
-	return `/stats/${ primarySiteSlug }`;
+	return `/stats/day/${ primarySiteSlug }`;
 }

--- a/client/test/root-section.ts
+++ b/client/test/root-section.ts
@@ -45,7 +45,7 @@ describe( 'Logged In Landing Page', () => {
 		await waitFor( () => expect( page.current ).toBe( '/sites' ) );
 	} );
 
-	test( 'user with a primary site but no permissions goes to stats', async () => {
+	test( 'user with a primary site but no permissions goes to day stats', async () => {
 		const state = {
 			currentUser: { id: 1, capabilities: { 1: {} }, user: { primary_blog: 1 } },
 			sites: {
@@ -61,7 +61,7 @@ describe( 'Logged In Landing Page', () => {
 
 		page( '/' );
 
-		await waitFor( () => expect( page.current ).toBe( '/stats/test.wordpress.com' ) );
+		await waitFor( () => expect( page.current ).toBe( '/stats/day/test.wordpress.com' ) );
 	} );
 
 	test( 'user with a primary site and edit permissions goes to My Home', async () => {
@@ -83,7 +83,7 @@ describe( 'Logged In Landing Page', () => {
 		await waitFor( () => expect( page.current ).toBe( '/home/test.wordpress.com' ) );
 	} );
 
-	test( 'user with a Jetpack site set as their primary site goes to stats', async () => {
+	test( 'user with a Jetpack site set as their primary site goes to day stats', async () => {
 		const state = {
 			currentUser: { id: 1, capabilities: { 1: { edit_posts: true } }, user: { primary_blog: 1 } },
 			sites: {
@@ -100,7 +100,7 @@ describe( 'Logged In Landing Page', () => {
 
 		page( '/' );
 
-		await waitFor( () => expect( page.current ).toBe( '/stats/test.jurassic.ninja' ) );
+		await waitFor( () => expect( page.current ).toBe( '/stats/day/test.jurassic.ninja' ) );
 	} );
 
 	test( 'user who opts in goes to sites page', async () => {


### PR DESCRIPTION
See: https://github.com/Automattic/dotcom-forge/issues/5346

When the user does not have the home dashboard enabled, a redirect to /stats is done. This page does not exist and redirects to `/stats/day`. It should redirect to the `/stats/day` page to avoid doing an additional unnecessary redirect that also loses the get params along the way.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Redirect to `/stats/day` when the home page is not enabled

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*  This can be tested with a VIP site, a Jetpack site (that is not Atomic) or when the user does not have the 'edit_posts' permission.
* When any of the above conditions are met, navigate to http://calypso.localhost:3000 and you should be redirected to the `/stats/day` page. Check the network tab of the developer tools to ensure no additional redirects are done.
* Additionally, try going to https://calypso.localhost:3000?get-param=1 and ensure that once you land on the `/stats/day` page the get param is still in the url, resulting in a url of `http://calypso.localhost:3000/stats/day/<your-site-slug>?get-param=1`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?