### PR TITLE
Add legacy upgrade check for jetpack

### DIFF
--- a/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/billing-period.jsx
@@ -40,7 +40,9 @@ export class PlanBillingPeriod extends Component {
 				'/checkout/' +
 				purchase.domain +
 				'/' +
-				yearlyPlanSlug
+				yearlyPlanSlug +
+				'?upgrade_from=' +
+				purchase.productSlug
 		);
 	};
 

--- a/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
+++ b/client/me/purchases/manage-purchase/plan-details/test/billing-period.jsx
@@ -47,7 +47,9 @@ describe( 'PlanBillingPeriod', () => {
 			render( <PlanBillingPeriod { ...props } /> );
 			const btn = screen.getByRole( 'button', { name: /upgrade/i } );
 			fireEvent.click( btn );
-			expect( page ).toHaveBeenCalledWith( '/checkout/site.com/jetpack_premium' );
+			expect( page ).toHaveBeenCalledWith(
+				'/checkout/site.com/jetpack_premium?upgrade_from=jetpack_premium_monthly'
+			);
 		} );
 
 		it( 'should display a message instead of the upgrade button for a disconnected site', () => {

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -1,4 +1,4 @@
-import { isJetpackLegacyItem } from '@automattic/calypso-products';
+import { isJetpackLegacyItem, isJetpackLegacyTermUpgrade } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
@@ -22,6 +22,7 @@ import {
 	getCurrentUserVisibleSiteCount,
 	isUserLoggedIn,
 } from 'calypso/state/current-user/selectors';
+import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import {
 	COMPARE_PLANS_QUERY_PARAM,
@@ -243,10 +244,11 @@ export function checkout( context, next ) {
 
 export function redirectJetpackLegacyPlans( context, next ) {
 	const product = getProductSlugFromContext( context );
+	const state = context.store.getState();
+	const selectedSite = getSelectedSite( state );
+	const sitePurchases = selectedSite ? getSitePurchases( state, selectedSite.id ) : [];
 
-	if ( isJetpackLegacyItem( product ) ) {
-		const state = context.store.getState();
-		const selectedSite = getSelectedSite( state );
+	if ( isJetpackLegacyItem( product ) && ! isJetpackLegacyTermUpgrade( product, sitePurchases ) ) {
 		const recommendedItems = LEGACY_TO_RECOMMENDED_MAP[ product ].join( ',' );
 
 		page(

--- a/client/my-sites/checkout/controller.jsx
+++ b/client/my-sites/checkout/controller.jsx
@@ -6,6 +6,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import { setSectionMiddleware } from 'calypso/controller';
 import { CALYPSO_PLANS_PAGE } from 'calypso/jetpack-connect/constants';
 import { MARKETING_COUPONS_KEY } from 'calypso/lib/analytics/utils';
+import { getQueryArgs } from 'calypso/lib/query-args';
 import { addQueryArgs } from 'calypso/lib/url';
 import LicensingThankYouAutoActivation from 'calypso/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation';
 import LicensingThankYouAutoActivationCompleted from 'calypso/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation-completed';
@@ -22,7 +23,6 @@ import {
 	getCurrentUserVisibleSiteCount,
 	isUserLoggedIn,
 } from 'calypso/state/current-user/selectors';
-import { getSitePurchases } from 'calypso/state/purchases/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import {
 	COMPARE_PLANS_QUERY_PARAM,
@@ -246,9 +246,9 @@ export function redirectJetpackLegacyPlans( context, next ) {
 	const product = getProductSlugFromContext( context );
 	const state = context.store.getState();
 	const selectedSite = getSelectedSite( state );
-	const sitePurchases = selectedSite ? getSitePurchases( state, selectedSite.id ) : [];
+	const upgradeFrom = getQueryArgs()?.upgrade_from;
 
-	if ( isJetpackLegacyItem( product ) && ! isJetpackLegacyTermUpgrade( product, sitePurchases ) ) {
+	if ( isJetpackLegacyItem( product ) && ! isJetpackLegacyTermUpgrade( product, upgradeFrom ) ) {
 		const recommendedItems = LEGACY_TO_RECOMMENDED_MAP[ product ].join( ',' );
 
 		page(

--- a/client/my-sites/checkout/test/controller.js
+++ b/client/my-sites/checkout/test/controller.js
@@ -50,7 +50,7 @@ describe( 'redirectJetpackLegacyPlans', () => {
 	it( 'should not redirect if the plan is not a Jetpack legacy plan', () => {
 		utils.getProductSlugFromContext.mockReturnValue( PRODUCT_JETPACK_BACKUP_T1_YEARLY );
 
-		redirectJetpackLegacyPlans( {}, next );
+		redirectJetpackLegacyPlans( { store }, next );
 
 		expect( spy ).not.toHaveBeenCalled();
 		expect( next ).toHaveBeenCalled();

--- a/packages/calypso-products/src/constants/jetpack.ts
+++ b/packages/calypso-products/src/constants/jetpack.ts
@@ -445,6 +445,19 @@ export const JETPACK_LEGACY_PLANS = < const >[
 	PLAN_JETPACK_PREMIUM,
 	PLAN_JETPACK_PREMIUM_MONTHLY,
 ];
+
+export const JETPACK_MONTHLY_LEGACY_PLANS = < const >[
+	PLAN_JETPACK_PERSONAL_MONTHLY,
+	PLAN_JETPACK_BUSINESS_MONTHLY,
+	PLAN_JETPACK_PREMIUM_MONTHLY,
+];
+
+export const JETPACK_YEARLY_LEGACY_PLANS = < const >[
+	PLAN_JETPACK_PERSONAL,
+	PLAN_JETPACK_BUSINESS,
+	PLAN_JETPACK_PREMIUM,
+];
+
 export const JETPACK_LEGACY_PLANS_MAX_PLUGIN_VERSION = '8.9.1'; // Jetpack versions prior to this one are not fully compatible with new plans
 
 // Security

--- a/packages/calypso-products/src/is-jetpack-legacy-term-upgrade.tsx
+++ b/packages/calypso-products/src/is-jetpack-legacy-term-upgrade.tsx
@@ -4,24 +4,15 @@ import type {
 	JetpackYearlyLegacyPlanSlug,
 	JetpackMonthlyLegacyPlanSlug,
 } from './types';
-// eslint-disable-next-line no-restricted-imports
-import type { Purchase } from 'calypso/lib/purchases/types';
 
 export default function isJetpackLegacyTermUpgrade(
 	itemSlug: string,
-	purchases: Array< Purchase >[]
+	upgradeFrom: string
 ): itemSlug is JetpackLegacyPlanSlug {
-	const purchaseSlugs = purchases.map( ( purchase: Purchase ) => {
-		return purchase.product_slug;
-	} );
-	const monthlyLegacyPurchases = purchaseSlugs.filter( ( purchase_slug: string ) => {
-		return JETPACK_MONTHLY_LEGACY_PLANS.includes( purchase_slug as JetpackMonthlyLegacyPlanSlug );
-	} );
-
 	// If the item the user is upgrading to is a yearly plan and they already have a monthly legacy plan
 	// This is not perfect since it does not check if the monthly and yearly plan are of the same type, but it will cover most cases
 	return (
 		JETPACK_YEARLY_LEGACY_PLANS.includes( itemSlug as JetpackYearlyLegacyPlanSlug ) &&
-		monthlyLegacyPurchases.length > 0
+		JETPACK_MONTHLY_LEGACY_PLANS.includes( upgradeFrom as JetpackMonthlyLegacyPlanSlug )
 	);
 }

--- a/packages/calypso-products/src/is-jetpack-legacy-term-upgrade.tsx
+++ b/packages/calypso-products/src/is-jetpack-legacy-term-upgrade.tsx
@@ -1,0 +1,27 @@
+import { JETPACK_MONTHLY_LEGACY_PLANS, JETPACK_YEARLY_LEGACY_PLANS } from './constants';
+import type {
+	JetpackLegacyPlanSlug,
+	JetpackYearlyLegacyPlanSlug,
+	JetpackMonthlyLegacyPlanSlug,
+} from './types';
+// eslint-disable-next-line no-restricted-imports
+import type { Purchase } from 'calypso/lib/purchases/types';
+
+export default function isJetpackLegacyTermUpgrade(
+	itemSlug: string,
+	purchases: Array< Purchase >[]
+): itemSlug is JetpackLegacyPlanSlug {
+	const purchaseSlugs = purchases.map( ( purchase: Purchase ) => {
+		return purchase.product_slug;
+	} );
+	const monthlyLegacyPurchases = purchaseSlugs.filter( ( purchase_slug: string ) => {
+		return JETPACK_MONTHLY_LEGACY_PLANS.includes( purchase_slug as JetpackMonthlyLegacyPlanSlug );
+	} );
+
+	// If the item the user is upgrading to is a yearly plan and they already have a monthly legacy plan
+	// This is not perfect since it does not check if the monthly and yearly plan are of the same type, but it will cover most cases
+	return (
+		JETPACK_YEARLY_LEGACY_PLANS.includes( itemSlug as JetpackYearlyLegacyPlanSlug ) &&
+		monthlyLegacyPurchases.length > 0
+	);
+}

--- a/packages/calypso-products/src/product-values.ts
+++ b/packages/calypso-products/src/product-values.ts
@@ -111,6 +111,7 @@ export { isJetpackBoostSlug } from './is-jetpack-boost-slug';
 export { isJetpackVideoPressSlug } from './is-jetpack-videopress-slug';
 export { isJetpackCreatorSlug } from './is-jetpack-creator-slug';
 export { default as isJetpackLegacyItem } from './is-jetpack-legacy-item';
+export { default as isJetpackLegacyTermUpgrade } from './is-jetpack-legacy-term-upgrade';
 export { default as isJetpackPurchasableItem } from './is-jetpack-purchasable-item';
 export * from './is-monthly';
 export { isNoAds } from './is-no-ads';

--- a/packages/calypso-products/src/types.ts
+++ b/packages/calypso-products/src/types.ts
@@ -9,6 +9,8 @@ import type {
 	PLAN_JETPACK_FREE,
 	JETPACK_PRODUCTS_LIST,
 	JETPACK_LEGACY_PLANS,
+	JETPACK_MONTHLY_LEGACY_PLANS,
+	JETPACK_YEARLY_LEGACY_PLANS,
 	JETPACK_RESET_PLANS,
 	TERMS_LIST,
 	PERIOD_LIST,
@@ -106,6 +108,8 @@ export type IncompleteWPcomPlan = Partial< WPComPlan > &
 // Jetpack
 export type JetpackProductSlug = ( typeof JETPACK_PRODUCTS_LIST )[ number ];
 export type JetpackLegacyPlanSlug = ( typeof JETPACK_LEGACY_PLANS )[ number ];
+export type JetpackYearlyLegacyPlanSlug = ( typeof JETPACK_YEARLY_LEGACY_PLANS )[ number ];
+export type JetpackMonthlyLegacyPlanSlug = ( typeof JETPACK_MONTHLY_LEGACY_PLANS )[ number ];
 export type JetpackResetPlanSlug = ( typeof JETPACK_RESET_PLANS )[ number ];
 export type JetpackPlanSlug =
 	| typeof PLAN_JETPACK_FREE


### PR DESCRIPTION
## Proposed Changes

* This PR allows for legacy Jetpack subscriptions to upgrade to a longer billing term - this action was blocked previously since new purchases of legacy plans are redirected.

## Testing Instructions

* Without this PR, obtain a test purchase for Jetpack Personal monthly
* From the purchase management screen in Calypso, click on the button that says "Switch to yearly billing"
* You will be redirected to a page that indicates the plan is no longer offered
* Now, with the PR applied, repeat the same steps.
* You should get to the cart with the yearly Jetpack Personal upgrade in the cart

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?