### PR TITLE
Stats: Adding busy button indication

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -53,6 +53,7 @@ const PersonalPurchase = ( {
 	const [ isSellingChecked, setSellingChecked ] = useState( false );
 	const [ isBusinessChecked, setBusinessChecked ] = useState( false );
 	const [ isDonationChecked, setDonationChecked ] = useState( false );
+	const [ isPosponeBusy, setPosponeBusy ] = useState( false );
 	const {
 		sliderStepPrice,
 		minSliderPrice,
@@ -134,6 +135,8 @@ const PersonalPurchase = ( {
 	};
 
 	const handleCheckoutPostponed = () => {
+		setPosponeBusy( true );
+
 		mutateNoticeVisbilityAsync()
 			.then( refetchNotices )
 			.finally( () => {
@@ -142,7 +145,10 @@ const PersonalPurchase = ( {
 				recordTracksEvent( `${ event_from }_stats_purchase_flow_skip_button_clicked` );
 
 				// redirect to the Traffic page
-				setTimeout( () => page( `/stats/day/${ siteSlug }` ), 250 );
+				setTimeout( () => {
+					setPosponeBusy( false );
+					page( `/stats/day/${ siteSlug }` );
+				}, 250 );
 			} );
 	};
 
@@ -273,7 +279,13 @@ const PersonalPurchase = ( {
 					</ButtonComponent>
 
 					{ isNewPurchaseFlowEnabled && (
-						<ButtonComponent variant="secondary" onClick={ handleCheckoutPostponed }>
+						<ButtonComponent
+							className="jetpack-connect__connect-button"
+							variant="secondary"
+							isBusy={ isPosponeBusy } // for <Button />
+							busy={ isPosponeBusy } // for <CalypsoButton />
+							onClick={ handleCheckoutPostponed }
+						>
 							{ translate( 'I will do it later' ) }
 						</ButtonComponent>
 					) }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -281,8 +281,8 @@ const PersonalPurchase = ( {
 					{ isNewPurchaseFlowEnabled && (
 						<ButtonComponent
 							variant="secondary"
-							isBusy={ isPosponeBusy } // for <Button />
-							busy={ isPosponeBusy } // for <CalypsoButton />
+							isBusy={ isWPCOMSite ? undefined : isPosponeBusy } // for <Button />
+							busy={ isWPCOMSite ? isPosponeBusy : undefined } // for <CalypsoButton />
 							onClick={ handleCheckoutPostponed }
 						>
 							{ translate( 'I will do it later' ) }

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -280,7 +280,6 @@ const PersonalPurchase = ( {
 
 					{ isNewPurchaseFlowEnabled && (
 						<ButtonComponent
-							className="jetpack-connect__connect-button"
 							variant="secondary"
 							isBusy={ isPosponeBusy } // for <Button />
 							busy={ isPosponeBusy } // for <CalypsoButton />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #86977 

## Proposed Changes

* disabling `I will do it later` button and adding the loading state after it was pressed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* create a JN and connect it
* navigate to the live branch and apply `stats/checkout-flows-v2` feature flag
* click the `I will do it later` button from the personal plan purchase page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?