### PR TITLE
Launchpad: Move tasklist view events to launchpad-internal

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -64,6 +64,7 @@ const Sidebar = ( {
 	const translate = useTranslate();
 	const site = useSite();
 	const siteIntentOption = site?.options?.site_intent ?? null;
+	const checklistSlug = siteIntentOption;
 	const clipboardButtonEl = useRef< HTMLButtonElement >( null );
 	const [ clipboardCopied, setClipboardCopied ] = useState( false );
 	const [ showPlansModal, setShowPlansModal ] = useState( false );
@@ -274,6 +275,7 @@ const Sidebar = ( {
 					) }
 					<LaunchpadInternal
 						siteSlug={ launchpadKey }
+						checklistSlug={ checklistSlug }
 						taskFilter={ () => enhancedTasks || [] }
 						makeLastTaskPrimaryAction={ true }
 					/>

--- a/packages/launchpad/src/launchpad-internal.tsx
+++ b/packages/launchpad/src/launchpad-internal.tsx
@@ -1,5 +1,6 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useLaunchpad } from '@automattic/data-stores';
-import { useRef, useMemo } from 'react';
+import { useRef, useMemo, useEffect } from 'react';
 import Checklist from './checklist';
 import type { Task } from './types';
 import type { UseLaunchpadOptions } from '@automattic/data-stores';
@@ -32,12 +33,47 @@ const LaunchpadInternal = ( {
 		launchpadContext
 	);
 	const { isFetchedAfterMount, data } = launchpadData;
+	const { checklist } = data;
 	const tasks = useRef< Task[] >( [] );
+	const tasklistCompleted = checklist?.every( ( task: Task ) => task.completed ) || false;
+
+	const numberOfSteps = checklist?.length || 0;
+	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
 
 	useMemo( () => {
 		const originalTasks = data.checklist || [];
 		tasks.current = taskFilter ? taskFilter( originalTasks ) : originalTasks;
 	}, [ data, taskFilter ] );
+
+	useEffect( () => {
+		// Record task list view as a whole.
+		recordTracksEvent( 'calypso_launchpad_tasklist_viewed', {
+			checklist_slug: checklistSlug,
+			tasks: `,${ checklist?.map( ( task: Task ) => task.id ).join( ',' ) },`,
+			is_completed: tasklistCompleted,
+			number_of_steps: numberOfSteps,
+			number_of_completed_steps: completedSteps,
+			context: launchpadContext,
+		} );
+
+		// Record views for each task.
+		checklist?.map( ( task: Task ) => {
+			recordTracksEvent( 'calypso_launchpad_task_view', {
+				checklist_slug: checklistSlug,
+				task_id: task.id,
+				is_completed: task.completed,
+				context: launchpadContext,
+				order: task.order,
+			} );
+		} );
+	}, [
+		checklist,
+		checklistSlug,
+		completedSteps,
+		numberOfSteps,
+		tasklistCompleted,
+		launchpadContext,
+	] );
 
 	return (
 		<div className="launchpad__checklist-wrapper">

--- a/packages/launchpad/src/launchpad.tsx
+++ b/packages/launchpad/src/launchpad.tsx
@@ -7,7 +7,7 @@ import {
 	useSortedLaunchpadTasks,
 } from '@automattic/data-stores';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { ShareSiteModal } from './action-components';
 import LaunchpadInternal from './launchpad-internal';
 import { setUpActionsForTasks } from './setup-actions';
@@ -41,9 +41,6 @@ const Launchpad = ( {
 
 	const tracksData = { recordTracksEvent, checklistSlug, tasklistCompleted, launchpadContext };
 
-	const numberOfSteps = checklist?.length || 0;
-	const completedSteps = ( checklist?.filter( ( task: Task ) => task.completed ) || [] ).length;
-
 	const site = useSelect(
 		( select ) => {
 			return siteSlug && ( select( SITE_STORE ) as SiteSelect ).getSite( siteSlug );
@@ -51,36 +48,6 @@ const Launchpad = ( {
 		[ siteSlug ]
 	);
 	const [ shareSiteModalIsOpen, setShareSiteModalIsOpen ] = useState( false );
-
-	useEffect( () => {
-		// Record task list view as a whole.
-		recordTracksEvent( 'calypso_launchpad_tasklist_viewed', {
-			checklist_slug: checklistSlug,
-			tasks: `,${ checklist?.map( ( task: Task ) => task.id ).join( ',' ) },`,
-			is_completed: tasklistCompleted,
-			number_of_steps: numberOfSteps,
-			number_of_completed_steps: completedSteps,
-			context: launchpadContext,
-		} );
-
-		// Record views for each task.
-		checklist?.map( ( task: Task ) => {
-			recordTracksEvent( 'calypso_launchpad_task_view', {
-				checklist_slug: checklistSlug,
-				task_id: task.id,
-				is_completed: task.completed,
-				context: launchpadContext,
-				order: task.order,
-			} );
-		} );
-	}, [
-		checklist,
-		checklistSlug,
-		completedSteps,
-		numberOfSteps,
-		tasklistCompleted,
-		launchpadContext,
-	] );
 
 	const taskFilter = ( tasks: Task[] ) => {
 		const baseTasks = setUpActionsForTasks( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #86970

## Proposed Changes

As part of restructuring/improving the Launchpad tracks events, this moves the mechanism for tracking Launchpad checklist views in the LaunchpadInternal component.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This is easiest to test locally so you can see the tracks events in the dev console. But you could also use the calypso.live link and the Tracks Vigilante browser extension.
* Apply this branch locally and run calypso.
* Create a new site by visiting http://calypso.localhost:3000/setup/free
* When you get to the full screen Launchpad, look at the browser dev console.
* You should see one `calypso_launchpad_tasklist_viewed` event and lots of `calypso_launchpad_task_view` events.

![CleanShot 2024-01-30 at 14 29 53](https://github.com/Automattic/wp-calypso/assets/917632/671799ba-d2b1-4fbb-9a5b-431802a3de86)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
