### PR TITLE
GitHub Deployments: add connect/disconnect UI

### DIFF
--- a/client/my-sites/github-deployments/authorize/authorize-button.tsx
+++ b/client/my-sites/github-deployments/authorize/authorize-button.tsx
@@ -1,0 +1,61 @@
+import { Button } from '@automattic/components';
+import requestExternalAccess from '@automattic/request-external-access';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { __ } from '@wordpress/i18n';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { requestKeyringConnections } from 'calypso/state/sharing/keyring/actions';
+import { getKeyringServiceByName } from 'calypso/state/sharing/services/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { GITHUB_DEPLOYMENTS_QUERY_KEY } from '../constants';
+import { GITHUB_CONNECTION_QUERY_KEY, GithubConnectionData } from '../use-github-connection-query';
+
+import './style.scss';
+
+interface GitHubAuthorizeProps {
+	buttonText?: string;
+}
+
+type Service = {
+	connect_URL: string;
+};
+
+export const GitHubAuthorizeButton = ( props: GitHubAuthorizeProps ) => {
+	const queryClient = useQueryClient();
+	const siteId = useSelector( getSelectedSiteId );
+	const dispatch = useDispatch();
+	const { buttonText = __( 'Authorize access to GitHub' ) } = props;
+
+	const github = useSelector( ( state ) =>
+		getKeyringServiceByName( state, 'github-app' )
+	) as Service;
+
+	const { mutate: authorize, isPending: isAuthorizing } = useMutation< void, unknown, string >( {
+		mutationFn: async ( connectURL ) => {
+			dispatch( recordTracksEvent( 'calypso_hosting_github_authorize_click' ) );
+			await new Promise( ( resolve ) => requestExternalAccess( connectURL, resolve ) );
+			await dispatch( requestKeyringConnections() );
+		},
+		onSuccess: async () => {
+			const connectionKey = [ GITHUB_DEPLOYMENTS_QUERY_KEY, siteId, GITHUB_CONNECTION_QUERY_KEY ];
+			await queryClient.invalidateQueries( {
+				queryKey: connectionKey,
+			} );
+
+			const authorized =
+				queryClient.getQueryData< GithubConnectionData >( connectionKey )?.connected;
+			dispatch( recordTracksEvent( 'calypso_hosting_github_authorize_complete', { authorized } ) );
+		},
+	} );
+
+	return (
+		<Button
+			primary
+			busy={ isAuthorizing }
+			disabled={ ! github || isAuthorizing }
+			onClick={ () => authorize( github.connect_URL ) }
+		>
+			{ buttonText }
+		</Button>
+	);
+};

--- a/client/my-sites/github-deployments/authorize/index.tsx
+++ b/client/my-sites/github-deployments/authorize/index.tsx
@@ -1,0 +1,14 @@
+import { Card } from '@automattic/components';
+import { __ } from '@wordpress/i18n';
+import { GitHubAuthorizeButton } from './authorize-button';
+
+import './style.scss';
+
+export const GitHubAuthorize = () => {
+	return (
+		<Card className="github-deployments-authorize-card">
+			<p>{ __( 'To create or connect repositories, begin by authorizing GitHub.' ) }</p>
+			<GitHubAuthorizeButton />
+		</Card>
+	);
+};

--- a/client/my-sites/github-deployments/authorize/style.scss
+++ b/client/my-sites/github-deployments/authorize/style.scss
@@ -1,0 +1,5 @@
+.github-deployments-authorize-card {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+}

--- a/client/my-sites/github-deployments/connected/accounts/account-list-item.tsx
+++ b/client/my-sites/github-deployments/connected/accounts/account-list-item.tsx
@@ -1,0 +1,115 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Button, ExternalLink, Spinner } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { useTranslate } from 'i18n-calypso';
+import EllipsisMenu from 'calypso/components/ellipsis-menu/index';
+import Image from 'calypso/components/image/index';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import PopoverMenuSeparator from 'calypso/components/popover-menu/separator';
+import { GITHUB_DEPLOYMENTS_QUERY_KEY } from 'calypso/my-sites/github-deployments/constants';
+import { GitHubConnection } from 'calypso/my-sites/github-deployments/types';
+import { GITHUB_CONNECTION_QUERY_KEY } from 'calypso/my-sites/github-deployments/use-github-connection-query';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { useDispatch, useSelector } from 'calypso/state/index';
+import { deleteStoredKeyringConnection } from 'calypso/state/sharing/keyring/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors/index';
+
+interface GitHubAccountListItemProps {
+	connection: GitHubConnection;
+}
+
+function getConfigureURL( { installation }: GitHubConnection ) {
+	if ( installation.type === 'User' ) {
+		return `https://github.com/settings/installations/${ installation.id }`;
+	}
+	return `https://github.com/organizations/${ installation.login }/settings/installations/${ installation.id }`;
+}
+
+function getRepositoryAccess( { installation: { repositories } }: GitHubConnection ) {
+	const repos = Object.values( repositories );
+	if ( repos.length === 1 && repos[ 0 ] === 'all' ) {
+		return <span>{ __( 'All repositories' ) }</span>;
+	} else if ( repos.length === 1 ) {
+		return (
+			<div className="github-deployments-account__repository-access">
+				<span>{ __( '1 repository' ) }</span>
+				<span className="github-deployments-account__repositories">{ repos[ 0 ] }</span>
+			</div>
+		);
+	}
+	return (
+		<div className="github-deployments-account__repository-access">
+			<span>
+				{ ' ' }
+				{ repos.length } { __( ' repositories' ) }
+			</span>
+			<span className="github-deployments-account__repositories">{ repos.join( ', ' ) }</span>
+		</div>
+	);
+}
+
+export const GitHubAccountListItem = ( props: GitHubAccountListItemProps ) => {
+	const { connection } = props;
+	const { installation } = connection;
+	const queryClient = useQueryClient();
+	const dispatch = useDispatch();
+	const translate = useTranslate();
+
+	const siteId = useSelector( getSelectedSiteId );
+
+	// Using ReactQuery to manage `isDisconnecting` state because it's not exposed from the Redux store.
+	const mutation = useMutation< unknown, unknown, GitHubConnection >( {
+		mutationFn: async ( connection ) => {
+			dispatch( recordTracksEvent( 'calypso_github_deployments_disconnect_account_click' ) );
+			await dispatch( deleteStoredKeyringConnection( connection ) );
+			await queryClient.invalidateQueries( {
+				queryKey: [ GITHUB_DEPLOYMENTS_QUERY_KEY, siteId, GITHUB_CONNECTION_QUERY_KEY ],
+			} );
+		},
+	} );
+	const { mutate: disconnect, isPending: isDisconnecting } = mutation;
+
+	return (
+		<tr>
+			<td>
+				<div className="github-deployments-account__details">
+					{ installation.avatar_url && (
+						<Image
+							style={ { maxHeight: 24 } } //stop flashing off larger image
+							className="github-deployments-account__profile-picture"
+							src={ installation.avatar_url }
+						/>
+					) }
+					@{ installation.login }
+				</div>
+			</td>
+			<td> { getRepositoryAccess( connection ) }</td>
+			<td>1st Feb 2024</td>
+			<td>
+				{ isDisconnecting ? (
+					<Spinner />
+				) : (
+					<EllipsisMenu position="bottom right">
+						<PopoverMenuItem
+							itemComponent={ ExternalLink }
+							href={ getConfigureURL( connection ) }
+							target="_blank"
+						>
+							{ translate( 'Configure on GitHub' ) }
+						</PopoverMenuItem>
+						<PopoverMenuSeparator />
+						<PopoverMenuItem
+							itemComponent={ Button }
+							className="github-deployments-account__menu-item-danger"
+							busy={ isDisconnecting }
+							disabled={ isDisconnecting }
+							onClick={ () => disconnect( connection ) }
+						>
+							{ translate( 'Disconnect account' ) }
+						</PopoverMenuItem>
+					</EllipsisMenu>
+				) }
+			</td>
+		</tr>
+	);
+};

--- a/client/my-sites/github-deployments/connected/accounts/account-list.tsx
+++ b/client/my-sites/github-deployments/connected/accounts/account-list.tsx
@@ -1,0 +1,29 @@
+import { __ } from '@wordpress/i18n';
+import { GitHubConnection } from 'calypso/my-sites/github-deployments/types';
+import { GitHubAccountListItem } from './account-list-item';
+
+interface GitHubAccountListProps {
+	connections: GitHubConnection[];
+}
+
+export const GitHubAccountList = ( { connections = [] }: GitHubAccountListProps ) => {
+	return (
+		<div>
+			<table>
+				<thead>
+					<tr>
+						<th>{ __( 'Name' ) }</th>
+						<th>{ __( ' Repository Access ' ) }</th>
+						<th>{ __( 'Connected on' ) } </th>
+						<th> </th>
+					</tr>
+				</thead>
+				<tbody>
+					{ connections.map( ( connection ) => (
+						<GitHubAccountListItem key={ connection.ID } connection={ connection } />
+					) ) }
+				</tbody>
+			</table>
+		</div>
+	);
+};

--- a/client/my-sites/github-deployments/connected/accounts/index.tsx
+++ b/client/my-sites/github-deployments/connected/accounts/index.tsx
@@ -32,7 +32,7 @@ export const GitHubAccounts = () => {
 				<SearchAccounts value={ query } onChange={ setQuery } />
 				<GitHubAuthorizeButton buttonText={ __( 'Connect GitHub Account' ) } />
 			</div>
-			<GitHubAccountList connections={ filter( connections ) } />
+			<GitHubAccountList connections={ filter( connections || [] ) } />
 		</div>
 	);
 };

--- a/client/my-sites/github-deployments/connected/accounts/index.tsx
+++ b/client/my-sites/github-deployments/connected/accounts/index.tsx
@@ -1,0 +1,38 @@
+import { __ } from '@wordpress/i18n';
+import { useState } from 'react';
+import { GitHubConnection } from 'calypso/my-sites/github-deployments/types';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { GitHubAuthorizeButton } from '../../authorize/authorize-button';
+import { useGithubConnectionQuery } from '../../use-github-connection-query';
+import { GitHubAccountList } from './account-list';
+import { SearchAccounts } from './search-accounts';
+
+import './style.scss';
+
+export const GitHubAccounts = () => {
+	const siteId = useSelector( getSelectedSiteId );
+	const [ query, setQuery ] = useState( '' );
+
+	const { data: connections } = useGithubConnectionQuery( siteId );
+
+	const filter = ( connections: GitHubConnection[] ) => {
+		const trimmed = query.toLowerCase().trim();
+		if ( ! trimmed ) {
+			return connections;
+		}
+		return connections.filter( ( connection ) =>
+			connection.external_name.toLowerCase().includes( trimmed )
+		);
+	};
+
+	return (
+		<div className="github-deployments-accounts">
+			<div className="github-deployments-accounts-header">
+				<SearchAccounts value={ query } onChange={ setQuery } />
+				<GitHubAuthorizeButton buttonText={ __( 'Connect GitHub Account' ) } />
+			</div>
+			<GitHubAccountList connections={ filter( connections ) } />
+		</div>
+	);
+};

--- a/client/my-sites/github-deployments/connected/accounts/search-accounts.tsx
+++ b/client/my-sites/github-deployments/connected/accounts/search-accounts.tsx
@@ -1,0 +1,22 @@
+import { __ } from '@wordpress/i18n';
+import { ChangeEvent } from 'react';
+import FormTextInput from 'calypso/components/forms/form-text-input/index';
+
+interface SearchAccountsProps {
+	value: string;
+	onChange( query: string ): void;
+}
+
+export const SearchAccounts = ( { value, onChange }: SearchAccountsProps ) => {
+	return (
+		<FormTextInput
+			className="github-deployments-search-accounts"
+			type="string"
+			onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
+				onChange( event.currentTarget.value )
+			}
+			value={ value }
+			placeholder={ __( 'Search accounts' ) }
+		/>
+	);
+};

--- a/client/my-sites/github-deployments/connected/accounts/style.scss
+++ b/client/my-sites/github-deployments/connected/accounts/style.scss
@@ -1,0 +1,78 @@
+.github-deployments-accounts {
+	margin-top: 32px;
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+
+	.github-deployments-accounts-header {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+
+		input {
+			max-width: 250px;
+		}
+
+		input.form-text-input {
+			margin: 0;
+			padding: 7px 14px;
+			width: 100%;
+			color: var(--color-neutral-70);
+			font-size: 1rem;
+			line-height: 1.5;
+			border: 1px solid var(--color-neutral-10);
+			border-radius: 2px;
+			background-color: var(--color-surface);
+			transition: all 0.15s ease-in-out;
+			box-sizing: border-box;
+		}
+	}
+
+	table {
+
+		thead th {
+			padding: 16px 0;
+		}
+
+		td {
+			vertical-align: middle !important;
+		}
+
+		.github-deployments-account__details {
+			display: flex;
+			gap: 8px;
+			align-items: center;
+		}
+
+		.github-deployments-account__profile-picture {
+			width: 24px;
+			height: 24px;
+			border-radius: 50%;
+			margin-right: 8px;
+		}
+
+		.github-deployments-account__repository-access {
+			display: flex;
+			flex-direction: column;
+			gap: 8px;
+
+			.github-deployments-account__repositories {
+				color: var(--color-text-subtle);
+				font-size: $font-body-small;
+				overflow: hidden;
+				white-space: nowrap;
+				text-overflow: ellipsis;
+				max-width: 250px;
+			}
+		}
+	}
+}
+
+.github-deployments-account__menu-item-danger {
+	color: var(--color-error) !important;
+
+	button:hover {
+		border: none;
+	}
+}
+

--- a/client/my-sites/github-deployments/connected/index.tsx
+++ b/client/my-sites/github-deployments/connected/index.tsx
@@ -1,0 +1,42 @@
+import { Card } from '@automattic/components';
+import { TabPanel } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { GitHubAccounts } from './accounts';
+import { GitHubRepositories } from './repositories';
+
+import './style.scss';
+
+export const GitHubConnected = () => {
+	const renderTab = ( tab: { name: string } ) => {
+		switch ( tab.name ) {
+			case 'accounts':
+				return <GitHubAccounts />;
+			case 'repositories':
+				return <GitHubRepositories />;
+			default:
+				return null;
+		}
+	};
+
+	return (
+		<Card className="github-deployments-authorized-card">
+			<TabPanel
+				initialTabName="accounts"
+				tabs={ [
+					{
+						name: 'repositories',
+						title: __( 'Repositories' ),
+						className: 'tab-one',
+					},
+					{
+						name: 'accounts',
+						title: __( 'Accounts' ),
+						className: 'tab-two',
+					},
+				] }
+			>
+				{ ( tab ) => renderTab( tab ) }
+			</TabPanel>
+		</Card>
+	);
+};

--- a/client/my-sites/github-deployments/connected/repositories/index.tsx
+++ b/client/my-sites/github-deployments/connected/repositories/index.tsx
@@ -1,0 +1,25 @@
+export const GitHubRepositories = () => {
+	return (
+		<div
+			style={ {
+				minHeight: 250,
+				display: 'flex',
+				justifyContent: 'center',
+				alignItems: 'center',
+				padding: 32,
+			} }
+		>
+			<p>
+				Will be implemented during{ ' ' }
+				<a
+					href="https://github.com/Automattic/dotcom-forge/issues/5332"
+					target="_blank"
+					rel="noreferrer"
+				>
+					{ ' ' }
+					#5332
+				</a>
+			</p>
+		</div>
+	);
+};

--- a/client/my-sites/github-deployments/connected/style.scss
+++ b/client/my-sites/github-deployments/connected/style.scss
@@ -1,0 +1,5 @@
+.github-deployments-authorized-card {
+	display: flex;
+	flex-direction: column;
+	padding-top: 8px;
+}

--- a/client/my-sites/github-deployments/constants.ts
+++ b/client/my-sites/github-deployments/constants.ts
@@ -1,0 +1,1 @@
+export const GITHUB_DEPLOYMENTS_QUERY_KEY = 'github-deployments';

--- a/client/my-sites/github-deployments/controller.tsx
+++ b/client/my-sites/github-deployments/controller.tsx
@@ -1,4 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
+import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
+import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
 import { PageViewTracker } from 'calypso/lib/analytics/page-view-tracker';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -10,6 +12,8 @@ export const githubDeployments: Callback = ( context, next ) => {
 	context.primary = (
 		<>
 			<PageViewTracker path="/github-deployments/:site" title="GitHub Deployments" delay={ 500 } />
+			<QueryKeyringServices />
+			<QueryKeyringConnections />
 			<GitHubDeployments />
 		</>
 	);

--- a/client/my-sites/github-deployments/loading-placeholder.tsx
+++ b/client/my-sites/github-deployments/loading-placeholder.tsx
@@ -1,0 +1,12 @@
+import { LoadingPlaceholder } from '@automattic/components';
+
+export const GitHubLoadingPlaceholder = () => {
+	return (
+		<div className="github-deployments-loading-placeholder">
+			<LoadingPlaceholder />
+			<LoadingPlaceholder />
+			<LoadingPlaceholder />
+			<LoadingPlaceholder />
+		</div>
+	);
+};

--- a/client/my-sites/github-deployments/main.tsx
+++ b/client/my-sites/github-deployments/main.tsx
@@ -3,14 +3,33 @@ import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
-import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { useSelector } from 'calypso/state/index';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors/index';
+import { GitHubAuthorize } from './authorize';
+import { GitHubConnected } from './connected';
+import { GitHubLoadingPlaceholder } from './loading-placeholder';
+import { useGithubConnectionQuery } from './use-github-connection-query';
+
+import './style.scss';
 
 export function GitHubDeployments() {
 	const titleHeader = translate( 'GitHub Deployments' );
 
+	const siteId = useSelector( getSelectedSiteId );
+	const { data: connections, isLoading } = useGithubConnectionQuery( siteId );
+
+	const renderContent = () => {
+		if ( isLoading ) {
+			return <GitHubLoadingPlaceholder />;
+		}
+		if ( connections?.length ) {
+			return <GitHubConnected />;
+		}
+		return <GitHubAuthorize />;
+	};
+
 	return (
 		<Main className="github-deployments" fullWidthLayout>
-			<PageViewTracker path="/github-deployments/:site" title="GitHub Deployments" />
 			<DocumentHead title={ titleHeader } />
 			<FormattedHeader
 				align="left"
@@ -26,6 +45,7 @@ export function GitHubDeployments() {
 					}
 				) }
 			></FormattedHeader>
+			{ renderContent() }
 		</Main>
 	);
 }

--- a/client/my-sites/github-deployments/style.scss
+++ b/client/my-sites/github-deployments/style.scss
@@ -1,0 +1,5 @@
+.github-deployments-loading-placeholder {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}

--- a/client/my-sites/github-deployments/types.ts
+++ b/client/my-sites/github-deployments/types.ts
@@ -1,0 +1,25 @@
+export interface GitHubConnection {
+	ID: number;
+	connected: boolean;
+	installation: Installation;
+	repo: string;
+	branch: string;
+	base_path: string;
+	label: string;
+	external_name: string;
+}
+
+export interface Installation {
+	id: number;
+	target_id: number;
+	target_type: string;
+	selection: string;
+	login: string;
+	avatar_url: string;
+	type: string;
+	repositories: [ key: string ];
+}
+
+export interface Repositories {
+	[ key: string ]: string;
+}

--- a/client/my-sites/github-deployments/use-github-connection-query.ts
+++ b/client/my-sites/github-deployments/use-github-connection-query.ts
@@ -1,0 +1,36 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+import { GitHubConnection } from 'calypso/my-sites/github-deployments/types';
+import { GITHUB_DEPLOYMENTS_QUERY_KEY } from './constants';
+
+export const GITHUB_CONNECTION_QUERY_KEY = 'github-connection';
+
+export interface GithubConnectionData {
+	ID: number;
+	connected: boolean;
+	external_profile_picture: string;
+	repo: string;
+	branch: string;
+	base_path: string;
+	label: string;
+	external_name: string;
+}
+
+export const useGithubConnectionQuery = (
+	siteId: number | null,
+	options?: UseQueryOptions< GitHubConnection[] >
+) => {
+	return useQuery< GitHubConnection[] >( {
+		queryKey: [ GITHUB_DEPLOYMENTS_QUERY_KEY, siteId, GITHUB_CONNECTION_QUERY_KEY ],
+		queryFn: (): GitHubConnection[] =>
+			wp.req.get( {
+				path: `/sites/${ siteId }/hosting/github-app/connections`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		enabled: !! siteId,
+		meta: {
+			persist: false,
+		},
+		...options,
+	} );
+};

--- a/client/my-sites/hosting/github/github-connect-card/index.tsx
+++ b/client/my-sites/hosting/github/github-connect-card/index.tsx
@@ -2,7 +2,7 @@ import { Button, Card } from '@automattic/components';
 import { ExternalLink } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
 import classNames from 'classnames';
-import { ComponentProps, useState } from 'react';
+import { useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormLabel from 'calypso/components/forms/form-label';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
@@ -20,7 +20,12 @@ import { useGithubConnectMutation } from './use-github-connect-mutation';
 import './style.scss';
 
 interface GithubConnectCardProps {
-	connection: ComponentProps< typeof DisconnectGitHubButton >[ 'connection' ];
+	connection: {
+		ID: number;
+		label: string;
+		external_profile_picture: string;
+		external_name: string;
+	};
 }
 const noticeOptions = {
 	duration: 3000,

--- a/client/state/sharing/keyring/actions.js
+++ b/client/state/sharing/keyring/actions.js
@@ -84,8 +84,6 @@ function deleteKeyringConnectionSuccess( connection ) {
  * @param  {Object} connection         Connection to be deleted.
  * @param  {number} connection.ID      ID of the connection to be deleted.
  * @param  {string} connection.label   Name of the service that was connected.
- * @param  {string} connection.external_name Name of the authorized resource.
- * @param  {string} connection.external_profile_picture The link to the resource's profile picture.
  * @returns {Function}                  Action thunk
  */
 export function deleteStoredKeyringConnection( connection ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5249

## Proposed Changes

<img width="1028" alt="Screenshot 2567-02-02 at 14 18 50" src="https://github.com/Automattic/wp-calypso/assets/6851384/7f5df782-3166-4a77-a74c-233aaa1fa92e">

<img width="1023" alt="Screenshot 2567-02-02 at 14 14 45" src="https://github.com/Automattic/wp-calypso/assets/6851384/7c70100d-438d-4c52-8030-aa5b4a55abd1">

Notes: 

1.  It's currently not clear what the final UI will look like. I have loosely based it on AkPDFrEtrfwxjLrVZzjRaj-fi-2129_9840.
2. The date is hardcoded. I think we can update this when we have our DB tables in place
3. When you configure your account to add/remove repos, the UI does not update. We can revisit when we are handling webooks

Done: 
* Allow connecting one or more GH accounts
* Allow disconnect accounts
* Allow searching for accounts
* Allow configuring accounts (link to GH website)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/github-deployments/:atomic-site` and give it a go. 
* Try disconnecting
* Try searching
* 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?