### PR TITLE
feat(developer): show dev survey for all locales

### DIFF
--- a/client/me/developer/main.jsx
+++ b/client/me/developer/main.jsx
@@ -25,6 +25,12 @@ class Developer extends Component {
 	developerSurveyNoticeId = 'developer-survey';
 
 	getSurveyHref = () => {
+		const isES = this.props.currentUser.localeSlug === 'es';
+
+		if ( isES ) {
+			return 'https://wordpressdotcom.survey.fm/developer-survey-es';
+		}
+
 		return 'https://wordpressdotcom.survey.fm/developer-survey';
 	};
 
@@ -39,12 +45,9 @@ class Developer extends Component {
 		const cookies = cookie.parse( document.cookie );
 
 		const isDevAccountEnabled = isDevAccount ?? this.props.getSetting( 'is_dev_account' );
-		const isEN = this.props.currentUser.localeSlug === 'en';
 
 		return (
-			isEN &&
-			isDevAccountEnabled &&
-			! [ 'completed', 'dismissed' ].includes( cookies.developer_survey )
+			isDevAccountEnabled && ! [ 'completed', 'dismissed' ].includes( cookies.developer_survey )
 		);
 	};
 


### PR DESCRIPTION


Related to https://github.com/orgs/Automattic/projects/865/views/1?pane=issue&itemId=51831686

## Proposed Changes
Before we launched dev survey ONLY for users with EN locale.
Since ES lang dev survey is ready, and by the end of this week we will have translations for other locales - we are going to show it for every locale.

## Testing Instructions
1. Remove `developer_survey` cookie
2. Open `http://calypso.localhost:3000/me/developer`
2. Turn on `I am a developer`
3. Assert that you see notice for dev survey
4. Open `http://calypso.localhost:3000/me/account`
5. Set ES lang
6. Reload `http://calypso.localhost:3000/me/developer`
7. Assert that you see dev survey notice with `-es` postfix in URL
5. Set any other lang
6. Reload `http://calypso.localhost:3000/me/developer`
7. Assert that you see dev survey notice (before it was available only for EN)