### PR TITLE
Jetpack Manage: Pricing page - Fix Error when navigating to the "Single license tab"

### DIFF
--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/all-license-items.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/all-license-items.tsx
@@ -33,7 +33,7 @@ export const AllLicenseItems = ( {
 					}
 
 					// If the product doesn't support bundles, force a bundle size of 1.
-					const supportedBundleSize = item.supported_bundles.length > 0 ? bundleSize : 1;
+					const supportedBundleSize = item?.supported_bundles?.length > 0 ? bundleSize : 1;
 
 					return (
 						<li key={ idx } className="jetpack-product-store__most-popular--item">

--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/most-popular-plans.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/most-popular-plans.tsx
@@ -32,7 +32,7 @@ export const MostPopularPlans = ( {
 					}
 
 					// If the product doesn't support bundles, force a bundle size of 1.
-					const supportedBundleSize = item.supported_bundles.length > 0 ? bundleSize : 1;
+					const supportedBundleSize = item?.supported_bundles?.length > 0 ? bundleSize : 1;
 
 					return (
 						<li key={ idx } className="jetpack-product-store__most-popular--item">


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/277

## Proposed Changes

* Fix error when navigating to `Single License`.

## Testing Instructions

* Open the `/manage/pricing` page.
* Navigate to the `Single license` option.
* Everything should work and the error should be gone.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?