### PR TITLE
Stats: Release new purchase flow

### DIFF
--- a/config/client.json
+++ b/config/client.json
@@ -23,6 +23,7 @@
 	"readerFollowingSource",
 	"siftscience_key",
 	"signup_url",
+	"stats/checkout-flows-v2",
 	"stats/date-control",
 	"stats/new-video-summary",
 	"stats/paid-wpcom-stats",

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -125,7 +125,7 @@
 		"site-indicator": true,
 		"site-profiler": true,
 		"ssr/prefetch-timebox": true,
-		"stats/checkout-flows-v2": false,
+		"stats/checkout-flows-v2": true,
 		"stats/date-control": true,
 		"stats/new-video-summary": false,
 		"stats/paid-wpcom-stats": true,

--- a/config/production.json
+++ b/config/production.json
@@ -165,7 +165,7 @@
 		"ssr/log-prefetch-errors": true,
 		"ssr/prefetch-timebox": true,
 		"ssr/sample-log-cache-misses": true,
-		"stats/checkout-flows-v2": false,
+		"stats/checkout-flows-v2": true,
 		"stats/date-control": true,
 		"stats/new-video-summary": false,
 		"stats/paid-wpcom-stats": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -159,7 +159,7 @@
 		"site-indicator": true,
 		"site-profiler": true,
 		"ssr/prefetch-timebox": true,
-		"stats/checkout-flows-v2": false,
+		"stats/checkout-flows-v2": true,
 		"stats/date-control": true,
 		"stats/new-video-summary": false,
 		"stats/paid-wpcom-stats": true,

--- a/config/test.json
+++ b/config/test.json
@@ -113,6 +113,7 @@
 		"site-indicator": true,
 		"site-profiler": true,
 		"ssr/prefetch-timebox": true,
+		"stats/checkout-flows-v2": true,
 		"stats/date-control": true,
 		"stats/new-video-summary": false,
 		"stats/paid-wpcom-stats": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -158,7 +158,7 @@
 		"site-indicator": true,
 		"site-profiler": true,
 		"ssr/prefetch-timebox": true,
-		"stats/checkout-flows-v2": false,
+		"stats/checkout-flows-v2": true,
 		"stats/date-control": true,
 		"stats/new-video-summary": false,
 		"stats/paid-wpcom-stats": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87065

## Proposed Changes

* release new purchase flow for Stats users

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* verify that you are redirected to the purchase page without any feature flags (for a new JN site)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?