### PR TITLE
Subscriber Stats: Remove the "Number of Subscribers" module with layout adjusted

### DIFF
--- a/client/my-sites/stats/grid-layout.scss
+++ b/client/my-sites/stats/grid-layout.scss
@@ -31,26 +31,45 @@ $grid-vertical-gutters: 32px;
 
 .stats__module-list.stats__module--unified.subscribers-page {
 	@include stats-desktop-grid(
-		"followers followers followers followers followers followers publicize publicize publicize publicize publicize publicize"
-		"emails emails emails emails emails emails emails emails emails emails emails emails",
-		2
+		"followers followers followers followers followers followers emails emails emails emails emails emails",
+		1
 	);
 
 	@include stats-tablet-grid(
-		"followers followers followers followers publicize publicize publicize publicize"
-		"emails emails emails emails emails emails emails emails",
-		2
+		"followers followers followers emails emails emails emails",
+		1
 	);
 
 	@include stats-mobile-grid(
 		"followers followers followers followers"
-		"publicize publicize publicize publicize"
 		"emails emails emails emails",
-		3
+		2
 	);
 
 	@media (max-width: 660px) {
 		padding: 0 16px;
+	}
+
+	// Eliminate the vertical gap appended to the bottom of the grid.
+	&::after {
+		display: none;
+	}
+
+	&.is-odyssey-stats {
+		@include stats-desktop-grid(
+			"followers followers followers followers followers followers followers followers followers followers followers followers",
+			1
+		);
+
+		@include stats-tablet-grid(
+			"followers followers followers followers followers followers",
+			1
+		);
+
+		@include stats-mobile-grid(
+			"followers followers followers followers",
+			1
+		);
 	}
 
 	.stats__module-wrapper--followers,

--- a/client/my-sites/stats/stats-subscribers/index.tsx
+++ b/client/my-sites/stats/stats-subscribers/index.tsx
@@ -23,7 +23,6 @@ import Followers from '../stats-followers';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsModuleEmails from '../stats-module-emails';
 import PageViewTracker from '../stats-page-view-tracker';
-import Reach from '../stats-reach';
 import SubscribersChartSection, { PeriodType } from '../stats-subscribers-chart-section';
 import SubscribersHighlightSection from '../stats-subscribers-highlight-section';
 import SubscribersOverview from '../stats-subscribers-overview';
@@ -111,7 +110,6 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 							) }
 							<div className={ statsModuleListClass }>
 								<Followers path="followers" />
-								<Reach />
 								{ ! isOdysseyStats && period && (
 									<StatsModuleEmails period={ period } query={ { period, date: today } } />
 								) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-roadmap/issues/872

## Proposed Changes

* Remove the `Number of Subscribers` module from the Subscriber Stats page.
* Adjust the module layout according to existing modules

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
#### Calypso Stats
* Spin this change up with the Calypso Live link.
* Navigate to the Stats > Subscribers page: `/stats/subscribers/{site-slug}`.
* Ensure the `Number of Subscribers` module is removed and the `Emails` module fills the space.

|Before|After|
|-|-|
|<img width="1271" alt="截圖 2024-01-30 下午11 20 32" src="https://github.com/Automattic/wp-calypso/assets/6869813/38a0e517-5a40-419f-9934-39e1ea02c840">|<img width="1258" alt="截圖 2024-01-30 下午11 20 47" src="https://github.com/Automattic/wp-calypso/assets/6869813/4087acc4-5766-4d70-89e9-7d0a7bb348f3">|

#### Odyssey Stats
* Spin this change up on the local Jetpack environment: `cd apps/odyssey-stats && STATS_PACKAGE_PATH=/path-to-jetpack/projects/packages/stats-admin yarn dev`.
* Navigate to the Stats > Subscribers page.
* Ensure the `Number of Subscribers` module is removed and the `Subscribers` module fills the space with full width.

|Before|After|
|-|-|
|<img width="1265" alt="截圖 2024-01-30 下午11 25 00" src="https://github.com/Automattic/wp-calypso/assets/6869813/0b494a1e-a0f9-4349-b55a-a353439e042b">|<img width="1270" alt="截圖 2024-01-30 下午11 20 18" src="https://github.com/Automattic/wp-calypso/assets/6869813/b0eadaf1-f690-4403-a21c-d213cab0f033">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?