### PR TITLE
Add CSS wrap property for the comparison grid

### DIFF
--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -907,6 +907,7 @@ body.is-section-signup.is-white-signup,
 				color: unset;
 				margin-bottom: 0;
 			}
+			text-wrap: pretty;
 		}
 
 		&:not(.has-feature):not(.has-conditional-feature) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* https://github.com/Automattic/wp-calypso/pull/86861 added a new feature list for themes to the comparison grid. This PR adds a `text-wrap` property as a UI improvement, to avoid an orphan. 

**BEFORE**
<img width="1341" alt="Screenshot 2024-01-30 at 11 49 45 AM" src="https://github.com/Automattic/wp-calypso/assets/1269602/dfb55270-c7a8-4506-bc52-9e624c007b2a">



**AFTER**
<img width="1340" alt="Screenshot 2024-01-30 at 11 25 03 AM" src="https://github.com/Automattic/wp-calypso/assets/1269602/d2186c85-10d8-4334-b2f1-1e315d6bfa29">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up your calypso.localhost and visit `/start/plans`. Scroll down to the Premium themes feature in the comparison grid. Verify that the "Dozens of premium themes" text is wrapped across two lines. 

