### PR TITLE
Hosting page: Update page title when admin interface is set to wp-admin

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -39,7 +39,7 @@ import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-us
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { requestSite } from 'calypso/state/sites/actions';
 import { isSiteOnBusinessTrial, isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
-import { getSiteOption, isJetpackSite } from 'calypso/state/sites/selectors';
+import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
 import {
 	getSelectedSite,
@@ -204,7 +204,6 @@ const Hosting = ( props ) => {
 		fetchUpdatedData,
 		isSiteAtomic,
 		transferState,
-		isAdminInterfaceWPAdmin,
 	} = props;
 
 	const [ isTrialAcknowledgeModalOpen, setIsTrialAcknowledgeModalOpen ] = useState( false );
@@ -339,18 +338,14 @@ const Hosting = ( props ) => {
 		! hasAtomicFeature || ( ! hasTransfer && ! hasSftpFeature && ! isWpcomStagingSite );
 	const banner = shouldShowUpgradeBanner ? getUpgradeBanner() : getAtomicActivationNotice();
 
-	const pageTitle = isAdminInterfaceWPAdmin
-		? translate( 'Hosting' )
-		: translate( 'Hosting Configuration' );
-
 	return (
 		<Main wideLayout className="hosting">
 			{ ! isLoadingSftpData && <ScrollToAnchorOnMount offset={ HEADING_OFFSET } /> }
 			<PageViewTracker path="/hosting-config/:site" title="Hosting" />
-			<DocumentHead title={ pageTitle } />
+			<DocumentHead title={ translate( 'Hosting' ) } />
 			<NavigationHeader
 				navigationItems={ [] }
-				title={ pageTitle }
+				title={ translate( 'Hosting' ) }
 				subtitle={ translate( 'Access your website’s database and more advanced settings.' ) }
 			/>
 			{ ! showHostingActivationBanner && ! isTrialAcknowledgeModalOpen && (
@@ -392,7 +387,6 @@ export default connect(
 		const isEligibleForHostingTrial =
 			isUserEligibleForFreeHostingTrial( state ) && site && site.plan?.is_free;
 		const isSiteAtomic = isSiteWpcomAtomic( state, siteId );
-		const adminInterface = getSiteOption( state, siteId, 'wpcom_admin_interface' );
 
 		return {
 			teams: getReaderTeams( state ),
@@ -409,7 +403,6 @@ export default connect(
 			hasStagingSitesFeature,
 			isEligibleForHostingTrial,
 			isSiteAtomic,
-			isAdminInterfaceWPAdmin: adminInterface === 'wp-admin',
 		};
 	},
 	{

--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -39,7 +39,7 @@ import { isUserEligibleForFreeHostingTrial } from 'calypso/state/selectors/is-us
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { requestSite } from 'calypso/state/sites/actions';
 import { isSiteOnBusinessTrial, isSiteOnECommerceTrial } from 'calypso/state/sites/plans/selectors';
-import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
+import { getSiteOption, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
 import {
 	getSelectedSite,
@@ -204,6 +204,7 @@ const Hosting = ( props ) => {
 		fetchUpdatedData,
 		isSiteAtomic,
 		transferState,
+		isAdminInterfaceWPAdmin,
 	} = props;
 
 	const [ isTrialAcknowledgeModalOpen, setIsTrialAcknowledgeModalOpen ] = useState( false );
@@ -338,14 +339,18 @@ const Hosting = ( props ) => {
 		! hasAtomicFeature || ( ! hasTransfer && ! hasSftpFeature && ! isWpcomStagingSite );
 	const banner = shouldShowUpgradeBanner ? getUpgradeBanner() : getAtomicActivationNotice();
 
+	const pageTitle = isAdminInterfaceWPAdmin
+		? translate( 'Hosting' )
+		: translate( 'Hosting Configuration' );
+
 	return (
 		<Main wideLayout className="hosting">
 			{ ! isLoadingSftpData && <ScrollToAnchorOnMount offset={ HEADING_OFFSET } /> }
-			<PageViewTracker path="/hosting-config/:site" title="Hosting Configuration" />
-			<DocumentHead title={ translate( 'Hosting Configuration' ) } />
+			<PageViewTracker path="/hosting-config/:site" title="Hosting" />
+			<DocumentHead title={ pageTitle } />
 			<NavigationHeader
 				navigationItems={ [] }
-				title={ translate( 'Hosting Configuration' ) }
+				title={ pageTitle }
 				subtitle={ translate( 'Access your website’s database and more advanced settings.' ) }
 			/>
 			{ ! showHostingActivationBanner && ! isTrialAcknowledgeModalOpen && (
@@ -387,6 +392,7 @@ export default connect(
 		const isEligibleForHostingTrial =
 			isUserEligibleForFreeHostingTrial( state ) && site && site.plan?.is_free;
 		const isSiteAtomic = isSiteWpcomAtomic( state, siteId );
+		const adminInterface = getSiteOption( state, siteId, 'wpcom_admin_interface' );
 
 		return {
 			teams: getReaderTeams( state ),
@@ -403,6 +409,7 @@ export default connect(
 			hasStagingSitesFeature,
 			isEligibleForHostingTrial,
 			isSiteAtomic,
+			isAdminInterfaceWPAdmin: adminInterface === 'wp-admin',
 		};
 	},
 	{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5388

## Proposed Changes

This PR updates the title from Hosting Configuration to Hosting.

| Before | After | 
| --- | --- |
| ![Screenshot 2024-01-31 at 11 43 49 AM](https://github.com/Automattic/wp-calypso/assets/797888/ebc213cd-6e10-474e-ac9c-6c11f65ee52e) | ![Screenshot 2024-01-31 at 11 44 10 AM](https://github.com/Automattic/wp-calypso/assets/797888/9112d39a-62c3-4540-8d30-8bdeffd74502) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/hosting-config/${site_slug}`.
* Ensure that the page title is "Hosting".

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?