### PR TITLE
Github Deployments i1: Add UI to create repository based on selected templates

### DIFF
--- a/client/my-sites/github-deployments/components/create-repository/create-repository-form.tsx
+++ b/client/my-sites/github-deployments/components/create-repository/create-repository-form.tsx
@@ -1,0 +1,114 @@
+import { FormLabel } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { createInterpolateElement } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import classNames from 'classnames';
+import { useState } from 'react';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormRadiosBar from 'calypso/components/forms/form-radios-bar';
+import FormSelect from 'calypso/components/forms/form-select';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import { getRepositoryTemplate } from './templates';
+import './style.scss';
+
+type CreateRepositoryFormProps = {
+	onRepositoryCreated?: () => void;
+	className?: string;
+	onCancel?: () => void;
+};
+
+type ProjectType = 'theme' | 'plugin' | 'site';
+
+export const CreateRepositoryForm = ( {
+	onRepositoryCreated,
+	className,
+	onCancel,
+}: CreateRepositoryFormProps ) => {
+	const { __ } = useI18n();
+	const [ checked, setChecked ] = useState< ProjectType >( 'theme' );
+	const [ selectedTemplate, setSelectedTemplate ] = useState(
+		getRepositoryTemplate( checked )[ 0 ]
+	);
+
+	const handleCreateRepository = () => {
+		onRepositoryCreated?.();
+	};
+
+	const handleCancel = () => {
+		onCancel?.();
+	};
+
+	const handleTemplateChange = ( event: React.ChangeEvent< HTMLSelectElement > ) => {
+		const selectedValue = event.currentTarget.value;
+		const templates = getRepositoryTemplate( checked );
+		const selectedTemplate = templates.find( ( template ) => template.value === selectedValue );
+
+		setSelectedTemplate( selectedTemplate || templates[ 0 ] );
+	};
+
+	const handleCheckedChange = ( event: React.ChangeEvent< HTMLInputElement > ) => {
+		const newCheckedValue = event.currentTarget.value as ProjectType;
+		setChecked( newCheckedValue );
+
+		const templates = getRepositoryTemplate( newCheckedValue );
+		setSelectedTemplate( templates[ 0 ] );
+	};
+
+	return (
+		<form className={ classNames( 'github-deployments-create-repository', className ) }>
+			<FormFieldset>
+				<FormLabel htmlFor="projectName">{ __( 'Project Name' ) }</FormLabel>
+				<FormTextInput id="projectName" />
+			</FormFieldset>
+			<FormFieldset>
+				<FormLabel>{ __( 'What are you building ' ) }</FormLabel>
+				<FormRadiosBar
+					items={ [
+						{ label: __( 'A theme' ), value: 'theme' },
+						{ label: __( 'A plugin' ), value: 'plugin' },
+						{ label: __( 'An entire site' ), value: 'site' },
+					] }
+					checked={ checked }
+					onChange={ handleCheckedChange }
+					disabled={ false }
+				/>
+			</FormFieldset>
+			<FormFieldset>
+				<FormLabel htmlFor="template">{ __( 'Select starter template' ) }</FormLabel>
+				<FormSelect
+					id="template"
+					value={ selectedTemplate.value }
+					onChange={ handleTemplateChange }
+				>
+					{ getRepositoryTemplate( checked ).map( ( template ) => (
+						<option key={ template.value } value={ template.value }>
+							{ template.name }
+						</option>
+					) ) }
+				</FormSelect>
+				<small style={ { marginTop: '12px' } }>
+					{ createInterpolateElement(
+						sprintf(
+							/* translators: %s is the name of the template */
+							__( 'Learn more about the <link>%s</link> template' ),
+							selectedTemplate.name
+						),
+						{
+							link: <InlineSupportLink supportContext="site-monitoring" showIcon={ false } />,
+						}
+					) }
+				</small>
+			</FormFieldset>
+			<div className="action-buttons">
+				<Button variant="primary" onClick={ handleCreateRepository }>
+					{ __( 'Create repository' ) }
+				</Button>
+				<Button variant="tertiary" onClick={ handleCancel }>
+					{ __( 'Cancel' ) }
+				</Button>
+			</div>
+		</form>
+	);
+};

--- a/client/my-sites/github-deployments/components/create-repository/index.tsx
+++ b/client/my-sites/github-deployments/components/create-repository/index.tsx
@@ -1,0 +1,29 @@
+import { Modal } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
+import { CreateRepositoryForm } from './create-repository-form';
+
+type CreateRepositoryModalProps = {
+	onClose: () => void;
+	onRepositoryCreated?: () => void;
+	className?: string;
+};
+
+export const CreateRepositoryModal = ( {
+	onClose,
+	className,
+	onRepositoryCreated,
+}: CreateRepositoryModalProps ) => {
+	const { __ } = useI18n();
+	return (
+		<Modal
+			className={ className }
+			onRequestClose={ onClose }
+			shouldCloseOnEsc={ false }
+			size="medium"
+			shouldCloseOnClickOutside={ false }
+			title={ __( 'Create repository' ) }
+		>
+			<CreateRepositoryForm onRepositoryCreated={ onRepositoryCreated } onCancel={ onClose } />
+		</Modal>
+	);
+};

--- a/client/my-sites/github-deployments/components/create-repository/style.scss
+++ b/client/my-sites/github-deployments/components/create-repository/style.scss
@@ -1,0 +1,44 @@
+@import "@wordpress/base-styles/mixins";
+
+.github-deployments-create-repository {
+	.form-radios-bar {
+		display: flex;
+		justify-content: space-between;
+		gap: 8px;
+
+		> * {
+			display: flex;
+			flex: 1;
+			font-size: 0.75rem;
+			margin: 0;
+			border: 1px solid var(--color-neutral-10);
+			cursor: pointer;
+			background: none;
+			transition: box-shadow 0.1s linear;
+			height: 42px;
+			align-items: center;
+			box-sizing: border-box;
+			padding: 6px 12px;
+			border-radius: 2px;
+			white-space: nowrap;
+
+			.form-radio {
+				margin: 0;
+			}
+			.form-radio__label {
+				margin: 8px;
+			}
+		}
+	}
+
+	.action-buttons {
+		display: flex;
+		justify-content: flex-start;
+		margin-top: 24px;
+		gap: 8px;
+
+		:last-child {
+			color: var(--color-neutral);
+		}
+	}
+}

--- a/client/my-sites/github-deployments/components/create-repository/templates.ts
+++ b/client/my-sites/github-deployments/components/create-repository/templates.ts
@@ -1,0 +1,60 @@
+const REPOSITORY_TEMPLATES = {
+	theme: [
+		{
+			name: 'Underscores',
+			value: 'underscores',
+		},
+		{
+			name: 'Timber',
+			value: 'timber',
+		},
+		{
+			name: 'Sage',
+			value: 'sage',
+		},
+		{
+			name: 'Understrap',
+			value: 'understrap',
+		},
+	],
+	plugin: [
+		{
+			name: 'WordPress Plugin Boilerplate',
+			value: 'wordpress-plugin-boilerplate',
+		},
+		{
+			name: 'Wordpress Plugin Template',
+			value: 'wordpress-plugin-template',
+		},
+		{
+			name: 'WPBP',
+			value: 'wpbp',
+		},
+		{
+			name: 'Team51',
+			value: 'team51',
+		},
+	],
+	site: [
+		{
+			name: 'LocalWp',
+			value: 'localwp',
+		},
+		{
+			name: 'VIP Go',
+			value: 'vip-go',
+		},
+		{
+			name: 'Team51',
+			value: 'team51',
+		},
+		{
+			name: 'Wordpress Playground',
+			value: 'wordpress-playground',
+		},
+	],
+};
+
+export const getRepositoryTemplate = ( projectType: keyof typeof REPOSITORY_TEMPLATES ) => {
+	return REPOSITORY_TEMPLATES[ projectType ];
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5253

## Proposed Changes

* Add component to allow selecting different repository templates to create a repository
* Create modal with Create repository form.

![image](https://github.com/Automattic/wp-calypso/assets/47489215/d603b8f7-4fe6-4925-939a-e492e8b79e31)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The modal is not rendered at the moment just a scaffold to get the process.
* You can checked out the code and render the modal in `client/my-sites/github-deployments/main.tsx` to see the modal.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?