### PR TITLE
Fix multi-site /stats page

### DIFF
--- a/client/my-sites/stats/controller.jsx
+++ b/client/my-sites/stats/controller.jsx
@@ -324,23 +324,26 @@ export function overview( context, next ) {
 
 	bumpStat( 'calypso_stats_overview_period', activeFilter.period );
 
-	context.primary = isPurchaseFlowEnabled ? (
-		<LoadStatsPage>
+	const siteId = getSelectedSiteId( context.store.getState() );
+
+	context.primary =
+		isPurchaseFlowEnabled && siteId !== null ? (
+			<LoadStatsPage>
+				<AsyncLoad
+					require="calypso/my-sites/stats/overview"
+					placeholder={ PageLoading }
+					period={ activeFilter.period }
+					path={ context.pathname }
+				/>
+			</LoadStatsPage>
+		) : (
 			<AsyncLoad
 				require="calypso/my-sites/stats/overview"
 				placeholder={ PageLoading }
 				period={ activeFilter.period }
 				path={ context.pathname }
 			/>
-		</LoadStatsPage>
-	) : (
-		<AsyncLoad
-			require="calypso/my-sites/stats/overview"
-			placeholder={ PageLoading }
-			period={ activeFilter.period }
-			path={ context.pathname }
-		/>
-	);
+		);
 	next();
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1706896284024599-slack-C02FMH4G8

## Proposed Changes

* This is potentially a temporary patch to get the multi-site /stats page working again and not cause regressions.

Before | After
--|--
<img width="1722" alt="Screenshot 2024-02-02 at 11 38 34 AM" src="https://github.com/Automattic/wp-calypso/assets/140841/f9f87804-9303-40fa-b82e-a9195c253e4a">  | <img width="1718" alt="Screenshot 2024-02-02 at 11 38 18 AM" src="https://github.com/Automattic/wp-calypso/assets/140841/e46114e5-34c5-4853-a3e4-48ed6ba99381">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* Go to http://calypso.localhost:3000/stats/ it should work
* Go to other /stats pages on Simple, Atomic, and Jetpack sites and check for regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?