### PR TITLE
Subscriber Stats: hide fractional number for y axis

### DIFF
--- a/client/my-sites/stats/stats-subscribers-chart-section/chart-utils.ts
+++ b/client/my-sites/stats/stats-subscribers-chart-section/chart-utils.ts
@@ -1,6 +1,7 @@
 import type uPlot from 'uplot';
 
 // Hide fractional values on the y-axis.
+// The function assumes the splits are sorted and the last number is an integer and the biggest number.
 export const hideFractionNumber = ( self: uPlot, splits: number[] ) => {
 	splits = splits.map( ( split ) => Math.floor( split ) );
 	const newSplits = [ splits[ 0 ] ];

--- a/client/my-sites/stats/stats-subscribers-chart-section/chart-utils.ts
+++ b/client/my-sites/stats/stats-subscribers-chart-section/chart-utils.ts
@@ -1,0 +1,15 @@
+import type uPlot from 'uplot';
+
+// Hide fractional values on the y-axis.
+export const hideFractionNumber = ( self: uPlot, splits: number[] ) => {
+	splits = splits.map( ( split ) => Math.floor( split ) );
+	const newSplits = [ splits[ 0 ] ];
+	for ( let i = 1; i < splits.length; i++ ) {
+		if ( splits[ i ] === splits[ i - 1 ] ) {
+			newSplits.push( null as unknown as number );
+		} else {
+			newSplits.push( splits[ i ] );
+		}
+	}
+	return newSplits;
+};

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -7,6 +7,7 @@ import Intervals from 'calypso/blocks/stats-navigation/intervals';
 import useSubscribersQuery from 'calypso/my-sites/stats/hooks/use-subscribers-query';
 import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsPeriodHeader from '../stats-period-header';
+import { hideFractionNumber } from './chart-utils';
 import SubscribersNavigationArrows from './subscribers-navigation-arrows';
 import type uPlot from 'uplot';
 
@@ -47,20 +48,6 @@ function transformData( data: SubscribersData[] ): uPlot.AlignedData {
 
 	return [ x, y ];
 }
-
-// Hide fractional values on the y-axis.
-export const hideFractionNumber = ( self: uPlot, splits: number[] ) => {
-	splits = splits.map( ( split ) => Math.floor( split ) );
-	const newSplits = [ splits[ 0 ] ];
-	for ( let i = 1; i < splits.length; i++ ) {
-		if ( splits[ i ] === splits[ i - 1 ] ) {
-			newSplits.push( null as unknown as number );
-		} else {
-			newSplits.push( splits[ i ] );
-		}
-	}
-	return newSplits;
-};
 
 export default function SubscribersChartSection( {
 	siteId,

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -49,7 +49,7 @@ function transformData( data: SubscribersData[] ): uPlot.AlignedData {
 }
 
 // Hide fractional values on the y-axis.
-const hideFractionNumber = ( self: uPlot, splits: number[] ) => {
+export const hideFractionNumber = ( self: uPlot, splits: number[] ) => {
 	splits = splits.map( ( split ) => Math.floor( split ) );
 	const newSplits = [ splits[ 0 ] ];
 	for ( let i = 1; i < splits.length; i++ ) {

--- a/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-chart-section/index.tsx
@@ -48,6 +48,20 @@ function transformData( data: SubscribersData[] ): uPlot.AlignedData {
 	return [ x, y ];
 }
 
+// Hide fractional values on the y-axis.
+const hideFractionNumber = ( self: uPlot, splits: number[] ) => {
+	splits = splits.map( ( split ) => Math.floor( split ) );
+	const newSplits = [ splits[ 0 ] ];
+	for ( let i = 1; i < splits.length; i++ ) {
+		if ( splits[ i ] === splits[ i - 1 ] ) {
+			newSplits.push( null as unknown as number );
+		} else {
+			newSplits.push( splits[ i ] );
+		}
+	}
+	return newSplits;
+};
+
 export default function SubscribersChartSection( {
 	siteId,
 	slug,
@@ -154,6 +168,7 @@ export default function SubscribersChartSection( {
 					mainColor={ isOdysseyStats ? '#069e08' : undefined }
 					fillColorFrom={ isOdysseyStats ? 'rgba(6, 158, 8, 0.4)' : undefined }
 					fillColorTo={ isOdysseyStats ? 'rgba(6, 158, 8, 0)' : undefined }
+					yAxisFilter={ hideFractionNumber }
 				/>
 			) }
 		</div>

--- a/client/my-sites/stats/stats-subscribers-chart-section/test/hide-fractional-number.test.js
+++ b/client/my-sites/stats/stats-subscribers-chart-section/test/hide-fractional-number.test.js
@@ -1,11 +1,21 @@
-import { hideFractionNumber } from '../index';
+import { hideFractionNumber } from '../chart-utils';
 
 describe( 'hideFractionNumber: floor all numbers and replace duplicate with null', () => {
 	test( 'should return integers', () => {
-		expect( hideFractionNumber( [ 1.1, 2.2, 3.5, 8.9, 10 ] ) ).toBe( [ 1, 2, 3, 8, 10 ] );
+		expect( hideFractionNumber( null, [ 1.1, 2.2, 3.5, 8.9, 10 ] ) ).toStrictEqual( [
+			1, 2, 3, 8, 10,
+		] );
 	} );
 
 	test( 'should replace null for consecusive duplicates', () => {
-		expect( [ 2.2, 2.3, 2.6, 8.9, 10, 10.1, 11 ] ).toBe( [ 2, null, null, 8, 10, null, 11 ] );
+		expect( hideFractionNumber( null, [ 2.2, 2.3, 2.6, 8.9, 10, 10.1, 11 ] ) ).toStrictEqual( [
+			2,
+			null,
+			null,
+			8,
+			10,
+			null,
+			11,
+		] );
 	} );
 } );

--- a/client/my-sites/stats/stats-subscribers-chart-section/test/hide-fractional-number.test.js
+++ b/client/my-sites/stats/stats-subscribers-chart-section/test/hide-fractional-number.test.js
@@ -1,0 +1,11 @@
+import { hideFractionNumber } from '../index';
+
+describe( 'hideFractionNumber: floor all numbers and replace duplicate with null', () => {
+	test( 'should return integers', () => {
+		expect( hideFractionNumber( [ 1.1, 2.2, 3.5, 8.9, 10 ] ) ).toBe( [ 1, 2, 3, 8, 10 ] );
+	} );
+
+	test( 'should replace null for consecusive duplicates', () => {
+		expect( [ 2.2, 2.3, 2.6, 8.9, 10, 10.1, 11 ] ).toBe( [ 2, null, null, 8, 10, null, 11 ] );
+	} );
+} );

--- a/packages/components/src/chart-uplot/index.tsx
+++ b/packages/components/src/chart-uplot/index.tsx
@@ -28,6 +28,7 @@ interface UplotChartProps {
 	legendContainer?: React.RefObject< HTMLDivElement >;
 	solidFill?: boolean;
 	period?: string;
+	yAxisFilter?: uPlot.Axis.Filter | undefined;
 }
 
 export default function UplotChart( {
@@ -35,6 +36,7 @@ export default function UplotChart( {
 	mainColor = '#3057DC',
 	fillColorFrom = 'rgba(48, 87, 220, 0.4)',
 	fillColorTo = 'rgba(48, 87, 220, 0)',
+	yAxisFilter = undefined,
 	legendContainer,
 	options: propOptions,
 	solidFill = false,
@@ -86,6 +88,7 @@ export default function UplotChart( {
 						ticks: {
 							show: false,
 						},
+						filter: yAxisFilter,
 					},
 				],
 				cursor: {
@@ -151,6 +154,7 @@ export default function UplotChart( {
 					},
 				},
 			};
+
 			return {
 				...defaultOptions,
 				...( typeof propOptions === 'object' ? propOptions : {} ),


### PR DESCRIPTION
Related to #87030 

## Proposed Changes

Hide fractional number for y axis because it doesn't make sense to show them.

## Testing Instructions

* Open Calypso Live and switch to site redp2
* Open Subscriber Stats

| before | After |
|--------|-----|
|<img width="556" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/027837f3-369b-4030-9553-3f48689ff322"> |<img width="548" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/61de98a7-4791-4f54-b97e-355c88692180"> |

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?