### PR TITLE
Hosting migration: Fire an event when url inserted is invalid

### DIFF
--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@automattic/components';
 import { NextButton } from '@automattic/onboarding';
 import { createElement, createInterpolateElement } from '@wordpress/element';
@@ -61,6 +62,12 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 		e.preventDefault();
 		isValid && onInputEnter( urlValue );
 		setSubmitted( true );
+
+		if ( ! isValid ) {
+			recordTracksEvent( 'calypso_importer_capture_input_invalid', {
+				url: urlValue,
+			} );
+		}
 	}
 
 	return (


### PR DESCRIPTION
In the `import` step of the `import-hosted-site` ( /setup/import-hosted-site/import?siteSlug=... ), we have to insert the url of the site to migrate it.

<img width="656" alt="image" src="https://github.com/Automattic/wp-calypso/assets/52076348/a4329e17-7c39-49f7-9044-d52cdb8aa255">

## Problem

An url with a query parameter appended fails. With this PR we just want to know how many people fail this step of the migration.

Added: `calypso_importer_capture_input_invalid` event

## Testing
1. Live link and go to the step
2. Record live links
3. Put an url with query parameters
4. You should see the error.