### PR TITLE
Update copy and order for admin interface style

### DIFF
--- a/client/my-sites/hosting/site-admin-interface-card/index.js
+++ b/client/my-sites/hosting/site-admin-interface-card/index.js
@@ -1,5 +1,6 @@
 /* eslint-disable wpcalypso/jsx-gridicon-size */
 import { Card, FormLabel } from '@automattic/components';
+import { useHasEnTranslation } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { useTranslate, localize } from 'i18n-calypso';
 import { useState, useEffect } from 'react';
@@ -34,6 +35,7 @@ const FormRadioStyled = styled( FormRadio )( {
 
 const SiteAdminInterfaceCard = ( { siteId } ) => {
 	const translate = useTranslate();
+	const hasEnTranslation = useHasEnTranslation();
 	const dispatch = useDispatch();
 	const removeAllNotices = () => {
 		dispatch( removeNotice( successNoticeId ) );
@@ -123,7 +125,9 @@ const SiteAdminInterfaceCard = ( { siteId } ) => {
 					/>
 				</FormLabel>
 				<FormSettingExplanation>
-					{ translate( 'Use WP-Admin to manage your site.' ) }
+					{ hasEnTranslation( 'Use WP-Admin to manage your site.' )
+						? translate( 'Use WP-Admin to manage your site.' )
+						: translate( 'The classic WP-Admin WordPress interface.' ) }
 				</FormSettingExplanation>
 			</FormFieldset>
 			<FormFieldset>
@@ -137,7 +141,9 @@ const SiteAdminInterfaceCard = ( { siteId } ) => {
 					/>
 				</FormLabel>
 				<FormSettingExplanation>
-					{ translate( 'Use WordPress.com’s legacy dashboard to manage your site.' ) }
+					{ hasEnTranslation( 'Use WordPress.com’s legacy dashboard to manage your site.' )
+						? translate( 'Use WordPress.com’s legacy dashboard to manage your site.' )
+						: translate( 'The WordPress.com redesign for a better experience.' ) }
 				</FormSettingExplanation>
 			</FormFieldset>
 		</Card>

--- a/client/my-sites/hosting/site-admin-interface-card/index.js
+++ b/client/my-sites/hosting/site-admin-interface-card/index.js
@@ -115,20 +115,6 @@ const SiteAdminInterfaceCard = ( { siteId } ) => {
 			<FormFieldset>
 				<FormLabel>
 					<FormRadioStyled
-						label={ translate( 'Default style' ) }
-						value="calypso"
-						checked={ selectedAdminInterface === 'calypso' }
-						onChange={ ( event ) => handleInputChange( event.target.value ) }
-						disabled={ isUpdating }
-					/>
-				</FormLabel>
-				<FormSettingExplanation>
-					{ translate( 'The WordPress.com redesign for a better experience.' ) }
-				</FormSettingExplanation>
-			</FormFieldset>
-			<FormFieldset>
-				<FormLabel>
-					<FormRadioStyled
 						label={ translate( 'Classic style' ) }
 						value="wp-admin"
 						checked={ selectedAdminInterface === 'wp-admin' }
@@ -137,7 +123,21 @@ const SiteAdminInterfaceCard = ( { siteId } ) => {
 					/>
 				</FormLabel>
 				<FormSettingExplanation>
-					{ translate( 'The classic WP-Admin WordPress interface.' ) }
+					{ translate( 'Use WP-Admin to manage your site.' ) }
+				</FormSettingExplanation>
+			</FormFieldset>
+			<FormFieldset>
+				<FormLabel>
+					<FormRadioStyled
+						label={ translate( 'Default style' ) }
+						value="calypso"
+						checked={ selectedAdminInterface === 'calypso' }
+						onChange={ ( event ) => handleInputChange( event.target.value ) }
+						disabled={ isUpdating }
+					/>
+				</FormLabel>
+				<FormSettingExplanation>
+					{ translate( 'Use WordPress.com’s legacy dashboard to manage your site.' ) }
 				</FormSettingExplanation>
 			</FormFieldset>
 		</Card>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5446

## Proposed Changes

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/3834dc9f-a197-4df9-a798-404e63735510">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/e4300cf7-f761-4b81-ae27-a2f704b733e2">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have an atomic site
* Go to /hosting-config/:site
* Check the copy

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?