### PR TITLE
Add WordPress.com > Site Tools page and Other tools section

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
 import { billingHistory } from 'calypso/me/purchases/paths';
 import SiteSettingsMain from 'calypso/my-sites/site-settings/main';
+import WpcomSiteTools from 'calypso/my-sites/site-settings/wpcom-site-tools';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import canCurrentUserStartSiteOwnerTransfer from 'calypso/state/selectors/can-current-user-start-site-owner-transfer';
@@ -63,6 +64,11 @@ export function redirectIfCantStartSiteOwnerTransfer( context, next ) {
 
 export function general( context, next ) {
 	context.primary = <SiteSettingsMain />;
+	next();
+}
+
+export function wpcomSiteTools( context, next ) {
+	context.primary = <WpcomSiteTools />;
 	next();
 }
 

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -15,6 +15,7 @@ import {
 	redirectToTraffic,
 	startOver,
 	startSiteOwnerTransfer,
+	wpcomSiteTools,
 } from 'calypso/my-sites/site-settings/controller';
 import { setScroll, siteSettings } from 'calypso/my-sites/site-settings/settings-controller';
 
@@ -115,6 +116,19 @@ export default function () {
 	page( '/settings/analytics/:site_id?', redirectToTraffic );
 	page( '/settings/seo/:site_id?', redirectToTraffic );
 	page( '/settings/theme-setup/:site_id?', redirectToGeneral );
+
+	// Site tools for the WordPress.com > Site Tools menu
+	// from the untangle Calypso project.
+	page(
+		'/settings/site-tools/:site_id',
+		siteSelection,
+		navigation,
+		setScroll,
+		siteSettings,
+		wpcomSiteTools,
+		makeLayout,
+		clientRender
+	);
 
 	page( '/settings/:section', legacyRedirects, siteSelection, sites, makeLayout, clientRender );
 }

--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -1,3 +1,4 @@
+import { translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import GeneralForm from 'calypso/my-sites/site-settings/form-general';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
@@ -11,7 +12,7 @@ const SiteSettingsGeneral = ( { site, isWPForTeamsSite, isP2Hub, isWpcomStagingS
 	<div className="site-settings__main general-settings">
 		<GeneralForm site={ site } />
 		{ isWPForTeamsSite && isP2Hub && <P2PreapprovedDomainsForm siteId={ site?.ID } /> }
-		{ ! isWpcomStagingSite && <SiteTools /> }
+		{ ! isWpcomStagingSite && <SiteTools headerTitle={ translate( 'Site tools' ) } /> }
 	</div>
 );
 

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -59,6 +59,7 @@ class SiteTools extends Component {
 			showManageConnection,
 			showStartSiteTransfer,
 			siteId,
+			headerTitle,
 		} = this.props;
 
 		const changeAddressLink = `/domains/manage/${ siteSlug }`;
@@ -97,7 +98,7 @@ class SiteTools extends Component {
 		return (
 			<div className="site-tools">
 				<QueryRewindState siteId={ siteId } />
-				<SettingsSectionHeader id="site-tools__header" title={ translate( 'Site tools' ) } />
+				<SettingsSectionHeader id="site-tools__header" title={ headerTitle } />
 				{ showChangeAddress && (
 					<SiteToolsLink
 						href={ changeAddressLink }

--- a/client/my-sites/site-settings/wpcom-site-tools-settings/index.jsx
+++ b/client/my-sites/site-settings/wpcom-site-tools-settings/index.jsx
@@ -1,0 +1,17 @@
+import { connect } from 'react-redux';
+import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import SiteTools from '../site-tools';
+
+const SiteSettingsGeneral = ( { isWpcomStagingSite } ) => (
+	<div className="site-settings__main general-settings">
+		{ ! isWpcomStagingSite && <SiteTools /> }
+	</div>
+);
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	return {
+		isWpcomStagingSite: isSiteWpcomStaging( state, siteId ),
+	};
+} )( SiteSettingsGeneral );

--- a/client/my-sites/site-settings/wpcom-site-tools-settings/index.jsx
+++ b/client/my-sites/site-settings/wpcom-site-tools-settings/index.jsx
@@ -1,3 +1,4 @@
+import { translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -5,7 +6,7 @@ import SiteTools from '../site-tools';
 
 const SiteSettingsGeneral = ( { isWpcomStagingSite } ) => (
 	<div className="site-settings__main general-settings">
-		{ ! isWpcomStagingSite && <SiteTools /> }
+		{ ! isWpcomStagingSite && <SiteTools headerTitle={ translate( 'Other tools' ) } /> }
 	</div>
 );
 

--- a/client/my-sites/site-settings/wpcom-site-tools.jsx
+++ b/client/my-sites/site-settings/wpcom-site-tools.jsx
@@ -30,10 +30,7 @@ const WpcomSiteTools = ( { isJetpack, isPossibleJetpackConnectionProblem, siteId
 			<NavigationHeader
 				navigationItems={ [] }
 				title={ translate( 'Site Tools' ) }
-				subtitle={ translate(
-					// TODO: define copy here
-					'Wordpress.com > Site Tools'
-				) }
+				subtitle={ translate( 'Manage your site settings, including site visibility, and more.' ) }
 			/>
 			<WpcomSiteToolsSettings />
 		</Main>

--- a/client/my-sites/site-settings/wpcom-site-tools.jsx
+++ b/client/my-sites/site-settings/wpcom-site-tools.jsx
@@ -1,0 +1,54 @@
+import { localize } from 'i18n-calypso';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import JetpackBackupCredsBanner from 'calypso/blocks/jetpack-backup-creds-banner';
+import DocumentHead from 'calypso/components/data/document-head';
+import QueryProductsList from 'calypso/components/data/query-products-list';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connection-health';
+import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
+import { withJetpackConnectionProblem } from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js';
+import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import JetpackDevModeNotice from './jetpack-dev-mode-notice';
+import WpcomSiteToolsSettings from './wpcom-site-tools-settings';
+
+import './style.scss';
+
+const WpcomSiteTools = ( { isJetpack, isPossibleJetpackConnectionProblem, siteId, translate } ) => {
+	return (
+		<Main className="site-settings">
+			{ isJetpack && isPossibleJetpackConnectionProblem && (
+				<JetpackConnectionHealthBanner siteId={ siteId } />
+			) }
+			<DocumentHead title={ translate( 'Site Tools' ) } />
+			<QueryProductsList />
+			<QuerySitePurchases siteId={ siteId } />
+			<JetpackDevModeNotice />
+			<JetpackBackupCredsBanner event="settings-backup-credentials" />
+			<NavigationHeader
+				navigationItems={ [] }
+				title={ translate( 'Site Tools' ) }
+				subtitle={ translate(
+					// TODO: define copy here
+					'Wordpress.com > Site Tools'
+				) }
+			/>
+			<WpcomSiteToolsSettings />
+		</Main>
+	);
+};
+
+WpcomSiteTools.propTypes = {
+	// Connected props
+	siteId: PropTypes.number,
+};
+
+export default connect( ( state ) => {
+	const siteId = getSelectedSiteId( state );
+	return {
+		siteId,
+		isJetpack: isJetpackSite( state, siteId ),
+	};
+} )( localize( withJetpackConnectionProblem( WpcomSiteTools ) ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5486

## Proposed Changes
We'll eventually move items under Settings that are not wp-admin core to WordPress.com > Site tools

![other tools](https://github.com/Automattic/wp-calypso/assets/6586048/fdc458dd-53de-4179-ab86-21f93540fe56)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /settings/site-tools/:site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?