### PR TITLE
Theme Tiers: Enable theme tiers on live preview

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-can-preview-but-need-upgrade.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import {
 	FEATURE_WOOP,
 	WPCOM_FEATURES_ATOMIC,
@@ -139,12 +138,7 @@ export const useCanPreviewButNeedUpgrade = (
 
 	const handleCanPreviewButNeedUpgrade = useCallback(
 		( previewingTheme: ReturnType< typeof usePreviewingTheme > ) => {
-			const livePreviewUpgradeTypes = [ WOOCOMMERCE_THEME, PREMIUM_THEME ];
-
-			// @TODO Remove this check once Theme Tiers is live. This feature check can't be enabled.
-			if ( config.isEnabled( 'themes/tiers' ) ) {
-				livePreviewUpgradeTypes.push( PERSONAL_THEME );
-			}
+			const livePreviewUpgradeTypes = [ WOOCOMMERCE_THEME, PREMIUM_THEME, PERSONAL_THEME ];
 
 			/**
 			 * Currently, Live Preview only supports upgrades for WooCommerce and Premium themes.

--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-previewing-theme.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { getPlan, PLAN_PERSONAL, PLAN_PREMIUM, PLAN_BUSINESS } from '@automattic/calypso-products';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useState, useMemo } from 'react';
@@ -22,32 +21,15 @@ const getThemeType = ( theme?: Theme ) => {
 	if ( isWooCommerceTheme ) {
 		return WOOCOMMERCE_THEME;
 	}
-	const themeStylesheet = theme?.stylesheet;
-	const isPremiumTheme = themeStylesheet && themeStylesheet.startsWith( 'premium/' );
-	if ( isPremiumTheme ) {
-		return PREMIUM_THEME;
-	}
 
-	// @TODO Replace all the logic above with the following code once Theme Tiers is live.
-	if ( config.isEnabled( 'themes/tiers' ) ) {
-		return theme?.theme_tier?.slug ?? undefined;
-	}
-
-	return undefined;
+	return theme?.theme_tier?.slug ?? undefined;
 };
 
 /**
  * Get the theme required feature.
  * This only support WooCommerce and Premium themes.
  */
-const getThemeFeature = ( theme?: Theme ) => {
-	// @TODO Once theme tiers is live we'll need to refactor use-can-preview-but-need-upgrade's checkNeedUpgrade function.
-	if ( config.isEnabled( 'themes/tiers' ) ) {
-		return theme?.theme_tier?.feature ?? undefined;
-	}
-
-	return undefined;
-};
+const getThemeFeature = ( theme?: Theme ) => theme?.theme_tier?.feature ?? undefined;
 
 export const usePreviewingThemeSlug = () => {
 	const location = useLocation();
@@ -82,13 +64,13 @@ export const usePreviewingTheme = () => {
 	let previewingThemePlan;
 	switch ( previewingThemeType ) {
 		case WOOCOMMERCE_THEME:
-			previewingThemePlan = getPlan( PLAN_BUSINESS ).getTitle();
+			previewingThemePlan = getPlan( PLAN_BUSINESS )?.getTitle();
 			break;
 		case PREMIUM_THEME:
-			previewingThemePlan = getPlan( PLAN_PREMIUM ).getTitle();
+			previewingThemePlan = getPlan( PLAN_PREMIUM )?.getTitle();
 			break;
 		case PERSONAL_THEME:
-			previewingThemePlan = getPlan( PLAN_PERSONAL ).getTitle();
+			previewingThemePlan = getPlan( PLAN_PERSONAL )?.getTitle();
 			break;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Related to:
- https://github.com/Automattic/dotcom-forge/issues/5200
- https://github.com/Automattic/wp-calypso/pull/86539

There shouldn't be anything to test since these changes have already been tested in:
- https://github.com/Automattic/wp-calypso/pull/85721
But feel free to follow the testing instructions in that PR if you wish.
## Proposed Changes

* Removed the config check so that the live preview works with the new themes.
* The feature check always returns false regardless of the feature, so if we need to revert we should restore the code.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open a starter theme's Live Preview
* You should see the necessary upsells and warnings.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?