### PR TITLE
Colour Schemes: Bring Back Classic Bright 

### DIFF
--- a/packages/calypso-color-schemes/src/calypso-color-schemes.scss
+++ b/packages/calypso-color-schemes/src/calypso-color-schemes.scss
@@ -4,6 +4,7 @@
 @import "shared/color-schemes/aquatic";
 @import "shared/color-schemes/blue";
 @import "shared/color-schemes/classic-blue";
+@import "shared/color-schemes/classic-bright";
 @import "shared/color-schemes/classic-dark";
 @import "shared/color-schemes/coffee";
 @import "shared/color-schemes/contrast";

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-bright.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-bright.scss
@@ -1,0 +1,107 @@
+.color-scheme.is-classic-bright {
+	/* Theme Properties */
+	--color-primary: var(--studio-blue-50);
+	--color-primary-rgb: var(--studio-blue-50-rgb);
+	--color-primary-dark: var(--studio-blue-70);
+	--color-primary-dark-rgb: var(--studio-blue-70-rgb);
+	--color-primary-light: var(--studio-blue-30);
+	--color-primary-light-rgb: var(--studio-blue-30-rgb);
+	--color-primary-0: var(--studio-blue-0);
+	--color-primary-0-rgb: var(--studio-blue-0-rgb);
+	--color-primary-5: var(--studio-blue-5);
+	--color-primary-5-rgb: var(--studio-blue-5-rgb);
+	--color-primary-10: var(--studio-blue-10);
+	--color-primary-10-rgb: var(--studio-blue-10-rgb);
+	--color-primary-20: var(--studio-blue-20);
+	--color-primary-20-rgb: var(--studio-blue-20-rgb);
+	--color-primary-30: var(--studio-blue-30);
+	--color-primary-30-rgb: var(--studio-blue-30-rgb);
+	--color-primary-40: var(--studio-blue-40);
+	--color-primary-40-rgb: var(--studio-blue-40-rgb);
+	--color-primary-50: var(--studio-blue-50);
+	--color-primary-50-rgb: var(--studio-blue-50-rgb);
+	--color-primary-60: var(--studio-blue-60);
+	--color-primary-60-rgb: var(--studio-blue-60-rgb);
+	--color-primary-70: var(--studio-blue-70);
+	--color-primary-70-rgb: var(--studio-blue-70-rgb);
+	--color-primary-80: var(--studio-blue-80);
+	--color-primary-80-rgb: var(--studio-blue-80-rgb);
+	--color-primary-90: var(--studio-blue-90);
+	--color-primary-90-rgb: var(--studio-blue-90-rgb);
+	--color-primary-100: var(--studio-blue-100);
+	--color-primary-100-rgb: var(--studio-blue-100-rgb);
+
+	--color-accent: var(--studio-pink-50);
+	--color-accent-rgb: var(--studio-pink-50-rgb);
+	--color-accent-dark: var(--studio-pink-70);
+	--color-accent-dark-rgb: var(--studio-pink-70-rgb);
+	--color-accent-light: var(--studio-pink-30);
+	--color-accent-light-rgb: var(--studio-pink-30-rgb);
+	--color-accent-0: var(--studio-pink-0);
+	--color-accent-0-rgb: var(--studio-pink-0-rgb);
+	--color-accent-5: var(--studio-pink-5);
+	--color-accent-5-rgb: var(--studio-pink-5-rgb);
+	--color-accent-10: var(--studio-pink-10);
+	--color-accent-10-rgb: var(--studio-pink-10-rgb);
+	--color-accent-20: var(--studio-pink-20);
+	--color-accent-20-rgb: var(--studio-pink-20-rgb);
+	--color-accent-30: var(--studio-pink-30);
+	--color-accent-30-rgb: var(--studio-pink-30-rgb);
+	--color-accent-40: var(--studio-pink-40);
+	--color-accent-40-rgb: var(--studio-pink-40-rgb);
+	--color-accent-50: var(--studio-pink-50);
+	--color-accent-50-rgb: var(--studio-pink-50-rgb);
+	--color-accent-60: var(--studio-pink-60);
+	--color-accent-60-rgb: var(--studio-pink-60-rgb);
+	--color-accent-70: var(--studio-pink-70);
+	--color-accent-70-rgb: var(--studio-pink-70-rgb);
+	--color-accent-80: var(--studio-pink-80);
+	--color-accent-80-rgb: var(--studio-pink-80-rgb);
+	--color-accent-90: var(--studio-pink-90);
+	--color-accent-90-rgb: var(--studio-pink-90-rgb);
+	--color-accent-100: var(--studio-pink-100);
+	--color-accent-100-rgb: var(--studio-pink-100-rgb);
+
+	/* Masterbar */
+	--color-masterbar-background: var(--studio-blue-60);
+	--color-masterbar-border: var(--studio-blue-70);
+	--color-masterbar-text: var(--studio-white);
+	--color-masterbar-item-hover-background: var(--studio-blue-70);
+	--color-masterbar-item-active-background: var(--studio-blue-90);
+	--color-masterbar-item-new-editor-background: var(--studio-gray-50);
+	--color-masterbar-item-new-editor-hover-background: var(--studio-gray-40);
+	--color-masterbar-unread-dot-background: var(--color-accent-20);
+
+	--color-masterbar-toggle-drafts-editor-background: var(--studio-gray-40);
+	--color-masterbar-toggle-drafts-editor-hover-background: var(--studio-gray-40);
+	--color-masterbar-toggle-drafts-editor-border: var(--studio-gray-10);
+
+	/* Sidebar */
+	--color-sidebar-background: var(--color-surface);
+	--color-sidebar-background-rgb: var(--studio-white-rgb);
+	--color-sidebar-border: var(--studio-gray-5);
+	--color-sidebar-text: var(--studio-gray-80);
+	--color-sidebar-text-rgb: var(--studio-gray-80-rgb);
+	--color-sidebar-text-alternative: var(--studio-gray-50);
+	--color-sidebar-gridicon-fill: var(--studio-gray-50);
+
+	/* Sidebar Selected */
+	--color-sidebar-menu-selected-background: var(--studio-blue-5);
+	--color-sidebar-menu-selected-background-rgb: var(--studio-blue-5-rgb);
+	--color-sidebar-menu-selected-text: var(--studio-blue-70);
+	--color-sidebar-menu-selected-text-rgb: var(--studio-blue-70-rgb);
+
+	/* Sidebar Hover */
+	--color-sidebar-menu-hover-background: var(--studio-gray-5);
+	--color-sidebar-menu-hover-background-rgb: var(--studio-gray-5-rgb);
+	--color-sidebar-menu-hover-text: var(--studio-gray-90);
+
+	/* Sidebar Submenu - Nav Unification */
+	--color-sidebar-submenu-background: var(--studio-blue-0);
+	--color-sidebar-submenu-text: var(--studio-blue-70);
+	--color-sidebar-submenu-hover-text: var(--color-accent);
+	--color-sidebar-submenu-selected-text: var(--color-accent);
+
+	/* Command Palette Items */
+	--wp-admin-theme-color: var(--studio-pink-50);
+}


### PR DESCRIPTION
Fixes #86892

## Proposed Changes

It looks like Classic Bright was accidentally removed when the colour schemes were moved to a new package - see #86892 for discussion on this. Let's bring it back! 

## Testing Instructions

Go to Me > Account Settings > Dashboard Colour Scheme and select "Classic Bright". Take a look around - does everything look as expected?

| <img width="1636" alt="Screenshot 2024-02-05 at 11 51 28" src="https://github.com/Automattic/wp-calypso/assets/43215253/77f317fb-1aff-46e7-acd8-7557347339ec"> | <img width="1634" alt="Screenshot 2024-02-05 at 11 51 46" src="https://github.com/Automattic/wp-calypso/assets/43215253/924140c0-6ee1-4733-a85c-7305145c41c8"> | <img width="1632" alt="Screenshot 2024-02-05 at 11 51 54" src="https://github.com/Automattic/wp-calypso/assets/43215253/a3532e14-bbb0-4faf-a4f6-c32cdba11f36"> |
|--------|--------|--------|

cc @mmtr 