### PR TITLE
Improve loading UX for Customer Home Launchpad

### DIFF
--- a/client/my-sites/customer-home/cards/launchpad/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/index.tsx
@@ -5,8 +5,9 @@ import {
 	useSortedLaunchpadTasks,
 } from '@automattic/data-stores';
 import { Launchpad, type Task } from '@automattic/launchpad';
+import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { FC } from 'react';
+import { type FC } from 'react';
 import EllipsisMenu from 'calypso/components/ellipsis-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import { useSelector } from 'calypso/state';
@@ -43,6 +44,12 @@ const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( {
 		return null;
 	}
 
+	const hasChecklist = checklist !== undefined && checklist !== null;
+	const launchpadTitle = hasChecklist ? title ?? translate( 'Next steps for your site' ) : ' ';
+	const headerClasses = classNames( 'customer-home-launchpad__header', {
+		'is-placeholder': ! hasChecklist,
+	} );
+
 	const temporaryDismiss = ( { dismissBy }: Pick< TemporaryDismiss, 'dismissBy' > ) => {
 		dismiss( {
 			dismissBy,
@@ -53,10 +60,8 @@ const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( {
 
 	return (
 		<div className="customer-home-launchpad">
-			<div className="customer-home-launchpad__header">
-				<h2 className="customer-home-launchpad__title">
-					{ title ?? translate( 'Next steps for your site' ) }
-				</h2>
+			<div className={ headerClasses }>
+				<h2 className="customer-home-launchpad__title">{ launchpadTitle }</h2>
 				{ numberOfSteps > completedSteps ? (
 					<div className="customer-home-launchpad__progress-bar-container">
 						<CircularProgressBar
@@ -80,16 +85,18 @@ const CustomerHomeLaunchpad: FC< CustomerHomeLaunchpadProps > = ( {
 						) }
 					</div>
 				) : (
-					<div className="customer-home-launchpad__dismiss-button">
-						<Button
-							className="themes__activation-modal-close-icon"
-							borderless
-							onClick={ permanentDismiss }
-						>
-							<div> { translate( 'Dismiss guide' ) } </div>
-							<Gridicon icon="cross" size={ 12 } />
-						</Button>
-					</div>
+					hasChecklist && (
+						<div className="customer-home-launchpad__dismiss-button">
+							<Button
+								className="themes__activation-modal-close-icon"
+								borderless
+								onClick={ permanentDismiss }
+							>
+								<div> { translate( 'Dismiss guide' ) } </div>
+								<Gridicon icon="cross" size={ 12 } />
+							</Button>
+						</div>
+					)
 				) }
 			</div>
 			<Launchpad

--- a/client/my-sites/customer-home/cards/launchpad/style.scss
+++ b/client/my-sites/customer-home/cards/launchpad/style.scss
@@ -16,6 +16,13 @@
 		display: flex;
 		align-items: center;
 
+		&.is-placeholder {
+			animation: loading-fade 1.6s ease-in-out infinite;
+			background-color: var(--color-neutral-light);
+			color: transparent;
+			min-height: 52px;
+		}
+
 		.customer-home-launchpad__progress-bar-container {
 			display: flex;
 			flex-direction: row;

--- a/client/my-sites/customer-home/cards/launchpad/test/index.tsx
+++ b/client/my-sites/customer-home/cards/launchpad/test/index.tsx
@@ -173,7 +173,9 @@ describe( 'CustomerHomeLaunchPad', () => {
 		it( 'hides the card when the user clicks on the dismiss guide button', async () => {
 			render( <CustomerHomeLaunchPad checklistSlug="some-check-list" /> );
 
-			userEvent.click( await screen.findByText( /Dismiss guide/ ) );
+			// Wait for the click event to be fully resolved.
+			await userEvent.click( await screen.findByText( /Dismiss guide/ ) );
+
 			expect( screen.queryByText( 'Some cool title for you task list' ) ).not.toBeInTheDocument();
 		} );
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR updates the loading UX for the Customer Home launchpad to do a few things:
  - Before we have any task list data returned, we now show a placeholder for the task list title
    - The new placeholder is given a min-height to ensure we don't have a layout shift when the task completion image is rendered after the tasks for the task list are loaded
  - While we are still loading the task list we ensure that we don't show the dismiss toggle

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site via `/setup/free`, and work through the flow to ensure that the site is launched
* Run this branch locally or via Calypso.live
* Navigate to Customer Home for the site
* Click on the CTA in Customer Home to set up your site
* Closely watch the UX for the launchpad to verify that we show a good loading experience

### Screen recordings

#### Before

https://github.com/Automattic/wp-calypso/assets/3376401/aa14a052-4efe-4246-bcb4-e8664ca1014d

#### After

https://github.com/Automattic/wp-calypso/assets/3376401/96e6bbcd-6744-493d-bbc5-652bca07f04f

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
