### PR TITLE
Plans 2023: Abstract plans grid dropdown options

### DIFF
--- a/packages/plans-grid-next/src/components/dropdown-option.tsx
+++ b/packages/plans-grid-next/src/components/dropdown-option.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import classnames from 'classnames';
 import { TranslateResult } from 'i18n-calypso';
 
 type DropdownOptionProps = {
@@ -35,7 +36,7 @@ const DropdownOption = ( { children, className, title }: DropdownOptionProps ) =
 	}
 
 	return (
-		<Container className={ className }>
+		<Container className={ classnames( className ) }>
 			<span className="title">{ title }</span>
 			{ children }
 		</Container>

--- a/packages/plans-grid-next/src/components/dropdown-option.tsx
+++ b/packages/plans-grid-next/src/components/dropdown-option.tsx
@@ -1,0 +1,49 @@
+import styled from '@emotion/styled';
+import { TranslateResult } from 'i18n-calypso';
+
+type DropdownOptionProps = {
+	children: React.ReactNode;
+	className?: string;
+	title?: TranslateResult;
+};
+
+const Container = styled.div`
+	& span.title,
+	&:visited span.title,
+	&:hover span.title {
+		color: var( --color-text );
+	}
+
+	span {
+		color: var( --studio-green-50 );
+	}
+
+	font-weight: 500;
+	font-size: 14px;
+
+	.title {
+		margin-right: 4px;
+		line-height: 20px;
+	}
+	.is-highlighted & {
+		background-color: #f6f7f7;
+	}
+	button & {
+		padding-right: 32px;
+	}
+`;
+
+const DropdownOption = ( { children, className, title }: DropdownOptionProps ) => {
+	if ( ! title ) {
+		return null;
+	}
+
+	return (
+		<Container className={ className }>
+			<span className="title">{ title }</span>
+			{ children }
+		</Container>
+	);
+};
+
+export default DropdownOption;

--- a/packages/plans-grid-next/src/components/dropdown-option.tsx
+++ b/packages/plans-grid-next/src/components/dropdown-option.tsx
@@ -19,7 +19,6 @@ const Container = styled.div`
 	}
 
 	font-weight: 500;
-	font-size: 14px;
 
 	.title {
 		margin-right: 4px;
@@ -27,9 +26,6 @@ const Container = styled.div`
 	}
 	.is-highlighted & {
 		background-color: #f6f7f7;
-	}
-	button & {
-		padding-right: 32px;
 	}
 `;
 

--- a/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -1,37 +1,7 @@
-import styled from '@emotion/styled';
 import { CustomSelectControl } from '@wordpress/components';
+import DropdownOption from '../../dropdown-option';
 import useIntervalOptions from '../hooks/use-interval-options';
 import type { IntervalTypeProps, SupportedUrlFriendlyTermType } from '../../../types';
-
-const IntervalTypeOption = styled.div`
-	& span.name,
-	&:visited span.name,
-	&:hover span.name {
-		color: var( --color-text );
-	}
-
-	font-weight: 500;
-	padding: 13px 13px 13px 16px;
-	font-size: 14px;
-	display: flex;
-	.discount {
-		color: var( --studio-green-50 );
-		display: flex;
-		line-height: 14px;
-		border-radius: 3px;
-		line-height: 20px;
-	}
-	.name {
-		margin-right: 4px;
-		line-height: 20px;
-	}
-	.is-highlighted & {
-		background-color: #f6f7f7;
-	}
-	button & {
-		padding-right: 32px;
-	}
-`;
 
 export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
 	const { hideDiscount, intervalType, displayedIntervals, onPlanIntervalChange } = props;
@@ -43,12 +13,14 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 	const selectOptionsList = Object.values( optionsList ).map( ( option ) => ( {
 		key: option.key,
 		name: (
-			<IntervalTypeOption>
-				<span className="name"> { option.name } </span>
+			<DropdownOption
+				className="plan-type-selector__interval-type-dropdown-option"
+				title={ option.name }
+			>
 				{ option.discountText && ! hideDiscount ? (
 					<span className="discount"> { option.discountText } </span>
 				) : null }
-			</IntervalTypeOption>
+			</DropdownOption>
 		),
 	} ) );
 

--- a/packages/plans-grid-next/src/components/plan-type-selector/style.scss
+++ b/packages/plans-grid-next/src/components/plan-type-selector/style.scss
@@ -94,6 +94,11 @@
 		.plan-type-selector__interval-type-dropdown-option {
 			display: flex;
 			padding: 13px 13px 13px 16px;
+			font-size: 0.875rem;
+
+			button & {
+				padding-right: 32px;
+			}
 
 			.discount {
 				display: flex;

--- a/packages/plans-grid-next/src/components/plan-type-selector/style.scss
+++ b/packages/plans-grid-next/src/components/plan-type-selector/style.scss
@@ -90,6 +90,18 @@
 		&:hover span.name {
 			color: var(--color-text);
 		}
+
+		.plan-type-selector__interval-type-dropdown-option {
+			display: flex;
+			padding: 13px 13px 13px 16px;
+
+			.discount {
+				display: flex;
+				border-radius: 3px;
+				line-height: 20px;
+			}
+		}
+
 		.components-flex {
 			overflow: hidden;
 			width: 100%;

--- a/packages/plans-grid-next/src/components/plan-type-selector/style.scss
+++ b/packages/plans-grid-next/src/components/plan-type-selector/style.scss
@@ -91,14 +91,14 @@
 			color: var(--color-text);
 		}
 
+		button .plan-type-selector__interval-type-dropdown-option {
+			padding-right: 32px;
+		}
+
 		.plan-type-selector__interval-type-dropdown-option {
 			display: flex;
 			padding: 13px 13px 13px 16px;
 			font-size: 0.875rem;
-
-			button & {
-				padding-right: 32px;
-			}
 
 			.discount {
 				display: flex;

--- a/packages/plans-grid-next/src/components/storage-add-on-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/storage-add-on-dropdown.tsx
@@ -7,6 +7,7 @@ import { usePlansGridContext } from '../grid-context';
 import useDefaultStorageOption from '../hooks/data-store/use-default-storage-option';
 import useIsLargeCurrency from '../hooks/use-is-large-currency';
 import { getStorageStringFromFeature } from '../util';
+import DropdownOption from './dropdown-option';
 import type { PlanSlug, StorageOption, WPComStorageAddOnSlug } from '@automattic/calypso-products';
 import type { AddOnMeta } from '@automattic/data-stores';
 
@@ -49,8 +50,7 @@ const StorageAddOnOption = ( {
 	return (
 		<>
 			{ price && ! isLargeCurrency && ! priceOnSeparateLine ? (
-				<div className="storage-add-on-dropdown-option__text-container">
-					<span className="storage-add-on-dropdown-option__title">{ title }</span>
+				<DropdownOption title={ title }>
 					<div className="storage-add-on-dropdown-option__price-container">
 						<span>
 							{ translate(
@@ -67,7 +67,7 @@ const StorageAddOnOption = ( {
 							) }
 						</span>
 					</div>
-				</div>
+				</DropdownOption>
 			) : (
 				<span className="storage-add-on-dropdown-option__title">{ title }</span>
 			) }

--- a/packages/plans-grid-next/src/components/storage-add-on-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/storage-add-on-dropdown.tsx
@@ -50,23 +50,21 @@ const StorageAddOnOption = ( {
 	return (
 		<>
 			{ price && ! isLargeCurrency && ! priceOnSeparateLine ? (
-				<DropdownOption title={ title }>
-					<div className="storage-add-on-dropdown-option__price-container">
-						<span>
-							{ translate(
-								'{{priceSpan}}+{{nbsp/}}%(price)s{{/priceSpan}}{{perMonthSpan}}/month{{/perMonthSpan}}',
-								{
-									args: { price },
-									components: {
-										nbsp: <>&nbsp;</>,
-										priceSpan: <span className="storage-add-on-dropdown-option__price" />,
-										perMonthSpan: <span className="storage-add-on-dropdown-option__per-month" />,
-									},
-									comment: 'The cost of a storage add on per month. Example reads as "+ $50/month"',
-								}
-							) }
-						</span>
-					</div>
+				<DropdownOption className="storage-add-on-dropdown-option" title={ title }>
+					<span>
+						{ translate(
+							'{{priceSpan}}+{{nbsp/}}%(price)s{{/priceSpan}}{{perMonthSpan}}/month{{/perMonthSpan}}',
+							{
+								args: { price },
+								components: {
+									nbsp: <>&nbsp;</>,
+									priceSpan: <span className="storage-add-on-dropdown-option__price" />,
+									perMonthSpan: <span className="storage-add-on-dropdown-option__per-month" />,
+								},
+								comment: 'The cost of a storage add on per month. Example reads as "+ $50/month"',
+							}
+						) }
+					</span>
 				</DropdownOption>
 			) : (
 				<span className="storage-add-on-dropdown-option__title">{ title }</span>

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -451,6 +451,12 @@ $mobile-card-max-width: 440px;
 	.storage-add-on-dropdown-option__price {
 		margin-left: 4px;
 	}
+
+	.components-custom-select-control__item {
+		&.is-highlighted {
+			background-color: var(--studio-gray-0);
+		}
+	}
 }
 
 .storage-add-on-dropdown__offset-price-container {

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -434,6 +434,9 @@ $mobile-card-max-width: 440px;
 
 	.storage-add-on-dropdown-option {
 		display: inline-block;
+		line-height: 20px;
+		min-height: 30px;
+		padding-top: 5px;
 	}
 
 	.storage-add-on-dropdown-option__title {

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -431,12 +431,7 @@ $mobile-card-max-width: 440px;
 .components-custom-select-control {
 	line-height: 0px;
 
-	.storage-add-on-dropdown-option__text-container {
-		padding: 6px 0;
-		line-height: 20px;
-	}
-
-	.storage-add-on-dropdown-option__price-container {
+	.storage-add-on-dropdown-option {
 		display: inline-block;
 	}
 
@@ -447,7 +442,6 @@ $mobile-card-max-width: 440px;
 
 	.storage-add-on-dropdown-option__price,
 	.storage-add-on-dropdown-option__per-month {
-		color: var(--studio-green-50);
 		display: inline-block;
 
 		// // Non standard rem allows us to match font size of other storage labels

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -430,6 +430,7 @@ $mobile-card-max-width: 440px;
 
 .components-custom-select-control {
 	line-height: 0px;
+	font-size: 0.75rem;
 
 	.storage-add-on-dropdown-option {
 		display: inline-block;

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -444,9 +444,7 @@ $mobile-card-max-width: 440px;
 	.storage-add-on-dropdown-option__per-month {
 		display: inline-block;
 
-		// // Non standard rem allows us to match font size of other storage labels
-		// /* stylelint-disable-next-line scales/font-sizes */
-		// font-size: 0.7rem;
+		font-size: 0.75rem;
 		font-weight: 500;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/growth-foundations/issues/302

## Proposed Changes

* Creates a shared dropdown option component to pare down on divergent styling between the storage add-on dropdown component and the plan term selector dropdown component

**Note:**
Currently the storage add-on dropdown and the plan term dropdown have two different implementations. We should, time permitting, create a more flexible shared dropdown component ( not just for the dropdown options, like in this PR ) to be reused in either instance. At this point, it seems like there are enough similarities to create a reasonable abstraction.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out this branch
* Navigate to `/start/plans`
* Verify that the plan term dropdown and storage add-on dropdown continue to behave as expected

<img width="1421" alt="Screenshot 2024-02-06 at 2 02 49 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/c6082789-4c18-4fa5-9cb5-708899206754">
<img width="1420" alt="Screenshot 2024-02-06 at 2 02 59 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/16a49d58-1389-4284-ba07-e863948bcef6">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?