### PR TITLE
Themes: Only Show Download Card for Free Themes

### DIFF
--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -917,7 +917,7 @@ class ThemeSheet extends Component {
 		const { download, isWpcomTheme, siteSlug, taxonomies, isPremium, themeTier } = this.props;
 
 		const showDownloadCard =
-			download && ( config.isEnabled( 'themes/tiers' ) ? 'free' === themeTier : ! isPremium );
+			download && ( config.isEnabled( 'themes/tiers' ) ? 'free' === themeTier?.slug : ! isPremium );
 
 		return (
 			<div>

--- a/client/my-sites/theme/main.jsx
+++ b/client/my-sites/theme/main.jsx
@@ -914,7 +914,10 @@ class ThemeSheet extends Component {
 	};
 
 	renderOverviewTab = () => {
-		const { download, isWpcomTheme, siteSlug, taxonomies, isPremium } = this.props;
+		const { download, isWpcomTheme, siteSlug, taxonomies, isPremium, themeTier } = this.props;
+
+		const showDownloadCard =
+			download && ( config.isEnabled( 'themes/tiers' ) ? 'free' === themeTier : ! isPremium );
 
 		return (
 			<div>
@@ -927,7 +930,7 @@ class ThemeSheet extends Component {
 						onClick={ this.trackFeatureClick }
 					/>
 				</div>
-				{ download && ! isPremium && <ThemeDownloadCard href={ download } /> }
+				{ showDownloadCard && <ThemeDownloadCard href={ download } /> }
 			</div>
 		);
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5149

## Proposed Changes

* Only show the download card for free themes in the Theme Details page.

With the Theme Tiers change, we have introduced multiple tiers of paid themes. Checks that only test for `isPremium` need to be updated to consider other paid tiers as well.

Note: some themes have a download button hardcoded in their description.
That will be addressed separately.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Theme Showcase.
* Select a Free theme and enter its Theme Details page.
* Scroll down and ensure the Download card (screenshot below) is visible.
* Select a paid theme (e.g. Starter or Explorer).
* Scroll down and ensure the Download card (screenshot below) is not visible.

<img width="620" alt="Screenshot 2024-02-05 at 10 20 43" src="https://github.com/Automattic/wp-calypso/assets/2070010/6e9f1e20-a211-4a4d-b92d-7d0ed5c6eb85">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?