### PR TITLE
Revert "Theme Tiers: Release Starter Themes on Live Preview"

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import {
 	FEATURE_WOOP,
 	WPCOM_FEATURES_ATOMIC,
@@ -138,7 +139,12 @@ export const useCanPreviewButNeedUpgrade = (
 
 	const handleCanPreviewButNeedUpgrade = useCallback(
 		( previewingTheme: ReturnType< typeof usePreviewingTheme > ) => {
-			const livePreviewUpgradeTypes = [ WOOCOMMERCE_THEME, PREMIUM_THEME, PERSONAL_THEME ];
+			const livePreviewUpgradeTypes = [ WOOCOMMERCE_THEME, PREMIUM_THEME ];
+
+			// @TODO Remove this check once Theme Tiers is live. This feature check can't be enabled.
+			if ( config.isEnabled( 'themes/tiers' ) ) {
+				livePreviewUpgradeTypes.push( PERSONAL_THEME );
+			}
 
 			/**
 			 * Currently, Live Preview only supports upgrades for WooCommerce and Premium themes.

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { getPlan, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useState, useMemo } from 'react';
@@ -27,14 +28,26 @@ const getThemeType = ( theme?: Theme ) => {
 		return PREMIUM_THEME;
 	}
 
-	return theme?.theme_tier?.slug ?? undefined;
+	// @TODO Replace all the logic above with the following code once Theme Tiers is live.
+	if ( config.isEnabled( 'themes/tiers' ) ) {
+		return theme?.theme_tier?.slug ?? undefined;
+	}
+
+	return undefined;
 };
 
 /**
  * Get the theme required feature.
  * This only support WooCommerce and Premium themes.
  */
-const getThemeFeature = ( theme?: Theme ) => theme?.theme_tier?.feature ?? undefined;
+const getThemeFeature = ( theme?: Theme ) => {
+	// @TODO Once theme tiers is live we'll need to refactor use-can-preview-but-need-upgrade's checkNeedUpgrade function.
+	if ( config.isEnabled( 'themes/tiers' ) ) {
+		return theme?.theme_tier?.feature ?? undefined;
+	}
+
+	return undefined;
+};
 
 export const usePreviewingThemeSlug = () => {
 	const location = useLocation();
@@ -69,13 +82,13 @@ export const usePreviewingTheme = () => {
 	let previewingThemePlan;
 	switch ( previewingThemeType ) {
 		case WOOCOMMERCE_THEME:
-			previewingThemePlan = getPlan( PLAN_BUSINESS )?.getTitle();
+			previewingThemePlan = getPlan( PLAN_BUSINESS ).getTitle();
 			break;
 		case PREMIUM_THEME:
-			previewingThemePlan = getPlan( PLAN_PREMIUM )?.getTitle();
+			previewingThemePlan = getPlan( PLAN_PREMIUM ).getTitle();
 			break;
 		case PERSONAL_THEME:
-			previewingThemePlan = getPlan( PLAN_PERSONAL )?.getTitle();
+			previewingThemePlan = getPlan( PLAN_PERSONAL ).getTitle();
 			break;
 	}
 


### PR DESCRIPTION
Reverts Automattic/wp-calypso#86539