### PR TITLE
Newsletter: Fix blank newsletter subscriber popup editor

### DIFF
--- a/client/data/themes/use-active-theme-query.ts
+++ b/client/data/themes/use-active-theme-query.ts
@@ -11,6 +11,7 @@ export type ActiveTheme = {
 	is_block_theme: boolean;
 	template: string;
 	theme_supports: ThemeSupports;
+	stylesheet: string;
 };
 
 export const useActiveThemeQuery = (

--- a/client/my-sites/site-settings/settings-newsletter/SubscribeModalSetting.tsx
+++ b/client/my-sites/site-settings/settings-newsletter/SubscribeModalSetting.tsx
@@ -26,7 +26,7 @@ export const SubscribeModalSetting = ( {
 	// Construct a link to edit the modal
 	const { data: activeThemeData } = useActiveThemeQuery( siteId, true );
 	const isFSEActive = activeThemeData?.[ 0 ]?.is_block_theme ?? false;
-	const themeSlug = activeThemeData?.[ 0 ]?.template;
+	const themeSlug = activeThemeData?.[ 0 ]?.stylesheet;
 	const siteEditorUrl = useSelector( ( state: object ) => getSiteEditorUrl( state, siteId ) );
 	const subscribeModalEditorUrl = isFSEActive
 		? addQueryArgs( siteEditorUrl, {


### PR DESCRIPTION
Fixes https://github.com/Automattic/jetpack/issues/35259

## Proposed Changes

Fixes the blank newsletter subscriber popup editor by using `stylesheet` instead of a `template` as a theme slug.

The change is consistent with how Jetpack is doing it:
https://github.com/Automattic/jetpack/blob/2f48ff68f3ade46e250800a313d40ef507ffd70e/projects/plugins/jetpack/_inc/client/newsletter/subscriptions-settings.jsx#L53

## Testing Instructions

* activate the non-child theme (e.g. Twenty Twenty-Four)
* go to Settings -> Newsletter
* click the "Preview and edit the popup" link
* make sure the popup is visible in the editor
* do the same with a child theme (e.g. Geologist)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?