### PR TITLE
Fix email upsell slug for secondary domains

### DIFF
--- a/client/components/thank-you-v2/upsell/style.scss
+++ b/client/components/thank-you-v2/upsell/style.scss
@@ -67,7 +67,7 @@
 		gap: 16px;
 	}
 
-	a.components-button {
+	.components-button {
 		border-radius: 4px;
 		background: var(--black-white-black, #000);
 		box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
@@ -77,7 +77,7 @@
 		justify-content: center;
 		padding: 10px 24px;
 
-		&:hover {
+		&:not(:disabled):hover {
 			background: var(--black-white-black, #333);
 			color: var(--black-white-white, #fff);
 		}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only.tsx
@@ -16,7 +16,11 @@ import type { ReceiptPurchase } from 'calypso/state/receipts/types';
 function UpsellActions( { domainNames, receiptId }: { domainNames: string[]; receiptId: number } ) {
 	const translate = useTranslate();
 	const [ selectedDomainName, setSelectedDomainName ] = useState( domainNames[ 0 ] );
+
 	const siteSlug = useSelector( getSelectedSiteSlug );
+	// For domain-only checkouts, `siteSlug` is null. However, this is in fact an illusion. A new
+	// site is actually created, using the first domain name in the cart for the site slug.
+	const siteSlugForUpsellPath = siteSlug ?? domainNames[ 0 ];
 
 	const domainNameOptions = domainNames.map( ( domainName ) => ( {
 		label: domainName,
@@ -35,7 +39,7 @@ function UpsellActions( { domainNames, receiptId }: { domainNames: string[]; rec
 
 			<Button
 				href={ getProfessionalEmailCheckoutUpsellPath(
-					siteSlug ?? selectedDomainName,
+					siteSlugForUpsellPath,
 					selectedDomainName,
 					receiptId
 				) }

--- a/client/my-sites/checkout/get-thank-you-page-url/index.ts
+++ b/client/my-sites/checkout/get-thank-you-page-url/index.ts
@@ -18,7 +18,6 @@ import {
 	isPlan,
 	isWpComPremiumPlan,
 	isTitanMail,
-	isDomainRegistration,
 	is100Year,
 } from '@automattic/calypso-products';
 import {
@@ -357,12 +356,10 @@ export default function getThankYouPageUrl( {
 	// signup flow that is not only for domain registrations and the cookie
 	// post-checkout URL is not the signup "intent" flow.
 	const signupFlowName = getSignupCompleteFlowName();
-	const isDomainOnly =
-		siteSlug === 'no-site' && getAllCartItems( cart ).every( isDomainRegistration );
+
 	if (
 		( [ 'no-user', 'no-site' ].includes( String( cart?.cart_key ?? '' ) ) ||
 			signupFlowName === 'domain' ) &&
-		! isDomainOnly &&
 		urlFromCookie &&
 		receiptIdOrPlaceholder &&
 		! urlFromCookie.includes( '/start/setup-site' )
@@ -384,7 +381,6 @@ export default function getThankYouPageUrl( {
 					siteSlug,
 					hideUpsell: Boolean( hideNudge ),
 					domains,
-					isDomainOnly,
 			  } )
 			: undefined;
 
@@ -671,14 +667,12 @@ function getRedirectUrlForPostCheckoutUpsell( {
 	siteSlug,
 	hideUpsell,
 	domains,
-	isDomainOnly,
 }: {
 	receiptId: ReceiptId | ReceiptIdPlaceholder;
 	cart: ResponseCart | undefined;
 	siteSlug: string | undefined;
 	hideUpsell: boolean;
 	domains: ResponseDomain[] | undefined;
-	isDomainOnly?: boolean;
 } ): string | undefined {
 	if ( hideUpsell ) {
 		return;
@@ -688,7 +682,6 @@ function getRedirectUrlForPostCheckoutUpsell( {
 		cart,
 		siteSlug,
 		domains,
-		isDomainOnly,
 	} );
 
 	if ( professionalEmailUpsellUrl ) {
@@ -728,7 +721,6 @@ function getProfessionalEmailUpsellUrl( {
 	cart: ResponseCart | undefined;
 	siteSlug: string | undefined;
 	domains: ResponseDomain[] | undefined;
-	isDomainOnly?: boolean;
 } ): string | undefined {
 	if ( ! cart ) {
 		return;

--- a/client/signup/config/flows.js
+++ b/client/signup/config/flows.js
@@ -112,7 +112,9 @@ function getDomainSignupFlowDestination( { domainItem, cartItem, siteId, designT
 		return `/checkout/thank-you/${ siteSlug }`;
 	}
 
-	return '/checkout/thank-you/no-site/:receiptId';
+	// `getThankYouPageUrl` appends a receipt ID to this slug even if it doesn't contain the
+	// `:receipt_id` placeholder
+	return '/checkout/thank-you/no-site';
 }
 
 function getEmailSignupFlowDestination( { siteId, siteSlug } ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5350

## Proposed Changes

Fixes buggy behavior from #86597. That PR introduced a dropdown menu in the email upsell box on the checkout thank you page in the domain-only flow. The idea being that users would be able to select which domain they'd want to purchase email for when they've purchased multiple domains. The bug made it so that users wouldn't be able to reach the email upsell page for any domain but the first one, since the `siteSlug` in the email upsell slug was incorrect.

My assumption had been that a domain-only site is created for each domain in the cart as part of the domain-only checkout flow. This assumption turned out to be wrong, as we only create a domain-only site for the first domain. The other domains are associated with that same domain-only site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Do **NOT** have the store sandbox enabled
2. Navigate to `/domains/manage`
3. Click `Add a domain > Register a new domain`
4. Search for a domain and **add two domains to the cart**
5. Complete checkout
6. On the thank you page, select the second domain in the email upsell dropdown menu and click `Add email`
7. Ensure that you land on a working page and that the one-click checkout is triggered when you complete the form

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?