### PR TITLE
Automattic Components: Remove form label component shim

### DIFF
--- a/client/components/forms/form-label/index.tsx
+++ b/client/components/forms/form-label/index.tsx
@@ -1,8 +1,0 @@
-import { FormLabel } from '@automattic/components';
-
-// We're in the process of migrating to @automattic/components. Because of this, we're using this wrapper
-// component to point references to the old count component to the new one in @automattic/components.
-// This allows us to transition in smaller pieces and without risking updates to the old Calypso component in the interim.
-// See https://github.com/Automattic/martech/issues/2028 for more details.
-
-export default FormLabel;

--- a/client/devdocs/design/playground-scope.js
+++ b/client/devdocs/design/playground-scope.js
@@ -13,6 +13,7 @@ export {
 	SegmentedControl,
 	Suggestions,
 	FoldableCard,
+	FormLabel,
 	Tooltip,
 } from '@automattic/components';
 
@@ -51,7 +52,6 @@ export { default as FormCheckbox } from 'calypso/components/forms/form-checkbox'
 export { default as FormCountrySelect } from 'calypso/components/forms/form-country-select';
 export { default as FormCurrencyInput } from 'calypso/components/forms/form-currency-input';
 export { default as FormFieldset } from 'calypso/components/forms/form-fieldset';
-export { default as FormLabel } from 'calypso/components/forms/form-label';
 export { default as FormLegend } from 'calypso/components/forms/form-legend';
 export { default as FormPasswordInput } from 'calypso/components/forms/form-password-input';
 export { default as FormPhoneInput } from 'calypso/components/forms/form-phone-input';

--- a/client/my-sites/exporter/export-card/post-type-options.jsx
+++ b/client/my-sites/exporter/export-card/post-type-options.jsx
@@ -1,9 +1,8 @@
-import { Tooltip } from '@automattic/components';
+import { FormLabel as Label, Tooltip } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { PureComponent } from 'react';
 import { connect } from 'react-redux';
-import Label from 'calypso/components/forms/form-label';
 import FormRadio from 'calypso/components/forms/form-radio';
 import { setPostType } from 'calypso/state/exporter/actions';
 import {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/2028
Tracking issue https://github.com/Automattic/martech/issues/2023

## Proposed Changes
Following up on https://github.com/Automattic/wp-calypso/pull/87103, there are no more `client/components/form-label` references in Calypso. All instances of the form label component are now imported from @automattic/components.

Because of this, we remove the unused `client/components/form-label` directory and its contents.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Smoke test instances of the count component ( see https://github.com/Automattic/wp-calypso/pull/80350 )

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?