### PR TITLE
Rename domain connect/disconnect to attach/detach

### DIFF
--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/disconnect/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/disconnect/index.tsx
@@ -118,10 +118,10 @@ const DisconnectDomainCard = ( { domain, selectedSite }: DomainInfoCardProps ) =
 		<>
 			<DomainInfoCard
 				type="click"
-				title="Disconnect"
-				description="Disconnect this domain from the site"
+				title={ translate( 'Detach' ) }
+				description={ translate( 'Detach this domain from the site' ) }
 				onClick={ () => setDialogVisible( true ) }
-				ctaText="Disconnect"
+				ctaText={ translate( 'Detach' ) }
 			/>
 			{ renderDialog() }
 		</>

--- a/client/my-sites/domains/domain-management/components/domain/domain-info-card/disconnect/index.tsx
+++ b/client/my-sites/domains/domain-management/components/domain/domain-info-card/disconnect/index.tsx
@@ -65,9 +65,7 @@ const DisconnectDomainCard = ( { domain, selectedSite }: DomainInfoCardProps ) =
 			dispatch( markAsPendingMove( selectedSite.ID, domain.name ) );
 
 			dispatch(
-				successNotice(
-					translate( 'The domain will be disconnected from this site in a few minutes.' )
-				)
+				successNotice( translate( 'The domain will be detached from this site in a few minutes.' ) )
 			);
 			setDisconnecting( false );
 			setDialogVisible( false );
@@ -85,7 +83,7 @@ const DisconnectDomainCard = ( { domain, selectedSite }: DomainInfoCardProps ) =
 		},
 		{
 			action: 'disconnect',
-			label: translate( 'Disconnect' ),
+			label: translate( 'Detach' ),
 			onClick: clickDisconnectDomain,
 			additionalClassNames: isDisconnecting ? 'is-busy' : '',
 			isPrimary: true,
@@ -98,15 +96,13 @@ const DisconnectDomainCard = ( { domain, selectedSite }: DomainInfoCardProps ) =
 				<div className="dialog__grid">
 					<div className="dialog__grid-column">
 						<FormSectionHeading>
-							{ translate( '{{strong}}Disconnect %(domain)s{{/strong}}', {
+							{ translate( '{{strong}}Detach %(domain)s{{/strong}}', {
 								args: { domain: domain.name },
 								components: { strong: <strong /> },
 							} ) }
 						</FormSectionHeading>
 						<p>
-							{ translate(
-								'Are you sure? This will disconnect the domain from its current site.'
-							) }
+							{ translate( 'Are you sure? This will detach the domain from its current site.' ) }
 						</p>
 					</div>
 				</div>

--- a/client/my-sites/domains/domain-management/settings/cards/domain-only-connect/index.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-only-connect/index.tsx
@@ -37,7 +37,7 @@ const DomainOnlyConnectCard = ( props: DomainOnlyConnectCardProps ) => {
 							currentRoute
 						) }
 					>
-						{ translate( 'Connect to an existing site' ) }
+						{ translate( 'Attach to an existing site' ) }
 					</Button>
 				) }
 			</div>

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/confirmation-dialog.jsx
@@ -41,7 +41,7 @@ class TransferConfirmationDialog extends PureComponent {
 		}
 
 		return translate(
-			'Do you want to connect {{strong}}%(domainName)s{{/strong}} ' +
+			'Do you want to attach {{strong}}%(domainName)s{{/strong}} ' +
 				'to site {{strong}}%(targetSiteTitle)s{{/strong}}?',
 			{
 				args: { domainName: domain.name, targetSiteTitle },
@@ -97,7 +97,7 @@ class TransferConfirmationDialog extends PureComponent {
 	render() {
 		const { domain, isMapping, translate } = this.props;
 		const actionLabel = ! isMapping
-			? translate( 'Confirm Connection' )
+			? translate( 'Confirm Attachment' )
 			: translate( 'Confirm Domain Connection Transfer' );
 		const buttons = [
 			{
@@ -118,7 +118,9 @@ class TransferConfirmationDialog extends PureComponent {
 
 		return (
 			<Dialog isVisible={ this.props.isVisible } buttons={ buttons } onClose={ this.props.onClose }>
-				<h1>{ translate( 'Confirm Connection' ) }</h1>
+				<h1>
+					{ ! isMapping ? translate( 'Confirm Attachment' ) : translate( 'Confirm Connection' ) }
+				</h1>
 				<p>{ this.getMessage() }</p>
 				{ hasEmailWithUs && this.renderEmailSubscriptionInformation() }
 				{ ! this.props.isTargetSiteOnPaidPlan && this.renderTargetSiteOnFreePlanWarnings() }

--- a/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
+++ b/client/my-sites/domains/domain-management/transfer/transfer-to-other-site/transfer-domain-to-other-site.tsx
@@ -121,7 +121,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 		const { selectedDomainName: domainName, translate } = this.props;
 		const translateArgs = { args: { domainName }, components: { strong: <strong /> } };
 		return translate(
-			"Connect {{strong}}%(domainName)s{{/strong}} to a site you're an administrator of:",
+			"Attach {{strong}}%(domainName)s{{/strong}} to a site you're an administrator of:",
 			translateArgs
 		);
 	}
@@ -173,7 +173,7 @@ export class TransferDomainToOtherSite extends Component< TransferDomainToOtherS
 				href: domainManagementEdit( selectedSite?.slug, selectedDomainName, currentRoute ),
 			},
 			{
-				label: translate( 'Connect' ),
+				label: translate( 'Attach' ),
 				href: domainManagementTransfer( selectedSite?.slug, selectedDomainName, currentRoute ),
 			},
 			{

--- a/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
+++ b/packages/domains-table/src/domains-table/__tests__/domains-table-row.tsx
@@ -386,7 +386,7 @@ describe( 'site linking ctas', () => {
 		fireEvent.click( domainActionsButton );
 
 		await waitFor( () => {
-			const connectAction = screen.getByText( 'Connect to an existing site' );
+			const connectAction = screen.getByText( 'Attach to an existing site' );
 
 			// The link itself is wrapped with a span element.
 			expect( connectAction.closest( '[role=menuitem]' ) ).toHaveAttribute(

--- a/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
+++ b/packages/domains-table/src/domains-table/domains-table-row-actions.tsx
@@ -113,7 +113,7 @@ export const DomainsTableRowActions = ( {
 			),
 			canConnectDomainToASite && (
 				<MenuItemLink href={ domainManagementTransferToOtherSiteLink( siteSlug, domain.domain ) }>
-					{ __( 'Connect to an existing site' ) }
+					{ __( 'Attach to an existing site' ) }
 				</MenuItemLink>
 			),
 			canChangeSiteAddress && (


### PR DESCRIPTION
## Proposed Changes

We want to change the term "connect/disconnect" to "attach/detach" for domain/blog connections/disconnections (moving a domain-only domain to a site and viceversa).

The reason is we are using the term connection in relation to domain mapping and this can confuse LLMs (AI chatbots for support).

## BEFORE
![naming-before-1](https://github.com/Automattic/wp-calypso/assets/2797601/ceb8e39d-9ea4-4229-a3d6-155e041b6ba8)
![naming-before-2](https://github.com/Automattic/wp-calypso/assets/2797601/217dc96e-ed10-4487-8bae-1d5ce749b6c8)
![naming-before-3](https://github.com/Automattic/wp-calypso/assets/2797601/c9913d21-3da8-4291-8f80-24c10e0f7e3f)
<img width="533" alt="Screenshot 2024-02-02 alle 14 35 25" src="https://github.com/Automattic/wp-calypso/assets/2797601/b68d3887-a25f-4816-aa1c-25056ce5f07b">
<img width="557" alt="Screenshot 2024-02-02 alle 14 36 52" src="https://github.com/Automattic/wp-calypso/assets/2797601/b7dbf72b-c8b7-4a59-bab5-0058871d20a1">
<img width="546" alt="Screenshot 2024-02-02 alle 14 43 46" src="https://github.com/Automattic/wp-calypso/assets/2797601/4788f146-ed2f-4397-a45a-08204ee96c0b">

## AFTER
![naming-after-1](https://github.com/Automattic/wp-calypso/assets/2797601/9b8c764b-763e-4938-8d92-8cbd5ee43158)
![naming-after-2](https://github.com/Automattic/wp-calypso/assets/2797601/ec383beb-aece-4f49-a9f0-6917940eeb9e)
![naming-after-3](https://github.com/Automattic/wp-calypso/assets/2797601/43b34313-bf8c-4315-9214-1636912b584b)
<img width="504" alt="Screenshot 2024-02-02 alle 14 36 38" src="https://github.com/Automattic/wp-calypso/assets/2797601/56cff812-e468-4daf-8c6d-9be0dfba9002">
<img width="512" alt="Screenshot 2024-02-02 alle 14 37 22" src="https://github.com/Automattic/wp-calypso/assets/2797601/095a0f8a-aa61-4123-9a14-26090b281e65">
<img width="533" alt="Screenshot 2024-02-02 alle 14 55 45" src="https://github.com/Automattic/wp-calypso/assets/2797601/c6aca1b5-568c-4cd2-9932-92f7a4ba9a86">

## Testing Instructions

Move a domain from a site to a domain-only site (and viceversa) and verify that the naming has been updated everywhere.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?