### PR TITLE
[WooCommerce] Fix unable to review Installed Themes in MyTheme tab

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -337,7 +337,9 @@ export const ConnectedThemesSelection = connect(
 			...( tabFilter === 'recommended' && { collection: 'recommended' } ),
 			...( tabFilter === 'all' && { sort: 'date' } ),
 		};
+
 		const themes = getThemesForQueryIgnoringPage( state, sourceSiteId, query );
+
 		const shouldFetchWpOrgThemes =
 			forceWpOrgSearch &&
 			sourceSiteId !== 'wporg' &&

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -74,9 +74,13 @@ class ThemesSelection extends Component {
 	};
 
 	componentDidMount() {
+		if ( this.props.isRequesting || this.props.isLastPage ) {
+			return;
+		}
+
 		// Create "buffer zone" to prevent overscrolling too early bugging pagination requests.
 		const { query } = this.props;
-		if ( query.number <= 20 && ! query.search && ! query.filter && ! query.tier ) {
+		if ( ! query.search && ! query.filter && ! query.tier ) {
 			this.props.incrementPage();
 		}
 	}

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -76,7 +76,7 @@ class ThemesSelection extends Component {
 	componentDidMount() {
 		// Create "buffer zone" to prevent overscrolling too early bugging pagination requests.
 		const { query } = this.props;
-		if ( ! query.search && ! query.filter && ! query.tier ) {
+		if ( query.number <= 20 && ! query.search && ! query.filter && ! query.tier ) {
 			this.props.incrementPage();
 		}
 	}
@@ -304,7 +304,7 @@ export const ConnectedThemesSelection = connect(
 	) => {
 		const isAtomic = isSiteAutomatedTransfer( state, siteId );
 		const premiumThemesEnabled = arePremiumThemesEnabled( state, siteId );
-		const hiddenFilters = getThemeHiddenFilters( state, siteId );
+		const hiddenFilters = getThemeHiddenFilters( state, siteId, tabFilter );
 		const hasUnlimitedPremiumThemes = siteHasFeature(
 			state,
 			siteId,
@@ -337,9 +337,7 @@ export const ConnectedThemesSelection = connect(
 			...( tabFilter === 'recommended' && { collection: 'recommended' } ),
 			...( tabFilter === 'all' && { sort: 'date' } ),
 		};
-
 		const themes = getThemesForQueryIgnoringPage( state, sourceSiteId, query );
-
 		const shouldFetchWpOrgThemes =
 			forceWpOrgSearch &&
 			sourceSiteId !== 'wporg' &&

--- a/client/my-sites/themes/themes-toolbar-group/index.tsx
+++ b/client/my-sites/themes/themes-toolbar-group/index.tsx
@@ -14,14 +14,11 @@ const ThemesToolbarGroup: React.FC< ThemesToolbarGroupProps > = ( {
 	selectedKey,
 	onSelect,
 } ) => {
-	const activeIndex = useMemo(
-		() =>
-			Math.max(
-				items.findIndex( ( { key } ) => key === selectedKey ),
-				0
-			),
-		[ items, selectedKey ]
-	);
+	const activeIndex = useMemo( () => {
+		const index = items.findIndex( ( { key } ) => key === selectedKey );
+		// If the selected key is not found, return undefined to disable the active state.
+		return index >= 0 ? index : undefined;
+	}, [ items, selectedKey ] );
 
 	return (
 		<ResponsiveToolbarGroup

--- a/client/state/themes/selectors/get-theme-hidden-filters.js
+++ b/client/state/themes/selectors/get-theme-hidden-filters.js
@@ -4,12 +4,15 @@ import { isSiteOnECommerceTrial, isSiteOnWooExpress } from 'calypso/state/sites/
  * Returns theme filters that are not shown in the UI nor navigation URL.
  * @param  {Object}  state   Global state tree
  * @param  {?number} siteId  Site ID to optionally use as context
+ * @param	 {?string} tabFilter Tab filter to optionally use as context
  * @returns {Array}          Array of filter slugs
  */
-export function getThemeHiddenFilters( state, siteId ) {
+export function getThemeHiddenFilters( state, siteId, tabFilter ) {
 	const filters = [];
+	const isECommerceTrialOrWooExpress =
+		isSiteOnECommerceTrial( state, siteId ) || isSiteOnWooExpress( state, siteId );
 
-	if ( isSiteOnECommerceTrial( state, siteId ) || isSiteOnWooExpress( state, siteId ) ) {
+	if ( isECommerceTrialOrWooExpress && tabFilter === 'recommended' ) {
 		filters.push( 'store' );
 	}
 

--- a/client/state/themes/selectors/get-theme-hidden-filters.js
+++ b/client/state/themes/selectors/get-theme-hidden-filters.js
@@ -4,7 +4,7 @@ import { isSiteOnECommerceTrial, isSiteOnWooExpress } from 'calypso/state/sites/
  * Returns theme filters that are not shown in the UI nor navigation URL.
  * @param  {Object}  state   Global state tree
  * @param  {?number} siteId  Site ID to optionally use as context
- * @param	 {?string} tabFilter Tab filter to optionally use as context
+ * @param  {?string} tabFilter Tab filter to optionally use as context
  * @returns {Array}          Array of filter slugs
  */
 export function getThemeHiddenFilters( state, siteId, tabFilter ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/86935

Fix unable to review Installed Themes in MyTheme tab

Please note that it's still not possible to search for themes that are not in .org or wpcom. It seems that the WPCOM's themes API doesn't support it.

## Proposed Changes

*  Remove the hidden `Store` filter for `My Themes` query
* Do not increment page on mount when `isRequesting` or `isLastPage`. This 'incrementPage' will cause an issue where if you directly visit the 'my themes' page through the URL, 'my themes' won't display correctly because 'page' is set to 2.
* Disable the filter tab active state if the selected key is not found. Since Woo Express doesn't have an 'ALL' filter, when searching for themes, the active tab filters should be disabled. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Create a Woo Express site (Paid plan)
2. Go to **Appearance > Themes > Install Themes** and upload a non-WP.com theme
3. Navigate away from the themes area and then go back to **Appearance > Themes**
4. Click on "My Theme"
5. Observe that you can see the installed theme
6. Searching for any theme
7. Observe that none of the filters are active.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?