### PR TITLE
Plans Next: Untangle Comparison Grid from media queries, up reuse and default responsiveness

### DIFF
--- a/client/my-sites/plans-features-main/components/comparison-grid-toggle.tsx
+++ b/client/my-sites/plans-features-main/components/comparison-grid-toggle.tsx
@@ -1,9 +1,9 @@
 import { Button } from '@automattic/components';
-import { plansBreakSmall } from '@automattic/plans-grid-next/src/media-queries';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { type TranslateResult } from 'i18n-calypso';
 import { forwardRef } from 'react';
+import { plansPageBreakSmall } from '../media-queries';
 import '../style.scss';
 
 const ComparisonGridToggle = forwardRef<
@@ -34,7 +34,7 @@ const ComparisonGridToggle = forwardRef<
 			max-width: 440px;
 			transition: border-color 0.15s ease-out;
 
-			${ plansBreakSmall( css`
+			${ plansPageBreakSmall( css`
 				width: initial;
 				height: 40px;
 			` ) }

--- a/client/my-sites/plans-features-main/media-queries.tsx
+++ b/client/my-sites/plans-features-main/media-queries.tsx
@@ -1,0 +1,31 @@
+import { css } from '@emotion/react';
+import type { SerializedStyles } from '@emotion/react';
+
+const sidebarWidth = 272; //in px
+const plansPageSmallBreakpoint = '780px';
+const plansPageSmallWithSidebarBreakpoint = `${ 780 + sidebarWidth }px`;
+
+/**
+ * Use this sparingly for plans page/section layout purposes.
+ * IMPORTANT: The plans grids do not rely on the same media queries and breakpoints for their rendering.
+ */
+export const plansPageBreakSmall = ( styles: SerializedStyles ) => css`
+	body.is-section-signup.is-white-signup &,
+	body.is-section-stepper & {
+		@media ( min-width: ${ plansPageSmallBreakpoint } ) {
+			${ styles }
+		}
+	}
+
+	.is-section-plans:not( .is-sidebar-collapsed ) & {
+		@media ( min-width: ${ plansPageSmallWithSidebarBreakpoint } ) {
+			${ styles }
+		}
+	}
+
+	.is-section-plans.is-sidebar-collapsed & {
+		@media ( min-width: ${ plansPageSmallBreakpoint } ) {
+			${ styles }
+		}
+	}
+`;

--- a/client/my-sites/plans-features-main/media-queries.tsx
+++ b/client/my-sites/plans-features-main/media-queries.tsx
@@ -6,8 +6,11 @@ const plansPageSmallBreakpoint = '780px';
 const plansPageSmallWithSidebarBreakpoint = `${ 780 + sidebarWidth }px`;
 
 /**
- * Use this sparingly for plans page/section layout purposes.
- * IMPORTANT: The plans grids do not rely on the same media queries and breakpoints for their rendering.
+ * Use this sparingly and primarily for general plans page (section) layout purposes.
+ * IMPORTANT: The grid components (features-grid, comparison-grid, etc.) from `plans-grid-next` package
+ * do not rely on screen media queries and breakpoints for their rendering. They are responsive
+ * based on the container width and the number of columns. For grid-related changes across different
+ * screen sizes, it might be best to use the mixins defined in `plans-grid-next`.
  */
 export const plansPageBreakSmall = ( styles: SerializedStyles ) => css`
 	body.is-section-signup.is-white-signup &,

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -44,6 +44,8 @@
 }
 
 .plans-features-main__comparison-grid-container {
+	width: 100%;
+
 	&.is-hidden {
 		display: none;
 	}
@@ -122,17 +124,14 @@
 .is-section-plans .plans-features-main__comparison-grid-container {
 	scroll-margin-top: $plan-features-header-banner-height + 24px;
 	margin: auto;
-	@include plan-comparison-grid-breakpoints-with-sidebar;
 }
 
 .is-section-signup .plans-features-main__comparison-grid-container {
 	margin: auto;
-	@include plan-comparison-grid-breakpoints;
 }
 
 .is-section-stepper .plans-features-main__comparison-grid-container {
 	margin: auto;
-	@include plan-comparison-grid-breakpoints;
 }
 
 .is-2023-pricing-grid .plan-features-2023-grid__content {

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -13,14 +13,6 @@
 	@include pricing-grid-breakpoints;
 }
 
-.is-section-plans:not(.is-sidebar-collapsed) .is-2023-pricing-grid .plans-features-main__comparison-grid-container {
-	@include plan-comparison-grid-breakpoints-with-sidebar;
-}
-
-.is-section-plans.is-sidebar-collapsed .is-2023-pricing-grid .plans-features-main__comparison-grid-container {
-	@include plan-comparison-grid-breakpoints;
-}
-
 .plans-step {
 	margin: 0 auto;
 	max-width: 700px;

--- a/packages/plans-grid-next/src/_media-queries.scss
+++ b/packages/plans-grid-next/src/_media-queries.scss
@@ -13,41 +13,11 @@ $minWidthToGridWidthMap: (
 	1200px: "100%",
 );
 
-// Plan Comparison Grid Breakpoints
-$plans-comparison-small-breakpoint: 880px;
-$plans-comparison-medium-breakpoint: 1024px;
-$plans-comparison-large-breakpoint: 1281px;
-
-$planComparisonMinWidthToGridWidthMap: (
-	780px: "686px",
-	880px: "870px",
-	1024px: "1024px",
-	1281px: "1238px",
-);
-
-// TODO: Replace with use of $plan-features-sidebar-width
-$planComparisonMinWidthToGridWidthWithSidebarMap: (
-	1052px: "686px",
-	1152px: "870px",
-	1296px: "1024px",
-	1553px: "1238px",
-);
-
 
 @mixin pricing-grid-breakpoints {
 	width: 100%;
 
 	@each $screenMinWidth, $gridWidth in $minWidthToGridWidthMap {
-		@media ( min-width: #{$screenMinWidth} ) {
-			width: #{$gridWidth};
-		}
-	}
-}
-
-@mixin plan-comparison-grid-breakpoints {
-	width: 100%;
-
-	@each $screenMinWidth, $gridWidth in $planComparisonMinWidthToGridWidthMap {
 		@media ( min-width: #{$screenMinWidth} ) {
 			width: #{$gridWidth};
 		}
@@ -62,19 +32,9 @@ $planComparisonMinWidthToGridWidthWithSidebarMap: (
 	width: 100%;
 }
 
-@mixin plan-comparison-grid-breakpoints-with-sidebar {
-	width: 100%;
-
-	@each $screenMinWidth, $gridWidth in $planComparisonMinWidthToGridWidthWithSidebarMap {
-		@media ( min-width: #{$screenMinWidth} ) {
-			width: #{$gridWidth};
-		}
-	}
-}
-
 /**
  * @deprecated
- * TODO clk Used in comparison grid
+ * TODO clk used in plans-features-main / should migrate there
  */
 @mixin plans-2023-break-small() {
 	body.is-section-stepper &,
@@ -92,31 +52,6 @@ $planComparisonMinWidthToGridWidthWithSidebarMap: (
 
 	.is-section-plans.is-sidebar-collapsed & {
 		@media ( min-width: $plans-2023-small-breakpoint ) {
-			@content;
-		}
-	}
-}
-
-/**
- * @deprecated
- * TODO clk Used in comparison grid
- */
-@mixin plans-2023-break-medium() {
-	body.is-section-stepper &,
-	body.is-section-signup.is-white-signup & {
-		@media ( min-width: $plans-2023-medium-breakpoint ) {
-			@content;
-		}
-	}
-
-	.is-section-plans:not(.is-sidebar-collapsed) & {
-		@media ( min-width: $plans-2023-medium-breakpoint + $plan-features-sidebar-width ) {
-			@content;
-		}
-	}
-
-	.is-section-plans.is-sidebar-collapsed & {
-		@media ( min-width: $plans-2023-medium-breakpoint ) {
 			@content;
 		}
 	}

--- a/packages/plans-grid-next/src/_media-queries.scss
+++ b/packages/plans-grid-next/src/_media-queries.scss
@@ -5,7 +5,6 @@ $plan-features-header-banner-height: 20px;
 
 // Plan Features Grid Breakpoints
 $plans-2023-small-breakpoint: 780px;
-$plans-2023-medium-breakpoint: 1350px;
 
 $minWidthToGridWidthMap: (
 	780px: "668px",
@@ -13,7 +12,12 @@ $minWidthToGridWidthMap: (
 	1200px: "100%",
 );
 
-
+/**
+ * @deprecated
+ * TODO clk used in plans-features-main / should migrate there
+ *   - creates a bit of snapping effect on the various breakpoints
+ *   - if it's not really necessary, we should remove it
+ */
 @mixin pricing-grid-breakpoints {
 	width: 100%;
 
@@ -27,6 +31,9 @@ $minWidthToGridWidthMap: (
 /**
  * Media queries for the plans grid on the /plans page.
  * This should stretch to fill it's container.
+ *
+ * @deprecated
+ * TODO clk this should just be set as the default behavior for the grid
  */
 @mixin pricing-grid-breakpoints-with-sidebar {
 	width: 100%;

--- a/packages/plans-grid-next/src/_mixins.scss
+++ b/packages/plans-grid-next/src/_mixins.scss
@@ -1,12 +1,15 @@
 @mixin plans-grid-large() {
-	.plans-grid-next.is-large & {
+	.plans-grid-next.is-large &,
+	.plans-grid-next.is-xlarge &, {
 		@content;
 	}
 }
 
 @mixin plans-grid-medium-large() {
+	.plans-grid-next.is-smedium &,
 	.plans-grid-next.is-medium &,
-	.plans-grid-next.is-large & {
+	.plans-grid-next.is-large &,
+	.plans-grid-next.is-xlarge & {
 		@content;
 	}
 }

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -974,10 +974,18 @@ const ComparisonGrid = ( {
 		let newVisiblePlans = displayedGridPlans.map( ( { planSlug } ) => planSlug );
 		let visibleLength = newVisiblePlans.length;
 
-		visibleLength = 'large' === gridSize ? 4 : visibleLength;
-		visibleLength = 'medium' === gridSize ? 3 : visibleLength;
-		visibleLength = 'smedium' === gridSize ? 2 : visibleLength;
-		visibleLength = 'small' === gridSize ? 2 : visibleLength;
+		switch ( gridSize ) {
+			case 'large':
+				visibleLength = 4;
+				break;
+			case 'medium':
+				visibleLength = 3;
+				break;
+			case 'smedium':
+			case 'small':
+				visibleLength = 2;
+				break;
+		}
 
 		if ( newVisiblePlans.length !== visibleLength ) {
 			newVisiblePlans = newVisiblePlans.slice( 0, visibleLength );

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -23,6 +23,7 @@ import {
 	forwardRef,
 } from 'react';
 import { useInView } from 'react-intersection-observer';
+import { plansGridMediumLarge } from '../../css-mixins';
 import { usePlansGridContext } from '../../grid-context';
 import useHighlightAdjacencyMatrix from '../../hooks/use-highlight-adjacency-matrix';
 import { useManageTooltipToggle } from '../../hooks/use-manage-tooltip-toggle';
@@ -30,7 +31,6 @@ import filterUnusedFeaturesObject from '../../lib/filter-unused-features-object'
 import getPlanFeaturesObject from '../../lib/get-plan-features-object';
 import { isStorageUpgradeableForPlan } from '../../lib/is-storage-upgradeable-for-plan';
 import { sortPlans } from '../../lib/sort-plan-properties';
-import { plansBreakSmall } from '../../media-queries';
 import { getStorageStringFromFeature } from '../../util';
 import PlanFeatures2023GridActions from '../actions';
 import PlanFeatures2023GridHeaderPrice from '../header-price';
@@ -94,7 +94,7 @@ const Title = styled.div< { isHiddenInMobile?: boolean } >`
 		flex-shrink: 0;
 	}
 
-	${ plansBreakSmall( css`
+	${ plansGridMediumLarge( css`
 		padding-inline-start: 0;
 		border: none;
 		padding: 0;
@@ -112,7 +112,7 @@ const Grid = styled.div< { isInSignup?: boolean } >`
 	background: #fff;
 	border: solid 1px #e0e0e0;
 
-	${ plansBreakSmall( css`
+	${ plansGridMediumLarge( css`
 		border-radius: 5px;
 	` ) }
 
@@ -132,7 +132,7 @@ const Row = styled.div< {
 	align-items: stretch;
 	display: ${ ( props ) => ( props.isHiddenInMobile ? 'none' : 'flex' ) };
 
-	${ plansBreakSmall( css`
+	${ plansGridMediumLarge( css`
 		display: flex;
 		align-items: center;
 		margin: 0 20px;
@@ -143,7 +143,7 @@ const Row = styled.div< {
 	${ ( props ) =>
 		props.isHighlighted &&
 		css`
-			${ plansBreakSmall( css`
+			${ plansGridMediumLarge( css`
 				background-color: #fafafa;
 				border-top: 1px solid #eee;
 				font-weight: bold;
@@ -159,7 +159,7 @@ const PlanRow = styled( Row )`
 		display: ${ ( props ) => ( props.isHiddenInMobile ? 'none' : 'flex' ) };
 	}
 
-	${ plansBreakSmall( css`
+	${ plansGridMediumLarge( css`
 		border-bottom: none;
 		align-items: stretch;
 
@@ -175,7 +175,7 @@ const TitleRow = styled( Row )`
 	cursor: pointer;
 	display: flex;
 
-	${ plansBreakSmall( css`
+	${ plansGridMediumLarge( css`
 		cursor: default;
 		border-bottom: none;
 		padding: 20px 0 10px;
@@ -212,12 +212,12 @@ const Cell = styled.div< { textAlign?: 'start' | 'center' | 'end' } >`
 	${ Row }:last-of-type & {
 		padding-bottom: 24px;
 
-		${ plansBreakSmall( css`
+		${ plansGridMediumLarge( css`
 			padding-bottom: 0px;
 		` ) }
 	}
 
-	${ plansBreakSmall( css`
+	${ plansGridMediumLarge( css`
 		padding: 0 14px;
 		border-right: none;
 		justify-content: center;
@@ -240,7 +240,7 @@ const RowTitleCell = styled.div`
 	display: none;
 	font-size: 14px;
 	padding-right: 10px;
-	${ plansBreakSmall( css`
+	${ plansGridMediumLarge( css`
 		display: block;
 		flex: 1;
 		min-width: 290px;
@@ -293,7 +293,7 @@ const StorageButton = styled.div`
 	min-width: 64px;
 	margin-top: 10px;
 
-	${ plansBreakSmall( css`
+	${ plansGridMediumLarge( css`
 		margin-top: 0;
 	` ) }
 `;
@@ -458,7 +458,7 @@ const ComparisonGridHeaderCell = ( {
 
 const PlanTypeSelectorWrapper = styled.div`
 	display: none;
-	${ plansBreakSmall( css`
+	${ plansGridMediumLarge( css`
 		display: block;
 	` ) }
 `;

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -31,7 +31,7 @@ import getPlanFeaturesObject from '../../lib/get-plan-features-object';
 import { isStorageUpgradeableForPlan } from '../../lib/is-storage-upgradeable-for-plan';
 import { sortPlans } from '../../lib/sort-plan-properties';
 import { plansBreakSmall } from '../../media-queries';
-import { getStorageStringFromFeature, usePricingBreakpoint } from '../../util';
+import { getStorageStringFromFeature } from '../../util';
 import PlanFeatures2023GridActions from '../actions';
 import PlanFeatures2023GridHeaderPrice from '../header-price';
 import PlanTypeSelector from '../plan-type-selector';
@@ -945,6 +945,7 @@ const ComparisonGrid = ( {
 	showRefundPeriod,
 	planTypeSelectorProps,
 	planUpgradeCreditsApplicable,
+	gridSize,
 }: ComparisonGridProps ) => {
 	const { gridPlans } = usePlansGridContext();
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
@@ -963,46 +964,27 @@ const ComparisonGrid = ( {
 		? getWooExpressFeaturesGrouped()
 		: getPlanFeaturesGrouped();
 
-	let largeBreakpoint;
-	let mediumBreakpoint;
-	let smallBreakpoint;
-
-	if ( isInSignup ) {
-		// Breakpoints without admin sidebar
-		largeBreakpoint = 1281;
-		mediumBreakpoint = 1024;
-		smallBreakpoint = 880;
-	} else {
-		// Breakpoints with admin sidebar
-		largeBreakpoint = 1553; // 1500px + 272px (sidebar)
-		mediumBreakpoint = 1296; // 1340px + 272px (sidebar)
-		smallBreakpoint = 1152; // keeping original breakpoint to match Plan Grid
-	}
-
-	const isLargeBreakpoint = usePricingBreakpoint( largeBreakpoint );
-	const isMediumBreakpoint = usePricingBreakpoint( mediumBreakpoint );
-	const isSmallBreakpoint = usePricingBreakpoint( smallBreakpoint );
-
 	const [ visiblePlans, setVisiblePlans ] = useState< PlanSlug[] >( [] );
 
 	const displayedGridPlans = useMemo( () => {
-		return sortPlans( gridPlans, currentSitePlanSlug, isMediumBreakpoint );
-	}, [ gridPlans, currentSitePlanSlug, isMediumBreakpoint ] );
+		return sortPlans( gridPlans, currentSitePlanSlug, 'small' === gridSize );
+	}, [ gridPlans, currentSitePlanSlug, gridSize ] );
 
 	useEffect( () => {
 		let newVisiblePlans = displayedGridPlans.map( ( { planSlug } ) => planSlug );
 		let visibleLength = newVisiblePlans.length;
 
-		visibleLength = isLargeBreakpoint ? 4 : visibleLength;
-		visibleLength = isMediumBreakpoint ? 3 : visibleLength;
-		visibleLength = isSmallBreakpoint ? 2 : visibleLength;
+		visibleLength = 'large' === gridSize ? 4 : visibleLength;
+		visibleLength = 'medium' === gridSize ? 3 : visibleLength;
+		visibleLength = 'smedium' === gridSize ? 2 : visibleLength;
+		visibleLength = 'small' === gridSize ? 2 : visibleLength;
 
 		if ( newVisiblePlans.length !== visibleLength ) {
 			newVisiblePlans = newVisiblePlans.slice( 0, visibleLength );
 		}
 
 		setVisiblePlans( newVisiblePlans );
-	}, [ isLargeBreakpoint, isMediumBreakpoint, isSmallBreakpoint, displayedGridPlans, isInSignup ] );
+	}, [ gridSize, displayedGridPlans, isInSignup ] );
 
 	const visibleGridPlans = useMemo(
 		() =>

--- a/packages/plans-grid-next/src/css-mixins.tsx
+++ b/packages/plans-grid-next/src/css-mixins.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
 
-export const plansBreakSmall = ( styles: SerializedStyles ) => css`
+export const plansGridMediumLarge = ( styles: SerializedStyles ) => css`
 	.plans-grid-next.is-smedium &,
 	.plans-grid-next.is-medium &,
 	.plans-grid-next.is-large &,

--- a/packages/plans-grid-next/src/index.tsx
+++ b/packages/plans-grid-next/src/index.tsx
@@ -48,19 +48,9 @@ const WrappedComparisonGrid = ( {
 			[ 'smedium', 686 ],
 			[ 'medium', 835 ], // enough to fit Enterpreneur plan. was 686
 			[ 'large', 1005 ], // enough to fit Enterpreneur plan. was 870
-			[ 'xlarge', 1238 ],
+			[ 'xlarge', 1180 ],
 		] ),
 	} );
-
-	// const gridSize = useGridSize( {
-	// 	containerRef: gridContainerRef,
-	// 	containerBreakpoints: new Map( [
-	// 		[ 'small', 0 ],
-	// 		[ 'smedium', 835 ], // enough to fit Enterpreneur plan. was 686
-	// 		[ 'medium', 1005 ], // enough to fit Enterpreneur plan. was 870
-	// 		[ 'large', 1238 ],
-	// 	] ),
-	// } );
 
 	const classNames = classnames( 'plans-grid-next', 'plans-grid-next__comparison-grid', {
 		'is-small': 'small' === gridSize,

--- a/packages/plans-grid-next/src/index.tsx
+++ b/packages/plans-grid-next/src/index.tsx
@@ -40,10 +40,39 @@ const WrappedComparisonGrid = ( {
 		onUpgradeClick,
 	} );
 
-	const classNames = classnames( 'plans-grid-next', 'plans-grid-next__comparison-grid' );
+	const gridContainerRef = useRef< HTMLDivElement | null >( null );
+	const gridSize = useGridSize( {
+		containerRef: gridContainerRef,
+		containerBreakpoints: new Map( [
+			[ 'small', 0 ],
+			[ 'smedium', 686 ],
+			[ 'medium', 835 ], // enough to fit Enterpreneur plan. was 686
+			[ 'large', 1005 ], // enough to fit Enterpreneur plan. was 870
+			[ 'xlarge', 1238 ],
+		] ),
+	} );
+
+	// const gridSize = useGridSize( {
+	// 	containerRef: gridContainerRef,
+	// 	containerBreakpoints: new Map( [
+	// 		[ 'small', 0 ],
+	// 		[ 'smedium', 835 ], // enough to fit Enterpreneur plan. was 686
+	// 		[ 'medium', 1005 ], // enough to fit Enterpreneur plan. was 870
+	// 		[ 'large', 1238 ],
+	// 	] ),
+	// } );
+
+	const classNames = classnames( 'plans-grid-next', 'plans-grid-next__comparison-grid', {
+		'is-small': 'small' === gridSize,
+		'is-smedium': 'smedium' === gridSize,
+		'is-medium': 'medium' === gridSize,
+		'is-large': 'large' === gridSize,
+		'is-xlarge': 'xlarge' === gridSize,
+		'is-visible': true,
+	} );
 
 	return (
-		<div className={ classNames }>
+		<div ref={ gridContainerRef } className={ classNames }>
 			<PlansGridContextProvider
 				intent={ intent }
 				selectedSiteId={ selectedSiteId }
@@ -65,6 +94,7 @@ const WrappedComparisonGrid = ( {
 					showUpgradeableStorage={ showUpgradeableStorage }
 					stickyRowOffset={ stickyRowOffset }
 					onStorageAddOnClick={ onStorageAddOnClick }
+					gridSize={ gridSize ?? undefined }
 					{ ...otherProps }
 				/>
 			</PlansGridContextProvider>

--- a/packages/plans-grid-next/src/media-queries.tsx
+++ b/packages/plans-grid-next/src/media-queries.tsx
@@ -1,31 +1,11 @@
 import { css } from '@emotion/react';
 import type { SerializedStyles } from '@emotion/react';
 
-const sidebarWidth = 272; //in px
-const plans2023SmallBreakpoint = '780px';
-const plans2023SmallWithSidebarBreakpoint = `${ 780 + sidebarWidth }px`;
-
-/**
- * @deprecated
- * TODO clk Used in comparison-grid-toggle and plans-features-main
- */
 export const plansBreakSmall = ( styles: SerializedStyles ) => css`
-	body.is-section-signup.is-white-signup &,
-	body.is-section-stepper & {
-		@media ( min-width: ${ plans2023SmallBreakpoint } ) {
-			${ styles }
-		}
-	}
-
-	.is-section-plans:not( .is-sidebar-collapsed ) & {
-		@media ( min-width: ${ plans2023SmallWithSidebarBreakpoint } ) {
-			${ styles }
-		}
-	}
-
-	.is-section-plans.is-sidebar-collapsed & {
-		@media ( min-width: ${ plans2023SmallBreakpoint } ) {
-			${ styles }
-		}
+	.plans-grid-next.is-smedium &,
+	.plans-grid-next.is-medium &,
+	.plans-grid-next.is-large &,
+	.plans-grid-next.is-xlarge & {
+		${ styles }
 	}
 `;

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -756,7 +756,7 @@ body.is-section-signup.is-white-signup {
 			display: none;
 		}
 
-		@include plans-2023-break-small {
+		@include plans-grid-medium-large {
 			padding-top: 34px;
 
 			&.popular-plan-parent-class {
@@ -778,7 +778,7 @@ body.is-section-signup.is-white-signup {
 			}
 		}
 
-		@include plans-2023-break-medium {
+		@include plans-grid-large {
 			&.plan-is-footer {
 				padding-top: 110px;
 			}
@@ -806,7 +806,7 @@ body.is-section-signup.is-white-signup {
 				}
 			}
 
-			@include plans-2023-break-small {
+			@include plans-grid-medium-large {
 				.plan-features-2023-grid__popular-badge {
 					padding: 20px 0 25px;
 					position: absolute;
@@ -894,10 +894,10 @@ body.is-section-signup.is-white-signup {
 			background-color: var(--studio-gray-80);
 			text-transform: unset;
 
-			@include plans-2023-break-small {
+			@include plans-grid-medium-large {
 				left: 15px;
 			}
-			@include plans-2023-break-medium {
+			@include plans-grid-large {
 				top: 55px;
 			}
 		}
@@ -947,7 +947,7 @@ body.is-section-signup.is-white-signup {
 
 		.plan-comparison-grid__plan-conditional-title {
 			@extend %plan-comparison-grid__plan-subtitle;
-			@include plans-2023-break-small {
+			@include plans-grid-medium-large {
 				color: unset;
 				margin-bottom: 0;
 			}
@@ -961,7 +961,7 @@ body.is-section-signup.is-white-signup {
 			}
 		}
 
-		@include plans-2023-break-small {
+		@include plans-grid-medium-large {
 			.plan-comparison-grid__plan-image,
 			.plan-comparison-grid__plan-title,
 			.plan-comparison-grid__plan-subtitle {
@@ -991,7 +991,7 @@ body.is-section-signup.is-white-signup {
 			right: -1px;
 		}
 
-		@include plans-2023-break-small {
+		@include plans-grid-medium-large {
 			&::before,
 			&:not(:last-of-type)::after {
 				display: block;
@@ -1017,7 +1017,7 @@ body.is-section-signup.is-white-signup {
 		min-height: 30px;
 		line-height: 1.3;
 
-		@include plans-2023-break-small {
+		@include plans-grid-medium-large {
 			margin: 7px 0 10px;
 		}
 
@@ -1027,12 +1027,12 @@ body.is-section-signup.is-white-signup {
 			font-weight: 400;
 			color: var(--studio-gray-80);
 
-			@include plans-2023-break-small {
+			@include plans-grid-medium-large {
 				font-size: $font-body-small;
 				line-height: 20px;
 			}
 
-			@include plans-2023-break-medium {
+			@include plans-grid-large {
 				font-size: $font-body-extra-small;
 				line-height: 16px;
 			}

--- a/packages/plans-grid-next/src/util.ts
+++ b/packages/plans-grid-next/src/util.ts
@@ -10,7 +10,6 @@ import {
 	FEATURE_P2_13GB_STORAGE,
 } from '@automattic/calypso-products';
 import { translate } from 'i18n-calypso';
-import { useCallback, useEffect, useState } from 'react';
 
 export const getStorageStringFromFeature = ( storageFeature: string ) => {
 	switch ( storageFeature ) {
@@ -37,26 +36,4 @@ export const getStorageStringFromFeature = ( storageFeature: string ) => {
 		default:
 			return null;
 	}
-};
-
-export const usePricingBreakpoint = ( targetBreakpoint: number ) => {
-	const [ breakpoint, setBreakpoint ] = useState( false );
-
-	const handleResize = useCallback( () => {
-		if ( typeof window === 'undefined' ) {
-			return;
-		}
-		setBreakpoint( window.innerWidth < targetBreakpoint );
-	}, [ targetBreakpoint ] );
-
-	useEffect( () => {
-		window.addEventListener( 'resize', handleResize );
-		return () => window.removeEventListener( 'resize', handleResize );
-	}, [ handleResize ] );
-
-	useEffect( () => {
-		handleResize();
-	}, [] );
-
-	return breakpoint;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79010
Branched from https://github.com/Automattic/wp-calypso/pull/86796
Fixes https://github.com/Automattic/wp-calypso/issues/78483

## Proposed Changes

This is part of a series of PRs for untangling the pricing grids/components from screen/media queries and any Calypso-dependent CSS context (such as sidebar width). The end goal is to (1) make the components responsive and reusable in any context, and (2) to be able to render the grids anywhere on a page (in a modal, sidebar, a half-page column, etc.). So pdgrnI-2uQ-p2 becomes relevant and this work should set the foundations for it.

In this PR:
- we untangle the Comparison Grid from media queries
- the approach is akin to "container queries", which we may consider surfacing down the line (assuming support is not an issue). This uses the same abstractions implemented previously in https://github.com/Automattic/wp-calypso/pull/86796

This should also fix some design inconsistencies we've noticed at times in production. It no longer relies on fixing the width of the component, but rather keeps it fluid across the various breakpoints (where we render less/more plans).

## Media

https://github.com/Automattic/wp-calypso/assets/1705499/e8b21e5d-2e58-4572-9e26-5657dfc8a7e0

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Confirm `/plans[ site ]` and `/start/plans` render comparison & features grids fine
* Confirm the comparison grid resizes properly and gives the various views (mobile, tablet, desktop)
    * The above may not be as precise as previously, but they should be rendering the grid without any overflows of text, like the plan titles/names. So if the grid fits, then we should be good
* Confirm margins and the rest of the layout are correct in `/setup` and `/start` across the various views (mobile, tablet, desktop)
* Confirm text sizes are correct across the various views (mobile, tablet, desktop)
* Confirm intents with less plans do not cause issues e.g. `/plans/[ newsletter site ]`
* Confirm `/plans/[ wooexpress site ]` renders fine (with any issues outlined in https://github.com/Automattic/wp-calypso/issues/78483 fixed)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?