### PR TITLE
Jetpack manage pricing page: Create a new component to show 'need more info' information

### DIFF
--- a/client/jetpack-cloud/sections/manage/pricing/pricing-need-more-info/index.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/pricing-need-more-info/index.tsx
@@ -1,0 +1,23 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+
+import './style.scss';
+
+export default function PricingNeedMoreInfo() {
+	const translate = useTranslate();
+
+	const href = 'http://jetpack.com/manage';
+
+	return (
+		<div className="pricing-need-more-info">
+			<h2 className="pricing-need-more-info__headline">{ translate( 'Need more info?' ) }</h2>
+			<Button href={ href }>
+				{ translate( 'Explore %(productName)s', {
+					args: {
+						productName: translate( 'Jetpack Manage' ),
+					},
+				} ) }
+			</Button>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/manage/pricing/pricing-need-more-info/style.scss
+++ b/client/jetpack-cloud/sections/manage/pricing/pricing-need-more-info/style.scss
@@ -1,0 +1,13 @@
+.pricing-need-more-info {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	margin: 4em 0;
+}
+
+.pricing-need-more-info__headline {
+	font-size: 1.5rem !important;
+	font-weight: 700 !important;
+	line-height: inherit;
+	padding-bottom: 0.9375rem;
+}

--- a/client/jetpack-cloud/sections/manage/pricing/primary/index.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/primary/index.tsx
@@ -15,6 +15,7 @@ import Header from '../header';
 import 'calypso/my-sites/plans/jetpack-plans/product-store/style.scss';
 import 'calypso/jetpack-cloud/sections/pricing/style.scss';
 import './style.scss';
+import PricingNeedMoreInfo from '../pricing-need-more-info';
 
 export default function ManagePricingPage() {
 	const translate = useTranslate();
@@ -39,6 +40,7 @@ export default function ManagePricingPage() {
 				/>
 				<div className="jetpack-product-store">
 					<Header />
+					<PricingNeedMoreInfo />
 					<Recommendations />
 					<StoreFooter />
 				</div>


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/246

## Proposed Changes

* This PR adds the needs more info component

## Testing Instructions

* Open the pricing page (`jetpack.cloud.localhost:3000/manage/pricing`)
* Check if the `Need more info` component shows according to the specs and figma found in https://github.com/Automattic/jetpack-manage/issues/246

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?