### PR TITLE
Hotfix: fix initial price for products w/o intro discount"

### DIFF
--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -282,6 +282,15 @@ function getYearlyVariantFromProduct( product: ResponseCartProduct ) {
 
 export function getSubtotalWithoutDiscounts( responseCart: ResponseCart ): number {
 	return responseCart.products.reduce( ( total, product ) => {
+		const isJetpack = isJetpackProduct( product ) || isJetpackPlan( product );
+
+		if ( isJetpack && isBiennially( product ) ) {
+			const yearlyVariant = getYearlyVariantFromProduct( product );
+
+			if ( yearlyVariant ) {
+				return total + yearlyVariant.price_before_discounts_integer * 2;
+			}
+		}
 		return total + product.item_original_subtotal_integer;
 	}, 0 );
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/86896

## Proposed Changes

Fix the issues that show incorrect first subtotal (before discounts):
![image](https://github.com/Automattic/wp-calypso/assets/8419292/0b9a2ee8-b0fc-4149-9e00-c91948c5464a)

## Testing Instructions

* Go to /checkout/jetpack/jetpack_ai_yearly
* Select "Two Year" plan, and make sure the pricing breakdown displays correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?