### PR TITLE
Editor Pages Modal: Show v2 patterns from Dotcompatterns for testing

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/starter-page-templates/class-starter-page-templates.php
@@ -290,7 +290,7 @@ class Starter_Page_Templates {
 	public function get_page_templates( string $locale ) {
 		$page_template_data   = get_transient( $this->get_templates_cache_key( $locale ) );
 		$override_source_site = apply_filters( 'a8c_override_patterns_source_site', false );
-		$is_assembler_v2_site = in_array( get_stylesheet(), array( 'pub/assembler', 'assembler' ), true );
+		$is_assembler_v2_site = in_array( get_stylesheet(), array( 'pub/assembler', 'assembler' ), true ) || isset( $_GET['v2_patterns'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		// Load fresh data if we don't have any or vertical_id doesn't match.
 		if ( $is_assembler_v2_site || false === $page_template_data || ( defined( 'WP_DEBUG' ) && WP_DEBUG ) || false !== $override_source_site ) {
@@ -302,7 +302,7 @@ class Starter_Page_Templates {
 
 			if ( $is_assembler_v2_site ) {
 				$request_params = array(
-					'site'       => 'assemblerv2patterns.wordpress.com',
+					'site'       => 'dotcompatterns.wordpress.com',
 					'categories' => 'page',
 					'post_type'  => 'wp_block',
 				);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Show v2 patterns from Dotcompatterns in pages modal for testing on
  * sites with the Assembler theme active (like Dotcompatterns)
  * any site with the param `v2_patterns` on the URL: `{ SITE }/wp-admin/post-new.php?post_type=page&v2_patterns`


### Sites with the Assembler theme active
|BEFORE|AFTER|
|-|-|
|<img width="1261" alt="Screenshot 2567-01-30 at 11 59 15" src="https://github.com/Automattic/wp-calypso/assets/1881481/c6507c03-ce79-4b9f-9083-575891fb1817">|<img width="1255" alt="Screenshot 2567-01-30 at 11 57 10" src="https://github.com/Automattic/wp-calypso/assets/1881481/efb552de-d956-4acd-a748-3aa5263368fe">|


### Any site with the param `v2_patterns` on the URL
|BEFORE|AFTER|
|-|-|
|<img width="1255" alt="Screenshot 2567-01-30 at 11 59 30" src="https://github.com/Automattic/wp-calypso/assets/1881481/0f62509a-9a0a-4685-8bed-9ea7567a1f88">|<img width="1256" alt="Screenshot 2567-01-30 at 11 58 02" src="https://github.com/Automattic/wp-calypso/assets/1881481/2b095b30-3b7a-4a71-879a-db6bc3a5ed16">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox a site and the public API
* Using a site with the Assembler theme active, visit `{ SITE }/wp-admin/post-new.php?post_type=page`
* Verify you see the v2 patterns from Dotcompatterns (note that the placeholder image is different)
* Using a site without the Assembler theme active, visit `{ SITE }/wp-admin/post-new.php?post_type=page&v2_patterns`
* Again, verify you see the v2 patterns from Dotcompatterns



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->


- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?