### PR TITLE
Remove hotjar tracking from unused instances

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -20,7 +20,6 @@ import { useGetDomainsQuery } from 'calypso/data/domains/use-get-domains-query';
 import useHomeLayoutQuery, { getCacheKey } from 'calypso/data/home/use-home-layout-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
-import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
 import { setDomainNotice } from 'calypso/lib/domains/set-domain-notice';
 import { preventWidows } from 'calypso/lib/formatting';
 import { getQueryArgs } from 'calypso/lib/query-args';
@@ -333,4 +332,4 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 
 const connectHome = connect( mapStateToProps, mapDispatchToProps, mergeProps );
 
-export default connectHome( withJetpackConnectionProblem( withTrackingTool( 'HotJar' )( Home ) ) );
+export default connectHome( withJetpackConnectionProblem( Home ) );

--- a/client/my-sites/importer/importing-pane.jsx
+++ b/client/my-sites/importer/importing-pane.jsx
@@ -10,7 +10,7 @@ import BusyImportingButton from 'calypso/my-sites/importer/importer-action-butto
 import ImporterCloseButton from 'calypso/my-sites/importer/importer-action-buttons/close-button';
 import ImporterActionButtonContainer from 'calypso/my-sites/importer/importer-action-buttons/container';
 import ImporterDoneButton from 'calypso/my-sites/importer/importer-action-buttons/done-button';
-import { loadTrackingTool, recordTracksEvent } from 'calypso/state/analytics/actions';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { mapAuthor, resetImport, startImporting } from 'calypso/state/imports/actions';
 import { appStates } from 'calypso/state/imports/constants';
 import AuthorMappingPane from './author-mapping-pane';
@@ -164,24 +164,6 @@ export class ImportingPane extends PureComponent {
 		return this.isInState( appStates.MAP_AUTHORS );
 	};
 
-	maybeLoadHotJar = () => {
-		if ( this.hjLoaded || ! this.isImporting() ) {
-			return;
-		}
-
-		this.hjLoaded = true;
-
-		this.props.loadTrackingTool( 'HotJar' );
-	};
-
-	componentDidMount() {
-		this.maybeLoadHotJar();
-	}
-
-	componentDidUpdate() {
-		this.maybeLoadHotJar();
-	}
-
 	handleOnMap = ( source, target ) =>
 		this.props.mapAuthor( this.props.importerStatus.importerId, source, target );
 
@@ -315,7 +297,6 @@ export class ImportingPane extends PureComponent {
 }
 
 export default connect( null, {
-	loadTrackingTool,
 	mapAuthor,
 	recordTracksEvent,
 	resetImport,

--- a/client/my-sites/people/invite-people/index.jsx
+++ b/client/my-sites/people/invite-people/index.jsx
@@ -28,7 +28,6 @@ import TokenField from 'calypso/components/token-field';
 import withSiteRoles from 'calypso/data/site-roles/with-site-roles';
 import accept from 'calypso/lib/accept';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
 import getWpcomFollowerRole from 'calypso/lib/get-wpcom-follower-role';
 import { userCan } from 'calypso/lib/site/utils';
 import wpcom from 'calypso/lib/wp';
@@ -800,6 +799,4 @@ const mapDispatchToProps = {
 
 const connectComponent = connect( mapStateToProps, mapDispatchToProps );
 
-export default connectComponent(
-	localize( withTrackingTool( 'HotJar' )( withSiteRoles( InvitePeople ) ) )
-);
+export default connectComponent( localize( withSiteRoles( InvitePeople ) ) );

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -33,7 +33,6 @@ import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import TrackComponentView from 'calypso/lib/analytics/track-component-view';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import withTrackingTool from 'calypso/lib/analytics/with-tracking-tool';
 import { getDomainRegistrations } from 'calypso/lib/cart-values/cart-items';
 import { PerformanceTrackerStop } from 'calypso/lib/performance-tracking';
 import PlansNavigation from 'calypso/my-sites/plans/navigation';
@@ -500,7 +499,7 @@ const ConnectedPlans = connect( ( state ) => {
 		domainFromHomeUpsellFlow: getDomainFromHomeUpsellInQuery( state ),
 		siteHasLegacyStorage: siteHasFeature( state, selectedSiteId, FEATURE_LEGACY_STORAGE_200GB ),
 	};
-} )( withCartKey( withShoppingCart( localize( withTrackingTool( 'HotJar' )( Plans ) ) ) ) );
+} )( withCartKey( withShoppingCart( localize( Plans ) ) ) );
 
 export default function PlansWrapper( props ) {
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pau2Xa-5wP-p2#comment-14801

## Proposed Changes

* This is a follow-up to https://github.com/Automattic/wp-calypso/pull/87167. Removes Hotjar from other unused instances. I have also added the PRs in which Hotjar was added for additional context.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Since `WithTrackingTool` is a HOC that does not pass any extra props to the child components, the removals in `client/my-sites/customer-home/main.jsx`, `client/my-sites/people/invite-people/index.jsx` and `client/my-sites/people/invite-people/index.jsx` are safe.
* The removal in `client/my-sites/importer/importing-pane.jsx` can be reviewed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?