### PR TITLE
Fix pricing breakdown issues

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -37,6 +37,7 @@ import {
 	getSubtotalWithoutDiscounts,
 	filterAndGroupCostOverridesForDisplay,
 	getCreditsLineItemFromCart,
+	getSubtotalWithDiscounts,
 } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -180,7 +181,7 @@ function CheckoutSummaryPriceList() {
 				<CheckoutSummaryLineItem key="checkout-summary-line-item-subtotal">
 					<span>{ translate( 'Subtotal' ) }</span>
 					<span>
-						{ formatCurrency( responseCart.sub_total_integer, responseCart.currency, {
+						{ formatCurrency( getSubtotalWithDiscounts( responseCart ), responseCart.currency, {
 							isSmallestUnit: true,
 							stripZeros: true,
 						} ) }

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -42,6 +42,7 @@ export function getEmptyResponseCartProduct(): ResponseCartProduct {
 		current_quantity: null,
 		item_original_cost_integer: 0,
 		item_original_cost_for_quantity_one_integer: 0,
+		item_original_monthly_cost_integer: 0,
 		item_subtotal_integer: 0,
 		item_subtotal_before_discounts_integer: 0,
 		product_cost_integer: 0,

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -372,6 +372,11 @@ export interface ResponseCartProduct {
 	item_original_cost_integer: number;
 
 	/**
+	 * The monthly term original amount of a cart item in the currency's smallest unit.
+	 */
+	item_original_monthly_cost_integer: number;
+
+	/**
 	 * The cart item's price before discounts with volume in the currency's
 	 * smallest unit. This is similar to `item_original_subtotal_integer`
 	 * except when it comes to introductory offers. Introductory offer


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/86896

## Proposed Changes

Fix the issues that show incorrect first subtotal (before discounts):
![image](https://github.com/Automattic/wp-calypso/assets/8419292/0b9a2ee8-b0fc-4149-9e00-c91948c5464a)

## Testing Instructions

* Go to /checkout/jetpack/jetpack_ai_yearly and /checkout/jetpack/jetpack_social_advanced_yearly
* Select "Two Year" plan, and make sure the pricing breakdown displays correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?