### PR TITLE
Plans Next: Migrate billing-timeframe under /components/shared

### DIFF
--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -35,11 +35,11 @@ import { sortPlans } from '../../lib/sort-plan-properties';
 import { plansBreakSmall } from '../../media-queries';
 import { getStorageStringFromFeature, usePricingBreakpoint } from '../../util';
 import PlanFeatures2023GridActions from '../actions';
-import PlanFeatures2023GridBillingTimeframe from '../billing-timeframe';
 import PlanFeatures2023GridHeaderPrice from '../header-price';
 import PlanTypeSelector from '../plan-type-selector';
 import { Plans2023Tooltip } from '../plans-2023-tooltip';
 import PopularBadge from '../popular-badge';
+import BillingTimeframe from '../shared/billing-timeframe';
 import { StickyContainer } from '../sticky-container';
 import StorageAddOnDropdown from '../storage-add-on-dropdown';
 import type {
@@ -443,10 +443,7 @@ const ComparisonGridHeaderCell = ( {
 				visibleGridPlans={ visibleGridPlans }
 			/>
 			<div className="plan-comparison-grid__billing-info">
-				<PlanFeatures2023GridBillingTimeframe
-					planSlug={ planSlug }
-					showRefundPeriod={ showRefundPeriod }
-				/>
+				<BillingTimeframe planSlug={ planSlug } showRefundPeriod={ showRefundPeriod } />
 			</div>
 			<PlanFeatures2023GridActions
 				currentSitePlanSlug={ currentSitePlanSlug }

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -26,12 +26,12 @@ import { Component } from 'react';
 import { isStorageUpgradeableForPlan } from '../../lib/is-storage-upgradeable-for-plan';
 import { getStorageStringFromFeature } from '../../util';
 import PlanFeatures2023GridActions from '../actions';
-import PlanFeatures2023GridBillingTimeframe from '../billing-timeframe';
 import PlanFeatures2023GridHeaderPrice from '../header-price';
 import { PlanFeaturesItem } from '../item';
 import PlanDivOrTdContainer from '../plan-div-td-container';
 import PlanFeaturesContainer from '../plan-features-container';
 import PlanLogo from '../plan-logo';
+import BillingTimeframe from '../shared/billing-timeframe';
 import { StickyContainer } from '../sticky-container';
 import StorageAddOnDropdown from '../storage-add-on-dropdown';
 import type { FeaturesGridProps, GridPlan } from '../../types';
@@ -278,7 +278,7 @@ class FeaturesGrid extends Component< FeaturesGridProps > {
 					isTableCell={ options?.isTableCell }
 					key={ planSlug }
 				>
-					<PlanFeatures2023GridBillingTimeframe
+					<BillingTimeframe
 						planSlug={ planSlug }
 						showRefundPeriod={ this.props.showRefundPeriod }
 					/>

--- a/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
@@ -15,8 +15,8 @@ import { Plans } from '@automattic/data-stores';
 import { formatCurrency } from '@automattic/format-currency';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { usePlansGridContext } from '../grid-context';
-import type { GridPlan } from '../types';
+import { usePlansGridContext } from '../../../grid-context';
+import type { GridPlan } from '../../../types';
 
 function usePerMonthDescription( { planSlug }: { planSlug: PlanSlug } ) {
 	const translate = useTranslate();
@@ -292,7 +292,7 @@ interface Props {
 	showRefundPeriod?: boolean;
 }
 
-const PlanFeatures2023GridBillingTimeframe = ( { showRefundPeriod, planSlug }: Props ) => {
+const BillingTimeframe = ( { showRefundPeriod, planSlug }: Props ) => {
 	const translate = useTranslate();
 	const { gridPlansIndex } = usePlansGridContext();
 	const {
@@ -320,7 +320,7 @@ const PlanFeatures2023GridBillingTimeframe = ( { showRefundPeriod, planSlug }: P
 		const price = formatCurrency( 25000, 'USD' );
 
 		return (
-			<div className="plan-features-2023-grid__vip-price">
+			<div className="plans-grid-next__billing-timeframe-vip-price">
 				{ translate( 'Starts at {{b}}%(price)s{{/b}} yearly', {
 					args: { price },
 					components: { b: <b /> },
@@ -342,4 +342,4 @@ const PlanFeatures2023GridBillingTimeframe = ( { showRefundPeriod, planSlug }: P
 	);
 };
 
-export default PlanFeatures2023GridBillingTimeframe;
+export default BillingTimeframe;

--- a/packages/plans-grid-next/src/components/test/billing-timeframe.tsx
+++ b/packages/plans-grid-next/src/components/test/billing-timeframe.tsx
@@ -35,9 +35,9 @@ import { formatCurrency } from '@automattic/format-currency';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { usePlansGridContext } from '../../grid-context';
-import PlanFeatures2023GridBillingTimeframe from '../billing-timeframe';
+import BillingTimeframe from '../shared/billing-timeframe';
 
-describe( 'PlanFeatures2023GridBillingTimeframe', () => {
+describe( 'BillingTimeframe', () => {
 	const defaultProps = {
 		billingTimeframe: 'per month, billed annually',
 	};
@@ -74,10 +74,7 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 		} ) );
 
 		const { container } = render(
-			<PlanFeatures2023GridBillingTimeframe
-				{ ...defaultProps }
-				planSlug={ PLAN_BUSINESS_MONTHLY }
-			/>
+			<BillingTimeframe { ...defaultProps } planSlug={ PLAN_BUSINESS_MONTHLY } />
 		);
 		const savings =
 			( 100 *
@@ -105,7 +102,7 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 		} ) );
 
 		const { container } = render(
-			<PlanFeatures2023GridBillingTimeframe { ...defaultProps } planSlug={ PLAN_BUSINESS } />
+			<BillingTimeframe { ...defaultProps } planSlug={ PLAN_BUSINESS } />
 		);
 
 		const discountedPrice = formatCurrency( pricing.discountedPrice.full, 'USD', {
@@ -133,10 +130,7 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 		} ) );
 
 		const { container } = render(
-			<PlanFeatures2023GridBillingTimeframe
-				{ ...defaultProps }
-				planSlug={ PLAN_BUSINESS_2_YEARS }
-			/>
+			<BillingTimeframe { ...defaultProps } planSlug={ PLAN_BUSINESS_2_YEARS } />
 		);
 		const discountedPrice = formatCurrency( pricing.discountedPrice.full, 'USD', {
 			stripZeros: true,
@@ -165,10 +159,7 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 		} ) );
 
 		const { container } = render(
-			<PlanFeatures2023GridBillingTimeframe
-				{ ...defaultProps }
-				planSlug={ PLAN_BUSINESS_3_YEARS }
-			/>
+			<BillingTimeframe { ...defaultProps } planSlug={ PLAN_BUSINESS_3_YEARS } />
 		);
 		const discountedPrice = formatCurrency( pricing.discountedPrice.full, 'USD', {
 			stripZeros: true,
@@ -197,7 +188,7 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 		} ) );
 
 		const { container } = render(
-			<PlanFeatures2023GridBillingTimeframe { ...defaultProps } planSlug={ PLAN_BUSINESS } />
+			<BillingTimeframe { ...defaultProps } planSlug={ PLAN_BUSINESS } />
 		);
 
 		const originalPrice = formatCurrency( pricing.originalPrice.full, 'USD', {
@@ -227,10 +218,7 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 		} ) );
 
 		const { container } = render(
-			<PlanFeatures2023GridBillingTimeframe
-				{ ...defaultProps }
-				planSlug={ PLAN_BUSINESS_2_YEARS }
-			/>
+			<BillingTimeframe { ...defaultProps } planSlug={ PLAN_BUSINESS_2_YEARS } />
 		);
 		const originalPrice = formatCurrency( pricing.originalPrice.full, 'USD', {
 			stripZeros: true,
@@ -259,10 +247,7 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 		} ) );
 
 		const { container } = render(
-			<PlanFeatures2023GridBillingTimeframe
-				{ ...defaultProps }
-				planSlug={ PLAN_BUSINESS_3_YEARS }
-			/>
+			<BillingTimeframe { ...defaultProps } planSlug={ PLAN_BUSINESS_3_YEARS } />
 		);
 		const originalPrice = formatCurrency( pricing.originalPrice.full, 'USD', {
 			stripZeros: true,
@@ -291,11 +276,7 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 		} ) );
 
 		const { getByText } = render(
-			<PlanFeatures2023GridBillingTimeframe
-				{ ...defaultProps }
-				planSlug={ PLAN_BUSINESS }
-				showRefundPeriod
-			/>
+			<BillingTimeframe { ...defaultProps } planSlug={ PLAN_BUSINESS } showRefundPeriod />
 		);
 
 		expect( getByText( /Refundable within 14 days. No questions asked./ ) ).toBeInTheDocument();
@@ -319,11 +300,7 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 		} ) );
 
 		const { getByText } = render(
-			<PlanFeatures2023GridBillingTimeframe
-				{ ...defaultProps }
-				planSlug={ PLAN_BUSINESS_MONTHLY }
-				showRefundPeriod
-			/>
+			<BillingTimeframe { ...defaultProps } planSlug={ PLAN_BUSINESS_MONTHLY } showRefundPeriod />
 		);
 
 		expect( getByText( /Refundable within 7 days. No questions asked./ ) ).toBeInTheDocument();
@@ -347,7 +324,7 @@ describe( 'PlanFeatures2023GridBillingTimeframe', () => {
 		} ) );
 
 		const { queryByText } = render(
-			<PlanFeatures2023GridBillingTimeframe
+			<BillingTimeframe
 				{ ...defaultProps }
 				planSlug={ PLAN_FREE }
 				showRefundPeriod // refund period won't be shown even though we set the prop to true

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -493,7 +493,7 @@ body.is-section-signup.is-white-signup,
 				padding-bottom: 0;
 			}
 
-			.plan-features-2023-grid__vip-price {
+			.plans-grid-next__billing-timeframe-vip-price {
 				font-size: $font-body;
 				line-height: 24px;
 				font-weight: 400;
@@ -976,7 +976,7 @@ body.is-section-signup.is-white-signup,
 			margin: 7px 0 10px;
 		}
 
-		.plan-features-2023-grid__vip-price {
+		.plans-grid-next__billing-timeframe-vip-price {
 			font-size: $font-body;
 			line-height: 24px;
 			font-weight: 400;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

- Migrates billing-timeframe under `/src/components/shared`
- Updates a relevant CSS classname to `plans-grid-next__billing-timeframe-vip-price` (which can be a convention to follow going forward)
- Moves it to its own folder as there are additional extractions that can happen (the internal hook and components can move out of the main index file)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* unit tests
* confirm price descriptions in `/plans[ site ]` and `/start/plans` render fine
* confirm Woo intro offers render fine in `/plans/[ WooExpress site ]`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?