### PR TITLE
Domains: Handle availability error better

### DIFF
--- a/client/components/domains/register-domain-step/index.jsx
+++ b/client/components/domains/register-domain-step/index.jsx
@@ -1085,6 +1085,11 @@ class RegisterDomainStep extends Component {
 
 					const availableDomainStatuses = [ AVAILABLE, UNKNOWN ];
 
+					if ( error ) {
+						resolve( null );
+						return;
+					}
+
 					if ( this.props.includeOwnedDomainInSuggestions ) {
 						availableDomainStatuses.push( REGISTERED_OTHER_SITE_SAME_USER );
 					}


### PR DESCRIPTION
Related to: https://github.com/Automattic/nomado-issues/issues/674

## Proposed Changes

* When there is a domain availability check error during a domain search fro a FQDN on https://wordpress.com/start/domain/domain-only, we should handle this gracefully and ignore the failure.

## Testing Instructions

Hack the back-end to trap the error and die in the availability endpoint code as if there were an error.

Make sure that an error is returned from the is-available call, but that there is no error shown when searching for a FQDN in https://wordpress.com/start/domain/domain-only
