### PR TITLE
Jetpack Manage - Pricing page: Fix Get buttons not passing bundle sizes and licensing page behavior when source is manage-pricing-page

### DIFF
--- a/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
@@ -83,7 +83,7 @@ export default function AgencySignupForm() {
 			if ( queryParams.get( 'source' ) === 'manage-pricing-page' ) {
 				const bundleSize = queryParams.get( 'bundle_size' ) || '1';
 				const path = `/partner-portal/issue-license?product_slug=${ queryParams.get(
-					'product_slug'
+					'products'
 				) }&bundle_size=${ bundleSize }&source=manage-pricing-page`;
 				page.redirect( path );
 			}

--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/all-license-items.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/all-license-items.tsx
@@ -32,12 +32,15 @@ export const AllLicenseItems = ( {
 						item = item[ 0 ];
 					}
 
+					// If the product doesn't support bundles, force a bundle size of 1.
+					const supportedBundleSize = item.supported_bundles.length > 0 ? bundleSize : 1;
+
 					return (
 						<li key={ idx } className="jetpack-product-store__most-popular--item">
 							{ Array.isArray( item ) ? (
 								<SimpleLicenseMultiItemCard
 									variants={ item }
-									bundleSize={ bundleSize }
+									bundleSize={ supportedBundleSize }
 									ctaAsPrimary={ true }
 									isCtaDisabled={ false }
 									isCtaExternal={ false }
@@ -45,7 +48,7 @@ export const AllLicenseItems = ( {
 							) : (
 								<SimpleLicenseItemCard
 									item={ item }
-									bundleSize={ bundleSize }
+									bundleSize={ supportedBundleSize }
 									ctaAsPrimary={ true }
 									isCtaDisabled={ false }
 									isCtaExternal={ false }

--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/featured-license-item-card.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/featured-license-item-card.tsx
@@ -76,13 +76,13 @@ export const FeaturedLicenseItemCard = ( {
 		( productSlug: string, bundleSize: number | undefined ) => {
 			if ( isLoggedIn && ! isAgency ) {
 				return addQueryArgs( `/manage/signup/`, {
-					products: productSlug,
+					products: `${ productSlug }:${ bundleSize }`,
 					source: 'manage-pricing-page',
 					bundle_size: bundleSize,
 				} );
 			}
 			return addQueryArgs( `/partner-portal/issue-license/`, {
-				products: productSlug,
+				products: `${ productSlug }:${ bundleSize }`,
 				source: 'manage-pricing-page',
 				bundle_size: bundleSize,
 			} );

--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/featured-license-multi-item-card.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/featured-license-multi-item-card.tsx
@@ -104,13 +104,13 @@ export const FeaturedLicenseMultiItemCard = ( {
 		( variantSlug: string, bundleSize: number | undefined ) => {
 			if ( isLoggedIn && ! isAgency ) {
 				return addQueryArgs( `/manage/signup/`, {
-					products: variantSlug,
+					products: `${ variantSlug }:${ bundleSize }`,
 					source: 'manage-pricing-page',
 					bundle_size: bundleSize,
 				} );
 			}
 			return addQueryArgs( `/partner-portal/issue-license/`, {
-				products: variantSlug,
+				products: `${ variantSlug }:${ bundleSize }`,
 				source: 'manage-pricing-page',
 				bundle_size: bundleSize,
 			} );

--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/index.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/index.tsx
@@ -14,18 +14,9 @@ export const LicenseProductsList = ( { bundleSize }: ProductsListProps ) => {
 	const selectedSite = null;
 	const usePublicQuery = true;
 
-	const { plans, products } = useProductAndPlans( {
+	const { plans, products, backupAddons, wooExtensions } = useProductAndPlans( {
 		selectedSite,
 		selectedProductFilter,
-		selectedBundleSize: bundleSize,
-		productSearchQuery,
-		usePublicQuery,
-	} );
-
-	const { backupAddons, wooExtensions } = useProductAndPlans( {
-		selectedSite,
-		selectedProductFilter,
-		selectedBundleSize: 1,
 		productSearchQuery,
 		usePublicQuery,
 	} );

--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/most-popular-plans.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/most-popular-plans.tsx
@@ -31,12 +31,15 @@ export const MostPopularPlans = ( {
 						item = item[ 0 ];
 					}
 
+					// If the product doesn't support bundles, force a bundle size of 1.
+					const supportedBundleSize = item.supported_bundles.length > 0 ? bundleSize : 1;
+
 					return (
 						<li key={ idx } className="jetpack-product-store__most-popular--item">
 							{ Array.isArray( item ) ? (
 								<FeaturedLicenseMultiItemCard
 									variants={ item }
-									bundleSize={ bundleSize }
+									bundleSize={ supportedBundleSize }
 									ctaAsPrimary={ true }
 									isCtaDisabled={ false }
 									isCtaExternal={ false }
@@ -44,7 +47,7 @@ export const MostPopularPlans = ( {
 							) : (
 								<FeaturedLicenseItemCard
 									item={ item }
-									bundleSize={ bundleSize }
+									bundleSize={ supportedBundleSize }
 									ctaAsPrimary={ true }
 									isCtaDisabled={ false }
 									isCtaExternal={ false }

--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/simple-license-item-card.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/simple-license-item-card.tsx
@@ -110,13 +110,13 @@ export const SimpleLicenseItemCard = ( {
 		( productSlug: string, bundleSize: number | undefined ) => {
 			if ( isLoggedIn && ! isAgency ) {
 				return addQueryArgs( `/manage/signup/`, {
-					products: productSlug,
+					products: `${ productSlug }:${ bundleSize }`,
 					source: 'manage-pricing-page',
 					bundle_size: bundleSize,
 				} );
 			}
 			return addQueryArgs( `/partner-portal/issue-license/`, {
-				products: productSlug,
+				products: `${ productSlug }:${ bundleSize }`,
 				source: 'manage-pricing-page',
 				bundle_size: bundleSize,
 			} );

--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/simple-license-multi-item-card.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/simple-license-multi-item-card.tsx
@@ -114,13 +114,13 @@ export const SimpleLicenseMultiItemCard = ( {
 		( variantSlug: string, bundleSize: number | undefined ) => {
 			if ( isLoggedIn && ! isAgency ) {
 				return addQueryArgs( `/manage/signup/`, {
-					products: variantSlug,
+					products: `${ variantSlug }:${ bundleSize }`,
 					source: 'manage-pricing-page',
 					bundle_size: bundleSize,
 				} );
 			}
 			return addQueryArgs( `/partner-portal/issue-license/`, {
-				products: variantSlug,
+				products: `${ variantSlug }:${ bundleSize }`,
 				source: 'manage-pricing-page',
 				bundle_size: bundleSize,
 			} );

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -93,7 +93,7 @@ export default function IssueLicense( { selectedSite, suggestedProduct }: Assign
 			dispatch(
 				recordTracksEvent( 'calypso_jetpack_manage_pricing_issue_license_review_licenses_show', {
 					total_licenses: getQueryArg( window.location.href, 'bundle_size' ),
-					product: getQueryArg( window.location.href, 'product_slug' ),
+					product: getQueryArg( window.location.href, 'products' ),
 				} )
 			);
 		}

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -97,7 +97,8 @@ export default function IssueLicense( { selectedSite, suggestedProduct }: Assign
 				} )
 			);
 		}
-	}, [ dispatch, getGroupedLicenses ] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] ); // Intentionally leaving the array empty and disabling the eslint warning, as we want this to run only once.
 
 	const currentStep = showReviewLicenses ? 'reviewLicense' : 'issueLicense';
 


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/264
Related to https://github.com/Automattic/jetpack-manage/issues/272

## Proposed Changes

* This PR fixes the behavior of `/partner-portal/issue-license` page with the `source=manage-pricing-page` parameter. Before this PR when `source=manage-pricing-page` is present a modal screen pops up every time a new license is selected. This PR fixes this.
* This PR fixes the bundle size when clicking on 'Get' buttons to select licenses from the pricing page (`/manage/pricing`). Now when the correct number of licenses is passed to the issue licenses page.

Context to the way `bundle_sizes` is being passed in the links in this PR:

https://github.com/Automattic/wp-calypso/blob/2f80e1347f865013cbbdfe36d6b9d8b9da6e2138/client/jetpack-cloud/sections/partner-portal/primary/issue-license/licenses-form/index.tsx#L67

https://github.com/Automattic/wp-calypso/blob/2f80e1347f865013cbbdfe36d6b9d8b9da6e2138/client/jetpack-cloud/sections/partner-portal/lib/querystring-products.ts#L7

Note: I intentionally kept the `bundle_sizes` arg because there is one place that still uses it in a way that would be hacky to remove:

https://github.com/Automattic/wp-calypso/blob/5e066228cb23bf072ab97d88ebab304c7866a716/client/jetpack-cloud/sections/partner-portal/primary/issue-license/hooks/use-product-bundle-size.ts#L6

## Testing Instructions

* Test once clicking on a `Get` button, dismissing the pop up after the new page loads, then navigating through the page and selecting more licenses. Pop ups should open only in the correct place now (`Review` button).
* Test all get buttons with all variants from the pricing page. The license size should be selected correctly in the new page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?