### PR TITLE
Fix E2E test broken by our changes on the Customer Home page

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/my-home-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/my-home-page.ts
@@ -3,10 +3,6 @@ import { getCalypsoURL } from '../../data-helper';
 
 const selectors = {
 	visitSiteButton: '.button >> text=Visit site',
-
-	// Task card (topmost card)
-	taskHeadingMessage: ( message: string ) => `h3:text("${ message }")`,
-
 	domainUpsellCard: `.domain-upsell__card`,
 	domainUpsellSuggestedDomain: `.domain-upsell__card .domain-upsell-illustration`,
 	domainUpsellBuyDomain: ( message: string ) =>
@@ -120,6 +116,6 @@ export class MyHomePage {
 	 * @param {string} message Partial or fully matching text to search.
 	 */
 	async validateTaskHeadingMessage( message: string ): Promise< void > {
-		await this.page.waitForSelector( selectors.taskHeadingMessage( message ) );
+		await this.page.getByRole( 'heading', { name: message } ).waitFor();
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/my-home-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/my-home-page.ts
@@ -5,8 +5,7 @@ const selectors = {
 	visitSiteButton: '.button >> text=Visit site',
 
 	// Task card (topmost card)
-	taskHeadingMessage: ( message: string ) =>
-		`.primary__customer-home-location-content :text("${ message }")`,
+	taskHeadingMessage: ( message: string ) => `h3:text("${ message }")`,
 
 	domainUpsellCard: `.domain-upsell__card`,
 	domainUpsellSuggestedDomain: `.domain-upsell__card .domain-upsell-illustration`,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* With our recent changes on the Customer Home, moving the layout to a two-column style made the e2e tests fail because it could no longer find the class `.primary__customer-home-location-content.`
* You can find more information about our changes on our heads-up post: p7DVsv-jQE-p2

More context: p1706695803872559-slack-C02DQP0FP

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visual inspection and making sure the tests passes is enough.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?