### PR TITLE
Theme Tiers: Fix Warnings and Update Tracks Events

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/index.js
+++ b/client/components/theme-tier/theme-tier-badge/index.js
@@ -42,11 +42,11 @@ export default function ThemeTierBadge( {
 			return <ThemeTierCommunityBadge />;
 		}
 
-		if ( 'partner' === themeTier.slug || MARKETPLACE_THEME === themeType ) {
+		if ( 'partner' === themeTier?.slug || MARKETPLACE_THEME === themeType ) {
 			return <ThemeTierPartnerBadge />;
 		}
 
-		if ( isThemeAllowed || ( 'premium' === themeTier.slug && isLegacyPremiumPurchased ) ) {
+		if ( isThemeAllowed || ( 'premium' === themeTier?.slug && isLegacyPremiumPurchased ) ) {
 			return null;
 		}
 

--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -271,7 +271,7 @@ ThemesList.propTypes = {
 	] ),
 	siteId: PropTypes.number,
 	searchTerm: PropTypes.string,
-	tier: PropTypes.oneOf( [ '', 'free', 'premium', 'marketplace' ] ),
+	tier: PropTypes.string,
 	upsellCardDisplayed: PropTypes.func,
 	children: PropTypes.node,
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -502,6 +502,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	function handleCheckout() {
 		recordTracksEvent( 'calypso_signup_design_upgrade_modal_checkout_button_click', {
 			theme: selectedDesign?.slug,
+			theme_tier: selectedDesign?.design_tier,
 			is_externally_managed: selectedDesign?.is_externally_managed,
 		} );
 

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1466,7 +1466,7 @@ class ThemeSheet extends Component {
 					isExternallyManagedTheme || isBundledSoftwareSet ? PLAN_BUSINESS : PLAN_PREMIUM;
 			}
 			const upsellNudgeFeature = config.isEnabled( 'themes/tiers' )
-				? `${ themeTier?.slug }-themes`
+				? themeTier?.feature
 				: WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED;
 
 			pageUpsellBanner = (
@@ -1484,6 +1484,7 @@ class ThemeSheet extends Component {
 					showIcon={ true }
 					forceDisplay={ forceDisplay }
 					displayAsLink={ onClick !== null }
+					tracksClickProperties={ { theme_tier: themeTier?.slug } }
 				/>
 			);
 		}
@@ -1515,7 +1516,11 @@ class ThemeSheet extends Component {
 					showIcon
 					event="theme_upsell_plan_click"
 					tracksClickName="calypso_theme_upsell_plan_click"
-					tracksClickProperties={ { theme_id: themeId, theme_name: themeName } }
+					tracksClickProperties={ {
+						theme_id: themeId,
+						theme_name: themeName,
+						theme_tier: themeTier?.slug,
+					} }
 				/>
 			);
 		}

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -1197,6 +1197,7 @@ class ThemeSheet extends Component {
 					this.props.recordTracksEvent( 'calypso_theme_sheet_primary_button_click', {
 						theme: this.props.themeId,
 						theme_type: themeType,
+						theme_tier: themeTier?.slug,
 						...( key && { action: key } ),
 					} );
 
@@ -1464,6 +1465,9 @@ class ThemeSheet extends Component {
 				upsellNudgePlan =
 					isExternallyManagedTheme || isBundledSoftwareSet ? PLAN_BUSINESS : PLAN_PREMIUM;
 			}
+			const upsellNudgeFeature = config.isEnabled( 'themes/tiers' )
+				? `${ themeTier?.slug }-themes`
+				: WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED;
 
 			pageUpsellBanner = (
 				<UpsellNudge
@@ -1472,7 +1476,7 @@ class ThemeSheet extends Component {
 					title={ this.getBannerUpsellTitle() }
 					description={ preventWidows( this.getBannerUpsellDescription() ) }
 					event="themes_plan_particular_free_with_plan"
-					feature={ WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED }
+					feature={ upsellNudgeFeature }
 					forceHref={ onClick === null }
 					disableHref={ onClick !== null }
 					onClick={ null === onClick ? noop : onClick }

--- a/client/my-sites/themes/collections/showcase-theme-collection.tsx
+++ b/client/my-sites/themes/collections/showcase-theme-collection.tsx
@@ -45,6 +45,7 @@ export default function ShowcaseThemeCollection( {
 		isLivePreviewStarted,
 		siteId,
 		getThemeType,
+		getThemeTierForTheme,
 		filterString,
 		getThemeDetailsUrl,
 	} = useThemeCollection( query );
@@ -56,6 +57,7 @@ export default function ShowcaseThemeCollection( {
 			themes,
 			filterString,
 			getThemeType,
+			getThemeTierForTheme,
 			isActive,
 			collectionSlug,
 			collectionIndex

--- a/client/my-sites/themes/collections/use-theme-collection.ts
+++ b/client/my-sites/themes/collections/use-theme-collection.ts
@@ -5,6 +5,7 @@ import {
 	getThemeDetailsUrl as getThemeDetailsUrlSelector,
 	getThemesForQueryIgnoringPage,
 	getThemeType as getThemeTypeSelector,
+	getThemeTierForTheme as getThemeTierForThemeSelector,
 	isInstallingTheme,
 	isThemeActive,
 	prependThemeFilterKeys,
@@ -46,6 +47,10 @@ export function useThemeCollection( query: ThemesQuery ) {
 		( state ) => ( themeId: string ) => getThemeTypeSelector( state, themeId )
 	);
 
+	const getThemeTierForTheme = useSelector(
+		( state ) => ( themeId: string ) => getThemeTierForThemeSelector( state, themeId )
+	);
+
 	const getThemeDetailsUrl = useSelector(
 		( state ) => ( themeId: string ) =>
 			getThemeDetailsUrlSelector( state, themeId, siteId as number )
@@ -61,6 +66,7 @@ export function useThemeCollection( query: ThemesQuery ) {
 		isLivePreviewStarted,
 		siteId,
 		getThemeType,
+		getThemeTierForTheme,
 		filterString,
 		getThemeDetailsUrl,
 	};

--- a/client/my-sites/themes/events/theme-showcase-tracks.ts
+++ b/client/my-sites/themes/events/theme-showcase-tracks.ts
@@ -24,6 +24,7 @@ const getThemeShowcaseEventRecorder = (
 	themes: Array< Theme >,
 	filterString: string,
 	getThemeType: ( themeId: string ) => string,
+	getThemeTierForTheme: ( themeId: string ) => object,
 	isActiveTheme: ( themeId: string ) => boolean,
 	defaultCollectionId: string | null = null,
 	defaultCollectionIndex: number | null = null
@@ -56,6 +57,8 @@ const getThemeShowcaseEventRecorder = (
 				theme_on_page: Math.floor( adjustedPosition / query.number ),
 				action: snakeCase( action ),
 				theme_type: getThemeType( themeId ),
+				// @ts-expect-error Tiers are not yet typed
+				theme_tier: getThemeTierForTheme( themeId )?.slug,
 				is_collection: isCollection,
 				...( isCollection
 					? {

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -29,6 +29,7 @@ import {
 	prependThemeFilterKeys,
 	getIsLivePreviewStarted,
 	getThemeType,
+	getThemeTierForTheme,
 } from 'calypso/state/themes/selectors';
 import { getThemeHiddenFilters } from 'calypso/state/themes/selectors/get-theme-hidden-filters';
 import { addOptionsToGetUrl, trackClick, interlaceThemes } from './helpers';
@@ -306,6 +307,10 @@ function bindGetThemeType( state ) {
 	return ( themeId ) => getThemeType( state, themeId );
 }
 
+function bindGetThemeTierForTheme( state ) {
+	return ( themeId ) => getThemeTierForTheme( state, themeId );
+}
+
 // Exporting this for use in customized themes lists (recommended-themes.jsx, etc.)
 // We do not want pagination triggered in that use of the component.
 export const ConnectedThemesSelection = connect(
@@ -377,12 +382,14 @@ export const ConnectedThemesSelection = connect(
 
 		const boundIsThemeActive = bindIsThemeActive( state, siteId );
 		const boundGetThemeType = bindGetThemeType( state );
+		const boundGetThemeTierForTheme = bindGetThemeTierForTheme( state );
 		const filterString = prependThemeFilterKeys( state, query.filter );
 		const themeShowcaseEventRecorder = getThemeShowcaseEventRecorder(
 			query,
 			themes,
 			filterString,
 			boundGetThemeType,
+			boundGetThemeTierForTheme,
 			boundIsThemeActive
 		);
 

--- a/client/state/themes/actions/live-preview.ts
+++ b/client/state/themes/actions/live-preview.ts
@@ -8,6 +8,7 @@ import {
 	getTheme,
 	getThemeType,
 	getThemePreviewThemeOptions,
+	getThemeTierForTheme,
 } from 'calypso/state/themes/selectors';
 import { CalypsoDispatch } from 'calypso/state/types';
 import { AppState } from 'calypso/types';
@@ -28,6 +29,7 @@ export function livePreview( siteId: number, themeId: string, source?: 'list' | 
 			site_id: siteId,
 			source,
 			theme_type: getThemeType( state, themeId ),
+			theme_tier: getThemeTierForTheme( state, themeId )?.slug,
 			theme: themeId,
 			theme_style:
 				themeId +

--- a/client/state/themes/actions/theme-activated.js
+++ b/client/state/themes/actions/theme-activated.js
@@ -9,6 +9,7 @@ import {
 	getLastThemeQuery,
 	getThemeType,
 	prependThemeFilterKeys,
+	getThemeTierForTheme,
 } from 'calypso/state/themes/selectors';
 
 import 'calypso/state/themes/init';
@@ -57,6 +58,7 @@ export function themeActivated(
 			search_taxonomies,
 			style_variation_slug: styleVariationSlug || '',
 			theme_type: getThemeType( getState(), themeId ),
+			theme_tier: getThemeTierForTheme( getState(), themeId )?.slug,
 		} );
 		dispatch( withAnalytics( trackThemeActivation, action ) );
 

--- a/client/state/themes/selectors/get-active-theme.ts
+++ b/client/state/themes/selectors/get-active-theme.ts
@@ -16,7 +16,7 @@ export function getActiveTheme( state: AppState, siteId: number | undefined ): s
 	if ( ! siteId ) {
 		return null;
 	}
-	const activeTheme = state.themes.activeThemes[ siteId ] ?? null;
+	const activeTheme = state.themes?.activeThemes?.[ siteId ];
 	// If the theme ID is suffixed with -wpcom, remove that string. This is because
 	// we want to treat WP.com themes identically, whether or not they're installed
 	// on a given Jetpack site (where the -wpcom suffix would be appended).

--- a/client/state/themes/selectors/get-theme-tier-for-theme.tsx
+++ b/client/state/themes/selectors/get-theme-tier-for-theme.tsx
@@ -3,5 +3,5 @@ import type { AppState } from 'calypso/types';
 
 export function getThemeTierForTheme( state: AppState, themeId: string ) {
 	const theme = getTheme( state, 'wpcom', themeId );
-	return theme?.theme_tier;
+	return theme?.theme_tier || {};
 }

--- a/client/state/themes/selectors/get-theme-tier-for-theme.tsx
+++ b/client/state/themes/selectors/get-theme-tier-for-theme.tsx
@@ -3,5 +3,5 @@ import type { AppState } from 'calypso/types';
 
 export function getThemeTierForTheme( state: AppState, themeId: string ) {
 	const theme = getTheme( state, 'wpcom', themeId );
-	return theme?.theme_tier || {};
+	return theme?.theme_tier;
 }

--- a/client/state/themes/selectors/is-theme-premium.js
+++ b/client/state/themes/selectors/is-theme-premium.js
@@ -1,4 +1,6 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { getTheme } from 'calypso/state/themes/selectors/get-theme';
+import { getThemeTierForTheme } from 'calypso/state/themes/selectors/get-theme-tier-for-theme';
 import { isPremium } from 'calypso/state/themes/utils';
 
 import 'calypso/state/themes/init';
@@ -10,5 +12,9 @@ import 'calypso/state/themes/init';
  * @returns {boolean}        True if the theme is premium
  */
 export function isThemePremium( state, themeId ) {
+	if ( isEnabled( 'themes/tiers' ) ) {
+		const themeTier = getThemeTierForTheme( state, themeId );
+		return 'premium' === themeTier?.slug;
+	}
 	return isPremium( getTheme( state, 'wpcom', themeId ) );
 }

--- a/client/state/themes/selectors/is-theme-premium.js
+++ b/client/state/themes/selectors/is-theme-premium.js
@@ -14,7 +14,9 @@ import 'calypso/state/themes/init';
 export function isThemePremium( state, themeId ) {
 	if ( isEnabled( 'themes/tiers' ) ) {
 		const themeTier = getThemeTierForTheme( state, themeId );
-		return 'premium' === themeTier?.slug;
+		if ( themeTier?.slug ) {
+			return 'premium' === themeTier?.slug;
+		}
 	}
 	return isPremium( getTheme( state, 'wpcom', themeId ) );
 }


### PR DESCRIPTION
This PR includes several minor updates to support the launch of Theme Tiers v1.

- Fix some console warnings.
- Guard against empty tier while loading on a clean state.
- Add tier props to many themes-related Tracks events.
- Aligned the client and server-side `isPremium` checks.