### PR TITLE
Theme Tiers: Remove hasTranslation checks

### DIFF
--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -29,13 +29,12 @@ import {
 } from '@automattic/calypso-products';
 import { Button, Dialog, ScreenReaderText } from '@automattic/components';
 import { ProductsList } from '@automattic/data-stores';
-import { englishLocales } from '@automattic/i18n-utils';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { Tooltip } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { Icon as WpIcon, check, close } from '@wordpress/icons';
 import classNames from 'classnames';
-import i18n, { useTranslate } from 'i18n-calypso';
+import { useTranslate } from 'i18n-calypso';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { getPlanFeaturesObject } from 'calypso/lib/plans/features-list';
 import { useBundleSettings } from 'calypso/my-sites/theme/hooks/use-bundle-settings';
@@ -376,13 +375,8 @@ export const ThemeUpgradeModal = ( {
 	};
 
 	const getPersonalPlanFeatureList = () => {
-		const localeSlug = i18n.getLocaleSlug();
-		const shouldShowThemesFeature =
-			config.isEnabled( 'themes/tiers' ) &&
-			( ( localeSlug && englishLocales.includes( localeSlug ) ) ||
-				i18n.hasTranslation( 'Dozens of premium themes' ) );
 		return getPlanFeaturesObject( [
-			...( shouldShowThemesFeature ? [ WPCOM_FEATURES_PREMIUM_THEMES_LIMITED ] : [] ),
+			...( config.isEnabled( 'themes/tiers' ) ? [ WPCOM_FEATURES_PREMIUM_THEMES_LIMITED ] : [] ),
 			FEATURE_CUSTOM_DOMAIN,
 			FEATURE_AD_FREE_EXPERIENCE,
 			FEATURE_FAST_DNS,

--- a/client/lib/plans/features-list.tsx
+++ b/client/lib/plans/features-list.tsx
@@ -526,12 +526,7 @@ export const FEATURES_LIST: FeatureList = {
 			if ( ! planSlug ) {
 				return '';
 			}
-			const localeSlug = i18n.getLocaleSlug();
-			const shouldShowInPersonalPlan =
-				config.isEnabled( 'themes/tiers' ) &&
-				( ( localeSlug && englishLocales.includes( localeSlug ) ) ||
-					i18n.hasTranslation( 'Dozens of premium themes' ) );
-			if ( shouldShowInPersonalPlan && isPersonalPlan( planSlug ) ) {
+			if ( config.isEnabled( 'themes/tiers' ) && isPersonalPlan( planSlug ) ) {
 				return i18n.translate( 'Dozens of premium themes' );
 			}
 			if (
@@ -548,15 +543,7 @@ export const FEATURES_LIST: FeatureList = {
 	[ WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED ]: {
 		getSlug: () => WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
 		getTitle: () => i18n.translate( 'Unlimited premium themes' ),
-		getDescription: () => {
-			const localeSlug = i18n.getLocaleSlug();
-			const shouldShowNewString =
-				( localeSlug && englishLocales.includes( localeSlug ) ) ||
-				i18n.hasTranslation( 'Switch between all of our premium design themes.' );
-			return shouldShowNewString
-				? i18n.translate( 'Switch between all of our premium design themes.' )
-				: i18n.translate( 'Switch between a collection of premium design themes.' );
-		},
+		getDescription: () => i18n.translate( 'Switch between all of our premium design themes.' ),
 	},
 
 	[ WPCOM_FEATURES_PREMIUM_THEMES_LIMITED ]: {


### PR DESCRIPTION
## Proposed Changes

Since the new strings added in https://github.com/Automattic/wp-calypso/pull/86861 have been translated (https://translate.wordpress.com/deliverables/overview/11095809), we no longer need to fallback to the previous strings, so this PR removes all the relevant `hasTranslation` checks.

## Testing Instructions

- Use the Calypso live link below
- Go to Upgrades > Plans
- Make sure there are no regressions