### PR TITLE
Subscriber Stats: Adjust subscriber highlight section with overview cards

### DIFF
--- a/client/my-sites/stats/hooks/use-subscribers-overview.ts
+++ b/client/my-sites/stats/hooks/use-subscribers-overview.ts
@@ -2,7 +2,7 @@ import { translate } from 'i18n-calypso';
 import { useSubscribersQueries } from './use-subscribers-query';
 
 // array of indices to use to calculate the dates to query for
-const DATES_TO_QUERY = [ 0, 30, 60, 90 ];
+const DATES_TO_QUERY = [ 30, 60, 90 ];
 
 function getLabels( dateToQuery: number ) {
 	switch ( dateToQuery ) {

--- a/client/my-sites/stats/hooks/use-subscribers-overview.ts
+++ b/client/my-sites/stats/hooks/use-subscribers-overview.ts
@@ -2,7 +2,8 @@ import { translate } from 'i18n-calypso';
 import { useSubscribersQueries } from './use-subscribers-query';
 
 // array of indices to use to calculate the dates to query for
-const DATES_TO_QUERY = [ 30, 60, 90 ];
+const DATES_TO_QUERY = [ 0, 30, 60, 90 ];
+const DATES_TO_QUERY_EXCLUDE_TODAY = [ 30, 60, 90 ];
 
 function getLabels( dateToQuery: number ) {
 	switch ( dateToQuery ) {
@@ -27,10 +28,12 @@ function calculateQueryDate( daysToSubtract: number ) {
 	return date.toISOString().split( 'T' )[ 0 ];
 }
 
-export default function useSubscribersOverview( siteId: number | null ) {
+export default function useSubscribersOverview( siteId: number | null, isTodayExcluded?: boolean ) {
 	const period = 'day';
 	const quantity = 1;
-	const dates = DATES_TO_QUERY.map( calculateQueryDate );
+	const datesToQuery = isTodayExcluded ? DATES_TO_QUERY_EXCLUDE_TODAY : DATES_TO_QUERY;
+	const dates = datesToQuery.map( calculateQueryDate );
+
 	const { isLoading, isError, subscribersData } = useSubscribersQueries(
 		siteId,
 		period,
@@ -39,11 +42,12 @@ export default function useSubscribersOverview( siteId: number | null ) {
 	);
 	const overviewData = subscribersData.map( ( data, index ) => {
 		const count = data?.data?.[ 0 ]?.subscribers || null;
-		const heading = getLabels( DATES_TO_QUERY[ index ] );
+		const heading = getLabels( datesToQuery[ index ] );
 		return {
 			count,
 			heading,
 		};
 	} );
+
 	return { isLoading, isError, overviewData };
 }

--- a/client/my-sites/stats/hooks/use-subscribers-overview.ts
+++ b/client/my-sites/stats/hooks/use-subscribers-overview.ts
@@ -39,10 +39,10 @@ export default function useSubscribersOverview( siteId: number | null ) {
 	);
 	const overviewData = subscribersData.map( ( data, index ) => {
 		const count = data?.data?.[ 0 ]?.subscribers || null;
-		const label = getLabels( DATES_TO_QUERY[ index ] );
+		const heading = getLabels( DATES_TO_QUERY[ index ] );
 		return {
 			count,
-			label,
+			heading,
 		};
 	} );
 	return { isLoading, isError, overviewData };

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -79,7 +79,6 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 					count={ isPaidSubscriptionProductsLoading ? null : highlight.count }
 					showValueTooltip
 					note={ highlight.note }
-					icon={ false }
 				/>
 			) ) }
 		</div>

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -32,7 +32,7 @@ function useSubscriberHighlights(
 		{
 			heading: translate( 'Total subscribers' ),
 			count: subscribersTotals?.total,
-			note: 'WordPress.com and Email subscribers excluding subscribers from social media',
+			note: translate( 'Total subscribers excluding social media subscribers' ),
 		},
 	] as { heading: string; count: number | null; note?: string }[];
 
@@ -41,12 +41,12 @@ function useSubscriberHighlights(
 			{
 				heading: translate( 'Paid subscribers' ),
 				count: subscribersTotals?.paid_subscribers || 0,
-				note: 'Paid WordPress.com subscribers',
+				note: translate( 'Paid WordPress.com subscribers' ),
 			},
 			{
 				heading: translate( 'Free subscribers' ),
 				count: subscribersTotals?.free_subscribers,
-				note: 'Email subscribers and free WordPress.com subscribers',
+				note: translate( 'Email subscribers and free WordPress.com subscribers' ),
 			},
 		] );
 	} else {

--- a/client/my-sites/stats/stats-subscribers-overview/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-overview/index.tsx
@@ -12,12 +12,12 @@ const SubscribersOverview: React.FC< SubscribersOverviewProps > = ( { siteId } )
 	return (
 		<div className="subscribers-overview highlight-cards">
 			<div className="highlight-cards-list">
-				{ overviewData.map( ( { count, label }, index ) => {
+				{ overviewData.map( ( { count, heading }, index ) => {
 					return (
 						// TODO: Communicate loading vs error state to the user.
 						<CountComparisonCard
 							key={ index }
-							heading={ label }
+							heading={ heading }
 							count={ isLoading || isError ? null : count }
 							showValueTooltip
 							icon={ false }

--- a/client/my-sites/stats/stats-subscribers/index.tsx
+++ b/client/my-sites/stats/stats-subscribers/index.tsx
@@ -26,6 +26,7 @@ import PageViewTracker from '../stats-page-view-tracker';
 import Reach from '../stats-reach';
 import SubscribersChartSection, { PeriodType } from '../stats-subscribers-chart-section';
 import SubscribersHighlightSection from '../stats-subscribers-highlight-section';
+import SubscribersOverview from '../stats-subscribers-overview';
 import type { Moment } from 'moment';
 
 interface StatsSubscribersPageProps {
@@ -78,6 +79,12 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 	// Necessary to properly configure the fixed navigation headers.
 	// sessionStorage.setItem( 'jp-stats-last-tab', 'subscribers' );
 
+	// Check if the site has any paid subscription products added.
+	const products = useSelector( ( state ) => state.memberships?.productList?.items[ siteId ?? 0 ] );
+	// Odyssey Stats doesn't support the membership API endpoint yet.
+	// Products with an `undefined` value rather than an empty array means the API call has not been completed yet.
+	const hasAddedPaidSubscriptionProduct = ! isOdysseyStats && products && products.length > 0;
+
 	return (
 		<Main fullWidthLayout>
 			<DocumentHead title={ translate( 'Jetpack Stats' ) } />
@@ -105,6 +112,7 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 										slug={ siteSlug }
 										period={ period.period }
 									/>
+									{ hasAddedPaidSubscriptionProduct && <SubscribersOverview siteId={ siteId } /> }
 								</>
 							) }
 							<div className={ statsModuleListClass }>

--- a/client/my-sites/stats/stats-subscribers/index.tsx
+++ b/client/my-sites/stats/stats-subscribers/index.tsx
@@ -26,7 +26,6 @@ import PageViewTracker from '../stats-page-view-tracker';
 import Reach from '../stats-reach';
 import SubscribersChartSection, { PeriodType } from '../stats-subscribers-chart-section';
 import SubscribersHighlightSection from '../stats-subscribers-highlight-section';
-import SubscribersOverview from '../stats-subscribers-overview';
 import type { Moment } from 'moment';
 
 interface StatsSubscribersPageProps {
@@ -106,7 +105,6 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 										slug={ siteSlug }
 										period={ period.period }
 									/>
-									<SubscribersOverview siteId={ siteId } />
 								</>
 							) }
 							<div className={ statsModuleListClass }>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-roadmap/issues/872

## Proposed Changes

* Replace Subscriber Stats highlight cards with overview cards: `30 days ago`, `60 days ago`, and `90 days ago` for sites **_not_** connected to paid subscription products.
* Remove the Subscriber Stats Overview section below the chart for sites **_not_** connected to paid subscription products.
* Keep the layout of sites **_connected_** to paid subscription products with card styling tweaks.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live link.
* Navigate to the Subscriber Stats page: `/stats/subscribers/{site-slug}`.
* Ensure the Subscriber Stats highlight cards align with the new design.

|Before|After|After - Sites connected to Stripe|
|-|-|-|
|<img width="1282" alt="截圖 2024-01-29 下午12 10 58" src="https://github.com/Automattic/wp-calypso/assets/6869813/3326976a-e07d-4bf3-8a2d-577eb9d7d219">|<img width="1307" alt="截圖 2024-01-29 下午12 10 36" src="https://github.com/Automattic/wp-calypso/assets/6869813/f0d40127-f2aa-47e3-b647-edeaeafa2421">|<img width="1277" alt="截圖 2024-01-30 下午1 20 37" src="https://github.com/Automattic/wp-calypso/assets/6869813/6f76b533-b185-45c9-b48f-ad8313890663">|

* Ensure the Subscriber Stats overview section is removed for sites **_not_** connected to paid subscription products.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?