### PR TITLE
Assembler: inject page titles in the upsell screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -512,11 +512,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 			return false;
 		}
 
-		if ( currentScreen.name === 'confirmation' ) {
-			return false;
-		}
-
-		return true;
+		return ! [ 'confirmation', 'upsell' ].includes( currentScreen.name );
 	};
 
 	const customActionButtons = () => {


### PR DESCRIPTION
Related to pdtkmj-2l9-p2#comment-4172

## Proposed Changes

Inject the selected page titles to the upsell screen. We missed this case.

|Before|After|
|-|-|
|<img width="794" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/cf2fff23-7371-40fe-9200-fe9861631f52">|<img width="739" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/1a5367e1-7d4b-4a26-931f-1976f5c0e8a2">|


## Testing Instructions

1. Go to the Assembler flow from any entrypoint (e.g. `/setup/assembler-first`)
2. Pick a premium style
3. Select some pages
4. In the upsell screen, verify that you see the selected page titles as shown in the screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?