### PR TITLE
Ensure hosting flow colors are not overriden

### DIFF
--- a/client/sites-dashboard/components/hosting-flow-forking-page.tsx
+++ b/client/sites-dashboard/components/hosting-flow-forking-page.tsx
@@ -43,6 +43,7 @@ export const HostingFlowForkingPage = ( { siteCount }: HostingFlowForkingPagePro
 			<div
 				css={ {
 					display: 'flex',
+					padding: '2px',
 					flexDirection: 'column',
 					[ MEDIA_QUERIES.small ]: {
 						width: '100%',

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -71,6 +71,20 @@ function hostingFlowForkingPage( context: PageJSContext, next: () => void ) {
 				min-height: auto; /* browsing a different page might inject this style on the page */
 			}
 
+			.button.is-primary {
+				min-width: 160px;
+				background-color: var( --studio-blue-50 );
+				border-color: var( --studio-blue-50 );
+			}
+
+			.button.is-primary:active:not( :disabled ),
+			.button.is-primary:hover:not( :disabled ),
+			.button.is-primary:focus:not( :disabled ) {
+				background-color: var( --studio-blue-60 );
+				border-color: var( --studio-blue-60 );
+				box-shadow: 0 0 0 2px var( --studio-blue-60 );
+			}
+
 			${ MEDIA_QUERIES.mediumOrLarger } {
 				height: 100vh;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Our hosting flow cta buttons have inconsistent colors. This happens due to calypso button color overrides.

| Before  | After |
| ------------- | ------------- |
| <img width="1920" alt="Screenshot 2024-02-05 at 19 10 23" src="https://github.com/Automattic/wp-calypso/assets/7000684/69bc7ac7-831d-4a1a-82a8-477e9d3c9fbf">  |  <img width="1920" alt="Screenshot 2024-02-05 at 19 15 08" src="https://github.com/Automattic/wp-calypso/assets/7000684/cc7d06a2-ce8d-4372-bea0-be36573b2d6e"> |

Fixes https://github.com/Automattic/wp-calypso/issues/87040

## Proposed Changes

* set button colors for hosting flow page

## Testing Instructions
- Use the container image link
- check the buttons at the hosting flow `sites?hosting-flow=true`

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?