### PR TITLE
Reader: Fix "Add a tag" Visibility

### DIFF
--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -32,10 +32,18 @@
 				color: rgba(var(--color-sidebar-text-rgb), 0.4);
 			}
 		}
+
+		.form-text-input-with-action__button {
+			color: rgba(var(--color-sidebar-text-rgb), 0.7);
+
+			&:disabled {
+				color: rgba(var(--color-sidebar-text-rgb), 0.4);
+				opacity: 1;
+			}
+		}
 	}
 
 	.reader-sidebar-tags__all-tags-link {
-		color: var(--studio-white);
 		font-weight: bold;
 		margin-bottom: 2px;
 	}

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -17,28 +17,28 @@
 		box-shadow: none;
 
 		.form-text-input {
-			color: var(--color-sidebar-text);
-			box-shadow: 0 0 1px var(--color-neutral-10);
+			color: var(--color-sidebar-submenu-text);
+			box-shadow: 0 0 1px var(--color-sidebar-submenu-text);
 			background-color: transparent;
 			padding: 0 8px;
 			margin: 4px 4px 4px 0;
 			font-size: $font-body-small;
 
 			&:focus {
-				box-shadow: 0 0 0 2px var(--color-primary-10);
+				box-shadow: 0 0 0 1px var(--color-sidebar-submenu-hover-text);
 			}
 
 			&::placeholder {
-				color: rgba(var(--color-sidebar-text-rgb), 0.4);
+				color: var(--color-sidebar-submenu-text);
+				opacity: 0.3; // Same as disabled button's opacity.
 			}
 		}
 
 		.form-text-input-with-action__button {
-			color: rgba(var(--color-sidebar-text-rgb), 0.7);
+			color: var(--color-sidebar-submenu-text);
 
 			&:disabled {
-				color: rgba(var(--color-sidebar-text-rgb), 0.4);
-				opacity: 1;
+				color: var(--color-sidebar-submenu-text);
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #86895

## Proposed Changes

Prevents the "Add a tag" and "See all tag" buttons from being invisible on the Reader sidebar.

## Testing Instructions

Go to '/tag/dailyprompt' and compare the following in different colour schemes (this uses Light and Classic Dark). Also verify that when entering something into the input, the "Add" button changes colour to make clear that it can now be clicked. 

**Current:** 

<img width="269" alt="Screenshot 2024-02-03 at 12 45 27" src="https://github.com/Automattic/wp-calypso/assets/43215253/1262fdca-23a0-45a1-acd8-6d745f26c7ee">
<img width="270" alt="Screenshot 2024-02-03 at 12 45 06" src="https://github.com/Automattic/wp-calypso/assets/43215253/287d13c5-3973-4206-b65c-412fc69cc4d4">


<img width="267" alt="Screenshot 2024-02-03 at 12 45 34" src="https://github.com/Automattic/wp-calypso/assets/43215253/0695ea66-15ac-444a-8ed5-25523db98280">
<img width="264" alt="Screenshot 2024-02-03 at 12 45 13" src="https://github.com/Automattic/wp-calypso/assets/43215253/748f0009-c79b-41b1-8c45-7b7240364eb1">

**Proposed:**

<img width="276" alt="Screenshot 2024-02-03 at 12 44 32" src="https://github.com/Automattic/wp-calypso/assets/43215253/5b4879dd-f2e0-4be0-ac0b-2e18e37a2646">
<img width="276" alt="Screenshot 2024-02-03 at 12 44 37" src="https://github.com/Automattic/wp-calypso/assets/43215253/c694130c-5e54-4520-a8fc-665fdfef9e92">

<img width="275" alt="Screenshot 2024-02-03 at 12 44 49" src="https://github.com/Automattic/wp-calypso/assets/43215253/5ee29768-0e2b-4b9d-bec6-d30186cf9484">
<img width="278" alt="Screenshot 2024-02-03 at 12 44 54" src="https://github.com/Automattic/wp-calypso/assets/43215253/0d6730bb-175c-4536-9528-77084039114e">

cc @sixhours, @roo2, @Addison-Stavlo 