### PR TITLE
Add padding to developer features page header to prevent notice overlap

### DIFF
--- a/client/me/developer/style.scss
+++ b/client/me/developer/style.scss
@@ -3,6 +3,8 @@
 @import "@automattic/components/src/styles/typography";
 
 .navigation-header.developer__header {
+	margin-top: 50px;
+
 	.formatted-header__title {
 		font-family: $brand-serif;
 		font-size: rem(44px);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1707160884771669-slack-C06ELHR6L9J

## Proposed Changes

Currently, we're using a standard notice to surface the survey prompt and it's overlapping the title, which looks a bit odd. This PR applies a margin to the header to ensure the notice doesn't overlap.

| Desktop Before | Desktop After |
| ------ | ------ |
|<img width="1195" alt="Screen Shot 2024-02-05 at 8 14 11 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/953d5cdc-0768-440d-8b92-fe4e85c532b7">|<img width="1197" alt="Screen Shot 2024-02-05 at 8 14 18 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/b856ab12-f9c1-4dc5-82e1-c57640246541">|

| Mobile Before | Mobile After |
| ------ | ------ |
|<img width="389" alt="Screen Shot 2024-02-05 at 8 15 05 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/f9cc093b-c993-4459-8476-637ce9def966">|<img width="392" alt="Screen Shot 2024-02-05 at 8 14 59 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/f593bd74-9edd-419d-b8dd-09c40f280b95">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Delete any `developer_survey` cookie.
* Navigate to `/me/developer`, enable the "I am a developer" toggle.
* Assert that the survey prompt does not overlap the page title.
