### PR TITLE
Exposing Hosting Trial: Allow adding free trial on hosting config page

### DIFF
--- a/client/my-sites/hosting/hosting-activate-status.tsx
+++ b/client/my-sites/hosting/hosting-activate-status.tsx
@@ -2,7 +2,9 @@ import { translate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { connect } from 'react-redux';
 import Notice from 'calypso/components/notice';
+import { useDispatch } from 'calypso/state';
 import { useAtomicTransferQuery } from 'calypso/state/atomic-transfer/use-atomic-transfer-query';
+import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { initiateThemeTransfer } from 'calypso/state/themes/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -29,6 +31,7 @@ const HostingActivateStatus = ( {
 	const { isTransferring, transferStatus } = useAtomicTransferQuery( siteId ?? 0, {
 		refetchInterval: 5000,
 	} );
+	const dispatch = useDispatch();
 	const isTransferCompleted = transferStatus === transferStates.COMPLETED;
 	const [ wasTransferring, setWasTransferring ] = useState( false );
 
@@ -38,6 +41,9 @@ const HostingActivateStatus = ( {
 		}
 		if ( ! isTransferring && wasTransferring && isTransferCompleted ) {
 			setWasTransferring( false );
+		}
+		if ( ! isTransferCompleted ) {
+			dispatch( fetchAutomatedTransferStatus( siteId ?? 0 ) );
 		}
 		onTick?.( isTransferring, wasTransferring, isTransferCompleted );
 	}, [ isTransferCompleted, isTransferring, onTick, wasTransferring ] );
@@ -93,6 +99,7 @@ const mapStateToProps = ( state: AppState ) => {
 
 const mapDispatchToProps = {
 	initiateTransfer: initiateThemeTransfer,
+	fetchAutomatedTransferStatus,
 };
 
 export default connect( mapStateToProps, mapDispatchToProps )( HostingActivateStatus );

--- a/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
+++ b/client/my-sites/hosting/hosting-upsell-nudge/index.tsx
@@ -1,18 +1,8 @@
-import config from '@automattic/calypso-config';
-import {
-	FEATURE_SFTP,
-	PLAN_BUSINESS,
-	PLAN_HOSTING_TRIAL_MONTHLY,
-	WPCOM_PLANS,
-	getPlan,
-} from '@automattic/calypso-products';
+import { FEATURE_SFTP, PLAN_BUSINESS, WPCOM_PLANS, getPlan } from '@automattic/calypso-products';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
-import useAddHostingTrialMutation from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import { preventWidows } from 'calypso/lib/formatting';
-import { useSelector } from 'calypso/state';
-import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import iconCloud from './icons/icon-cloud.svg';
 import iconComments from './icons/icon-comments.svg';
 import iconDatabase from './icons/icon-database.svg';
@@ -39,9 +29,16 @@ interface HostingUpsellNudgeTargetPlan {
 interface HostingUpsellNudgeProps {
 	siteId: number;
 	targetPlan?: HostingUpsellNudgeTargetPlan;
+	secondaryCallToAction?: string;
+	secondaryOnClick?: () => void;
 }
 
-export function HostingUpsellNudge( { siteId, targetPlan }: HostingUpsellNudgeProps ) {
+export function HostingUpsellNudge( {
+	siteId,
+	targetPlan,
+	secondaryCallToAction,
+	secondaryOnClick,
+}: HostingUpsellNudgeProps ) {
 	const translate = useTranslate();
 	const features = useFeatureList();
 	const callToActionText = translate( 'Upgrade to %(businessPlanName)s Plan', {
@@ -62,16 +59,6 @@ export function HostingUpsellNudge( { siteId, targetPlan }: HostingUpsellNudgePr
 		  } );
 	const plan = targetPlan ? targetPlan.plan : PLAN_BUSINESS;
 	const title = targetPlan ? targetPlan.title : titleText;
-	const isEligibleForTrial = useSelector( isUserEligibleForFreeHostingTrial );
-	const secondaryCallToAction =
-		config.isEnabled( 'hosting-trial' ) && isEligibleForTrial ? translate( 'Start for free' ) : '';
-	const { mutateAsync: addHostingTrial } = useAddHostingTrialMutation();
-
-	const secondaryOnClick = async () => {
-		// TODO: Handle Trial acknowledge once it's isolated from the stepper
-		addHostingTrial( { siteId, planSlug: PLAN_HOSTING_TRIAL_MONTHLY } );
-		window.location.href = '/setup/transferring-hosted-site/processing?siteId=' + siteId;
-	};
 
 	return (
 		<UpsellNudge

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -214,6 +214,7 @@ const Hosting = ( props ) => {
 				transferStates.INQUIRING,
 				transferStates.ERROR,
 				transferStates.COMPLETED,
+				transferStates.COMPLETE,
 			].includes( transferState )
 	);
 

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -7,7 +7,7 @@ import {
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { localize } from 'i18n-calypso';
-import { Fragment, useRef } from 'react';
+import { Fragment, useState, useCallback } from 'react';
 import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import QueryJetpackModules from 'calypso/components/data/query-jetpack-modules';
@@ -29,18 +29,25 @@ import { GitHubCard } from 'calypso/my-sites/hosting/github';
 import TrialBanner from 'calypso/my-sites/plans/trials/trial-banner';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { useAtomicTransferQuery } from 'calypso/state/atomic-transfer/use-atomic-transfer-query';
 import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
 import { transferStates } from 'calypso/state/automated-transfer/constants';
 import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
 import { getAtomicHostingIsLoadingSftpData } from 'calypso/state/selectors/get-atomic-hosting-is-loading-sftp-data';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
+import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-user-eligible-for-free-hosting-trial';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { requestSite } from 'calypso/state/sites/actions';
 import { isSiteOnBusinessTrial, isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import {
+	getSelectedSite,
+	getSelectedSiteId,
+	getSelectedSiteSlug,
+} from 'calypso/state/ui/selectors';
+import { TrialAcknowledgeModal } from '../plans/trials/trial-acknowledge/acknowlege-modal';
+import { WithOnclickTrialRequest } from '../plans/trials/trial-acknowledge/with-onclick-trial-request';
 import CacheCard from './cache-card';
 import HostingActivateStatus from './hosting-activate-status';
 import { HostingUpsellNudge } from './hosting-upsell-nudge';
@@ -193,25 +200,58 @@ const Hosting = ( props ) => {
 		hasSftpFeature,
 		hasStagingSitesFeature,
 		isJetpack,
+		isEligibleForHostingTrial,
+		fetchUpdatedData,
+		isSiteAtomic,
+		transferState,
 	} = props;
 
-	const { isTransferring, transferStatus } = useAtomicTransferQuery( siteId, {
-		refetchInterval: 5000,
-	} );
+	const [ isTrialAcknowledgeModalOpen, setIsTrialAcknowledgeModalOpen ] = useState( false );
+	const [ hasTransfer, setHasTransferring ] = useState(
+		transferState &&
+			! [
+				transferStates.NONE,
+				transferStates.INQUIRING,
+				transferStates.ERROR,
+				transferStates.COMPLETED,
+			].includes( transferState )
+	);
 
-	const hasFetchedTransferStatus = transferStatus !== undefined;
-	const hasFetchedTransferStatusAtLeastOnce = useRef( false );
-	if ( hasFetchedTransferStatus ) {
-		hasFetchedTransferStatusAtLeastOnce.current = true;
-	}
-
-	const isSiteAtomic =
-		transferStatus === transferStates.COMPLETE || transferStatus === transferStates.COMPLETED;
 	const canSiteGoAtomic = ! isSiteAtomic && hasSftpFeature;
-	const showHostingActivationBanner =
-		canSiteGoAtomic && hasFetchedTransferStatusAtLeastOnce.current;
+	const showHostingActivationBanner = canSiteGoAtomic && ! hasTransfer;
+
+	const onSecondaryCTAClick = () => {
+		if ( ! isEligibleForHostingTrial ) {
+			return;
+		}
+		setIsTrialAcknowledgeModalOpen( true );
+	};
+
+	const setOpenModal = ( isOpen ) => {
+		setIsTrialAcknowledgeModalOpen( isOpen );
+	};
+
+	const trialRequested = () => {
+		setHasTransferring( true );
+	};
+
+	const requestUpdatedSiteData = useCallback(
+		( isTransferring, wasTransferring, isTransferCompleted ) => {
+			if ( isTransferring && ! hasTransfer ) {
+				setHasTransferring( true );
+			}
+
+			if ( ! isTransferring && wasTransferring && isTransferCompleted ) {
+				fetchUpdatedData();
+			}
+		},
+		[]
+	);
 
 	const getUpgradeBanner = () => {
+		if ( hasTransfer ) {
+			return null;
+		}
 		// The eCommerce Trial requires a different upsell path.
 		const targetPlan = ! isECommerceTrial
 			? undefined
@@ -221,8 +261,15 @@ const Hosting = ( props ) => {
 					href: `/plans/${ siteSlug }?feature=${ encodeURIComponent( FEATURE_SFTP_DATABASE ) }`,
 					title: translate( 'Upgrade your plan to access all hosting features' ),
 			  };
-
-		return <HostingUpsellNudge siteId={ siteId } targetPlan={ targetPlan } />;
+		const secondaryCallToAction = isEligibleForHostingTrial ? translate( 'Try for free' ) : null;
+		return (
+			<HostingUpsellNudge
+				siteId={ siteId }
+				targetPlan={ targetPlan }
+				secondaryCallToAction={ secondaryCallToAction }
+				secondaryOnClick={ onSecondaryCTAClick }
+			/>
+		);
 	};
 
 	const getAtomicActivationNotice = () => {
@@ -268,7 +315,7 @@ const Hosting = ( props ) => {
 								isBasicHostingDisabled={ ! hasAtomicFeature || ! isSiteAtomic }
 								isGithubIntegrationEnabled={ isGithubIntegrationEnabled }
 								isWpcomStagingSite={ isWpcomStagingSite }
-								isBusinessTrial={ isBusinessTrial }
+								isBusinessTrial={ isBusinessTrial && ! hasTransfer }
 								siteId={ siteId }
 							/>
 						</Column>
@@ -287,7 +334,7 @@ const Hosting = ( props ) => {
 	 * Otherwise, we show the activation notice, which may be empty.
 	 */
 	const shouldShowUpgradeBanner =
-		! hasAtomicFeature || ( ! isTransferring && ! hasSftpFeature && ! isWpcomStagingSite );
+		! hasAtomicFeature || ( ! hasTransfer && ! hasSftpFeature && ! isWpcomStagingSite );
 	const banner = shouldShowUpgradeBanner ? getUpgradeBanner() : getAtomicActivationNotice();
 
 	return (
@@ -300,9 +347,15 @@ const Hosting = ( props ) => {
 				title={ translate( 'Hosting Configuration' ) }
 				subtitle={ translate( 'Access your website’s database and more advanced settings.' ) }
 			/>
-			<HostingActivateStatus context="hosting" />
+			{ ! showHostingActivationBanner && ! isTrialAcknowledgeModalOpen && (
+				<HostingActivateStatus
+					context="hosting"
+					onTick={ requestUpdatedSiteData }
+					keepAlive={ ! isSiteAtomic && hasTransfer }
+				/>
+			) }
 			{ ! isBusinessTrial && banner }
-			{ isBusinessTrial && (
+			{ isBusinessTrial && ( ! hasTransfer || isSiteAtomic ) && (
 				<TrialBanner
 					callToAction={
 						<Button primary href={ `/plans/${ siteSlug }` }>
@@ -312,6 +365,9 @@ const Hosting = ( props ) => {
 				/>
 			) }
 			{ getContent() }
+			{ isEligibleForHostingTrial && isTrialAcknowledgeModalOpen && (
+				<TrialAcknowledgeModal setOpenModal={ setOpenModal } trialRequested={ trialRequested } />
+			) }
 			<QueryReaderTeams />
 		</Main>
 	);
@@ -326,6 +382,11 @@ export default connect(
 		const hasAtomicFeature = siteHasFeature( state, siteId, WPCOM_FEATURES_ATOMIC );
 		const hasSftpFeature = siteHasFeature( state, siteId, FEATURE_SFTP );
 		const hasStagingSitesFeature = siteHasFeature( state, siteId, FEATURE_SITE_STAGING_SITES );
+		const site = getSelectedSite( state );
+		const isEligibleForHostingTrial =
+			isUserEligibleForFreeHostingTrial( state ) && site && site.plan?.is_free;
+		const isSiteAtomic = isSiteWpcomAtomic( state, siteId );
+
 		return {
 			teams: getReaderTeams( state ),
 			isJetpack: isJetpackSite( state, siteId ),
@@ -339,6 +400,8 @@ export default connect(
 			siteId,
 			isWpcomStagingSite: isSiteWpcomStaging( state, siteId ),
 			hasStagingSitesFeature,
+			isEligibleForHostingTrial,
+			isSiteAtomic,
 		};
 	},
 	{
@@ -346,4 +409,4 @@ export default connect(
 		fetchAutomatedTransferStatus,
 		requestSiteById: requestSite,
 	}
-)( localize( Hosting ) );
+)( localize( WithOnclickTrialRequest( Hosting ) ) );

--- a/client/my-sites/hosting/test/index.js
+++ b/client/my-sites/hosting/test/index.js
@@ -206,7 +206,7 @@ describe( 'Hosting Configuration', () => {
 			await waitFor( () => expect( wpcomGetStub ).toHaveBeenCalled() );
 
 			expect(
-				screen.getByText( 'Upgrade to the Creator plan to access all hosting features:' )
+				await screen.findByText( 'Upgrade to the Creator plan to access all hosting features:' )
 			).toBeVisible();
 			expect( screen.getByText( 'Upgrade to Creator Plan' ) ).toBeVisible();
 
@@ -227,7 +227,7 @@ describe( 'Hosting Configuration', () => {
 			await waitFor( () => expect( wpcomGetStub ).toHaveBeenCalled() );
 
 			expect(
-				screen.getByText( 'Upgrade to the Creator plan to access all hosting features:' )
+				await screen.findByText( 'Upgrade to the Creator plan to access all hosting features:' )
 			).toBeVisible();
 
 			expect( screen.getByText( 'Upgrade to Creator Plan' ) ).toBeVisible();


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5097

## Proposed Changes

This PR allow user to add a free trial from the hosting config page.

* Add trial acknowledge modal and start a trial
* Fix issue where double notice was showing

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `/hosting-config/simple_site`
* Verify you can start a free trial successfully
* Upgrade a simple site to Creator plan then verify you can activate hosting features as normal.

![image](https://github.com/Automattic/wp-calypso/assets/47489215/b9701fff-d0c5-4c60-800f-445160e107e5)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
