### PR TITLE
Add isErrorResponse utility for payment processor responses

### DIFF
--- a/packages/composite-checkout/src/lib/payment-processors.ts
+++ b/packages/composite-checkout/src/lib/payment-processors.ts
@@ -27,6 +27,16 @@ export function makeErrorResponse( errorMessage: string ): PaymentProcessorError
 	return { type: PaymentProcessorResponseType.ERROR, payload: errorMessage };
 }
 
+export function isErrorResponse( value: unknown ): boolean {
+	return (
+		!! value &&
+		typeof value === 'object' &&
+		'type' in value &&
+		value.type === PaymentProcessorResponseType.ERROR &&
+		'payload' in value
+	);
+}
+
 export function makeSuccessResponse(
 	transaction: PaymentProcessorResponseData
 ): PaymentProcessorSuccess {

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -30,6 +30,7 @@ import {
 	makeSuccessResponse,
 	makeRedirectResponse,
 	makeErrorResponse,
+	isErrorResponse,
 } from './lib/payment-processors';
 import checkoutTheme from './lib/theme';
 import { useTransactionStatus } from './lib/transaction-status';
@@ -52,6 +53,7 @@ export {
 	checkoutTheme,
 	createCheckoutStepGroupStore,
 	makeErrorResponse,
+	isErrorResponse,
 	makeManualResponse,
 	makeRedirectResponse,
 	makeSuccessResponse,


### PR DESCRIPTION
Payment processors generally work by chaining together two or more asynchronous function calls which handle interacting with the API to advance the order, and then return a final response to be consumed by more generic checkout components.

It is sometimes the case that this chain of calls can short circuit, as when one of the steps throws an exception. We handle the exception case with a `.catch()` clause. Generally this is reserved for **error** errors where there is either a bug or a payment error (e.g. card decline, mfa failure). However there are other situations where we want to short circuit the processor and return the form to a ready state, and even show an error notification, but we haven't encountered an error per se. The motivating example of this comes from Razorpay, where the user can interrupt the order flow by closing the modal window. In that situation the payment has "failed" in the sense that to complete the purchase the payment must start over, but we wouldn't consider this a payment failure for the purpose of tracking stats.

The purpose of `isErrorResponse` is to allow processors to return an error response in one async step, and have subsequent steps pass on this error to the last step in the chain. There is a monad transformer stack hiding here.

Related to #86197

## Proposed Changes

* Adds a utility method, `isErrorResponse`, which detects objects constructed by `makeErrorResponse`.

## Testing Instructions

* TC; this code is not active.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
