### PR TITLE
Invite-Accept: Add tracking

### DIFF
--- a/client/my-sites/invites/invite-accept-logged-out/index.jsx
+++ b/client/my-sites/invites/invite-accept-logged-out/index.jsx
@@ -52,6 +52,10 @@ class InviteAcceptLoggedOut extends Component {
 
 	submitForm = ( form, userData, _, afterSubmitCallback = noop ) => {
 		const { invite } = this.props;
+		recordTracksEvent( 'calypso_invite_accept_logged_out_submit', {
+			role: invite?.role,
+			siteID: invite?.site?.ID,
+		} );
 
 		this.setState( { submitting: true } );
 		debug( 'Storing invite_accepted: ' + JSON.stringify( invite ) );

--- a/client/my-sites/invites/invite-accept/index.jsx
+++ b/client/my-sites/invites/invite-accept/index.jsx
@@ -39,6 +39,10 @@ class InviteAccept extends Component {
 	componentDidMount() {
 		this.mounted = true;
 
+		recordTracksEvent( 'calypso_invite_accept_load_page', {
+			loggedIn: !! this.props.user,
+		} );
+
 		// The site ID and invite key are required, so only fetch if set
 		if ( this.props.siteId && this.props.inviteKey ) {
 			this.fetchInvite();


### PR DESCRIPTION
We're working on improving and making [passwordless](https://github.com/Automattic/wp-calypso/issues/86758) the `invite-accept` form.

![image](https://github.com/Automattic/wp-calypso/assets/52076348/2ae7230a-ca65-4c1e-80f3-abc5687eb65c)

This PR adds a couple of track events, to better be able to identify our impact with our changes.

## Testing
1. Live link and go to `invite-accept` from an invitation
2. Track live events fired
3. Check that `calypso_invite_accept_load_page` and `calypso_invite_accept_logged_out_submit` are fired.