### PR TITLE
Jetpack Manage: Pricing page - Modifying default bundleSize for Addons and Woo Extensions

### DIFF
--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/index.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/index.tsx
@@ -14,10 +14,18 @@ export const LicenseProductsList = ( { bundleSize }: ProductsListProps ) => {
 	const selectedSite = null;
 	const usePublicQuery = true;
 
-	const { plans, backupAddons, products, wooExtensions } = useProductAndPlans( {
+	const { plans, products } = useProductAndPlans( {
 		selectedSite,
 		selectedProductFilter,
 		selectedBundleSize: bundleSize,
+		productSearchQuery,
+		usePublicQuery,
+	} );
+
+	const { backupAddons, wooExtensions } = useProductAndPlans( {
+		selectedSite,
+		selectedProductFilter,
+		selectedBundleSize: 1,
 		productSearchQuery,
 		usePublicQuery,
 	} );


### PR DESCRIPTION
## Proposed Changes

* The bundleSizes now have a default of 5, which has affected the Backup Addons and Woo Extensions (they won't show unless a bundleSize of 1 is selected).

## Testing Instructions

* To test, in trunk visit `http://jetpack.cloud.localhost:3000/manage/pricing`. Notice no cards show by default for Woo Extensions and Backup Add-ons, unless you selected 1 as the license bundlesize.
* Checkout this branch, and the cards should show regardless. They are not meant to increase in price as bundleSizes increase. See design specs at pf36In-Gb-p2.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?