### PR TITLE
GitHub authorization: Detach from Blog ID

### DIFF
--- a/client/lib/github/constants.ts
+++ b/client/lib/github/constants.ts
@@ -1,0 +1,1 @@
+export const GITHUB_INTEGRATION_QUERY_KEY = 'github-app-integration';

--- a/client/lib/github/use-github-authorization-query.ts
+++ b/client/lib/github/use-github-authorization-query.ts
@@ -1,0 +1,33 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+import { deleteStoredKeyringConnection } from 'calypso/state/sharing/keyring/actions';
+import { GITHUB_INTEGRATION_QUERY_KEY } from './constants';
+
+export const GITHUB_CONNECTION_QUERY_KEY = 'github-connection';
+
+export interface GithubConnectionData {
+	ID: number;
+	connected: boolean;
+	external_profile_picture: string;
+	label: string;
+	external_name: string;
+}
+
+export type Connection = Parameters< typeof deleteStoredKeyringConnection >[ 0 ];
+
+export const useGithubAuthorizationQuery = (
+	options?: UseQueryOptions< GithubConnectionData[] >
+) => {
+	return useQuery( {
+		queryKey: [ GITHUB_INTEGRATION_QUERY_KEY, GITHUB_CONNECTION_QUERY_KEY ],
+		queryFn: (): Promise< GithubConnectionData[] > =>
+			wp.req.get( {
+				path: '/hosting/github-app/connections',
+				apiNamespace: 'wpcom/v2',
+			} ),
+		meta: {
+			persist: false,
+		},
+		...options,
+	} );
+};

--- a/client/lib/github/use-github-authorize-mutation.ts
+++ b/client/lib/github/use-github-authorize-mutation.ts
@@ -1,0 +1,37 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import requestExternalAccess from '@automattic/request-external-access';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useDispatch } from 'calypso/state';
+import { requestKeyringConnections } from 'calypso/state/sharing/keyring/actions';
+import { GITHUB_INTEGRATION_QUERY_KEY } from './constants';
+import {
+	GITHUB_CONNECTION_QUERY_KEY,
+	GithubConnectionData,
+} from './use-github-authorization-query';
+
+export const useGitHubAuthorizeMutation = () => {
+	const queryClient = useQueryClient();
+	const dispatch = useDispatch();
+
+	const { mutate: authorize, isPending: isAuthorizing } = useMutation< void, unknown, string >( {
+		mutationFn: async ( connectURL ) => {
+			await new Promise( ( resolve ) => requestExternalAccess( connectURL, resolve ) );
+			await dispatch( requestKeyringConnections() );
+		},
+		onSuccess: async () => {
+			const connectionKey = [ GITHUB_INTEGRATION_QUERY_KEY, GITHUB_CONNECTION_QUERY_KEY ];
+			await queryClient.invalidateQueries( {
+				queryKey: connectionKey,
+			} );
+
+			const authorized =
+				queryClient.getQueryData< GithubConnectionData >( connectionKey )?.connected;
+			dispatch( recordTracksEvent( 'calypso_hosting_github_authorize_complete', { authorized } ) );
+		},
+	} );
+
+	return {
+		authorize,
+		isAuthorizing,
+	};
+};

--- a/client/lib/github/use-github-deauthorize-mutation.ts
+++ b/client/lib/github/use-github-deauthorize-mutation.ts
@@ -1,0 +1,26 @@
+import { useQueryClient, useMutation } from '@tanstack/react-query';
+import { useDispatch } from 'calypso/state';
+import { deleteStoredKeyringConnection } from 'calypso/state/sharing/keyring/actions';
+import { GITHUB_INTEGRATION_QUERY_KEY } from './constants';
+import { Connection, GITHUB_CONNECTION_QUERY_KEY } from './use-github-authorization-query';
+
+export const useGitHubDeauthorizeMutation = () => {
+	const queryClient = useQueryClient();
+	const dispatch = useDispatch();
+	// Using ReactQuery to manage `isDisconnecting` state because it's not exposed from the Redux store.
+	const mutation = useMutation< unknown, unknown, Connection >( {
+		mutationFn: async ( c ) => {
+			await dispatch( deleteStoredKeyringConnection( c ) );
+			await queryClient.invalidateQueries( {
+				queryKey: [ GITHUB_INTEGRATION_QUERY_KEY, GITHUB_CONNECTION_QUERY_KEY ],
+			} );
+		},
+	} );
+
+	const { mutate: deauthorize, isPending: isDeauthorizing } = mutation;
+
+	return {
+		deauthorize,
+		isDeauthorizing,
+	};
+};

--- a/client/me/account/main.jsx
+++ b/client/me/account/main.jsx
@@ -59,9 +59,9 @@ import {
 } from 'calypso/state/user-settings/actions';
 import { isFetchingUserSettings } from 'calypso/state/user-settings/selectors';
 import { saveUnsavedUserSettings } from 'calypso/state/user-settings/thunks';
+import { GitHubAuthorization } from '../github-authorization/github-authorization';
 import AccountSettingsCloseLink from './close-link';
 import ToggleSitesAsLandingPage from './toggle-sites-as-landing-page';
-
 import './style.scss';
 
 export const noticeId = 'me-settings-notice';
@@ -921,6 +921,15 @@ class Account extends Component {
 						</TransitionGroup>
 					</form>
 				</Card>
+
+				{ config.isEnabled( 'github-integration-i1' ) && (
+					<>
+						<SectionHeader label={ translate( 'GitHub connection' ) } />
+						<Card className="account__settings">
+							<GitHubAuthorization />
+						</Card>
+					</>
+				) }
 
 				<SectionHeader label={ translate( 'Interface settings' ) } />
 				<Card className="account__settings">

--- a/client/me/github-authorization/disconnect-button.tsx
+++ b/client/me/github-authorization/disconnect-button.tsx
@@ -1,0 +1,27 @@
+import { Button } from '@automattic/components';
+import { useI18n } from '@wordpress/react-i18n';
+import { Connection } from 'calypso/lib/github/use-github-authorization-query';
+import { useGitHubDeauthorizeMutation } from 'calypso/lib/github/use-github-deauthorize-mutation';
+
+import './style.scss';
+
+interface DisconnectGitHubButtonProps {
+	connection: Connection;
+}
+
+export function DisconnectGitHubButton( { connection }: DisconnectGitHubButtonProps ) {
+	const { deauthorize, isDeauthorizing } = useGitHubDeauthorizeMutation();
+	const { __ } = useI18n();
+
+	return (
+		<Button
+			scary
+			primary
+			onClick={ () => deauthorize( connection ) }
+			busy={ isDeauthorizing }
+			disabled={ isDeauthorizing } // `busy` doesn't actually disable the button
+		>
+			{ __( 'Disconnect' ) }
+		</Button>
+	);
+}

--- a/client/me/github-authorization/github-authorization.tsx
+++ b/client/me/github-authorization/github-authorization.tsx
@@ -1,0 +1,87 @@
+import { Button, Card } from '@automattic/components';
+import { translate } from 'i18n-calypso';
+import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections/index';
+import QueryKeyringServices from 'calypso/components/data/query-keyring-services/index';
+import { useGithubAuthorizationQuery } from 'calypso/lib/github/use-github-authorization-query';
+import { useSelector } from 'calypso/state';
+import { getKeyringServiceByName } from 'calypso/state/sharing/services/selectors';
+import KeyringConnectButton from '../../blocks/keyring-connect-button';
+import { useGitHubAuthorizeMutation } from '../../lib/github/use-github-authorize-mutation';
+import { DisconnectGitHubButton } from './disconnect-button';
+
+type Service = {
+	connect_URL: string;
+};
+
+export const GitHubAuthorization = () => {
+	const github = useSelector( ( state ) =>
+		getKeyringServiceByName( state, 'github-app' )
+	) as Service;
+
+	const { data: connections = [] } = useGithubAuthorizationQuery();
+	const { authorize, isAuthorizing } = useGitHubAuthorizeMutation();
+
+	return (
+		<>
+			{ /* <QueryKeyringServices />
+			<QueryKeyringConnections /> */ }
+			<div
+				style={ {
+					display: 'flex',
+					flexDirection: 'column',
+					alignItems: 'flex-start',
+					gap: 16,
+					width: '100%',
+				} }
+			>
+				<KeyringConnectButton serviceId="github-app" onConnect={ console.log }>
+					{ translate( 'Authorize GitHub Account' ) }
+				</KeyringConnectButton>
+				{ /* { github && (
+					<Button
+						className="is-primary"
+						busy={ isAuthorizing }
+						disabled={ ! github || isAuthorizing }
+						onClick={ () => authorize( github.connect_URL ) }
+					>
+						{ translate( 'Authorize GitHub Account' ) }
+					</Button>
+				) } */ }
+
+				{ connections.map( ( connection, key ) => (
+					<div key={ key } style={ { display: 'flex', alignItems: 'center', width: '100%' } }>
+						<span style={ { marginRight: 'auto' } }>{ connection.external_name }</span>
+						<span
+							style={ {
+								marginRight: 'auto',
+								maxWidth: 150,
+								fontSize: 'small',
+								overflow: 'hidden',
+								whiteSpace: 'nowrap',
+								textOverflow: 'ellipsis',
+							} }
+							title={ Object.keys( connection.installation.repositories ).join( ', ' ) }
+						>
+							Repos: { Object.keys( connection.installation.repositories ).join( ', ' ) }
+						</span>
+						<div style={ { display: 'flex', alignItems: 'center', gap: 24 } }>
+							<Button
+								className="is-primary"
+								busy={ isAuthorizing }
+								disabled={ ! github || isAuthorizing }
+								onClick={ () =>
+									authorize(
+										`https://github.com/settings/installations/${ connection?.installation.id }`
+									)
+								}
+							>
+								{ translate( 'Modify' ) }
+							</Button>
+							<DisconnectGitHubButton connection={ connection } />
+						</div>
+					</div>
+				) ) }
+			</div>
+		</>
+	);
+};

--- a/client/me/github-authorization/style.scss
+++ b/client/me/github-authorization/style.scss
@@ -1,0 +1,8 @@
+.disconnect-github {
+	font-style: inherit;
+	font-weight: 400;
+	line-height: inherit;
+	padding: 0;
+	font-size: inherit;
+	margin-left: 8px;
+}

--- a/client/state/sharing/services/actions.js
+++ b/client/state/sharing/services/actions.js
@@ -23,8 +23,10 @@ export function requestKeyringServices() {
 
 		return wpcom.req
 			.get( {
-				path: `/sites/${ siteId }/external-services`,
-				apiNamespace: 'wpcom/v2',
+				path: siteId
+					? `/sites/${ siteId }/external-services`
+					: '/meta/external-services?http_envelope=1',
+				apiNamespace: siteId ? 'wpcom/v2' : 'rest/v1.1',
 			} )
 			.then( ( response ) => {
 				dispatch( {

--- a/config/development.json
+++ b/config/development.json
@@ -68,7 +68,7 @@
 		"external-media/google-photos": true,
 		"external-media/openverse": true,
 		"cookie-banner": false,
-		"github-integration-i1": false,
+		"github-integration-i1": true,
 		"google-drive": true,
 		"google-my-business": true,
 		"help": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
