### PR TITLE
Plans 2023: Add dropdown separator between selected term and term options

### DIFF
--- a/packages/plans-grid-next/src/components/plan-type-selector/style.scss
+++ b/packages/plans-grid-next/src/components/plan-type-selector/style.scss
@@ -116,7 +116,6 @@
 			border-bottom-left-radius: 2px;
 			box-sizing: border-box;
 			border: 1px solid var(--studio-gray-10);
-			border-top: none;
 			margin-top: -2px;
 		}
 		.components-custom-select-control__item {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to peP6yB-1Z8-p2#comment-924 and p1706714903415179/1706301817.392089-slack-CV2TX2PAN 

## Proposed Changes

* Adds visual separator to distinguish between selected plan term interval and plan term interval options

## Screenshots
### Before
<img width="386" alt="Screenshot 2024-01-31 at 3 00 08 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/bc672163-76e4-4e57-ae7b-db714ba5de03">

### After
<img width="417" alt="Screenshot 2024-01-31 at 2 59 57 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/c7727104-a7c7-481a-9e42-0bd66213d6a5">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* Check out branch
* Navigate to `/setup/newsletter` or any other stepper flows ( flows prefixed by `/setup` ) noted in PCYsg-RDT-p2
* Follow onboarding steps until at the plans page
* Select a new plan interval ( 2yr, 3yr, etc. )
* Verify that the scroll position of the viewport is not reset
* Confirm the same for the mobile view

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?