### PR TITLE
Design Setup: Fetch Starter Design with locale

### DIFF
--- a/packages/data-stores/src/starter-designs-queries/use-starter-design-by-slug.ts
+++ b/packages/data-stores/src/starter-designs-queries/use-starter-design-by-slug.ts
@@ -1,3 +1,4 @@
+import { useLocale } from '@automattic/i18n-utils';
 import { useQuery, UseQueryResult, QueryOptions } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { Design } from '@automattic/design-picker/src/types';
@@ -11,18 +12,23 @@ export function useStarterDesignBySlug(
 	slug: string,
 	queryOptions: Options = {}
 ): UseQueryResult< Design > {
+	const localeSlug = useLocale();
+
 	return useQuery( {
-		queryKey: [ 'starter-designs-get', slug ],
-		queryFn: () => fetchStarterDesignBySlug( slug ),
+		queryKey: [ 'starter-designs-get', slug, localeSlug ],
+		queryFn: () => fetchStarterDesignBySlug( slug, localeSlug ),
 		refetchOnMount: 'always',
 		staleTime: Infinity,
 		...queryOptions,
 	} );
 }
 
-function fetchStarterDesignBySlug( slug: string ): Promise< Design > {
+function fetchStarterDesignBySlug( slug: string, localeSlug: string ): Promise< Design > {
+	const params = new URLSearchParams( { _locale: localeSlug } );
+
 	return wpcomRequest< Design >( {
 		apiNamespace: 'wpcom/v2',
 		path: `/starter-designs/${ encodeURIComponent( slug ) }`,
+		query: params.toString(),
 	} );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 724-gh-Automattic/i18n-issues

## Proposed Changes

* Pass the locale param when fetching starter design theme details.

**Before:**
![CleanShot 2024-02-02 at 15 15 31](https://github.com/Automattic/wp-calypso/assets/2722412/79405c8c-0a9b-4cfa-8a80-5a79b7668f32)

**After:**
![CleanShot 2024-02-02 at 15 15 09](https://github.com/Automattic/wp-calypso/assets/2722412/bce93ffa-3f81-41c8-b116-361acef30b63)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Boot locally or use calypso.live build.
* Switch UI to a Mag-16 locale.
* Create a new site and navigate to the design setup step (i.e. `/setup/site-setup/designSetup?siteSlug=...`).
* Confirm theme description is translated.
* Code review.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
