### PR TITLE
Zendesk Messaging: set dev account tag when creating a chat

### DIFF
--- a/packages/help-center/src/components/index.d.ts
+++ b/packages/help-center/src/components/index.d.ts
@@ -94,6 +94,11 @@ declare module 'calypso/state/selectors/get-primary-site-id' {
 	export default getPrimarySiteId;
 }
 
+declare module 'calypso/state/selectors/get-user-setting' {
+	const getUserSetting: ( state: unknown, setting: string ) => boolean | number | string;
+	export default getUserSetting;
+}
+
 declare module 'calypso/state/selectors/has-cancelable-user-purchases' {
 	const hasCancelableUserPurchases: ( state: unknown ) => boolean;
 	export default hasCancelableUserPurchases;

--- a/packages/help-center/src/components/types.d.ts
+++ b/packages/help-center/src/components/types.d.ts
@@ -2,10 +2,13 @@
 declare const __i18n_text_domain__: string;
 interface Window {
 	helpCenterData: any;
-	zE?: (
-		action: string,
-		value: string,
-		handler?: ( callback: ( data: string | number ) => void ) => void
-	) => void;
+	zE?: {
+		( action: string, value: string, conversationTags: string[] ): void;
+		(
+			action: string,
+			value: string,
+			handler?: ( callback: ( data: string | number ) => void ) => void
+		): void;
+	};
 }
 declare module '*.jpg';

--- a/packages/help-center/src/hooks/use-chat-widget.ts
+++ b/packages/help-center/src/hooks/use-chat-widget.ts
@@ -7,6 +7,7 @@ import { useSelector } from 'react-redux';
 /**
  * External Dependencies
  */
+import getUserSetting from 'calypso/state/selectors/get-user-setting'; /* eslint-disable-line no-restricted-imports */
 import { getSectionName } from 'calypso/state/ui/selectors'; /* eslint-disable-line no-restricted-imports */
 import { useUpdateZendeskUserFieldsMutation } from '../data/use-update-zendesk-user-fields';
 import { HELP_CENTER_STORE } from '../stores';
@@ -31,6 +32,8 @@ export default function useChatWidget(
 
 	const { isMessagingScriptLoaded } = useZendeskMessaging( configName, enabled, enabled );
 
+	const isDevAccount = useSelector( ( state ) => getUserSetting( state, 'is_dev_account' ) );
+
 	const openChatWidget = ( {
 		aiChatId,
 		message = 'No message from user',
@@ -52,6 +55,10 @@ export default function useChatWidget(
 				if ( typeof window.zE === 'function' ) {
 					window.zE( 'messenger', 'open' );
 					window.zE( 'messenger', 'show' );
+
+					if ( isDevAccount ) {
+						window.zE( 'messenger:set', 'conversationTags', [ 'wpcom_dev_account' ] );
+					}
 				}
 			} )
 			.catch( () => {


### PR DESCRIPTION
To identify developer accounts in Zendesk, we'll set a chat tag when creating a new chat for a user with a developer account.
See peCdcN-sN-p2

## Proposed Changes

* Set a Zendesk tag on the chat when the user is set as a developer

## Testing Instructions
(these instructions require working against local calypso)
* Set your user to a dev account by ticking "I am a developer" in `/me`
* Log in to the woothemes1654197491 Zendesk instance  (dev sandbox)
* Start a chat by opening the help center, clicking "Still need help" then "Live Chat", enter a message and continue with "still contact us" after you've received the AI answer
* Get the chat started by typing an actual message in the ZD box.
* On the Zendesk instance, check that the `wpcom_dev_account` tag was added to the chat.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?