### PR TITLE
Assembler v2: Update pattern rendering constants and receive URL params for testing

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/constants.ts
@@ -92,3 +92,13 @@ export const ORDERED_PATTERN_PAGES_CATEGORIES = [
 	'posts',
 	'contact',
 ];
+
+// From URL params for testing
+const searchParams = new URLSearchParams( window.location.search );
+const viewportWidth = searchParams.get( 'viewportWidth' );
+const placeholderHeight = searchParams.get( 'placeholderHeight' );
+
+// Pattern rendering
+export const DEFAULT_VIEWPORT_HEIGHT = 500;
+export const DEFAULT_VIEWPORT_WIDTH = Number( viewportWidth ) || 1200;
+export const PLACEHOLDER_HEIGHT = Number( placeholderHeight ) || 150;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pages/page-preview.tsx
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import { CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import useOutsideClickCallback from 'calypso/lib/use-outside-click-callback';
+import { DEFAULT_VIEWPORT_WIDTH, DEFAULT_VIEWPORT_HEIGHT } from '../constants';
 import { PATTERN_ASSEMBLER_EVENTS } from '../events';
 import prependTitleBlockToPagePattern from '../html-transformers/prepend-title-block-to-page-pattern';
 import PatternTooltipDeadClick from '../pattern-tooltip-dead-click';
@@ -30,9 +31,6 @@ interface PagePreviewProps extends BasePageProps {
 	onFullscreenLeave: () => void;
 }
 
-const PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_HEIGHT = 500;
-const PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_WIDTH = 1080;
-
 const Page = ( { className, style, patterns, transformPatternHtml }: PageProps ) => {
 	const pageTitle = useMemo( () => {
 		return patterns.find( isPagePattern )?.title ?? '';
@@ -56,8 +54,8 @@ const Page = ( { className, style, patterns, transformPatternHtml }: PageProps )
 					key={ pattern.ID }
 					maxHeight="none"
 					patternId={ encodePatternId( pattern.ID ) }
-					viewportWidth={ PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_WIDTH }
-					viewportHeight={ PATTERN_PAGE_PREVIEW_ITEM_VIEWPORT_HEIGHT }
+					viewportWidth={ DEFAULT_VIEWPORT_WIDTH }
+					viewportHeight={ DEFAULT_VIEWPORT_HEIGHT }
 					transformHtml={
 						isPagePattern( pattern ) ? transformPagePatternHtml : transformPatternHtml
 					}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-large-preview.tsx
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import React, { useRef, useEffect, useState, useMemo, CSSProperties, useCallback } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
+import { DEFAULT_VIEWPORT_WIDTH } from './constants';
 import { PATTERN_ASSEMBLER_EVENTS } from './events';
 import { injectTitlesToPageListBlock } from './html-transformers';
 import PatternActionBar from './pattern-action-bar';
@@ -167,6 +168,7 @@ const PatternLargePreview = ( {
 						key={ device }
 						patternId={ encodePatternId( pattern.ID ) }
 						viewportHeight={ viewportHeight }
+						viewportWidth={ DEFAULT_VIEWPORT_WIDTH }
 						// Disable default max-height
 						maxHeight="none"
 						transformHtml={ transformPatternHtml }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
@@ -3,6 +3,7 @@ import { Tooltip, __unstableCompositeItem as CompositeItem } from '@wordpress/co
 import classnames from 'classnames';
 import { useEffect, useCallback, useRef } from 'react';
 import { useInView } from 'react-intersection-observer';
+import { DEFAULT_VIEWPORT_WIDTH, DEFAULT_VIEWPORT_HEIGHT, PLACEHOLDER_HEIGHT } from './constants';
 import { encodePatternId, isPriorityPattern } from './utils';
 import type { Pattern } from './types';
 import './pattern-list-renderer.scss';
@@ -29,10 +30,6 @@ interface PatternListRendererProps {
 	onSelect: ( selectedPattern: Pattern | null ) => void;
 	isShowMorePatterns?: boolean;
 }
-
-const DEFAULT_VIEWPORT_WIDTH = 1060;
-const DEFAULT_VIEWPORT_HEIGHT = 500;
-const PLACEHOLDER_HEIGHT = 100;
 
 const PatternListItem = ( {
 	pattern,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Update pattern rendering constants 
  * `viewportWidth`
    * for patterns on the inserter and on the large preview from `1060` to `1200` pixels
    * for pages from `1080` to `1200` pixels
  * `placeholderHeight` from `50` to `150` pixels
* set new defaults:
  * `viewportWidth=1200` for all previews
  * `placeholderHeight=150` for the height of the pattern placeholder. 150px seems to improve the loading effect because the average pattern height is quite tall now.  
* and receive URL params to allow testing live:
  * `viewportWidth`
  * `placeholderHeight`

### Intro Patterns 

|Before|After|
|-|-|
|<img width="2006" alt="Screenshot 2567-01-26 at 18 38 21" src="https://github.com/Automattic/wp-calypso/assets/1881481/c8234b3c-b658-41fa-806e-06c5f8dc3a09">|<img width="2004" alt="Screenshot 2567-01-26 at 18 45 52" src="https://github.com/Automattic/wp-calypso/assets/1881481/56d422ba-2873-4bf1-8da9-40dc9c6f814d">|

It's easier to see the differences in a video:

https://github.com/Automattic/wp-calypso/assets/1881481/c4bfb349-02bf-48e9-b4a9-178a434ab13c


### Page patterns

|Before|After|
|-|-|
|<img width="2002" alt="Screenshot 2567-01-26 at 18 42 17" src="https://github.com/Automattic/wp-calypso/assets/1881481/1121666b-e19e-45b8-bdbc-4ae9aa8c57c7">|<img width="2004" alt="Screenshot 2567-01-26 at 18 45 35" src="https://github.com/Automattic/wp-calypso/assets/1881481/ff7a281e-2325-49a0-b95f-071d61dfbf2c">|

It's easier to see the differences in a video:

https://github.com/Automattic/wp-calypso/assets/1881481/ad54b020-a0c2-4b75-8c35-d981e0391c28


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access Assembler using this URL: `https://container-vigorous-thompson.calypso.live/setup/with-theme-assembler/pattern-assembler?siteSlug={ SITE }&flags=pattern-assembler/v2&viewportWidth=1200&placeholderHeight=150`
  * If that link doesn't work, you have to click [here](https://calypso.live/?image=registry.a8c.com/calypso/app:commit-134a3a6fe063d7bfb83c364b662349183c13f0ec) and then update the URL manually.
  * Note that you can configure the params, for instance try `&flags=pattern-assembler/v2&viewportWidth=1400&placeholderHeight=200`
* Verify the patterns load is a bit better than before because the placeholder is taller
* Verify the patterns look better because all previews use the same width, which is now wider

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?