### PR TITLE
update styles of sensei purpose screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/components/sensei-step-container/styles.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/components/sensei-step-container/styles.scss
@@ -56,6 +56,19 @@
 		}
 	}
 
+	.sensei-step-white {
+		background-color: $white;
+
+		.formatted-header .formatted-header__subtitle {
+			color: inherit;
+			text-align: center;
+		}
+
+		.sensei-button {
+			@include sensei-button;
+		}
+	}
+
 	@media (max-width: $breakpoint-mobile) {
 		.step-container__header .formatted-header .formatted-header__title,
 		.step-container__header .formatted-header .formatted-header__subtitle {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-purpose/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-purpose/index.tsx
@@ -68,7 +68,7 @@ const SenseiPurpose: Step = ( { navigation: { submit } } ) => {
 	return (
 		<SenseiStepContainer
 			stepName="senseiPurpose"
-			className="sensei-step-green"
+			className="sensei-step-white"
 			recordTracksEvent={ recordTracksEvent }
 			formattedHeader={
 				<FormattedHeader

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-purpose/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-purpose/style.scss
@@ -11,7 +11,7 @@ $checked-color: #000;
 		background-color: $sensei-purple-50;
 	}
 	.step-container__header {
-		width: 444px;
+		width: 680px;
 		padding: 0 20px;
 		max-width: 100%;
 	}
@@ -19,7 +19,8 @@ $checked-color: #000;
 .sensei-setup-wizard {
 	&__purpose-container {
 		padding: 0 20px;
-		width: 444px;
+		margin-top: 10px;
+		width: 512px;
 		max-width: 100%;
 	}
 	&__purpose-list {


### PR DESCRIPTION
Resolves #86899 

Related to #

## Proposed Changes

Change background color, button colors, and header spacing/layout styles according to image in issue for the sensei purpose page @ /setup/sensei/senseiPurpose.

 See screen shots for styles when a checkbox is check vs unchecked.

Unchecked
<img width="865" alt="Screenshot 2024-01-27 at 5 35 25 PM" src="https://github.com/Automattic/wp-calypso/assets/66364639/ca6eff96-c90a-4d6c-9622-50823c7092fe">

Checked
<img width="865" alt="Screenshot 2024-01-27 at 5 35 32 PM" src="https://github.com/Automattic/wp-calypso/assets/66364639/ccd387e3-606c-40ee-bf57-a0e081151aa3">

cc @mikeyarce 
