### PR TITLE
Site Transfer: allows any user.

### DIFF
--- a/client/my-sites/people/team-members-site-transfer/index.tsx
+++ b/client/my-sites/people/team-members-site-transfer/index.tsx
@@ -1,0 +1,63 @@
+import { Card } from '@automattic/components';
+import InfiniteList from 'calypso/components/infinite-list';
+import { useSelector } from 'calypso/state';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import PeopleListItemTransfer from './people-list-item-transfer';
+import type { UsersQuery } from './types';
+import type { Member } from '../types';
+
+import './style.scss';
+
+interface Props {
+	search?: string;
+	usersQuery: UsersQuery;
+	onClick: ( userLogin: string ) => void;
+}
+function TeamMembersSiteTransfer( props: Props ) {
+	const { search, usersQuery } = props;
+	const site = useSelector( getSelectedSite );
+
+	const listKey = [ 'team-members', site?.ID, search ].join( '-' );
+	const { data, fetchNextPage, isLoading, isFetchingNextPage, hasNextPage } = usersQuery;
+
+	const members = data?.users || [];
+
+	function getPersonRef( user: Member ) {
+		return 'user-' + user?.ID;
+	}
+
+	function onClick( user: Member ) {
+		props.onClick( user.login );
+	}
+
+	function renderPerson( user: Member ) {
+		return (
+			<PeopleListItemTransfer key={ user?.ID } user={ user } site={ site } onClick={ onClick } />
+		);
+	}
+
+	function renderLoadingPeople() {
+		return <PeopleListItemTransfer key="people-list-item-placeholder" />;
+	}
+
+	return (
+		<>
+			<Card className="people-team-members-list">
+				{ isLoading && renderLoadingPeople() }
+				<InfiniteList
+					listkey={ listKey }
+					items={ members }
+					fetchNextPage={ fetchNextPage }
+					fetchingNextPage={ isFetchingNextPage }
+					lastPage={ ! hasNextPage }
+					renderItem={ renderPerson }
+					renderLoadingPlaceholders={ renderLoadingPeople }
+					guessedItemHeight={ 126 }
+					getItemRef={ getPersonRef }
+				/>
+			</Card>
+		</>
+	);
+}
+
+export default TeamMembersSiteTransfer;

--- a/client/my-sites/people/team-members-site-transfer/index.tsx
+++ b/client/my-sites/people/team-members-site-transfer/index.tsx
@@ -1,6 +1,7 @@
 import { Card } from '@automattic/components';
 import InfiniteList from 'calypso/components/infinite-list';
 import { useSelector } from 'calypso/state';
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import PeopleListItemTransfer from './people-list-item-transfer';
 import type { UsersQuery } from './types';
@@ -16,11 +17,12 @@ interface Props {
 function TeamMembersSiteTransfer( props: Props ) {
 	const { search, usersQuery } = props;
 	const site = useSelector( getSelectedSite );
+	const currentUserId = useSelector( getCurrentUserId );
 
 	const listKey = [ 'team-members', site?.ID, search ].join( '-' );
 	const { data, fetchNextPage, isLoading, isFetchingNextPage, hasNextPage } = usersQuery;
 
-	const members = data?.users || [];
+	const members = data?.users.filter( ( user ) => user.ID !== currentUserId ) || [];
 
 	function getPersonRef( user: Member ) {
 		return 'user-' + user?.ID;

--- a/client/my-sites/people/team-members-site-transfer/people-list-item-transfer/index.jsx
+++ b/client/my-sites/people/team-members-site-transfer/people-list-item-transfer/index.jsx
@@ -1,0 +1,38 @@
+import { CompactCard } from '@automattic/components';
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { PureComponent } from 'react';
+import { connect } from 'react-redux';
+import PeopleProfile from 'calypso/my-sites/people/people-profile';
+import './style.scss';
+
+class PeopleListItemTransfer extends PureComponent {
+	static displayName = 'PeopleListItem';
+
+	static propTypes = {
+		site: PropTypes.object,
+	};
+
+	render() {
+		const { siteId, translate, user, onClick } = this.props;
+
+		return (
+			<CompactCard className="people-list-item" onClick={ () => onClick( user ) }>
+				<div className="people-list-item-transfer__profile-container">
+					<PeopleProfile siteId={ siteId } user={ user } />
+					<span className="people-list-item-transfer__action">
+						{ translate( 'Transfer ownership' ) }
+					</span>
+				</div>
+			</CompactCard>
+		);
+	}
+}
+
+export default connect( ( state, ownProps ) => {
+	const { site } = ownProps;
+
+	return {
+		siteId: site?.ID,
+	};
+} )( localize( PeopleListItemTransfer ) );

--- a/client/my-sites/people/team-members-site-transfer/people-list-item-transfer/style.scss
+++ b/client/my-sites/people/team-members-site-transfer/people-list-item-transfer/style.scss
@@ -1,0 +1,33 @@
+.people-list-item.card.is-compact {
+	border-bottom: 1px solid var(--color-neutral-0);
+	box-shadow: none;
+	display: flex;
+	overflow: hidden;
+	position: relative;
+
+	@include breakpoint-deprecated( ">480px" ) {
+		padding: 24px;
+	}
+
+	&:last-of-type {
+		border-bottom: none;
+	}
+
+	&:focus {
+		outline: 2px solid var(--color-primary-light);
+		z-index: z-index("root", ".people-list-item.card.is-compact:focus");
+	}
+}
+
+.people-list-item-transfer__profile-container {
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+	flex-grow: 1;
+	overflow: hidden;
+	cursor: pointer;
+}
+
+.people-list-item-transfer__action {
+	color: #3858e9;
+}

--- a/client/my-sites/people/team-members-site-transfer/style.scss
+++ b/client/my-sites/people/team-members-site-transfer/style.scss
@@ -1,0 +1,3 @@
+.people-team-members-list {
+	padding: 0;
+}

--- a/client/my-sites/people/team-members-site-transfer/types.ts
+++ b/client/my-sites/people/team-members-site-transfer/types.ts
@@ -1,0 +1,10 @@
+import type { Member, UseQuery } from '../types';
+
+export type UsersQueryData = {
+	users: Member[];
+	total: number;
+};
+
+export type UsersQuery = {
+	data?: UsersQueryData;
+} & UseQuery;

--- a/client/my-sites/people/team-members/index.tsx
+++ b/client/my-sites/people/team-members/index.tsx
@@ -15,10 +15,11 @@ interface Props {
 	search?: string;
 	usersQuery: UsersQuery;
 	showAddTeamMembersBtn?: boolean;
+	showHeader?: boolean;
 }
 function TeamMembers( props: Props ) {
 	const translate = useTranslate();
-	const { search, usersQuery, showAddTeamMembersBtn = true } = props;
+	const { search, usersQuery, showAddTeamMembersBtn = true, showHeader = true } = props;
 	const site = useSelector( getSelectedSite );
 
 	const listKey = [ 'team-members', site?.ID, search ].join( '-' );
@@ -78,13 +79,15 @@ function TeamMembers( props: Props ) {
 		case 'loading':
 			return (
 				<>
-					<PeopleListSectionHeader isPlaceholder={ isLoading } label={ getHeaderLabel() }>
-						{ showAddTeamMembersBtn && (
-							<Button compact primary href={ addTeamMemberLink }>
-								{ translate( 'Add a team member' ) }
-							</Button>
-						) }
-					</PeopleListSectionHeader>
+					{ showHeader && (
+						<PeopleListSectionHeader isPlaceholder={ isLoading } label={ getHeaderLabel() }>
+							{ showAddTeamMembersBtn && (
+								<Button compact primary href={ addTeamMemberLink }>
+									{ translate( 'Add a team member' ) }
+								</Button>
+							) }
+						</PeopleListSectionHeader>
+					) }
 					<Card className="people-team-members-list">
 						{ isLoading && renderLoadingPeople() }
 						<InfiniteList

--- a/client/my-sites/site-settings/site-owner-transfer/confirmation-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/confirmation-transfer.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import Notice from 'calypso/components/notice';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useConfirmTransfer } from './use-confirm-transfer';
 
 /**
@@ -23,6 +24,7 @@ export function ConfirmationTransfer( {
 		{ siteId },
 		{
 			onSuccess: () => {
+				recordTracksEvent( 'calypso_site_owner_transfer_confirm_success' );
 				page.redirect( `/sites?site-transfer-confirm=true` );
 			},
 			onError: ( error ) => {

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
@@ -15,7 +15,6 @@ import PendingDomainTransfer from './pending-domain-transfer';
 import SiteOwnerTransferEligibility from './site-owner-user-search';
 import { SiteTransferCard } from './site-transfer-card';
 import StartSiteOwnerTransfer from './start-site-owner-transfer';
-import { User } from './use-administrators';
 import { useConfirmationTransferHash } from './use-confirmation-transfer-hash';
 
 const Strong = styled( 'strong' )( {
@@ -46,7 +45,7 @@ const SiteTransferComplete = () => {
 const SiteOwnerTransfer = () => {
 	useQueryUserPurchases();
 	const selectedSite = useSelector( getSelectedSite );
-	const [ newSiteOwner, setNewSiteOwner ] = useState< User | null >( null );
+	const [ newSiteOwner, setNewSiteOwner ] = useState< string | null >( null );
 	const [ transferSiteSuccess, setSiteTransferSuccess ] = useState( false );
 
 	const translate = useTranslate();

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
@@ -1,10 +1,11 @@
 import page from '@automattic/calypso-router';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useQueryUserPurchases } from 'calypso/components/data/query-user-purchases';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
@@ -58,6 +59,10 @@ const SiteOwnerTransfer = () => {
 	const pendingDomain = nonWpcomDomains?.find(
 		( wpcomDomain: ResponseDomain ) => wpcomDomain.pendingTransfer
 	);
+
+	useEffect( () => {
+		dispatch( recordTracksEvent( 'calypso_site_owner_transfer_page_view' ) );
+	}, [ dispatch ] );
 
 	if ( ! selectedSite?.ID || ! selectedSite?.slug ) {
 		return null;

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
@@ -89,7 +89,7 @@ const SiteOwnerTransferEligibility = ( {
 		<form onSubmit={ handleFormSubmit }>
 			<FormText>
 				{ translate(
-					'Email or WordPress.com Username of the person you want to transfer ownership of {{strong}}%(siteSlug)s{{/strong}} to:',
+					'Transfer the ownership of {{strong}}%(siteSlug)s{{/strong}} and related purchases to another user by adding their Email or their WordPress.com Usernamei in the following form.',
 					{
 						args: { siteSlug },
 						components: { strong: <Strong /> },
@@ -98,7 +98,7 @@ const SiteOwnerTransferEligibility = ( {
 			</FormText>
 
 			<FormFieldset>
-				<FormLabel>{ translate( 'Email or WordPress.com username.' ) }</FormLabel>
+				<FormLabel>{ translate( 'Email or WordPress.com username' ) }</FormLabel>
 				<FormTextInput
 					id="recipient"
 					name="recipient"
@@ -122,7 +122,7 @@ const SiteOwnerTransferEligibility = ( {
 				) }
 				<NonWPUserExplanation>
 					{ translate(
-						"If the person you want to transfer ownership doesn't have a WordPress.com account yet they will be invited to add create one."
+						"If the person you want to transfer ownership doesn't have a WordPress.com account yet they will be invited to create one."
 					) }
 				</NonWPUserExplanation>
 			</FormFieldset>

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
@@ -55,7 +55,7 @@ const SiteOwnerTransferEligibility = ( {
 		search_columns: [ 'display_name', 'user_login', 'user_email' ],
 		include_viewers: false,
 	} ) as unknown as UsersQuery;
-	const usersFound = usersQuery?.data?.users?.length > 0;
+	const usersFound = usersQuery?.data?.users?.length ?? 0 > 0;
 
 	const { checkSiteTransferEligibility, isPending: isCheckingSiteTransferEligibility } =
 		useCheckSiteTransferEligibility( siteId, {

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
@@ -55,7 +55,7 @@ const SiteOwnerTransferEligibility = ( {
 		search_columns: [ 'display_name', 'user_login', 'user_email' ],
 		include_viewers: false,
 	} ) as unknown as UsersQuery;
-	const usersFound = usersQuery?.data?.users?.length ?? 0 > 0;
+	const usersFound = ( usersQuery?.data?.users?.length ?? 0 ) > 0;
 
 	const { checkSiteTransferEligibility, isPending: isCheckingSiteTransferEligibility } =
 		useCheckSiteTransferEligibility( siteId, {

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
@@ -83,7 +83,7 @@ const SiteOwnerTransferEligibility = ( {
 
 	function onUserClick( userLogin: string ) {
 		onRecipientChange( userLogin );
-		checkSiteTransferEligibility( { newSiteOwner: tempSiteOwner } );
+		checkSiteTransferEligibility( { newSiteOwner: userLogin } );
 	}
 
 	function onRecipientChange( recipient: string ) {

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
@@ -32,7 +32,7 @@ const ErrorText = styled.p( {
 	fontSize: '100%',
 } );
 
-const NonWPUserExplanation = styled( FormSettingExplanation )( {
+const FieldExplanation = styled( FormSettingExplanation )( {
 	a: {
 		color: 'var(--studio-gray-50)',
 		textDecoration: 'underline',
@@ -89,7 +89,7 @@ const SiteOwnerTransferEligibility = ( {
 		<form onSubmit={ handleFormSubmit }>
 			<FormText>
 				{ translate(
-					'Transfer the ownership of {{strong}}%(siteSlug)s{{/strong}} and related purchases to another user by adding their Email or their WordPress.com Usernamei in the following form.',
+					"Ready to transfer {{strong}}%(siteSlug)s{{/strong}} and its associated purchases? Simply enter the new owner's email or WordPress.com username below, or choose an existing user to start the transfer process.",
 					{
 						args: { siteSlug },
 						components: { strong: <Strong /> },
@@ -120,11 +120,11 @@ const SiteOwnerTransferEligibility = ( {
 						<ErrorText>{ siteTransferEligibilityError }</ErrorText>
 					</Error>
 				) }
-				<NonWPUserExplanation>
+				<FieldExplanation>
 					{ translate(
-						"If the person you want to transfer ownership doesn't have a WordPress.com account yet they will be invited to create one."
+						"If the new owner isn't on WordPress.com yet, we'll guide them through a simple sign-up process."
 					) }
-				</NonWPUserExplanation>
+				</FieldExplanation>
 			</FormFieldset>
 
 			<ButtonStyled

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
@@ -6,7 +6,7 @@ import { useState, FormEvent, ChangeEvent } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import useUsersQuery from 'calypso/data/users/use-users-query';
-import TeamMembers from 'calypso/my-sites/people/team-members';
+import TeamMembersSiteTransfer from 'calypso/my-sites/people/team-members-site-transfer';
 import { useCheckSiteTransferEligibility } from './use-check-site-transfer-eligibility';
 import type { UsersQuery } from 'calypso/my-sites/people/team-members/types';
 
@@ -81,6 +81,11 @@ const SiteOwnerTransferEligibility = ( {
 		checkSiteTransferEligibility( { newSiteOwner: tempSiteOwner } );
 	};
 
+	function onUserClick( userLogin: string ) {
+		onRecipientChange( userLogin );
+		checkSiteTransferEligibility( { newSiteOwner: tempSiteOwner } );
+	}
+
 	function onRecipientChange( recipient: string ) {
 		const value = recipient.trim();
 		setTempSiteOwner( value );
@@ -130,11 +135,10 @@ const SiteOwnerTransferEligibility = ( {
 			) }
 
 			{ tempSiteOwner && usersFound && (
-				<TeamMembers
+				<TeamMembersSiteTransfer
 					search={ tempSiteOwner }
 					usersQuery={ usersQuery }
-					showAddTeamMembersBtn={ false }
-					showHeader={ false }
+					onClick={ ( userLogin: string ) => onUserClick( userLogin ) }
 				/>
 			) }
 

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
@@ -6,6 +6,7 @@ import { useState, FormEvent, ChangeEvent } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import useUsersQuery from 'calypso/data/users/use-users-query';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import TeamMembersSiteTransfer from 'calypso/my-sites/people/team-members-site-transfer';
 import { useCheckSiteTransferEligibility } from './use-check-site-transfer-eligibility';
 import type { UsersQuery } from 'calypso/my-sites/people/team-members/types';
@@ -64,6 +65,9 @@ const SiteOwnerTransferEligibility = ( {
 			},
 			onError: ( e ) => {
 				setSiteTransferEligibilityError( e.message );
+				recordTracksEvent( 'calypso_site_owner_transfer_eligibility_error', {
+					message: e.message,
+				} );
 			},
 			onSuccess: () => {
 				if ( ! tempSiteOwner ) {
@@ -78,6 +82,10 @@ const SiteOwnerTransferEligibility = ( {
 		if ( ! tempSiteOwner ) {
 			return;
 		}
+
+		recordTracksEvent( 'calypso_site_owner_transfer_eligibility_submit', {
+			temp_site_owner: tempSiteOwner,
+		} );
 		checkSiteTransferEligibility( { newSiteOwner: tempSiteOwner } );
 	};
 

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-user-search.tsx
@@ -111,7 +111,7 @@ const SiteOwnerTransferEligibility = ( {
 					name="recipient"
 					value={ tempSiteOwner }
 					isError={ recipientError }
-					placeholder={ translate( 'my-client@example.com' ) }
+					placeholder="@"
 					onChange={ ( e: ChangeEvent< HTMLInputElement > ) => onRecipientChange( e.target.value ) }
 				/>
 				{ recipientError && (

--- a/client/my-sites/site-settings/site-owner-transfer/site-transfer-card.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-transfer-card.tsx
@@ -31,14 +31,11 @@ export function SiteTransferCard( {
 			<NavigationHeader
 				navigationItems={ [] }
 				title={ translate( 'Site Transfer' ) }
-				subtitle={ translate(
-					'Transfer your site to another WordPress.com user. {{a}}Learn more.{{/a}}',
-					{
-						components: {
-							a: <InlineSupportLink supportContext="site-transfer" showIcon={ false } />,
-						},
-					}
-				) }
+				subtitle={ translate( 'Transfer your site, plan and purchases. {{a}}Learn more.{{/a}}', {
+					components: {
+						a: <InlineSupportLink supportContext="site-transfer" showIcon={ false } />,
+					},
+				} ) }
 			/>
 
 			<PageViewTracker

--- a/client/my-sites/site-settings/site-owner-transfer/site-transfer-card.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-transfer-card.tsx
@@ -31,11 +31,14 @@ export function SiteTransferCard( {
 			<NavigationHeader
 				navigationItems={ [] }
 				title={ translate( 'Site Transfer' ) }
-				subtitle={ translate( 'Transfer your site, plan and purchases. {{a}}Learn more.{{/a}}', {
-					components: {
-						a: <InlineSupportLink supportContext="site-transfer" showIcon={ false } />,
-					},
-				} ) }
+				subtitle={ translate(
+					'Transfer this site to a new or existing site member with just a few clicks. {{a}}Learn more.{{/a}}',
+					{
+						components: {
+							a: <InlineSupportLink supportContext="site-transfer" showIcon={ false } />,
+						},
+					}
+				) }
 			/>
 
 			<PageViewTracker

--- a/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
@@ -13,7 +13,6 @@ import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import { IAppState } from 'calypso/state/types';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { User } from './use-administrators';
 import { useStartSiteOwnerTransfer } from './use-start-site-owner-transfer';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
@@ -90,7 +89,7 @@ const DomainsCard = ( {
 }: {
 	domains: ResponseDomain[];
 	siteSlug: string | null;
-	siteOwner: User;
+	siteOwner: string;
 } ) => {
 	const translate = useTranslate();
 	return (
@@ -104,9 +103,9 @@ const DomainsCard = ( {
 								// translators: siteSlug is the current site slug, username is the user that the site is going to
 								// transer to
 								translate(
-									'The domain name <strong>%(siteSlug)s</strong> will be transferred to <strong>%(username)s</strong> and will remain working on the site.'
+									'The domain name <strong>%(siteSlug)s</strong> will be transferred to <strong>%(siteOwner)s</strong> and will remain working on the site.'
 								),
-								{ siteSlug, username: siteOwner.login }
+								{ siteSlug, siteOwner }
 							),
 							{ strong: <Strong /> }
 						) }
@@ -119,9 +118,9 @@ const DomainsCard = ( {
 							sprintf(
 								// translators: username is the user that the site is going to transfer to
 								translate(
-									'The following domains will be transferred to <strong>%(username)s</strong> and will remain working on the site:'
+									'The following domains will be transferred to <strong>%(siteOwner)s</strong> and will remain working on the site:'
 								),
-								{ username: siteOwner.login }
+								{ siteOwner }
 							),
 							{ strong: <Strong /> }
 						) }
@@ -139,6 +138,7 @@ const DomainsCard = ( {
 		</>
 	);
 };
+
 const UpgradesCard = ( {
 	purchases,
 	siteSlug,
@@ -146,7 +146,7 @@ const UpgradesCard = ( {
 }: {
 	purchases: Purchase[];
 	siteSlug: string | null;
-	siteOwner: User;
+	siteOwner: string;
 } ) => {
 	const translate = useTranslate();
 	if ( purchases.length === 0 ) {
@@ -161,9 +161,9 @@ const UpgradesCard = ( {
 						// translators: siteSlug is the current site slug, username is the user that the site is going to
 						// transer to
 						translate(
-							'Your paid upgrades on <strong>%(siteSlug)s</strong> will be transferred to <strong>%(username)s</strong> and will remain with the site.'
+							'Your paid upgrades on <strong>%(siteSlug)s</strong> will be transferred to <strong>%(siteOwner)s</strong> and will remain with the site.'
 						),
-						{ siteSlug, username: siteOwner.login }
+						{ siteSlug, siteOwner }
 					),
 					{ strong: <Strong /> }
 				) }
@@ -178,7 +178,7 @@ const ContentAndOwnershipCard = ( {
 	isAtomicSite,
 }: {
 	siteSlug: string | null;
-	siteOwner: User;
+	siteOwner: string;
 	isAtomicSite: any;
 } ) => {
 	const translate = useTranslate();
@@ -192,9 +192,9 @@ const ContentAndOwnershipCard = ( {
 							// translators: siteSlug is the current site slug, userInfo is the user that the site is going to
 							// transer to
 							translate(
-								'You’ll be removed as owner of <strong>%(siteSlug)s</strong> and <strong>%(userInfo)s</strong> will be the new owner from now on.'
+								'You’ll be removed as owner of <strong>%(siteSlug)s</strong> and <strong>%(siteOwner)s</strong> will be the new owner from now on.'
 							),
-							{ siteSlug, userInfo: `${ siteOwner.login } (${ siteOwner.email })` }
+							{ siteSlug, siteOwner }
 						),
 						{ strong: <Strong /> }
 					) }
@@ -204,9 +204,9 @@ const ContentAndOwnershipCard = ( {
 						sprintf(
 							// translators: username is the user that the site is going to transer to
 							translate(
-								'You will keep your admin access unless <strong>%(username)s</strong> removes you.'
+								'You will keep your admin access unless <strong>%(siteOwner)s</strong> removes you.'
 							),
-							{ username: siteOwner.login }
+							{ siteOwner }
 						),
 						{ strong: <Strong /> }
 					) }
@@ -229,9 +229,9 @@ const ContentAndOwnershipCard = ( {
 							sprintf(
 								// translators: siteSlug is the current site slug, username is the user that the site will be transerred to
 								translate(
-									'If your site <strong>%(siteSlug)s</strong> has a staging site, it will be transferred to <strong>%(username)s</strong>.'
+									'If your site <strong>%(siteSlug)s</strong> has a staging site, it will be transferred to <strong>%(siteOwner)s</strong>.'
 								),
-								{ siteSlug, username: siteOwner.login }
+								{ siteSlug, siteOwner }
 							),
 							{ strong: <Strong /> }
 						) }

--- a/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
@@ -20,7 +20,7 @@ import type { Purchase } from 'calypso/lib/purchases/types';
 type Props = {
 	selectedSiteId: number | null;
 	selectedSiteSlug: string | null;
-	siteOwner: User;
+	siteOwner: string;
 	customDomains: ResponseDomain[];
 	isAtomicSite: boolean | null;
 	onSiteTransferSuccess: () => void;
@@ -280,10 +280,10 @@ const StartSiteOwnerTransfer = ( {
 
 	const handleFormSubmit = ( event: FormEvent< HTMLFormElement > ) => {
 		event.preventDefault();
-		if ( ! siteOwner?.email ) {
+		if ( ! siteOwner ) {
 			return;
 		}
-		startSiteOwnerTransfer( { newSiteOwner: siteOwner.email } );
+		startSiteOwnerTransfer( { newSiteOwner: siteOwner } );
 	};
 
 	const startSiteTransferForm = (

--- a/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/start-site-owner-transfer.tsx
@@ -8,6 +8,7 @@ import { useState, FormEvent } from 'react';
 import { connect, useSelector } from 'react-redux';
 import ActionPanelBody from 'calypso/components/action-panel/body';
 import Notice from 'calypso/components/notice';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { ResponseDomain } from 'calypso/lib/domains/types';
 import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -269,6 +270,9 @@ const StartSiteOwnerTransfer = ( {
 			},
 			onError: ( error ) => {
 				setStartSiteTransferError( error.message );
+				recordTracksEvent( 'calypso_site_owner_transfer_start_transfer_error', {
+					message: error.message,
+				} );
 				onSiteTransferError?.();
 			},
 			onSuccess: () => {
@@ -283,6 +287,10 @@ const StartSiteOwnerTransfer = ( {
 		if ( ! siteOwner ) {
 			return;
 		}
+
+		recordTracksEvent( 'calypso_site_owner_transfer_start_transfer_submit', {
+			site_owner: siteOwner,
+		} );
 		startSiteOwnerTransfer( { newSiteOwner: siteOwner } );
 	};
 

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -92,9 +92,7 @@ class SiteTools extends Component {
 		const cloneText = translate( 'Clone your existing site and all its data to a new location.' );
 
 		const startSiteTransferTitle = translate( 'Transfer your site' );
-		const startSiteTransferText = translate(
-			'Transfer your site and plan to another WordPress.com user.'
-		);
+		const startSiteTransferText = translate( 'Transfer your site, plan and purchases.' );
 
 		return (
 			<div className="site-tools">


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5363
First merge D137375-code and right after this PR.

## Proposed Changes

This PR aims to allow any user to be selected for transferring the site, even when not an administrator. Also, allows for any email, even not registered in WP.com to be selected for transferring the site.

* Updates the copy to reflect the changes
* Changes the select field to a text field

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Use D137375-code

* Go to `/settings/start-site-transfer/`
* Try transferring the site to another non a11n username or email that it's not member of the site
* Try transferring the site to another email that it's not member of the site
* Try transferring the site to a non existent username
* Observe that in the next page, all references to the new user ( username or email ) appear correctly. Checking on an Atomic site will show more notices to test.
* Click `Start Transfer` you should receive an email to verify that the transfer should happen.

|Before | After|
|-------|------|
|![CleanShot 2024-01-30 at 18 41 12@2x](https://github.com/Automattic/wp-calypso/assets/12430020/aab7a296-74ec-4ea2-bdf2-404e76394cc5)|![CleanShot 2024-01-30 at 18 40 46@2x](https://github.com/Automattic/wp-calypso/assets/12430020/2b0905ec-1c8c-4739-b30b-f5be740833b1)|
|![CleanShot 2024-01-30 at 18 41 34@2x](https://github.com/Automattic/wp-calypso/assets/12430020/951ddff9-ec61-4590-ba7d-2ef08cf23aa1)|![CleanShot 2024-02-16 at 12 25 55@2x](https://github.com/Automattic/wp-calypso/assets/12430020/27ace1b5-fce1-40a7-a422-60887ee450e6)|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?