### PR TITLE
Jetpack Cloud: Fix (some) broken cloud.jetpack.com/{lang}/pricing route

### DIFF
--- a/client/sections.js
+++ b/client/sections.js
@@ -576,8 +576,15 @@ const sections = [
 		enableLoggedOut: true,
 	},
 	{
+		name: 'jetpack-cloud-manage-pricing',
+		paths: [ '/manage/pricing' ],
+		module: 'calypso/jetpack-cloud/sections/manage/pricing',
+		group: 'jetpack-cloud',
+		enableLoggedOut: true,
+	},
+	{
 		name: 'jetpack-cloud-pricing',
-		paths: [ '/pricing', '/[^\\/|^manage/]+/pricing', '/plans', '/[^\\/]+/plans' ],
+		paths: [ '/pricing', '/[^\\/]+/pricing', '/plans', '/[^\\/]+/plans' ],
 		module: 'calypso/jetpack-cloud/sections/pricing',
 		group: 'jetpack-cloud',
 		enableLoggedOut: true,
@@ -588,13 +595,6 @@ const sections = [
 				href: 'https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap',
 			},
 		],
-	},
-	{
-		name: 'jetpack-cloud-manage-pricing',
-		paths: [ '/manage/pricing' ],
-		module: 'calypso/jetpack-cloud/sections/manage/pricing',
-		group: 'jetpack-cloud',
-		enableLoggedOut: true,
 	},
 	{
 		name: 'jetpack-cloud-features-comparison',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

#86765 changed the regex used to identify `/{lang-code}/pricing` routes, so it would ignore the new `/manage/pricing` page, but it introduces a regex error so some `/{lang-code}/pricing` paths no longer worked.

_Note: Languages codes that contains any of the letters `mange` was affected by this issue._
_E.g. was `/sv/pricing` working which was randomly used for parts of the team to test the new route, but `/es/pricing` would cause an error since it contained `e`._

## Proposed Changes

* Move the manage pricing page route above the the normal Jetpack pricing page routes in `/client/sections.js`
* Revert to the "old" pricing page regex to restore functionality.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up branch
* Visit http://jetpack.cloud.localhost:3000/manage/pricing and verify it shows a "Jetpack Manage" specific page.
* Visit e.g. http://jetpack.cloud.localhost:3000/es/pricing/ and verify it shows the normal Jetpack pricing page in Spanish

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?