### PR TITLE
Reader: Fix spacing around no tags found message

### DIFF
--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -51,9 +51,10 @@ class TagEmptyContent extends Component {
 		);
 
 		const message = this.props.translate(
-			'No posts have recently been tagged with {{tagName /}} for your language.',
+			'{{wrapper}}No posts have recently been tagged with {{tagName /}} for your language.{{/wrapper}}',
 			{
 				components: {
+					wrapper: <div />,
 					tagName: <em>{ this.props.decodedTagSlug }</em>,
 				},
 			}

--- a/client/reader/tag-stream/empty.jsx
+++ b/client/reader/tag-stream/empty.jsx
@@ -54,7 +54,7 @@ class TagEmptyContent extends Component {
 			'{{wrapper}}No posts have recently been tagged with {{tagName /}} for your language.{{/wrapper}}',
 			{
 				components: {
-					wrapper: <div />,
+					wrapper: <div className="tag-stream__empty-content-message" />,
 					tagName: <em>{ this.props.decodedTagSlug }</em>,
 				},
 			}

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -97,7 +97,7 @@
 .is-reader-page .main .tag-stream__empty-content {
 	margin-top: 15px;
 
-	div {
+	.tag-stream__empty-content-message {
 		margin: 16px 0 24px;
 	}
 }

--- a/client/reader/tag-stream/style.scss
+++ b/client/reader/tag-stream/style.scss
@@ -96,6 +96,10 @@
 
 .is-reader-page .main .tag-stream__empty-content {
 	margin-top: 15px;
+
+	div {
+		margin: 16px 0 24px;
+	}
 }
 
 // Tag page only shows site titles in the sidebar, so spacing needs to be tighter


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/83369

## Proposed Changes

* Add some space around the empty content message when no posts are found for a tag.

**Before**

<img width="588" alt="Screenshot 2024-01-31 at 2 17 39 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/a02c4f6c-ebf3-4bb0-8c54-c66a81b9b919">

**After**

<img width="673" alt="Screenshot 2024-01-31 at 2 17 26 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/900f1bdc-f97c-430d-b859-d150b1b8bce8">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/tag/computron` or another tag that doesn't have posts associated with it
* Note the visual tweaks.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?