### PR TITLE
Fix `Free for…` text alignment in domain onboarding

### DIFF
--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -381,11 +381,6 @@ body.is-section-signup.is-white-signup {
 			justify-content: space-between;
 		}
 
-		.domain-product-price {
-			max-width: 180px;
-			width: unset;
-		}
-
 		.domain-product-price__free-text {
 			color: var(--color-neutral-60);
 			font-size: $font-body;
@@ -455,6 +450,11 @@ body.is-section-signup.is-white-signup {
 				.domain-registration-suggestion__domain-title-tld {
 					font-weight: 500;
 				}
+			}
+
+			.domain-product-price {
+				max-width: 180px;
+				width: unset;
 			}
 
 			.domain-product-price__free-text {

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -386,6 +386,14 @@ body.is-section-signup.is-white-signup {
 			color: var(--studio-green-60);
 		}
 
+		.domain-product-price__free-price {
+			font-weight: initial;
+
+			@include break-mobile {
+				font-weight: 500;
+			}
+		}
+
 		.domain-product-price__price {
 			font-size: $font-body-small;
 			font-weight: initial;

--- a/client/components/domains/domain-suggestion/style.scss
+++ b/client/components/domains/domain-suggestion/style.scss
@@ -382,8 +382,8 @@ body.is-section-signup.is-white-signup {
 		}
 
 		.domain-product-price__free-text {
-			color: var(--color-neutral-60);
-			font-size: $font-body;
+			font-size: $font-body-small;
+			color: var(--studio-green-60);
 		}
 
 		.domain-product-price__price {
@@ -420,18 +420,6 @@ body.is-section-signup.is-white-signup {
 			white-space: nowrap;
 		}
 
-		& .domain-product-price__free-price {
-			font-size: $font-body-small;
-			font-weight: initial;
-			color: var(--studio-green-60);
-			line-height: 20px;
-			letter-spacing: 0.2px;
-
-			@include break-mobile {
-				font-weight: 500;
-			}
-		}
-
 		&:not(.featured-domain-suggestion) {
 			background: none;
 			border-bottom: 1px solid rgba(220, 220, 222, 0.64);
@@ -453,8 +441,11 @@ body.is-section-signup.is-white-signup {
 			}
 
 			.domain-product-price {
-				max-width: 180px;
 				width: unset;
+
+				@include break-small {
+					max-width: 180px;
+				}
 			}
 
 			.domain-product-price__free-text {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes a regression from #85983 (tagging @davemart-in for review to make sure I'm not missing anything here 👋)

## Proposed Changes

The `Free for the first year with annual paid plans` text in the onboarding flow aligns weirdly because of a `max-width` CSS rule. This PR fixes that. I also tweaked the line height, which previously was weirdly high in relation to the actual font size of that text.

Hopefully the screenshots below clarify the change:

| Before | After |
| - | - |
| ![before](https://github.com/Automattic/wp-calypso/assets/1101677/acb1ec64-8793-4540-a90b-e7ea2f86792f) | ![after](https://github.com/Automattic/wp-calypso/assets/1101677/a1a0e15a-b8a5-459a-acd3-c467150c019b) |
| ![before](https://github.com/Automattic/wp-calypso/assets/1101677/b855cc31-0304-4c63-b7bc-88baf5839380) | ![after](https://github.com/Automattic/wp-calypso/assets/1101677/1b24ff14-45c1-49f5-a213-d3f3f8c3fe21) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to `/domains/manage`
2. Click `Add a domain` > `Register a new domain`
3. Search for a domain name
4. Ensure that you get a `.blog` domain name in the top two results
5. Ensure that the `Free for the first year with annual paid plans` text is displayed on a single row

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?