### PR TITLE
Email management: mailbox names link to email app

### DIFF
--- a/client/components/popover-menu/item.jsx
+++ b/client/components/popover-menu/item.jsx
@@ -10,6 +10,7 @@ const noop = () => {};
 export default class PopoverMenuItem extends Component {
 	static propTypes = {
 		href: PropTypes.string,
+		disabled: PropTypes.bool,
 		className: PropTypes.string,
 		isSelected: PropTypes.bool,
 		icon: PropTypes.oneOfType( [ PropTypes.object, PropTypes.string ] ),
@@ -38,7 +39,7 @@ export default class PopoverMenuItem extends Component {
 	};
 
 	render() {
-		const { children, className, href, icon, isExternalLink, isSelected } = this.props;
+		const { children, className, disabled, href, icon, isExternalLink, isSelected } = this.props;
 		const itemProps = omit(
 			this.props,
 			'icon',
@@ -53,10 +54,10 @@ export default class PopoverMenuItem extends Component {
 		} );
 
 		let ItemComponent = this.props.itemComponent;
-		if ( isExternalLink && href ) {
+		if ( isExternalLink && href && ! disabled ) {
 			ItemComponent = ExternalLink;
 			itemProps.icon = true;
-		} else if ( href ) {
+		} else if ( href && ! disabled ) {
 			ItemComponent = 'a';
 		}
 

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -89,24 +89,21 @@ const getTitanMenuItems = ( {
 			} ),
 			onClick: getTitanClickHandler( 'webmail' ),
 		},
-		...( canCurrentUserAddEmail( domain )
-			? [
-					{
-						isInternalLink: true,
-						materialIcon: 'delete',
-						onClick: () => {
-							showRemoveMailboxDialog?.();
+		{
+			isInternalLink: true,
+			materialIcon: 'delete',
+			disabled: ! canCurrentUserAddEmail( domain ),
+			onClick: () => {
+				showRemoveMailboxDialog?.();
 
-							recordTracksEvent( 'calypso_email_management_titan_remove_mailbox_click', {
-								domain_name: mailbox.domain,
-								mailbox: mailbox.mailbox,
-							} );
-						},
-						key: `remove_mailbox:${ mailbox.mailbox }`,
-						title: translate( 'Remove mailbox' ),
-					},
-			  ]
-			: [] ),
+				recordTracksEvent( 'calypso_email_management_titan_remove_mailbox_click', {
+					domain_name: mailbox.domain,
+					mailbox: mailbox.mailbox,
+				} );
+			},
+			key: `remove_mailbox:${ mailbox.mailbox }`,
+			title: translate( 'Remove mailbox' ),
+		},
 	];
 };
 
@@ -367,11 +364,13 @@ const EmailMailboxActionMenu = ( { account, domain, mailbox } ) => {
 						materialIcon,
 						onClick,
 						title,
+						disabled,
 					} ) => (
 						<PopoverMenuItem
 							key={ href || key }
 							className="email-mailbox-action-menu__menu-item"
 							isExternalLink={ ! isInternalLink }
+							disabled={ disabled }
 							href={ href }
 							onClick={ onClick }
 						>

--- a/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
+++ b/client/my-sites/email/email-management/home/email-mailbox-action-menu.jsx
@@ -83,7 +83,6 @@ const getTitanMenuItems = ( {
 			href: getTitanEmailUrl( titanAppsUrlPrefix, email, false, window.location.href ),
 			image: titanMailIcon,
 			imageAltText: translate( 'Titan Mail icon' ),
-			isInternalLink: true,
 			title: translate( 'View Mail', {
 				comment: 'View the Email application (i.e. the webmail) for Titan',
 			} ),

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -2,14 +2,24 @@ import { Badge, CompactCard, Gridicon } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import ExternalLink from 'calypso/components/external-link';
 import MaterialIcon from 'calypso/components/material-icon';
 import SectionHeader from 'calypso/components/section-header';
 import { isRecentlyRegistered } from 'calypso/lib/domains/utils';
-import { getEmailForwardAddress, isEmailForward, isEmailUserAdmin } from 'calypso/lib/emails';
+import {
+	getEmailAddress,
+	getEmailForwardAddress,
+	isEmailForward,
+	isEmailForwardAccount,
+	isEmailUserAdmin,
+	isTitanMailAccount,
+} from 'calypso/lib/emails';
 import { EMAIL_ACCOUNT_TYPE_FORWARD } from 'calypso/lib/emails/email-provider-constants';
-import { getGSuiteSubscriptionStatus } from 'calypso/lib/gsuite';
+import { getGSuiteSubscriptionStatus, getGmailUrl } from 'calypso/lib/gsuite';
+import { getTitanEmailUrl, useTitanAppsUrlPrefix } from 'calypso/lib/titan';
 import EmailMailboxActionMenu from 'calypso/my-sites/email/email-management/home/email-mailbox-action-menu';
 import EmailMailboxWarnings from 'calypso/my-sites/email/email-management/home/email-mailbox-warnings';
+import { recordEmailAppLaunchEvent } from './utils';
 
 const getListHeaderTextForAccountType = ( accountType, translate ) => {
 	if ( accountType === EMAIL_ACCOUNT_TYPE_FORWARD ) {
@@ -49,25 +59,54 @@ const MailboxListItem = ( { children, isError = false, isPlaceholder, hasNoEmail
 	);
 };
 
-const MailboxListItemSecondaryDetails = ( { children, className } ) => {
-	const fullClassName = classNames(
-		'email-plan-mailboxes-list__mailbox-secondary-details',
-		className
-	);
-	return <div className={ fullClassName }>{ children }</div>;
-};
-
-const getSecondaryContentForMailbox = ( mailbox ) => {
+function EmailForwardSecondaryDetails( { mailbox } ) {
 	if ( isEmailForward( mailbox ) ) {
 		return (
-			<MailboxListItemSecondaryDetails className="email-plan-mailboxes-list__mailbox-list-forward">
+			<div className="email-plan-mailboxes-list__mailbox-secondary-details">
 				<Gridicon icon="chevron-right" />
 				<span>{ getEmailForwardAddress( mailbox ) }</span>
-			</MailboxListItemSecondaryDetails>
+			</div>
 		);
 	}
 	return null;
-};
+}
+
+function MailboxLink( { account, mailbox } ) {
+	const titanAppsUrlPrefix = useTitanAppsUrlPrefix();
+	const emailAddress = getEmailAddress( mailbox );
+
+	if ( isEmailForwardAccount( account ) ) {
+		return (
+			<div className="email-plan-mailboxes-list__mailbox-list-link">
+				<span>{ emailAddress }</span>
+			</div>
+		);
+	}
+
+	const isTitan = isTitanMailAccount( account );
+	const primaryHref = isTitan
+		? getTitanEmailUrl( titanAppsUrlPrefix, emailAddress, false, window.location.href )
+		: getGmailUrl( emailAddress );
+
+	return (
+		<ExternalLink
+			className="email-plan-mailboxes-list__mailbox-list-link"
+			href={ primaryHref }
+			onClick={ () => {
+				recordEmailAppLaunchEvent( {
+					app: isTitan ? titanAppsUrlPrefix : 'webmail',
+					context: 'email-management-list',
+					provider: isTitan ? 'titan' : 'google',
+				} );
+			} }
+			target="_blank"
+			rel="noreferrer"
+		>
+			<span>{ emailAddress }</span>
+			<Gridicon icon="external" size={ 18 } />
+		</ExternalLink>
+	);
+}
 
 function EmailPlanMailboxesList( { account, domain, isLoadingEmails, mailboxes } ) {
 	const translate = useTranslate();
@@ -111,14 +150,10 @@ function EmailPlanMailboxesList( { account, domain, isLoadingEmails, mailboxes }
 		return (
 			<MailboxListItem key={ mailbox.mailbox } isError={ mailboxHasWarnings }>
 				<div className="email-plan-mailboxes-list__mailbox-list-item-main">
-					<div>
-						<MaterialIcon icon="email" />
-						<span>
-							{ mailbox.mailbox }@{ mailbox.domain }
-						</span>
-					</div>
-					{ getSecondaryContentForMailbox( mailbox ) }
+					<MailboxLink account={ account } mailbox={ mailbox } />
+					<EmailForwardSecondaryDetails mailbox={ mailbox } />
 				</div>
+
 				{ isEmailUserAdmin( mailbox ) && (
 					<Badge type="info">
 						{ translate( 'Admin', {

--- a/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
+++ b/client/my-sites/email/email-management/home/email-plan-mailboxes-list.jsx
@@ -100,7 +100,7 @@ function MailboxLink( { account, mailbox } ) {
 				} );
 			} }
 			target="_blank"
-			rel="noreferrer"
+			rel="noopener noreferrer"
 		>
 			<span>{ emailAddress }</span>
 			<Gridicon icon="external" size={ 18 } />

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -253,7 +253,7 @@
 	}
 
 	&.is-selected,
-	&:hover,
+	&:not(:disabled):hover,
 	&:focus {
 		> img {
 			filter: grayscale(100%) brightness(0.2) invert(1);
@@ -262,6 +262,10 @@
 		> svg {
 			fill: var(--studio-white);
 		}
+	}
+
+	&:disabled > svg {
+		fill: currentColor;
 	}
 
 	&.external-link > .gridicons-external {
@@ -299,6 +303,7 @@
 	.email-plan-mailboxes-list__mailbox-list-item-main {
 		display: flex;
 		flex-direction: column;
+		gap: 0.5em;
 		padding-right: 40px;
 
 		@include break-mobile {
@@ -308,10 +313,6 @@
 		@include break-xlarge {
 			/* Padding moves to parent mailbox-list-item when we shift to flex-direction: row */
 			padding-right: 0;
-		}
-
-		> div:not(:first-child) {
-			margin-top: 0.5em;
 		}
 	}
 
@@ -326,11 +327,14 @@
 		font-style: italic;
 	}
 
-	> svg,
+	.email-plan-mailboxes-list__mailbox-list-link {
+		display: inline-flex;
+		gap: 10px;
+	}
+
 	.email-plan-mailboxes-list__mailbox-list-item-main svg {
 		fill: var(--studio-gray-40);
-		margin-right: 10px;
-		vertical-align: middle;
+		margin: 0;
 	}
 
 	.email-plan-mailboxes-list__mailbox-list-item-main span {
@@ -338,14 +342,19 @@
 		word-break: break-all;
 	}
 
+	.email-plan-mailboxes-list__mailbox-secondary-details {
+		display: flex;
+		gap: 10px;
+	}
+
 	> .badge {
+		align-self: center;
 		/* Hide admin badge in mobile layouts */
 		display: none;
 
 		@include break-xlarge {
 			display: unset;
 			margin-left: 10px;
-			margin-top: 3px;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5397

## Proposed Changes

The `Mailboxes` page is slated for removal (in wp-admin, at least). To preserve its functionality, we decided to let the mailbox names on the email management page serve as links to the webmail (Titan or Gmail).

@wongasy suggested that we remove the context menu (three dots action menu) and replace it with a _delete mailbox_ button. I opted to **not do this** for a few reasons:
- For Google mailboxes, we link to several apps from that menu.
- For such a destructive action, I find it actually doesn't hurt to hide it behind an additional click.
- The fact that we now have two links to the webmail app for Titan/Google doesn't really hurt either IMO. It might not be necessary and I probably wouldn't advocate it if we were greenfielding, but seeing as we're not, I think it doesn't hurt.

I'm open to reconsidering this approach, but given the time constraints, I suggest we still ship this as the first iteration.

| Titan | Gmail | Forwarding |
| - | - | - |
| ![titan2](https://github.com/Automattic/wp-calypso/assets/1101677/80c56545-3cc8-40d5-905b-9cd3eba2f776) | ![google](https://github.com/Automattic/wp-calypso/assets/1101677/515ed5a5-4ab0-44c5-a6dd-4ac9d67654d4) | ![forwarding](https://github.com/Automattic/wp-calypso/assets/1101677/4d93b98a-57e8-4ab3-b51f-8931cf28b2b6) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Have a Professional Email subscription
2. Go to the email management page for that subscription
3. Ensure that clicking the mailbox name takes you to Titan's webmail
4. Have a Google Workspace subscription
5. Go to the email management page for that subscription
6. Ensure that clicking the mailbox name takes you to Gmail
7. Have an Email forwarding domain
8. Go to the email management page for that domain
9. Ensure that the page looks OK

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?