### PR TITLE
Theme Tiers: Enable flag in dev

### DIFF
--- a/client/components/theme/test/__snapshots__/index.jsx.snap
+++ b/client/components/theme/test/__snapshots__/index.jsx.snap
@@ -34,7 +34,7 @@ exports[`Theme rendering should match snapshot 1`] = `
           Twenty Seventeen
         </span>
       </h2>
-      <components--theme-type-badge
+      <components--theme-tier-badge
         islockedstylevariation="false"
         themeid="twentyseventeen"
       />

--- a/config/development.json
+++ b/config/development.json
@@ -218,7 +218,7 @@
 		"themes/subscription-purchases": true,
 		"themes/text-search-lots": true,
 		"themes/assembler-first": true,
-		"themes/tiers": false,
+		"themes/tiers": true,
 		"titan/iframe-control-panel": false,
 		"two-factor/enhanced-security": true,
 		"upgrades/redirect-payments": true,

--- a/config/test.json
+++ b/config/test.json
@@ -123,7 +123,7 @@
 		"stepper-woocommerce-poc": true,
 		"storage-addon": true,
 		"themes/premium": true,
-		"themes/tiers": false,
+		"themes/tiers": true,
 		"upgrades/redirect-payments": true,
 		"upgrades/upcoming-renewals-notices": true,
 		"upgrades/wpcom-monthly-plans": true,


### PR DESCRIPTION
## Proposed Changes

This PR enables back the `themes/tiers` feature flag in the development and test environment so we can work more conveniently on fixes/improvements if needed before attempting another release to prod.

## Testing Instructions

CI