### PR TITLE
GitHub deployments: support connecting/disconnecting GH (WIP)

### DIFF
--- a/client/my-sites/hosting/github-app/constants.ts
+++ b/client/my-sites/hosting/github-app/constants.ts
@@ -1,0 +1,1 @@
+export const GITHUB_INTEGRATION_QUERY_KEY = 'github-app-integration';

--- a/client/my-sites/hosting/github-app/disconnect-github-button/index.tsx
+++ b/client/my-sites/hosting/github-app/disconnect-github-button/index.tsx
@@ -1,0 +1,46 @@
+import { Button } from '@automattic/components';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useI18n } from '@wordpress/react-i18n';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { deleteStoredKeyringConnection } from 'calypso/state/sharing/keyring/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { GITHUB_INTEGRATION_QUERY_KEY } from '../constants';
+import { GITHUB_CONNECTION_QUERY_KEY } from '../use-github-connection-query';
+import './style.scss';
+
+type Connection = Parameters< typeof deleteStoredKeyringConnection >[ 0 ];
+
+interface DisconnectGitHubButtonProps {
+	connection: Connection;
+}
+
+export function DisconnectGitHubButton( { connection }: DisconnectGitHubButtonProps ) {
+	const queryClient = useQueryClient();
+	const siteId = useSelector( getSelectedSiteId );
+	const { __ } = useI18n();
+	const dispatch = useDispatch();
+	// Using ReactQuery to manage `isDisconnecting` state because it's not exposed from the Redux store.
+	const mutation = useMutation< unknown, unknown, Connection >( {
+		mutationFn: async ( c ) => {
+			dispatch( recordTracksEvent( 'calypso_hosting_github_unauthorize_click' ) );
+			await dispatch( deleteStoredKeyringConnection( c ) );
+			await queryClient.invalidateQueries( {
+				queryKey: [ GITHUB_INTEGRATION_QUERY_KEY, siteId, GITHUB_CONNECTION_QUERY_KEY ],
+			} );
+		},
+	} );
+	const { mutate: disconnect, isPending: isDisconnecting } = mutation;
+
+	return (
+		<Button
+			scary
+			primary
+			onClick={ () => disconnect( connection ) }
+			busy={ isDisconnecting }
+			disabled={ isDisconnecting } // `busy` doesn't actually disable the button
+		>
+			{ __( 'Disconnect' ) }
+		</Button>
+	);
+}

--- a/client/my-sites/hosting/github-app/disconnect-github-button/style.scss
+++ b/client/my-sites/hosting/github-app/disconnect-github-button/style.scss
@@ -1,0 +1,8 @@
+.disconnect-github {
+	font-style: inherit;
+	font-weight: 400;
+	line-height: inherit;
+	padding: 0;
+	font-size: inherit;
+	margin-left: 8px;
+}

--- a/client/my-sites/hosting/github-app/index.tsx
+++ b/client/my-sites/hosting/github-app/index.tsx
@@ -1,0 +1,105 @@
+import { Button, Card } from '@automattic/components';
+import requestExternalAccess from '@automattic/request-external-access';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { translate } from 'i18n-calypso';
+import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections/index';
+import QueryKeyringServices from 'calypso/components/data/query-keyring-services/index';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { requestKeyringConnections } from 'calypso/state/sharing/keyring/actions';
+import { getKeyringServiceByName } from 'calypso/state/sharing/services/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { GITHUB_INTEGRATION_QUERY_KEY } from './constants';
+import { DisconnectGitHubButton } from './disconnect-github-button/index';
+import {
+	GITHUB_CONNECTION_QUERY_KEY,
+	GithubConnectionData,
+	useGithubConnectionQuery,
+} from './use-github-connection-query';
+
+type Service = {
+	connect_URL: string;
+};
+
+export const GitHubAppCard = () => {
+	const queryClient = useQueryClient();
+	const siteId = useSelector( getSelectedSiteId );
+	const dispatch = useDispatch();
+	const github = useSelector( ( state ) =>
+		getKeyringServiceByName( state, 'github-app' )
+	) as Service;
+
+	const { data: connections } = useGithubConnectionQuery( siteId );
+
+	const { mutate: authorize, isPending: isAuthorizing } = useMutation< void, unknown, string >( {
+		mutationFn: async ( connectURL ) => {
+			dispatch( recordTracksEvent( 'calypso_hosting_github_authorize_click' ) );
+			await new Promise( ( resolve ) => requestExternalAccess( connectURL, resolve ) );
+			await dispatch( requestKeyringConnections() );
+		},
+		onSuccess: async () => {
+			const connectionKey = [ GITHUB_INTEGRATION_QUERY_KEY, siteId, GITHUB_CONNECTION_QUERY_KEY ];
+			await queryClient.invalidateQueries( {
+				queryKey: connectionKey,
+			} );
+
+			const authorized =
+				queryClient.getQueryData< GithubConnectionData >( connectionKey )?.connected;
+			dispatch( recordTracksEvent( 'calypso_hosting_github_authorize_complete', { authorized } ) );
+		},
+	} );
+
+	return (
+		<>
+			<QueryKeyringServices />
+			<QueryKeyringConnections />
+			<Card className="github-hosting-card">
+				<span>GitHub App</span>
+				<div
+					style={ {
+						display: 'flex',
+						flexDirection: 'column',
+						alignItems: 'flex-start',
+						gap: 16,
+						width: '100%',
+					} }
+				>
+					{ github && (
+						<Button
+							className="is-primary"
+							busy={ isAuthorizing }
+							disabled={ ! github || isAuthorizing }
+							onClick={ () => authorize( github.connect_URL ) }
+						>
+							{ translate( 'Authorize GitHub Account' ) }
+						</Button>
+					) }
+
+					{ ( connections || [] ).map( ( connection, key ) => (
+						<div key={ key } style={ { display: 'flex', alignItems: 'center', width: '100%' } }>
+							<span style={ { marginRight: 'auto' } }>{ connection.external_name }</span>
+							<span style={ { marginRight: 'auto' } }>
+								Repos: { connection?.installation.selection }
+							</span>
+							<div style={ { display: 'flex', alignItems: 'center', gap: 24 } }>
+								<Button
+									className="is-primary"
+									busy={ isAuthorizing }
+									disabled={ ! github || isAuthorizing }
+									onClick={ () =>
+										authorize(
+											`https://github.com/settings/installations/${ connection?.installation.id }`
+										)
+									}
+								>
+									{ translate( 'Modify' ) }
+								</Button>
+								<DisconnectGitHubButton connection={ connection } />
+							</div>
+						</div>
+					) ) }
+				</div>
+			</Card>
+		</>
+	);
+};

--- a/client/my-sites/hosting/github-app/index.tsx
+++ b/client/my-sites/hosting/github-app/index.tsx
@@ -78,8 +78,18 @@ export const GitHubAppCard = () => {
 					{ ( connections || [] ).map( ( connection, key ) => (
 						<div key={ key } style={ { display: 'flex', alignItems: 'center', width: '100%' } }>
 							<span style={ { marginRight: 'auto' } }>{ connection.external_name }</span>
-							<span style={ { marginRight: 'auto' } }>
-								Repos: { connection?.installation.selection }
+							<span
+								style={ {
+									marginRight: 'auto',
+									maxWidth: 150,
+									fontSize: 'small',
+									overflow: 'hidden',
+									whiteSpace: 'nowrap',
+									textOverflow: 'ellipsis',
+								} }
+								title={ Object.keys( connection.installation.repositories ).join( ', ' ) }
+							>
+								Repos: { Object.keys( connection.installation.repositories ).join( ', ' ) }
 							</span>
 							<div style={ { display: 'flex', alignItems: 'center', gap: 24 } }>
 								<Button

--- a/client/my-sites/hosting/github-app/use-github-connection-query.ts
+++ b/client/my-sites/hosting/github-app/use-github-connection-query.ts
@@ -1,0 +1,35 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+import { GITHUB_INTEGRATION_QUERY_KEY } from './constants';
+
+export const GITHUB_CONNECTION_QUERY_KEY = 'github-connection';
+
+export interface GithubConnectionData {
+	ID: number;
+	connected: boolean;
+	external_profile_picture: string;
+	repo: string;
+	branch: string;
+	base_path: string;
+	label: string;
+	external_name: string;
+}
+
+export const useGithubConnectionQuery = (
+	siteId: number | null,
+	options?: UseQueryOptions< GithubConnectionData >
+) => {
+	return useQuery< GithubConnectionData >( {
+		queryKey: [ GITHUB_INTEGRATION_QUERY_KEY, siteId, GITHUB_CONNECTION_QUERY_KEY ],
+		queryFn: (): GithubConnectionData =>
+			wp.req.get( {
+				path: `/sites/${ siteId }/hosting/github-app/connections`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		enabled: !! siteId,
+		meta: {
+			persist: false,
+		},
+		...options,
+	} );
+};

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -26,6 +26,7 @@ import { ScrollToAnchorOnMount } from 'calypso/components/scroll-to-anchor-on-mo
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { GitHubCard } from 'calypso/my-sites/hosting/github';
+import { GitHubAppCard } from 'calypso/my-sites/hosting/github-app';
 import TrialBanner from 'calypso/my-sites/plans/trials/trial-banner';
 import { isAutomatticTeamMember } from 'calypso/reader/lib/teams';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -121,6 +122,13 @@ const MainCards = ( {
 			? {
 					feature: 'github',
 					content: <GitHubCard />,
+					type: 'advanced',
+			  }
+			: null,
+		isGithubIntegrationEnabled
+			? {
+					feature: 'github',
+					content: <GitHubAppCard />,
 					type: 'advanced',
 			  }
 			: null,

--- a/config/development.json
+++ b/config/development.json
@@ -68,7 +68,7 @@
 		"external-media/google-photos": true,
 		"external-media/openverse": true,
 		"cookie-banner": false,
-		"github-integration-i1": false,
+		"github-integration-i1": true,
 		"google-drive": true,
 		"google-my-business": true,
 		"help": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5249

<img width="756" alt="Screenshot 2567-01-30 at 15 47 12" src="https://github.com/Automattic/wp-calypso/assets/6851384/ce844a5b-aeb7-4cd7-8a76-0c40bc2f5ee5">

## Proposed Changes

* Add a temp UI to test connecting/disconnecting multiple GH accounts
* Support modifying connections, e.g. change authorised repos
* Show repos that are authorised
* ~~TODO after modifying authorised repos, show the updated repo lis~~ Will do this later when working with the global webhook

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* ~~Apply D136195-code~~ it's on trunk now
* Visit `/hosting-config/:atomic-site`
* Scroll to GH card and test it out. See p1706519123512899-slack-C06D9M3CHMK 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?