### PR TITLE
Design picker: Add premium themes feature to the theme upgrade modal for the Starter plan

### DIFF
--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -29,6 +29,7 @@ import {
 } from '@automattic/calypso-products';
 import { Button, Dialog, ScreenReaderText } from '@automattic/components';
 import { ProductsList } from '@automattic/data-stores';
+import { englishLocales } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { Tooltip } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
@@ -378,7 +379,7 @@ export const ThemeUpgradeModal = ( {
 		const localeSlug = i18n.getLocaleSlug();
 		const shouldShowThemesFeature =
 			config.isEnabled( 'themes/tiers' ) &&
-			( ( localeSlug && config< string >( 'english_locales' ).includes( localeSlug ) ) ||
+			( ( localeSlug && englishLocales.includes( localeSlug ) ) ||
 				i18n.hasTranslation( 'Dozens of premium themes' ) );
 		return getPlanFeaturesObject( [
 			...( shouldShowThemesFeature ? [ WPCOM_FEATURES_PREMIUM_THEMES_LIMITED ] : [] ),

--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -34,7 +34,7 @@ import { Tooltip } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { Icon as WpIcon, check, close } from '@wordpress/icons';
 import classNames from 'classnames';
-import { useTranslate } from 'i18n-calypso';
+import i18n, { useTranslate } from 'i18n-calypso';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import { useBundleSettings } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
@@ -375,7 +375,13 @@ export const ThemeUpgradeModal = ( {
 	};
 
 	const getPersonalPlanFeatureList = () => {
+		const localeSlug = i18n.getLocaleSlug();
+		const shouldShowThemesFeature =
+			config.isEnabled( 'themes/tiers' ) &&
+			( ( localeSlug && config< string >( 'english_locales' ).includes( localeSlug ) ) ||
+				i18n.hasTranslation( 'Dozens of premium themes' ) );
 		return getPlanFeaturesObject( [
+			...( shouldShowThemesFeature ? [ WPCOM_FEATURES_PREMIUM_THEMES_LIMITED ] : [] ),
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_AD_FREE_EXPERIENCE,
 			FEATURE_FAST_DNS,


### PR DESCRIPTION
Requires https://github.com/Automattic/wp-calypso/pull/86861

## Proposed Changes

Add a "Dozens of premium themes" feature to the theme upgrade modal displayed in the Design Picker after selecting a Starter tier theme.

Before | After
--- | ---
<img width="795" alt="Screenshot 2024-01-26 at 17 52 34" src="https://github.com/Automattic/wp-calypso/assets/1233880/0f086c9c-a5ff-48a3-9a43-a0e788662e3d"> | <img width="808" alt="Screenshot 2024-01-26 at 17 51 58" src="https://github.com/Automattic/wp-calypso/assets/1233880/460ab9c5-7c46-47a2-bc3f-d20ad39f50e0">


## Testing Instructions

- Use the Calypso live link below
- Go to `/setup/site-setup/designSetup?siteSlug=<FREE_SITE_DOMAIN>&theme=kaze&flags=themes/tiers`
- Click on the "Unlock theme" modal
- Make sure the list of features that is displayed on the right includes "Dozens of premium themes"