### PR TITLE
Marketplace Reviews: Show reviews link for Marketplace plugins

### DIFF
--- a/client/my-sites/plugins/plugin-details-header/index.jsx
+++ b/client/my-sites/plugins/plugin-details-header/index.jsx
@@ -94,7 +94,7 @@ const PluginDetailsHeader = ( {
 						<div className="plugin-details-header__info-title">{ translate( 'Ratings' ) }</div>
 						<div className="plugin-details-header__info-value">
 							<PluginRatings rating={ rating } />
-							{ numberOfReviews > 0 && (
+							{ ( numberOfReviews > 0 || isMarketplaceProduct ) && (
 								<Button
 									borderless
 									className="plugin-details-header__number-reviews-link is-link"


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add a condition to display the link when there are no reviews with the text `Write a review` for Marketplace plugins 

|Free plugins | Marketplace plugins|
|-------|------|
|  ![CleanShot 2024-01-26 at 13 25 24@2x](https://github.com/Automattic/wp-calypso/assets/3519124/cde30389-760b-4555-92d1-91e8ed6d2e54) | ![CleanShot 2024-01-26 at 13 25 35@2x](https://github.com/Automattic/wp-calypso/assets/3519124/3338f8c0-5de9-4e7d-a2f6-f106f5b08c59)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to a Marketplace plugin that do not have reviews, e.g. `/plugins/sensei-pro`
* Ensure there is a link under the ratings that reads `Write a review`
* Go to a Free plugin, e.g. `/plugins/wordpress-seo`
* Ensure there is no link under the ratings star

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?