### PR TITLE
Upsell Nudge: enable 1-click checkout by default

### DIFF
--- a/client/blocks/upsell-nudge/index.tsx
+++ b/client/blocks/upsell-nudge/index.tsx
@@ -144,7 +144,7 @@ export const UpsellNudge = ( {
 	isSiteWooExpressOrEcomFreeTrial,
 	isBusy,
 	isEligibleForOneClickCheckout,
-	isOneClickCheckoutEnabled,
+	isOneClickCheckoutEnabled = true,
 }: Props ) => {
 	const [ showPurchaseModal, setShowPurchaseModal ] = useState( false );
 	const shouldNotDisplay =


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pau2Xa-5sP-p2#comment-14697

## Proposed Changes

* Enables one-click checkout by default for all Upsell Nudges. Please see the linked post above for more details.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* One-click checkout is already enabled in a few different places, so this should not require any additional testing of the checkout experience itself. 
* Smoke test a few places where this will be in action:
  * Make sure you have a saved credit card on file.
  * Go to `/theme/annalee/<site slug>` for a site on the free plan. Click on the "Access this theme..." nudge. Confirm it opens the checkout modal.
  * Go to `/hosting-config/<site slug>` for a site on the free plan. Click on the "Upgrade to..." nudge. Confirm it opens the checkout modal.
  * Go to `/marketing/traffic/<site slug>` for a site on the free plan. Click on the "Boost your..." nudge. Confirm it opens the checkout modal.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?