### PR TITLE
Jetpack Manage: Implement review licenses for selected licenses on the dashboard

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -35,6 +35,7 @@ import DashboardBanners from './dashboard-banners';
 import DashboardDataContext from './dashboard-data-context';
 import useQueryProvisioningBlogIds from './hooks/use-query-provisioning-blog-ids';
 import { DASHBOARD_PRODUCT_SLUGS_BY_TYPE } from './lib/constants';
+import ReviewSelectedSiteLicenses from './review-selected-site-licenses';
 import SiteAddLicenseNotification from './site-add-license-notification';
 import SiteContent from './site-content';
 import useDashboardShowLargeScreen from './site-content/hooks/use-dashboard-show-large-screen';
@@ -73,6 +74,7 @@ export default function SitesOverview() {
 	const highlightFavoriteTab = getQueryArg( window.location.href, 'highlight' ) === 'favorite-tab';
 
 	const [ highlightTab, setHighlightTab ] = useState( false );
+	const [ showReviewLicenses, setShowReviewLicenses ] = useState( false );
 
 	const {
 		search,
@@ -235,7 +237,7 @@ export default function SitesOverview() {
 
 	const handleIssueLicenses = () => {
 		if ( isStreamlinedPurchasesEnabled ) {
-			// TODO: Show a modal with the selected licenses and a button to issue them.
+			setShowReviewLicenses( true );
 			return;
 		}
 		dispatch(
@@ -411,6 +413,13 @@ export default function SitesOverview() {
 				<div className="sites-overview__issue-licenses-button-small-screen">
 					{ renderIssueLicenseButton() }
 				</div>
+			) }
+			{ showReviewLicenses && (
+				<ReviewSelectedSiteLicenses
+					onClose={ () => setShowReviewLicenses( false ) }
+					selectedLicenses={ selectedSiteLicenses }
+					sites={ data?.sites ?? [] }
+				/>
 			) }
 		</div>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/review-selected-site-licenses/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/review-selected-site-licenses/index.tsx
@@ -1,0 +1,64 @@
+import useProductAndPlans from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/licenses-form/hooks/use-product-and-plans';
+import ReviewLicenses from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/review-licenses';
+import { SelectedLicenseProp } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/types';
+import { DASHBOARD_PRODUCT_SLUGS_BY_TYPE } from '../lib/constants';
+import type { Site } from '../types';
+
+interface Props {
+	onClose: () => void;
+	selectedLicenses: Array< { siteId: number; products: Array< string > } >;
+	sites: Site[];
+}
+
+export default function ReviewSelectedSiteLicenses( { onClose, selectedLicenses, sites }: Props ) {
+	const { filteredProductsAndBundles } = useProductAndPlans( {} );
+
+	const handleIssueLicense = () => {
+		// TODO: implement issue license
+	};
+
+	const isLoading = false; // TODO: implement loading state
+
+	const mappedSelectedLicenses = selectedLicenses.reduce(
+		( acc: SelectedLicenseProp[], license ) => {
+			license.products.forEach( ( product ) => {
+				const productBundle = filteredProductsAndBundles.find(
+					( productBundle ) => DASHBOARD_PRODUCT_SLUGS_BY_TYPE[ product ] === productBundle.slug
+				);
+
+				if ( ! productBundle ) {
+					return;
+				}
+
+				const siteUrl = sites.find( ( site ) => site.blog_id === license.siteId )?.url ?? '';
+
+				const foundBundle = acc.find(
+					( bundle ) => bundle.product_id === productBundle.product_id
+				);
+
+				if ( foundBundle ) {
+					foundBundle.quantity++;
+					foundBundle.siteUrls?.push( siteUrl );
+				} else {
+					acc.push( {
+						...productBundle,
+						quantity: 1,
+						siteUrls: [ siteUrl ],
+					} );
+				}
+			} );
+			return acc;
+		},
+		[]
+	);
+
+	return (
+		<ReviewLicenses
+			isMultiSiteSelect
+			onClose={ onClose }
+			selectedLicenses={ mappedSelectedLicenses }
+			handleIssueLicense={ handleIssueLicense }
+			isLoading={ isLoading }
+		/>
+	);
+}

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/review-licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/review-licenses/index.tsx
@@ -12,12 +12,22 @@ import type { SiteDetails } from '@automattic/data-stores';
 import './style.scss';
 
 interface Props {
+	isMultiSiteSelect?: boolean;
 	onClose: () => void;
 	selectedLicenses: SelectedLicenseProp[];
 	selectedSite?: SiteDetails | null;
+	handleIssueLicense?: () => void;
+	isLoading?: boolean;
 }
 
-export default function ReviewLicenses( { onClose, selectedLicenses, selectedSite }: Props ) {
+export default function ReviewLicenses( {
+	isMultiSiteSelect = false,
+	onClose,
+	selectedLicenses,
+	selectedSite,
+	handleIssueLicense,
+	isLoading,
+}: Props ) {
 	const translate = useTranslate();
 
 	const { sidebarRef, mainRef, initMobileSidebar } = useMobileSidebar();
@@ -41,6 +51,7 @@ export default function ReviewLicenses( { onClose, selectedLicenses, selectedSit
 								key={ `license-info-${ license.product_id }-${ license.quantity }` }
 								product={ license }
 								selectedSite={ selectedSite }
+								isMultiSiteSelect={ isMultiSiteSelect }
 							/>
 						) ) }
 					</div>
@@ -48,7 +59,12 @@ export default function ReviewLicenses( { onClose, selectedLicenses, selectedSit
 			</JetpackLightboxMain>
 
 			<JetpackLightboxAside ref={ sidebarRef }>
-				<PricingSummary selectedLicenses={ selectedLicenses } selectedSite={ selectedSite } />
+				<PricingSummary
+					selectedLicenses={ selectedLicenses }
+					selectedSite={ selectedSite }
+					handleIssueLicense={ handleIssueLicense }
+					isLoading={ isLoading }
+				/>
 			</JetpackLightboxAside>
 		</JetpackLightbox>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/review-licenses/license-info.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/review-licenses/license-info.tsx
@@ -7,9 +7,11 @@ import type { SiteDetails } from '@automattic/data-stores';
 export default function LicenseInfo( {
 	product,
 	selectedSite,
+	isMultiSiteSelect = false,
 }: {
 	product: SelectedLicenseProp;
 	selectedSite?: SiteDetails | null;
+	isMultiSiteSelect?: boolean;
 } ) {
 	const translate = useTranslate();
 
@@ -30,7 +32,7 @@ export default function LicenseInfo( {
 						<label htmlFor={ title } className="review-licenses__license-label">
 							{ title }
 						</label>
-						{ ! selectedSite && (
+						{ ! isMultiSiteSelect && ! selectedSite && (
 							<span className="review-licenses__license-count">
 								{ translate( '%(numLicenses)d license', '%(numLicenses)d licenses', {
 									context: 'button label',
@@ -45,6 +47,27 @@ export default function LicenseInfo( {
 					<p className="review-licenses__license-description">
 						{ productInfo.lightboxDescription }
 					</p>
+					{ isMultiSiteSelect && (
+						<div className="review-licenses__license-count">
+							<div className="review-licenses__license-count-text">
+								{ translate( '%(numLicenses)d license', '%(numLicenses)d licenses', {
+									context: 'button label',
+									count: product.quantity,
+									args: {
+										numLicenses: product.quantity,
+									},
+								} ) }
+							</div>
+							{ product.siteUrls?.map( ( url ) => (
+								<div
+									key={ `license-site-url-${ product.product_id }-${ url }` }
+									className="review-licenses__license-site-url"
+								>
+									{ url }
+								</div>
+							) ) }
+						</div>
+					) }
 				</div>
 			</div>
 		</div>

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/review-licenses/pricing-summary.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/review-licenses/pricing-summary.tsx
@@ -14,9 +14,13 @@ import type { SiteDetails } from '@automattic/data-stores';
 export default function PricingSummary( {
 	selectedLicenses,
 	selectedSite,
+	handleIssueLicense,
+	isLoading,
 }: {
 	selectedLicenses: SelectedLicenseProp[];
 	selectedSite?: SiteDetails | null;
+	handleIssueLicense?: () => void;
+	isLoading?: boolean;
 } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -71,8 +75,8 @@ export default function PricingSummary( {
 			<Button
 				primary
 				className="review-licenses__cta-button"
-				onClick={ handleCTAClick }
-				busy={ ! isFormReady }
+				onClick={ handleIssueLicense ?? handleCTAClick }
+				busy={ ! isFormReady || isLoading }
 			>
 				{ translate( 'Issue %(numLicenses)d license', 'Issue %(numLicenses)d licenses', {
 					context: 'button label',

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/review-licenses/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/review-licenses/style.scss
@@ -83,7 +83,15 @@
 			padding: 5px 15px;
 			border-radius: 4px;
 			font-weight: 500;
+			margin-block-start: 16px;
+		}
 
+		.review-licenses__license-count-text {
+			font-weight: bold;
+		}
+
+		.review-licenses__license-site-url {
+			margin-block: 8px;
 		}
 
 		.review-licenses__license-description {


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/208

## Proposed Changes

This PR implements review licenses for selected licenses on the dashboard.

<img width="1120" alt="Screenshot 2024-01-30 at 8 58 57 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/35370e3c-a854-4dc8-bc7d-ed71e17db52f">

## Testing Instructions

**Prerequisites**

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

**Instructions**

**NOTE**: Clicking on `Issue X licenses` does nothing for now and will be implemented in another PR.

1. Visit the Jetpack Cloud link > Append the URL with `?flags=jetpack/streamline-license-purchases`.
2. Click on `+ Add` for `Backup` & `Scan` on any site > Try adding multiple licenses from multiple sites > Click the `Review X licenses` button > Verify that the review screen is shown with the correct data.
3. Switch to the mobile view > Refresh the page and repeat step 2. 
4. Remove the feature flag and verify the flow works as expected. You should be able to select a license from only one site at a time and you should be redirected to the partner portal to issue a license.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?