### PR TITLE
Jetpack Manage: Pricing page redirect fix from agency signup form to the issue license form

### DIFF
--- a/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
@@ -82,7 +82,7 @@ export default function AgencySignupForm() {
 		if ( createPartner.isSuccess ) {
 			if ( queryParams.get( 'source' ) === 'manage-pricing-page' ) {
 				const bundleSize = queryParams.get( 'bundle_size' ) || '1';
-				const path = `/partner-portal/issue-license?product_slug=${ queryParams.get(
+				const path = `/partner-portal/issue-license?products=${ queryParams.get(
 					'products'
 				) }&bundle_size=${ bundleSize }&source=manage-pricing-page`;
 				page.redirect( path );

--- a/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
+++ b/client/jetpack-cloud/sections/agency-signup/agency-signup-form/index.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import QueryJetpackPartnerPortalPartner from 'calypso/components/data/query-jetpack-partner-portal-partner';
 import CompanyDetailsForm from 'calypso/jetpack-cloud/sections/partner-portal/company-details-form';
@@ -78,17 +78,17 @@ export default function AgencySignupForm() {
 	// Redirect the user to the dashboard if they are already a partner,
 	// or the overview page if the form was submitted successfully,
 	// or the issue licenses page if coming via the /manage/pricing page.
+	const source = useRef( queryParams.get( 'source' ) );
+	const bundleSize = useRef( queryParams.get( 'bundle_size' ) );
+	const products = useRef( queryParams.get( 'products' ) );
 	useEffect( () => {
 		if ( createPartner.isSuccess ) {
-			if ( queryParams.get( 'source' ) === 'manage-pricing-page' ) {
-				const bundleSize = queryParams.get( 'bundle_size' ) || '1';
-				const path = `/partner-portal/issue-license?products=${ queryParams.get(
-					'products'
-				) }&bundle_size=${ bundleSize }&source=manage-pricing-page`;
+			if ( source.current === 'manage-pricing-page' ) {
+				const path = `/partner-portal/issue-license?products=${ products.current }&bundle_size=${ bundleSize.current }&source=manage-pricing-page`;
 				page.redirect( path );
+			} else {
+				page.redirect( overviewPath() );
 			}
-			// Redirect to dashboard until Overview page is built.
-			page.redirect( overviewPath() );
 		} else if ( partner ) {
 			page.redirect( dashboardPath() );
 		}


### PR DESCRIPTION
Related (as a partial fix) to https://github.com/Automattic/jetpack-manage/issues/279

## Proposed Changes

* This PR is the second part to fixing the issue mentioned at the issue above - fixing the redirect URL which will redirect a customer from a successful agency form completion to the issue licenses page, with product and quantity included, when clicking on a Get button from the `cloud.jetpack.com/manage/pricing` page (if not logged in AND not a partner to start with).

## Testing Instructions

* On `http://jetpack.cloud.localhost:3000/manage/pricing`, with a non-logged in user (eg. incognito), click on the Get button next to any product, for any bundle size.
* The Get button for a non logged-in non-partner should take you to the WPCom login page then the partner-portal 'Licensing' page. There is a new button there to sign up for Jetpack Manage (and new paragraph text linking to the /manage/ info page). Click that, and you'll be taken to the sign up page - then on completion redirected from there to the issue licenses page once signed up. On the issue licenses page, you should immediately see a modal showing the product and quantity you selected on the manage pricing page.
* Note that until the first part of the above linked issue is fixed, you'd need to use a direct Get button URL to mimic the intended behaviour, eg. `http://jetpack.cloud.localhost:3000/partner-portal/issue-license/?products=jetpack-complete%3A5&source=manage-pricing-page&bundle_size=5`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?