### PR TITLE
fix: adjusted woo express plan title copy

### DIFF
--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -543,20 +543,19 @@ export const FEATURES_LIST: FeatureList = {
 
 	[ WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED ]: {
 		getSlug: () => WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
-		getTitle: ( { planSlug = undefined } = { planSlug: undefined } ) => {
+		getTitle: ( { planSlug = undefined } = {} ) => {
 			if ( planSlug && isWooExpressPlan( planSlug ) ) {
 				return i18n.translate( 'Beautiful themes' );
 			}
 			return i18n.translate( 'Unlimited premium themes' );
 		},
-		getDescription: () => {
+		getDescription: ( { planSlug = undefined } = {} ) => {
 			if ( planSlug && isWooExpressPlan( planSlug ) ) {
 				return i18n.translate( 'Switch between a collection of beautiful themes.' );
 			}
-        }
-		return i18n.translate( 'Switch between all of our premium design themes.' );
+			return i18n.translate( 'Switch between all of our premium design themes.' );
+		},
 	},
-
 	[ WPCOM_FEATURES_PREMIUM_THEMES_LIMITED ]: {
 		getSlug: () => WPCOM_FEATURES_PREMIUM_THEMES_LIMITED,
 		getTitle: () => i18n.translate( 'Dozens of premium themes' ),
@@ -676,7 +675,7 @@ export const FEATURES_LIST: FeatureList = {
 			i18n.translate( 'Free .blog Domain for one year', {
 				context: 'title',
 			} ),
-		getDescription: ( { domainName = undefined } = { domainName: undefined } ) => {
+		getDescription: ( { domainName = undefined } = {} ) => {
 			if ( domainName ) {
 				return i18n.translate( 'Your domain (%s) is included with this plan.', {
 					args: domainName,
@@ -691,7 +690,7 @@ export const FEATURES_LIST: FeatureList = {
 
 	[ FEATURE_CUSTOM_DOMAIN ]: {
 		getSlug: () => FEATURE_CUSTOM_DOMAIN,
-		getTitle: ( { domainName = undefined } = { domainName: undefined } ) => {
+		getTitle: ( { domainName = undefined } = {} ) => {
 			if ( domainName ) {
 				return i18n.translate( '%(domainName)s is included', {
 					args: { domainName },
@@ -703,7 +702,7 @@ export const FEATURES_LIST: FeatureList = {
 			} );
 		},
 		getAlternativeTitle: () => i18n.translate( 'Free custom domain' ),
-		getDescription: ( { domainName = undefined } = { domainName: undefined } ) => {
+		getDescription: ( { domainName = undefined } = {} ) => {
 			if ( domainName ) {
 				return i18n.translate( 'Your domain (%s) is included with this plan.', {
 					args: domainName,

--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -312,6 +312,7 @@ import {
 	FEATURE_SENSEI_JETPACK,
 	WPCOM_FEATURES_PREMIUM_THEMES_LIMITED,
 	WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
+	isWooExpressPlan,
 } from '@automattic/calypso-products';
 import { englishLocales, localizeUrl } from '@automattic/i18n-utils';
 import i18n from 'i18n-calypso';
@@ -542,8 +543,18 @@ export const FEATURES_LIST: FeatureList = {
 
 	[ WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED ]: {
 		getSlug: () => WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
-		getTitle: () => i18n.translate( 'Unlimited premium themes' ),
-		getDescription: () => i18n.translate( 'Switch between all of our premium design themes.' ),
+		getTitle: ( { planSlug = undefined } = { planSlug: undefined } ) => {
+			if ( planSlug && isWooExpressPlan( planSlug ) ) {
+				return i18n.translate( 'Beautiful themes' );
+			}
+			return i18n.translate( 'Unlimited premium themes' );
+		},
+		getDescription: () => {
+			if ( planSlug && isWooExpressPlan( planSlug ) ) {
+				return i18n.translate( 'Switch between a collection of beautiful themes.' );
+			}
+        }
+		return i18n.translate( 'Switch between all of our premium design themes.' );
 	},
 
 	[ WPCOM_FEATURES_PREMIUM_THEMES_LIMITED ]: {
@@ -665,7 +676,7 @@ export const FEATURES_LIST: FeatureList = {
 			i18n.translate( 'Free .blog Domain for one year', {
 				context: 'title',
 			} ),
-		getDescription: ( domainName?: string ) => {
+		getDescription: ( { domainName = undefined } = { domainName: undefined } ) => {
 			if ( domainName ) {
 				return i18n.translate( 'Your domain (%s) is included with this plan.', {
 					args: domainName,
@@ -680,7 +691,7 @@ export const FEATURES_LIST: FeatureList = {
 
 	[ FEATURE_CUSTOM_DOMAIN ]: {
 		getSlug: () => FEATURE_CUSTOM_DOMAIN,
-		getTitle: ( domainName?: string ) => {
+		getTitle: ( { domainName = undefined } = { domainName: undefined } ) => {
 			if ( domainName ) {
 				return i18n.translate( '%(domainName)s is included', {
 					args: { domainName },
@@ -692,7 +703,7 @@ export const FEATURES_LIST: FeatureList = {
 			} );
 		},
 		getAlternativeTitle: () => i18n.translate( 'Free custom domain' ),
-		getDescription: ( domainName?: string ) => {
+		getDescription: ( { domainName = undefined } = { domainName: undefined } ) => {
 			if ( domainName ) {
 				return i18n.translate( 'Your domain (%s) is included with this plan.', {
 					args: domainName,

--- a/client/my-sites/plans/current-plan/trials/ecommerce-trial-included.tsx
+++ b/client/my-sites/plans/current-plan/trials/ecommerce-trial-included.tsx
@@ -27,11 +27,11 @@ const ECommerceTrialIncluded: FunctionComponent< Props > = ( props ) => {
 			buttonText: translate( 'Ask a question' ),
 		},
 		{
-			title: translate( 'Premium themes' ),
+			title: translate( 'Beautiful themes' ),
 			text: translate( 'Choose from a wide selection of beautifully designed themes.' ),
 			illustration: premiumThemes,
 			showButton: true,
-			buttonText: translate( 'Browse premium themes' ),
+			buttonText: translate( 'Browse beautiful themes' ),
 		},
 		{
 			title: translate( 'Simple customization' ),

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -36,11 +36,11 @@ export type Feature = string;
 
 export type FeatureObject = {
 	getSlug: () => string;
-	getTitle: ( domainName?: string ) => TranslateResult;
+	getTitle: ( params?: { domainName?: string; planSlug?: string } ) => TranslateResult;
 	getAlternativeTitle?: () => TranslateResult;
 	getConditionalTitle?: ( planSlug?: string ) => TranslateResult;
 	getHeader?: () => TranslateResult;
-	getDescription?: ( domainName?: string ) => TranslateResult;
+	getDescription?: ( params?: { domainName?: string; planSlug?: string } ) => TranslateResult;
 	getStoreSlug?: () => string;
 	getCompareTitle?: () => TranslateResult;
 	getCompareSubtitle?: () => TranslateResult;

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -6,6 +6,7 @@ import {
 	getWooExpressFeaturesGrouped,
 	FEATURE_GROUP_PAYMENT_TRANSACTION_FEES,
 	getPlans,
+	PLAN_WOOEXPRESS_MEDIUM_MONTHLY,
 } from '@automattic/calypso-products';
 import { Gridicon, JetpackLogo } from '@automattic/components';
 import { css } from '@emotion/react';
@@ -750,6 +751,9 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 	const featureSlug = feature?.getSlug() ?? '';
 	const footnote = planFeatureFootnotes?.footnotesByFeature?.[ featureSlug ];
 	const tooltipId = `${ feature?.getSlug() }-comparison-grid`;
+	const hasWooExpressPlans = visibleGridPlans.some( ( { planSlug } ) =>
+		isWooExpressPlan( planSlug )
+	);
 
 	return (
 		<Row
@@ -776,12 +780,16 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 						{ feature && (
 							<>
 								<Plans2023Tooltip
-									text={ feature.getDescription?.() }
+									text={ feature.getDescription?.( {
+										planSlug: hasWooExpressPlans ? PLAN_WOOEXPRESS_MEDIUM_MONTHLY : undefined,
+									} ) }
 									setActiveTooltipId={ setActiveTooltipId }
 									activeTooltipId={ activeTooltipId }
 									id={ tooltipId }
 								>
-									{ feature.getTitle() }
+									{ feature.getTitle( {
+										planSlug: hasWooExpressPlans ? PLAN_WOOEXPRESS_MEDIUM_MONTHLY : undefined,
+									} ) }
 									{ footnote && (
 										<FeatureFootnote>
 											<sup>{ footnote }</sup>

--- a/packages/plans-grid-next/src/components/features.tsx
+++ b/packages/plans-grid-next/src/components/features.tsx
@@ -130,12 +130,12 @@ const PlanFeatures2023GridFeatures: React.FC< {
 										</Plans2023Tooltip>
 									) : (
 										<Plans2023Tooltip
-											text={ currentFeature.getDescription?.() }
+											text={ currentFeature.getDescription?.( { planSlug } ) }
 											activeTooltipId={ activeTooltipId }
 											setActiveTooltipId={ setActiveTooltipId }
 											id={ key }
 										>
-											{ currentFeature.getTitle( paidDomainName ) }
+											{ currentFeature.getTitle( { domainName: paidDomainName, planSlug } ) }
 										</Plans2023Tooltip>
 									) }
 								</span>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/80809

## Proposed Changes

* Modified `getTitle()` and `getDescription()` calls in the plans page such that they pass in `domainName` and `planSlug` as keys in the object
* Adjusted copy for Woo Express theme feature since it does not actually display any premium themes

Note: I could not find any instance of `getDescription()` being called with `domainName` even before this PR, even though there are feature definitions with `getDescription()` functions that seem to accept it being called with `domainName`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Setup and run this PR
* Open a few different test sites, with plans active such as Woo Express Free trial, Woo Express Performance, WPCOM free trial, other WPCOM plans
* Go to `http://calypso.localhost:3000/plans/<siteSlug>`, e.g: `http://calypso.localhost:3000/plans/woo-speedily-stupendous-giver.wpcomstaging.com`
* Observe that the copy shows "Beautiful Themes" for Woo Express plans and "Unlimited Premium Themes" otherwise.
* Observe that the free domain feature title still renders correctly (ensure no regression because we changed the parameter from a positional string param to an object)

<img width="819" alt="image" src="https://github.com/Automattic/wp-calypso/assets/27843274/f1d6bdf6-104a-40bf-8299-06026b3bf3b7">
<img width="1103" alt="image" src="https://github.com/Automattic/wp-calypso/assets/27843274/76a602b7-c276-4ffa-9693-75c95a33b456">
<img width="1049" alt="image" src="https://github.com/Automattic/wp-calypso/assets/27843274/fdb36a5b-9431-438d-9d47-df07d5408099">
<img width="1012" alt="image" src="https://github.com/Automattic/wp-calypso/assets/27843274/4c2ece06-c038-44e6-b446-bd0fd16cbcae">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?