### PR TITLE
Assembler: clean up code for testing that forces using site data from Assembler demo site in previews on Horizon

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-assembler-container.tsx
@@ -1,5 +1,4 @@
 import { BlockRendererProvider, PatternsRendererProvider } from '@automattic/block-renderer';
-import { isEnabled } from '@automattic/calypso-config';
 import { getPlaceholderSiteID } from '@automattic/data-stores/src/site/constants';
 import { useMemo } from 'react';
 import StepperLoader from '../../components/stepper-loader';
@@ -47,10 +46,7 @@ const PatternAssemblerContainer = ( {
 				// such as the logo, title, tagline, pages, posts, etc.
 				// For the newly created site, we use the placeholder site to render the content.
 				// Otherwise, we use the current site to display the site-related blocks.
-				// For Horizon, forcing to use the content from Assembler demo site to help testing with any existing site.
-				siteId={
-					isNewSite || isEnabled( 'pattern-assembler/v2' ) ? getPlaceholderSiteID() : siteId
-				}
+				siteId={ isNewSite ? getPlaceholderSiteID() : siteId }
 				stylesheet={ stylesheet }
 				patternIdsByCategory={ patternIdsByCategory }
 				// Use siteInfo to overwrite site-related things such as title, and tagline.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* For existing sites, use the site data on pattern previews rather than from Assembler demo site

>[!Note]
>This change was done to help test the placeholders we use only for new sites.

|BEFORE|AFTER|
|-|-|
|<img width="946" alt="Screenshot 2567-02-02 at 19 10 17" src="https://github.com/Automattic/wp-calypso/assets/1881481/32018d30-102d-47bc-a2a1-4b6440929948">|<img width="935" alt="Screenshot 2567-02-02 at 19 11 14" src="https://github.com/Automattic/wp-calypso/assets/1881481/1de82ad6-0c65-489f-9927-10181b8ddb8b">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access Assembler on an existing site: https://wordpress.com/setup/assembler-first
* Open the Headers category to explore the patterns
* Verify you see your site name, site description, logo, and navigation menu

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?