### PR TITLE
E2E: Fix promise handling in BlazeCampaignPage

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts
@@ -43,14 +43,17 @@ export class BlazeCampaignPage {
 	 * @param {TestFile} path TestFile object.
 	 */
 	async uploadImage( path: TestFile ) {
-		const fileChooserPromise = this.page.waitForEvent( 'filechooser', { timeout: 15_000 } );
+		const timeout = 15_000;
+		const fileChooserPromise = this.page.waitForEvent( 'filechooser', { timeout } );
 
-		await this.page
-			.getByRole( 'region', { name: 'Appearance' } )
-			.getByRole( 'button', { name: 'Upload' } )
-			.click();
+		const [ fileChooser ] = await Promise.all( [
+			fileChooserPromise,
+			this.page
+				.getByRole( 'region', { name: 'Appearance' } )
+				.getByRole( 'button', { name: 'Upload' } )
+				.click( { timeout } ),
+		] );
 
-		const fileChooser = await fileChooserPromise;
 		await fileChooser.setFiles( path.fullpath );
 
 		await this.page.getByRole( 'region', { name: 'Appearance' } ).locator( 'img' ).waitFor();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

If you have two promises active, await one, and then the other one rejects before the first settles, node will exit immediately. No outer catch will save you.

In the case here, the best solution seems to be to await both promises with `Promise.all`.

Then let's also set the same timeout for `.click()` as we do for the first promise, so it doesn't exit earlier than expected (cf. #86662).

See also the failed test run linked at p1706885255307419-slack-C034JEXD1RD.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* To reproduce the problem, change "Appearance" in [line 52](https://github.com/Automattic/wp-calypso/blob/94e0ef25fc54c3f02e3cdc03273c6242e534c489/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts#L52) to something that does not exist. Then run the test with e.g. `yarn workspace wp-e2e-tests build && TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/tools/advertising__promote.ts`
  * On trunk, the test process should exit before completing with output like this:
    ```
     RUNS  specs/tools/advertising__promote.ts
    node:internal/process/promises:289
                triggerUncaughtException(err, true /* fromPromise */);
                ^
    
    page.waitForEvent: Page closed
    =========================== logs ===========================
    waiting for event "filechooser"
    ============================================================
        at BlazeCampaignPage.waitForEvent [as uploadImage] (/usr/local/src/automattic/wp-calypso/packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts:46:40)
        at Object.uploadImage (/usr/local/src/automattic/wp-calypso/test/e2e/specs/tools/advertising__promote.ts:104:28)
    
    Node.js v20.11.0
    ```
  * With this PR, the process should complete as usual for a failed test:
    ```
     FAIL  specs/tools/advertising__promote.ts (25.354 s)
      Advertising: Promote (Atomic: default)
        ✓ Navigate to Tools > Advertising page (3953 ms)
        ✓ Click on Promote for the first post (1007 ms)
        ✓ Land in Blaze campaign landing page (4 ms)
        ✓ Click on Get started (1098 ms)
        ✕ Upload image (15008 ms)
        ○ skipped Enter title and snippet
        ○ skipped Validate preview
    
      ● Advertising: Promote (Atomic: default) › Upload image
    
        page.waitForEvent: Timeout 15000ms exceeded while waiting for event "filechooser"
        =========================== logs ===========================
        waiting for event "filechooser"
        ============================================================
    
          45 | 	async uploadImage( path: TestFile ) {
          46 | 		const timeout = 15_000;
        > 47 | 		const fileChooserPromise = this.page.waitForEvent( 'filechooser', { timeout } );
             | 		                                     ^
          48 |
          49 | 		const [ fileChooser ] = await Promise.all( [
          50 | 			fileChooserPromise,
    
          at BlazeCampaignPage.waitForEvent [as uploadImage] (../../packages/calypso-e2e/src/lib/pages/blaze-campaign-page.ts:47:40)
          at Object.uploadImage (specs/tools/advertising__promote.ts:104:28)
    
    Test Suites: 1 failed, 1 total
    Tests:       1 failed, 2 skipped, 4 passed, 7 total
    Snapshots:   0 total
    Time:        26.523 s
    Ran all test suites matching /test\/e2e\/specs\/tools\/advertising__promote.ts/i.
    ```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?