### PR TITLE
Stats: Adding new purchase analytics events

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -16,6 +16,11 @@ interface StatsCommercialPriceDisplayProps {
 	currencyCode: string;
 }
 
+interface StatsSingleItemPagePurchaseFrameProps {
+	children: React.ReactNode;
+	isFree?: boolean;
+}
+
 const StatsCommercialPriceDisplay = ( {
 	planValue,
 	currencyCode,
@@ -158,11 +163,6 @@ const StatsBenefitsFree = () => {
 		</div>
 	);
 };
-
-interface StatsSingleItemPagePurchaseFrameProps {
-	children: React.ReactNode;
-	isFree?: boolean;
-}
 
 const StatsSingleItemPagePurchaseFrame = ( {
 	children,

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -216,7 +216,9 @@ const StatsPersonalPurchase = ( {
 	// change the plan to commercial on the personal plan confirmation
 	const handlePlanSwap = ( e: React.MouseEvent ) => {
 		e.preventDefault();
-		recordTracksEvent( `calypso_stats_plan_switched_from_personal_to_commercial` );
+		const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
+		const event_from = isOdysseyStats ? 'jetpack_odyssey' : 'calypso';
+		recordTracksEvent( `${ event_from }_stats_plan_switched_from_personal_to_commercial` );
 
 		page( `/stats/purchase/${ siteSlug }?productType=commercial&flags=stats/type-detection` );
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86135 #86138

## Proposed Changes

* adding new analytics events to follow the usage
* showing a loader while fetching the initial notice flag

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* create a JN and connect it
* navigate to the live branch and apply `stats/checkout-flows-v2` feature flag
* navigate to the stats and after redirecting to the purchase page, verify in your network tab (developer tools) if events described in pejTkB-18O-p2 are triggered (`I'll do it later` button and switching from a commercial to a personal page type)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?