### PR TITLE
Theme Showcase: Update Controllers for an "All Sites" View

### DIFF
--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -883,7 +883,7 @@ export function selectSiteIfLoggedIn( context, next ) {
  * If the section has an "all sites" view to delay the site selection,
  * only handle the site selection with 0 or 1 sites.
  */
-export function selectSiteIfLoggedInWithOneSite( context, next ) {
+export function selectSiteOrSkipIfLoggedInWithMultipleSites( context, next ) {
 	const state = context.store.getState();
 	const isLoggedIn = isUserLoggedIn( state );
 	const siteCount = getCurrentUserSiteCount( state );

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -879,16 +879,6 @@ export function selectSiteIfLoggedIn( context, next ) {
 	selectSite( context );
 }
 
-export function selectSiteIfLoggedInWithSites( context, next ) {
-	const state = context.store.getState();
-	if ( isUserLoggedIn( state ) && getCurrentUserSiteCount( state ) && ! context.params.site_id ) {
-		selectSite( context );
-		return;
-	}
-
-	siteSelection( context, next );
-}
-
 /**
  * If the section has an "all sites" view to delay the site selection,
  * only handle the site selection with 0 or 1 sites.

--- a/client/my-sites/controller.js
+++ b/client/my-sites/controller.js
@@ -889,6 +889,36 @@ export function selectSiteIfLoggedInWithSites( context, next ) {
 	siteSelection( context, next );
 }
 
+/**
+ * If the section has an "all sites" view to delay the site selection,
+ * only handle the site selection with 0 or 1 sites.
+ */
+export function selectSiteIfLoggedInWithOneSite( context, next ) {
+	const state = context.store.getState();
+	const isLoggedIn = isUserLoggedIn( state );
+	const siteCount = getCurrentUserSiteCount( state );
+	const siteFragment =
+		context.params.site || context.params.site_id || getSiteFragment( context.path );
+
+	// If the user is logged out, has 0 sites, or the path contains a site fragment,
+	// proceed with the regular site selection.
+	if ( ! isLoggedIn || ! siteCount || !! siteFragment ) {
+		siteSelection( context, next );
+		return;
+	}
+
+	// If the user only has 1 site and the path doesn't contain a site fragment,
+	// select the site automatically and move on.
+	if ( siteCount === 1 ) {
+		selectSite( context );
+		return;
+	}
+
+	// If the user has multiple sites and the path doesn't contain a site fragment,
+	// proceed with rendering the page, delaying the site selection.
+	next();
+}
+
 export function hideNavigationIfLoggedInWithNoSites( context, next ) {
 	const state = context.store.getState();
 	if ( isUserLoggedIn( state ) && getCurrentUserSiteCount( state ) === 0 ) {

--- a/client/my-sites/theme/index.web.js
+++ b/client/my-sites/theme/index.web.js
@@ -2,7 +2,7 @@ import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import { makeLayout, redirectWithoutLocaleParamIfLoggedIn } from 'calypso/controller';
 import {
-	selectSiteIfLoggedInWithSites,
+	selectSiteIfLoggedInWithOneSite,
 	redirectToLoginIfSiteRequested,
 } from 'calypso/my-sites/controller';
 import { getTheme } from 'calypso/state/themes/selectors';
@@ -31,7 +31,7 @@ export default function ( router ) {
 		redirectWithoutLocaleParamIfLoggedIn,
 		redirectToLoginIfSiteRequested,
 		setTitleIfThemeExisted,
-		selectSiteIfLoggedInWithSites,
+		selectSiteIfLoggedInWithOneSite,
 		fetchThemeDetailsData,
 		details,
 		makeLayout

--- a/client/my-sites/theme/index.web.js
+++ b/client/my-sites/theme/index.web.js
@@ -2,7 +2,7 @@ import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import { makeLayout, redirectWithoutLocaleParamIfLoggedIn } from 'calypso/controller';
 import {
-	selectSiteIfLoggedInWithOneSite,
+	selectSiteOrSkipIfLoggedInWithMultipleSites,
 	redirectToLoginIfSiteRequested,
 } from 'calypso/my-sites/controller';
 import { getTheme } from 'calypso/state/themes/selectors';
@@ -31,7 +31,7 @@ export default function ( router ) {
 		redirectWithoutLocaleParamIfLoggedIn,
 		redirectToLoginIfSiteRequested,
 		setTitleIfThemeExisted,
-		selectSiteIfLoggedInWithOneSite,
+		selectSiteOrSkipIfLoggedInWithMultipleSites,
 		fetchThemeDetailsData,
 		details,
 		makeLayout

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -8,7 +8,7 @@ import {
 } from 'calypso/controller';
 import {
 	navigation,
-	selectSiteIfLoggedInWithOneSite,
+	selectSiteOrSkipIfLoggedInWithMultipleSites,
 	siteSelection,
 	sites,
 	hideNavigationIfLoggedInWithNoSites,
@@ -73,7 +73,7 @@ export default function ( router ) {
 		routesWithoutSites,
 		redirectWithoutLocaleParamIfLoggedIn,
 		fetchAndValidateVerticalsAndFilters,
-		selectSiteIfLoggedInWithOneSite,
+		selectSiteOrSkipIfLoggedInWithMultipleSites,
 		renderThemes,
 		hideNavigationIfLoggedInWithNoSites,
 		addNavigationIfLoggedIn,

--- a/client/my-sites/themes/index.web.js
+++ b/client/my-sites/themes/index.web.js
@@ -8,7 +8,7 @@ import {
 } from 'calypso/controller';
 import {
 	navigation,
-	selectSiteIfLoggedInWithSites,
+	selectSiteIfLoggedInWithOneSite,
 	siteSelection,
 	sites,
 	hideNavigationIfLoggedInWithNoSites,
@@ -73,7 +73,7 @@ export default function ( router ) {
 		routesWithoutSites,
 		redirectWithoutLocaleParamIfLoggedIn,
 		fetchAndValidateVerticalsAndFilters,
-		selectSiteIfLoggedInWithSites,
+		selectSiteIfLoggedInWithOneSite,
 		renderThemes,
 		hideNavigationIfLoggedInWithNoSites,
 		addNavigationIfLoggedIn,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5383

## Proposed Changes

* Add a new `selectSiteIfLoggedInWithOneSite` routing callback to be used in logged-in `/themes` and `/theme`.

The new callback allows for a new "All Sites" view, accessible to users owning multiple sites, that defers the site selection to the latest possible moment, rather than before opening the Theme Showcase.

This change's purpose is to let users browse themes immediately instead of having to select a site first, using the old and unappealing site selector.

The new `selectSiteIfLoggedInWithOneSite` callback practically replaces the previous `selectSiteIfLoggedInWithSites`, introduced in https://github.com/Automattic/wp-calypso/pull/82917 in support of a "no sites" view. The old callback remains available, but it's currently not used anywhere. 

After the change, we'll have the following routing situation:

| Sites | Before | After | Notes |
|--------|--------|--------|--------|
| 0 | <img width="1139" alt="Screenshot 2024-02-05 at 13 18 45" src="https://github.com/Automattic/wp-calypso/assets/2070010/5dbf3a5f-7c35-4019-a3fc-6ae85a2e7d11"> | <img width="1139" alt="Screenshot 2024-02-05 at 13 18 45" src="https://github.com/Automattic/wp-calypso/assets/2070010/1b0fd949-c536-413b-b383-2e7ee5183008"> | No changes |
| 1 | <img width="1139" alt="Screenshot 2024-02-05 at 13 21 07" src="https://github.com/Automattic/wp-calypso/assets/2070010/8bbdaaee-f9af-4a8e-8144-60928b68f768"> | <img width="1139" alt="Screenshot 2024-02-05 at 13 21 07" src="https://github.com/Automattic/wp-calypso/assets/2070010/049502f5-a620-4081-af99-98ad81345ed6"> | No changes |
| 2+ | <img width="1139" alt="Screenshot 2024-02-05 at 13 21 55" src="https://github.com/Automattic/wp-calypso/assets/2070010/979d5e08-2d00-4ba5-b4a9-ab1907298696"> | <img width="1139" alt="Screenshot 2024-02-05 at 13 19 17" src="https://github.com/Automattic/wp-calypso/assets/2070010/16991067-42e9-49a9-8957-22429ae3742d"> | "Pick theme" actions trigger a `start/with-theme` flow. |

### About Theme Actions and the `with-theme` Flow

This is only the first step of a larger project.

This PR is only responsible for changing routing.
Another PR will introduce a deferred site selection modal integrated with the various "Pick theme" (and similar) actions.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a test user with zero sites.
  * Open `/themes` or `/theme/bedrock` (or any other Theme Details page) without site fragment in URL.
  * Ensure both pages open without additional steps.
* Use a test user with exactly one site.
  * Open `/themes` or `/theme/bedrock` (or any other Theme Details page) without site fragment in URL.
  * Ensure the routing automatically selects the only site, and both pages open without additional steps.
* Use a test user with two or more sites.
  * Open `/themes` or `/theme/bedrock` (or any other Theme Details page) without site fragment in URL.
  * Ensure both pages open without additional steps.
  * Try clicking on various theme links.
  * Ensure they start a new onboarding flow (just like the zero sites example).


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?