### PR TITLE
Checkout: Show introductory offer details in discount list

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -82,10 +82,7 @@ export function CostOverridesList( {
 		<CostOverridesListStyle>
 			{ nonCouponOverrides.map( ( costOverride ) => {
 				return (
-					<div
-						className="cost-overrides-list-item"
-						key={ costOverride.humanReadableReason + costOverride.overrideCode }
-					>
+					<div className="cost-overrides-list-item" key={ costOverride.uniqueId }>
 						<span className="cost-overrides-list-item__reason">
 							{ costOverride.humanReadableReason }
 						</span>
@@ -98,7 +95,7 @@ export function CostOverridesList( {
 			{ ! removeCoupon &&
 				couponOverrides.map( ( costOverride ) => {
 					return (
-						<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
+						<div className="cost-overrides-list-item" key={ costOverride.uniqueId }>
 							<span className="cost-overrides-list-item__reason">
 								{ couponCode.length > 0
 									? translate( 'Coupon: %(couponCode)s', { args: { couponCode } } )
@@ -117,7 +114,7 @@ export function CostOverridesList( {
 					return (
 						<div
 							className="cost-overrides-list-item cost-overrides-list-item--coupon"
-							key={ costOverride.humanReadableReason }
+							key={ costOverride.uniqueId }
 						>
 							<span className="cost-overrides-list-item__reason">
 								{ couponCode.length > 0

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -82,7 +82,7 @@ export function CostOverridesList( {
 		<CostOverridesListStyle>
 			{ nonCouponOverrides.map( ( costOverride ) => {
 				return (
-					<div className="cost-overrides-list-item" key={ costOverride.uniqueId }>
+					<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
 						<span className="cost-overrides-list-item__reason">
 							{ costOverride.humanReadableReason }
 						</span>
@@ -95,7 +95,7 @@ export function CostOverridesList( {
 			{ ! removeCoupon &&
 				couponOverrides.map( ( costOverride ) => {
 					return (
-						<div className="cost-overrides-list-item" key={ costOverride.uniqueId }>
+						<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
 							<span className="cost-overrides-list-item__reason">
 								{ couponCode.length > 0
 									? translate( 'Coupon: %(couponCode)s', { args: { couponCode } } )
@@ -114,7 +114,7 @@ export function CostOverridesList( {
 					return (
 						<div
 							className="cost-overrides-list-item cost-overrides-list-item--coupon"
-							key={ costOverride.uniqueId }
+							key={ costOverride.humanReadableReason }
 						>
 							<span className="cost-overrides-list-item__reason">
 								{ couponCode.length > 0

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -204,11 +204,13 @@ function CheckoutSummaryPriceList() {
 				</CheckoutSubtotalSection>
 
 				<CheckoutSummaryTotal>
-					<span>{ translate( 'Total' ) }</span>
+					<span>{ translate( 'Total due today' ) }</span>
 					<span className="wp-checkout-order-summary__total-price">
 						{ totalLineItem.formattedAmount }
 					</span>
 				</CheckoutSummaryTotal>
+				<IntroductoryOfferFutureTotal responseCart={ responseCart } />
+
 				{ hasIntroductoryDiscount( responseCart ) && (
 					<CheckoutSummaryExplanation>
 						{ preventWidows(
@@ -218,6 +220,45 @@ function CheckoutSummaryPriceList() {
 				) }
 			</CheckoutSummaryAmountWrapper>
 		</>
+	);
+}
+
+function getRenewalDateAfterIntroductoryOffer( product: ResponseCartProduct ): Date {
+	// FIXME: this has to come from the backend
+	return new Date();
+}
+
+function IntroductoryOfferFutureTotal( { responseCart }: { responseCart: ResponseCart } ) {
+	const translate = useTranslate();
+	// FIXME: do this for every offer, not just the first
+	const firstProductWithOffer = responseCart.products.find(
+		( product ) => product.introductory_offer_terms?.enabled
+	);
+	if ( ! firstProductWithOffer ) {
+		return null;
+	}
+
+	const endOfIntroductoryOfferDate = getRenewalDateAfterIntroductoryOffer( firstProductWithOffer );
+	const totalDue = formatCurrency(
+		firstProductWithOffer.item_original_subtotal_integer,
+		responseCart.currency,
+		{
+			isSmallestUnit: true,
+			stripZeros: true,
+		}
+	);
+
+	return (
+		<CheckoutSummaryTotal>
+			<span>
+				{ translate( 'Due %(endOfIntroductoryOfferDate)s', {
+					args: {
+						endOfIntroductoryOfferDate: endOfIntroductoryOfferDate.toDateString(),
+					},
+				} ) }
+			</span>
+			<span className="wp-checkout-order-summary__total-price">{ totalDue }</span>
+		</CheckoutSummaryTotal>
 	);
 }
 

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -157,6 +157,7 @@ function CheckoutSummaryPriceList() {
 	const costOverridesList = filterAndGroupCostOverridesForDisplay( responseCart, translate );
 
 	const subtotalBeforeDiscounts = getSubtotalWithoutDiscounts( responseCart );
+	const renewalInfo = filterAndGroupIntroductoryOfferRenewalInfoForDisplay( responseCart );
 
 	return (
 		<>
@@ -204,12 +205,16 @@ function CheckoutSummaryPriceList() {
 				</CheckoutSubtotalSection>
 
 				<CheckoutSummaryTotal>
-					<span>{ translate( 'Total due today' ) }</span>
+					<span>
+						{ renewalInfo.length > 0 ? translate( 'Total due today' ) : translate( 'Total' ) }
+					</span>
 					<span className="wp-checkout-order-summary__total-price">
 						{ totalLineItem.formattedAmount }
 					</span>
 				</CheckoutSummaryTotal>
-				<IntroductoryOfferFutureTotal responseCart={ responseCart } />
+				{ renewalInfo.length > 0 && (
+					<IntroductoryOfferFutureTotal responseCart={ responseCart } renewalInfo={ renewalInfo } />
+				) }
 
 				{ hasIntroductoryDiscount( responseCart ) && (
 					<CheckoutSummaryExplanation>
@@ -298,9 +303,14 @@ function filterAndGroupIntroductoryOfferRenewalInfoForDisplay(
 	);
 }
 
-function IntroductoryOfferFutureTotal( { responseCart }: { responseCart: ResponseCart } ) {
+function IntroductoryOfferFutureTotal( {
+	responseCart,
+	renewalInfo,
+}: {
+	responseCart: ResponseCart;
+	renewalInfo: IntroductoryOfferRenewalInfo[];
+} ) {
 	const translate = useTranslate();
-	const renewalInfo = filterAndGroupIntroductoryOfferRenewalInfoForDisplay( responseCart );
 
 	return renewalInfo.map( ( info ) => {
 		return (

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -37,6 +37,7 @@ import {
 	getSubtotalWithoutDiscounts,
 	filterAndGroupCostOverridesForDisplay,
 	getCreditsLineItemFromCart,
+	CostOverrideForDisplay,
 } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -146,6 +147,29 @@ export function CheckoutSummaryFeaturedList( {
 	);
 }
 
+/**
+ * The sidebar displays a notice that introductory offers are for the first
+ * term only if that is true. Since introductory offers do not read
+ * "Introductory Offer" (see `makeIntroductoryOfferCostOverrideUnique()`), we
+ * need to mark them to associate them with this notice.
+ *
+ * This function adds an asterisk after each one to do that, matching the
+ * asterisk on the sidebar notice.
+ *
+ * However, this asterisk is only added if the offer is for the first term so
+ * that the notice makes sense.
+ */
+function addAsteriskToSingleTermIntroductoryOffers(
+	costOverrides: CostOverrideForDisplay[]
+): CostOverrideForDisplay[] {
+	return costOverrides.map( ( override ) => {
+		if ( override.isSingleTermIntroductoryOffer ) {
+			override.humanReadableReason += '*';
+		}
+		return override;
+	} );
+}
+
 function hasIntroductoryOfferForInitialPurchaseOnly( responseCart: ResponseCart ): boolean {
 	return responseCart.products.some(
 		( product ) =>
@@ -180,7 +204,7 @@ function CheckoutSummaryPriceList() {
 			) }
 			{ ! hasCheckoutVersion( '2' ) && costOverridesList.length > 0 && (
 				<CostOverridesList
-					costOverridesList={ costOverridesList }
+					costOverridesList={ addAsteriskToSingleTermIntroductoryOffers( costOverridesList ) }
 					currency={ responseCart.currency }
 					couponCode={ responseCart.coupon }
 				/>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -249,16 +249,20 @@ function IntroductoryOfferFutureTotal( { responseCart }: { responseCart: Respons
 	);
 
 	return (
-		<CheckoutSummaryTotal>
+		<CheckoutSummaryTotalAfterIntroductoryOffer>
 			<span>
 				{ translate( 'Due %(endOfIntroductoryOfferDate)s', {
 					args: {
-						endOfIntroductoryOfferDate: endOfIntroductoryOfferDate.toDateString(),
+						endOfIntroductoryOfferDate: endOfIntroductoryOfferDate.toLocaleDateString( undefined, {
+							month: 'short',
+							day: 'numeric',
+							year: 'numeric',
+						} ),
 					},
 				} ) }
 			</span>
 			<span className="wp-checkout-order-summary__total-price">{ totalDue }</span>
-		</CheckoutSummaryTotal>
+		</CheckoutSummaryTotalAfterIntroductoryOffer>
 	);
 }
 
@@ -989,6 +993,14 @@ const CheckoutSummaryLineItem = styled.div< { isDiscount?: boolean } >`
 const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )`
 	color: ${ ( props ) => props.theme.colors.textColorDark };
 	font-size: 20px;
+	font-weight: ${ ( props ) => props.theme.weights.bold };
+	line-height: 26px;
+	margin-bottom: 16px;
+`;
+
+const CheckoutSummaryTotalAfterIntroductoryOffer = styled( CheckoutSummaryLineItem )`
+	color: ${ ( props ) => props.theme.colors.textColorDark };
+	font-size: 14px;
 	font-weight: ${ ( props ) => props.theme.weights.bold };
 	line-height: 26px;
 	margin-bottom: 16px;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -186,6 +186,9 @@ function CheckoutSummaryPriceList() {
 	const totalLineItem = getTotalLineItemFromCart( responseCart );
 	const translate = useTranslate();
 	const costOverridesList = filterAndGroupCostOverridesForDisplay( responseCart, translate );
+	const isJetpackNotAtomic = responseCart.products.some( ( product ) => {
+		return isJetpackProduct( product ) || isJetpackPlan( product );
+	} );
 
 	const subtotalBeforeDiscounts = getSubtotalWithoutDiscounts( responseCart );
 
@@ -204,7 +207,11 @@ function CheckoutSummaryPriceList() {
 			) }
 			{ ! hasCheckoutVersion( '2' ) && costOverridesList.length > 0 && (
 				<CostOverridesList
-					costOverridesList={ addAsteriskToSingleTermIntroductoryOffers( costOverridesList ) }
+					costOverridesList={
+						isJetpackNotAtomic
+							? addAsteriskToSingleTermIntroductoryOffers( costOverridesList )
+							: costOverridesList
+					}
 					currency={ responseCart.currency }
 					couponCode={ responseCart.coupon }
 				/>
@@ -241,7 +248,7 @@ function CheckoutSummaryPriceList() {
 					</span>
 				</CheckoutSummaryTotal>
 
-				{ hasIntroductoryOfferForInitialPurchaseOnly( responseCart ) && (
+				{ isJetpackNotAtomic && hasIntroductoryOfferForInitialPurchaseOnly( responseCart ) && (
 					<CheckoutSummaryExplanation>
 						{ preventWidows(
 							translate( '*Introductory offer first term only, renews at regular rate.' )

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -37,7 +37,6 @@ import {
 	getSubtotalWithoutDiscounts,
 	filterAndGroupCostOverridesForDisplay,
 	getCreditsLineItemFromCart,
-	hasIntroductoryDiscount,
 } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -147,6 +146,14 @@ export function CheckoutSummaryFeaturedList( {
 	);
 }
 
+function hasIntroductoryOfferForInitialPurchaseOnly( responseCart: ResponseCart ): boolean {
+	return responseCart.products.some(
+		( product ) =>
+			!! product.introductory_offer_terms?.enabled &&
+			product.introductory_offer_terms.transition_after_renewal_count === 0
+	);
+}
+
 function CheckoutSummaryPriceList() {
 	const cartKey = useCartKey();
 	const { responseCart } = useShoppingCart( cartKey );
@@ -210,7 +217,7 @@ function CheckoutSummaryPriceList() {
 					</span>
 				</CheckoutSummaryTotal>
 
-				{ hasIntroductoryDiscount( responseCart ) && (
+				{ hasIntroductoryOfferForInitialPurchaseOnly( responseCart ) && (
 					<CheckoutSummaryExplanation>
 						{ preventWidows(
 							translate( '*Introductory offer first term only, renews at regular rate.' )

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -725,8 +725,10 @@ export interface TermsOfServiceRecordArgsBase {
 	product_meta: string;
 	product_name: string;
 	renewal_price: string;
+	renewal_price_integer: number;
 	is_renewal_price_prorated: boolean;
 	regular_renewal_price: string;
+	regular_renewal_price_integer: number;
 	email?: string;
 	card_type?: string;
 	card_last_4?: string;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -521,12 +521,53 @@ export interface ResponseCartCostOverride {
 	does_override_original_cost: boolean;
 }
 
+export type IntroductoryOfferUnit = 'day' | 'week' | 'month' | 'year' | 'indefinite';
+
 export interface IntroductoryOfferTerms {
+	/**
+	 * True if the introductory offer is active on this product.
+	 */
 	enabled: boolean;
-	interval_unit: string;
+
+	/**
+	 * The unit that, when combined with `interval_count`, determines how long
+	 * the introductory offer lasts. eg: if `interval_count` is 3 and
+	 * `interval_unit` is 'month', the discount lasts for 3 months.
+	 */
+	interval_unit: IntroductoryOfferUnit;
+
+	/**
+	 * The count that, when combined with `interval_unit`, determines how long
+	 * the introductory offer lasts. eg: if `interval_count` is 3 and
+	 * `interval_unit` is 'month', the discount lasts for 3 months.
+	 */
 	interval_count: number;
+
+	/**
+	 * If the introductory offer is not active (if `enabled` is false), the
+	 * reason will probably be a human-readable reason why (although it may not
+	 * exist even then).
+	 */
 	reason?: string;
+
+	/**
+	 * The number of times the introductory offer cost and period will be used
+	 * during renewals before using the regular cost and period. This can be
+	 * used in place of `interval_unit` and `interval_count` to determine when
+	 * the introductory offer will end.
+	 *
+	 * This will be 0 if it is not used and we should rely on `interval_count`.
+	 */
 	transition_after_renewal_count: number;
+
+	/**
+	 * True if the first renewal will subtract the introductory offer period
+	 * from the full period when calculating the price. For example: if you
+	 * provide a 3 month free trial on a yearly plan, the first renewal would
+	 * only cover 9 months (12 – 3 months). This reduced period is also
+	 * reflected in the renewal price, as the user will only pay for the 9
+	 * months instead of the full year.
+	 */
 	should_prorate_when_offer_ends: boolean;
 }
 

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -508,7 +508,9 @@ export interface ResponseCartProductVariant {
 	price_integer: number;
 	price_before_discounts_integer: number;
 	introductory_offer_discount_integer: number;
-	introductory_offer_terms: Record< string, never > | IntroductoryOfferTerms;
+	introductory_offer_terms:
+		| Record< string, never >
+		| Pick< IntroductoryOfferTerms, 'interval_unit' | 'interval_count' >;
 	volume?: number;
 }
 

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -531,15 +531,22 @@ export interface IntroductoryOfferTerms {
 
 	/**
 	 * The unit that, when combined with `interval_count`, determines how long
-	 * the introductory offer lasts. eg: if `interval_count` is 3 and
-	 * `interval_unit` is 'month', the discount lasts for 3 months.
+	 * the introductory offer disount should be applied.
 	 */
 	interval_unit: IntroductoryOfferUnit;
 
 	/**
 	 * The count that, when combined with `interval_unit`, determines how long
 	 * the introductory offer lasts. eg: if `interval_count` is 3 and
-	 * `interval_unit` is 'month', the discount lasts for 3 months.
+	 * `interval_unit` is 'month', the discount lasts for 3 months (but always
+	 * ends before the next renewal unless `transition_after_renewal_count` is
+	 * set). If the `interval_unit` is 'month' and the product normally renews
+	 * yearly, then the first renewal will be based on `interval_count` (eg:
+	 * after 3 months) instead.
+	 *
+	 * Note that we sometimes renew products a 30 days before their expiry
+	 * date, so in the above example, we would likely renew at the 2 month mark
+	 * instead.
 	 */
 	interval_count: number;
 
@@ -552,19 +559,17 @@ export interface IntroductoryOfferTerms {
 
 	/**
 	 * The number of times the introductory offer cost and period will be used
-	 * during renewals before using the regular cost and period. This can be
-	 * used in place of `interval_unit` and `interval_count` to determine when
-	 * the introductory offer will end.
-	 *
-	 * This will be 0 if it is not used and we should rely on `interval_count`.
+	 * during renewals before using the regular cost and period. If this is 0,
+	 * the discount will last just for the initial purchase; otherwise it will
+	 * last for additional renewals also.
 	 */
 	transition_after_renewal_count: number;
 
 	/**
-	 * True if the first renewal will subtract the introductory offer period
-	 * from the full period when calculating the price. For example: if you
-	 * provide a 3 month free trial on a yearly plan, the first renewal would
-	 * only cover 9 months (12 – 3 months). This reduced period is also
+	 * True if the last discounted renewal will subtract the introductory offer
+	 * period from the full period when calculating the price. For example: if
+	 * you provide a 3 month free trial on a yearly plan, the first renewal
+	 * would only cover 9 months (12 – 3 months). This reduced period is also
 	 * reflected in the renewal price, as the user will only pay for the 9
 	 * months instead of the full year.
 	 */

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -507,9 +507,8 @@ export interface ResponseCartProductVariant {
 	currency: string;
 	price_integer: number;
 	price_before_discounts_integer: number;
-	introductory_offer_terms:
-		| Record< string, never >
-		| Pick< IntroductoryOfferTerms, 'interval_unit' | 'interval_count' >;
+	introductory_offer_discount_integer: number;
+	introductory_offer_terms: Record< string, never > | IntroductoryOfferTerms;
 	volume?: number;
 }
 

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -425,14 +425,6 @@ export function getSubtotalWithoutDiscounts( responseCart: ResponseCart ): numbe
 	}, 0 );
 }
 
-export function hasIntroductoryDiscount( responseCart: ResponseCart ): boolean {
-	return responseCart.products.some(
-		( product ) =>
-			( isJetpackPlan( product ) || isJetpackProduct( product ) ) &&
-			!! product.introductory_offer_terms?.enabled
-	);
-}
-
 export function getTotalDiscountsWithoutCredits(
 	responseCart: ResponseCart,
 	translate: ReturnType< typeof useTranslate >

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -147,6 +147,7 @@ export interface CostOverrideForDisplay {
 	humanReadableReason: string;
 	overrideCode: string;
 	discountAmount: number;
+	isSingleTermIntroductoryOffer?: boolean;
 }
 
 function isUserVisibleCostOverride(
@@ -244,6 +245,10 @@ export function filterAndGroupCostOverridesForDisplay(
 					overrideCode: costOverride.override_code,
 					discountAmount:
 						discountAmount + getDiscountForCostOverrideForDisplay( costOverride, product ),
+					isSingleTermIntroductoryOffer: Boolean(
+						product.introductory_offer_terms?.enabled &&
+							product.introductory_offer_terms.transition_after_renewal_count === 0
+					),
 				};
 			} );
 

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -145,6 +145,7 @@ function getDiscountReasonForIntroductoryOffer(
 export interface CostOverrideForDisplay {
 	humanReadableReason: string;
 	overrideCode: string;
+	uniqueId: string;
 	discountAmount: number;
 }
 
@@ -181,6 +182,7 @@ export function filterAndGroupCostOverridesForDisplay(
 						args: { productName: product.product_name },
 					} ),
 					overrideCode: costOverride.override_code,
+					uniqueId: costOverride.override_code + '__' + product.uuid,
 					discountAmount: newDiscountAmount,
 				};
 				return;
@@ -199,6 +201,7 @@ export function filterAndGroupCostOverridesForDisplay(
 					costOverride.old_subtotal_integer - costOverride.new_subtotal_integer;
 				grouped[ 'introductory-offer__' + product.uuid ] = {
 					overrideCode: costOverride.override_code,
+					uniqueId: costOverride.override_code + '__' + product.uuid,
 					discountAmount: newDiscountAmount,
 					humanReadableReason: getDiscountReasonForIntroductoryOffer(
 						product.introductory_offer_terms,
@@ -215,6 +218,7 @@ export function filterAndGroupCostOverridesForDisplay(
 			grouped[ costOverride.override_code ] = {
 				humanReadableReason: costOverride.human_readable_reason,
 				overrideCode: costOverride.override_code,
+				uniqueId: costOverride.override_code,
 				discountAmount: discountAmount + newDiscountAmount,
 			};
 		} );
@@ -229,6 +233,7 @@ export function filterAndGroupCostOverridesForDisplay(
 			grouped[ 'multi-year-discount' ] = {
 				humanReadableReason: translate( 'Multi-year discount' ),
 				overrideCode: 'multi-year-discount',
+				uniqueId: 'multi-year-discount',
 				discountAmount: discountAmount + multiYearDiscount,
 			};
 		}

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -316,9 +316,9 @@ function getMultiYearDiscountForProduct( product: ResponseCartProduct ): number 
 	const oneYearVariant = getYearlyVariantFromProduct( product );
 	if ( oneYearVariant ) {
 		const numberOfYears = product.months_per_bill_period / 12;
-		const multiYearDiscount =
-			oneYearVariant.price_before_discounts_integer * numberOfYears -
-			product.item_original_cost_integer;
+		const expectedMultiYearPrice = oneYearVariant.price_before_discounts_integer * numberOfYears;
+		const actualMultiYearPrice = product.item_original_cost_integer;
+		const multiYearDiscount = expectedMultiYearPrice - actualMultiYearPrice;
 		if ( multiYearDiscount > 0 ) {
 			return multiYearDiscount;
 		}

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -134,40 +134,16 @@ function getDiscountTimePeriodForIntroductoryOfferByCount(
 	translate: ReturnType< typeof useTranslate >
 ): string | undefined {
 	switch ( unit ) {
-		case 'day':
-			if ( count === 1 ) {
-				return translate( 'Discount for first day', {
-					textOnly: true,
-				} );
-			}
-			return translate( 'Discount for first %(unitCount)d days', {
-				textOnly: true,
-				args: {
-					unitCount: count,
-				},
-			} );
-		case 'week':
-			if ( count === 1 ) {
-				return translate( 'Discount for first week', {
-					textOnly: true,
-				} );
-			}
-			return translate( 'Discount for first %(unitCount)d weeks', {
-				textOnly: true,
-				args: {
-					unitCount: count,
-				},
-			} );
 		case 'month':
 			if ( count === 1 ) {
 				return translate( 'Discount for first month', {
 					textOnly: true,
 				} );
 			}
-			return translate( 'Discount for first %(unitCount)d months', {
+			return translate( 'Discount for first %(numberOfMonths)d months', {
 				textOnly: true,
 				args: {
-					unitCount: count,
+					numberOfMonths: count,
 				},
 			} );
 		case 'year':
@@ -176,10 +152,10 @@ function getDiscountTimePeriodForIntroductoryOfferByCount(
 					textOnly: true,
 				} );
 			}
-			return translate( 'Discount for first %(unitCount)d years', {
+			return translate( 'Discount for first %(numberOfYears)d years', {
 				textOnly: true,
 				args: {
-					unitCount: count,
+					numberOfYears: count,
 				},
 			} );
 	}

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -6,10 +6,10 @@ import {
 } from '@automattic/calypso-products';
 import { formatCurrency } from '@automattic/format-currency';
 import { translate, useTranslate } from 'i18n-calypso';
+import { getIntroductoryOfferIntervalDisplay } from './introductory-offer';
 import type { LineItemType } from './types';
 import type {
 	IntroductoryOfferTerms,
-	IntroductoryOfferUnit,
 	ResponseCart,
 	ResponseCartProduct,
 	TaxBreakdownItem,
@@ -128,70 +128,18 @@ export function getCreditsLineItemFromCart( responseCart: ResponseCart ): LineIt
 	};
 }
 
-function getDiscountTimePeriodForIntroductoryOfferByCount(
-	unit: IntroductoryOfferUnit,
-	count: number,
-	translate: ReturnType< typeof useTranslate >
-): string | undefined {
-	switch ( unit ) {
-		case 'month':
-			if ( count === 1 ) {
-				return translate( 'Discount for first month', {
-					textOnly: true,
-				} );
-			}
-			return translate( 'Discount for first %(numberOfMonths)d months', {
-				textOnly: true,
-				args: {
-					numberOfMonths: count,
-				},
-			} );
-		case 'year':
-			if ( count === 1 ) {
-				return translate( 'Discount for first year', {
-					textOnly: true,
-				} );
-			}
-			return translate( 'Discount for first %(numberOfYears)d years', {
-				textOnly: true,
-				args: {
-					numberOfYears: count,
-				},
-			} );
-	}
-	return undefined;
-}
-
-function getDiscountTimePeriodForIntroductoryOffer(
-	terms: IntroductoryOfferTerms,
-	translate: ReturnType< typeof useTranslate >
-): string | undefined {
-	if ( terms.transition_after_renewal_count ) {
-		if ( terms.transition_after_renewal_count === 1 ) {
-			return translate( 'Discount for first renewal', {
-				textOnly: true,
-			} );
-		}
-		return translate( 'Discount for first %(unitCount)d renewals', {
-			textOnly: true,
-			args: {
-				unitCount: terms.transition_after_renewal_count,
-			},
-		} );
-	}
-	return getDiscountTimePeriodForIntroductoryOfferByCount(
-		terms.interval_unit,
-		terms.interval_count,
-		translate
-	);
-}
-
 function getDiscountReasonForIntroductoryOffer(
 	terms: IntroductoryOfferTerms,
 	translate: ReturnType< typeof useTranslate >
 ): string {
-	const timePeriod = getDiscountTimePeriodForIntroductoryOffer( terms, translate );
-	return timePeriod ?? translate( 'Introductory offer' );
+	return getIntroductoryOfferIntervalDisplay(
+		translate,
+		terms.interval_unit,
+		terms.interval_count,
+		false,
+		'checkout',
+		terms.transition_after_renewal_count
+	);
 }
 
 export interface CostOverrideForDisplay {

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -258,20 +258,14 @@ export function filterAndGroupCostOverridesForDisplay(
 			product.product_variants.length > 1 &&
 			product.product_variants[ 0 ].bill_period_in_months < product.months_per_bill_period
 		) {
-			const discountAmount = grouped[ 'multi-year-discount' ]?.discountAmount ?? 0;
-
-			const oneYearVariant = getYearlyVariantFromProduct( product );
-			if ( oneYearVariant ) {
-				const newDiscountAmount =
-					product.item_original_cost_integer - oneYearVariant.price_before_discounts_integer;
-
-				if ( newDiscountAmount > 0 ) {
-					grouped[ 'multi-year-discount' ] = {
-						humanReadableReason: translate( 'Multi-year discount' ),
-						overrideCode: 'multi-year-discount',
-						discountAmount: discountAmount + newDiscountAmount,
-					};
-				}
+			const newDiscountAmount = getMultiYearDiscountForProduct( product );
+			if ( newDiscountAmount > 0 ) {
+				const discountAmount = grouped[ 'multi-year-discount' ]?.discountAmount ?? 0;
+				grouped[ 'multi-year-discount' ] = {
+					humanReadableReason: translate( 'Multi-year discount' ),
+					overrideCode: 'multi-year-discount',
+					discountAmount: discountAmount + newDiscountAmount,
+				};
 			}
 		}
 		return grouped;

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -253,20 +253,14 @@ export function filterAndGroupCostOverridesForDisplay(
 			}
 		} );
 
-		if (
-			product.months_per_bill_period &&
-			product.product_variants.length > 1 &&
-			product.product_variants[ 0 ].bill_period_in_months < product.months_per_bill_period
-		) {
-			const newDiscountAmount = getMultiYearDiscountForProduct( product );
-			if ( newDiscountAmount > 0 ) {
-				const discountAmount = grouped[ 'multi-year-discount' ]?.discountAmount ?? 0;
-				grouped[ 'multi-year-discount' ] = {
-					humanReadableReason: translate( 'Multi-year discount' ),
-					overrideCode: 'multi-year-discount',
-					discountAmount: discountAmount + newDiscountAmount,
-				};
-			}
+		const multiYearDiscount = getMultiYearDiscountForProduct( product );
+		if ( multiYearDiscount > 0 ) {
+			const discountAmount = grouped[ 'multi-year-discount' ]?.discountAmount ?? 0;
+			grouped[ 'multi-year-discount' ] = {
+				humanReadableReason: translate( 'Multi-year discount' ),
+				overrideCode: 'multi-year-discount',
+				discountAmount: discountAmount + multiYearDiscount,
+			};
 		}
 		return grouped;
 	}, {} );

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -382,9 +382,11 @@ function getSubtotalWithoutDiscountsForProduct( product: ResponseCartProduct ): 
 	// discount, since that is not a real discount) by the cost of each
 	// product's multi-year discount so that we can display that savings as a
 	// discount.
-	const multiYearDiscount = getMultiYearDiscountForProduct( product );
-	if ( multiYearDiscount ) {
-		return product.item_original_subtotal_integer + multiYearDiscount;
+	if ( ! shouldConsiderIntroOfferAsMultiYearDiscount( product ) ) {
+		const multiYearDiscount = getMultiYearDiscountForProduct( product );
+		if ( multiYearDiscount ) {
+			return product.item_original_subtotal_integer + multiYearDiscount;
+		}
 	}
 
 	return product.item_original_subtotal_integer;

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -244,6 +244,9 @@ export function filterAndGroupCostOverridesForDisplay(
 				'introductory-offer' === costOverride.override_code &&
 				product.introductory_offer_terms?.enabled
 			) {
+				if ( ! canDisplayIntroductoryOfferDiscountForProduct( product ) ) {
+					return;
+				}
 				const newDiscountAmount =
 					costOverride.old_subtotal_integer - costOverride.new_subtotal_integer;
 				grouped[ 'introductory-offer__' + product.uuid ] = {
@@ -292,6 +295,18 @@ function getCreditsUsedByCart( responseCart: ResponseCart ): number {
 
 function getYearlyVariantFromProduct( product: ResponseCartProduct ) {
 	return product.product_variants.find( ( variant ) => 12 === variant.bill_period_in_months );
+}
+
+/**
+ * Introductory offer discounts can sometimes be misleading. If we want to hide
+ * them for a product in checkout, we can do so in this function.
+ */
+function canDisplayIntroductoryOfferDiscountForProduct( product: ResponseCartProduct ): boolean {
+	// Social Advanced has free trial that we don't consider "introduction offer"
+	if ( isJetpackSocialAdvancedSlug( product.product_slug ) ) {
+		return false;
+	}
+	return true;
 }
 
 /**

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -259,6 +259,16 @@ export function filterAndGroupCostOverridesForDisplay(
 				};
 				return;
 			}
+
+			// Most cost overrides go here.
+			const discountAmount = grouped[ costOverride.override_code ]?.discountAmount ?? 0;
+			const newDiscountAmount =
+				costOverride.old_subtotal_integer - costOverride.new_subtotal_integer;
+			grouped[ costOverride.override_code ] = {
+				humanReadableReason: costOverride.human_readable_reason,
+				overrideCode: costOverride.override_code,
+				discountAmount: discountAmount + newDiscountAmount,
+			};
 		} );
 
 		// Add a fake "multi-year" discount if applicable. These are not real

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -9,6 +9,7 @@ import { translate, useTranslate } from 'i18n-calypso';
 import type { LineItemType } from './types';
 import type {
 	IntroductoryOfferTerms,
+	IntroductoryOfferUnit,
 	ResponseCart,
 	ResponseCartProduct,
 	TaxBreakdownItem,
@@ -127,80 +128,94 @@ export function getCreditsLineItemFromCart( responseCart: ResponseCart ): LineIt
 	};
 }
 
-function getDiscountUnitForIntroductoryOffer(
-	terms: IntroductoryOfferTerms,
+function getDiscountTimePeriodForIntroductoryOfferByCount(
+	unit: IntroductoryOfferUnit,
+	count: number,
 	translate: ReturnType< typeof useTranslate >
 ): string | undefined {
-	switch ( terms.interval_unit ) {
+	switch ( unit ) {
 		case 'day':
-			if ( terms.interval_count === 1 ) {
-				return translate( 'day', {
+			if ( count === 1 ) {
+				return translate( 'Discount for first day', {
 					textOnly: true,
 				} );
 			}
-			return translate( '%(unitCount)d days', {
+			return translate( 'Discount for first %(unitCount)d days', {
 				textOnly: true,
 				args: {
-					unitCount: terms.interval_count,
+					unitCount: count,
 				},
 			} );
 		case 'week':
-			if ( terms.interval_count === 1 ) {
-				return translate( 'week', {
+			if ( count === 1 ) {
+				return translate( 'Discount for first week', {
 					textOnly: true,
 				} );
 			}
-			return translate( '%(unitCount)d weeks', {
+			return translate( 'Discount for first %(unitCount)d weeks', {
 				textOnly: true,
 				args: {
-					unitCount: terms.interval_count,
+					unitCount: count,
 				},
 			} );
 		case 'month':
-			if ( terms.interval_count === 1 ) {
-				return translate( 'month', {
+			if ( count === 1 ) {
+				return translate( 'Discount for first month', {
 					textOnly: true,
 				} );
 			}
-			return translate( '%(unitCount)d months', {
+			return translate( 'Discount for first %(unitCount)d months', {
 				textOnly: true,
 				args: {
-					unitCount: terms.interval_count,
+					unitCount: count,
 				},
 			} );
 		case 'year':
-			if ( terms.interval_count === 1 ) {
-				return translate( 'year', {
+			if ( count === 1 ) {
+				return translate( 'Discount for first year', {
 					textOnly: true,
 				} );
 			}
-			return translate( '%(unitCount)d years', {
+			return translate( 'Discount for first %(unitCount)d years', {
 				textOnly: true,
 				args: {
-					unitCount: terms.interval_count,
+					unitCount: count,
 				},
 			} );
 	}
 	return undefined;
 }
 
+function getDiscountTimePeriodForIntroductoryOffer(
+	terms: IntroductoryOfferTerms,
+	translate: ReturnType< typeof useTranslate >
+): string | undefined {
+	if ( terms.transition_after_renewal_count ) {
+		if ( terms.transition_after_renewal_count === 1 ) {
+			return translate( 'Discount for first renewal', {
+				textOnly: true,
+			} );
+		}
+		return translate( 'Discount for first %(unitCount)d renewals', {
+			textOnly: true,
+			args: {
+				unitCount: terms.transition_after_renewal_count,
+			},
+		} );
+	}
+	return getDiscountTimePeriodForIntroductoryOfferByCount(
+		terms.interval_unit,
+		terms.interval_count,
+		translate
+	);
+}
+
 function getDiscountReasonForIntroductoryOffer(
 	terms: IntroductoryOfferTerms,
 	translate: ReturnType< typeof useTranslate >
 ): string {
-	if ( ! terms.transition_after_renewal_count ) {
-		const discountUnit = getDiscountUnitForIntroductoryOffer( terms, translate );
-		if ( discountUnit ) {
-			return translate( 'Discount for first %(discountUnit)s', {
-				textOnly: true,
-				args: {
-					discountUnit,
-				},
-			} );
-		}
-	}
-	// FIXME: handle transition_after_renewal_count
-	return translate( 'Introductory offer' );
+	const timePeriod = getDiscountTimePeriodForIntroductoryOffer( terms, translate );
+	return timePeriod ?? translate( 'Introductory offer' );
 }
 
 export interface CostOverrideForDisplay {

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -146,7 +146,6 @@ function getDiscountReasonForIntroductoryOffer(
 export interface CostOverrideForDisplay {
 	humanReadableReason: string;
 	overrideCode: string;
-	uniqueId: string;
 	discountAmount: number;
 }
 
@@ -243,7 +242,6 @@ export function filterAndGroupCostOverridesForDisplay(
 				grouped[ costOverride.human_readable_reason ] = {
 					humanReadableReason: costOverride.human_readable_reason,
 					overrideCode: costOverride.override_code,
-					uniqueId: costOverride.human_readable_reason,
 					discountAmount:
 						discountAmount + getDiscountForCostOverrideForDisplay( costOverride, product ),
 				};
@@ -259,7 +257,6 @@ export function filterAndGroupCostOverridesForDisplay(
 			grouped[ 'multi-year-discount' ] = {
 				humanReadableReason: translate( 'Multi-year discount' ),
 				overrideCode: 'multi-year-discount',
-				uniqueId: 'multi-year-discount',
 				discountAmount: discountAmount + multiYearDiscount,
 			};
 		}


### PR DESCRIPTION
## Proposed Changes

This PR updates the sidebar discount list to include details for Introductory offers. Instead of just reading "Introductory offer", it will now read something like "Discount for first year".

Here's a Jetpack introductory offer:

Before             |  After
:-------------------------:|:-------------------------:
<img width="335" alt="Screenshot 2024-02-05 at 12 10 35 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/c2b91172-d61e-48aa-bb6f-658c3b19d350"> | <img width="332" alt="Screenshot 2024-02-05 at 12 10 56 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/977b480d-2642-429a-9777-e24211479aad">

Here's a WPCom introductory offer (note that we also merge Sale coupons, which we should have done originally in https://github.com/Automattic/wp-calypso/pull/86371):

Before             |  After
:-------------------------:|:-------------------------:
<img width="321" alt="Screenshot 2024-02-05 at 12 20 45 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/333b4be9-e452-4527-be11-cc472a203d91"> | <img width="314" alt="Screenshot 2024-02-05 at 1 44 55 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/4e023af7-7311-4ac4-bb15-b41cdfd6fc59">


> [!NOTE]
> This preserves the multi-year discount for Jetpack biennial and hiding introductory offers for Jetpack social added by https://github.com/Automattic/wp-calypso/pull/86353. They've been made modular so we could change or extend those features to other products more easily in the future (eg: showing multi-year discounts for WPCom plans), although doing so is outside the scope of this PR.

> [!NOTE]
> Jetpack introductory offers showed an asterisk next to the "Introductory offer" item and then a notice at the bottom of the list that explains the offer is valid for the first term only. I've retained this behavior but fixed it to only display if the introductory offer is indeed for the first term. There are some issues with this notice (https://github.com/Automattic/wp-calypso/issues/87194) but they are outside the scope of this PR.

Here's Jetpack with a multi-year discount:

Before             |  After
:-------------------------:|:-------------------------:
<img width="318" alt="Screenshot 2024-02-05 at 12 12 26 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/eef2176a-b9d4-486e-846b-98a31dab3d9c"> | <img width="314" alt="Screenshot 2024-02-05 at 12 12 36 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/ea9cd582-ffef-43ac-87c1-0da84599302e">

Fixes https://github.com/Automattic/wp-calypso/issues/87108

## Testing Instructions

- Add products to your cart with introductory offers (eg: most Jetpack products, or Titan mail).
- Verify that the subtotals and totals appear the same.
- Verify that the sidebar discount list shows details about each offer in a way that makes sense.
- Verify that the price in the sidebar for those offers is correct.