### PR TITLE
Allow subdomains in glue records

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -164,7 +164,11 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		if ( ! nameserver ) {
 			return false;
 		}
-		if ( ! nameserver.match( /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/ ) ) {
+		if (
+			! nameserver.match(
+				/^([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)(.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$/
+			)
+		) {
 			return false;
 		}
 		return true;

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -165,8 +165,9 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 			return false;
 		}
 		if (
+			nameserver.length > 50 ||
 			! nameserver.match(
-				/^([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)(.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$/
+				/^([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)(\.[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)*$/
 			)
 		) {
 			return false;


### PR DESCRIPTION
## Proposed Changes

This PR allows the use of subdomains in glue records.

## Testing Instructions

Apply this patch and verify that you can add glue records that include subdomain.

![glue-records-subdomain](https://github.com/Automattic/wp-calypso/assets/2797601/d5149a2d-550c-4ebb-af28-66b241345759)
## Pre-merge Checklist
<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?