### PR TITLE
[WooCommerce] Fix inconsistent social login screen when email matches an existing account

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -819,7 +819,7 @@ class Login extends Component {
 	}
 
 	render() {
-		const { isJetpack, oauth2Client, locale } = this.props;
+		const { isJetpack, oauth2Client, locale, isWoo } = this.props;
 
 		return (
 			<div
@@ -830,7 +830,8 @@ class Login extends Component {
 			>
 				{ this.renderHeader() }
 
-				<ErrorNotice locale={ locale } />
+				{ /* For Woo, we render the ErrrorNotice component in login-form.jsx */ }
+				{ ! isWoo && <ErrorNotice locale={ locale } /> }
 
 				{ this.renderNotice() }
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -3,6 +3,7 @@ import page from '@automattic/calypso-router';
 import { Button, Card, FormInputValidation, FormLabel, Gridicon } from '@automattic/components';
 import { alert } from '@automattic/components/src/icons';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { Spinner } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -859,8 +860,12 @@ export class LoginForm extends Component {
 					<p className="login__form-terms">{ socialToS }</p>
 					{ isWoo && ! isPartnerSignup && this.renderLostPasswordLink() }
 					<div className="login__form-action">
-						<FormsButton primary busy={ isSendingEmail } disabled={ isSubmitButtonDisabled }>
-							{ this.getLoginButtonText() }
+						<FormsButton
+							primary
+							busy={ ! isWoo && isSendingEmail }
+							disabled={ isSubmitButtonDisabled }
+						>
+							{ isWoo && isSendingEmail ? <Spinner /> : this.getLoginButtonText() }
 						</FormsButton>
 					</div>
 

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -603,17 +603,6 @@ export class LoginForm extends Component {
 	};
 
 	getMagicLoginPageLink() {
-		if (
-			! canDoMagicLogin(
-				this.props.twoFactorAuthType,
-				this.props.oauth2Client,
-				this.props.wccomFrom,
-				this.props.isJetpackWooCommerceFlow
-			)
-		) {
-			return null;
-		}
-
 		const loginLink = getLoginLinkPageUrl(
 			this.props.locale,
 			this.props.currentRoute,
@@ -643,6 +632,19 @@ export class LoginForm extends Component {
 				},
 			}
 		);
+	}
+
+	renderPasswordValidationError() {
+		if (
+			canDoMagicLogin(
+				this.props.twoFactorAuthType,
+				this.props.oauth2Client,
+				this.props.isJetpackWooCommerceFlow
+			)
+		) {
+			return this.renderMagicLoginLink();
+		}
+		return this.props.requestError.message;
 	}
 
 	render() {
@@ -852,7 +854,7 @@ export class LoginForm extends Component {
 							/>
 
 							{ requestError && requestError.field === 'password' && (
-								<FormInputValidation isError text={ this.renderMagicLoginLink() } />
+								<FormInputValidation isError text={ this.renderPasswordValidationError() } />
 							) }
 						</div>
 					</div>

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -60,6 +60,7 @@ import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
+import ErrorNotice from './error-notice';
 import SocialLoginForm from './social';
 
 import './login-form.scss';
@@ -747,6 +748,7 @@ export class LoginForm extends Component {
 				{ this.renderPrivateSiteNotice() }
 
 				<Card className="login__form">
+					{ isWoo && <ErrorNotice /> }
 					<div className="login__form-userdata">
 						{ ! isWoo && linkingSocialUser && (
 							<p>

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -2,6 +2,7 @@
 @import "@automattic/typography/styles/woo-commerce";
 
 .woo {
+	$woo-purple-40: #966ccf;
 	$woo-purple-50: #7f54b3;
 	$woo-purple-60: #674399;
 	$woo-purple-70: #533582;
@@ -63,17 +64,21 @@
 	}
 
 	a,
-	a:visited,
-	a:hover,
-	.wp-login__links a:hover,
-	.wp-login__links button:hover,
-	.button:not(.social-buttons__button) {
+	.wp-login__links a,
+	.wp-login__links button,
+	.button:not(.social-buttons__button),
+	.magic-login__footer a {
 		font-size: $woo-font-size-base;
 		line-height: 28px;
 		text-align: center;
 		color: $gray-50;
 		text-decoration: underline;
 		letter-spacing: 0;
+
+		&:hover,
+		&:visited {
+			color: $gray-50;
+		}
 	}
 
 	.button:not(.social-buttons__button) {
@@ -86,12 +91,15 @@
 	}
 
 	.button.is-primary,
-	.button.is-primary[disabled],
 	.login .button.is-primary {
-		background: $woo-purple-60;
+		background-color: $woo-purple-60;
 		border: none;
 		color: #fff;
 		width: 100%;
+
+		&:hover {
+			background-color: $woo-purple-40;
+		}
 
 		&:disabled {
 			background-color: var(--studio-gray-0);
@@ -137,9 +145,9 @@
 			line-height: 20px; /* 142.857% */
 			letter-spacing: -0.24px;
 
+
 			a,
-			a:visited,
-			a:hover, {
+			a:visited, {
 				color: $woo-purple-60;
 				font-size: rem(14px);
 				font-style: normal;
@@ -147,6 +155,10 @@
 				line-height: 20px;
 				letter-spacing: -0.24px;
 				text-decoration: none;
+			}
+
+			a:hover {
+				color: $woo-purple-40;
 			}
 		}
 	}
@@ -314,6 +326,10 @@
 			font-weight: 400;
 			font-size: 1rem;
 			text-decoration: none;
+
+			&:hover {
+				color: $woo-purple-40;
+			}
 		}
 
 		@media screen and ( max-width: 660px ) {
@@ -660,6 +676,10 @@
 
 	.wp-login__footer--oauth {
 		display: none;
+	}
+
+	.app-promo.magic-link-app-promo {
+		padding: 24px;
 	}
 
 	.auth-form__social-buttons-tos {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -91,7 +91,8 @@
 	}
 
 	.button.is-primary,
-	.login .button.is-primary {
+	.login .button.is-primary,
+	.magic-login.is-white-login .magic-login__form-action .button.is-primary:not([disabled]) {
 		background-color: $woo-purple-60;
 		border: none;
 		color: #fff;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -97,6 +97,10 @@
 		color: #fff;
 		width: 100%;
 
+		&.is-busy {
+			background-image: none;
+		}
+
 		&:hover {
 			background-color: $woo-purple-40;
 		}

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -184,10 +184,6 @@ export const canDoMagicLogin = ( twoFactorAuthType, oauth2Client, isJetpackWooCo
 		return false;
 	}
 
-	if ( isWooOAuth2Client( oauth2Client ) ) {
-		return false;
-	}
-
 	if ( isJetpackWooCommerceFlow ) {
 		return false;
 	}

--- a/client/login/magic-login/emailed-login-link-successfully.jsx
+++ b/client/login/magic-login/emailed-login-link-successfully.jsx
@@ -1,17 +1,24 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
+import { get } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import RedirectWhenLoggedIn from 'calypso/components/redirect-when-logged-in';
 import { preventWidows } from 'calypso/lib/formatting/prevent-widows';
-import { lostPassword } from 'calypso/lib/paths';
+import { isReactLostPasswordScreenEnabled } from 'calypso/lib/login';
+import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { login, lostPassword } from 'calypso/lib/paths';
 import {
 	recordPageViewWithClientId as recordPageView,
 	enhanceWithSiteType,
 } from 'calypso/state/analytics/actions';
+import { getRedirectToOriginal } from 'calypso/state/login/selectors';
+import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
+import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import { withEnhancers } from 'calypso/state/utils';
 import { MagicLoginEmailWrapper } from './magic-login-email/magic-login-email-wrapper';
 class EmailedLoginLinkSuccessfully extends Component {
@@ -24,8 +31,22 @@ class EmailedLoginLinkSuccessfully extends Component {
 		this.props.recordPageView( '/log-in/link', 'Login > Link > Emailed' );
 	}
 
-	onLostPasswordClick = () => {
+	onLostPasswordClick = ( event ) => {
 		recordTracksEvent( 'calypso_magic_login_lost_password_click' );
+
+		if ( isReactLostPasswordScreenEnabled() && this.props.isWoo ) {
+			event.preventDefault();
+
+			page(
+				login( {
+					redirectTo: this.props.redirectTo,
+					locale: this.props.locale,
+					action: 'lostpassword',
+					oauth2ClientId: this.props.oauth2Client && this.props.oauth2Client.id,
+					from: get( this.props.currentQuery, 'from' ),
+				} )
+			);
+		}
 	};
 
 	render() {
@@ -81,6 +102,10 @@ class EmailedLoginLinkSuccessfully extends Component {
 
 const mapState = ( state ) => ( {
 	locale: getCurrentLocaleSlug( state ),
+	isWoo: isWooOAuth2Client( getCurrentOAuth2Client( state ) ),
+	currentQuery: getCurrentQueryArguments( state ),
+	redirectTo: getRedirectToOriginal( state ),
+	oauth2Client: getCurrentOAuth2Client( state ),
 } );
 
 const mapDispatch = {

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -16,6 +16,7 @@ import {
 	isGravatarOAuth2Client,
 	isWPJobManagerOAuth2Client,
 	isGravPoweredOAuth2Client,
+	isWooOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import {
@@ -190,6 +191,10 @@ class MagicLogin extends Component {
 	}
 
 	renderGutenboardingLogo() {
+		if ( this.props.isWoo ) {
+			return null;
+		}
+
 		return (
 			<div className="magic-login__gutenboarding-wordpress-logo">
 				<svg
@@ -508,6 +513,7 @@ const mapState = ( state ) => ( {
 		getCurrentQueryArguments( state ).email_address ||
 		getInitialQueryArguments( state ).email_address,
 	localeSuggestions: getLocaleSuggestions( state ),
+	isWoo: isWooOAuth2Client( getCurrentOAuth2Client( state ) ),
 } );
 
 const mapDispatch = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/86885

## Proposed Changes

* Fix button loading style
* Fix reset password link
* Do not display Gutenboarding Logo for Woo
* Update Woo login screen style

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


1. Set up local Woo Start environment https://github.com/woocommerce/woocommerce-start-dev-env/tree/trunk to test social login.
2. Create a WP.com account with Gmail or [disconnect Google from your existing WP.com account]( https://wordpress.com/me/security/social-login) Please use non-a8c account.
3. Log out WP.com
4. Go to https://woo.com/sso?next=%2F
5. Continue with Google
6. Observe that it shows `You already have a WordPress.com account with this email address. Add your password to log in or create a new account.`
7. Observe that it shows the "Check your email" screen.
8. Click on the reset password link
9. Confirm it shows the Woo lost password screen

![Screenshot 2024-02-01 at 13 53 09](https://github.com/Automattic/wp-calypso/assets/4344253/79fe9d7a-8c5b-42d5-ba50-5a84ce04a209)



![Screenshot 2024-02-01 at 13 48 32](https://github.com/Automattic/wp-calypso/assets/4344253/8419cc4d-40dc-4ded-9fe1-ee0b053d8f75)




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?