### PR TITLE
Assembler: use text and button colors for color variation swatches

### DIFF
--- a/packages/global-styles/src/components/color-palette-variations/index.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/index.tsx
@@ -70,7 +70,7 @@ const ColorPaletteVariation = ( {
 						<div className="global-styles-variation__item-preview" ref={ ref }>
 							{ ( isActive || inView ) && (
 								<GlobalStylesContext.Provider value={ context }>
-									<ColorPaletteVariationPreview title={ colorPaletteVariation.title } />
+									<ColorPaletteVariationPreview />
 								</GlobalStylesContext.Provider>
 							) }
 						</div>

--- a/packages/global-styles/src/components/color-palette-variations/preview.tsx
+++ b/packages/global-styles/src/components/color-palette-variations/preview.tsx
@@ -1,43 +1,22 @@
-import {
-	__experimentalHStack as HStack,
-	__experimentalVStack as VStack,
-} from '@wordpress/components';
+import { __experimentalHStack as HStack } from '@wordpress/components';
 import { useResizeObserver } from '@wordpress/compose';
-import { translate } from 'i18n-calypso';
 import {
 	STYLE_PREVIEW_WIDTH,
 	STYLE_PREVIEW_HEIGHT,
 	STYLE_PREVIEW_COLOR_SWATCH_SIZE,
 } from '../../constants';
-import { useGlobalSetting, useGlobalStyle } from '../../gutenberg-bridge';
+import { useGlobalStyle } from '../../gutenberg-bridge';
 import GlobalStylesVariationContainer from '../global-styles-variation-container';
-import type { Color } from '../../types';
 
-interface Props {
-	title?: string;
-}
-
-const ColorPaletteVariationPreview = ( { title }: Props ) => {
-	const [ fontWeight ] = useGlobalStyle( 'typography.fontWeight' );
-	const [ fontFamily = 'serif' ] = useGlobalStyle( 'typography.fontFamily' );
-	const [ headingFontFamily = fontFamily ] = useGlobalStyle( 'elements.h1.typography.fontFamily' );
-	const [ headingFontWeight = fontWeight ] = useGlobalStyle( 'elements.h1.typography.fontWeight' );
+const ColorPaletteVariationPreview = () => {
 	const [ textColor = 'black' ] = useGlobalStyle( 'color.text' );
-	const [ headingColor = textColor ] = useGlobalStyle( 'elements.h1.color.text' );
+	const [ buttonColor = textColor ] = useGlobalStyle( 'elements.button.color.background' );
 	const [ backgroundColor = 'white' ] = useGlobalStyle( 'color.background' );
 	const [ gradientValue ] = useGlobalStyle( 'color.gradient' );
-	const [ themeColors ] = useGlobalSetting( 'color.palette.theme' );
 	const [ containerResizeListener, { width } ] = useResizeObserver();
 	const ratio = width ? width / STYLE_PREVIEW_WIDTH : 1;
 	const normalizedHeight = Math.ceil( STYLE_PREVIEW_HEIGHT * ratio );
 	const normalizedSwatchSize = STYLE_PREVIEW_COLOR_SWATCH_SIZE * ratio * 2;
-	const uniqueColors = [ ...new Set< string >( themeColors.map( ( { color }: Color ) => color ) ) ];
-	const highlightedColors = uniqueColors
-		.filter(
-			// we exclude background color because it is already visible in the preview.
-			( color ) => color !== backgroundColor
-		)
-		.slice( 0, 2 );
 
 	return (
 		<GlobalStylesVariationContainer
@@ -60,54 +39,26 @@ const ColorPaletteVariationPreview = ( { title }: Props ) => {
 						overflow: 'hidden',
 					} }
 				>
-					{ title ? (
-						<HStack
-							spacing={ 10 * ratio }
-							justify="center"
-							style={ {
-								height: '100%',
-								overflow: 'hidden',
-							} }
-						>
-							{ highlightedColors.map( ( color, index ) => (
-								<div
-									key={ index }
-									style={ {
-										height: normalizedSwatchSize,
-										width: normalizedSwatchSize,
-										background: color,
-										borderRadius: normalizedSwatchSize / 2,
-									} }
-								/>
-							) ) }
-						</HStack>
-					) : (
-						<VStack
-							spacing={ 3 * ratio }
-							justify="center"
-							style={ {
-								height: '100%',
-								overflow: 'hidden',
-								padding: 10 * ratio,
-								boxSizing: 'border-box',
-							} }
-						>
+					<HStack
+						spacing={ 10 * ratio }
+						justify="center"
+						style={ {
+							height: '100%',
+							overflow: 'hidden',
+						} }
+					>
+						{ [ textColor, buttonColor ].map( ( color, index ) => (
 							<div
+								key={ index }
 								style={ {
-									fontSize: 40 * ratio,
-									fontFamily: headingFontFamily,
-									color: headingColor,
-									fontWeight: headingFontWeight,
-									lineHeight: '1em',
-									textAlign: 'center',
+									height: normalizedSwatchSize,
+									width: normalizedSwatchSize,
+									background: color,
+									borderRadius: normalizedSwatchSize / 2,
 								} }
-							>
-								{ translate( 'Default', {
-									comment: 'The default value of the color palette',
-								} ) }
-							</div>
-						</VStack>
-					) }
+							/>
+						) ) }
+					</HStack>
 				</div>
 			</div>
 		</GlobalStylesVariationContainer>


### PR DESCRIPTION
Related to pbxlJb-5xe-p2

## Proposed Changes

In this PR, we show the text color as the first dot, and the button color as the second dot, instead of showing theme's unique color palette colors.

This will make users less confused when trying out the colors, because those colors are those which are used the most in the patterns.

### Assembler v2

|Before|After|
|-|-|
|<img width="294" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/8caf0abc-790e-4275-9548-cd3d4bd6a84f">|<img width="297" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/788bafe1-5a79-4dea-8937-91fba0f78bb3">|

### Assembler v1

|Before|After|
|-|-|
|<img width="311" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/7b71884b-164b-4040-a1da-e4e7c9e0e6d7">|<img width="311" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/e3d0957d-3d0c-465c-a5da-217573288e5b">|

## Testing Instructions

1. Go to any Assembler entrypoint (e.g. `/setup/assembler-first`).
2. Select some patterns and advance to the Styles page.
3. Try out the colors. Observe that the colors that we show in the swatches are more "natural" and "WYSIWYG" than before.
4. Also try with the `flags=pattern-assembler/v2`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?