### PR TITLE
Updating Bing tag with new structure for custom events

### DIFF
--- a/client/lib/analytics/ad-tracking/record-order.ts
+++ b/client/lib/analytics/ad-tracking/record-order.ts
@@ -416,12 +416,14 @@ function recordOrderInBing(
 	if ( wpcomJetpackCartInfo.containsWpcomProducts ) {
 		if ( null !== wpcomJetpackCartInfo.wpcomCostUSD ) {
 			const params = {
-				event_cateogry: 'purchase',
+				event_category: 'purchase',
+				event_label: 'purchase',
 				revenue_value: wpcomJetpackCartInfo.wpcomCostUSD,
 				currency: 'USD',
 			};
+
 			debug( 'recordOrderInBing: record WPCom purchase', params );
-			window.uetq.push( 'event', '', params );
+			window.uetq.push( 'event', 'purchase', params );
 		} else {
 			debug( `recordOrderInBing: currency ${ cart.currency } not supported, dropping WPCom pixel` );
 		}

--- a/client/lib/analytics/ad-tracking/record-order.ts
+++ b/client/lib/analytics/ad-tracking/record-order.ts
@@ -416,11 +416,12 @@ function recordOrderInBing(
 	if ( wpcomJetpackCartInfo.containsWpcomProducts ) {
 		if ( null !== wpcomJetpackCartInfo.wpcomCostUSD ) {
 			const params = {
-				ec: 'purchase',
-				gv: wpcomJetpackCartInfo.wpcomCostUSD,
+				event_cateogry: 'purchase',
+				revenue_value: wpcomJetpackCartInfo.wpcomCostUSD,
+				currency: 'USD',
 			};
 			debug( 'recordOrderInBing: record WPCom purchase', params );
-			window.uetq.push( params );
+			window.uetq.push( 'event', '', params );
 		} else {
 			debug( `recordOrderInBing: currency ${ cart.currency } not supported, dropping WPCom pixel` );
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#2629

## Proposed Changes

* This changes the shape of the data we send to Bing to define some parameters explicitly. This may not be needed, but it's a backup in case the default values do not populate correctly to be able to make custom audiences.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Enable ad-tracking and cookie-banner in development.json.  Ensure your browser does not send DNT headers.
* Store sandbox
* Purchase a plan or any other WPcom product.
* Verify that you see bat.js loading and that you see a subsequent request matching the data set in the code.

You can see more details in the linked Martech issue above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
