### PR TITLE
LiTS Survey v2: Show the new survey on the LiTS

### DIFF
--- a/client/my-sites/themes/survey/index.tsx
+++ b/client/my-sites/themes/survey/index.tsx
@@ -5,6 +5,7 @@ import './survey.scss';
 
 export enum SurveyType {
 	DECEMBER_2023 = 'DECEMBER_2023',
+	FEBRUARY_2024 = 'FEBRUARY_2024',
 }
 
 const surveys = new Map< SurveyType, { eventName: string; eventUrl: string } >( [
@@ -13,6 +14,13 @@ const surveys = new Map< SurveyType, { eventName: string; eventUrl: string } >( 
 		{
 			eventName: 'theme-showcase-december-2023',
 			eventUrl: 'https://automattic.survey.fm/lits-survey-v1',
+		},
+	],
+	[
+		SurveyType.FEBRUARY_2024,
+		{
+			eventName: 'theme-showcase-february-2024',
+			eventUrl: 'https://automattic.survey.fm/lits-survey-v2',
 		},
 	],
 ] );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -24,7 +24,7 @@ import ActivationModal from 'calypso/my-sites/themes/activation-modal';
 import { THEME_COLLECTIONS } from 'calypso/my-sites/themes/collections/collection-definitions';
 import ShowcaseThemeCollection from 'calypso/my-sites/themes/collections/showcase-theme-collection';
 import ThemeCollectionViewHeader from 'calypso/my-sites/themes/collections/theme-collection-view-header';
-import ThemeShowcaseSurvey from 'calypso/my-sites/themes/survey';
+import ThemeShowcaseSurvey, { SurveyType } from 'calypso/my-sites/themes/survey';
 import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import getLastNonEditorRoute from 'calypso/state/selectors/get-last-non-editor-route';
@@ -619,7 +619,7 @@ class ThemeShowcase extends Component {
 				/>
 				{ isLoggedIn && (
 					<ThemeShowcaseSurvey
-						survey={ null }
+						survey={ SurveyType.FEBRUARY_2024 }
 						condition={ () => lastNonEditorRoute.includes( 'theme/' ) }
 					/>
 				) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/5381

## Proposed Changes

* Added the new developer focused survey to the LiTS.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Go to the LiTS
* Open a theme's details and navigate back
* You should see the survey banner, click on it.
* You should see the new v2 survey

After:
![Screenshot 2024-01-30 at 14 52 04](https://github.com/Automattic/wp-calypso/assets/1989914/c1962204-5297-436c-b840-61a908846574)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?