### PR TITLE
Show user's debt

### DIFF
--- a/client/data/promote-post/use-promote-post-billing-summary-query.ts
+++ b/client/data/promote-post/use-promote-post-billing-summary-query.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
+import { requestDSP } from 'calypso/lib/promote-post';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+
+const useBillingSummaryQuery = ( queryOptions = {} ) => {
+	const selectedSiteId = useSelector( getSelectedSiteId );
+
+	return useQuery( {
+		queryKey: [ 'promote-post-billing-summary-siteid', selectedSiteId ],
+		queryFn: async () => {
+			if ( selectedSiteId ) {
+				const { debt } = await requestDSP< { debt: string } >(
+					selectedSiteId,
+					`/user/billing-summary`
+				);
+				return debt ? parseFloat( debt ).toFixed( 2 ) : undefined;
+			}
+			throw new Error( 'wpcomUserId is undefined' );
+		},
+		...queryOptions,
+		enabled: !! selectedSiteId,
+		retryDelay: 3000,
+		meta: {
+			persist: false,
+		},
+	} );
+};
+
+export default useBillingSummaryQuery;

--- a/client/my-sites/promote-post-i2/components/debt-notifier/index.tsx
+++ b/client/my-sites/promote-post-i2/components/debt-notifier/index.tsx
@@ -1,0 +1,22 @@
+import { sprintf } from '@wordpress/i18n';
+import { useTranslate } from 'i18n-calypso';
+import React from 'react';
+import useBillingSummaryQuery from 'calypso/data/promote-post/use-promote-post-billing-summary-query';
+
+function DebtNotifier() {
+	const translate = useTranslate();
+
+	const { data: debt = '0.00' } = useBillingSummaryQuery();
+
+	if ( debt !== '0.00' ) {
+		return (
+			<div className="promote-post-i2__debt-notifier">
+				{ sprintf( translate( 'Current debt is $%s.' ), debt.replace( '.00', '' ) ) }
+			</div>
+		);
+	}
+
+	return '';
+}
+
+export default DebtNotifier;

--- a/client/my-sites/promote-post-i2/main.tsx
+++ b/client/my-sites/promote-post-i2/main.tsx
@@ -33,6 +33,7 @@ import { useSelector } from 'calypso/state';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import BlazePageViewTracker from './components/blaze-page-view-tracker';
 import CreditBalance from './components/credit-balance';
+import DebtNotifier from './components/debt-notifier';
 import MainWrapper from './components/main-wrapper';
 import PostsListBanner from './components/posts-list-banner';
 import WooBanner from './components/woo-banner';
@@ -257,6 +258,8 @@ export default function PromotedPosts( { tab }: Props ) {
 			{ headerSubtitle( true ) /* for mobile */ }
 
 			{ showBanner && ( isWooBlaze ? <WooBanner /> : <PostsListBanner /> ) }
+
+			<DebtNotifier />
 
 			<PromotePostTabBar tabs={ tabs } selectedTab={ selectedTab } />
 

--- a/client/my-sites/promote-post-i2/style.scss
+++ b/client/my-sites/promote-post-i2/style.scss
@@ -297,6 +297,11 @@ body.is-section-promote-post-i2 {
 		}
 	}
 
+	.promote-post-i2__debt-notifier {
+		color: $studio-gray-100;
+		padding-top: 16px;
+	}
+
 	.section-nav-tab {
 		margin-right: 16px;
 
@@ -452,6 +457,7 @@ body.is-section-promote-post-i2 {
 
 				.promote-post-i2__header-subtitle_mobile,
 				.promote-post-i2__search-bar-wrapper,
+				.promote-post-i2__debt-notifier,
 				.posts-list__table,
 				.posts-list__loading-container,
 				.promote-post-i2__table,
@@ -564,6 +570,7 @@ $break-medium-expanded-menu: $break-medium + 272px;
 	.promote-post-i2__search-bar-wrapper,
 	.promote-post-i2__table,
 	.promote-post-i2__aux-wrapper,
+	.promote-post-i2__debt-notifier,
 	.posts-list-banner__container .posts-list-banner__content,
 	.posts-list-woo-banner__container .posts-list-banner__content {
 		margin-left: auto;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes
We want our advertisers to be aware of current amount of debt (if exists).

To do we we will untilize the new endpoint in DSP `/user/billing-summary` to get a response object containing `debt` property. When user do not have a debt the value will be `0.00`.

When they have a debt, it might look like:

![Screenshot 2024-01-31 at 21 04 50](https://github.com/Automattic/wp-calypso/assets/115007291/3d9e8f27-b27f-4465-ba09-ed47cadb0698)


## Testing Instructions
- Prepare local DSP API that contains the new endpoint,
- Adjust DSP DB in the way your user have a debt (see how in related DSP PR),
- sandbox WPCOM, tunnel your local DSP through WPCOM,
- open local Calypso,
- make sure the request `/user/billing-summary` returns value of debt,
- ensure that for 0 values of debt nothing is shown and for non-zero, they see debt

Note: there were no design requirements, that's why it looks a bit raw. Will appreciate comments on how to design it better.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
