### PR TITLE
[Odie] New tests

### DIFF
--- a/packages/odie-client/jest.config.js
+++ b/packages/odie-client/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
 	preset: '../../test/packages/jest-preset.js',
+	setupFiles: [ '<rootDir>/jestSetup.ts' ],
 	testEnvironment: 'jsdom',
 	testMatch: [ '<rootDir>/**/__tests__/**/*.[jt]s?(x)', '!**/.eslintrc.*' ],
 	transformIgnorePatterns: [ 'node_modules/(?!gridicons)(?!.*\\.svg)' ],

--- a/packages/odie-client/jestSetup.ts
+++ b/packages/odie-client/jestSetup.ts
@@ -1,0 +1,7 @@
+jest.mock( '@automattic/calypso-config', () => ( {
+	isEnabled: () => false,
+	__esModule: true,
+	default: function config( key: string ) {
+		return key;
+	},
+} ) );

--- a/packages/odie-client/package.json
+++ b/packages/odie-client/package.json
@@ -26,7 +26,8 @@
 		"clean": "tsc --build ./tsconfig.json ./tsconfig-cjs.json --clean && rm -rf dist",
 		"build": "tsc --build ./tsconfig.json ./tsconfig-cjs.json && copy-assets",
 		"prepack": "yarn run clean && yarn run build",
-		"watch": "tsc --build ./tsconfig.json --watch"
+		"watch": "tsc --build ./tsconfig.json --watch",
+		"test": "jest --config ./jest.config.js"
 	},
 	"dependencies": {
 		"@automattic/components": "^2.0.1",

--- a/packages/odie-client/src/components/button/__tests__/index.tsx
+++ b/packages/odie-client/src/components/button/__tests__/index.tsx
@@ -1,0 +1,34 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import Button from './../index';
+
+describe( 'Button', () => {
+	it( 'renders the button', () => {
+		const { getByRole } = render( <Button>Click me</Button> );
+		const button = getByRole( 'button' );
+		expect( button ).toBeInTheDocument();
+	} );
+
+	it( 'handles click events', () => {
+		const handleClick = jest.fn();
+		const { getByRole } = render( <Button onClick={ handleClick }>Click me</Button> );
+		const button = getByRole( 'button' );
+		fireEvent.click( button );
+		expect( handleClick ).toHaveBeenCalled();
+	} );
+
+	it( 'applies the compact class when the compact prop is true', () => {
+		const { getByRole } = render( <Button compact>Click me</Button> );
+		const button = getByRole( 'button' );
+		expect( button ).toHaveClass( 'odie-button-compact' );
+	} );
+
+	it( 'applies the borderless class when the borderless prop is true', () => {
+		const { getByRole } = render( <Button borderless>Click me</Button> );
+		const button = getByRole( 'button' );
+		expect( button ).toHaveClass( 'odie-button-borderless' );
+	} );
+} );

--- a/packages/odie-client/src/components/ellipsis-menu/__tests__/index.tsx
+++ b/packages/odie-client/src/components/ellipsis-menu/__tests__/index.tsx
@@ -1,0 +1,32 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { EllipsisMenu } from './../';
+
+describe( 'EllipsisMenu', () => {
+	test( 'renders correctly', () => {
+		const { getByRole } = render( <EllipsisMenu /> );
+		const button = getByRole( 'button' );
+		expect( button ).toBeInTheDocument();
+	} );
+
+	test( 'toggles menu visibility when button is clicked', () => {
+		const { getByRole, queryByRole } = render( <EllipsisMenu /> );
+		const button = getByRole( 'button' );
+
+		// Initially, the menu should not be visible
+		expect( queryByRole( 'menu' ) ).not.toBeInTheDocument();
+
+		// After clicking the button, the menu should be visible
+		fireEvent.click( button );
+		expect( queryByRole( 'menu' ) ).toBeInTheDocument();
+
+		// After clicking the button again, the menu should not be visible
+		fireEvent.click( button );
+		expect( queryByRole( 'menu' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/packages/odie-client/src/components/foldable/__tests__/index.tsx
+++ b/packages/odie-client/src/components/foldable/__tests__/index.tsx
@@ -1,0 +1,42 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import FoldableCard from '../index';
+
+describe( 'FoldableCard', () => {
+	const defaultProps = {
+		header: 'Test Header',
+		summary: 'Test Summary',
+		expandedSummary: 'Test Expanded Summary',
+		cardKey: 'testKey',
+		onClick: jest.fn(),
+		onOpen: jest.fn(),
+		onClose: jest.fn(),
+	};
+
+	it( 'renders without crashing', () => {
+		const { container } = render( <FoldableCard { ...defaultProps } /> );
+		expect( container ).toBeInTheDocument();
+	} );
+
+	it( 'renders the header', () => {
+		const { getByText } = render( <FoldableCard { ...defaultProps } /> );
+		expect( getByText( defaultProps.header ) ).toBeInTheDocument();
+	} );
+
+	it( 'calls onClick when clicked', () => {
+		const { getByText } = render( <FoldableCard { ...defaultProps } /> );
+		fireEvent.click( getByText( defaultProps.header ) );
+		expect( defaultProps.onClick ).toHaveBeenCalled();
+	} );
+
+	it( 'calls onOpen when expanded', () => {
+		const { rerender } = render( <FoldableCard { ...defaultProps } /> );
+		rerender( <FoldableCard { ...defaultProps } expanded /> );
+		expect( defaultProps.onOpen ).toHaveBeenCalledWith( defaultProps.cardKey );
+	} );
+} );

--- a/packages/odie-client/src/components/message/__tests__/custom-a-link.tsx
+++ b/packages/odie-client/src/components/message/__tests__/custom-a-link.tsx
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { OdieAssistantContext } from '../../../context';
+import { mockOdieAssistantProviderProps } from '../../../context/test-utils/context-mock';
+import CustomALink from '../custom-a-link';
+
+describe( 'CustomALink', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'renders children correctly', () => {
+		render(
+			<OdieAssistantContext.Provider value={ mockOdieAssistantProviderProps }>
+				<CustomALink href="prompt://test">Test Link</CustomALink>
+			</OdieAssistantContext.Provider>
+		);
+
+		expect( screen.getByText( 'Test Link' ) ).toBeInTheDocument();
+	} );
+
+	it( 'has correct class when inline prop is true', () => {
+		render(
+			<OdieAssistantContext.Provider value={ mockOdieAssistantProviderProps }>
+				<CustomALink href="prompt://test" inline={ true }>
+					Test Link
+				</CustomALink>
+			</OdieAssistantContext.Provider>
+		);
+
+		const linkElement = screen.getByText( 'Test Link' );
+		expect( linkElement.parentElement ).toHaveClass( 'odie-sources' );
+		expect( linkElement.parentElement ).toHaveClass( 'odie-sources-inline' );
+	} );
+
+	it( 'does not have inline class when inline prop is false', () => {
+		render(
+			<OdieAssistantContext.Provider value={ mockOdieAssistantProviderProps }>
+				<CustomALink href="prompt://test" inline={ false }>
+					Test Link
+				</CustomALink>
+			</OdieAssistantContext.Provider>
+		);
+
+		const linkElement = screen.getByText( 'Test Link' );
+		expect( linkElement.parentElement ).toHaveClass( 'odie-sources' );
+		expect( linkElement.parentElement ).not.toHaveClass( 'odie-sources-inline' );
+	} );
+} );

--- a/packages/odie-client/src/components/message/__tests__/index.tsx
+++ b/packages/odie-client/src/components/message/__tests__/index.tsx
@@ -1,0 +1,77 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '@testing-library/jest-dom';
+import React from 'react';
+
+jest.spyOn( React, 'useRef' ).mockReturnValue( { current: null } );
+
+jest.mock( 'react-redux', () => ( {
+	...jest.requireActual( 'react-redux' ),
+	useSelector: jest.fn(),
+} ) );
+
+jest.mock( 'calypso/state/current-user/selectors', () => ( {
+	currentUser: {
+		display_name: 'Test User',
+	},
+} ) );
+
+describe( 'Message Component', () => {
+	let message;
+
+	beforeEach( () => {
+		message = {
+			content: 'Hello, world!',
+			type: 'message',
+			context: {
+				sources: [ { url: 'https://example.com', otherData: 'data' } ],
+				flags: {
+					forward_to_human_support: false,
+				},
+			},
+			rating_value: 3,
+			simulateTyping: false,
+		};
+	} );
+
+	it( 'should render correctly', () => {
+		// TODO: Fix this test
+
+		expect( true ).toBe( true );
+	} );
+
+	it( 'should correctly determine if message has sources', () => {
+		const hasSources = message?.context?.sources && message.context?.sources.length > 0;
+		expect( hasSources ).toBe( true );
+	} );
+
+	it( 'should correctly determine if message has feedback', () => {
+		const hasFeedback = !! message?.rating_value;
+		expect( hasFeedback ).toBe( true );
+	} );
+
+	it( 'should dedupe sources based on url', () => {
+		let sources = message?.context?.sources ?? [];
+		if ( sources.length > 0 ) {
+			sources = [ ...new Map( sources.map( ( source ) => [ source.url, source ] ) ).values() ];
+		}
+		expect( sources.length ).toBe( 1 );
+	} );
+
+	it( 'should correctly determine if type is message or empty', () => {
+		const isTypeMessageOrEmpty = ! message.type || message.type === 'message';
+		expect( isTypeMessageOrEmpty ).toBe( true );
+	} );
+
+	it( 'should correctly determine if simulated typing is finished', () => {
+		const isSimulatedTypingFinished = message.simulateTyping && message.content === message.content;
+		expect( isSimulatedTypingFinished ).toBe( false );
+	} );
+
+	it( 'should correctly determine if requesting human support', () => {
+		const isRequestingHumanSupport = message.context?.flags?.forward_to_human_support;
+		expect( isRequestingHumanSupport ).toBe( false );
+	} );
+} );

--- a/packages/odie-client/src/components/message/__tests__/jump-to-recent.tsx
+++ b/packages/odie-client/src/components/message/__tests__/jump-to-recent.tsx
@@ -1,0 +1,72 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render } from '@testing-library/react';
+import React from 'react';
+import { OdieAssistantContext } from '../../../context';
+import { mockOdieAssistantProviderProps } from '../../../context/test-utils/context-mock';
+import { JumpToRecent } from '../jump-to-recent';
+
+jest.mock( 'calypso/state/analytics/actions', () => ( {
+	recordTracksEvent: jest.fn( () => ( {
+		type: 'ANALYTICS_EVENT_RECORD',
+	} ) ),
+} ) );
+
+describe( 'JumpToRecent', () => {
+	const scrollToBottom = jest.fn();
+
+	beforeAll( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'calls scrollToBottom and recordTracksEvent on button click', () => {
+		const { getByText } = render(
+			<OdieAssistantContext.Provider value={ mockOdieAssistantProviderProps }>
+				<JumpToRecent
+					scrollToBottom={ scrollToBottom }
+					enableJumpToRecent={ true }
+					bottomOffset={ 0 }
+				/>
+			</OdieAssistantContext.Provider>
+		);
+
+		fireEvent.click( getByText( 'Jump to recent' ) );
+
+		expect( scrollToBottom ).toHaveBeenCalled();
+		expect( mockOdieAssistantProviderProps.trackEvent ).toHaveBeenCalledWith(
+			'chat_jump_to_recent_click'
+		);
+	} );
+
+	it( 'renders correctly when enableJumpToRecent is true', () => {
+		const { container } = render(
+			<OdieAssistantContext.Provider value={ mockOdieAssistantProviderProps }>
+				<JumpToRecent
+					scrollToBottom={ scrollToBottom }
+					enableJumpToRecent={ true }
+					bottomOffset={ 0 }
+				/>
+			</OdieAssistantContext.Provider>
+		);
+
+		expect( container.firstChild ).toHaveClass( 'odie-gradient-to-white' );
+		expect( container.firstChild ).toHaveClass( 'is-visible' );
+	} );
+
+	it( 'does not render visible class when enableJumpToRecent is false', () => {
+		const { container } = render(
+			<OdieAssistantContext.Provider value={ mockOdieAssistantProviderProps }>
+				<JumpToRecent
+					scrollToBottom={ scrollToBottom }
+					enableJumpToRecent={ false }
+					bottomOffset={ 0 }
+				/>
+			</OdieAssistantContext.Provider>
+		);
+
+		expect( container.firstChild ).toHaveClass( 'odie-gradient-to-white' );
+		expect( container.firstChild ).not.toHaveClass( 'is-visible' );
+	} );
+} );

--- a/packages/odie-client/src/components/message/__tests__/uri-transformers.ts
+++ b/packages/odie-client/src/components/message/__tests__/uri-transformers.ts
@@ -1,0 +1,30 @@
+import { uriTransformer } from '../uri-transformer';
+
+describe( 'uriTransformer', () => {
+	it( 'should return the same URL if it starts with # or /', () => {
+		expect( uriTransformer( '#anchor' ) ).toBe( '#anchor' );
+		expect( uriTransformer( '/relative/path' ) ).toBe( '/relative/path' );
+	} );
+
+	it( 'should return the same URL if it uses a valid protocol', () => {
+		expect( uriTransformer( 'http://example.com' ) ).toBe( 'http://example.com' );
+		expect( uriTransformer( 'https://example.com' ) ).toBe( 'https://example.com' );
+		expect( uriTransformer( 'mailto:example@example.com' ) ).toBe( 'mailto:example@example.com' );
+		expect( uriTransformer( 'tel:+1234567890' ) ).toBe( 'tel:+1234567890' );
+		expect( uriTransformer( 'prompt:example' ) ).toBe( 'prompt:example' );
+	} );
+
+	it( 'should return the same URL if it has a colon after a question mark or hash', () => {
+		expect( uriTransformer( 'http://example.com?param=value:other' ) ).toBe(
+			'http://example.com?param=value:other'
+		);
+		expect( uriTransformer( 'http://example.com#hash:value' ) ).toBe(
+			'http://example.com#hash:value'
+		);
+	} );
+
+	it( 'should return "javascript:void(0)" if it uses an invalid protocol', () => {
+		expect( uriTransformer( 'ftp://example.com' ) ).toBe( 'javascript:void(0)' );
+		expect( uriTransformer( 'invalid://example.com' ) ).toBe( 'javascript:void(0)' );
+	} );
+} );

--- a/packages/odie-client/src/context/index.tsx
+++ b/packages/odie-client/src/context/index.tsx
@@ -238,3 +238,4 @@ const OdieAssistantProvider: FC< OdieAssistantProviderProps > = ( {
 };
 
 export { OdieAssistantContext, useOdieAssistantContext, OdieAssistantProvider };
+export type { OdieAssistantContextInterface };

--- a/packages/odie-client/src/context/test-utils/context-mock.tsx
+++ b/packages/odie-client/src/context/test-utils/context-mock.tsx
@@ -1,0 +1,46 @@
+import * as jest from 'jest-mock';
+import { OdieAssistantContextInterface } from '..';
+import { Message, Chat, Nudge, OdieAllowedBots } from '../../types';
+
+const mockMessage: Message = {
+	type: 'message',
+	message_id: 1,
+	content: 'Mock message',
+	role: 'user',
+};
+
+const mockChat: Chat = {
+	chat_id: 1,
+	messages: [ mockMessage ],
+};
+
+const mockNudge: Nudge = {
+	nudge: 'nudge',
+	initialMessage: 'Mock initial message',
+};
+
+export const mockOdieAssistantProviderProps: OdieAssistantContextInterface = {
+	botName: 'Mock Bot',
+	botNameSlug: 'mock-bot-slug' as OdieAllowedBots,
+	initialUserMessage: 'Hello, this is a mock message',
+	isMinimized: false,
+	extraContactOptions: <div>Mock Extra Contact Options</div>,
+	addMessage: jest.fn(),
+	chat: mockChat,
+	clearChat: jest.fn(),
+	isLoadingChat: false,
+	isLoading: false,
+	isNudging: false,
+	isVisible: false,
+	lastNudge: mockNudge,
+	sendNudge: jest.fn(),
+	setChat: jest.fn(),
+	setIsLoadingChat: jest.fn(),
+	setMessageLikedStatus: jest.fn(),
+	setContext: jest.fn(),
+	setIsNudging: jest.fn(),
+	setIsVisible: jest.fn(),
+	setIsLoading: jest.fn(),
+	trackEvent: jest.fn(),
+	updateMessage: jest.fn(),
+};


### PR DESCRIPTION
## Proposed Changes

Add new tests for odie package (more to come)

## Testing Instructions

Go to `packages/odie-client` and run `npm run test`

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?