### PR TITLE
Jetpack: Make sure we have license before rendering <PricingSummary>

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/review-licenses/pricing-summary.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/review-licenses/pricing-summary.tsx
@@ -2,6 +2,7 @@ import { Button } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
+import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
@@ -49,13 +50,18 @@ export default function PricingSummary( {
 	const learnMoreLink =
 		'https://jetpack.com/support/jetpack-manage-instructions/jetpack-manage-billing-payment-faqs';
 
-	const currency = selectedLicenses[ 0 ].currency; // FIXME: Fix if multiple currencies are supported
-
 	const onClickLearnMore = useCallback( () => {
 		dispatch(
 			recordTracksEvent( 'calypso_jetpack_agency_issue_license_review_licenses_learn_more_click' )
 		);
 	}, [ dispatch ] );
+
+	// Make sure we have a/any selected licenses available to prevent fatal errors in the console.
+	if ( selectedLicenses.length === 0 ) {
+		return <TextPlaceholder />;
+	}
+
+	const currency = selectedLicenses[ 0 ].currency; // FIXME: Fix if multiple currencies are supported
 
 	return (
 		<>


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-manage/issues/269

The `<PricingSummary>` component used to review license selections in the Jetpack partner portal was missing a condition that checks if passed licenses has been correctly loaded before making assumptions that they are.

This introduced an edge-case in the form of the below error, if the component is "rendered too early":

```
pricing-summary.tsx:62 Uncaught TypeError: Cannot read properties of undefined (reading 'currency')
```

Which ultimately would cause the page itself from not being rendered correctly:

![Screenshot 2024-01-31 at 19 14 31](https://github.com/Automattic/wp-calypso/assets/3846700/716bb493-f117-43d0-bd4c-ea77f1e3c09a)


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add a condition to check if "license(s)" exists before making any hard assumptions.
  * We implement this condition in the component itself, and not a parent component, because it might be used in a second location someday, and this makes the component itself safe to render.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

_**(This assumes that you have a "Jetpack Partner" and thereby access to the Jetpack Manage dashboard)**_

* Spin up trunk
* `/partner-portal/issue-license?product_slug=jetpack-monitor&source=manage-pricing-page`
  * You might have to add a network throttle to ensure this happens.
  * Another idea is to clear the store so it's fetched from the beginning on a new page load (e.g. in Chrome, open _DevTools > Application > IndexedDB > Calypso_ and right-click `calypso_store` and select `clear`).
* Verify that the error from the summary occurs
* Checkout this PR
* Clear state again and go to `/partner-portal/issue-license?product_slug=jetpack-monitor&source=manage-pricing-page`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?

## Screenshots

**Newly introduced loading state**

![Screenshot 2024-01-31 at 18 56 36](https://github.com/Automattic/wp-calypso/assets/3846700/17c1f306-84ef-4e78-82d4-82ff8547da17)

**The (untouched) final render state of the component**

![Screenshot 2024-01-31 at 18 58 37](https://github.com/Automattic/wp-calypso/assets/3846700/b73c0078-db77-4c05-a86a-8c63c3eca986)
