### PR TITLE
My Themes: Fix my themes not loading

### DIFF
--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -40,6 +40,7 @@ class ThemesSelection extends Component {
 		getOptions: PropTypes.func,
 		getActionLabel: PropTypes.func,
 		incrementPage: PropTypes.func,
+		resetPage: PropTypes.func,
 		listLabel: PropTypes.string,
 		onScreenshotClick: PropTypes.func,
 		query: PropTypes.object.isRequired,
@@ -78,6 +79,12 @@ class ThemesSelection extends Component {
 		const { query } = this.props;
 		if ( ! query.search && ! query.filter && ! query.tier ) {
 			this.props.incrementPage();
+		}
+	}
+
+	componentDidUpdate( nextProps ) {
+		if ( nextProps.query.number !== this.props.query.number ) {
+			this.props.resetPage();
 		}
 	}
 
@@ -445,6 +452,7 @@ class ThemesSelectionWithPage extends React.Component {
 				{ ...this.props }
 				page={ this.state.page }
 				incrementPage={ this.incrementPage }
+				resetPage={ this.resetPage }
 			>
 				{ this.props.children }
 			</ConnectedThemesSelection>


### PR DESCRIPTION
…owcase when accessing it directly

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/wp-calypso/issues/85207

## Proposed Changes
The issue is mostly caused by how the `themes-selection` component is defined. It's split across three components. One component handles the internal page state and defines functions for advancing and resetting the current page. Then we have the `ConnectedThemesSelection` which calculates among other things the number of pages we're going to fetch.

Since the number of pages to fetch isn't in the outermost component, when this number gets updated, the page number isn't reset. This happens while fetching some information and that's why it works when navigating between tabs but not when loading the My Themes tab directly.

This PR addresses this by also providing the reset function as a prop so that when the number of elements to be retrieved changes we reset the page we're fetching. That way we can avoid the error described in the parent task.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live Link
* Go to an Atomic site
* Go to https://wordpress.com/themes/my-themes/your-site
* Do a hard refresh on the page
* All the site's themes should be displayed.


https://github.com/Automattic/wp-calypso/assets/1989914/682d78b3-4d76-4d58-90ad-663e5ef1d602



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?