### PR TITLE
Untangle: Implement SiteSettingPrivacy

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -701,19 +701,8 @@ export class SiteSettingsFormGeneral extends Component {
 	}
 
 	privacySettings() {
-		const {
-			fields,
-			handleSubmitForm,
-			updateFields,
-			isP2HubSite,
-			isRequestingSettings,
-			isSavingSettings,
-		} = this.props;
-
-		if ( isP2HubSite ) {
-			return <></>;
-		}
-
+		const { fields, handleSubmitForm, updateFields, isRequestingSettings, isSavingSettings } =
+			this.props;
 		return (
 			<SiteSettingPrivacy
 				fields={ fields }

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -29,7 +29,6 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormRadio from 'calypso/components/forms/form-radio';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormInput from 'calypso/components/forms/form-text-input';
-import InfoPopover from 'calypso/components/info-popover';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import SiteLanguagePicker from 'calypso/components/language-picker/site-language-picker';
 import Notice from 'calypso/components/notice';
@@ -40,6 +39,7 @@ import { preventWidows } from 'calypso/lib/formatting';
 import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
 import { domainManagementEdit } from 'calypso/my-sites/domains/paths';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import SiteSettingPrivacy from 'calypso/my-sites/site-settings/site-setting-privacy';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
@@ -703,35 +703,31 @@ export class SiteSettingsFormGeneral extends Component {
 	}
 
 	privacySettings() {
-		const { isRequestingSettings, translate, handleSubmitForm, isSavingSettings, isP2HubSite } =
-			this.props;
+		const {
+			fields,
+			handleSubmitForm,
+			updateFields,
+			isP2HubSite,
+			isRequestingSettings,
+			isSavingSettings,
+			eventTracker,
+			trackEvent,
+		} = this.props;
 
 		if ( isP2HubSite ) {
 			return <></>;
 		}
+
 		return (
-			<>
-				<SettingsSectionHeader
-					disabled={ isRequestingSettings || isSavingSettings }
-					id="site-privacy-settings"
-					isSaving={ isSavingSettings }
-					onButtonClick={ handleSubmitForm }
-					showButton
-					title={ translate(
-						'Privacy {{infoPopover}} Control who can view your site. {{a}}Learn more{{/a}}. {{/infoPopover}}',
-						{
-							components: {
-								a: <InlineSupportLink showIcon={ false } supportContext="privacy" />,
-								infoPopover: <InfoPopover position="bottom right" />,
-							},
-							comment: 'Privacy Settings header',
-						}
-					) }
-				/>
-				<Card>
-					<form> { this.visibilityOptionsComingSoon() }</form>
-				</Card>
-			</>
+			<SiteSettingPrivacy
+				fields={ fields }
+				handleSubmitForm={ handleSubmitForm }
+				updateFields={ updateFields }
+				isRequestingSettings={ isRequestingSettings }
+				isSavingSettings={ isSavingSettings }
+				eventTracker={ eventTracker }
+				trackEvent={ trackEvent }
+			/>
 		);
 	}
 

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -1,10 +1,8 @@
 import { isEnabled } from '@automattic/calypso-config';
 import {
 	PLAN_BUSINESS,
-	PLAN_PREMIUM,
 	WPCOM_FEATURES_NO_WPCOM_BRANDING,
 	WPCOM_FEATURES_SITE_PREVIEW_LINKS,
-	FEATURE_STYLE_CUSTOMIZATION,
 	getPlan,
 } from '@automattic/calypso-products';
 import {
@@ -710,8 +708,6 @@ export class SiteSettingsFormGeneral extends Component {
 			isP2HubSite,
 			isRequestingSettings,
 			isSavingSettings,
-			eventTracker,
-			trackEvent,
 		} = this.props;
 
 		if ( isP2HubSite ) {
@@ -725,8 +721,6 @@ export class SiteSettingsFormGeneral extends Component {
 				updateFields={ updateFields }
 				isRequestingSettings={ isRequestingSettings }
 				isSavingSettings={ isSavingSettings }
-				eventTracker={ eventTracker }
-				trackEvent={ trackEvent }
 			/>
 		);
 	}
@@ -970,43 +964,6 @@ export class SiteSettingsFormGeneral extends Component {
 				) }
 				{ this.toolbarOption() }
 			</div>
-		);
-	}
-
-	advancedCustomizationNotice() {
-		const { translate, selectedSite, siteSlug } = this.props;
-		const upgradeUrl = `/plans/${ siteSlug }?plan=${ PLAN_PREMIUM }&feature=${ FEATURE_STYLE_CUSTOMIZATION }`;
-
-		return (
-			<>
-				<div className="site-settings__advanced-customization-notice">
-					<div className="site-settings__advanced-customization-notice-cta">
-						<Gridicon icon="info-outline" />
-						<span>
-							{ translate(
-								'Your site contains premium styles that will only be visible once you upgrade to a %(planName)s plan.',
-								{
-									args: {
-										planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '',
-									},
-								}
-							) }
-						</span>
-					</div>
-					<div className="site-settings__advanced-customization-notice-buttons">
-						<Button href={ selectedSite.URL } target="_blank">
-							{ translate( 'View site' ) }
-						</Button>
-						<Button
-							className="is-primary"
-							href={ upgradeUrl }
-							onClick={ this.trackAdvancedCustomizationUpgradeClick }
-						>
-							{ translate( 'Upgrade' ) }
-						</Button>
-					</div>
-				</div>
-			</>
 		);
 	}
 }

--- a/client/my-sites/site-settings/site-setting-privacy/form.tsx
+++ b/client/my-sites/site-settings/site-setting-privacy/form.tsx
@@ -116,7 +116,9 @@ const SiteSettingPrivacyForm = ( {
 										} )
 									}
 									disabled={ isComingSoonDisabled }
-									onClick={ recordEvent( 'Clicked Site Visibility Radio Button' ) }
+									onClick={ () => {
+										recordEvent( 'Clicked Site Visibility Radio Button' );
+									} }
 									label={ translate( 'Coming Soon' ) }
 								/>
 							</FormLabel>

--- a/client/my-sites/site-settings/site-setting-privacy/form.tsx
+++ b/client/my-sites/site-settings/site-setting-privacy/form.tsx
@@ -1,0 +1,297 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import {
+	PLAN_PREMIUM,
+	FEATURE_STYLE_CUSTOMIZATION,
+	WPCOM_FEATURES_SITE_PREVIEW_LINKS,
+	getPlan,
+} from '@automattic/calypso-products';
+import { Button, FormLabel, Gridicon } from '@automattic/components';
+import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import FormRadio from 'calypso/components/forms/form-radio';
+import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
+import SitePreviewLink from 'calypso/components/site-preview-link';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
+import {
+	getSelectedSite,
+	getSelectedSiteId,
+	getSelectedSiteSlug,
+} from 'calypso/state/ui/selectors';
+import type { Fields } from './index';
+import type { SiteDetails } from '@automattic/data-stores';
+
+interface SiteSettingPrivacyFormProps {
+	fields: Fields;
+	updateFields: ( fields: Fields ) => void;
+	isAtomicAndEditingToolkitDeactivated: boolean;
+	isComingSoon: boolean;
+	isRequestingSettings: boolean;
+	isSavingSettings: boolean;
+	isUnlaunchedSite: boolean;
+	isWPForTeamsSite: boolean | null;
+	isWpcomStagingSite: boolean;
+	siteIsAtomic: boolean | null;
+	siteIsJetpack: boolean | null;
+	eventTracker: ( message: string ) => void;
+	trackEvent: ( message: string ) => void;
+}
+
+interface SiteSettingPrivacyFormNoticeProps {
+	selectedSite: SiteDetails | null | undefined;
+	siteSlug: string | null;
+}
+
+const SiteSettingPrivacyFormNotice = ( {
+	selectedSite,
+	siteSlug,
+}: SiteSettingPrivacyFormNoticeProps ) => {
+	const translate = useTranslate();
+	const upgradeUrl = `/plans/${ siteSlug }?plan=${ PLAN_PREMIUM }&feature=${ FEATURE_STYLE_CUSTOMIZATION }`;
+
+	return (
+		<>
+			<div className="site-settings__advanced-customization-notice">
+				<div className="site-settings__advanced-customization-notice-cta">
+					<Gridicon icon="info-outline" />
+					<span>
+						{ translate(
+							'Your site contains premium styles that will only be visible once you upgrade to a %(planName)s plan.',
+							{
+								args: {
+									planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '',
+								},
+							}
+						) }
+					</span>
+				</div>
+				<div className="site-settings__advanced-customization-notice-buttons">
+					{ selectedSite && (
+						<Button href={ selectedSite.URL } target="_blank">
+							{ translate( 'View site' ) }
+						</Button>
+					) }
+					<Button
+						className="is-primary"
+						href={ upgradeUrl }
+						onClick={ () => {
+							recordTracksEvent( 'calypso_global_styles_gating_settings_notice_upgrade_click', {
+								cta_name: 'settings_site_privacy',
+							} );
+						} }
+					>
+						{ translate( 'Upgrade' ) }
+					</Button>
+				</div>
+			</div>
+		</>
+	);
+};
+
+const SiteSettingPrivacyForm = ( {
+	fields,
+	siteIsAtomic,
+	siteIsJetpack,
+	updateFields,
+	isAtomicAndEditingToolkitDeactivated,
+	isComingSoon,
+	isRequestingSettings,
+	isSavingSettings,
+	isUnlaunchedSite,
+	isWPForTeamsSite,
+	isWpcomStagingSite,
+	eventTracker,
+	trackEvent,
+}: SiteSettingPrivacyFormProps ) => {
+	const translate = useTranslate();
+	const selectedSite = useSelector( getSelectedSite );
+	const siteId = useSelector( getSelectedSiteId ) || -1;
+	const siteSlug = useSelector( getSelectedSiteSlug );
+	const hasSitePreviewLink = useSelector( ( state ) =>
+		siteHasFeature( state, siteId, WPCOM_FEATURES_SITE_PREVIEW_LINKS )
+	);
+	const { globalStylesInUse, shouldLimitGlobalStyles } = useSiteGlobalStylesStatus( siteId );
+
+	const blogPublic = Number( fields.blog_public );
+	const wpcomComingSoon = 1 === Number( fields.wpcom_coming_soon );
+	const wpcomPublicComingSoon = 1 === Number( fields.wpcom_public_coming_soon );
+	// isPrivateAndUnlaunched means it is an unlaunched coming soon v1 site
+	const isPrivateAndUnlaunched = -1 === blogPublic && isUnlaunchedSite;
+	const isNonAtomicJetpackSite = siteIsJetpack && ! siteIsAtomic;
+	const isAnyComingSoonEnabled =
+		( 0 === blogPublic && wpcomPublicComingSoon ) || isPrivateAndUnlaunched || wpcomComingSoon;
+	const isComingSoonDisabled = isRequestingSettings || isAtomicAndEditingToolkitDeactivated;
+	const isPublicChecked =
+		( wpcomPublicComingSoon && blogPublic === 0 && isComingSoonDisabled ) ||
+		( blogPublic === 0 && ! wpcomPublicComingSoon ) ||
+		blogPublic === 1;
+
+	const showPreviewLink = isComingSoon && hasSitePreviewLink;
+	const shouldShowPremiumStylesNotice = globalStylesInUse && shouldLimitGlobalStyles;
+
+	const handleVisibilityOptionChange = ( {
+		blog_public,
+		wpcom_coming_soon,
+		wpcom_public_coming_soon,
+	}: Fields ) => {
+		trackEvent( `Set blog_public to ${ blog_public }` );
+		trackEvent( `Set wpcom_coming_soon to ${ wpcom_coming_soon }` );
+		trackEvent( `Set wpcom_public_coming_soon to ${ wpcom_public_coming_soon }` );
+		updateFields( { blog_public, wpcom_coming_soon, wpcom_public_coming_soon } );
+	};
+
+	return (
+		<form>
+			<FormFieldset>
+				{ ! isNonAtomicJetpackSite &&
+					! isWPForTeamsSite &&
+					! isAtomicAndEditingToolkitDeactivated && (
+						<>
+							{ shouldShowPremiumStylesNotice && (
+								<SiteSettingPrivacyFormNotice selectedSite={ selectedSite } siteSlug={ siteSlug } />
+							) }
+							<FormLabel
+								className={ classnames( 'site-settings__visibility-label is-coming-soon', {
+									'is-coming-soon-disabled': isComingSoonDisabled,
+								} ) }
+							>
+								<FormRadio
+									className={ undefined }
+									name="blog_public"
+									value="0"
+									checked={ isAnyComingSoonEnabled }
+									onChange={ () =>
+										handleVisibilityOptionChange( {
+											blog_public: 0,
+											wpcom_coming_soon: 0,
+											wpcom_public_coming_soon: 1,
+										} )
+									}
+									disabled={ isComingSoonDisabled }
+									onClick={ eventTracker( 'Clicked Site Visibility Radio Button' ) }
+									label={ translate( 'Coming Soon' ) }
+								/>
+							</FormLabel>
+							<FormSettingExplanation>
+								{ translate(
+									'Your site is hidden from visitors behind a "Coming Soon" notice until it is ready for viewing.'
+								) }
+							</FormSettingExplanation>
+							{ showPreviewLink && selectedSite && (
+								<div className="site-settings__visibility-label is-checkbox">
+									<SitePreviewLink
+										siteUrl={ selectedSite.URL }
+										siteId={ siteId }
+										disabled={ ! isAnyComingSoonEnabled || isSavingSettings }
+										forceOff={ ! isAnyComingSoonEnabled }
+										source="privacy-settings"
+									/>
+								</div>
+							) }
+						</>
+					) }
+				{ ! isNonAtomicJetpackSite && (
+					<>
+						<FormLabel className="site-settings__visibility-label is-public">
+							<FormRadio
+								className={ undefined }
+								name="blog_public"
+								value="1"
+								checked={ isPublicChecked }
+								onChange={ () =>
+									handleVisibilityOptionChange( {
+										blog_public: isWpcomStagingSite ? 0 : 1,
+										wpcom_coming_soon: 0,
+										wpcom_public_coming_soon: 0,
+									} )
+								}
+								disabled={ isRequestingSettings }
+								onClick={ () => {
+									eventTracker( 'Clicked Site Visibility Radio Button' );
+								} }
+								label={ translate( 'Public' ) }
+							/>
+						</FormLabel>
+						<FormSettingExplanation>
+							{ isWpcomStagingSite
+								? translate(
+										'Your site is visible to everyone, but search engines are discouraged from indexing staging sites.'
+								  )
+								: translate( 'Your site is visible to everyone.' ) }
+						</FormSettingExplanation>
+					</>
+				) }
+
+				{ ! isWpcomStagingSite && (
+					<>
+						<FormLabel className="site-settings__visibility-label is-checkbox is-hidden">
+							<FormInputCheckbox
+								name="blog_public"
+								value="0"
+								checked={
+									( wpcomPublicComingSoon && blogPublic === 0 && isComingSoonDisabled ) ||
+									( 0 === blogPublic && ! wpcomPublicComingSoon )
+								}
+								onChange={ () =>
+									handleVisibilityOptionChange( {
+										blog_public:
+											wpcomPublicComingSoon || blogPublic === -1 || blogPublic === 1 ? 0 : 1,
+										wpcom_coming_soon: 0,
+										wpcom_public_coming_soon: 0,
+									} )
+								}
+								disabled={ isRequestingSettings }
+								onClick={ () => {
+									eventTracker( 'Clicked Site Visibility Radio Button' );
+								} }
+							/>
+							<span>{ translate( 'Discourage search engines from indexing this site' ) }</span>
+							<FormSettingExplanation>
+								{ translate(
+									'This option does not block access to your site — it is up to search engines to honor your request.'
+								) }
+							</FormSettingExplanation>
+						</FormLabel>
+					</>
+				) }
+				{ ! isNonAtomicJetpackSite && (
+					<>
+						<FormLabel className="site-settings__visibility-label is-private">
+							<FormRadio
+								className={ undefined }
+								name="blog_public"
+								value="-1"
+								checked={
+									( -1 === blogPublic && ! wpcomComingSoon && ! isPrivateAndUnlaunched ) ||
+									( wpcomComingSoon && isAtomicAndEditingToolkitDeactivated )
+								}
+								onChange={ () =>
+									handleVisibilityOptionChange( {
+										blog_public: -1,
+										wpcom_coming_soon: 0,
+										wpcom_public_coming_soon: 0,
+									} )
+								}
+								disabled={ isRequestingSettings }
+								onClick={ () => {
+									eventTracker( 'Clicked Site Visibility Radio Button' );
+								} }
+								label={ translate( 'Private' ) }
+							/>
+						</FormLabel>
+						<FormSettingExplanation>
+							{ translate(
+								'Your site is only visible to you and logged-in members you approve. Everyone else will see a log in screen.'
+							) }
+						</FormSettingExplanation>
+					</>
+				) }
+			</FormFieldset>
+		</form>
+	);
+};
+
+export default SiteSettingPrivacyForm;

--- a/client/my-sites/site-settings/site-setting-privacy/index.tsx
+++ b/client/my-sites/site-settings/site-setting-privacy/index.tsx
@@ -81,6 +81,7 @@ const SiteSettingPrivacy = ( {
 					updateFields={ updateFields }
 					isAtomicAndEditingToolkitDeactivated={ isAtomicAndEditingToolkitDeactivated }
 					isComingSoon={ isComingSoon }
+					isP2HubSite={ isP2HubSite }
 					isRequestingSettings={ isRequestingSettings }
 					isSavingSettings={ isSavingSettings }
 					isUnlaunchedSite={ isUnlaunched }

--- a/client/my-sites/site-settings/site-setting-privacy/index.tsx
+++ b/client/my-sites/site-settings/site-setting-privacy/index.tsx
@@ -26,8 +26,6 @@ interface SiteSettingPrivacyProps {
 	updateFields: ( fields: Fields ) => void;
 	isRequestingSettings: boolean;
 	isSavingSettings: boolean;
-	eventTracker: () => void;
-	trackEvent: () => void;
 }
 
 const SiteSettingPrivacy = ( {
@@ -36,8 +34,6 @@ const SiteSettingPrivacy = ( {
 	updateFields,
 	isRequestingSettings,
 	isSavingSettings,
-	eventTracker,
-	trackEvent,
 }: SiteSettingPrivacyProps ) => {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId ) || -1;
@@ -85,8 +81,6 @@ const SiteSettingPrivacy = ( {
 					isWpcomStagingSite={ isWpcomStagingSite }
 					siteIsAtomic={ siteIsAtomic }
 					siteIsJetpack={ siteIsJetpack }
-					eventTracker={ eventTracker }
-					trackEvent={ trackEvent }
 				/>
 			</Card>
 		</>

--- a/client/my-sites/site-settings/site-setting-privacy/index.tsx
+++ b/client/my-sites/site-settings/site-setting-privacy/index.tsx
@@ -14,6 +14,7 @@ import { getSiteOption, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SiteSettingPrivacyForm from './form';
 import type { AppState } from 'calypso/types';
+import './style.scss';
 
 export interface Fields {
 	blog_public: number;

--- a/client/my-sites/site-settings/site-setting-privacy/index.tsx
+++ b/client/my-sites/site-settings/site-setting-privacy/index.tsx
@@ -1,0 +1,96 @@
+import { Card } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
+import InfoPopover from 'calypso/components/info-popover';
+import InlineSupportLink from 'calypso/components/inline-support-link';
+import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
+import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
+import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
+import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
+import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
+import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
+import { getSiteOption, isJetpackSite } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import SiteSettingPrivacyForm from './form';
+import type { AppState } from 'calypso/types';
+
+export interface Fields {
+	blog_public: number;
+	wpcom_coming_soon: number;
+	wpcom_public_coming_soon: number;
+}
+
+interface SiteSettingPrivacyProps {
+	fields: Fields;
+	handleSubmitForm: ( event: React.FormEvent< HTMLFormElement > ) => void;
+	updateFields: ( fields: Fields ) => void;
+	isRequestingSettings: boolean;
+	isSavingSettings: boolean;
+	eventTracker: () => void;
+	trackEvent: () => void;
+}
+
+const SiteSettingPrivacy = ( {
+	fields,
+	handleSubmitForm,
+	updateFields,
+	isRequestingSettings,
+	isSavingSettings,
+	eventTracker,
+	trackEvent,
+}: SiteSettingPrivacyProps ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId ) || -1;
+	const siteIsAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
+	const siteIsJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
+	const isComingSoon = useSelector( ( state: AppState ) => isSiteComingSoon( state, siteId ) );
+	const isUnlaunched = useSelector( ( state: AppState ) => isUnlaunchedSite( state, siteId ) );
+	const isWpcomStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
+	const isWPForTeamsSite = useSelector( ( state ) => isSiteWPForTeams( state, siteId ) );
+	const isEditingToolkitActive = useSelector(
+		( state ) => !! getSiteOption( state, siteId, 'editing_toolkit_is_active' )
+	);
+	const isAtomicAndEditingToolkitDeactivated = !! siteIsAtomic && ! isEditingToolkitActive;
+
+	return (
+		<>
+			{ /* @ts-expect-error SettingsSectionHeader is not typed and is causing errors */ }
+			<SettingsSectionHeader
+				id="site-privacy-settings"
+				disabled={ isRequestingSettings || isSavingSettings }
+				isSaving={ isSavingSettings }
+				onButtonClick={ handleSubmitForm }
+				showButton
+				title={ translate(
+					'Privacy {{infoPopover}} Control who can view your site. {{a}}Learn more{{/a}}. {{/infoPopover}}',
+					{
+						components: {
+							a: <InlineSupportLink showIcon={ false } supportContext="privacy" />,
+							infoPopover: <InfoPopover position="bottom right" />,
+						},
+						comment: 'Privacy Settings header',
+					}
+				) }
+			/>
+			<Card>
+				<SiteSettingPrivacyForm
+					fields={ fields }
+					updateFields={ updateFields }
+					isAtomicAndEditingToolkitDeactivated={ isAtomicAndEditingToolkitDeactivated }
+					isComingSoon={ isComingSoon }
+					isRequestingSettings={ isRequestingSettings }
+					isSavingSettings={ isSavingSettings }
+					isUnlaunchedSite={ isUnlaunched }
+					isWPForTeamsSite={ isWPForTeamsSite }
+					isWpcomStagingSite={ isWpcomStagingSite }
+					siteIsAtomic={ siteIsAtomic }
+					siteIsJetpack={ siteIsJetpack }
+					eventTracker={ eventTracker }
+					trackEvent={ trackEvent }
+				/>
+			</Card>
+		</>
+	);
+};
+
+export default SiteSettingPrivacy;

--- a/client/my-sites/site-settings/site-setting-privacy/index.tsx
+++ b/client/my-sites/site-settings/site-setting-privacy/index.tsx
@@ -6,6 +6,7 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import SettingsSectionHeader from 'calypso/my-sites/site-settings/settings-section-header';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
+import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
@@ -40,6 +41,7 @@ const SiteSettingPrivacy = ( {
 	const siteIsAtomic = useSelector( ( state ) => isSiteAutomatedTransfer( state, siteId ) );
 	const siteIsJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const isComingSoon = useSelector( ( state: AppState ) => isSiteComingSoon( state, siteId ) );
+	const isP2HubSite = useSelector( ( state: AppState ) => isSiteP2Hub( state, siteId ) );
 	const isUnlaunched = useSelector( ( state: AppState ) => isUnlaunchedSite( state, siteId ) );
 	const isWpcomStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, siteId ) );
 	const isWPForTeamsSite = useSelector( ( state ) => isSiteWPForTeams( state, siteId ) );
@@ -47,6 +49,10 @@ const SiteSettingPrivacy = ( {
 		( state ) => !! getSiteOption( state, siteId, 'editing_toolkit_is_active' )
 	);
 	const isAtomicAndEditingToolkitDeactivated = !! siteIsAtomic && ! isEditingToolkitActive;
+
+	if ( isP2HubSite ) {
+		return <></>;
+	}
 
 	return (
 		<>

--- a/client/my-sites/site-settings/site-setting-privacy/index.tsx
+++ b/client/my-sites/site-settings/site-setting-privacy/index.tsx
@@ -81,7 +81,6 @@ const SiteSettingPrivacy = ( {
 					updateFields={ updateFields }
 					isAtomicAndEditingToolkitDeactivated={ isAtomicAndEditingToolkitDeactivated }
 					isComingSoon={ isComingSoon }
-					isP2HubSite={ isP2HubSite }
 					isRequestingSettings={ isRequestingSettings }
 					isSavingSettings={ isSavingSettings }
 					isUnlaunchedSite={ isUnlaunched }

--- a/client/my-sites/site-settings/site-setting-privacy/notice.tsx
+++ b/client/my-sites/site-settings/site-setting-privacy/notice.tsx
@@ -1,0 +1,55 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { FEATURE_STYLE_CUSTOMIZATION, PLAN_PREMIUM, getPlan } from '@automattic/calypso-products';
+import { Button, Gridicon } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import type { SiteDetails } from '@automattic/data-stores';
+
+interface SiteSettingPrivacyNoticeProps {
+	selectedSite: SiteDetails | null | undefined;
+	siteSlug: string | null;
+}
+
+const SiteSettingPrivacyNotice = ( { selectedSite, siteSlug }: SiteSettingPrivacyNoticeProps ) => {
+	const translate = useTranslate();
+	const upgradeUrl = `/plans/${ siteSlug }?plan=${ PLAN_PREMIUM }&feature=${ FEATURE_STYLE_CUSTOMIZATION }`;
+
+	return (
+		<>
+			<div className="site-settings__advanced-customization-notice">
+				<div className="site-settings__advanced-customization-notice-cta">
+					<Gridicon icon="info-outline" />
+					<span>
+						{ translate(
+							'Your site contains premium styles that will only be visible once you upgrade to a %(planName)s plan.',
+							{
+								args: {
+									planName: getPlan( PLAN_PREMIUM )?.getTitle() ?? '',
+								},
+							}
+						) }
+					</span>
+				</div>
+				<div className="site-settings__advanced-customization-notice-buttons">
+					{ selectedSite && (
+						<Button href={ selectedSite.URL } target="_blank">
+							{ translate( 'View site' ) }
+						</Button>
+					) }
+					<Button
+						className="is-primary"
+						href={ upgradeUrl }
+						onClick={ () => {
+							recordTracksEvent( 'calypso_global_styles_gating_settings_notice_upgrade_click', {
+								cta_name: 'settings_site_privacy',
+							} );
+						} }
+					>
+						{ translate( 'Upgrade' ) }
+					</Button>
+				</div>
+			</div>
+		</>
+	);
+};
+
+export default SiteSettingPrivacyNotice;

--- a/client/my-sites/site-settings/site-setting-privacy/style.scss
+++ b/client/my-sites/site-settings/site-setting-privacy/style.scss
@@ -1,0 +1,56 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+#site-privacy-settings .section-header__label-text button {
+	vertical-align: middle;
+}
+
+.site-settings__visibility-label {
+	&:not(:first-child) {
+		margin-top: 15px;
+	}
+	&.is-checkbox:not(:only-child) {
+		margin-left: 25px;
+	}
+}
+
+.site-settings__advanced-customization-notice {
+	display: flex;
+	flex-direction: column;
+	padding: 20px;
+	background-color: var(--color-neutral-0);
+	align-items: center;
+	justify-content: space-between;
+
+	.site-settings__advanced-customization-notice-cta {
+		display: flex;
+		align-items: center;
+	}
+
+	svg.gridicon.gridicons-info-outline {
+		color: var(--color-warning-30);
+		padding-right: 10px;
+	}
+
+	.site-settings__advanced-customization-notice-buttons {
+		display: flex;
+		padding-top: 10px;
+		min-width: 185px;
+
+		.button.is-primary {
+			margin-left: 5px;
+		}
+	}
+
+	@include break-xlarge {
+		flex-direction: row;
+
+		.site-settings__advanced-customization-notice-cta {
+			margin-right: 20px;
+		}
+
+		.site-settings__advanced-customization-notice-buttons {
+			padding-top: 0;
+		}
+	}
+}

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -371,15 +371,6 @@
 	}
 }
 
-.site-settings__visibility-label {
-	&:not(:first-child) {
-		margin-top: 15px;
-	}
-	&.is-checkbox:not(:only-child) {
-		margin-left: 25px;
-	}
-}
-
 .site-settings__footer-credit-container {
 	margin-bottom: 16px;
 }
@@ -588,10 +579,6 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 	pointer-events: none;
 }
 
-#site-privacy-settings .section-header__label-text button {
-	vertical-align: middle;
-}
-
 .site-settings__writing-settings {
 	.theme-enhancements__card {
 		.form-fieldset.minileven {
@@ -639,47 +626,6 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 .site-settings__page-optimize {
 	margin-top: -16px;
 	margin-bottom: 16px;
-}
-
-.site-settings__advanced-customization-notice {
-	display: flex;
-	flex-direction: column;
-	padding: 20px;
-	background-color: var(--color-neutral-0);
-	align-items: center;
-	justify-content: space-between;
-
-	.site-settings__advanced-customization-notice-cta {
-		display: flex;
-		align-items: center;
-	}
-
-	svg.gridicon.gridicons-info-outline {
-		color: var(--color-warning-30);
-		padding-right: 10px;
-	}
-
-	.site-settings__advanced-customization-notice-buttons {
-		display: flex;
-		padding-top: 10px;
-		min-width: 185px;
-
-		.button.is-primary {
-			margin-left: 5px;
-		}
-	}
-
-	@include break-xlarge {
-		flex-direction: row;
-
-		.site-settings__advanced-customization-notice-cta {
-			margin-right: 20px;
-		}
-
-		.site-settings__advanced-customization-notice-buttons {
-			padding-top: 0;
-		}
-	}
 }
 
 .site-settings__gifting-container {

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -32,6 +32,7 @@ import timezonesReducer from 'calypso/state/timezones/reducer';
 import uiReducer from 'calypso/state/ui/reducer';
 import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { SiteSettingsFormGeneral } from '../form-general';
+import SiteSettingPrivacyForm from '../site-setting-privacy/form';
 
 moment.tz = {
 	guess: () => moment(),
@@ -339,6 +340,17 @@ describe( 'SiteSettingsFormGeneral', () => {
 		} );
 
 		test( 'Jetpack Site, Public -> click Discourage Search Engines', async () => {
+			const { container } = renderWithRedux( <SiteSettingsFormGeneral { ...jetpackProps } />, {
+				ui: {
+					selectedSiteId: 1234,
+				},
+			} );
+			expect(
+				container.querySelectorAll( '.site-settings__general-settings-launch-site' ).length
+			).toBe( 0 );
+		} );
+
+		test( 'Jetpack Site, Public -> click Discourage Search Engines, Privacy Setting', async () => {
 			testProps = {
 				...jetpackProps,
 				isComingSoon: false,
@@ -350,16 +362,14 @@ describe( 'SiteSettingsFormGeneral', () => {
 				},
 			};
 			const { container, getByLabelText } = renderWithRedux(
-				<SiteSettingsFormGeneral { ...testProps } />,
+				<SiteSettingPrivacyForm { ...testProps } />,
 				{
 					ui: {
 						selectedSiteId: 1234,
 					},
 				}
 			);
-			expect(
-				container.querySelectorAll( '.site-settings__general-settings-launch-site' ).length
-			).toBe( 0 );
+
 			expect( container.querySelectorAll( '[name="blog_public"]' ).length ).toBe( 1 );
 
 			const discourageRadio = getByLabelText( 'Discourage search engines from indexing this site', {
@@ -386,6 +396,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 					blog_public: 0,
 				},
 			};
+
 			const { container } = renderWithRedux( <SiteSettingsFormGeneral { ...testProps } /> );
 			expect(
 				container.querySelectorAll( '.site-settings__general-settings-launch-site' ).length
@@ -404,8 +415,9 @@ describe( 'SiteSettingsFormGeneral', () => {
 					blog_public: 0,
 				},
 			};
+
 			const { container, getByLabelText } = renderWithRedux(
-				<SiteSettingsFormGeneral { ...testProps } />
+				<SiteSettingPrivacyForm { ...testProps } />
 			);
 			expect(
 				container.querySelectorAll( '.site-settings__general-settings-launch-site' ).length
@@ -430,8 +442,9 @@ describe( 'SiteSettingsFormGeneral', () => {
 					blog_public: 1,
 				},
 			};
+
 			const { container, getByLabelText } = renderWithRedux(
-				<SiteSettingsFormGeneral { ...testProps } />
+				<SiteSettingPrivacyForm { ...testProps } />
 			);
 			expect(
 				container.querySelectorAll( '.site-settings__general-settings-launch-site' ).length
@@ -456,13 +469,29 @@ describe( 'SiteSettingsFormGeneral', () => {
 					blog_public: 0,
 				},
 			};
-			const { container, getByLabelText } = renderWithRedux(
-				<SiteSettingsFormGeneral { ...testProps } />
-			);
+
+			const { container } = renderWithRedux( <SiteSettingsFormGeneral { ...testProps } /> );
 			// Staging sites shouldn't ever show the 'Launch site' container.
 			expect(
 				container.querySelectorAll( '.site-settings__general-settings-launch-site' ).length
 			).toBe( 0 );
+		} );
+
+		test( 'Atomic Staging Site, Unlaunched, Privacy Setting', () => {
+			testProps = {
+				...atomicStagingProps,
+				isComingSoon: true,
+				isUnlaunchedSite: true,
+				fields: {
+					wpcom_public_coming_soon: 1,
+					wpcom_coming_soon: 0,
+					blog_public: 0,
+				},
+			};
+
+			const { container, getByLabelText } = renderWithRedux(
+				<SiteSettingPrivacyForm { ...testProps } />
+			);
 			expect( container.querySelectorAll( '[name="blog_public"]' ).length ).toBe( 3 );
 			expect( getByLabelText( 'Coming Soon' ) ).toBeChecked();
 		} );
@@ -478,12 +507,28 @@ describe( 'SiteSettingsFormGeneral', () => {
 					blog_public: 0,
 				},
 			};
-			const { container, getByLabelText } = renderWithRedux(
-				<SiteSettingsFormGeneral { ...testProps } />
-			);
+
+			const { container } = renderWithRedux( <SiteSettingsFormGeneral { ...testProps } /> );
 			expect(
 				container.querySelectorAll( '.site-settings__general-settings-launch-site' ).length
 			).toBe( 0 );
+		} );
+
+		test( 'Atomic Staging Site, Coming Soon -> click Public, Privacy Setting', async () => {
+			testProps = {
+				...atomicStagingProps,
+				isComingSoon: true,
+				isUnlaunchedSite: false,
+				fields: {
+					wpcom_public_coming_soon: 1,
+					wpcom_coming_soon: 0,
+					blog_public: 0,
+				},
+			};
+
+			const { container, getByLabelText } = renderWithRedux(
+				<SiteSettingPrivacyForm { ...testProps } />
+			);
 			expect( container.querySelectorAll( '[name="blog_public"]' ).length ).toBe( 3 );
 
 			const publicRadio = getByLabelText( 'Public' );
@@ -511,12 +556,28 @@ describe( 'SiteSettingsFormGeneral', () => {
 					blog_public: 1,
 				},
 			};
-			const { container, getByLabelText } = renderWithRedux(
-				<SiteSettingsFormGeneral { ...testProps } />
-			);
+
+			const { container } = renderWithRedux( <SiteSettingsFormGeneral { ...testProps } /> );
 			expect(
 				container.querySelectorAll( '.site-settings__general-settings-launch-site' ).length
 			).toBe( 0 );
+		} );
+
+		test( 'Atomic Staging Site, Public, Privacy Setting', () => {
+			testProps = {
+				...atomicStagingProps,
+				isComingSoon: false,
+				isUnlaunchedSite: false,
+				fields: {
+					wpcom_public_coming_soon: 0,
+					wpcom_coming_soon: 0,
+					blog_public: 1,
+				},
+			};
+
+			const { container, getByLabelText } = renderWithRedux(
+				<SiteSettingPrivacyForm { ...testProps } />
+			);
 			expect( container.querySelectorAll( '[name="blog_public"]' ).length ).toBe( 3 );
 			expect( getByLabelText( 'Coming Soon' ) ).not.toBeChecked();
 			expect( getByLabelText( 'Public' ) ).toBeChecked();
@@ -534,12 +595,28 @@ describe( 'SiteSettingsFormGeneral', () => {
 					blog_public: 0,
 				},
 			};
-			const { container, getByLabelText } = renderWithRedux(
-				<SiteSettingsFormGeneral { ...testProps } />
-			);
+
+			const { container } = renderWithRedux( <SiteSettingsFormGeneral { ...testProps } /> );
 			expect(
 				container.querySelectorAll( '.site-settings__general-settings-launch-site' ).length
 			).toBe( 0 );
+		} );
+
+		test( 'Atomic Staging Site, Search Engines Discouraged, Privacy Setting', () => {
+			testProps = {
+				...atomicStagingProps,
+				isComingSoon: false,
+				isUnlaunchedSite: false,
+				fields: {
+					wpcom_public_coming_soon: 0,
+					wpcom_coming_soon: 0,
+					blog_public: 0,
+				},
+			};
+
+			const { container, getByLabelText } = renderWithRedux(
+				<SiteSettingPrivacyForm { ...testProps } />
+			);
 			expect( container.querySelectorAll( '[name="blog_public"]' ).length ).toBe( 3 );
 			expect( getByLabelText( 'Coming Soon' ) ).not.toBeChecked();
 			expect( getByLabelText( 'Public' ) ).toBeChecked();
@@ -662,7 +739,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 						},
 					};
 
-					const { getByLabelText } = renderWithRedux( <SiteSettingsFormGeneral { ...newProps } /> );
+					const { getByLabelText } = renderWithRedux( <SiteSettingPrivacyForm { ...newProps } /> );
 					const radioButtonComingSoon = getByLabelText( 'Coming soon', { exact: false } );
 					expect( radioButtonComingSoon ).not.toBeChecked();
 
@@ -679,7 +756,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 						},
 					};
 
-					const { getByLabelText } = renderWithRedux( <SiteSettingsFormGeneral { ...newProps } /> );
+					const { getByLabelText } = renderWithRedux( <SiteSettingPrivacyForm { ...newProps } /> );
 					const radioButtonComingSoon = getByLabelText( 'Coming soon', { exact: false } );
 					expect( radioButtonComingSoon ).toBeChecked();
 
@@ -698,7 +775,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 					};
 
 					const { getByLabelText, container } = renderWithRedux(
-						<SiteSettingsFormGeneral { ...newProps } />
+						<SiteSettingPrivacyForm { ...newProps } />
 					);
 					expect(
 						container.querySelector( '.site-settings__visibility-label.is-coming-soon' )
@@ -732,7 +809,7 @@ describe( 'SiteSettingsFormGeneral', () => {
 					isAtomicAndEditingToolkitDeactivated: false,
 				};
 
-				const { container } = renderWithRedux( <SiteSettingsFormGeneral { ...newProps } /> );
+				const { container } = renderWithRedux( <SiteSettingPrivacyForm { ...newProps } /> );
 				expect(
 					container.querySelectorAll( '.site-settings__visibility-label.is-coming-soon' )
 				).toHaveLength( 1 );
@@ -743,7 +820,8 @@ describe( 'SiteSettingsFormGeneral', () => {
 					...props,
 					isAtomicAndEditingToolkitDeactivated: true,
 				};
-				const { container } = renderWithRedux( <SiteSettingsFormGeneral { ...newProps } /> );
+
+				const { container } = renderWithRedux( <SiteSettingPrivacyForm { ...newProps } /> );
 				expect(
 					container.querySelectorAll( '.site-settings__visibility-label.is-coming-soon' )
 				).toHaveLength( 0 );
@@ -758,8 +836,9 @@ describe( 'SiteSettingsFormGeneral', () => {
 					},
 					isAtomicAndEditingToolkitDeactivated: true,
 				};
-				const { getByLabelText, container } = renderWithRedux(
-					<SiteSettingsFormGeneral { ...newProps } />
+
+				const { container, getByLabelText } = renderWithRedux(
+					<SiteSettingPrivacyForm { ...newProps } />
 				);
 				expect( container.querySelector( '.site-settings__visibility-label.is-coming-soon' ) ).toBe(
 					null

--- a/client/my-sites/site-settings/test/form-general.jsx
+++ b/client/my-sites/site-settings/test/form-general.jsx
@@ -10,6 +10,8 @@ jest.mock(
 		}
 );
 
+jest.mock( 'calypso/state/selectors/is-site-p2-hub' );
+
 import {
 	PLAN_FREE,
 	PLAN_BLOGGER,
@@ -27,6 +29,7 @@ import moment from 'moment';
 import editorReducer from 'calypso/state/editor/reducer';
 import jetpackReducer from 'calypso/state/jetpack/reducer';
 import mediaReducer from 'calypso/state/media/reducer';
+import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import siteSettingsReducer from 'calypso/state/site-settings/reducer';
 import timezonesReducer from 'calypso/state/timezones/reducer';
 import uiReducer from 'calypso/state/ui/reducer';
@@ -160,7 +163,6 @@ describe( 'SiteSettingsFormGeneral', () => {
 				siteIsJetpack: true,
 				siteIsP2Hub: false,
 				isAtomicAndEditingToolkitDeactivated: false,
-				isP2HubSite: false,
 				isWPForTeamsSite: false,
 				isWpcomStagingSite: false,
 				updateFields: jest.fn( ( fields ) => {
@@ -180,7 +182,6 @@ describe( 'SiteSettingsFormGeneral', () => {
 				siteIsJetpack: true,
 				siteIsP2Hub: false,
 				isAtomicAndEditingToolkitDeactivated: false,
-				isP2HubSite: false,
 				isWPForTeamsSite: false,
 				isWpcomStagingSite: true,
 				updateFields: jest.fn( ( fields ) => {
@@ -200,7 +201,6 @@ describe( 'SiteSettingsFormGeneral', () => {
 				siteIsJetpack: true,
 				siteIsP2Hub: false,
 				isAtomicAndEditingToolkitDeactivated: false,
-				isP2HubSite: false,
 				isWPForTeamsSite: false,
 				isWpcomStagingSite: false,
 				updateFields: jest.fn( ( fields ) => {
@@ -216,7 +216,6 @@ describe( 'SiteSettingsFormGeneral', () => {
 				siteIsJetpack: false,
 				siteIsP2Hub: false,
 				isAtomicAndEditingToolkitDeactivated: false,
-				isP2HubSite: false,
 				isWPForTeamsSite: false,
 				isWpcomStagingSite: false,
 				updateFields: jest.fn( ( fields ) => {
@@ -859,13 +858,9 @@ describe( 'SiteSettingsFormGeneral', () => {
 
 		describe( 'P2 Hub', () => {
 			it( 'Should not show the privacy settings UI', () => {
-				testProps = {
-					...testProps,
-					isP2HubSite: true,
-				};
+				isSiteP2Hub.mockImplementation( () => true );
 
 				const { container } = renderWithRedux( <SiteSettingsFormGeneral { ...testProps } /> );
-
 				expect( container.querySelectorAll( '#site-privacy-settings' ) ).toHaveLength( 0 );
 			} );
 		} );

--- a/client/my-sites/site-settings/wpcom-site-tools-settings/index.jsx
+++ b/client/my-sites/site-settings/wpcom-site-tools-settings/index.jsx
@@ -5,24 +5,49 @@ import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import getIsUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import SiteSettingPrivacy from '../site-setting-privacy';
 import SiteTools from '../site-tools';
 import { SOURCE_SETTINGS_SITE_TOOLS } from '../site-tools/utils';
 import LaunchSite from '../site-visibility/launch-site';
+import wrapSettingsForm from '../wrap-settings-form';
 
 const SiteSettingsGeneral = ( {
+	fields,
+	handleSubmitForm,
+	updateFields,
+	isRequestingSettings,
+	isSavingSettings,
+
 	isWpcomStagingSite,
 	isAtomicAndEditingToolkitDeactivated,
 	isUnlaunchedSite,
 } ) => (
 	<div className="site-settings__main general-settings">
-		{ isUnlaunchedSite && ! isAtomicAndEditingToolkitDeactivated && ! isWpcomStagingSite && (
+		{ isUnlaunchedSite && ! isAtomicAndEditingToolkitDeactivated && ! isWpcomStagingSite ? (
 			<LaunchSite />
+		) : (
+			<SiteSettingPrivacy
+				fields={ fields }
+				handleSubmitForm={ handleSubmitForm }
+				updateFields={ updateFields }
+				isRequestingSettings={ isRequestingSettings }
+				isSavingSettings={ isSavingSettings }
+			/>
 		) }
 		{ ! isWpcomStagingSite && (
 			<SiteTools headerTitle={ translate( 'Other tools' ) } source={ SOURCE_SETTINGS_SITE_TOOLS } />
 		) }
 	</div>
 );
+
+const getFormSettings = ( settings ) => {
+	if ( ! settings ) {
+		return {};
+	}
+
+	const { blog_public, wpcom_coming_soon, wpcom_public_coming_soon } = settings;
+	return { blog_public, wpcom_coming_soon, wpcom_public_coming_soon };
+};
 
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
@@ -33,4 +58,4 @@ export default connect( ( state ) => {
 			getSiteOption( state, siteId, 'editing_toolkit_is_active' ) === false,
 		isUnlaunchedSite: getIsUnlaunchedSite( state, siteId ),
 	};
-} )( SiteSettingsGeneral );
+} )( wrapSettingsForm( getFormSettings )( SiteSettingsGeneral ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5320

## Proposed Changes

This PR implements the component `SiteSettingPrivacy` which is intended to be reused in `/settings/general/:site` and `/settings/site-tools/:site`. See the screenshot below for what the component entails:

![Screenshot 2024-02-15 at 5 30 46 PM](https://github.com/Automattic/wp-calypso/assets/797888/76df276b-580e-40ec-8a81-f522b340686a)

> [!NOTE]
> There are some improvements such as removing the dependecy of the `wrapSettingsForm` helper, or rewrite unit tests using mocks instead of passing props that we can address in future PRs. It's likely that `wrapSettingsForm` can be helpful as we move more settings into `/settings/site-tools/:site`.   

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/settings/general/:site`.
* Ensure that the Privacy settings works the same as in production.
* Head to `/settings/site-tools/:site`
* Ensure that the Privacy settings works the same as in `/settings/general/:site`.
* Make sure to test the banner that shows when the site uses custom styles.
* Make sure to test that the tracking events are fired properly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?