### PR TITLE
Localize the My Home widget when showing Support Articles

### DIFF
--- a/client/blocks/inline-help/inline-help-search-results.jsx
+++ b/client/blocks/inline-help/inline-help-search-results.jsx
@@ -4,7 +4,7 @@ import { getContextResults } from '@automattic/data-stores';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { speak } from '@wordpress/a11y';
 import { Icon, page as pageIcon, arrowRight } from '@wordpress/icons';
-import { useTranslate } from 'i18n-calypso';
+import { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import { Fragment, useEffect, useMemo } from 'react';
@@ -78,7 +78,7 @@ function HelpSearchResults( {
 
 	const { data: searchData, isInitialLoading: isSearching } = useHelpSearchQuery(
 		searchQuery,
-		'',
+		getLocaleSlug(),
 		{},
 		sectionName
 	);

--- a/client/data/help/use-help-search-query.ts
+++ b/client/data/help/use-help-search-query.ts
@@ -23,6 +23,7 @@ const fetchArticlesAPI = ( search: string, locale: string, sectionName: string )
 	const queryString = buildQueryString( {
 		query: search,
 		locale,
+		_locale: locale,
 		section: sectionName,
 	} );
 

--- a/client/data/help/use-help-search-query.ts
+++ b/client/data/help/use-help-search-query.ts
@@ -23,7 +23,6 @@ const fetchArticlesAPI = ( search: string, locale: string, sectionName: string )
 	const queryString = buildQueryString( {
 		query: search,
 		locale,
-		_locale: locale,
 		section: sectionName,
 	} );
 


### PR DESCRIPTION
Currently, the My Home widget in Calypso always shows English Support Articles, regardless of locale.

This commit updates the `useHelpSearchQuery()` call to include the locale, thus showing localized support links in the My Home widget.

Related to https://github.com/Automattic/i18n-issues/issues/651


## Proposed Changes

* Includes the current locale in calls to the useHelpSearchQuery hook.

## Testing Instructions
* Sandbox the API using D136406-code
* Change your default locale to a MAG-16 locale, e.g. Spanish
* Verify that the My Home widget in Calypso has non-English locales

## Screenshots

**Before**
![image](https://github.com/Automattic/wp-calypso/assets/31164683/78970b37-f686-4ec8-8bc6-532b00f19e60)

**After**
![image](https://github.com/Automattic/wp-calypso/assets/31164683/81a56662-a22e-482f-a1c3-0778f1b2f0fe)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?