### PR TITLE
Add check for site redirection analyzer source URL

### DIFF
--- a/client/data/site-migration/use-source-migration-status-query.ts
+++ b/client/data/site-migration/use-source-migration-status-query.ts
@@ -8,11 +8,20 @@ export const useSourceMigrationStatusQuery = (
 ) => {
 	return useQuery( {
 		queryKey: [ 'source-migration-status', sourceIdOrSlug ],
-		queryFn: (): Promise< SourceSiteMigrationDetails > =>
-			wp.req.get( {
+		queryFn: (): Promise< SourceSiteMigrationDetails > => {
+			if ( ! parseInt( sourceIdOrSlug as string ) ) {
+				const url = decodeURIComponent( sourceIdOrSlug as string );
+				const parsed = new URL( url );
+
+				// Need to force the URL to origin URL.
+				sourceIdOrSlug = parsed.origin;
+			}
+
+			return wp.req.get( {
 				path: '/migrations/from-source/' + encodeURIComponent( sourceIdOrSlug as string ),
 				apiNamespace: 'wpcom/v2',
-			} ),
+			} );
+		},
 		meta: {
 			persist: false,
 		},


### PR DESCRIPTION
See D136217-code for description.

## Proposed Changes

* Force URL to origin URL in the migration status query

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
See diff for testing instructions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?