### PR TITLE
JP Manage: Pricing page redirect should open correct modal and select product on page load

### DIFF
--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/featured-license-item-card.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/featured-license-item-card.tsx
@@ -76,13 +76,13 @@ export const FeaturedLicenseItemCard = ( {
 		( productSlug: string, bundleSize: number | undefined ) => {
 			if ( isLoggedIn && ! isAgency ) {
 				return addQueryArgs( `/manage/signup/`, {
-					product_slug: productSlug,
+					products: productSlug,
 					source: 'manage-pricing-page',
 					bundle_size: bundleSize,
 				} );
 			}
 			return addQueryArgs( `/partner-portal/issue-license/`, {
-				product_slug: productSlug,
+				products: productSlug,
 				source: 'manage-pricing-page',
 				bundle_size: bundleSize,
 			} );

--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/featured-license-multi-item-card.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/featured-license-multi-item-card.tsx
@@ -104,13 +104,13 @@ export const FeaturedLicenseMultiItemCard = ( {
 		( variantSlug: string, bundleSize: number | undefined ) => {
 			if ( isLoggedIn && ! isAgency ) {
 				return addQueryArgs( `/manage/signup/`, {
-					product_slug: variantSlug,
+					products: variantSlug,
 					source: 'manage-pricing-page',
 					bundle_size: bundleSize,
 				} );
 			}
 			return addQueryArgs( `/partner-portal/issue-license/`, {
-				product_slug: variantSlug,
+				products: variantSlug,
 				source: 'manage-pricing-page',
 				bundle_size: bundleSize,
 			} );

--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/simple-license-item-card.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/simple-license-item-card.tsx
@@ -110,13 +110,13 @@ export const SimpleLicenseItemCard = ( {
 		( productSlug: string, bundleSize: number | undefined ) => {
 			if ( isLoggedIn && ! isAgency ) {
 				return addQueryArgs( `/manage/signup/`, {
-					product_slug: productSlug,
+					products: productSlug,
 					source: 'manage-pricing-page',
 					bundle_size: bundleSize,
 				} );
 			}
 			return addQueryArgs( `/partner-portal/issue-license/`, {
-				product_slug: productSlug,
+				products: productSlug,
 				source: 'manage-pricing-page',
 				bundle_size: bundleSize,
 			} );

--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/simple-license-multi-item-card.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/simple-license-multi-item-card.tsx
@@ -114,13 +114,13 @@ export const SimpleLicenseMultiItemCard = ( {
 		( variantSlug: string, bundleSize: number | undefined ) => {
 			if ( isLoggedIn && ! isAgency ) {
 				return addQueryArgs( `/manage/signup/`, {
-					product_slug: variantSlug,
+					products: variantSlug,
 					source: 'manage-pricing-page',
 					bundle_size: bundleSize,
 				} );
 			}
 			return addQueryArgs( `/partner-portal/issue-license/`, {
-				product_slug: variantSlug,
+				products: variantSlug,
 				source: 'manage-pricing-page',
 				bundle_size: bundleSize,
 			} );

--- a/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
@@ -176,7 +176,6 @@ export default function LicenseMultiProductCard( props: Props ) {
 				: ( item = getItem( 'jetpack-backup-t2' ) );
 			if ( item ) {
 				setProduct( item );
-				setShowLightbox( true );
 			}
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/license-multi-product-card/index.tsx
@@ -1,5 +1,4 @@
 import { Gridicon } from '@automattic/components';
-import { getQueryArg } from '@wordpress/url';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useState } from 'react';
@@ -143,43 +142,6 @@ export default function LicenseMultiProductCard( props: Props ) {
 			setProduct( selectedOption );
 		}
 	}, [ selectedOption ] );
-
-	const getItem = ( slug: string ) => {
-		const itemType = products;
-		let item = itemType.find(
-			( item ) => ( Array.isArray( item ) ? item[ item.length - 1 ]?.slug : item.slug ) === slug
-		);
-		if ( Array.isArray( item ) ) {
-			item = item[ 1 ];
-		}
-
-		if ( item ) {
-			const itemBundle = {
-				...( item as APIProductFamilyProduct ),
-				quantity,
-			};
-			return itemBundle;
-		}
-	};
-
-	useEffect( () => {
-		const source = getQueryArg( window.location.href, 'source' );
-		const itemSlug = getQueryArg( window.location.href, 'product_slug' );
-
-		if (
-			source === 'manage-pricing-page' &&
-			( itemSlug === 'jetpack-security-t2' || itemSlug === 'jetpack-backup-t2' )
-		) {
-			let item;
-			itemSlug === 'jetpack-security-t2'
-				? ( item = getItem( 'jetpack-security-t2' ) )
-				: ( item = getItem( 'jetpack-backup-t2' ) );
-			if ( item ) {
-				setProduct( item );
-			}
-		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [] );
 
 	return (
 		<>

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -87,11 +87,7 @@ export default function IssueLicense( { selectedSite, suggestedProduct }: Assign
 
 	// If URL params are present, use them to open the review licenses modal directly.
 	useEffect( () => {
-		if (
-			getQueryArg( window.location.href, 'source' ) === 'manage-pricing-page' &&
-			getQueryArg( window.location.href, 'product_slug' ) !== 'jetpack-backup-t2' &&
-			getQueryArg( window.location.href, 'product_slug' ) !== 'jetpack-security-t2'
-		) {
+		if ( getQueryArg( window.location.href, 'source' ) === 'manage-pricing-page' ) {
 			getGroupedLicenses();
 			setShowReviewLicenses( true );
 			dispatch(


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-manage/issues/267

We're displaying the wrong modal when being redirected to the `/partner-portal/issue-license` page from the new Jetpack Manage Pricing page, if a variant of a product is selected.
Read: `jetpack-security-t1` would work as expected, but `jetpack-security-t2` would not be shown in the correct modal, and the variant wouldn't be selected on the page itself when the modal is closed.

For context, then we're currently using the following query parameters:

* `product_slug`: a way for us to redirect the (potentially anonymous) reader from the manage pricing page, to the "issue license" page while carrying along the product they've shown interest in.
* `source`: a trigger to identify how the initial load of the "issue license" page should act.
* `bundle_size`: _Currently being developed_.


## Proposed Changes

* Remove the `jetpack-security-t2` and `jetpack-backup-t2` hardcoded exceptions in `<LicenseMultiProductCard>`.
  * This also removes the `setShowLightbox( true );` line which would trigger the incorrect modal.
* Change the query parameter from `product_slug` to `products` since the `<LicensesForm>` component (read: `/issue-license` page) already supports `products` as a query parameter and that logic will detect variants as well.
* Update our redirects from the Jetpack Manage pricing page to use `products` query parameter

The final result of the above changes is that we correctly select the variant as the "active product" on the page and therefore don't have to implement any of the previous custom logic to select it.

For good measure, then the redirect URL changes from:

```
/partner-portal/issue-license?product_slug=jetpack-security-t2&source=manage-pricing-page&bundle_size=1
``` 

... to:

```
/partner-portal/issue-license?products=jetpack-security-t2&source=manage-pricing-page&bundle_size=1
```

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**(These testing instructions assumes that you have a Jetpack Partner account)**

* Apply patch
* Go to `/partner-portal/issue-license?products=jetpack-security-t2&source=manage-pricing-page&bundle_size=1`
  * _You might have to log in first_
* Verify that you see the below screen

_**Bonus points**_

* Apply patch
* Press all the possible "Get" buttons. Possible variants: 
  * Plans section (for single licenses and bundled offerings)
  * Products section (for single licenses and bundled offerings)
  * Addons section (for single licenses and bundled offerings)
  * WooCommerce section (for single licenses and bundled offerings)
  * Open the "More about <product>" modal and select license (for single licenses and bundled offerings)

**Screenshot of expected modal**

![Screenshot 2024-02-02 at 16 13 45](https://github.com/Automattic/wp-calypso/assets/3846700/6e5aa04b-f324-48ce-b27a-f8a257328031)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?