### PR TITLE
Jetpack Manage: Pricing - adding a tracks event linked to clicking the Get / Select license button

### DIFF
--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/featured-license-item-card.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/featured-license-item-card.tsx
@@ -90,7 +90,13 @@ export const FeaturedLicenseItemCard = ( {
 
 	const onSelectProduct = useCallback( () => {
 		page.redirect( getIssueLicenseURL( productSlug, bundleSize ) );
-	}, [ bundleSize, getIssueLicenseURL, productSlug ] );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_manage_on_select_product_button_click', {
+				product: productSlug,
+				bundle_size: bundleSize,
+			} )
+		);
+	}, [ bundleSize, dispatch, getIssueLicenseURL, productSlug ] );
 
 	const onHideLightbox = useCallback( () => {
 		resetParams( [ LICENSE_INFO_MODAL_ID ] );

--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/featured-license-multi-item-card.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/featured-license-multi-item-card.tsx
@@ -118,7 +118,13 @@ export const FeaturedLicenseMultiItemCard = ( {
 
 	const onSelectProduct = useCallback( () => {
 		page.redirect( getIssueLicenseURL( variantSlug, bundleSize ) );
-	}, [ bundleSize, getIssueLicenseURL, variantSlug ] );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_manage_on_select_product_button_click', {
+				product: variantSlug,
+				bundle_size: bundleSize,
+			} )
+		);
+	}, [ bundleSize, dispatch, getIssueLicenseURL, variantSlug ] );
 
 	const onHideLightbox = useCallback( () => {
 		resetParams( [ LICENSE_INFO_MODAL_ID ] );

--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/simple-license-item-card.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/simple-license-item-card.tsx
@@ -124,7 +124,13 @@ export const SimpleLicenseItemCard = ( {
 
 	const onSelectProduct = useCallback( () => {
 		page.redirect( getIssueLicenseURL( productSlug, bundleSize ) );
-	}, [ bundleSize, getIssueLicenseURL, productSlug ] );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_manage_on_select_product_button_click', {
+				product: productSlug,
+				bundle_size: bundleSize,
+			} )
+		);
+	}, [ bundleSize, dispatch, getIssueLicenseURL, productSlug ] );
 
 	const onHideLightbox = useCallback( () => {
 		resetParams( [ LICENSE_INFO_MODAL_ID ] );

--- a/client/jetpack-cloud/sections/manage/pricing/license-products-list/simple-license-multi-item-card.tsx
+++ b/client/jetpack-cloud/sections/manage/pricing/license-products-list/simple-license-multi-item-card.tsx
@@ -128,7 +128,13 @@ export const SimpleLicenseMultiItemCard = ( {
 
 	const onSelectProduct = useCallback( () => {
 		page.redirect( getIssueLicenseURL( variantSlug, bundleSize ) );
-	}, [ bundleSize, getIssueLicenseURL, variantSlug ] );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_manage_on_select_product_button_click', {
+				product: variantSlug,
+				bundle_size: bundleSize,
+			} )
+		);
+	}, [ bundleSize, dispatch, getIssueLicenseURL, variantSlug ] );
 
 	const onHideLightbox = useCallback( () => {
 		resetParams( [ LICENSE_INFO_MODAL_ID ] );


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/280

## Proposed Changes

* This PR adds a new tracks event - `calypso_jetpack_manage_on_select_product_button_click` - that fires when clicking on 'Get' or 'Select License' (from the More Info lightbox) from any product card on the Jetpack Manage pricing page.

## Testing Instructions

* To test with this PR checked out, visit the `http://jetpack.cloud.localhost:3000/manage/pricing` page. On any product or plan card:
* Click the Get button, and observe via Tracks Vigilante or via the Network tab of your inspector that the `calypso_jetpack_manage_on_select_product_button_click` event has fired.
* Click on the 'More about' link within any product card, and then click on 'Select license'. Observe via Tracks Vigilante or via the Network tab of your inspector that the `calypso_jetpack_manage_on_select_product_button_click` event has fired.
* In both cases, note that the event also should include a product property and bundle_size property.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?