### PR TITLE
Subscriber Stats: remove tabs to filter emails and wpcom subscribers

### DIFF
--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-import { SimplifiedSegmentedControl } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { flowRight, get } from 'lodash';
@@ -18,62 +17,12 @@ import { SUBSCRIBERS_SUPPORT_URL } from '../const';
 import ErrorPanel from '../stats-error';
 import StatsListCard from '../stats-list/stats-list-card';
 import StatsModulePlaceholder from '../stats-module/placeholder';
-import StatsModuleSelectDropdown from '../stats-module/select-dropdown';
 import './style.scss';
 
 class StatModuleFollowers extends Component {
 	state = {
 		activeFilter: 'wpcom-followers',
 	};
-
-	changeFilter = ( selection ) => {
-		const filter = selection.value;
-		let gaEvent;
-		if ( filter !== this.state.activeFilter ) {
-			switch ( filter ) {
-				case 'wpcom-followers':
-					gaEvent = 'Clicked By WordPress.com Followers Toggle';
-					break;
-				case 'email-followers':
-					gaEvent = 'Clicked Email Followers Toggle';
-					break;
-			}
-			if ( gaEvent ) {
-				this.props.recordGoogleEvent( 'Stats', gaEvent );
-			}
-
-			this.setState( {
-				activeFilter: filter,
-			} );
-		}
-	};
-
-	filterSelect() {
-		const { emailData, wpcomData } = this.props;
-		const hasEmailFollowers = !! get( emailData, 'subscribers', [] ).length;
-		const hasWpcomFollowers = !! get( wpcomData, 'subscribers', [] ).length;
-		if ( ! hasWpcomFollowers || ! hasEmailFollowers ) {
-			return null;
-		}
-
-		const options = this.filterOptions();
-
-		return <StatsModuleSelectDropdown options={ options } onSelect={ this.changeFilter } />;
-	}
-
-	filterOptions() {
-		const { translate } = this.props;
-		return [
-			{
-				value: 'wpcom-followers',
-				label: translate( 'WordPress.com' ),
-			},
-			{
-				value: 'email-followers',
-				label: translate( 'Email' ),
-			},
-		];
-	}
 
 	calculateOffset( pastValue ) {
 		const { translate } = this.props;
@@ -119,7 +68,6 @@ class StatModuleFollowers extends Component {
 		const hasEmailFollowers = !! get( emailData, 'subscribers', [] ).length;
 		const hasWpcomFollowers = !! get( wpcomData, 'subscribers', [] ).length;
 		const noData = ! hasWpcomFollowers && ! hasEmailFollowers;
-		const activeFilter = ! hasWpcomFollowers ? 'email-followers' : this.state.activeFilter;
 		const hasError = hasEmailQueryFailed || hasWpcomQueryFailed;
 
 		const summaryPageSlug = siteSlug || '';
@@ -128,11 +76,11 @@ class StatModuleFollowers extends Component {
 		let summaryPageLink = '/people/subscribers/' + summaryPageSlug;
 
 		// Limit scope for Odyssey stats, as the Followers page is not yet available.
-		summaryPageLink = ! isOdysseyStats ? summaryPageLink : null;
+		summaryPageLink = ! isOdysseyStats
+			? summaryPageLink
+			: 'https://wordpress.com' + summaryPageLink;
 
-		const data =
-			( activeFilter === 'wpcom-followers' ? wpcomData?.subscribers : emailData?.subscribers ) ||
-			[];
+		const data = [ ...( wpcomData?.subscribers ?? [] ), ...( emailData?.subscribers ?? [] ) ];
 
 		return (
 			<>
@@ -187,14 +135,7 @@ class StatModuleFollowers extends Component {
 						)
 					}
 					loader={ isLoading && <StatsModulePlaceholder isLoading={ isLoading } /> }
-					toggleControl={
-						<SimplifiedSegmentedControl
-							options={ this.filterOptions() }
-							onSelect={ this.changeFilter }
-						/>
-					}
 					className="stats__modernised-followers"
-					isLinkUnderlined={ activeFilter === 'wpcom-followers' }
 					showLeftIcon
 				/>
 			</>

--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -19,6 +19,8 @@ import StatsListCard from '../stats-list/stats-list-card';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import './style.scss';
 
+const MAX_FOLLOWERS_TO_SHOW = 10;
+
 class StatModuleFollowers extends Component {
 	state = {
 		activeFilter: 'wpcom-followers',
@@ -80,7 +82,10 @@ class StatModuleFollowers extends Component {
 			? summaryPageLink
 			: 'https://wordpress.com' + summaryPageLink;
 
-		const data = [ ...( wpcomData?.subscribers ?? [] ), ...( emailData?.subscribers ?? [] ) ];
+		const data = [ ...( wpcomData?.subscribers ?? [] ), ...( emailData?.subscribers ?? [] ) ].slice(
+			0,
+			MAX_FOLLOWERS_TO_SHOW
+		);
 
 		return (
 			<>


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-roadmap/issues/872

## Proposed Changes

* Link 'view details' in Subscriber stats on Odyssey to wp.com
* Remove tabs to filter wpcom / email subscribers
* The underline for links are intentionally removed, because it doesn't seem to support single item styling currently(?)

## Testing Instructions

* Open Subscriber Stasts on Calypso Live
* Ensure WPCOM and Email subscribers are concanated in a single list
* Test on Odyssey
* Ensure 'view details' link to wpcom subscriber management page

<img width="594" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/049a8a10-15db-41b6-ac95-a74044d3ccc7">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?