### PR TITLE
Add razorpay modal response type

### DIFF
--- a/packages/calypso-razorpay/src/index.tsx
+++ b/packages/calypso-razorpay/src/index.tsx
@@ -11,11 +11,20 @@ export interface RazorpayConfiguration {
 export interface RazorpayOptions {
 	key: string;
 	order_id?: string; // This is a razorpay order ID; the name is constrained by a 3rd party library.
-	handler?: ( response: {
-		razorpay_payment_id: string;
-		razorpay_order_id: string;
-		razorpay_signature: string;
-	} ) => void;
+	handler?: ( response: RazorpayModalResponse ) => void;
+	prefill?: {
+		contact?: string;
+		email?: string;
+	};
+	modal?: {
+		ondismiss?: ( response: RazorpayModalResponse ) => void;
+	};
+}
+
+export interface RazorpayModalResponse {
+	razorpay_payment_id: string;
+	razorpay_order_id: string;
+	razorpay_signature: string;
 }
 
 export interface RazorpayConfirmationRequestArgs {
@@ -156,14 +165,12 @@ function useRazorpayConfiguration(
 					return;
 				}
 				if ( ! configuration.js_url ) {
-					debug( 'Invalid razorpay configuration; js_url missing' );
-					debug( configuration );
+					debug( 'Invalid razorpay configuration; js_url missing', configuration );
 					throw new RazorpayConfigurationError(
 						'Error loading payment method configuration. Received invalid data from the server.'
 					);
 				}
-				debug( 'Razorpay configuration received' );
-				debug( configuration );
+				debug( 'Razorpay configuration received', configuration );
 				setRazorpayConfiguration( configuration ?? null );
 			} )
 			.catch( ( error ) => {


### PR DESCRIPTION
Minor update to the types exported by calypso-razorpay (these are not currently used by any live code) to better support customization of the modal window.

Related to #86197

## Proposed Changes

* Update types in calypso-razorpay package.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TC

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
