### PR TITLE
Signup: Remove translation stuff

### DIFF
--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { localizeUrl, englishLocales } from '@automattic/i18n-utils';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { isNewsletterFlow, isHostingSignupFlow } from '@automattic/onboarding';
 import { isMobile } from '@automattic/viewport';
 import { Button } from '@wordpress/components';
@@ -466,13 +466,10 @@ export class UserStep extends Component {
 			wccomFrom,
 			isSocialFirst,
 			userLoggedIn,
-			locale,
 		} = this.props;
 
 		if ( userLoggedIn ) {
-			if ( englishLocales.includes( locale ) ) {
-				return translate( 'Is this you?' );
-			}
+			return translate( 'Is this you?' );
 		}
 
 		if ( isCrowdsignalOAuth2Client( oauth2Client ) ) {


### PR DESCRIPTION
This PR removes the `englishLocales` used to check for translations in https://github.com/Automattic/wp-calypso/pull/86840