### PR TITLE
Fixed the spacing between badges on the design setup screen

### DIFF
--- a/packages/design-preview/src/components/style.scss
+++ b/packages/design-preview/src/components/style.scss
@@ -191,7 +191,7 @@ $design-preview-sidebar-width: 311px;
 		.premium-badge,
 		.bundled-badge {
 			letter-spacing: 0.2px;
-			margin: 0;
+			margin: 0 8px 0 0;
 		}
 	}
 


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the inked issue.
-->
Related to:
- https://github.com/Automattic/dotcom-forge/issues/5529

## Proposed Changes

There was no spacing between badges on the design setup screen which made the badges touch each other and not be consistent with how the badges are show at other places.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the calypso live link
* Go to the design picker
* Pick a Premium WooCommerce theme.
* On the details, the badges should have spacing between them.

Before:
![Screenshot 2024-02-05 at 13 07 54](https://github.com/Automattic/wp-calypso/assets/1989914/069c5b94-3d70-42f4-b654-69238e3f26f6)

After:
![Screenshot 2024-02-05 at 13 08 15](https://github.com/Automattic/wp-calypso/assets/1989914/55f7f06f-b396-49a8-a566-365dc91da797)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?