### PR TITLE
Theme Tier: Add Explorer plan to checkout when selecting a locked style variation of a Starter theme

### DIFF
--- a/client/my-sites/themes/theme-options.js
+++ b/client/my-sites/themes/theme-options.js
@@ -1,4 +1,10 @@
-import { WPCOM_FEATURES_INSTALL_PLUGINS, getPlan } from '@automattic/calypso-products';
+import {
+	WPCOM_FEATURES_INSTALL_PLUGINS,
+	PLAN_PERSONAL,
+	PLAN_PREMIUM,
+	getPlan,
+} from '@automattic/calypso-products';
+import { isDefaultGlobalStylesVariationSlug } from '@automattic/design-picker';
 import { addQueryArgs } from '@wordpress/url';
 import { localize } from 'i18n-calypso';
 import { mapValues, pickBy, flowRight as compose } from 'lodash';
@@ -61,7 +67,16 @@ function getAllThemeOptions( { translate, isFSEActive } ) {
 			const themeTier = options.themeTier;
 
 			const tierMinimumUpsellPlan = THEME_TIERS[ themeTier?.slug ]?.minimumUpsellPlan;
-			const mappedPlan = getPlan( tierMinimumUpsellPlan );
+			const isLockedStyleVariation =
+				options?.styleVariationSlug &&
+				! isDefaultGlobalStylesVariationSlug( options.styleVariationSlug );
+
+			const minimumPlan =
+				tierMinimumUpsellPlan === PLAN_PERSONAL && isLockedStyleVariation
+					? PLAN_PREMIUM
+					: tierMinimumUpsellPlan;
+
+			const mappedPlan = getPlan( minimumPlan );
 			const planPathSlug = mappedPlan?.getPathSlug();
 
 			return `/checkout/${ slug }/${ planPathSlug }?redirect_to=${ redirectTo }`;


### PR DESCRIPTION
## Proposed Changes

Fixes an issue that was incorrectly sendings users to the checkout with the Starter plan in the cart after selecting a Starter tier theme and a premium style variation.

The Explorer theme is now added instead.

Before | After
--- | ---
<img width="1269" alt="Screenshot 2024-01-30 at 17 19 49" src="https://github.com/Automattic/wp-calypso/assets/1233880/1a2d7904-874a-4e67-8e1c-4135f0378bd2"> | <img width="1279" alt="Screenshot 2024-01-30 at 17 27 43" src="https://github.com/Automattic/wp-calypso/assets/1233880/2eb6c3dd-7bd1-4fcf-8bbc-b0aedc9868be">


## Testing Instructions

- Use the Calypso live link below
- Go to `/theme/erma/<FREE_SITE_DOMAIN>?flags=themes/tiers`
- Select a premium style variation
- Click on "Upgrade to activate"
- Make sure the Explorer plan is added to the checkout