### PR TITLE
Subscribers Page: Fix invalid total count when user isn't subscribed to its own site

### DIFF
--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -127,7 +127,7 @@ export const SubscribersPageProvider = ( {
 	const grandTotal =
 		isCurrentUserSubscribed && subscribersTotals?.email_subscribers
 			? subscribersTotals.email_subscribers - 1
-			: 0;
+			: subscribersTotals?.email_subscribers;
 
 	const { pageChangeCallback } = usePagination(
 		pageNumber,

--- a/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
+++ b/client/my-sites/subscribers/components/subscribers-page/subscribers-page-context.tsx
@@ -127,7 +127,7 @@ export const SubscribersPageProvider = ( {
 	const grandTotal =
 		isCurrentUserSubscribed && subscribersTotals?.email_subscribers
 			? subscribersTotals.email_subscribers - 1
-			: subscribersTotals?.email_subscribers;
+			: subscribersTotals?.email_subscribers ?? 0;
 
 	const { pageChangeCallback } = usePagination(
 		pageNumber,


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/85667

## Proposed Changes

* The subscribers total was incorrectly set to 0 when a user isn't subscribed to its own site.

## Testing Instructions

* Apply this PR to your local
* Using a site with some subscribers
* Unsubscribe from your site (through Reader)
* Go to https://wordpress.com/subscribers/{your-site}
* You should see the list of subscribers as usual 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?