### PR TITLE
Jetpack Manage: Pricing page - Fix multi select options in product and plan cards generating console errors

### DIFF
--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/featured-license-multi-item-card.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/featured-license-multi-item-card.tsx
@@ -1,7 +1,5 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
-import 'calypso/my-sites/plans/jetpack-plans/product-store/featured-item-card/style.scss';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useState } from 'react';
@@ -16,11 +14,14 @@ import LicenseLightbox from 'calypso/jetpack-cloud/sections/partner-portal/licen
 import LicenseLightboxLink from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox-link/index';
 import { HeroImageAPIFamily } from 'calypso/my-sites/plans/jetpack-plans/product-store/hero-image';
 import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { ItemPrice } from './item-price';
+
 import './style.scss';
+import 'calypso/my-sites/plans/jetpack-plans/product-store/featured-item-card/style.scss';
 
 type FeaturedLicenseMultiItemCardProps = {
 	variants: APIProductFamilyProduct[];

--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/simple-license-multi-item-card.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/simple-license-multi-item-card.tsx
@@ -1,4 +1,3 @@
-import { recordTracksEvent } from '@automattic/calypso-analytics';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
 import { addQueryArgs } from '@wordpress/url';
@@ -15,10 +14,12 @@ import getProductVariantShortTitle from 'calypso/jetpack-cloud/sections/partner-
 import LicenseLightbox from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox/index';
 import LicenseLightboxLink from 'calypso/jetpack-cloud/sections/partner-portal/license-lightbox-link/index';
 import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
 import { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 import { ItemPrice } from './item-price';
+
 import 'calypso/my-sites/plans/jetpack-plans/product-store/simple-item-card/style.scss';
 import './style.scss';
 


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/265

## Proposed Changes

* This PR fixes the import of `recordTracksEvent` to stop generating console errors.

## Testing Instructions

* Open up `http://jetpack.cloud.localhost:3000/manage/pricing`
* Select `Single license` in the licenses selector
* Change the `Security` variant (`10GB` and `1TB`)
* Change the `VaultPress Backup` variant (`10GB` and `1TB`)
* Check if the track events are still being generated.

In `trunk` you will see console errors.
In `fix/265-jetpack-manage-pricing-page-multi-select-generating-errors` there will be no errors

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?