### PR TITLE
Jetpack Backup: add preflight checks for granular restores

### DIFF
--- a/client/my-sites/backup/backup-contents-page/index.tsx
+++ b/client/my-sites/backup/backup-contents-page/index.tsx
@@ -4,6 +4,7 @@ import { arrowLeft, Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
+import QuerySiteCredentials from 'calypso/components/data/query-site-credentials';
 import ActionButtons from 'calypso/components/jetpack/daily-backup-status/action-buttons';
 import cloudIcon from 'calypso/components/jetpack/daily-backup-status/status-card/icons/cloud-success.svg';
 import useGetDisplayDate from 'calypso/components/jetpack/daily-backup-status/use-get-display-date';
@@ -42,6 +43,7 @@ const BackupContentsPage: FunctionComponent< OwnProps > = ( { rewindId, siteId }
 
 	return (
 		<>
+			<QuerySiteCredentials siteId={ siteId } />
 			<Main className="backup-contents-page">
 				<DocumentHead title={ translate( 'Backup contents' ) } />
 				{ isJetpackCloud() && <SidebarNavigation /> }

--- a/client/my-sites/backup/rewind-flow/granular-restore.tsx
+++ b/client/my-sites/backup/rewind-flow/granular-restore.tsx
@@ -575,6 +575,7 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 					siteSlug={ siteSlug }
 					enterCredentialsEventName="calypso_jetpack_backup_granular_restore_missing_credentials_cta"
 					goBackEventName="calypso_jetpack_backup_granular_restore_missing_credentials_back"
+					goBackUrl={ goBackUrl }
 				/>
 			);
 		} else if ( isInProgress ) {

--- a/client/my-sites/backup/rewind-flow/granular-restore.tsx
+++ b/client/my-sites/backup/rewind-flow/granular-restore.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button, Card, Gridicon } from '@automattic/components';
 import { Button as WordPressButton } from '@wordpress/components';
 import { useCallback, useEffect, useState } from '@wordpress/element';
@@ -13,17 +14,28 @@ import { Interval, EVERY_FIVE_SECONDS } from 'calypso/lib/interval';
 import { useDispatch, useSelector } from 'calypso/state';
 import { rewindGranularRestore } from 'calypso/state/activity-log/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
-import { areJetpackCredentialsInvalid } from 'calypso/state/jetpack/credentials/selectors';
+import {
+	areJetpackCredentialsInvalid,
+	hasJetpackCredentials,
+} from 'calypso/state/jetpack/credentials/selectors';
 import { setValidFrom } from 'calypso/state/jetpack-review-prompt/actions';
 import { requestRewindBackups } from 'calypso/state/rewind/backups/actions';
 import {
 	BackupBrowserSelectedItem,
 	BackupBrowserItemType,
 } from 'calypso/state/rewind/browser/types';
+import {
+	useEnqueuePreflightCheck,
+	usePreflightStatusQuery,
+} from 'calypso/state/rewind/preflight/hooks';
+import { getPreflightStatus } from 'calypso/state/rewind/preflight/selectors';
+import { PreflightTestStatus } from 'calypso/state/rewind/preflight/types';
 import { getInProgressBackupForSite } from 'calypso/state/rewind/selectors';
 import getBackupBrowserCheckList from 'calypso/state/rewind/selectors/get-backup-browser-check-list';
 import getBackupBrowserSelectedList from 'calypso/state/rewind/selectors/get-backup-browser-selected-list';
+import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
 import getInProgressRewindStatus from 'calypso/state/selectors/get-in-progress-rewind-status';
+import getIsRestoreInProgress from 'calypso/state/selectors/get-is-restore-in-progress';
 import getRestoreProgress from 'calypso/state/selectors/get-restore-progress';
 import getRewindState from 'calypso/state/selectors/get-rewind-state';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
@@ -34,6 +46,7 @@ import GranularRestoreLoading from './loading-placeholder/granular-restore';
 import ProgressBar from './progress-bar';
 import RewindFlowNotice, { RewindFlowNoticeLevel } from './rewind-flow-notice';
 import CheckYourEmail from './rewind-flow-notice/check-your-email';
+import MissingCredentials from './steps/missing-credentials';
 import type { RestoreProgress } from 'calypso/state/data-layer/wpcom/activity-log/rewind/restore-status/type';
 import type { RewindState } from 'calypso/state/data-layer/wpcom/sites/rewind/type';
 
@@ -139,6 +152,7 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 	);
 
 	const [ userHasRequestedRestore, setUserHasRequestedRestore ] = useState( false );
+	const [ restoreInitiated, setRestoreInitiated ] = useState( false );
 
 	const rewindState = useSelector( ( state ) => getRewindState( state, siteId ) ) as RewindState;
 	const inProgressRewindStatus = useSelector( ( state ) =>
@@ -154,6 +168,13 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 	);
 	const [ loading, setLoading ] = useState( true );
 
+	const requestRestore = useCallback( () => {
+		const includePaths = browserCheckList.includeList.map( ( item ) => item.id ).join( ',' );
+		const excludePaths = browserCheckList.excludeList.map( ( item ) => item.id ).join( ',' );
+
+		dispatch( rewindGranularRestore( siteId, rewindId, includePaths, excludePaths ) );
+	}, [ browserCheckList.excludeList, browserCheckList.includeList, dispatch, rewindId, siteId ] );
+
 	useEffect( () => {
 		if ( rewindState.state === 'uninitialized' ) {
 			setLoading( true );
@@ -162,20 +183,66 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 		setLoading( false );
 	}, [ rewindState ] );
 
+	const preflightStatus = useSelector( ( state ) => getPreflightStatus( state, siteId ) );
+	const hasCredentials = useSelector( ( state ) => hasJetpackCredentials( state, siteId ) );
+	const credentialsAreValid = hasCredentials && ! areCredentialsInvalid;
+	const isRestoreInProgress = useSelector( ( state ) => getIsRestoreInProgress( state, siteId ) );
+	const needCredentials = useSelector( ( state ) => getDoesRewindNeedCredentials( state, siteId ) );
+	const isPreflightEnabled = config.isEnabled( 'jetpack/backup-restore-preflight-checks' );
+	const { refetch: refetchPreflightStatus } = usePreflightStatusQuery(
+		siteId,
+		// Only enable the preflight check if the user has requested a restore and we don't need credentials.
+		userHasRequestedRestore && ! needCredentials
+	);
+	const preflightCheck = useEnqueuePreflightCheck( siteId );
+
+	useEffect( () => {
+		const preflightPassed = isPreflightEnabled && preflightStatus === PreflightTestStatus.SUCCESS;
+
+		if ( userHasRequestedRestore && ! isRestoreInProgress && ! restoreInitiated ) {
+			if ( credentialsAreValid || preflightPassed ) {
+				dispatch( setValidFrom( 'restore', Date.now() ) );
+				requestRestore();
+				setRestoreInitiated( true );
+			}
+		}
+	}, [
+		credentialsAreValid,
+		dispatch,
+		isPreflightEnabled,
+		isRestoreInProgress,
+		preflightStatus,
+		requestRestore,
+		restoreInitiated,
+		userHasRequestedRestore,
+	] );
+
 	const onConfirm = useCallback( () => {
-		const includePaths = browserCheckList.includeList.map( ( item ) => item.id ).join( ',' );
-		const excludePaths = browserCheckList.excludeList.map( ( item ) => item.id ).join( ',' );
-		dispatch( setValidFrom( 'restore', Date.now() ) );
+		// Queue preflight
+		if ( isPreflightEnabled && ! credentialsAreValid ) {
+			preflightCheck.mutate(
+				{ siteId },
+				{
+					onSuccess: () => {
+						refetchPreflightStatus();
+					},
+				}
+			);
+		}
+
+		// Mark that the user has requested a restore
 		setUserHasRequestedRestore( true );
 
-		// Given that it may take some time for the restore to queue/start, let's add a loading state
-		// It will be removed once the restore is officially queued
-		setLoading( true );
-
-		dispatch( rewindGranularRestore( siteId, rewindId, includePaths, excludePaths ) );
-
+		// Track the restore confirmation event.
 		dispatch( recordTracksEvent( 'calypso_jetpack_granular_restore_confirm' ) );
-	}, [ browserCheckList.excludeList, browserCheckList.includeList, dispatch, rewindId, siteId ] );
+	}, [
+		isPreflightEnabled,
+		credentialsAreValid,
+		dispatch,
+		preflightCheck,
+		siteId,
+		refetchPreflightStatus,
+	] );
 
 	const onCancel = useCallback( () => {
 		dispatch( recordTracksEvent( 'calypso_jetpack_granular_restore_cancel' ) );
@@ -491,11 +558,25 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 		}
 	}, [ inProgressRewindStatus, isInProgress, userHasRequestedRestore ] );
 
+	useEffect( () => {
+		if ( isFinished ) {
+			setRestoreInitiated( false );
+			setUserHasRequestedRestore( false );
+		}
+	}, [ isFinished ] );
 	const render = () => {
 		if ( loading ) {
 			return <GranularRestoreLoading />;
 		} else if ( shouldRenderConfirmation ) {
 			return renderConfirm();
+		} else if ( ! inProgressRewindStatus && needCredentials ) {
+			return (
+				<MissingCredentials
+					siteSlug={ siteSlug }
+					enterCredentialsEventName="calypso_jetpack_backup_granular_restore_missing_credentials_cta"
+					goBackEventName="calypso_jetpack_backup_granular_restore_missing_credentials_back"
+				/>
+			);
 		} else if ( isInProgress ) {
 			return renderInProgress();
 		} else if ( isFinished ) {

--- a/client/my-sites/backup/rewind-flow/granular-restore.tsx
+++ b/client/my-sites/backup/rewind-flow/granular-restore.tsx
@@ -545,25 +545,24 @@ const BackupGranularRestoreFlow: FunctionComponent< Props > = ( {
 		</Error>
 	);
 
+	const isFinished = inProgressRewindStatus !== null && inProgressRewindStatus === 'finished';
 	const isInProgress =
 		( ! inProgressRewindStatus && userHasRequestedRestore ) ||
-		( inProgressRewindStatus && [ 'queued', 'running' ].includes( inProgressRewindStatus ) );
-	const isFinished = inProgressRewindStatus !== null && inProgressRewindStatus === 'finished';
+		( inProgressRewindStatus && [ 'queued', 'running' ].includes( inProgressRewindStatus ) ) ||
+		( restoreInitiated && userHasRequestedRestore );
 
-	const shouldRenderConfirmation = ( ! isInProgress || ! isFinished ) && ! userHasRequestedRestore;
+	const shouldRenderConfirmation = ( ! isInProgress || ! isFinished ) && ! restoreInitiated;
 
 	useEffect( () => {
 		if ( isInProgress && ! userHasRequestedRestore ) {
 			setUserHasRequestedRestore( true );
 		}
-	}, [ inProgressRewindStatus, isInProgress, userHasRequestedRestore ] );
 
-	useEffect( () => {
 		if ( isFinished ) {
-			setRestoreInitiated( false );
 			setUserHasRequestedRestore( false );
 		}
-	}, [ isFinished ] );
+	}, [ inProgressRewindStatus, isFinished, isInProgress, userHasRequestedRestore ] );
+
 	const render = () => {
 		if ( loading ) {
 			return <GranularRestoreLoading />;

--- a/client/my-sites/backup/rewind-flow/restore.tsx
+++ b/client/my-sites/backup/rewind-flow/restore.tsx
@@ -9,6 +9,7 @@ import QueryRewindBackups from 'calypso/components/data/query-rewind-backups';
 import QueryRewindRestoreStatus from 'calypso/components/data/query-rewind-restore-status';
 import QueryRewindState from 'calypso/components/data/query-rewind-state';
 import { Interval, EVERY_FIVE_SECONDS } from 'calypso/lib/interval';
+import { backupPath } from 'calypso/lib/jetpack/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { rewindRestore } from 'calypso/state/activity-log/actions';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
@@ -324,6 +325,7 @@ const BackupRestoreFlow: FunctionComponent< Props > = ( {
 					siteSlug={ siteSlug }
 					enterCredentialsEventName="calypso_jetpack_backup_restore_missing_credentials_cta"
 					goBackEventName="calypso_jetpack_backup_restore_missing_credentials_back"
+					goBackUrl={ backupPath( siteSlug ) }
 				/>
 			);
 		} else if ( isInProgress ) {

--- a/client/my-sites/backup/rewind-flow/steps/missing-credentials.tsx
+++ b/client/my-sites/backup/rewind-flow/steps/missing-credentials.tsx
@@ -1,7 +1,7 @@
 import { Button, Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
-import { backupPath, settingsPath } from 'calypso/lib/jetpack/paths';
+import { settingsPath } from 'calypso/lib/jetpack/paths';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 
@@ -9,12 +9,14 @@ interface Props {
 	siteSlug: string | null;
 	enterCredentialsEventName: string;
 	goBackEventName: string;
+	goBackUrl: string;
 }
 
 const MissingCredentials: FunctionComponent< Props > = ( {
 	siteSlug,
 	enterCredentialsEventName,
 	goBackEventName,
+	goBackUrl,
 } ) => {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
@@ -32,7 +34,7 @@ const MissingCredentials: FunctionComponent< Props > = ( {
 			</p>
 			<div className="rewind-flow__btn-group rewind-flow__btn-group--centered">
 				<Button
-					href={ backupPath( siteSlug ) }
+					href={ goBackUrl }
 					className="rewind-flow__back-button"
 					onClick={ () => {
 						dispatch( recordTracksEvent( goBackEventName ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Related to https://github.com/Automattic/jetpack-backup-team/issues/290
Related to https://github.com/Automattic/wp-calypso/pull/85921

## Proposed Changes

* Enqueue and validate preflight checks on the **granular restore** confirmation page, only available under the `jetpack/backup-restore-preflight-checks` feature flag.
  * It will enqueue and validate preflight checks only when the site has no credentials configured, or they are invalid.
* Add a **Missing Credentials** message when a site starts a restore with no credentials and preflight checks fail. Note that the style is quite different in comparison to regular restores confirmation page. Let's keep it that way and raise and later ask design which design we should keep for restores.
![CleanShot 2024-02-01 at 23 13 11@2x](https://github.com/Automattic/wp-calypso/assets/1488641/af19f5e6-096f-41d5-9ec5-da0a1fae0c3c)
* Update `MissingCredentials` component to support a `goBackUrl` prop, so we could return to the customer to different pages depending if this is a regular restore or a granular restore.
* Add Tracks events on `Enter credentials` and `Go back` button on the missing credentials message:
  * Enter credentials: `calypso_jetpack_backup_granular_restore_missing_credentials_cta`
  * Go back: `calypso_jetpack_backup_restore_granular_missing_credentials_back`

## Demo

Here's a quick demo of the new Missing Credentials page.

https://github.com/Automattic/wp-calypso/assets/1488641/a11e273d-be44-443c-9a25-507270313887

## Known issues

We have some kind of duplicated code between regular restores and granular restores that we introduced in order to move faster shipping the granular restore feature. In future iterations, we will start working on unifying both features so we could reduce any duplicated code as much as possible.

## Testing Instructions
* Spin up a Calypso or Jetpack Cloud live branch
* Continue the flow depending on the scenario you want to test:

### Regression test
Given we are adding this functionality under the `jetpack/backup-restore-preflight-checks` feature flag, we need to ensure everything is still working as usual if the feature flag is disabled.

**> Site with credentials**
* Pick a site with a Jetpack VaultPress Backup plan and ensure it has working credentials configured.
* Navigate to the Backup page.
* Pick a backup and click on `Actions (+)` then in `View files`
* Click any files do you want to restore from the backup browser and then click on `Restore selected files`
* Click on `Confirm restore`
* The restore should complete and should display the `Your site has been successfully restored` message at the end.

**> Site without credentials (or non-working credentials)**
* Pick a site with a Jetpack VaultPress Backup plan and ensure it does not have credentials configured.
* Navigate to the Backup page.
* Pick a backup and click on `Actions (+)` then in `View files`
* Ensure restore buttons are disabled.

### New feature testing
Now that we ensured everything is working okay, we could test the new feature using the `jetpack/backup-restore-preflight-checks` flag.

* Pass `?flags=jetpack/backup-restore-preflight-checks` at the end of the URL of your Calypso/Jetpack Cloud live branch site.
* Pick a site with a Jetpack VaultPress Backup plan
* Navigate to the Backup page
* Ensure the `Add your server credentials` is not visible
* Ensure restore buttons are not disabled
* Pick a backup and click on `Actions (+)` then in `View files`
* Click any files do you want to restore from the backup browser and then click on `Restore selected files`
* Click on `Confirm restore`
* Let's continue, depending on the scenario you would like to test:

**> Site with working credentials**
* The restore should complete and should display the `Your site has been successfully restored` message at the end.

**> Site with no credentials and preflight checks are OK**
* The restore will attempt to start, and then an error will be thrown. This is because we are not allowing credential-less restores on WPCOM API yet (it validates if the site has credentials). This is OK, we need to revisit it and test it when backend is ready.
  ![CleanShot 2024-02-02 at 00 33 40@2x](https://github.com/Automattic/wp-calypso/assets/1488641/e21e03fb-3b02-49d5-abab-1c00a93f0f14)

**> Site with no credentials and preflight checks are failing**
* The restore will attempt to start and then it will display the **Missing Credentials** message.
  ![CleanShot 2024-02-01 at 23 13 11@2x](https://github.com/Automattic/wp-calypso/assets/1488641/af19f5e6-096f-41d5-9ec5-da0a1fae0c3c)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?