### PR TITLE
Theme Tiers: Rename dropdown to "Included with"

### DIFF
--- a/client/components/theme-tier/constants.js
+++ b/client/components/theme-tier/constants.js
@@ -5,7 +5,22 @@ import {
 	PLAN_PREMIUM,
 	getPlan,
 } from '@automattic/calypso-products';
-import { translate } from 'i18n-calypso';
+import { englishLocales } from '@automattic/i18n-utils';
+import i18n, { translate } from 'i18n-calypso';
+
+const getIncludedWithLabel = ( planSlug ) => {
+	const localeSlug = i18n.getLocaleSlug();
+
+	const shouldShowNewString =
+		( localeSlug && englishLocales.includes( i18n.getLocaleSlug() ) ) ||
+		i18n.hasTranslation( 'Included with %(planName)s' );
+
+	return shouldShowNewString
+		? translate( 'Included with %(planName)s', {
+				args: { planName: getPlan( planSlug )?.getTitle() },
+		  } )
+		: getPlan( PLAN_PERSONAL )?.getTitle();
+};
 
 /**
  * @typedef {Object} THEME_TIERS
@@ -23,11 +38,11 @@ export const THEME_TIERS = {
 		minimumUpsellPlan: PLAN_FREE,
 	},
 	personal: {
-		label: getPlan( PLAN_PERSONAL )?.getTitle(),
+		label: getIncludedWithLabel( PLAN_PERSONAL ),
 		minimumUpsellPlan: PLAN_PERSONAL,
 	},
 	premium: {
-		label: getPlan( PLAN_PREMIUM )?.getTitle(),
+		label: getIncludedWithLabel( PLAN_PREMIUM ),
 		minimumUpsellPlan: PLAN_PREMIUM,
 	},
 	partner: {

--- a/client/components/theme-tier/constants.js
+++ b/client/components/theme-tier/constants.js
@@ -19,7 +19,7 @@ const getIncludedWithLabel = ( planSlug ) => {
 		? translate( 'Included with %(planName)s', {
 				args: { planName: getPlan( planSlug )?.getTitle() },
 		  } )
-		: getPlan( PLAN_PERSONAL )?.getTitle();
+		: getPlan( planSlug )?.getTitle();
 };
 
 /**


### PR DESCRIPTION
## Proposed Changes

As discussed in paYJgx-4zE-p2, this PR renames the Starter/Explorer options of the tiers dropdown in the Theme Showcase to "Included with Starter/Explorer", so it's clearer for users what those filters do.

Before | After
--- | ---
<img width="981" alt="Screenshot 2024-01-29 at 13 08 34" src="https://github.com/Automattic/wp-calypso/assets/1233880/5ff0e903-2114-419b-8536-df757cb0a52c"> | <img width="965" alt="Screenshot 2024-01-29 at 13 15 42" src="https://github.com/Automattic/wp-calypso/assets/1233880/9a62ed62-f531-4672-87db-b2a9e6010743">

Note that both "Included with Starter/Explorer" options won’t include lower plans.

## Testing Instructions

- Use the Calypso live link below.
- Go to `/themes/<SITE_DOMAIN>?flags=themes/tiers`
- Open the tiers dropdown.
- Make sure you see the options have been renamed.