### PR TITLE
 Jetpack Manage: Fix the issue with the Plugin confirmation modal displaying when an update fails.

### DIFF
--- a/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
+++ b/client/my-sites/plugins/plugin-management-v2/update-plugin/index.tsx
@@ -2,7 +2,7 @@ import { Button } from '@automattic/components';
 import { Icon, arrowRight } from '@wordpress/icons';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import ConfirmModal from 'calypso/components/confirm-modal';
 import { UPDATE_PLUGIN } from 'calypso/lib/plugins/constants';
 import { useSelector } from 'calypso/state';
@@ -53,63 +53,46 @@ export default function UpdatePlugin( {
 			( selectedSite ? parseInt( status.siteId ) === selectedSite.ID : true )
 	);
 
-	const handleUpdateConfirmation = () => {
-		setDisplayConfirmModal( true );
-	};
-
 	const pluginUpdateConfirmationTitle = translate( 'Update %(plugin)s', {
 		args: {
 			plugin: plugin.name ?? plugin.slug,
 		},
 	} );
 
-	const showConfirmationModal = () => (
-		<ConfirmModal
-			isVisible={ displayConfirmModal }
-			confirmButtonLabel={ translate( 'Update' ) }
-			text={ translate(
-				'You are about to update the %(plugin)s plugin to version %(version)s, on %(siteCount)d site. ',
-				'You are about to update the %(plugin)s plugin to version %(version)s, on %(siteCount)d sites. ',
-				{
-					count: siteCount ?? 1,
-					args: {
-						version: updatedVersions[ 0 ],
-						plugin: plugin.name ?? plugin.slug,
-						siteCount: String( siteCount ),
-					},
-				}
-			) }
-			title={ String( pluginUpdateConfirmationTitle ) }
-			onCancel={ () => setDisplayConfirmModal( false ) }
-			onConfirm={ () => {
-				updatePlugin && updatePlugin( plugin );
-			} }
-		/>
-	);
+	const onUpdatePlugin = useCallback( () => {
+		updatePlugin && updatePlugin( plugin );
+		setDisplayConfirmModal( false );
+	}, [ plugin, updatePlugin ] );
+
+	const onShowUpdateConfirmationModal = useCallback( () => {
+		setDisplayConfirmModal( true );
+	}, [] );
+
+	const onHideUpdateConfirmationModal = useCallback( () => {
+		setDisplayConfirmModal( false );
+	}, [] );
 
 	if ( ! allowedActions?.autoupdate ) {
 		content = <div>{ translate( 'Auto-managed on this site' ) }</div>;
 	} else if ( updateStatuses.length > 0 ) {
 		content = (
-			<>
-				<div className="update-plugin__plugin-action-status">
-					<PluginActionStatus
-						showMultipleStatuses={ false }
-						currentSiteStatuses={ updateStatuses }
-						selectedSite={ selectedSite }
-						retryButton={
-							<Button
-								onClick={ () => updatePlugin && updatePlugin( plugin ) }
-								className="update-plugin__retry-button"
-								borderless
-								compact
-							>
-								{ translate( 'Retry' ) }
-							</Button>
-						}
-					/>
-				</div>
-			</>
+			<div className="update-plugin__plugin-action-status">
+				<PluginActionStatus
+					showMultipleStatuses={ false }
+					currentSiteStatuses={ updateStatuses }
+					selectedSite={ selectedSite }
+					retryButton={
+						<Button
+							onClick={ onUpdatePlugin }
+							className="update-plugin__retry-button"
+							borderless
+							compact
+						>
+							{ translate( 'Retry' ) }
+						</Button>
+					}
+				/>
+			</div>
 		);
 	} else if ( hasUpdate ) {
 		content = (
@@ -123,7 +106,7 @@ export default function UpdatePlugin( {
 				</span>
 				<Button
 					primary
-					onClick={ handleUpdateConfirmation }
+					onClick={ onShowUpdateConfirmationModal }
 					className="update-plugin__new-version"
 					compact
 				>
@@ -134,9 +117,29 @@ export default function UpdatePlugin( {
 						args: updatedVersions[ 0 ],
 					} ) }
 				</Button>
-				{ displayConfirmModal && showConfirmationModal() }
+
+				<ConfirmModal
+					isVisible={ displayConfirmModal }
+					confirmButtonLabel={ translate( 'Update' ) }
+					text={ translate(
+						'You are about to update the %(plugin)s plugin to version %(version)s, on %(siteCount)d site. ',
+						'You are about to update the %(plugin)s plugin to version %(version)s, on %(siteCount)d sites. ',
+						{
+							count: siteCount ?? 1,
+							args: {
+								version: updatedVersions[ 0 ],
+								plugin: plugin.name ?? plugin.slug,
+								siteCount: String( siteCount ),
+							},
+						}
+					) }
+					title={ String( pluginUpdateConfirmationTitle ) }
+					onCancel={ onHideUpdateConfirmationModal }
+					onConfirm={ onUpdatePlugin }
+				/>
 			</div>
 		);
 	}
+
 	return content ? <div className={ classNames( className ) }>{ content }</div> : null;
 }


### PR DESCRIPTION
This pull request resolves an issue with the confirmation modal for Plugin updates that kept appearing after a failed update. The cause of the problem was a flag that was responsible for displaying the modal, which was not properly reset after clicking the "Update Plugin" button. In cases where the update failed, the modal was not completely destroyed, leading to its reappearance.

https://github.com/Automattic/wp-calypso/assets/56598660/38e72c18-301d-4b36-a859-e4b2b1260e32


## Proposed Changes

* To prevent unexpected modal display, We will now set the 'displayConfirmModal' flag to false every time the Update plugin is dispatched.
* Additionally, I made a few code improvements in the `UpdatePlugin` component for better code readability.
## Testing Instructions

**Reproducing the issue**
* Spin up a pressable or WP site that you can shut down anytime.
* Connect your site to the Jetpack cloud.
* In your site, install at least two plugins that are on the older version. (We will need this to have plugins we can update)
* Go to Jetpack cloud plugin management (`plugins/manage?site=YOUR_SITE`) and confirm you can see the plugins that require updates.
   <img width="1464" alt="Screenshot 2024-01-26 at 6 55 31 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/a87f7aa6-33a5-4f89-ae97-01384f034713">
* Before pressing the Update plugin button, shut down the site first. This way, we can simulate a failed update.
* Select any plugin you want to update. This should show the failed status.
    <img width="884" alt="Screenshot 2024-01-26 at 6 58 06 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/6c65b347-dbbe-420c-8130-c5617a1c713f">
 * Now select another plugin to update. Noticed that after confirming the update, the modal for the other plugin shows up.
  **Expected Result:**  The modal should not show up.

**Testing the fix**
* Use the Cloud Live link below and repeat the steps above.
* Confirm that the issue no longer occurs.

https://github.com/Automattic/wp-calypso/assets/56598660/2efa40d9-947f-4f64-b496-840aa967d1b1


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?