### PR TITLE
AI Logo Generator: Fix requests for Atomic sites

### DIFF
--- a/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
+++ b/packages/jetpack-ai-calypso/src/logo-generator/hooks/use-logo-generator.ts
@@ -180,7 +180,6 @@ For example: user's prompt: A logo for an ice cream shop. Returned prompt: A log
 
 		try {
 			const tokenData = await requestJwt( { siteDetails } );
-			const isSimple = ! siteDetails.is_wpcom_atomic;
 
 			if ( ! tokenData || ! tokenData.token ) {
 				throw new Error( 'No token provided' );
@@ -198,29 +197,19 @@ The image should contain a single icon, without variations, color palettes or di
 
 User request:${ prompt }`;
 
-			let data;
 			const body = {
 				prompt: imageGenerationPrompt,
 				feature: 'jetpack-ai-logo-generator',
 				response_format: 'url',
 			};
-			if ( ! isSimple ) {
-				// TODO: unsure how to handle this
-				// data = await proxy( {
-				// 	path: '/jetpack/v4/jetpack-ai-jwt?_cacheBuster=' + Date.now(),
-				// 	method: 'GET',
-				// 	query: `prompt=${ prompt }&token=${ tokenData.token }&response_format=url`,
-				// } );
-				throw new Error( 'Site type not implemented' );
-			} else {
-				data = await wpcomLimitedRequest( {
-					apiNamespace: 'wpcom/v2',
-					path: '/jetpack-ai-image',
-					method: 'POST',
-					token: tokenData.token,
-					body,
-				} );
-			}
+
+			const data = await wpcomLimitedRequest( {
+				apiNamespace: 'wpcom/v2',
+				path: '/jetpack-ai-image',
+				method: 'POST',
+				token: tokenData.token,
+				body,
+			} );
 
 			return data as { data: { url: string }[] };
 		} catch ( error ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86961

## Proposed Changes

* Uses the wpcom endpoint directly, as we are already in Calypso

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Select an Atomic site
* Generate a logo
* Check that the requests are executed as expected and the logo is generated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?