### PR TITLE
Theme Tiers: Fix premium theme signup E2E

### DIFF
--- a/client/components/theme-tier/theme-tier-badge/index.js
+++ b/client/components/theme-tier/theme-tier-badge/index.js
@@ -60,7 +60,13 @@ export default function ThemeTierBadge( {
 	}
 
 	return (
-		<div className={ classNames( 'theme-tier-badge', className ) }>
+		<div
+			className={ classNames(
+				'theme-tier-badge',
+				`theme-tier-badge--${ themeTier.slug }`,
+				className
+			) }
+		>
 			<ThemeTierBadgeContextProvider
 				canGoToCheckout={ canGoToCheckout }
 				showUpgradeBadge={ showUpgradeBadge }

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.ts
@@ -62,12 +62,7 @@ describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscripti
 		} );
 
 		it( 'Selects a Premium theme', async function () {
-			await page
-				.locator(
-					'div.theme-card:has(div.premium-badge):not(div.theme-card:has(div.is-marketplace))'
-				)
-				.first()
-				.click();
+			await page.locator( 'div.theme-card:has(div.theme-tier-badge--premium)' ).first().click();
 		} );
 
 		it( 'Navigate to Signup page', async function () {


### PR DESCRIPTION
## Proposed Changes

Fixes the premium theme signup E2E test that we had to temporary mute because the release of theme tiers changed the DOM that this test was expecting.

To fix the test, this PR adds an additional call to the theme tier badge component so we can identify which themes belong to the Premium/Explorer tier with a single CSS selector.

## Testing Instructions

- Start Calypso locally
- Follow these instructions to locally setup the E2E environment: https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e#quick-start
- Change the E2E target domain: `export CALYPSO_BASE_URL='http://calypso.localhost:3000'`
- Execute the premium theme signup E2E test: `yarn workspace wp-e2e-tests test -- test/e2e/specs/onboarding/signup__with-theme-premium.ts`
- Make sure it passes