### PR TITLE
Add visual feedback when paginate or searching subscribers.

### DIFF
--- a/client/my-sites/subscribers/queries/use-subscribers-query.tsx
+++ b/client/my-sites/subscribers/queries/use-subscribers-query.tsx
@@ -1,4 +1,4 @@
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { DEFAULT_PER_PAGE, SubscribersFilterBy, SubscribersSortBy } from '../constants';
 import { getSubscribersCacheKey } from '../helpers';
@@ -53,7 +53,6 @@ const useSubscribersQuery = ( {
 			} );
 		},
 		enabled: !! siteId && shouldFetch,
-		placeholderData: keepPreviousData,
 	} );
 };
 


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/86865

## Proposed Changes

At the subscribers page, there is no loading feedback while navigating through pages.

![Screen Recording 2024-01-29 at 17 05 48](https://github.com/Automattic/wp-calypso/assets/33497086/14451a98-feee-4d04-9dc3-7e4e24670172)


This happens due to the use of `keepPreviousData` as `placeholderData`. So after the initial page is ready, react-query is never set on a loading state as the previews page is fallback data.

It is important to differentiate `placeholderData` and cached data:
- `placeholderData` -> Will keep displaying page 1 while we load page 2. (we are removing it)
- Cached data -> Will get page 2 instantly on a second load. (we want to keep it, but needs to be clean before test to see the loading state)

## Testing Instructions

- Open calypso page.
- Open browser dev tools and clear the site data. This will remove preview react-query cached data.
- On network tab, disable cache. That is another cache layer.
- Reload the page.
- Open a blog that the subscriber list is at least 2 pages long.
- Open the first page.
- Throttle your internet connection to `Slow 3G`.
- Paginate to the second page.
- You should see the loading status between pages.
- Make a search.
- You should see the loading status before the result.

If you need to test the same page or search term a second time, you need to clean the site data again and refresh the page. But it should be fine loading the another page or trying a different search term.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?