### PR TITLE
Migration onboarding: Hide nav back button when migration is in progress

### DIFF
--- a/client/blocks/importer/wordpress/utils.js
+++ b/client/blocks/importer/wordpress/utils.js
@@ -1,4 +1,5 @@
 export const SESSION_STORAGE_IS_MIGRATE_FROM_WP = 'is_migrate_from_wp';
+export const SESSION_STORAGE_MIGRATION_STATUS = 'migration_status';
 
 export const storeMigrateSource = () => {
 	window.sessionStorage.setItem( SESSION_STORAGE_IS_MIGRATE_FROM_WP, 'true' );
@@ -10,4 +11,16 @@ export const clearMigrateSource = () => {
 
 export const retrieveMigrateSource = () => {
 	return window.sessionStorage.getItem( SESSION_STORAGE_IS_MIGRATE_FROM_WP );
+};
+
+export const storeMigrationStatus = ( status ) => {
+	window.sessionStorage.setItem( SESSION_STORAGE_MIGRATION_STATUS, status );
+};
+
+export const clearMigrationStatus = () => {
+	window.sessionStorage.removeItem( SESSION_STORAGE_MIGRATION_STATUS );
+};
+
+export const retrieveMigrationStatus = () => {
+	return window.sessionStorage.getItem( SESSION_STORAGE_MIGRATION_STATUS );
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/importer/index.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable wpcalypso/jsx-classname-namespace */
+import { MigrationStatus } from '@automattic/data-stores';
 import { StepContainer } from '@automattic/onboarding';
 import { useSelect } from '@wordpress/data';
 import { useI18n } from '@wordpress/react-i18n';
@@ -7,6 +8,7 @@ import { useEffect, useState } from 'react';
 import NotAuthorized from 'calypso/blocks/importer/components/not-authorized';
 import NotFound from 'calypso/blocks/importer/components/not-found';
 import { getImporterTypeForEngine } from 'calypso/blocks/importer/util';
+import { retrieveMigrationStatus } from 'calypso/blocks/importer/wordpress/utils';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySites from 'calypso/components/data/query-sites';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
@@ -70,6 +72,11 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 		const fromSite = currentSearchParams.get( 'from' ) || '';
 		const fromSiteData = useSelector( getUrlData );
 		const stepNavigator = useStepNavigator( flow, navigation, siteId, siteSlug, fromSite );
+		const migrationStatus = retrieveMigrationStatus();
+		const isMigrationInProgress =
+			migrationStatus === MigrationStatus.BACKING_UP ||
+			migrationStatus === MigrationStatus.BACKING_UP_QUEUED ||
+			migrationStatus === MigrationStatus.RESTORING;
 
 		/**
 	 	↓ Effects
@@ -203,6 +210,7 @@ export function withImporterWrapper( Importer: ImporterCompType ) {
 					) }
 					stepName="importer-step"
 					hideSkip={ true }
+					hideBack={ isMigrationInProgress }
 					hideFormattedHeader={ true }
 					goBack={ onGoBack }
 					isWideLayout={ true }

--- a/client/my-sites/migrate/section-migrate.jsx
+++ b/client/my-sites/migrate/section-migrate.jsx
@@ -12,6 +12,10 @@ import { get, isEmpty, omit } from 'lodash';
 import moment from 'moment';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import {
+	storeMigrationStatus,
+	clearMigrationStatus,
+} from 'calypso/blocks/importer/wordpress/utils';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import Main from 'calypso/components/main';
@@ -67,6 +71,7 @@ export class SectionMigrate extends Component {
 	componentDidMount() {
 		const { targetSite, targetSiteId, targetSiteSlug, sourceSite, sourceSiteId } = this.props;
 		const sourceSiteUrl = get( sourceSite, 'URL', sourceSiteId );
+		clearMigrationStatus();
 
 		if ( this.isNonAtomicJetpack() ) {
 			return page( `/import/${ this.props.targetSiteSlug }` );
@@ -185,6 +190,7 @@ export class SectionMigrate extends Component {
 	};
 
 	setMigrationState = ( state ) => {
+		storeMigrationStatus( state.migrationStatus );
 		// A response from the status endpoint may come in after the
 		// migrate/from endpoint has returned an error. This avoids that
 		// response accidentally clearing the error state.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/86499

## Proposed Changes

* Hide stepper navigation's back button when migration is in progress

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/import-focused?siteSlug={SITE_SLUG}`
* Enter any self-hosted website URL
* Run the migration process
* Check if the "Back" button is hidden during the migration process

<img width="1728" alt="Screenshot 2024-02-04 at 17 41 51" src="https://github.com/Automattic/wp-calypso/assets/1241413/f8e4b1b3-1571-442a-9a26-59be53b685ba">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?