### PR TITLE
Migration flow: Improve guidance and messaging for the NotAuthorized component

### DIFF
--- a/client/blocks/importer/components/not-authorized/index.tsx
+++ b/client/blocks/importer/components/not-authorized/index.tsx
@@ -3,10 +3,15 @@ import { BackButton, NextButton, SubTitle, Title } from '@automattic/onboarding'
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useEffect } from 'react';
 import { HintJetpackConnection } from '../../wordpress/import-everything/migration-error/hint-jetpack-connection';
+import { HintJetpackConnectionMovePlugin } from '../../wordpress/import-everything/migration-error/hint-jetpack-connection-move-plugin';
 
 import './style.scss';
 
-export type NotAuthorizedType = 'generic' | 'target-site-staging' | 'source-site-not-connected';
+export type NotAuthorizedType =
+	| 'generic'
+	| 'target-site-staging'
+	| 'source-site-not-connected'
+	| 'source-site-not-connected-move-plugin';
 
 interface Props {
 	type?: NotAuthorizedType;
@@ -82,7 +87,23 @@ const NotAuthorized: React.FunctionComponent< Props > = ( props ) => {
 							/>
 
 							<div className="import__buttons-group">
-								{ startImport && <NextButton onClick={ startImport }>Try Again</NextButton> }
+								{ startImport && (
+									<NextButton onClick={ startImport }>{ __( 'Try again' ) }</NextButton>
+								) }
+							</div>
+						</>
+					) }
+
+					{ type === 'source-site-not-connected-move-plugin' && (
+						<>
+							<Title>{ __( "We couldn't start the migration" ) }</Title>
+
+							<HintJetpackConnectionMovePlugin sourceSiteUrl={ sourceSiteUrl || '' } />
+
+							<div className="import__buttons-group">
+								{ startImport && (
+									<NextButton onClick={ startImport }>{ __( 'Try again' ) }</NextButton>
+								) }
 							</div>
 						</>
 					) }

--- a/client/blocks/importer/components/not-authorized/index.tsx
+++ b/client/blocks/importer/components/not-authorized/index.tsx
@@ -2,10 +2,17 @@ import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { BackButton, NextButton, SubTitle, Title } from '@automattic/onboarding';
 import { useI18n } from '@wordpress/react-i18n';
 import React, { useEffect } from 'react';
+import { HintJetpackConnection } from '../../wordpress/import-everything/migration-error/hint-jetpack-connection';
 
 import './style.scss';
 
+export type NotAuthorizedType = 'generic' | 'target-site-staging' | 'source-site-not-connected';
+
 interface Props {
+	type?: NotAuthorizedType;
+	sourceSiteUrl?: string;
+	targetSiteUrl?: string;
+	startImport?: () => void;
 	onBackToStart?: () => void;
 	onStartBuilding?: () => void;
 	onStartBuildingText?: string;
@@ -13,7 +20,15 @@ interface Props {
 
 const NotAuthorized: React.FunctionComponent< Props > = ( props ) => {
 	const { __ } = useI18n();
-	const { onBackToStart, onStartBuilding, onStartBuildingText } = props;
+	const {
+		type = 'generic',
+		sourceSiteUrl,
+		targetSiteUrl,
+		startImport,
+		onBackToStart,
+		onStartBuilding,
+		onStartBuildingText,
+	} = props;
 
 	const startBuildingText = onStartBuildingText ?? __( 'Start building' );
 
@@ -25,19 +40,52 @@ const NotAuthorized: React.FunctionComponent< Props > = ( props ) => {
 		<div className="import__not-authorized import-layout__center">
 			<div className="import__header">
 				<div className="import__heading  import__heading-center">
-					<Title>{ __( 'You are not authorized to import content' ) }</Title>
-					<SubTitle>{ __( 'Please check with your site admin.' ) }</SubTitle>
+					{ type === 'generic' && (
+						<>
+							<Title>{ __( 'You are not authorized to import content' ) }</Title>
+							<SubTitle>{ __( 'Please check with your site admin.' ) }</SubTitle>
 
-					<div className="import__buttons-group">
-						{ onStartBuilding && (
-							<NextButton onClick={ onStartBuilding }>{ startBuildingText }</NextButton>
-						) }
-						{ onBackToStart && (
-							<div>
-								<BackButton onClick={ onBackToStart }>{ __( 'Back to start' ) }</BackButton>
+							<div className="import__buttons-group">
+								{ onStartBuilding && (
+									<NextButton onClick={ onStartBuilding }>{ startBuildingText }</NextButton>
+								) }
+								{ onBackToStart && (
+									<div>
+										<BackButton onClick={ onBackToStart }>{ __( 'Back to start' ) }</BackButton>
+									</div>
+								) }
 							</div>
-						) }
-					</div>
+						</>
+					) }
+
+					{ type === 'target-site-staging' && (
+						<>
+							<Title>
+								{ __( 'You are not authorized to perform migration on the staging site' ) }
+							</Title>
+
+							<div className="import__buttons-group">
+								{ onStartBuilding && (
+									<NextButton onClick={ onStartBuilding }>{ startBuildingText }</NextButton>
+								) }
+							</div>
+						</>
+					) }
+
+					{ type === 'source-site-not-connected' && (
+						<>
+							<Title>{ __( "We couldn't start the migration" ) }</Title>
+
+							<HintJetpackConnection
+								sourceSiteUrl={ sourceSiteUrl || '' }
+								targetSiteUrl={ targetSiteUrl || '' }
+							/>
+
+							<div className="import__buttons-group">
+								{ startImport && <NextButton onClick={ startImport }>Try Again</NextButton> }
+							</div>
+						</>
+					) }
 				</div>
 			</div>
 		</div>

--- a/client/blocks/importer/components/not-authorized/style.scss
+++ b/client/blocks/importer/components/not-authorized/style.scss
@@ -1,5 +1,5 @@
 .import__not-authorized {
-	.import__header .onboarding-title {
-		max-width: 500px;
+	.migration-error--hint {
+		margin-top: 2.5rem;
 	}
 }

--- a/client/blocks/importer/util.ts
+++ b/client/blocks/importer/util.ts
@@ -11,6 +11,16 @@ export function isTargetSitePlanCompatible( targetSite: SiteDetails | undefined 
 	return planSlug && planHasFeature( planSlug, FEATURE_UPLOAD_THEMES_PLUGINS );
 }
 
+export function addProtocolToUrl( url: string, protocol = 'https' ) {
+	if ( ! url ) {
+		return '';
+	}
+	if ( url.startsWith( 'http' ) ) {
+		return url;
+	}
+	return `${ protocol }://${ url }`;
+}
+
 export function formatSlugToURL( inputUrl: string ) {
 	if ( ! inputUrl ) {
 		return '';

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -167,6 +167,7 @@ export class ImportEverything extends SectionMigrate {
 		if ( targetSite && targetSite.is_wpcom_staging_site ) {
 			return (
 				<NotAuthorized
+					type="target-site-staging"
 					onStartBuilding={ () => {
 						recordTracksEvent( 'calypso_site_importer_skip_to_dashboard', {
 							from: 'target-staging',
@@ -191,12 +192,6 @@ export class ImportEverything extends SectionMigrate {
 					startImport={ this.startMigration }
 					navigateToVerifyEmailStep={ () => stepNavigator.goToVerifyEmailPage?.() }
 					onContentOnlyClick={ onContentOnlySelection }
-					onNotAuthorizedClick={ () => {
-						recordTracksEvent( 'calypso_site_importer_skip_to_dashboard', {
-							from: 'pre-migration',
-						} );
-						stepNavigator?.goToDashboardPage();
-					} }
 				/>
 			</>
 		);

--- a/client/blocks/importer/wordpress/import-everything/migration-error/hint-jetpack-connection-move-plugin.tsx
+++ b/client/blocks/importer/wordpress/import-everything/migration-error/hint-jetpack-connection-move-plugin.tsx
@@ -1,0 +1,69 @@
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useTranslate } from 'i18n-calypso';
+
+interface Props {
+	sourceSiteUrl: string;
+}
+export const HintJetpackConnectionMovePlugin = ( props: Props ) => {
+	const translate = useTranslate();
+	const { sourceSiteUrl } = props;
+
+	return (
+		<div className="migration-error--hint">
+			<p>
+				{ translate(
+					'Looks like the Jetpack connection is broken on your {{a}}source site{{/a}}. To fix that, you’ll just need to:',
+					{
+						components: {
+							a: <a href={ `${ sourceSiteUrl }/wp-admin` } target="_blank" rel="noreferrer" />,
+						},
+					}
+				) }
+			</p>
+			<ol>
+				<li>
+					{ translate(
+						"Check that your Jetpack connection is working properly by heading to the 'Connection' options in your {{linkA}}My Jetpack menu{{/linkA}}. You'll want to make sure that both site and user show a 'connected' status and that the user account is the same for the {{linkB}}source{{/linkB}} and the one you are logged in on {{linkC}}WordPress.com{{/linkC}}.",
+						{
+							components: {
+								linkA: (
+									<a
+										href={ `${ sourceSiteUrl }/wp-admin/admin.php?page=my-jetpack` }
+										target="_blank"
+										rel="noreferrer"
+									/>
+								),
+								linkB: (
+									<a
+										href={ `${ sourceSiteUrl }/wp-admin/users.php` }
+										target="_blank"
+										rel="noreferrer"
+									/>
+								),
+								linkC: <a href="https://wordpress.com" target="_blank" rel="noreferrer" />,
+							},
+						}
+					) }
+				</li>
+				<li>
+					{ translate(
+						'If you still can’t establish a Jetpack connection, please follow {{a}}these instructions{{/a}}.',
+						{
+							components: {
+								a: (
+									<a
+										href={ localizeUrl(
+											'https://jetpack.com/support/getting-started-with-jetpack/fixing-jetpack-connection-issues/'
+										) }
+										target="_blank"
+										rel="noreferrer"
+									/>
+								),
+							},
+						}
+					) }
+				</li>
+			</ol>
+		</div>
+	);
+};

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -202,7 +202,8 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 					type="source-site-not-connected"
 					sourceSiteUrl={ sourceSiteUrl }
 					targetSiteUrl={ targetSite.URL }
-					startImport={ startImport }
+					// After resolving the issue, we need to reload the page to re-fetch initial data
+					startImport={ () => window.location.reload() }
 				/>
 			);
 

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -32,7 +32,6 @@ interface PreMigrationProps {
 	startImport: ( props?: StartImportTrackingProps ) => void;
 	navigateToVerifyEmailStep: () => void;
 	onContentOnlyClick: () => void;
-	onNotAuthorizedClick: () => void;
 }
 
 export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = (
@@ -48,7 +47,6 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		startImport,
 		navigateToVerifyEmailStep,
 		onContentOnlyClick,
-		onNotAuthorizedClick,
 	} = props;
 
 	const translate = useTranslate();
@@ -201,8 +199,10 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 		case 'not-authorized':
 			return (
 				<NotAuthorized
-					onStartBuilding={ onNotAuthorizedClick }
-					onStartBuildingText={ translate( 'Skip to dashboard' ) }
+					type="source-site-not-connected"
+					sourceSiteUrl={ sourceSiteUrl }
+					targetSiteUrl={ targetSite.URL }
+					startImport={ startImport }
 				/>
 			);
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
@@ -69,6 +69,7 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 			return (
 				<NotAuthorized
 					type="source-site-not-connected-move-plugin"
+					sourceSiteUrl={ sourceSiteSlug }
 					startImport={ () => window.location.reload() }
 				/>
 			);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
@@ -12,7 +12,6 @@ import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { ONBOARD_STORE, USER_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { triggerMigrationStartingEvent } from 'calypso/my-sites/migrate/helpers';
-import { redirect } from '../import/util';
 import type { Step } from '../../types';
 import type { UserSelect } from '@automattic/data-stores';
 import './styles.scss';
@@ -65,17 +64,12 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 		return __( 'Scanning your site' );
 	};
 
-	const skipToDashboard = () => {
-		recordTracksEvent( 'calypso_importer_migration_skip_to_dashboard' );
-		return redirect( '/' );
-	};
-
 	const renderContent = () => {
 		if ( isUnAuthorized ) {
 			return (
 				<NotAuthorized
-					onStartBuilding={ skipToDashboard }
-					onStartBuildingText={ __( 'Skip to dashboard' ) }
+					type="source-site-not-connected-move-plugin"
+					startImport={ () => window.location.reload() }
 				/>
 			);
 		}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/index.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
 import { useEffect, useState } from 'react';
 import NotAuthorized from 'calypso/blocks/importer/components/not-authorized';
+import { addProtocolToUrl } from 'calypso/blocks/importer/util';
 import DocumentHead from 'calypso/components/data/document-head';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { useSourceMigrationStatusQuery } from 'calypso/data/site-migration/use-source-migration-status-query';
@@ -69,7 +70,7 @@ const MigrationHandler: Step = function MigrationHandler( { navigation } ) {
 			return (
 				<NotAuthorized
 					type="source-site-not-connected-move-plugin"
-					sourceSiteUrl={ sourceSiteSlug }
+					sourceSiteUrl={ addProtocolToUrl( sourceSiteSlug ) }
 					startImport={ () => window.location.reload() }
 				/>
 			);

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/test/index.test.tsx
@@ -124,7 +124,6 @@ describe( 'MigrationHandlerStep', () => {
 		await waitFor( () => {
 			expect( jest.spyOn( navigation, 'submit' ) ).not.toHaveBeenCalled();
 			expect( screen.getByText( "We couldn't start the migration" ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Try again.' ) ).toBeInTheDocument();
 		} );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/test/index.test.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/migration-handler/test/index.test.tsx
@@ -123,8 +123,8 @@ describe( 'MigrationHandlerStep', () => {
 
 		await waitFor( () => {
 			expect( jest.spyOn( navigation, 'submit' ) ).not.toHaveBeenCalled();
-			expect( screen.getByText( 'You are not authorized to import content' ) ).toBeInTheDocument();
-			expect( screen.getByText( 'Please check with your site admin.' ) ).toBeInTheDocument();
+			expect( screen.getByText( "We couldn't start the migration" ) ).toBeInTheDocument();
+			expect( screen.getByText( 'Try again.' ) ).toBeInTheDocument();
 		} );
 	} );
 } );


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/86943
Closes https://github.com/Automattic/dotcom-forge/issues/3548

## Proposed Changes

* Extended NotAuthorized component with handling different use cases
* Handled case when "target site is a staging"
* Handled case when "jetpack connection is broken"
* Handled case when "jetpack connection is broken" on self-hosted site with Move to WPCOM plugin installed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/import-focused?siteSlug={STAGING_SITE_SLUG}`
* Enter a self-hosted website (can be JN)
* Pass through the flow
* Check if there is a message with the title "You are not authorized to perform migration on the staging site"

**Generic**
<img width="934" alt="Screenshot 2024-02-01 at 13 55 03" src="https://github.com/Automattic/wp-calypso/assets/1241413/88a9c156-0d58-4373-839b-e5fcb79108c9">

**Target site is a staging**
<img width="816" alt="Screenshot 2024-02-01 at 12 44 51" src="https://github.com/Automattic/wp-calypso/assets/1241413/7b6921b5-245c-4fda-a62a-d8930dd75613">

**Source site jetpack connection is broken**
<img width="918" alt="Screenshot 2024-02-01 at 13 40 52" src="https://github.com/Automattic/wp-calypso/assets/1241413/af9fbffa-982d-4c56-8066-eee8bb05b127">

**Source site jetpack connection is broken on self-hosted site with Move to WPCOM plugin installed**
<img width="933" alt="Screenshot 2024-02-02 at 12 06 10" src="https://github.com/Automattic/wp-calypso/assets/1241413/551c0f1a-6965-40e8-92d2-9b804a696f39">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?