### PR TITLE
Add introductory offers explanation for jetpack products

### DIFF
--- a/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/style.scss
+++ b/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/style.scss
@@ -16,7 +16,7 @@
 	}
 
 	.checkout-sidebar-plan-upsell__plan-grid {
-		grid-template-columns: 2fr 1fr;
+		grid-template-columns: 3fr 2fr;
 		grid-template-rows: auto;
 
 		> div {

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -37,12 +37,14 @@ import {
 	getSubtotalWithoutDiscounts,
 	filterAndGroupCostOverridesForDisplay,
 	getCreditsLineItemFromCart,
+	hasFirstYearIntroductoryDiscount,
 } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import * as React from 'react';
 import { hasFreeCouponTransfersOnly } from 'calypso/lib/cart-values/cart-items';
+import { preventWidows } from 'calypso/lib/formatting';
 import { isWcMobileApp } from 'calypso/lib/mobile-app';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
@@ -205,6 +207,13 @@ function CheckoutSummaryPriceList() {
 						{ totalLineItem.formattedAmount }
 					</span>
 				</CheckoutSummaryTotal>
+				{ hasFirstYearIntroductoryDiscount( responseCart ) && (
+					<CheckoutSummaryExplanation>
+						{ preventWidows(
+							translate( '*Introductory offer first year only, renews at regular rate.' )
+						) }
+					</CheckoutSummaryExplanation>
+				) }
 			</CheckoutSummaryAmountWrapper>
 		</>
 	);
@@ -929,7 +938,7 @@ const CheckoutSummaryLineItem = styled.div< { isDiscount?: boolean } >`
 
 	color: ${ ( props ) => ( props.isDiscount ? props.theme.colors.discount : 'inherit' ) };
 
-	&:nth-last-of-type( 2 ) {
+	&:nth-last-of-type( 3 ) {
 		border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 		margin-bottom: 20px;
 		padding-bottom: 20px;
@@ -945,6 +954,15 @@ const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )`
 	font-size: 20px;
 	font-weight: ${ ( props ) => props.theme.weights.bold };
 	line-height: 26px;
+	margin-bottom: 16px;
+`;
+
+const CheckoutSummaryExplanation = styled( CheckoutSummaryLineItem )`
+	color: ${ ( props ) => props.theme.colors.textColorLight };
+	font-size: 12px;
+	font-weight: ${ ( props ) => props.theme.weights.normal };
+	font-style: italic;
+	line-height: 16px;
 `;
 
 const LoadingCopy = styled.p`

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -37,7 +37,7 @@ import {
 	getSubtotalWithoutDiscounts,
 	filterAndGroupCostOverridesForDisplay,
 	getCreditsLineItemFromCart,
-	hasFirstYearIntroductoryDiscount,
+	hasIntroductoryDiscount,
 } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -207,10 +207,10 @@ function CheckoutSummaryPriceList() {
 						{ totalLineItem.formattedAmount }
 					</span>
 				</CheckoutSummaryTotal>
-				{ hasFirstYearIntroductoryDiscount( responseCart ) && (
+				{ hasIntroductoryDiscount( responseCart ) && (
 					<CheckoutSummaryExplanation>
 						{ preventWidows(
-							translate( '*Introductory offer first year only, renews at regular rate.' )
+							translate( '*Introductory offer first term only, renews at regular rate.' )
 						) }
 					</CheckoutSummaryExplanation>
 				) }

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -292,13 +292,11 @@ export function getSubtotalWithoutDiscounts( responseCart: ResponseCart ): numbe
 	}, 0 );
 }
 
-export function hasFirstYearIntroductoryDiscount( responseCart: ResponseCart ): boolean {
+export function hasIntroductoryDiscount( responseCart: ResponseCart ): boolean {
 	return responseCart.products.some(
 		( product ) =>
 			( isJetpackPlan( product ) || isJetpackProduct( product ) ) &&
-			!! product.introductory_offer_terms?.enabled &&
-			product.introductory_offer_terms.interval_count === 1 &&
-			product.introductory_offer_terms.interval_unit === 'year'
+			!! product.introductory_offer_terms?.enabled
 	);
 }
 


### PR DESCRIPTION
## Proposed Changes

Adding asterisk with first year introductory offer explanation and improving style of upsell.

## Testing Instructions

* Go to /checkout/jetpack/jetpack_complete
* Notice the section on the right
![CleanShot 2024-01-26 at 20 27 27@2x](https://github.com/Automattic/wp-calypso/assets/8419292/1505ccee-1064-4d2c-823a-cf305b1f0804)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?