### PR TITLE
Un-iframe Post Editor (except in production/staging)

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/class-wpcom-block-editor-nav-sidebar.php
@@ -92,8 +92,10 @@ class WPCOM_Block_Editor_Nav_Sidebar {
 	 */
 	public function get_current_site() {
 		return array(
-			'launchpad_screen' => get_option( 'launchpad_screen' ),
-			'site_intent'      => get_option( 'site_intent' ),
+			'launchpad_screen'           => get_option( 'launchpad_screen' ),
+			'site_intent'                => get_option( 'site_intent' ),
+			'admin_interface'            => get_option( 'wpcom_admin_interface' ),
+			'admin_menu_preferred_views' => get_user_option( 'jetpack_admin_menu_preferred_views' ),
 		);
 	}
 }

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/components/nav-sidebar/index.tsx
@@ -123,7 +123,27 @@ function WpcomBlockEditorNavSidebar() {
 		defaultCloseUrl = `${ siteOrigin }/setup/${ siteIntent }/launchpad?siteSlug=${ siteSlug }`;
 		defaultCloseLabel = __( 'Next steps', 'full-site-editing' );
 	} else {
+		const currentSite = window?.wpcomBlockEditorNavSidebar?.currentSite;
+		const adminInterface = currentSite?.admin_interface;
+		const adminMenuPreferredViews = ( currentSite?.admin_menu_preferred_views || {} ) as {
+			[ key: string ]: string;
+		};
+		const editPagePreferredViewKey =
+			'edit.php' + ( postType.slug === 'post' ? '' : '?post_type=' + postType.slug );
+		const isEditPagePreferredViewClassic =
+			adminInterface === 'wp-admin' ||
+			adminMenuPreferredViews[ editPagePreferredViewKey ] === 'classic';
+
 		defaultCloseUrl = addQueryArgs( 'edit.php', { post_type: postType.slug } );
+
+		if ( ! isEditPagePreferredViewClassic ) {
+			if ( [ 'post', 'page' ].includes( postType.slug ) ) {
+				defaultCloseUrl = `${ siteOrigin }/${ postType.slug }s/${ siteSlug }`;
+			} else if ( [ 'jetpack-testimonial', 'jetpack-portfolio' ].includes( postType.slug ) ) {
+				defaultCloseUrl = `${ siteOrigin }/types/${ postType.slug }/${ siteSlug }`;
+			}
+		}
+
 		defaultCloseLabel = get(
 			postType,
 			[ 'labels', 'all_items' ],

--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/constants.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nav-sidebar/src/constants.ts
@@ -7,6 +7,8 @@ declare global {
 			currentSite: {
 				launchpad_screen: boolean | string;
 				site_intent: boolean | string;
+				admin_interface: boolean | string;
+				admin_menu_preferred_views: boolean | { [ key: string ]: string };
 			};
 		};
 	}

--- a/client/state/selectors/get-editor-url.ts
+++ b/client/state/selectors/get-editor-url.ts
@@ -24,6 +24,10 @@ export const getEditorUrl = (
 			url = addQueryArgs( { calypsoify: '1' }, url );
 		}
 
+		if ( typeof window !== 'undefined' && window.location.origin !== 'https://wordpress.com' ) {
+			url = addQueryArgs( { calypso_origin: window.location.origin }, url );
+		}
+
 		return url;
 	}
 

--- a/client/state/selectors/should-load-gutenframe.js
+++ b/client/state/selectors/should-load-gutenframe.js
@@ -1,7 +1,9 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { isEligibleForGutenframe } from 'calypso/state/gutenberg-iframe-eligible/is-eligible-for-gutenframe';
 import { getPreferredEditorView } from 'calypso/state/selectors/get-preferred-editor-view';
 
 export const shouldLoadGutenframe = ( state, siteId, postType = 'post' ) =>
+	isEnabled( 'block-editor/iframe' ) &&
 	isEligibleForGutenframe( state, siteId ) &&
 	getPreferredEditorView( state, siteId, postType ) === 'default';
 

--- a/config/production.json
+++ b/config/production.json
@@ -24,6 +24,7 @@
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-assembler": false,
 		"bilmur-script": true,
+		"block-editor/iframe": true,
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -19,6 +19,7 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/checkout-quantity-dropdown": true,
+		"block-editor/iframe": true,
 		"calypso/ai-blogging-prompts": false,
 		"calypso/ai-assembler": false,
 		"calypso/help-center": true,

--- a/packages/calypso-e2e/src/lib/pages/editor-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/editor-page.ts
@@ -156,7 +156,7 @@ export class EditorPage {
 		// Lacking a perfect cross-site type (Simple/Atomic) way to check the loading state,
 		// it is a fairly good stand-in.
 		await Promise.all( [
-			this.page.waitForURL( /(\/post\/.+|\/page\/+|\/post-new.php)/, { timeout } ),
+			this.page.waitForURL( /(\/post.php|\/post-new.php|\/edit.php)/, { timeout } ),
 			this.page.waitForResponse( /.*posts.*/, { timeout } ),
 		] );
 	}

--- a/test/e2e/specs/blocks/blocks__media.ts
+++ b/test/e2e/specs/blocks/blocks__media.ts
@@ -90,16 +90,6 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 			await imageBlock.upload( testFiles.imageReservedName.fullpath );
 		} );
 
-		it( `${ ImageBlock.blockName } block: upload image file using Calypso media modal `, async function () {
-			const blockHandle = await editorPage.addBlockFromSidebar(
-				ImageBlock.blockName,
-				ImageBlock.blockEditorSelector,
-				{ noSearch: true }
-			);
-			const imageBlock = new ImageBlock( page, blockHandle );
-			await imageBlock.uploadThroughMediaLibrary( testFiles.image.fullpath );
-		} );
-
 		it( `${ AudioBlock.blockName } block: upload audio file`, async function () {
 			const blockHandle = await editorPage.addBlockFromSidebar(
 				AudioBlock.blockName,
@@ -143,10 +133,6 @@ describe( DataHelper.createSuiteTitle( 'Blocks: Media (Upload)' ), function () {
 			await ImageBlock.validatePublishedContent( page, [
 				testFiles.imageReservedName.filename.replace( /[^a-zA-Z ]/g, '' ),
 			] );
-		} );
-
-		it( 'Image added via Calypso modal is visible', async function () {
-			await ImageBlock.validatePublishedContent( page, [ testFiles.image.filename ] );
 		} );
 
 		it( `Audio block is visible`, async function () {

--- a/test/e2e/specs/editor/editor__revisions.ts
+++ b/test/e2e/specs/editor/editor__revisions.ts
@@ -7,7 +7,6 @@ import {
 	TestAccount,
 	envVariables,
 	EditorPage,
-	RevisionsComponent,
 	RevisionsPage,
 	getTestAccountByFeature,
 	envToFeatureKey,
@@ -27,7 +26,6 @@ describe( `Editor: Revisions`, function () {
 	] );
 
 	let editorPage: EditorPage;
-	let revisionsComponent: RevisionsComponent;
 	let revisionsPage: RevisionsPage;
 	let page: Page;
 
@@ -60,23 +58,12 @@ describe( `Editor: Revisions`, function () {
 	} );
 
 	it( 'Select first revision', async function () {
-		if ( envVariables.TEST_ON_ATOMIC ) {
-			revisionsPage = new RevisionsPage( page );
-			await revisionsPage.selectRevision( 1 );
-		} else {
-			revisionsComponent = new RevisionsComponent( page );
-			await revisionsComponent.selectRevision( 1 );
-		}
+		revisionsPage = new RevisionsPage( page );
+		await revisionsPage.selectRevision( 1 );
 	} );
 
 	it( 'Validate selected revision diff', async function () {
-		let revisionContent: string;
-
-		if ( envVariables.TEST_ON_ATOMIC ) {
-			revisionContent = await page.innerText( '.revisions-diff' );
-		} else {
-			revisionContent = await page.innerText( '.editor-diff-viewer__content' );
-		}
+		const revisionContent = await page.innerText( '.revisions-diff' );
 
 		expect( revisionContent ).toContain( 'Revision 1' );
 		expect( revisionContent ).not.toContain( 'Revision 2' );
@@ -84,14 +71,12 @@ describe( `Editor: Revisions`, function () {
 	} );
 
 	it( 'Load selected revision', async function () {
-		if ( envVariables.TEST_ON_ATOMIC ) {
-			await revisionsPage.loadSelectedRevision();
-		} else {
-			await revisionsComponent.loadSelectedRevision();
-		}
+		await revisionsPage.loadSelectedRevision();
 	} );
 
 	it( 'Validate loaded revision content', async function () {
+		await editorPage.waitUntilLoaded();
+
 		const postContent = await editorPage.getText();
 
 		expect( postContent ).toBe( 'Revision 1' );


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/5327

Also see the companion post: pfsHM7-4W-p2

## Proposed Changes

This PR removes the iframe around Post (& Page) Editor.

For now, this is done by always redirecting to the corresponding wp-admin URL when the following Calypso URLs are visited:

|Calypso URL|wp-admin URL|
|-|-|
|(create new post)<br><br>/{post,page}/:siteSlug<br>/edit/jetpack-{testimonial,portfolio}/:siteSlug|:siteSlug/wp-admin/post-new.php?post_type=:postType|
|(edit a post)<br><br>/{post,page}/:siteSlug/:postId<br>/edit/jetpack-{testimonial,portfolio}/:siteSlug/:postId|:siteSlug/wp-admin/post.php?post=:postId&action=edit|

Also, this PR makes sure that the back button in the block editor nav sidebar is pointing to the correct view of the "post listing" screen, respecting the current user's preferred style (default or classic):

<img width="604" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/63a06849-a537-4d26-ab99-4a37558d8953">

### Credit

This PR is inspired by @mattwiebe's prior arts:

- https://github.com/Automattic/wp-calypso/pull/74384
- https://github.com/Automattic/wp-calypso/pull/74801

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

(Please read the whole instructions first before testing.)

### A. Testing the URLs

1. Apply the ETK changes to your sandbox.
2. Start with a (sandboxed) Simple site.
3. Test scenarios around Post:
    1. Go to Posts.
    2. Ensure the Default view is set.
    3. Create a new post. Verify that you're redirected to the wp-admin URL.
    4. Go back by clicking the back button from the sidebar (see screenshot above). Verify that you're correctly taken to the Calypso URL.
    5. Repeat steps iii-iv above, but this time edit an existing post.
    6. Go back to Posts.
    7. Now switch to the Classic view.
    8. Repeat steps iii-v above, but this time verify that the back button takes you to the wp-admin URL.
4. Repeat step 3 above, but this time with Pages.
5. Now, prepare an Atomic site.
6. Ensure your Atomic site uses default style (Settings -> Hosting Configuration).
7. Upload the ETK artifact to the Atomic site.
8. Test steps 3-4 above in your Atomic site.
9. Enable Jetpack Testimonial & Portfolio (Settings -> Writing -> Content types)
10. Repeat step 3 with Testimonials and Portfolios.
11. Set your Atomic site to use classic style (Settings -> Hosting Configuration).
12. Repeat steps 8-10, verify that the back button always takes you to the wp-admin URL.

### B. Testing the un-iframed functionalities

While doing the testing above, take some time to test the following. Note that everything should be already fine in theory, as we already show the wp-admin URLs to users with classic view turned on, but just in case.

1. Test core Revisions functionality; verify that you see the Core version, and nothing breaks. Note that Revisions UI only shows up when you have saved the post at least 2 times.

    <img width="361" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/86a59e90-e7ed-4432-8483-9fc767efd578">

2. Test core Media Library functionality; verify that you see the Core version, and nothing breaks.

    <img width="570" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/9700e469-aaef-4a9b-908c-9beec0a4a2fa">

3. Test the premium block upsell flow; verify that nothing breaks.

    <img width="453" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/52079c3c-1c50-4c9e-8755-5e5053f8b11e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?