### PR TITLE
Plans 2023: Fix plan term dropdown scroll reset

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -16,6 +16,7 @@ import {
 import { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 import { useDesktopBreakpoint } from '@automattic/viewport-react';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useState } from '@wordpress/element';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
@@ -35,6 +36,7 @@ import { ONBOARD_STORE } from '../../../../stores';
 import type { OnboardSelect } from '@automattic/data-stores';
 import type { PlansIntent } from '@automattic/plans-grid-next';
 import './style.scss';
+import consoleDispatcher from 'calypso/state/console-dispatch';
 
 interface Props {
 	shouldIncludeFAQ?: boolean;
@@ -88,6 +90,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		}
 	}, [ selectedSiteId, siteId, setSelectedSiteId ] );
 
+	const [ planIntervalPath, setPlanIntervalPath ] = useState< string >( '' );
 	const { __ } = useI18n();
 	const translate = useTranslate();
 	const isDesktop = useDesktopBreakpoint();
@@ -103,14 +106,22 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		: reduxHideFreePlan;
 
 	useLayoutEffect( () => {
+		// Plan intervals are changed by parsing query params. Updating query params
+		// with react-router, however, rerenders the whole page. The effect is that,
+		// whenever a new plan interval is selected, the viewport is reset to the top
+		// of the page. Because of this, we manually restore scroll position here.
+		// Ideally we'd switch to using react-router <ScrollRestoration> whenever stepper
+		// flows are refactored to use a data router
 		document.documentElement.scrollTop = location.state?.scrollTop || 0;
-	} );
+	}, [ location.state?.scrollTop, planIntervalPath ] );
 
 	const onPlanIntervalChange = ( path: string ) => {
+		setPlanIntervalPath( path );
+
 		navigate( path, {
 			preventScrollReset: true,
 			replace: true,
-			state: { scrollTop: document.documentElement?.scrollTop },
+			state: { scrollTop: document.documentElement.scrollTop },
 		} );
 	};
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -19,9 +19,9 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { localize, useTranslate } from 'i18n-calypso';
-import React, { useEffect } from 'react';
+import React, { useEffect, useLayoutEffect } from 'react';
 import { connect } from 'react-redux';
-import { useNavigate } from 'react-router';
+import { useNavigate, useLocation } from 'react-router';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { getPlanCartItem } from 'calypso/lib/cart-values/cart-items';
 import PlansFeaturesMain from 'calypso/my-sites/plans-features-main';
@@ -92,6 +92,7 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 	const translate = useTranslate();
 	const isDesktop = useDesktopBreakpoint();
 	const navigate = useNavigate();
+	const location = useLocation();
 	const stepName = 'plans';
 	const customerType = 'personal';
 	const headerText = __( 'Choose a plan' );
@@ -101,8 +102,16 @@ const PlansWrapper: React.FC< Props > = ( props ) => {
 		? reduxHideFreePlan && 'plans-blog-onboarding' === plansIntent
 		: reduxHideFreePlan;
 
+	useLayoutEffect( () => {
+		document.documentElement.scrollTop = location.state?.scrollTop || 0;
+	} );
+
 	const onPlanIntervalChange = ( path: string ) => {
-		navigate( path );
+		navigate( path, {
+			preventScrollReset: true,
+			replace: true,
+			state: { scrollTop: document.documentElement?.scrollTop },
+		} );
 	};
 
 	const onUpgradeClick = ( cartItems?: MinimalRequestCartProduct[] | null ) => {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/plans/plans-wrapper.tsx
@@ -36,7 +36,6 @@ import { ONBOARD_STORE } from '../../../../stores';
 import type { OnboardSelect } from '@automattic/data-stores';
 import type { PlansIntent } from '@automattic/plans-grid-next';
 import './style.scss';
-import consoleDispatcher from 'calypso/state/console-dispatch';
 
 interface Props {
 	shouldIncludeFAQ?: boolean;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/growth-foundations/issues/302

## Proposed Changes

* The plan term dropdown operates by parsing query params. It searches for the `intervalType` key  to determine which interval pricing to show for plans ( monthly, 1y, 2y, 3y ).
* Stepper flows, which depend on `react-router`, re-mount the page when query params are updated for the URL. This causes the viewport to abruptly reset to the top of the page every time a new plan term is chosen
* Ideally we'd use the [ScrollRestoration](https://reactrouter.com/en/main/components/scroll-restoration) `react-router` component to solve this problem. It would, however, require a non-trivial refactor away from the current implementation of `<BrowserRouter />`

## Gifs
### Before
| Desktop      | Mobile |
| ----- | ----- |
| ![2024-01-30 19 52 55](https://github.com/Automattic/wp-calypso/assets/5414230/7c95cad8-1eac-4528-a1ed-e3f4c87849a5)      | ![2024-01-30 19 53 12](https://github.com/Automattic/wp-calypso/assets/5414230/f2846036-367a-48ef-b0c7-bedfcba6f43d)   |

### After
![2024-01-31 12 04 16](https://github.com/Automattic/wp-calypso/assets/5414230/845b6a81-116a-4c51-a00a-0285819d6280)

## Testing Instructions
<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out branch
* Navigate to `/setup/newsletter` or any other stepper flows ( flows prefixed by `/setup` ) noted in PCYsg-RDT-p2
* Follow onboarding steps until at the plans page
* Select a new plan interval ( 2yr, 3yr, etc. )
* Verify that the scroll position of the viewport is not reset
* Confirm the same for the mobile view

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?