### PR TITLE
Two Factor: Allow users to log in with backup codes and improve the security keys flow

### DIFF
--- a/client/blocks/login/two-factor-authentication/security-key-form.jsx
+++ b/client/blocks/login/two-factor-authentication/security-key-form.jsx
@@ -31,8 +31,12 @@ class SecurityKeyForm extends Component {
 		isAuthenticating: false,
 	};
 
+	componentDidMount() {
+		setTimeout( () => this.initiateSecurityKeyAuthentication(), 100 );
+	}
+
 	initiateSecurityKeyAuthentication = ( event ) => {
-		event.preventDefault();
+		event?.preventDefault();
 
 		const { onSuccess } = this.props;
 		this.setState( { isAuthenticating: true } );

--- a/client/blocks/login/two-factor-authentication/security-key-form.jsx
+++ b/client/blocks/login/two-factor-authentication/security-key-form.jsx
@@ -32,12 +32,10 @@ class SecurityKeyForm extends Component {
 	};
 
 	componentDidMount() {
-		setTimeout( () => this.initiateSecurityKeyAuthentication(), 100 );
+		this.initiateSecurityKeyAuthentication();
 	}
 
-	initiateSecurityKeyAuthentication = ( event ) => {
-		event?.preventDefault();
-
+	initiateSecurityKeyAuthentication = () => {
 		const { onSuccess } = this.props;
 		this.setState( { isAuthenticating: true } );
 		this.props

--- a/client/blocks/login/two-factor-authentication/security-key-form.jsx
+++ b/client/blocks/login/two-factor-authentication/security-key-form.jsx
@@ -52,7 +52,10 @@ class SecurityKeyForm extends Component {
 				className={ classNames( 'two-factor-authentication__verification-code-form-wrapper', {
 					isWoo: isWoo,
 				} ) }
-				onSubmit={ this.initiateSecurityKeyAuthentication }
+				onSubmit={ ( event ) => {
+					event.preventDefault();
+					this.initiateSecurityKeyAuthentication();
+				} }
 			>
 				<Card compact className="two-factor-authentication__verification-code-form">
 					{ ! this.state.isAuthenticating && (

--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -44,6 +44,15 @@ class TwoFactorActions extends Component {
 
 		this.props.switchTwoFactorAuthType( 'authenticator' );
 	};
+
+	recordBackupLinkClick = ( event ) => {
+		event.preventDefault();
+
+		this.props.recordTracksEvent( 'calypso_login_two_factor_switch_to_backup_link_click' );
+
+		this.props.switchTwoFactorAuthType( 'backup' );
+	};
+
 	recordSecurityKey = ( event ) => {
 		event.preventDefault();
 		this.props.switchTwoFactorAuthType( 'webauthn' );
@@ -52,6 +61,7 @@ class TwoFactorActions extends Component {
 	render() {
 		const {
 			isAuthenticatorSupported,
+			isBackupCodeSupported,
 			isSecurityKeySupported,
 			isSmsSupported,
 			translate,
@@ -59,12 +69,18 @@ class TwoFactorActions extends Component {
 		} = this.props;
 
 		const isSmsAvailable = isSmsSupported && twoFactorAuthType !== 'sms';
+		const isBackupCodeAvailable = isBackupCodeSupported && twoFactorAuthType !== 'backup';
 		const isAuthenticatorAvailable =
 			isAuthenticatorSupported && twoFactorAuthType !== 'authenticator';
 		const isSecurityKeyAvailable =
 			isWebAuthnSupported() && isSecurityKeySupported && twoFactorAuthType !== 'webauthn';
 
-		if ( ! isSmsAvailable && ! isAuthenticatorAvailable && ! isSecurityKeyAvailable ) {
+		if (
+			! isSmsAvailable &&
+			! isAuthenticatorAvailable &&
+			! isSecurityKeyAvailable &&
+			! isBackupCodeAvailable
+		) {
 			return null;
 		}
 
@@ -89,6 +105,12 @@ class TwoFactorActions extends Component {
 							{ translate( 'Continue with your authenticator\u00A0app' ) }
 						</Button>
 					) }
+
+					{ isBackupCodeAvailable && (
+						<Button data-e2e-link="2fa-otp-link" onClick={ this.recordBackupLinkClick }>
+							{ translate( 'Continue with a backup code' ) }
+						</Button>
+					) }
 				</Card>
 			</Fragment>
 		);
@@ -98,6 +120,7 @@ class TwoFactorActions extends Component {
 export default connect(
 	( state ) => ( {
 		isAuthenticatorSupported: isTwoFactorAuthTypeSupported( state, 'authenticator' ),
+		isBackupCodeSupported: isTwoFactorAuthTypeSupported( state, 'backup' ),
 		isSmsSupported: isTwoFactorAuthTypeSupported( state, 'sms' ),
 		isSecurityKeySupported: isTwoFactorAuthTypeSupported( state, 'webauthn' ),
 		isWoo:

--- a/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
+++ b/client/blocks/login/two-factor-authentication/two-factor-actions.jsx
@@ -107,7 +107,7 @@ class TwoFactorActions extends Component {
 					) }
 
 					{ isBackupCodeAvailable && (
-						<Button data-e2e-link="2fa-otp-link" onClick={ this.recordBackupLinkClick }>
+						<Button onClick={ this.recordBackupLinkClick }>
 							{ translate( 'Continue with a backup code' ) }
 						</Button>
 					) }

--- a/client/me/reauth-required/security-key-form.jsx
+++ b/client/me/reauth-required/security-key-form.jsx
@@ -21,8 +21,12 @@ class SecurityKeyForm extends Component {
 		showError: false,
 	};
 
+	componentDidMount() {
+		setTimeout( () => this.initiateSecurityKeyAuthentication(), 100 );
+	}
+
 	initiateSecurityKeyAuthentication = ( event, retryRequest = true ) => {
-		event.preventDefault();
+		event?.preventDefault();
 		this.setState( { isAuthenticating: true, showError: false } );
 
 		this.props.twoStepAuthorization

--- a/client/me/reauth-required/security-key-form.jsx
+++ b/client/me/reauth-required/security-key-form.jsx
@@ -61,7 +61,12 @@ class SecurityKeyForm extends Component {
 		const { isAuthenticating } = this.state;
 
 		return (
-			<form onSubmit={ this.initiateSecurityKeyAuthentication }>
+			<form
+				onSubmit={ ( event ) => {
+					event.preventDefault();
+					this.initiateSecurityKeyAuthentication();
+				} }
+			>
 				<Card compact className="security-key-form__verification-code-form">
 					{ ! isAuthenticating ? (
 						<div>

--- a/client/me/reauth-required/security-key-form.jsx
+++ b/client/me/reauth-required/security-key-form.jsx
@@ -22,11 +22,10 @@ class SecurityKeyForm extends Component {
 	};
 
 	componentDidMount() {
-		setTimeout( () => this.initiateSecurityKeyAuthentication(), 100 );
+		this.initiateSecurityKeyAuthentication();
 	}
 
-	initiateSecurityKeyAuthentication = ( event, retryRequest = true ) => {
-		event?.preventDefault();
+	initiateSecurityKeyAuthentication = ( retryRequest = true ) => {
 		this.setState( { isAuthenticating: true, showError: false } );
 
 		this.props.twoStepAuthorization
@@ -37,7 +36,7 @@ class SecurityKeyForm extends Component {
 				if ( errors.some( ( e ) => e.code === 'invalid_two_step_nonce' ) ) {
 					this.props.twoStepAuthorization.fetch( () => {
 						if ( retryRequest ) {
-							this.initiateSecurityKeyAuthentication( event, false );
+							this.initiateSecurityKeyAuthentication( false );
 						} else {
 							// We only retry once, so let's show the original error.
 							this.setState( { isAuthenticating: false, showError: true } );


### PR DESCRIPTION
Users with a TOTP based second factor (either SMS or an App) are able to enter backup codes directly into the verification form when they log in, however it's not clear for most users they can use them.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* We add an explicit button "Continue with a backup code" to instruct users to enter a 2fa backup code instead.
Before
<img width="404" alt="Screenshot 2024-02-06 at 12 03 09" src="https://github.com/Automattic/wp-calypso/assets/1081870/52b1e081-4b56-4cc4-b560-d22f2ae1648d">
Verification form
<img width="410" alt="Screenshot 2024-02-06 at 12 03 17" src="https://github.com/Automattic/wp-calypso/assets/1081870/378cea04-d48b-4f31-aaf5-729a212719c7">

After
<img width="386" alt="Screenshot 2024-02-06 at 12 02 39" src="https://github.com/Automattic/wp-calypso/assets/1081870/455dc621-cca7-462b-a370-eecaf3cc96da">
Verification form for backup codes
<img width="406" alt="Screenshot 2024-02-06 at 12 02 51" src="https://github.com/Automattic/wp-calypso/assets/1081870/0edd75f6-ed22-4f1d-accf-5b4baf0b24f9">


* We also remove the requirement to click on the "Continue with security key" button when signing in with a security key. If it fails for some reason, the old button will still work as always if the user decides to retry the same action.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open an incognito window.
* Log in with a WP.com user using a security key as second factor (you might need to add a specific key for the calypso development environment).
* Notice you don't need to click any button before the security key flow starts.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
