### PR TITLE
Subscribers: show exact total as tooltip when count is abbreviated

### DIFF
--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -69,7 +69,7 @@ const SubscriberListContainer = ( {
 							title={
 								total > 1000
 									? formatNumber( total, getLocaleSlug() || undefined, { notation: 'standard' } )
-									: ''
+									: undefined
 							}
 						>
 							{ formatNumber( total, getLocaleSlug() || undefined ) }

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -66,6 +66,7 @@ const SubscriberListContainer = ( {
 							className={ `subscriber-list-container__subscriber-count ${
 								isLoading ? 'loading-placeholder' : ''
 							}` }
+							title={ total > 1000 ? total.toLocaleString() : '' }
 						>
 							{ formatNumber( total, getLocaleSlug() || undefined ) }
 						</span>

--- a/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
+++ b/client/my-sites/subscribers/components/subscriber-list-container/subscriber-list-container.tsx
@@ -66,7 +66,11 @@ const SubscriberListContainer = ( {
 							className={ `subscriber-list-container__subscriber-count ${
 								isLoading ? 'loading-placeholder' : ''
 							}` }
-							title={ total > 1000 ? total.toLocaleString() : '' }
+							title={
+								total > 1000
+									? formatNumber( total, getLocaleSlug() || undefined, { notation: 'standard' } )
+									: ''
+							}
 						>
 							{ formatNumber( total, getLocaleSlug() || undefined ) }
 						</span>


### PR DESCRIPTION

## Proposed Changes

Adds tootlip when count is abbreviated:

<img width="180" alt="Screenshot 2024-02-05 at 13 57 34" src="https://github.com/Automattic/wp-calypso/assets/87168/b59a1ec2-ec68-415e-b784-0acca477d726">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Hover over the count when it's over 1K => shows tooltip.
* When under 1K => Doesn't show tooltip.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
