### PR TITLE
Jetpack Manage pricing page: Page styles adjustments

### DIFF
--- a/client/jetpack-cloud/sections/manage/pricing/header/style.scss
+++ b/client/jetpack-cloud/sections/manage/pricing/header/style.scss
@@ -26,7 +26,7 @@
 .header__main-title
 .formatted-header__title {
 	max-width: 280px;
-	margin-bottom: 32px;
+	margin-bottom: 0;
 	margin-right: auto;
 	margin-left: auto;
 
@@ -46,4 +46,8 @@
 
 .theme-jetpack-cloud .layout.is-section-jetpack-cloud-manage-pricing.has-no-masterbar {
 	padding-top: 0;
+}
+
+.is-group-jetpack-cloud.is-section-jetpack-cloud-manage-pricing div.jpcom-masterbar header.header {
+	margin-bottom: 0;
 }

--- a/client/jetpack-cloud/sections/manage/pricing/header/style.scss
+++ b/client/jetpack-cloud/sections/manage/pricing/header/style.scss
@@ -43,3 +43,7 @@
 	}
 
 }
+
+.theme-jetpack-cloud .layout.is-section-jetpack-cloud-manage-pricing.has-no-masterbar {
+	padding-top: 0;
+}

--- a/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/main-menu-item.tsx
+++ b/client/jetpack-cloud/sections/pricing/jpcom-masterbar/components/main-menu-item.tsx
@@ -33,6 +33,16 @@ const MainMenuItem: FC< MainMenuItemProps > = ( { section, bundles } ) => {
 		};
 	}, [] );
 
+	useEffect( () => {
+		// Toggle scrolling based on menu state.
+		document.body.style.overflow = isOpen ? 'hidden' : 'auto';
+
+		return () => {
+			// Ensure that scrolling is enabled when the component unmounts. Example where this can happen without the click action: user hits the escape key.
+			document.body.style.overflow = 'auto';
+		};
+	}, [ isOpen ] );
+
 	if ( ! section ) {
 		return <></>;
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-manage/issues/253

## Proposed Changes

* This PR removes unnecessary padding at the top due to the styles in .theme-jetpack-cloud .layout.has-no-masterbar.
* This PR make scrolling down the page impossible when the menu is open.

## Testing Instructions
* Open the pricing page (`http://jetpack.cloud.localhost:3000/manage/pricing`)
* Check that the following adjustments are met:
  * There's a unnecessary padding at the top due to the styles in .theme-jetpack-cloud .layout.has-no-masterbar.
    Because the top nav isn't sticky, the spacing in .is-group-jetpack-cloud.is-section-jetpack-cloud-manage-pricing .header pushes the content down. Setting the top-margin to 0 seems to fix that.
  * When the menu is open I'd make scrolling down the page impossible via overflow-y: hidden or something like that. It's sort of hacky and not ideal, but if we want to add a sticky license number selector later on, it's the only option I can think of right now.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?