### PR TITLE
Hosting Command Palette: Add "View developer features" command

### DIFF
--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -7,6 +7,7 @@ import {
 	backup as backupIcon,
 	brush as brushIcon,
 	chartBar as statsIcon,
+	code as codeIcon,
 	commentAuthorAvatar as profileIcon,
 	commentAuthorName as subscriberIcon,
 	download as downloadIcon,
@@ -437,6 +438,16 @@ export const useCommandsArrayWpcom = ( {
 			context: [ '/sites' ],
 			callback: commandNavigation( `/me` ),
 			icon: profileIcon,
+		},
+		{
+			name: 'viewDeveloperFeatures',
+			label: __( 'View developer features' ),
+			searchLabel: [
+				_x( 'view developer features', 'Keyword for the View developer features command' ),
+				_x( 'profile', 'Keyword for the View developer features command' ),
+			].join( ' ' ),
+			callback: commandNavigation( `/me/developer` ),
+			icon: codeIcon,
 		},
 		{
 			name: 'openReader',


### PR DESCRIPTION
## Proposed Changes

Adds a "View developer features" command to the command palette:

![CleanShot 2024-01-29 at 12 00 30@2x](https://github.com/Automattic/wp-calypso/assets/36432/0d260ca0-d5df-49c3-bfd2-eeba77601a61)

## Testing Instructions

1. Navigate to the Sites page.
2. Type in "dev" and verify "View developer features" appears in the command palette.
3. Select the command and verify you end up on `/me/developer`.