### PR TITLE
Account signup flow: use more relevant steps messaging

### DIFF
--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -1,4 +1,4 @@
-import { HOSTING_LP_FLOW } from '@automattic/onboarding';
+import { ACCOUNT_FLOW, HOSTING_LP_FLOW } from '@automattic/onboarding';
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import classnames from 'classnames';
@@ -33,7 +33,7 @@ const useSteps = ( { flowName, hasPaidDomain, isDestinationSetupSiteFlow } ) => 
 				{ title: __( 'Planning the next chess move' ) },
 			];
 			break;
-		case 'account':
+		case ACCOUNT_FLOW:
 		case HOSTING_LP_FLOW:
 			steps = [ { title: __( 'Creating your account' ) } ];
 			break;

--- a/client/signup/reskinned-processing-screen/index.jsx
+++ b/client/signup/reskinned-processing-screen/index.jsx
@@ -33,6 +33,7 @@ const useSteps = ( { flowName, hasPaidDomain, isDestinationSetupSiteFlow } ) => 
 				{ title: __( 'Planning the next chess move' ) },
 			];
 			break;
+		case 'account':
 		case HOSTING_LP_FLOW:
 			steps = [ { title: __( 'Creating your account' ) } ];
 			break;

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -1,3 +1,4 @@
+export const ACCOUNT_FLOW = 'account';
 export const AI_ASSEMBLER_FLOW = 'ai-assembler';
 export const NEWSLETTER_FLOW = 'newsletter';
 export const NEWSLETTER_POST_SETUP_FLOW = 'newsletter-post-setup';


### PR DESCRIPTION
I noticed we were showing site-creation-related messaging when signing up with account-only steps. 

## Proposed Changes

* Update the steps messaging when signing up with the account-only flow

## Screenshots

**Before:**
<img src="https://github.com/Automattic/wp-calypso/assets/844866/ea8f7a66-cb5f-4012-bb6c-4f1537dfa693" width=240 />

**After:**
<img src="https://github.com/Automattic/wp-calypso/assets/844866/bc57c94b-5bce-4a02-9309-4e28221b75f8" width=240 />


## Testing Instructions

* When not logged-in, visit `/start/account/user-social` on the `calypso.live` link
* Select "Continue with Email"
* Enter a non-a8c email address and click continue
* Make sure you see a "Creating your account" step, and not "Building your site" or "Applying design"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?