### PR TITLE
Fix GA module in Tools > Marketing > Traffic for Atomic sites

### DIFF
--- a/client/my-sites/site-settings/analytics/form-google-analytics.jsx
+++ b/client/my-sites/site-settings/analytics/form-google-analytics.jsx
@@ -115,6 +115,7 @@ const mapStateToProps = ( state ) => {
 		siteId,
 		siteIsJetpack,
 		sitePlugins,
+		jetpackModuleActive,
 		isJetpackModuleAvailable,
 		isAtomic: isAtomicSite( state, siteId ),
 		isGoogleAnalyticsEligible,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/pull/86780#issuecomment-1925029050

## Proposed Changes

Adds back the removed prop to display fields in GA module

## Testing Instructions

#### Testing Atomic with Jetpack's GA module

* Use a creator plan site
* Ensure it's an Atomic site by installing a plugin
* Go to `Tools > Marketing > Traffic`
* Enable toggle `Add Google`
* Observe the fields are shown as screenshot:

<img width="1080" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3747241/7f8d3db6-7888-4bea-b131-a9b57d33f445">


#### Testing site without Jetpack's GA module

1. Use a site on Woo Express, free trial, or entrepreneur plan
2. Go to Tools > Marketing > Traffic
3. Observe that Google Analytics panel is NOT visible, per screenshot

<img width="1072" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3747241/5c09c8be-5eda-4be5-a9ae-3df7b6655d90">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
