### PR TITLE
Checkout: Fix "Tax" line border position without discounts

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -179,27 +179,29 @@ function CheckoutSummaryPriceList() {
 				/>
 			) }
 			<CheckoutSummaryAmountWrapper>
-				<CheckoutSummaryLineItem key="checkout-summary-line-item-subtotal">
-					<span>{ translate( 'Subtotal' ) }</span>
-					<span>
-						{ formatCurrency( responseCart.sub_total_integer, responseCart.currency, {
-							isSmallestUnit: true,
-							stripZeros: true,
-						} ) }
-					</span>
-				</CheckoutSummaryLineItem>
-				{ taxLineItems.map( ( taxLineItem ) => (
-					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + taxLineItem.id }>
-						<span>{ taxLineItem.label }</span>
-						<span>{ taxLineItem.formattedAmount }</span>
+				<CheckoutSubtotalSection>
+					<CheckoutSummaryLineItem key="checkout-summary-line-item-subtotal">
+						<span>{ translate( 'Subtotal' ) }</span>
+						<span>
+							{ formatCurrency( responseCart.sub_total_integer, responseCart.currency, {
+								isSmallestUnit: true,
+								stripZeros: true,
+							} ) }
+						</span>
 					</CheckoutSummaryLineItem>
-				) ) }
-				{ creditsLineItem && responseCart.sub_total_integer > 0 && (
-					<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + creditsLineItem.id }>
-						<span>{ creditsLineItem.label }</span>
-						<span>{ creditsLineItem.formattedAmount }</span>
-					</CheckoutSummaryLineItem>
-				) }
+					{ taxLineItems.map( ( taxLineItem ) => (
+						<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + taxLineItem.id }>
+							<span>{ taxLineItem.label }</span>
+							<span>{ taxLineItem.formattedAmount }</span>
+						</CheckoutSummaryLineItem>
+					) ) }
+					{ creditsLineItem && responseCart.sub_total_integer > 0 && (
+						<CheckoutSummaryLineItem key={ 'checkout-summary-line-item-' + creditsLineItem.id }>
+							<span>{ creditsLineItem.label }</span>
+							<span>{ creditsLineItem.formattedAmount }</span>
+						</CheckoutSummaryLineItem>
+					) }
+				</CheckoutSubtotalSection>
 
 				<CheckoutSummaryTotal>
 					<span>{ translate( 'Total' ) }</span>
@@ -904,6 +906,12 @@ CheckoutSummaryFeaturesListItem.defaultProps = {
 	isSupported: true,
 };
 
+const CheckoutSubtotalSection = styled.div`
+	border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
+	margin-bottom: 20px;
+	padding-bottom: 20px;
+`;
+
 const CheckoutSummaryAmountWrapper = styled.div`
 	border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 	padding: 20px 0;
@@ -916,12 +924,6 @@ const CheckoutFirstSubtotalLineItem = styled.div`
 	justify-content: space-between;
 	line-height: 20px;
 	margin-bottom: 16px;
-
-	&:nth-last-of-type( 2 ) {
-		border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-		margin-bottom: 20px;
-		padding-bottom: 20px;
-	}
 
 	.is-loading & {
 		animation: ${ pulse } 1.5s ease-in-out infinite;
@@ -937,12 +939,6 @@ const CheckoutSummaryLineItem = styled.div< { isDiscount?: boolean } >`
 	margin-bottom: 4px;
 
 	color: ${ ( props ) => ( props.isDiscount ? props.theme.colors.discount : 'inherit' ) };
-
-	&:nth-last-of-type( 3 ) {
-		border-bottom: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-		margin-bottom: 20px;
-		padding-bottom: 20px;
-	}
 
 	.is-loading & {
 		animation: ${ pulse } 1.5s ease-in-out infinite;


### PR DESCRIPTION
## Proposed Changes

The "Tax" sidebar item is visually grouped with the "Subtotal" item in checkout. However, this was done using CSS `nth-last-of-type` rules which don't always apply correctly now that a bunch of things have changed in the sidebar (mostly https://github.com/Automattic/wp-calypso/pull/86360).

In this PR we change the grouping to use a wrapper div instead so that it always works correctly.

Fixes https://github.com/Automattic/wp-calypso/issues/87112

Situation | Before             |  After
:-------------------------:|:-------------------------:|:-------------------------:
No discounts | <img width="343" alt="Screenshot 2024-02-02 at 4 16 52 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/4389ca3f-eb5d-40d5-935c-1865a9129c09"> | <img width="341" alt="Screenshot 2024-02-02 at 4 20 41 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/82426364-e79b-4447-86e1-557c6440939c">
With discounts | <img width="316" alt="Screenshot 2024-02-02 at 4 21 48 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/72f34091-804a-4373-8406-9036e23787a1"> | <img width="315" alt="Screenshot 2024-02-02 at 4 21 31 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/79fee3de-c23c-4af6-bbfd-f154d0373fd2">
No tax | <img width="322" alt="Screenshot 2024-02-02 at 4 23 51 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/0a67b153-4547-477e-98dd-15ec82be3798"> | <img width="322" alt="Screenshot 2024-02-02 at 4 24 31 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/52828903-77c1-4e78-a0a9-cc58961f0da6">

## Testing Instructions

- Visit http://wordpress.com/checkout/jetpack/jetpack_complete
- Enter billing details that include tax.
- Change the renewal interval to monthly and notice that the "Tax" line is with "Subtotal".
- Change the renew interval to yearly and notice that the "Tax" line is with "Subtotal".
