### PR TITLE
Add RazorpayHookProvider to checkout tests

### DIFF
--- a/bin/audit-svg-colors.js
+++ b/bin/audit-svg-colors.js
@@ -91,7 +91,7 @@ const SVG_IGNORE_PATHS = [
 
 	// Credit card and payment gateway logos (the disabled versions are allowed)
 	/upgrades\/cc-(?:amex|diners|discover|jcb|mastercard|unionpay|visa)\.svg$/,
-	/upgrades\/(?:alipay|bancontact|emergent-paywall|eps|giropay|ideal|netbanking|p24|paypal|paytm|sofort|tef|wechat)/,
+	/upgrades\/(?:alipay|bancontact|emergent-paywall|eps|giropay|ideal|netbanking|p24|paypal|paytm|sofort|tef|wechat|razorpay)/,
 
 	// Color scheme thumbnails that rely on .org colors
 	/color-scheme-thumbnail-(?:blue|classic-dark|coffee|ectoplasm|light|modern|ocean|sunrise)\.svg$/,

--- a/client/my-sites/checkout/src/test/credit-card.tsx
+++ b/client/my-sites/checkout/src/test/credit-card.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import {
 	CheckoutProvider,
@@ -20,7 +21,12 @@ import {
 	createCreditCardPaymentMethodStore,
 	createCreditCardMethod,
 } from 'calypso/my-sites/checkout/src/payment-methods/credit-card';
-import { createTestReduxStore, fetchStripeConfiguration, stripeConfiguration } from './util';
+import {
+	createTestReduxStore,
+	fetchRazorpayConfiguration,
+	fetchStripeConfiguration,
+	stripeConfiguration,
+} from './util';
 import type { CardStoreType } from 'calypso/my-sites/checkout/src/payment-methods/credit-card/types';
 
 jest.mock( '@stripe/react-stripe-js', () => {
@@ -65,17 +71,19 @@ function TestWrapperInner( { paymentProcessors = undefined } ) {
 		<>
 			<GlobalNotices />
 			<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
-				<CheckoutProvider
-					paymentMethods={ [ paymentMethod ] }
-					selectFirstAvailablePaymentMethod
-					paymentProcessors={ paymentProcessors ?? {} }
-				>
-					<CheckoutStepGroup>
-						<CompleteCreditCardFields />
-						<PaymentMethodStep />
-						<CheckoutFormSubmit />
-					</CheckoutStepGroup>
-				</CheckoutProvider>
+				<RazorpayHookProvider fetchRazorpayConfiguration={ fetchRazorpayConfiguration }>
+					<CheckoutProvider
+						paymentMethods={ [ paymentMethod ] }
+						selectFirstAvailablePaymentMethod
+						paymentProcessors={ paymentProcessors ?? {} }
+					>
+						<CheckoutStepGroup>
+							<CompleteCreditCardFields />
+							<PaymentMethodStep />
+							<CheckoutFormSubmit />
+						</CheckoutStepGroup>
+					</CheckoutProvider>
+				</RazorpayHookProvider>
 			</StripeHookProvider>
 		</>
 	);

--- a/client/my-sites/checkout/src/test/util/index.ts
+++ b/client/my-sites/checkout/src/test/util/index.ts
@@ -42,6 +42,18 @@ export const stripeConfiguration = {
 	setup_intent_id: undefined,
 };
 
+export const razorpayConfiguration = {
+	js_url: 'https://checkout.razorpay.com/v1/checkout.js',
+	options: {
+		key: 'razorpay-public-key',
+		config: {
+			display: {
+				language: 'en',
+			},
+		},
+	},
+};
+
 export const processorOptions = {
 	includeDomainDetails: false,
 	includeGSuiteDetails: false,
@@ -445,6 +457,8 @@ export const professionalEmailMonthly: ResponseCartProduct = {
 };
 
 export const fetchStripeConfiguration = async () => stripeConfiguration;
+
+export const fetchRazorpayConfiguration = async () => razorpayConfiguration;
 
 export function mockSetCartEndpointWith( { currency, locale } ): SetCart {
 	return async ( _: CartKey, requestCart: RequestCart ): Promise< ResponseCart > => {

--- a/client/my-sites/checkout/src/test/util/mock-checkout.tsx
+++ b/client/my-sites/checkout/src/test/util/mock-checkout.tsx
@@ -1,12 +1,15 @@
+import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import { ShoppingCartProvider, createShoppingCartManagerClient } from '@automattic/shopping-cart';
 import { PropsOf } from '@emotion/react';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import CheckoutMain from 'calypso/my-sites/checkout/src/components/checkout-main';
 import {
 	mockGetCartEndpointWith,
 	fetchStripeConfiguration,
+	fetchRazorpayConfiguration,
 	siteId,
 	countryList,
 	mockSetCartEndpointWith,
@@ -28,7 +31,7 @@ export function MockCheckout( {
 	useUndefinedSiteId?: boolean;
 } ) {
 	const reduxStore = createTestReduxStore();
-	const queryClient = new QueryClient();
+	const [ queryClient ] = useState( () => new QueryClient() );
 
 	const mockSetCartEndpoint = mockSetCartEndpointWith( {
 		currency: initialCart.currency,
@@ -44,12 +47,14 @@ export function MockCheckout( {
 			<QueryClientProvider client={ queryClient }>
 				<ShoppingCartProvider managerClient={ managerClient }>
 					<StripeHookProvider fetchStripeConfiguration={ fetchStripeConfiguration }>
-						<CheckoutMain
-							siteId={ useUndefinedSiteId ? undefined : siteId }
-							siteSlug="foo.com"
-							overrideCountryList={ countryList }
-							{ ...additionalProps }
-						/>
+						<RazorpayHookProvider fetchRazorpayConfiguration={ fetchRazorpayConfiguration }>
+							<CheckoutMain
+								siteId={ useUndefinedSiteId ? undefined : siteId }
+								siteSlug="foo.com"
+								overrideCountryList={ countryList }
+								{ ...additionalProps }
+							/>
+						</RazorpayHookProvider>
 					</StripeHookProvider>
 				</ShoppingCartProvider>
 			</QueryClientProvider>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86197

## Proposed Changes

* Wrap mock checkout in RazorpayHookProvider.

## Testing Instructions

* TC

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
