### PR TITLE
Jetpack Manage: Pricing page - License Selector

### DIFF
--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/index.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/index.tsx
@@ -30,6 +30,7 @@ export const LicenseProductsList = ( { bundleSize }: ProductsListProps ) => {
 					'Save big with comprehensive bundles of Jetpack security, performance, and growth tools.'
 				) }
 				items={ plans }
+				bundleSize={ bundleSize }
 			/>
 			<AllLicenseItems
 				heading={ translate( 'Products' ) }
@@ -37,6 +38,7 @@ export const LicenseProductsList = ( { bundleSize }: ProductsListProps ) => {
 					'Mix and match powerful security, performance, and growth tools for your site.'
 				) }
 				items={ products }
+				bundleSize={ bundleSize }
 			/>
 			<AllLicenseItems
 				heading={ translate( 'VaultPress Backup Add-ons' ) }
@@ -44,6 +46,7 @@ export const LicenseProductsList = ( { bundleSize }: ProductsListProps ) => {
 					'Add additional storage to your current VaultPress Backup plans.'
 				) }
 				items={ backupAddons }
+				bundleSize={ bundleSize }
 			/>
 			<AllLicenseItems
 				heading={ translate( 'WooCommerce Extensions' ) }
@@ -51,6 +54,7 @@ export const LicenseProductsList = ( { bundleSize }: ProductsListProps ) => {
 					'You must have WooCommerce installed to utilize these paid extensions.'
 				) }
 				items={ wooExtensions }
+				bundleSize={ bundleSize }
 			/>
 		</div>
 	);

--- a/client/jetpack-cloud/sections/manage/pricing/pricing-license-selector/index.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/pricing-license-selector/index.tsx
@@ -1,0 +1,61 @@
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { getSupportedBundleSizes } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/hooks/use-product-bundle-size';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { usePublicProductsQuery } from 'calypso/state/partner-portal/licenses/hooks/use-products-query';
+
+import './style.scss';
+
+interface PricingLicenseSelectorProps {
+	selectedSize: number;
+	setSelectedSize: ( size: number ) => void;
+}
+
+export default function PricingLicenseSelector( {
+	selectedSize,
+	setSelectedSize,
+}: PricingLicenseSelectorProps ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const { data: products } = usePublicProductsQuery();
+	const supportedBundleSizes = getSupportedBundleSizes( products );
+
+	const navItems = supportedBundleSizes.map( ( size ) => {
+		return {
+			label:
+				size === 1
+					? translate( 'Single license' )
+					: ( translate( '%(size)d licenses', {
+							args: { size },
+					  } ) as string ),
+			selected: selectedSize === size,
+			onClick: () => {
+				setSelectedSize( size );
+				dispatch(
+					recordTracksEvent( 'calypso_jetpack_manage_pricing_license_selector_tab_click', {
+						bundle_size: size,
+					} )
+				);
+			},
+		};
+	} );
+
+	return (
+		<div className="pricing-license-selector-wrapper">
+			<div className="pricing-license-selector">
+				{ navItems.map( ( item, index ) => (
+					<div className="pricing-license-option-outer">
+						<button
+							key={ index }
+							onClick={ item.onClick }
+							className={ classNames( 'pricing-license-option', { 'is-selected': item.selected } ) }
+						>
+							{ item.label }
+						</button>
+					</div>
+				) ) }
+			</div>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/manage/pricing/pricing-license-selector/index.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/pricing-license-selector/index.tsx
@@ -23,6 +23,7 @@ export default function PricingLicenseSelector( {
 
 	const navItems = supportedBundleSizes.map( ( size ) => {
 		return {
+			key: size,
 			label:
 				size === 1
 					? translate( 'Single license' )
@@ -45,7 +46,7 @@ export default function PricingLicenseSelector( {
 		<div className="pricing-license-selector-wrapper">
 			<div className="pricing-license-selector">
 				{ navItems.map( ( item, index ) => (
-					<div className="pricing-license-option-outer">
+					<div key={ item.key } className="pricing-license-option-outer">
 						<button
 							key={ index }
 							onClick={ item.onClick }

--- a/client/jetpack-cloud/sections/manage/pricing/pricing-license-selector/style.scss
+++ b/client/jetpack-cloud/sections/manage/pricing/pricing-license-selector/style.scss
@@ -7,47 +7,47 @@
 	top: 0;
 	z-index: 1;
 	backdrop-filter: blur(4px);
-}
 
-.pricing-license-selector {
-	display: flex;
-	align-items: center;
-	background: #f4f4f4;
-	border-radius: 8px; /* stylelint-disable-line scales/radii */
-	width: 682px;
-	height: 30px;
-	overflow: hidden;
-	margin: 20px auto;
-	padding: 1px 2px;
-}
+	.pricing-license-selector {
+		display: flex;
+		align-items: center;
+		background: #f4f4f4;
+		border-radius: 8px; /* stylelint-disable-line scales/radii */
+		width: 682px;
+		height: 30px;
+		overflow: hidden;
+		margin: 20px auto;
+		padding: 1px 2px;
+	}
 
-.pricing-license-option-outer {
-	justify-content: center; /* Centers the inner div horizontally */
-	align-items: center; /* Centers the inner div vertically */
-	display: flex;
-	flex: 1;
-	width: 113px;
-	height: 30px;
-}
+	.pricing-license-option-outer {
+		justify-content: center; /* Centers the inner div horizontally */
+		align-items: center; /* Centers the inner div vertically */
+		display: flex;
+		flex: 1;
+		width: 113px;
+		height: 30px;
 
-.pricing-license-option {
-	padding: 5px 0;
-	color: var(--studio-gray-60);
-	background: transparent;
-	text-align: center;
-	width: 100%;
-	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-	font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
-	cursor: pointer; /* Changes the cursor to a pointer */
-	user-select: none; /* Prevents text selection */
-}
+		.pricing-license-option {
+			padding: 5px 0;
+			color: var(--studio-gray-60);
+			background: transparent;
+			text-align: center;
+			width: 100%;
+			font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+			font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			cursor: pointer; /* Changes the cursor to a pointer */
+			user-select: none; /* Prevents text selection */
 
-.pricing-license-option.is-selected {
-	box-shadow: 0 3px 8px rgba(0, 0, 0, 0.12), 0 3px 1px rgba(0, 0, 0, 0.04);
-	border-radius: 7px; /* stylelint-disable-line scales/radii */
-	font-weight: 500;
-	color: #000;
-	background-color: #fff;
+			&.is-selected {
+				box-shadow: 0 3px 8px rgba(0, 0, 0, 0.12), 0 3px 1px rgba(0, 0, 0, 0.04);
+				border-radius: 7px; /* stylelint-disable-line scales/radii */
+				font-weight: 500;
+				color: #000;
+				background-color: #fff;
+			}
+		}
+	}
 }
 
 .is-group-jetpack-cloud.is-section-jetpack-cloud-manage-pricing div.jpcom-masterbar div.header__submenu-content {

--- a/client/jetpack-cloud/sections/manage/pricing/pricing-license-selector/style.scss
+++ b/client/jetpack-cloud/sections/manage/pricing/pricing-license-selector/style.scss
@@ -1,0 +1,55 @@
+.pricing-license-selector-wrapper {
+	display: flex;
+	width: 100%;
+	height: 72px;
+	background: rgba(255, 255, 255, 0.84);
+	position: sticky;
+	top: 0;
+	z-index: 1;
+	backdrop-filter: blur(4px);
+}
+
+.pricing-license-selector {
+	display: flex;
+	align-items: center;
+	background: #f4f4f4;
+	border-radius: 8px; /* stylelint-disable-line scales/radii */
+	width: 682px;
+	height: 30px;
+	overflow: hidden;
+	margin: 20px auto;
+	padding: 1px 2px;
+}
+
+.pricing-license-option-outer {
+	justify-content: center; /* Centers the inner div horizontally */
+	align-items: center; /* Centers the inner div vertically */
+	display: flex;
+	flex: 1;
+	width: 113px;
+	height: 30px;
+}
+
+.pricing-license-option {
+	padding: 5px 0;
+	color: var(--studio-gray-60);
+	background: transparent;
+	text-align: center;
+	width: 100%;
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+	font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+	cursor: pointer; /* Changes the cursor to a pointer */
+	user-select: none; /* Prevents text selection */
+}
+
+.pricing-license-option.is-selected {
+	box-shadow: 0 3px 8px rgba(0, 0, 0, 0.12), 0 3px 1px rgba(0, 0, 0, 0.04);
+	border-radius: 7px; /* stylelint-disable-line scales/radii */
+	font-weight: 500;
+	color: #000;
+	background-color: #fff;
+}
+
+.is-group-jetpack-cloud.is-section-jetpack-cloud-manage-pricing div.jpcom-masterbar div.header__submenu-content {
+	z-index: 2;
+}

--- a/client/jetpack-cloud/sections/manage/pricing/primary/index.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/primary/index.tsx
@@ -19,10 +19,12 @@ import './style.scss';
 import PricingLicenseSelector from '../pricing-license-selector';
 import PricingNeedMoreInfo from '../pricing-need-more-info';
 
+const DEFAULT_SELECTED_BUNDLE_SIZE = 5;
+
 export default function ManagePricingPage() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
-	const [ selectedSize, setSelectedSize ] = useState< number >( 1 );
+	const [ selectedSize, setSelectedSize ] = useState< number >( DEFAULT_SELECTED_BUNDLE_SIZE );
 
 	useEffect( () => {
 		dispatch( recordTracksEvent( 'calypso_jetpack_manage_pricing_visit' ) );

--- a/client/jetpack-cloud/sections/manage/pricing/primary/index.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/primary/index.tsx
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import JetpackComFooter from 'calypso/jetpack-cloud/sections/pricing/jpcom-footer';
@@ -16,11 +16,13 @@ import { LicenseProductsList } from '../license-products-list';
 import 'calypso/my-sites/plans/jetpack-plans/product-store/style.scss';
 import 'calypso/jetpack-cloud/sections/pricing/style.scss';
 import './style.scss';
+import PricingLicenseSelector from '../pricing-license-selector';
 import PricingNeedMoreInfo from '../pricing-need-more-info';
 
 export default function ManagePricingPage() {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
+	const [ selectedSize, setSelectedSize ] = useState< number >( 1 );
 
 	useEffect( () => {
 		dispatch( recordTracksEvent( 'calypso_jetpack_manage_pricing_visit' ) );
@@ -41,7 +43,11 @@ export default function ManagePricingPage() {
 				/>
 				<div className="jetpack-product-store">
 					<Header />
-					<LicenseProductsList bundleSize={ 1 } />
+					<PricingLicenseSelector
+						selectedSize={ selectedSize }
+						setSelectedSize={ setSelectedSize }
+					/>
+					<LicenseProductsList bundleSize={ selectedSize } />
 					<PricingNeedMoreInfo />
 					<Recommendations />
 					<StoreFooter />


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/249

## Proposed Changes

* This PR adds the license selector to our manage pricing page as described in https://github.com/Automattic/jetpack-manage/issues/249.
* This PR also fixes a small bug that prevented prices from being updated in the `LicenseProductsList` when the `bundleSize` was changed.

## Testing Instructions

* Open the pricing page (`jetpack.cloud.localhost:3000/manage/pricing`)
* You should see a sticky license selector as described in https://github.com/Automattic/jetpack-manage/issues/249
* When clicked, it should pass the selected value to the `LicenseProductsList` component.
* Also when clicked, it should track the event `calypso_jetpack_manage_pricing_license_selector_tab_click` with the selected size store in the property `bundle_size`.

## Context

PT: pf36In-wp-p2
Design: pf36In-Gb-p2
Technical scope: pf36In-Iz-p2#license-selector

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?