### PR TITLE
Github Deployments i1: Add GitHub deployments section

### DIFF
--- a/client/my-sites/github-deployments/controller.tsx
+++ b/client/my-sites/github-deployments/controller.tsx
@@ -3,14 +3,14 @@ import { PageViewTracker } from 'calypso/lib/analytics/page-view-tracker';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { GithubDeployments } from './main';
+import { GitHubDeployments } from './main';
 import type { Callback } from '@automattic/calypso-router';
 
 export const githubDeployments: Callback = ( context, next ) => {
 	context.primary = (
 		<>
 			<PageViewTracker path="/github-deployments/:site" title="Github Deployments" delay={ 500 } />
-			<GithubDeployments />
+			<GitHubDeployments />
 		</>
 	);
 	next();

--- a/client/my-sites/github-deployments/controller.tsx
+++ b/client/my-sites/github-deployments/controller.tsx
@@ -9,7 +9,7 @@ import type { Callback } from '@automattic/calypso-router';
 export const githubDeployments: Callback = ( context, next ) => {
 	context.primary = (
 		<>
-			<PageViewTracker path="/github-deployments/:site" title="Github Deployments" delay={ 500 } />
+			<PageViewTracker path="/github-deployments/:site" title="GitHub Deployments" delay={ 500 } />
 			<GitHubDeployments />
 		</>
 	);

--- a/client/my-sites/github-deployments/controller.tsx
+++ b/client/my-sites/github-deployments/controller.tsx
@@ -1,0 +1,34 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { PageViewTracker } from 'calypso/lib/analytics/page-view-tracker';
+import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { GithubDeployments } from './main';
+import type { Callback } from '@automattic/calypso-router';
+
+export const githubDeployments: Callback = ( context, next ) => {
+	context.primary = (
+		<>
+			<PageViewTracker path="/github-deployments/:site" title="Github Deployments" delay={ 500 } />
+			<GithubDeployments />
+		</>
+	);
+	next();
+};
+
+export const redirectHomeIfIneligible: Callback = ( context, next ) => {
+	const state = context.store.getState();
+	const siteId = getSelectedSiteId( state );
+
+	if ( ! isEnabled( 'github-integration-i1' ) || ! isAtomicSite( state, siteId ) ) {
+		context.page.replace( `/home/${ context.params.siteId }` );
+		return;
+	}
+
+	if ( isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } ) ) {
+		context.page.replace( `/stats/day/${ context.params.siteId }` );
+		return;
+	}
+
+	next();
+};

--- a/client/my-sites/github-deployments/index.ts
+++ b/client/my-sites/github-deployments/index.ts
@@ -1,0 +1,18 @@
+import page from '@automattic/calypso-router';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
+import { redirectHomeIfIneligible, githubDeployments } from './controller';
+
+export default function () {
+	page( '/github-deployments', siteSelection, sites, makeLayout, clientRender );
+
+	page(
+		'/github-deployments/:siteId',
+		siteSelection,
+		redirectHomeIfIneligible,
+		navigation,
+		githubDeployments,
+		makeLayout,
+		clientRender
+	);
+}

--- a/client/my-sites/github-deployments/main.tsx
+++ b/client/my-sites/github-deployments/main.tsx
@@ -1,4 +1,3 @@
-import { useI18n } from '@wordpress/react-i18n';
 import { translate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -6,15 +5,12 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
-//import './style.scss';
-
-export function GithubDeployments() {
-	const { __ } = useI18n();
-	const titleHeader = __( 'Github Deployments' );
+export function GitHubDeployments() {
+	const titleHeader = translate( 'GitHub Deployments' );
 
 	return (
 		<Main className="github-deployments" fullWidthLayout>
-			<PageViewTracker path="/github-deployments/:site" title="Github Deployments" />
+			<PageViewTracker path="/github-deployments/:site" title="GitHub Deployments" />
 			<DocumentHead title={ titleHeader } />
 			<FormattedHeader
 				align="left"
@@ -24,11 +20,7 @@ export function GithubDeployments() {
 					{
 						components: {
 							learnMoreLink: (
-								<InlineSupportLink
-									key="learnMore"
-									supportContext="site-monitoring"
-									showIcon={ false }
-								/>
+								<InlineSupportLink supportContext="site-monitoring" showIcon={ false } />
 							),
 						},
 					}

--- a/client/my-sites/github-deployments/main.tsx
+++ b/client/my-sites/github-deployments/main.tsx
@@ -1,0 +1,39 @@
+import { useI18n } from '@wordpress/react-i18n';
+import { translate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import Main from 'calypso/components/main';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+
+//import './style.scss';
+
+export function GithubDeployments() {
+	const { __ } = useI18n();
+	const titleHeader = __( 'Github Deployments' );
+
+	return (
+		<Main className="github-deployments" fullWidthLayout>
+			<PageViewTracker path="/github-deployments/:site" title="Github Deployments" />
+			<DocumentHead title={ titleHeader } />
+			<FormattedHeader
+				align="left"
+				headerText={ titleHeader }
+				subHeaderText={ translate(
+					"Changes pushed to the selected branch's repos will be automatically deployed. {{learnMoreLink}}Learn more{{/learnMoreLink}}.",
+					{
+						components: {
+							learnMoreLink: (
+								<InlineSupportLink
+									key="learnMore"
+									supportContext="site-monitoring"
+									showIcon={ false }
+								/>
+							),
+						},
+					}
+				) }
+			></FormattedHeader>
+		</Main>
+	);
+}

--- a/client/my-sites/sidebar/static-data/fallback-menu.js
+++ b/client/my-sites/sidebar/static-data/fallback-menu.js
@@ -523,7 +523,7 @@ export default function buildFallbackResponse( {
 							{
 								parent: 'tools.php',
 								slug: 'tools-github-deployments',
-								title: translate( 'Github Deployments' ),
+								title: translate( 'GitHub Deployments' ),
 								type: 'submenu-item',
 								url: `/github-deployments/${ siteDomain }`,
 							},

--- a/client/my-sites/sidebar/static-data/fallback-menu.js
+++ b/client/my-sites/sidebar/static-data/fallback-menu.js
@@ -39,6 +39,7 @@ export default function buildFallbackResponse( {
 	shouldShowAdControl = false,
 	shouldShowAddOns = false,
 	showSiteMonitoring = false,
+	showGithubDeployments = false,
 } = {} ) {
 	let mailboxes = [];
 	if ( shouldShowMailboxes ) {
@@ -517,6 +518,17 @@ export default function buildFallbackResponse( {
 					type: 'submenu-item',
 					url: `/export/${ siteDomain }`,
 				},
+				...( showGithubDeployments
+					? [
+							{
+								parent: 'tools.php',
+								slug: 'tools-github-deployments',
+								title: translate( 'Github Deployments' ),
+								type: 'submenu-item',
+								url: `/github-deployments/${ siteDomain }`,
+							},
+					  ]
+					: [] ),
 				...( showSiteMonitoring
 					? [
 							{

--- a/client/my-sites/sites/index.jsx
+++ b/client/my-sites/sites/index.jsx
@@ -153,6 +153,9 @@ class Sites extends Component {
 			case 'site-monitoring':
 				path = translate( 'Site Monitoring' );
 				break;
+			case 'github-deployments':
+				path = translate( 'GitHub Deployments' );
+				break;
 		}
 
 		return translate( 'Select a site to open {{strong}}%(path)s{{/strong}}', {

--- a/client/sections.js
+++ b/client/sections.js
@@ -664,6 +664,12 @@ const sections = [
 		module: 'calypso/my-sites/site-monitoring',
 		group: 'sites',
 	},
+	{
+		name: 'github-deployments',
+		paths: [ '/github-deployments' ],
+		module: 'calypso/my-sites/github-deployments',
+		group: 'sites',
+	},
 ];
 
 module.exports = sections;

--- a/config/development.json
+++ b/config/development.json
@@ -68,7 +68,7 @@
 		"external-media/google-photos": true,
 		"external-media/openverse": true,
 		"cookie-banner": false,
-		"github-integration-i1": false,
+		"github-integration-i1": true,
 		"google-drive": true,
 		"google-my-business": true,
 		"help": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5247

## Proposed Changes

* Renders github deployments section at `/github-deployments/:siteId`
* Enabled and reuse the `github-integration-i1` flag on dev

![image](https://github.com/Automattic/wp-calypso/assets/47489215/34f34166-6d6e-4797-b54b-77bf4d429746)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `/github-deployments/atomic_site` verify the github deployments page
* go to `/github-deployments/simple_site` verify redirected to `/home`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?