### PR TITLE
Checkout: Add gap to CostOverridesListItem between price and name

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -21,6 +21,7 @@ const CostOverridesListStyle = styled.div`
 		justify-content: space-between;
 		grid-template-columns: auto auto;
 		margin-top: 4px;
+		gap: 16px;
 	}
 
 	& .cost-overrides-list-item--coupon {


### PR DESCRIPTION
## Proposed Changes

This adds spacing between the discount amount and the discount name in the list of discounts in the sidebar.

Before             |  After
:-------------------------:|:-------------------------:
<img width="298" alt="Screenshot 2024-01-30 at 1 32 02 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/f50a15c7-1862-4c99-b236-2b125de8ff19"> | <img width="302" alt="Screenshot 2024-01-30 at 1 32 27 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/54f768ae-071b-4858-954b-979c200c1b6b">

## Testing Instructions

This is a little tricky to test because it only happens for very specific word lengths in the discount names. Here's how I tested it:

- Sandbox the API.
- Add a product to your cart that has a discount of any kind and visit checkout. Make sure you see it in the sidebar.
- On the backend, change the cost override reason for the discount to be `Prorated balance from previous number of items`.
- Reload checkout and verify that there's space between the discount name and the price.