### PR TITLE
Shopping Cart: Remove hacks for introductory offer discounts

### DIFF
--- a/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
@@ -133,8 +133,7 @@ const useCalculatedDiscounts = () => {
 
 	// Coupon discount is added on top of other discounts
 	if ( product.coupon_savings_integer ) {
-		const couponRate =
-			product.coupon_savings_integer / product.item_subtotal_before_discounts_integer;
+		const couponRate = product.coupon_savings_integer / product.item_original_subtotal_integer;
 		priceBreakdown.push( {
 			label: __( 'Coupon' ),
 			priceInteger: biennial.priceInteger * couponRate,

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -44,7 +44,6 @@ export function getEmptyResponseCartProduct(): ResponseCartProduct {
 		item_original_cost_for_quantity_one_integer: 0,
 		item_original_monthly_cost_integer: 0,
 		item_subtotal_integer: 0,
-		item_subtotal_before_discounts_integer: 0,
 		item_original_subtotal_integer: 0,
 		is_included_for_100yearplan: false,
 		is_domain_registration: false,

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -371,21 +371,6 @@ export interface ResponseCartProduct {
 	item_original_monthly_cost_integer: number;
 
 	/**
-	 * The cart item's price before discounts with volume in the currency's
-	 * smallest unit. This is similar to `item_original_subtotal_integer`
-	 * except when it comes to introductory offers. Introductory offer
-	 * discounts are not cost overrides; they actually reassign the base cost
-	 * of the product. However, the shopping-cart endpoint then returns the
-	 * "original" cost of the cart item as the product without the introductory
-	 * offer. This is confusing because the introductory offer isn't really a
-	 * savings of any kind in terms of the way we track discounts. The savings
-	 * is only other kinds of discounts (eg: a coupon). In order to calculate
-	 * the actual savings, we need therefore to know the actual subtotal before
-	 * (non-introductory-offer) discounts. That's what this value is.
-	 */
-	item_subtotal_before_discounts_integer: number;
-
-	/**
 	 * The cart item's original price with volume in the currency's smallest unit.
 	 *
 	 * Discounts are not included, but volume and quantity are included.

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -202,40 +202,6 @@ export function filterAndGroupCostOverridesForDisplay(
 			productDiscountAmountTotal += newDiscountAmount;
 		} );
 
-		// Add a fake cost override for introductory offers until D134600-code
-		// is merged because they are otherwise discounts that are invisible to
-		// the list of cost overrides. Remove this once that diff is merged.
-		if (
-			product.introductory_offer_terms?.enabled &&
-			! costOverrides.some( ( override ) => override.override_code === 'introductory-offer' )
-		) {
-			const discountAmount = grouped[ 'introductory-offer' ]?.discountAmount ?? 0;
-			let newDiscountAmount =
-				product.item_original_subtotal_integer - product.item_subtotal_before_discounts_integer;
-			// Override for Jetpack two-year products: we show introductory discount for yearly variant (the rest is considered multi-year discount)
-			if ( isJetpackSocialAdvancedSlug( product.product_slug ) ) {
-				// Social Advanced has free trial that we don't consider "introduction offer"
-				newDiscountAmount = 0;
-			} else if ( isJetpack && isBiennially( product ) ) {
-				// For all other products, we show introductory discount for yearly variant (the rest is considered multi-year discount)
-				const yearlyVariant = getYearlyVariantFromProduct( product );
-				if ( yearlyVariant ) {
-					newDiscountAmount =
-						yearlyVariant.price_before_discounts_integer - yearlyVariant.price_integer;
-				}
-			}
-			if ( newDiscountAmount > 0 ) {
-				grouped[ 'introductory-offer' ] = {
-					humanReadableReason: isJetpack
-						? translate( 'Introductory offer*' )
-						: translate( 'Introductory offer' ),
-					overrideCode: 'introductory-offer',
-					discountAmount: discountAmount + newDiscountAmount,
-				};
-				productDiscountAmountTotal += newDiscountAmount;
-			}
-		}
-
 		if ( isJetpack && isBiennially( product ) ) {
 			const discountAmount = grouped[ 'multi-year-discount' ]?.discountAmount ?? 0;
 			const yearlyVariant = getYearlyVariantFromProduct( product );


### PR DESCRIPTION
## Proposed Changes

D134600-code made Introductory offers into discounts. Prior to that, the discounted price from an introductory offer actually replaced the base price of the product and the shopping-cart endpoint returned the "original" price as the undiscounted price by using a hack. As a result, it was not possible to find out the discounted base price before other discounts were applied so we could display the amount that the introductory offer saved. This led to the introduction of several hacks to determine this value.

Now that the diff has been merged, we can remove these hacks.

## Testing Instructions

- Visit checkout with a product that has an introductory offer.
- Verify that the "Introductory offer" discount in the sidebar is displayed and that the math makes sense.