### PR TITLE
My Plan: Fix Incorrect WordAds Link

### DIFF
--- a/client/blocks/product-purchase-features-list/monetize-site.jsx
+++ b/client/blocks/product-purchase-features-list/monetize-site.jsx
@@ -3,9 +3,7 @@ import wordAdsImage from 'calypso/assets/images/illustrations/dotcom-wordads.svg
 import PurchaseDetail from 'calypso/components/purchase-detail';
 
 export default localize( ( { selectedSite, translate } ) => {
-	const adSettingsUrl = selectedSite.jetpack
-		? '/marketing/traffic/' + selectedSite.slug
-		: '/earn/ads-settings/' + selectedSite.slug;
+	const adSettingsUrl = '/earn/ads-settings/' + selectedSite.slug;
 	return (
 		<div className="product-purchase-features-list__item">
 			<PurchaseDetail


### PR DESCRIPTION
## Proposed Changes

The link for "Monetize your site with Ads" seems off. Atomic sites should never have been redirected to the Marketing section, and Jetpack sites now shouldn't either since the feature lives in Earn for all sites.  

## Testing Instructions

Verify that this link on My Sites > My Plan now takes you to the Ads Dashboard. You'll need a site with a paid plan that includes access to the WordAds feature for this. 

<img width="633" alt="Screenshot 2024-01-28 at 23 05 11" src="https://github.com/Automattic/wp-calypso/assets/43215253/17678432-8f2a-45ec-8e60-fc1b4fab9fd0">

cc @chrismccluskey
