### PR TITLE
Two Step: Fix security keys invalid nonce and missing backup code section

### DIFF
--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -15,7 +15,6 @@ import Notice from 'calypso/components/notice';
 import WarningCard from 'calypso/components/warning-card';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
 import { redirectToLogout } from 'calypso/state/current-user/actions';
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import SecurityKeyForm from './security-key-form';
 import TwoFactorActions from './two-factor-actions';
 import './style.scss';
@@ -134,12 +133,6 @@ class ReauthRequired extends Component {
 	preValidateAuthCode() {
 		return this.state.code.length && this.state.code.length > 5;
 	}
-
-	loginUserWithSecurityKey = () => {
-		return this.props.twoStepAuthorization.loginUserWithSecurityKey( {
-			user_id: this.props.currentUserId,
-		} );
-	};
 
 	renderFailedValidationMsg() {
 		if ( ! this.props.twoStepAuthorization.codeValidationFailed() ) {
@@ -286,10 +279,7 @@ class ReauthRequired extends Component {
 				isVisible={ this.props?.twoStepAuthorization.isReauthRequired() }
 			>
 				{ isSecurityKeySupported && twoFactorAuthType === 'webauthn' ? (
-					<SecurityKeyForm
-						loginUserWithSecurityKey={ this.loginUserWithSecurityKey }
-						onComplete={ this.refreshNonceOnFailure }
-					/>
+					<SecurityKeyForm twoStepAuthorization={ this.props.twoStepAuthorization } />
 				) : (
 					this.renderVerificationForm()
 				) }
@@ -319,18 +309,6 @@ class ReauthRequired extends Component {
 		);
 	}
 
-	refreshNonceOnFailure = ( error ) => {
-		const errors = [].slice.call( error?.data?.errors ?? [] );
-		const onErrorCallback = error?.onErrorCallback ?? ( () => {} );
-		if ( errors.some( ( e ) => e.code === 'invalid_two_step_nonce' ) ) {
-			this.props.twoStepAuthorization.fetch( () => {
-				this.loginUserWithSecurityKey().catch( () => onErrorCallback() );
-			} );
-		} else if ( error ) {
-			onErrorCallback();
-		}
-	};
-
 	handleAuthSwitch = ( authType ) => {
 		this.setState( { twoFactorAuthType: authType } );
 		if ( authType === 'sms' ) {
@@ -350,17 +328,12 @@ class ReauthRequired extends Component {
 }
 
 ReauthRequired.propTypes = {
-	currentUserId: PropTypes.number.isRequired,
+	twoStepAuthorization: PropTypes.object.isRequired,
 };
 
 /* eslint-enable jsx-a11y/no-autofocus, jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions, jsx-a11y/anchor-is-valid */
 
-export default connect(
-	( state ) => ( {
-		currentUserId: getCurrentUserId( state ),
-	} ),
-	{
-		redirectToLogout,
-		recordGoogleEvent,
-	}
-)( localize( ReauthRequired ) );
+export default connect( null, {
+	redirectToLogout,
+	recordGoogleEvent,
+} )( localize( ReauthRequired ) );

--- a/client/me/reauth-required/index.jsx
+++ b/client/me/reauth-required/index.jsx
@@ -321,8 +321,13 @@ class ReauthRequired extends Component {
 
 	refreshNonceOnFailure = ( error ) => {
 		const errors = [].slice.call( error?.data?.errors ?? [] );
+		const onErrorCallback = error?.onErrorCallback ?? ( () => {} );
 		if ( errors.some( ( e ) => e.code === 'invalid_two_step_nonce' ) ) {
-			this.props.twoStepAuthorization.fetch();
+			this.props.twoStepAuthorization.fetch( () => {
+				this.loginUserWithSecurityKey().catch( () => onErrorCallback() );
+			} );
+		} else if ( error ) {
+			onErrorCallback();
 		}
 	};
 

--- a/client/me/reauth-required/security-key-form.jsx
+++ b/client/me/reauth-required/security-key-form.jsx
@@ -28,8 +28,13 @@ class SecurityKeyForm extends Component {
 			.loginUserWithSecurityKey()
 			.then( ( response ) => this.onComplete( null, response ) )
 			.catch( ( error ) => {
-				this.setState( { isAuthenticating: false, showError: true } );
-				this.onComplete( error, null );
+				this.onComplete(
+					{
+						onErrorCallback: () => this.setState( { isAuthenticating: false, showError: true } ),
+						...error,
+					},
+					null
+				);
 			} );
 	};
 

--- a/client/me/reauth-required/security-key-form.jsx
+++ b/client/me/reauth-required/security-key-form.jsx
@@ -22,7 +22,6 @@ class SecurityKeyForm extends Component {
 	};
 
 	initiateSecurityKeyAuthentication = ( event, retryRequest = true ) => {
-
 		event.preventDefault();
 		this.setState( { isAuthenticating: true, showError: false } );
 
@@ -38,6 +37,7 @@ class SecurityKeyForm extends Component {
 						} else {
 							// We only retry once, so let's show the original error.
 							this.setState( { isAuthenticating: false, showError: true } );
+							this.onComplete( error, null );
 						}
 					} );
 					return;
@@ -109,8 +109,6 @@ class SecurityKeyForm extends Component {
 	}
 }
 
-export default connect(
-	( state ) => ( {
-		currentUserId: getCurrentUserId( state ),
-	} )
-)( localize( SecurityKeyForm ) );
+export default connect( ( state ) => ( {
+	currentUserId: getCurrentUserId( state ),
+} ) )( localize( SecurityKeyForm ) );

--- a/client/me/reauth-required/security-key-form.jsx
+++ b/client/me/reauth-required/security-key-form.jsx
@@ -21,8 +21,7 @@ class SecurityKeyForm extends Component {
 		showError: false,
 	};
 
-	initiateSecurityKeyAuthentication = ( event, retry ) => {
-		const retryRequest = retry ?? true;
+	initiateSecurityKeyAuthentication = ( event, retryRequest = true ) => {
 
 		event.preventDefault();
 		this.setState( { isAuthenticating: true, showError: false } );
@@ -31,7 +30,7 @@ class SecurityKeyForm extends Component {
 			.loginUserWithSecurityKey( { user_id: this.props.currentUserId } )
 			.then( ( response ) => this.onComplete( null, response ) )
 			.catch( ( error ) => {
-				const errors = [].slice.call( error?.data?.errors ?? [] );
+				const errors = error?.data?.errors ?? [];
 				if ( errors.some( ( e ) => e.code === 'invalid_two_step_nonce' ) ) {
 					this.props.twoStepAuthorization.fetch( () => {
 						if ( retryRequest ) {
@@ -113,6 +112,5 @@ class SecurityKeyForm extends Component {
 export default connect(
 	( state ) => ( {
 		currentUserId: getCurrentUserId( state ),
-	} ),
-	null
+	} )
 )( localize( SecurityKeyForm ) );

--- a/client/me/two-step/index.jsx
+++ b/client/me/two-step/index.jsx
@@ -102,9 +102,8 @@ class TwoStep extends Component {
 	};
 
 	render() {
-		const { path, translate, userSettings } = this.props;
+		const { path, translate } = this.props;
 		const useCheckupMenu = isEnabled( 'security/security-checkup' );
-		const useEnhancedSecurity = isEnabled( 'two-step/enhanced-security' );
 
 		return (
 			<Main wideLayout className="security two-step">
@@ -128,9 +127,7 @@ class TwoStep extends Component {
 
 				{ this.renderEnhancedSecuritySetting() }
 				{ this.render2faKey() }
-				{ ! useEnhancedSecurity && ! userSettings?.two_step_enhanced_security
-					? this.renderBackupCodes()
-					: null }
+				{ this.renderBackupCodes() }
 				{ this.renderApplicationPasswords() }
 			</Main>
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Retry automatically the security key action when it fails with an expired login nonce error.
* Show the generate backup code section when the enhanced security mode is on.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
For the missing backup code section.

* Navigate to `/me/security/two-step` and make sure the backup code is shown when the enhanced security mode is on (you can turn it on on the same page, it should no longer hide it).

For the security key related error.
* Navigate to `/me/security/two-step` and make sure the backup code is shown when the enhanced security mode is on.
* Remove the `two-step` auth cookie and reload the window.
* Remove the `webauthn` nonce from your user attribute to simulate the expired error nonce.
* Make sure you don't see the expired nonce error right away.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
