### PR TITLE
Updated CTAs on domain only thank you page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only.tsx
@@ -100,7 +100,7 @@ export default function DomainOnlyThankYou( { purchases, receiptId }: DomainOnly
 				purchase={ purchase }
 				key={ `domain-${ purchase.meta }` }
 				siteSlug={ domainOnlySite?.slug }
-				shareSite
+				isDomainOnly
 			/>
 		);
 	} );

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
@@ -2,7 +2,6 @@ import { isDomainTransfer } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
 import { Button } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
-import QuerySites from 'calypso/components/data/query-sites';
 import ThankYouProduct from 'calypso/components/thank-you-v2/product';
 import {
 	createSiteFromDomainOnly,
@@ -10,14 +9,6 @@ import {
 	domainManagementRoot,
 } from 'calypso/my-sites/domains/paths';
 import type { ReceiptPurchase } from 'calypso/state/receipts/types';
-
-type ThankYouDomainProductProps = {
-	purchase?: ReceiptPurchase;
-	domainName?: string;
-	isDomainOnly?: boolean;
-	siteSlug?: string | null;
-	currency?: string;
-};
 
 type DomainTransferSectionProps = {
 	purchase: ReceiptPurchase;
@@ -41,6 +32,14 @@ const DomainTransferSection = ( { purchase, currency }: DomainTransferSectionPro
 	};
 
 	return <p>{ purchaseLabel( purchase.priceInteger ) }</p>;
+};
+
+type ThankYouDomainProductProps = {
+	purchase?: ReceiptPurchase;
+	domainName?: string;
+	isDomainOnly?: boolean;
+	siteSlug?: string | null;
+	currency?: string;
 };
 
 export default function ThankYouDomainProduct( {
@@ -72,8 +71,6 @@ export default function ThankYouDomainProduct( {
 
 		actions = (
 			<>
-				<QuerySites siteId={ purchase.blogId } />
-
 				{ isDomainOnly && (
 					<Button className="is-primary" { ...createSiteProps }>
 						{ translate( 'Create site' ) }
@@ -98,7 +95,6 @@ export default function ThankYouDomainProduct( {
 			name={ domainName }
 			isFree={ purchase?.priceInteger === 0 }
 			actions={ actions }
-			key={ 'domain-' + domainName }
 		/>
 	);
 }

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/domain-product.tsx
@@ -1,16 +1,20 @@
 import { isDomainTransfer } from '@automattic/calypso-products';
 import formatCurrency from '@automattic/format-currency';
-import { Button, ClipboardButton } from '@wordpress/components';
-import { translate } from 'i18n-calypso';
-import { useState } from 'react';
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import QuerySites from 'calypso/components/data/query-sites';
 import ThankYouProduct from 'calypso/components/thank-you-v2/product';
-import { domainManagementList, domainManagementRoot } from 'calypso/my-sites/domains/paths';
+import {
+	createSiteFromDomainOnly,
+	domainManagementEdit,
+	domainManagementRoot,
+} from 'calypso/my-sites/domains/paths';
 import type { ReceiptPurchase } from 'calypso/state/receipts/types';
 
 type ThankYouDomainProductProps = {
 	purchase?: ReceiptPurchase;
 	domainName?: string;
-	shareSite?: boolean;
+	isDomainOnly?: boolean;
 	siteSlug?: string | null;
 	currency?: string;
 };
@@ -21,6 +25,8 @@ type DomainTransferSectionProps = {
 };
 
 const DomainTransferSection = ( { purchase, currency }: DomainTransferSectionProps ) => {
+	const translate = useTranslate();
+
 	const purchaseLabel = ( priceInteger: number ) => {
 		if ( priceInteger === 0 ) {
 			return translate( 'We’ve paid for an extra year' );
@@ -40,48 +46,59 @@ const DomainTransferSection = ( { purchase, currency }: DomainTransferSectionPro
 export default function ThankYouDomainProduct( {
 	purchase,
 	domainName,
-	shareSite,
+	isDomainOnly,
 	siteSlug,
 	currency,
 }: ThankYouDomainProductProps ) {
-	const [ isCopying, setIsCopying ] = useState( false );
-	const domain = domainName ?? purchase?.meta;
+	const translate = useTranslate();
+
+	domainName ??= purchase?.meta;
 
 	// Do not proceed if a domain is not specified by domain name or a purchase object.
-	if ( ! domain ) {
+	if ( ! domainName ) {
 		return null;
 	}
 
-	const actions =
-		purchase && isDomainTransfer( purchase ) ? (
-			<DomainTransferSection purchase={ purchase } currency={ currency ?? 'USD' } />
-		) : (
+	let actions;
+
+	if ( purchase && isDomainTransfer( purchase ) ) {
+		actions = <DomainTransferSection purchase={ purchase } currency={ currency ?? 'USD' } />;
+	} else if ( purchase?.blogId && siteSlug ) {
+		const createSiteHref = siteSlug && createSiteFromDomainOnly( siteSlug, purchase.blogId );
+		const createSiteProps = createSiteHref ? { href: createSiteHref } : { disabled: true };
+
+		const manageDomainHref = siteSlug && domainManagementEdit( siteSlug, domainName );
+		const manageDomainProps = manageDomainHref ? { href: manageDomainHref } : { disabled: true };
+
+		actions = (
 			<>
-				{ shareSite && domain && (
-					<ClipboardButton
-						className="is-primary"
-						onCopy={ () => setIsCopying( true ) }
-						onFinishCopy={ () => setIsCopying( false ) }
-						text={ domain }
-					>
-						{ isCopying ? translate( 'Site copied' ) : translate( 'Share site' ) }
-					</ClipboardButton>
+				<QuerySites siteId={ purchase.blogId } />
+
+				{ isDomainOnly && (
+					<Button className="is-primary" { ...createSiteProps }>
+						{ translate( 'Create site' ) }
+					</Button>
 				) }
-				<Button
-					variant={ shareSite ? 'secondary' : 'primary' }
-					href={ siteSlug ? domainManagementList( siteSlug ) : domainManagementRoot() }
-				>
-					{ translate( 'Manage domains' ) }
+
+				<Button variant={ isDomainOnly ? 'secondary' : 'primary' } { ...manageDomainProps }>
+					{ translate( 'Manage domain' ) }
 				</Button>
 			</>
 		);
+	} else {
+		actions = (
+			<Button variant={ isDomainOnly ? 'secondary' : 'primary' } href={ domainManagementRoot() }>
+				{ translate( 'Manage domains' ) }
+			</Button>
+		);
+	}
 
 	return (
 		<ThankYouProduct
-			name={ domain }
+			name={ domainName }
 			isFree={ purchase?.priceInteger === 0 }
 			actions={ actions }
-			key={ 'domain-' + domain }
+			key={ 'domain-' + domainName }
 		/>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/4734

## Proposed Changes

Summary:
- Update the primary CTA on the domain-only thank you page to `Create site`
- Update the secondary CTA on the domain-only thank you page to lead to the domain settings for the newly purchased domain (it previously led to the domains management list)

Background:

The primary CTA on the thank you page users land on after completing domain only checkout currently says `Share site`. Aside from the slightly misleading terminology (`Share site` will in fact copy the domain name), we've also questioned if this is truly a reasonable primary CTA and wanted to change it to `Create site` instead. 

I initially struggled with inconsistent data from the API about domain only purchases. After some help from the payments team, I understood that this was just an effect of using the store sandbox. See p1706643602738329/1706624428.332789-slack-C096PD42U

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Do **NOT** enable the store sandbox
2. Navigate to `/domains/manage`
3. Click `Add a domain` > `Register a new domain`
4. Find a domain and complete checkout
5. On the thank you page, ensure that the primary CTA is clickable and that it takes you to another onboarding flow
6. Ensure that the secondary CTA takes you to the domain settings for your newly purchased domain

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?