### PR TITLE
Import onboarding: Update credentials form

### DIFF
--- a/client/blocks/import/style/base.scss
+++ b/client/blocks/import/style/base.scss
@@ -41,6 +41,10 @@
 			font-size: inherit;
 			text-decoration: underline;
 		}
+
+		&.onboarding-subtitle--full-width {
+			max-width: 100%;
+		}
 	}
 
 	.import__header {

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/credentials-form.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/credentials-form.tsx
@@ -190,6 +190,7 @@ export const CredentialsForm: React.FunctionComponent< Props > = ( props ) => {
 					disabled={ isFormSubmissionPending || isPending }
 					formErrors={ formErrors }
 					formMode={ formMode }
+					formModeSwitcher="simple"
 					formState={ formState }
 					host={ props.selectedHost }
 					role="main"

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/credentials-form.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/credentials-form.tsx
@@ -219,33 +219,37 @@ export const CredentialsForm: React.FunctionComponent< Props > = ( props ) => {
 					</div>
 				) }
 
-				<div className="pre-migration__content pre-migration__proceed import__footer-button-container">
+				<div className="credentials-form__actions">
 					<NextButton type="submit" isBusy={ isFormSubmissionPending || isPending }>
 						{ isFormSubmissionPending || isPending
 							? translate( 'Testing credentials' )
 							: translate( 'Start migration' ) }
 					</NextButton>
-					<Button
-						borderless={ true }
-						className="action-buttons__borderless"
-						onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) => {
-							e.preventDefault();
+					<div>
+						<Button
+							borderless={ true }
+							className="action-buttons__borderless"
+							onClick={ ( e: React.MouseEvent< HTMLButtonElement > ) => {
+								e.preventDefault();
 
-							if ( ! migrationConfirmed ) {
-								setShowConfirmModal( true );
-								setConfirmCallback( () =>
-									startImportCallback.bind( null, {
-										type: 'skip-credentials',
-										...migrationTrackingProps,
-									} )
-								);
-							} else {
-								startImportCallback( { type: 'skip-credentials', ...migrationTrackingProps } );
-							}
-						} }
-					>
-						{ translate( 'Skip credentials (slower setup)' ) }
-					</Button>
+								if ( ! migrationConfirmed ) {
+									setShowConfirmModal( true );
+									setConfirmCallback( () =>
+										startImportCallback.bind( null, {
+											type: 'skip-credentials',
+											...migrationTrackingProps,
+										} )
+									);
+								} else {
+									startImportCallback( { type: 'skip-credentials', ...migrationTrackingProps } );
+								}
+							} }
+						>
+							{ translate( 'Skip credentials' ) }
+						</Button>
+						&nbsp;
+						{ translate( 'for a slower setup' ) }
+					</div>
 				</div>
 			</form>
 		</>

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/credentials.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/credentials.tsx
@@ -39,15 +39,18 @@ export function Credentials( props: Props ) {
 			<div className="import__heading import__heading-center">
 				<Title>{ translate( 'You are ready to migrate' ) }</Title>
 				<SubTitle className="onboarding-subtitle--full-width">
-					{ translate(
-						'Provide your SSH server credentials to migrate %(sourceSite)s to %(targetSite)s',
-						{
-							args: {
-								sourceSite: sourceSite?.slug,
-								targetSite: targetSite?.slug,
-							},
-						}
-					) }
+					{
+						// translators: %(sourceSite)s and %(targetSite)s are the site slugs - e.g. my-website.wordpress.com
+						translate(
+							'Provide your SSH server credentials to migrate %(sourceSite)s to %(targetSite)s',
+							{
+								args: {
+									sourceSite: sourceSite?.slug,
+									targetSite: targetSite?.slug,
+								},
+							}
+						)
+					}
 				</SubTitle>
 			</div>
 

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/credentials.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/credentials.tsx
@@ -1,5 +1,5 @@
 import { SiteDetails } from '@automattic/data-stores';
-import { Title } from '@automattic/onboarding';
+import { Title, SubTitle } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import React, { useState } from 'react';
 import { CredentialsForm } from './credentials-form';
@@ -38,6 +38,17 @@ export function Credentials( props: Props ) {
 		<div className="import__pre-migration import__import-everything import__import-everything--redesign">
 			<div className="import__heading import__heading-center">
 				<Title>{ translate( 'You are ready to migrate' ) }</Title>
+				<SubTitle className="onboarding-subtitle--full-width">
+					{ translate(
+						'Provide your SSH server credentials to migrate %(sourceSite)s to %(targetSite)s',
+						{
+							args: {
+								sourceSite: sourceSite?.slug,
+								targetSite: targetSite?.slug,
+							},
+						}
+					) }
+				</SubTitle>
 			</div>
 
 			<div className="pre-migration__form-container pre-migration__credentials-form">

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/style.scss
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/style.scss
@@ -35,19 +35,16 @@
 		}
 
 		.pre-migration__credentials-help {
-			text-align: left;
-			width: 100%;
+			display: none;
 			order: 1;
+			width: 240px;
+			text-align: left;
+			margin-inline-start: rem(40px);
+			margin-top: 200px;
 			margin-bottom: 1rem;
 
-			@include break-medium {
-				margin-inline-start: rem(40px);
-				width: 220px;
-				order: 2;
-			}
-
 			@include break-large {
-				width: 240px;
+				display: block;
 			}
 
 			h3 {

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/style.scss
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/style.scss
@@ -31,6 +31,10 @@
 
 			@include break-large {
 				width: 550px;
+
+				.credentials-form__username {
+					max-width: 320px;
+				}
 			}
 
 			.credentials-form {
@@ -49,16 +53,6 @@
 
 			.credentials-form__kpri {
 				margin-bottom: 0;
-			}
-
-			.credentials-form__username {
-				max-width: 320px;
-				//margin: 0;
-			}
-
-			.credentials-form__server-address {
-				margin: 0;
-				margin-inline-end: 1rem;
 			}
 
 			.credentials-form__user-pass {

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/style.scss
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/style.scss
@@ -63,6 +63,23 @@
 				width: 100%;
 			}
 		}
+
+		.credentials-form__actions {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+
+			button[type="submit"] {
+				min-width: 225px !important;
+			}
+
+			& > div {
+				font-size: 0.875rem;
+				/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+				line-height: 2.5rem;
+				text-align: center;
+			}
+		}
 	}
 
 	.step-container__content {

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/style.scss
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/style.scss
@@ -15,6 +15,11 @@
 		justify-content: center;
 		width: 100%;
 
+		p {
+			font-size: 0.875rem;
+			color: var(--color-text-subtle);
+		}
+
 		.pre-migration__form {
 			width: 100%;
 			order: 2;
@@ -30,7 +35,47 @@
 
 			.credentials-form {
 				margin-top: 0;
-				margin-bottom: rem(20px);
+				margin-bottom: 3rem;
+			}
+
+			.form-setting-explanation {
+				font-style: normal;
+			}
+
+			.button-plain {
+				text-decoration: underline;
+				cursor: pointer;
+			}
+
+			.credentials-form__kpri {
+				margin-bottom: 0;
+			}
+
+			.credentials-form__username {
+				max-width: 320px;
+				//margin: 0;
+			}
+
+			.credentials-form__server-address {
+				margin: 0;
+				margin-inline-end: 1rem;
+			}
+
+			.credentials-form__user-pass {
+				flex-direction: column;
+
+				& > fieldset {
+					flex: 0;
+					margin-inline-end: 0;
+
+					&.credentials-form__username {
+						margin-right: 0;
+					}
+
+					&:last-child {
+						margin-bottom: 0.5rem;
+					}
+				}
 			}
 		}
 
@@ -50,6 +95,7 @@
 			h3 {
 				font-weight: 500;
 				font-size: 1rem;
+				margin-bottom: 1rem;
 			}
 
 			p {
@@ -157,15 +203,6 @@
 
 		.credentials-form__support-info {
 			margin-bottom: rem(8px);
-		}
-
-		/** Adjust margins to also work well with RTL languages **/
-		.credentials-form__server-address.form-fieldset,
-		.credentials-form__username.form-fieldset {
-			@include break-large {
-				margin: 0;
-				margin-inline-end: rem(16px);
-			}
 		}
 	}
 }

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/test/index.test.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/test/index.test.tsx
@@ -228,7 +228,7 @@ describe( 'PreMigration', () => {
 		fireEvent.click( provideCredentialsBtn );
 		expect( screen.getByText( 'Do you need help locating your credentials?' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'Start migration' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Skip credentials (slower setup)' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Skip credentials' ) ).toBeInTheDocument();
 
 		const hostAddressInput = document.getElementById( 'host-address' ) as HTMLInputElement;
 		expect( hostAddressInput.value ).toBe( sourceSite.slug );
@@ -284,7 +284,7 @@ describe( 'PreMigration', () => {
 				screen.getByText( 'Do you need help locating your credentials?' )
 			).toBeInTheDocument();
 			expect( screen.getByText( 'Start migration' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Skip credentials (slower setup)' ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Skip credentials' ) ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/client/components/advanced-credentials/credentials-form/index.tsx
+++ b/client/components/advanced-credentials/credentials-form/index.tsx
@@ -20,6 +20,7 @@ import './style.scss';
 interface Props {
 	formErrors: FormErrors;
 	formMode: FormMode;
+	formModeSwitcher?: 'segmented' | 'simple';
 	disabled?: boolean;
 	formState: FormState;
 	onFormStateChange: ( newFormState: FormState ) => void;
@@ -37,6 +38,7 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 	formState,
 	formErrors,
 	formMode,
+	formModeSwitcher = 'segmented',
 	onFormStateChange,
 	onModeChange,
 	host,
@@ -117,7 +119,7 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 	const renderServerUsernameForm = () => (
 		<FormFieldset className="credentials-form__username">
 			<div className="credentials-form__support-info">
-				<FormLabel htmlFor="server-username">{ translate( 'Server username' ) }</FormLabel>
+				<FormLabel htmlFor="server-username">{ translate( 'Username' ) }</FormLabel>
 				{ hostInfo?.inline?.user && (
 					<InfoPopover>
 						<InlineInfo
@@ -151,7 +153,7 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 			{ renderServerUsernameForm() }
 			<FormFieldset className="credentials-form__password">
 				<div className="credentials-form__support-info">
-					<FormLabel htmlFor="server-password">{ translate( 'Server password' ) }</FormLabel>
+					<FormLabel htmlFor="server-password">{ translate( 'Password' ) }</FormLabel>
 					{ hostInfo?.inline?.pass && (
 						<InfoPopover>
 							<InlineInfo
@@ -211,9 +213,11 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 						formErrors.kpri && ( interactions.kpri || ! formErrors.kpri.waitForInteraction )
 					}
 				/>
-				<FormSettingExplanation>
-					{ translate( 'Only non-encrypted private keys are supported.' ) }
-				</FormSettingExplanation>
+				{ formModeSwitcher === 'segmented' && (
+					<FormSettingExplanation>
+						{ translate( 'Only non-encrypted private keys are supported.' ) }
+					</FormSettingExplanation>
+				) }
 				{ formErrors.kpri && ( interactions.kpri || ! formErrors.kpri.waitForInteraction ) && (
 					<FormInputValidation isError={ true } text={ formErrors.kpri.message } />
 				) }
@@ -397,7 +401,6 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 			{ ! isAlternate && withHeader && <h3>{ getFormHeaderText() }</h3> }
 			{ withHeader && <p className="credentials-form__intro-text">{ getSubHeaderText() }</p> }
 			{ withHeader && renderCredentialLinks() }
-
 			{ ! allowFtp && <input type="hidden" name="protocol" value="ssh" /> }
 			{ allowFtp && (
 				<FormFieldset className="credentials-form__protocol-type">
@@ -426,7 +429,6 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 					</FormSelect>
 				</FormFieldset>
 			) }
-
 			<div className="credentials-form__row">
 				<FormFieldset className="credentials-form__server-address">
 					<div className="credentials-form__support-info">
@@ -488,7 +490,6 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 					) }
 				</FormFieldset>
 			</div>
-
 			<FormFieldset className="credentials-form__path">
 				<div className="credentials-form__support-info">
 					<FormLabel htmlFor="wordpress-path">
@@ -516,13 +517,11 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 						formErrors.path && ( interactions.path || ! formErrors.path.waitForInteraction )
 					}
 				/>
-
 				{ formErrors.path && ( interactions.path || ! formErrors.path.waitForInteraction ) && (
 					<FormInputValidation isError={ true } text={ formErrors.path.message } />
 				) }
 			</FormFieldset>
-
-			{ 'ftp' !== formState.protocol && (
+			{ formModeSwitcher === 'segmented' && 'ftp' !== formState.protocol && (
 				<div className="credentials-form__mode-control">
 					<div className="credentials-form__support-info">
 						<SegmentedControl disabled={ disabled }>
@@ -552,9 +551,36 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 					</div>
 				</div>
 			) }
-
+			{ formModeSwitcher === 'simple' && (
+				<FormFieldset>
+					<FormLabel>{ translate( 'SSH credentials' ) }</FormLabel>
+					<FormSettingExplanation>
+						{ translate(
+							'Your credentials will be used only to migrate the site and won’t be stored anywhere.'
+						) }
+					</FormSettingExplanation>
+				</FormFieldset>
+			) }
 			{ formMode === FormMode.Password ? renderPasswordForm() : renderPrivateKeyForm() }
-
+			{ formModeSwitcher === 'simple' && (
+				<>
+					{ formMode === FormMode.Password && (
+						<p>
+							<Button plain onClick={ () => onModeChange( FormMode.PrivateKey ) }>
+								{ translate( 'Use private key instead' ) }
+							</Button>
+						</p>
+					) }
+					{ formMode === FormMode.PrivateKey && (
+						<p>
+							<span>{ translate( 'Only non-encrypted private keys are supported.' ) }</span>{ ' ' }
+							<Button plain onClick={ () => onModeChange( FormMode.Password ) }>
+								{ translate( 'Use a password instead' ) }
+							</Button>
+						</p>
+					) }
+				</>
+			) }
 			{ isAlternate && (
 				<FormFieldset className="credentials-form__save-for-later">
 					<FormLabel htmlFor="save-for-later">

--- a/client/components/advanced-credentials/credentials-form/index.tsx
+++ b/client/components/advanced-credentials/credentials-form/index.tsx
@@ -397,31 +397,35 @@ const ServerCredentialsForm: FunctionComponent< Props > = ( {
 			{ ! isAlternate && withHeader && <h3>{ getFormHeaderText() }</h3> }
 			{ withHeader && <p className="credentials-form__intro-text">{ getSubHeaderText() }</p> }
 			{ withHeader && renderCredentialLinks() }
-			<FormFieldset className="credentials-form__protocol-type">
-				<div className="credentials-form__support-info">
-					<FormLabel htmlFor="protocol-type">{ translate( 'Credential type' ) }</FormLabel>
-					{ hostInfo?.inline?.protocol && (
-						<InfoPopover>
-							<InlineInfo
-								field="protocol"
-								host={ host }
-								info={ hostInfo.inline.protocol }
-								protocol={ formState.protocol }
-							/>
-						</InfoPopover>
-					) }
-				</div>
-				<FormSelect
-					name="protocol"
-					id="protocol-type"
-					value={ formState.protocol }
-					onChange={ handleFormChange }
-					disabled={ disabled }
-				>
-					{ allowFtp && <option value="ftp">{ translate( 'FTP' ) }</option> }
-					<option value="ssh">{ translate( 'SSH/SFTP' ) }</option>
-				</FormSelect>
-			</FormFieldset>
+
+			{ ! allowFtp && <input type="hidden" name="protocol" value="ssh" /> }
+			{ allowFtp && (
+				<FormFieldset className="credentials-form__protocol-type">
+					<div className="credentials-form__support-info">
+						<FormLabel htmlFor="protocol-type">{ translate( 'Credential type' ) }</FormLabel>
+						{ hostInfo?.inline?.protocol && (
+							<InfoPopover>
+								<InlineInfo
+									field="protocol"
+									host={ host }
+									info={ hostInfo.inline.protocol }
+									protocol={ formState.protocol }
+								/>
+							</InfoPopover>
+						) }
+					</div>
+					<FormSelect
+						name="protocol"
+						id="protocol-type"
+						value={ formState.protocol }
+						onChange={ handleFormChange }
+						disabled={ disabled }
+					>
+						<option value="ftp">{ translate( 'FTP' ) }</option>
+						<option value="ssh">{ translate( 'SSH/SFTP' ) }</option>
+					</FormSelect>
+				</FormFieldset>
+			) }
 
 			<div className="credentials-form__row">
 				<FormFieldset className="credentials-form__server-address">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/86940

## Proposed Changes

* Adjusted credentials step to match the new design proposal

<img width="432" alt="Screenshot 2024-01-30 at 15 18 07" src="https://github.com/Automattic/wp-calypso/assets/1241413/304361b5-ff94-43a7-9fce-0b37d5197b5b">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `setup/import-focused?siteSlug={SITE_SLUG}`
* Pass through the flow and reach the Credentials step
* Check if everything looks as proposed in the figma design: RM0R6AwIQRiSVCLdK12pyr-fi-800_14498
* Check if the form works without any problem

<img width="992" alt="Screenshot 2024-01-30 at 15 15 06" src="https://github.com/Automattic/wp-calypso/assets/1241413/2f5fec54-4a46-4526-b4b1-6fb2224bc045">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?