### PR TITLE
Upsell Nudge: do not show non-upgradeable plans for checkout

### DIFF
--- a/client/blocks/upsell-nudge/index.tsx
+++ b/client/blocks/upsell-nudge/index.tsx
@@ -9,6 +9,9 @@ import {
 	GROUP_WPCOM,
 	WPCOM_FEATURES_NO_ADVERTS,
 	isFreePlanProduct,
+	isWpComPlan,
+	getPlan,
+	findFirstSimilarPlanKey,
 } from '@automattic/calypso-products';
 import classnames from 'classnames';
 import debugFactory from 'debug';
@@ -208,12 +211,25 @@ export const UpsellNudge = ( {
 		onClick?.();
 	};
 
+	/**
+	 * Users can upgrade only to plans on their current plan term or higher.
+	 * This ensures that users on a 2-year plan, for example, are not shown an
+	 * upsell to 1-year plan.
+	 */
+	let upsellPlan = plan;
+	if ( site?.plan?.product_slug && plan && isWpComPlan( plan ) ) {
+		const upsellPlanType = getPlan( plan )?.type;
+		upsellPlan = findFirstSimilarPlanKey( site.plan.product_slug, {
+			type: upsellPlanType,
+		} );
+	}
+
 	return (
 		<>
 			{ showPurchaseModal && (
 				<AsyncLoad
 					require="./purchase-modal-wrapper"
-					plan={ plan }
+					plan={ upsellPlan }
 					siteSlug={ siteSlug }
 					setShowPurchaseModal={ setShowPurchaseModal }
 				/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* The consumers of the <UpsellNudge/> component typically pass an annual plan slug as the `plan` prop. This causes users on 2y/3y plans to see an upsell for a 1y plan, which results in a shopping cart error.
* This change prevents incompatible plan upsells for the 1-click checkout modal. Users can only upgrade to plans that are on the same or higher term as their current plan.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/themes/upload/<site slug>` for a site on 2y Explorer/Starter plan.
* Click on the `Upgrade to Creator...` upsell nudge.
* Confirm that you can see checkout modal with the 2y Creator plan in the cart.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?