### PR TITLE
Live Preview: revert async-loading mechanism

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/index.tsx
@@ -1,11 +1,7 @@
 import { useSelect } from '@wordpress/data';
 import domReady from '@wordpress/dom-ready';
 import { registerPlugin } from '@wordpress/plugins';
-import { Suspense, lazy } from 'react';
-
-const LivePreviewNoticePlugin = lazy(
-	() => import( /* webpackChunkName: "wpcom-live-preview-notice" */ './live-preview-notice-plugin' )
-);
+import LivePreviewNoticePlugin from './live-preview-notice-plugin';
 
 const LivePreviewPlugin = () => {
 	const siteEditorStore = useSelect( ( select ) => select( 'core/edit-site' ), [] );
@@ -15,11 +11,7 @@ const LivePreviewPlugin = () => {
 		return null;
 	}
 
-	return (
-		<Suspense fallback={ null }>
-			<LivePreviewNoticePlugin />
-		</Suspense>
-	);
+	return <LivePreviewNoticePlugin />;
 };
 
 const registerLivePreviewPlugin = () => {

--- a/apps/wpcom-block-editor/webpack.config.js
+++ b/apps/wpcom-block-editor/webpack.config.js
@@ -27,7 +27,6 @@ const shouldEmitStats = process.env.EMIT_STATS && process.env.EMIT_STATS !== 'fa
  * @param   {Object}  argv.entry                    Entry point(s)
  * @param   {string}  argv.outputPath               Output path
  * @param   {string}  argv.outputFilename           Output filename pattern
- * @param   {string}  argv.outputChunkFilename      Output chunk filename pattern
  * @returns {Object}                                webpack config
  */
 function getWebpackConfig(
@@ -42,12 +41,10 @@ function getWebpackConfig(
 		},
 		outputPath = path.join( __dirname, 'dist' ),
 		outputFilename = isDevelopment ? '[name].js' : '[name].min.js',
-		outputChunkFilename = isDevelopment ? '[name]-[contenthash].js' : '[name]-[contenthash].min.js',
 	}
 ) {
 	const webpackConfig = getBaseWebpackConfig( env, {
 		entry,
-		'output-chunk-filename': outputChunkFilename,
 		'output-filename': outputFilename,
 		'output-path': outputPath,
 	} );


### PR DESCRIPTION
## Proposed Changes

This reverts the async-loading mechanism introduced via https://github.com/Automattic/wp-calypso/pull/86105 and https://github.com/Automattic/wp-calypso/pull/86691.

We found that on Atomic sites, this mechanism doesn't really work, as Atomic sites don't get the updated version of `wpcom-block-editor` instantly after a release, so some sites might be still referencing an old version of the live preview chunk which does not exist anymore.

See also: p1706582051787999-slack-CRWCHQGUB

## Testing Instructions

- Apply this change to your sandbox.
- Sandbox `widgets.wp.com`. Might need to disable cache so that the dev version is actually picked.
- Live-preview a theme; verify it works.
- Open Site Editor without previewing a theme; verify it works.
- Open Post Editor; verify it works.
- Open Page Editor; verify it works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?a