### PR TITLE
Add/warning notice for legacy upgrades

### DIFF
--- a/client/my-sites/checkout/src/components/prepurchase-notices/cart-item-is-legacy-bundle-upgrade.tsx
+++ b/client/my-sites/checkout/src/components/prepurchase-notices/cart-item-is-legacy-bundle-upgrade.tsx
@@ -1,4 +1,3 @@
-import { getJetpackProductDisplayName } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
@@ -15,13 +14,11 @@ const SitePlanIsLegacyBundleUpgrade: FunctionComponent< Props > = ( { sitePlan, 
 	const translate = useTranslate();
 	const supportUrl = localizeUrl( 'https://jetpack.com/contact-support/' );
 	const message = translate(
-		'The {{product /}} plan you are purchasing will replace your existing %(existingPlan)s plan. The new {{product /}} plan has a lower storage limit and shorter retention policy - some of your older backups maybe deleted after the upgrade. Please contact support about a free storage upgrade for one year.',
+		'The %(product)s plan you are purchasing will replace your existing %(existingPlan)s plan. The new %(product)s plan has a lower storage limit and shorter retention policy - some of your older backups maybe deleted after the upgrade. Please contact support about a free storage upgrade for one year.',
 		{
 			args: {
 				existingPlan: sitePlan.product_name_short,
-			},
-			components: {
-				product: <>{ getJetpackProductDisplayName( cartProduct ) }</>,
+				product: cartProduct.product_name,
 			},
 			comment:
 				'The `plan` variable refers to the short name of the plan the customer owns already. `product` refers to the product in the cart that is an upgrade.',

--- a/client/my-sites/checkout/src/components/prepurchase-notices/cart-item-is-legacy-bundle-upgrade.tsx
+++ b/client/my-sites/checkout/src/components/prepurchase-notices/cart-item-is-legacy-bundle-upgrade.tsx
@@ -14,7 +14,7 @@ const SitePlanIsLegacyBundleUpgrade: FunctionComponent< Props > = ( { sitePlan, 
 	const translate = useTranslate();
 	const supportUrl = localizeUrl( 'https://jetpack.com/contact-support/' );
 	const message = translate(
-		'The %(product)s plan you are purchasing will replace your existing %(existingPlan)s plan. The new %(product)s plan has a lower storage limit and shorter retention policy - some of your older backups maybe deleted after the upgrade. Please contact support about a free storage upgrade for one year.',
+		'The %(product)s plan will replace your %(existingPlan)s plan. %(product)s is packed with additional features, but does have a lower backup storage capacity. Please contact support for a free storage upgrade for one year.',
 		{
 			args: {
 				existingPlan: sitePlan.product_name_short,

--- a/client/my-sites/checkout/src/components/prepurchase-notices/cart-item-is-legacy-bundle-upgrade.tsx
+++ b/client/my-sites/checkout/src/components/prepurchase-notices/cart-item-is-legacy-bundle-upgrade.tsx
@@ -1,0 +1,40 @@
+import { getJetpackProductDisplayName } from '@automattic/calypso-products';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
+import PrePurchaseNotice from './prepurchase-notice';
+import type { ResponseCartProduct } from '@automattic/shopping-cart';
+import type { SitePlan } from 'calypso/state/sites/selectors/get-site-plan';
+
+type Props = {
+	sitePlan: SitePlan;
+	cartProduct: ResponseCartProduct;
+};
+
+const SitePlanIsLegacyBundleUpgrade: FunctionComponent< Props > = ( { sitePlan, cartProduct } ) => {
+	const translate = useTranslate();
+	const supportUrl = localizeUrl( 'https://jetpack.com/contact-support/' );
+	const message = translate(
+		'The {{product /}} plan you are purchasing will replace your existing %(existingPlan)s plan. The new {{product /}} plan has a lower storage limit and shorter retention policy - some of your older backups maybe deleted after the upgrade. Please contact support about a free storage upgrade for one year.',
+		{
+			args: {
+				existingPlan: sitePlan.product_name_short,
+			},
+			components: {
+				product: <>{ getJetpackProductDisplayName( cartProduct ) }</>,
+			},
+			comment:
+				'The `plan` variable refers to the short name of the plan the customer owns already. `product` refers to the product in the cart that is an upgrade.',
+		}
+	);
+
+	return (
+		<PrePurchaseNotice
+			message={ message }
+			linkUrl={ supportUrl }
+			linkText={ translate( 'Contact Support' ) }
+		/>
+	);
+};
+
+export default SitePlanIsLegacyBundleUpgrade;

--- a/client/my-sites/checkout/src/components/prepurchase-notices/style.scss
+++ b/client/my-sites/checkout/src/components/prepurchase-notices/style.scss
@@ -6,8 +6,9 @@
 		margin: 0;
 	}
 
+	.notice.is-info .notice__icon-wrapper,
 	.notice.is-info .notice__icon-wrapper-drop {
-		background-color: var(--color-accent-40);
+		background-color: var(--studio-blue-60);
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

* This PR adds a notice message in the cart when upgrading from a legacy bundle to a new bundle with a lower storage limit for backups

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You will need a test Jetpack site with a Jetpack Personal subscription
* Checkout this PR locally
* Make sure you are sandboxing the public API
* You will also need to apply D136784-code on the backend
* From your purchase management page for the Jetpack Personal subscription, click the "upgrade" button
* Add Jetpack Complete to your cart
* Confirm that you see the message pictured below and that the link takes you to the support page on Jetpack.com

![Screenshot 2024-02-02 at 8 29 43 PM](https://github.com/Automattic/wp-calypso/assets/18016357/b2a9693e-d109-471e-a842-ded3048bded9)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?