### PR TITLE
Stats: Add mobile version of Subscriber highlights

### DIFF
--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -91,9 +91,8 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 
 	const highlights = useSubscriberHighlights( siteId, hasAddedPaidSubscriptionProduct );
 
-	return (
-		<div className="highlight-cards-list">
-			{ siteId && ! isOdysseyStats && <QueryMembershipProducts siteId={ siteId } /> }
+	const standardHighlights = (
+		<>
 			{ highlights.map( ( highlight ) => (
 				<CountComparisonCard
 					key={ highlight.heading }
@@ -103,6 +102,13 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 					note={ highlight.note }
 				/>
 			) ) }
+		</>
+	);
+
+	return (
+		<div className="highlight-cards-list">
+			{ siteId && ! isOdysseyStats && <QueryMembershipProducts siteId={ siteId } /> }
+			{ standardHighlights }
 		</div>
 	);
 }

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { ComponentSwapper, CountComparisonCard, formattedNumber } from '@automattic/components';
+import { ComponentSwapper, CountComparisonCard, ShortenedNumber } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import QueryMembershipProducts from 'calypso/components/data/query-memberships';
 import useSubscribersOverview from 'calypso/my-sites/stats/hooks/use-subscribers-overview';
@@ -111,7 +111,11 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 				<div className="highlight-cards-list-mobile__item">
 					<span className="highlight-cards-list-mobile__item-heading">{ highlight.heading }</span>
 					<span className="highlight-cards-list-mobile__item-count">
-						{ isPaidSubscriptionProductsLoading ? '-' : formattedNumber( highlight.count ) }
+						{ isPaidSubscriptionProductsLoading ? (
+							'-'
+						) : (
+							<ShortenedNumber value={ highlight.count } />
+						) }
 					</span>
 				</div>
 			) ) }

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -96,7 +96,7 @@ function SubscriberHighlightsStandard( {
 }
 
 function SubscriberHighlightsMobile( { highlights, isLoading }: SubscriberHighlightsRenderProps ) {
-	const mobileHighlights = (
+	return (
 		<div className="highlight-cards-list-mobile">
 			{ highlights.map( ( highlight ) => (
 				<div className="highlight-cards-list-mobile__item" key={ highlight.heading }>
@@ -108,7 +108,6 @@ function SubscriberHighlightsMobile( { highlights, isLoading }: SubscriberHighli
 			) ) }
 		</div>
 	);
-	return mobileHighlights;
 }
 
 export default function SubscribersHighlightSection( { siteId }: { siteId: number | null } ) {

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { ComponentSwapper, CountComparisonCard } from '@automattic/components';
+import { ComponentSwapper, CountComparisonCard, formattedNumber } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import QueryMembershipProducts from 'calypso/components/data/query-memberships';
 import useSubscribersOverview from 'calypso/my-sites/stats/hooks/use-subscribers-overview';
@@ -111,7 +111,7 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 				<div className="highlight-cards-list-mobile__item">
 					<span className="highlight-cards-list-mobile__item-heading">{ highlight.heading }</span>
 					<span className="highlight-cards-list-mobile__item-count">
-						{ isPaidSubscriptionProductsLoading ? '-' : highlight.count }
+						{ isPaidSubscriptionProductsLoading ? '-' : formattedNumber( highlight.count ) }
 					</span>
 				</div>
 			) ) }

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -65,18 +65,6 @@ function useSubscriberHighlights(
 	return highlights;
 }
 
-function SubscriberHighlightsHeader() {
-	const translate = useTranslate();
-	const localizedTitle = translate( 'All-time stats', {
-		comment: 'Heading for Subscribers page highlights section',
-	} );
-
-	// TODO: Add an explanation here if we're running an older version of Odyssey Stats
-	//       without support for subscriber highlights API endpoint support.
-
-	return <h1 className="highlight-cards-heading">{ localizedTitle }</h1>;
-}
-
 type HighlightData = {
 	heading: string;
 	count: number | null;
@@ -123,22 +111,28 @@ function SubscriberHighlightsMobile( { highlights, isLoading }: SubscriberHighli
 	return mobileHighlights;
 }
 
-function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
+export default function SubscribersHighlightSection( { siteId }: { siteId: number | null } ) {
+	const translate = useTranslate();
+	const localizedTitle = translate( 'All-time stats', {
+		comment: 'Heading for Subscribers page highlights section',
+	} );
+
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
 	// Check if the site has any paid subscription products added.
-	// Intentionally not using `getProductsForSiteId` here because we want to show the loading state.
+	// Intentionally not using getProductsForSiteId here because we want to show the loading state.
 	const products = useSelector( ( state ) => state.memberships?.productList?.items[ siteId ?? 0 ] );
 
 	// Odyssey Stats doesn't support the membership API endpoint yet.
-	// Products with an `undefined` value rather than an empty array means the API call has not been completed yet.
+	// Products with an undefined value rather than an empty array means the API call has not been completed yet.
 	const isPaidSubscriptionProductsLoading = ! isOdysseyStats && ! products;
 	const hasAddedPaidSubscriptionProduct = ! isOdysseyStats && products && products.length > 0;
 
 	const highlights = useSubscriberHighlights( siteId, hasAddedPaidSubscriptionProduct );
 
 	return (
-		<>
+		<div className="highlight-cards subscribers-page has-odyssey-stats-bg-color">
+			<h1 className="highlight-cards-heading">{ localizedTitle }</h1>
 			{ siteId && ! isOdysseyStats && <QueryMembershipProducts siteId={ siteId } /> }
 			<ComponentSwapper
 				breakpoint="<660px"
@@ -155,15 +149,6 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 					/>
 				}
 			/>
-		</>
-	);
-}
-
-export default function SubscribersHighlightSection( { siteId }: { siteId: number | null } ) {
-	return (
-		<div className="highlight-cards subscribers-page has-odyssey-stats-bg-color">
-			<SubscriberHighlightsHeader />
-			<SubscriberHighlightsListing siteId={ siteId } />
 		</div>
 	);
 }

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -106,8 +106,15 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 	);
 
 	const mobileHighlights = (
-		<div>
-			<p>mobile highlights here</p>
+		<div className="highlight-cards-list-mobile">
+			{ highlights.map( ( highlight ) => (
+				<div className="highlight-cards-list-mobile__item">
+					<span className="highlight-cards-list-mobile__item-heading">{ highlight.heading }</span>
+					<span className="highlight-cards-list-mobile__item-count">
+						{ isPaidSubscriptionProductsLoading ? '-' : highlight.count }
+					</span>
+				</div>
+			) ) }
 		</div>
 	);
 

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -137,27 +137,23 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 
 	const highlights = useSubscriberHighlights( siteId, hasAddedPaidSubscriptionProduct );
 
-	const standardHighlights = (
-		<SubscriberHighlightsStandard
-			highlights={ highlights }
-			isLoading={ isPaidSubscriptionProductsLoading }
-		/>
-	);
-
-	const mobileHighlights = (
-		<SubscriberHighlightsMobile
-			highlights={ highlights }
-			isLoading={ isPaidSubscriptionProductsLoading }
-		/>
-	);
-
 	return (
 		<>
 			{ siteId && ! isOdysseyStats && <QueryMembershipProducts siteId={ siteId } /> }
 			<ComponentSwapper
 				breakpoint="<660px"
-				breakpointActiveComponent={ mobileHighlights }
-				breakpointInactiveComponent={ standardHighlights }
+				breakpointActiveComponent={
+					<SubscriberHighlightsMobile
+						highlights={ highlights }
+						isLoading={ isPaidSubscriptionProductsLoading }
+					/>
+				}
+				breakpointInactiveComponent={
+					<SubscriberHighlightsStandard
+						highlights={ highlights }
+						isLoading={ isPaidSubscriptionProductsLoading }
+					/>
+				}
 			/>
 		</>
 	);

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -1,5 +1,5 @@
 import config from '@automattic/calypso-config';
-import { CountComparisonCard } from '@automattic/components';
+import { ComponentSwapper, CountComparisonCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import QueryMembershipProducts from 'calypso/components/data/query-memberships';
 import useSubscribersOverview from 'calypso/my-sites/stats/hooks/use-subscribers-overview';
@@ -92,7 +92,7 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 	const highlights = useSubscriberHighlights( siteId, hasAddedPaidSubscriptionProduct );
 
 	const standardHighlights = (
-		<>
+		<div className="highlight-cards-list">
 			{ highlights.map( ( highlight ) => (
 				<CountComparisonCard
 					key={ highlight.heading }
@@ -102,14 +102,24 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 					note={ highlight.note }
 				/>
 			) ) }
-		</>
+		</div>
+	);
+
+	const mobileHighlights = (
+		<div>
+			<p>mobile highlights here</p>
+		</div>
 	);
 
 	return (
-		<div className="highlight-cards-list">
+		<>
 			{ siteId && ! isOdysseyStats && <QueryMembershipProducts siteId={ siteId } /> }
-			{ standardHighlights }
-		</div>
+			<ComponentSwapper
+				breakpoint="<660px"
+				breakpointActiveComponent={ mobileHighlights }
+				breakpointInactiveComponent={ standardHighlights }
+			/>
+		</>
 	);
 }
 

--- a/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/index.tsx
@@ -77,6 +77,52 @@ function SubscriberHighlightsHeader() {
 	return <h1 className="highlight-cards-heading">{ localizedTitle }</h1>;
 }
 
+type HighlightData = {
+	heading: string;
+	count: number | null;
+	note?: string | undefined;
+};
+
+type SubscriberHighlightsRenderProps = {
+	highlights: HighlightData[];
+	isLoading: boolean;
+};
+
+function SubscriberHighlightsStandard( {
+	highlights,
+	isLoading,
+}: SubscriberHighlightsRenderProps ) {
+	return (
+		<div className="highlight-cards-list">
+			{ highlights.map( ( highlight ) => (
+				<CountComparisonCard
+					key={ highlight.heading }
+					heading={ isLoading ? '-' : highlight.heading }
+					count={ isLoading ? null : highlight.count }
+					showValueTooltip
+					note={ highlight.note }
+				/>
+			) ) }
+		</div>
+	);
+}
+
+function SubscriberHighlightsMobile( { highlights, isLoading }: SubscriberHighlightsRenderProps ) {
+	const mobileHighlights = (
+		<div className="highlight-cards-list-mobile">
+			{ highlights.map( ( highlight ) => (
+				<div className="highlight-cards-list-mobile__item" key={ highlight.heading }>
+					<span className="highlight-cards-list-mobile__item-heading">{ highlight.heading }</span>
+					<span className="highlight-cards-list-mobile__item-count">
+						{ isLoading ? '-' : <ShortenedNumber value={ highlight.count } /> }
+					</span>
+				</div>
+			) ) }
+		</div>
+	);
+	return mobileHighlights;
+}
+
 function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 	const isOdysseyStats = config.isEnabled( 'is_running_in_jetpack_site' );
 
@@ -92,34 +138,17 @@ function SubscriberHighlightsListing( { siteId }: { siteId: number | null } ) {
 	const highlights = useSubscriberHighlights( siteId, hasAddedPaidSubscriptionProduct );
 
 	const standardHighlights = (
-		<div className="highlight-cards-list">
-			{ highlights.map( ( highlight ) => (
-				<CountComparisonCard
-					key={ highlight.heading }
-					heading={ isPaidSubscriptionProductsLoading ? '-' : highlight.heading }
-					count={ isPaidSubscriptionProductsLoading ? null : highlight.count }
-					showValueTooltip
-					note={ highlight.note }
-				/>
-			) ) }
-		</div>
+		<SubscriberHighlightsStandard
+			highlights={ highlights }
+			isLoading={ isPaidSubscriptionProductsLoading }
+		/>
 	);
 
 	const mobileHighlights = (
-		<div className="highlight-cards-list-mobile">
-			{ highlights.map( ( highlight ) => (
-				<div className="highlight-cards-list-mobile__item">
-					<span className="highlight-cards-list-mobile__item-heading">{ highlight.heading }</span>
-					<span className="highlight-cards-list-mobile__item-count">
-						{ isPaidSubscriptionProductsLoading ? (
-							'-'
-						) : (
-							<ShortenedNumber value={ highlight.count } />
-						) }
-					</span>
-				</div>
-			) ) }
-		</div>
+		<SubscriberHighlightsMobile
+			highlights={ highlights }
+			isLoading={ isPaidSubscriptionProductsLoading }
+		/>
 	);
 
 	return (

--- a/client/my-sites/stats/stats-subscribers-highlight-section/style.scss
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/style.scss
@@ -55,6 +55,8 @@
 		display: flex;
 		align-items: center;
 		box-shadow: 0 0 0 1px var(--color-border-subtle);
+		border-radius: 5px; /* stylelint-disable-line scales/radii */
+		background: var(--color-surface);
 		padding: 12px;
 	}
 

--- a/client/my-sites/stats/stats-subscribers-highlight-section/style.scss
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/style.scss
@@ -54,6 +54,8 @@
 	.highlight-cards-list-mobile__item {
 		display: flex;
 		align-items: center;
+		box-shadow: 0 0 0 1px var(--color-border-subtle);
+		padding: 12px;
 	}
 
 	.highlight-cards-list-mobile__item-heading {
@@ -63,7 +65,9 @@
 	}
 	.highlight-cards-list-mobile__item-count {
 		margin-left: auto;
-		font-size: 1rem;
-		line-height: 24px;
+		font-size: 1.5rem;
+		line-height: 32px;
+
+		font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
 	}
 }

--- a/client/my-sites/stats/stats-subscribers-highlight-section/style.scss
+++ b/client/my-sites/stats/stats-subscribers-highlight-section/style.scss
@@ -44,3 +44,26 @@
 		}
 	}
 }
+
+.highlight-cards-list-mobile {
+	display: flex;
+	flex-direction: column;
+	row-gap: 16px;
+	margin: 24px;
+
+	.highlight-cards-list-mobile__item {
+		display: flex;
+		align-items: center;
+	}
+
+	.highlight-cards-list-mobile__item-heading {
+		font-weight: 500;
+		font-size: 0.875rem;
+		line-height: 20px;
+	}
+	.highlight-cards-list-mobile__item-count {
+		margin-left: auto;
+		font-size: 1rem;
+		line-height: 24px;
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #80590.

## Proposed Changes

For mobile screen sizes only, turn the highlight cards into a simple vertical list of cards. This approach is probably safest when considering localization. Currently looks like this:

<img width="418" alt="SCR-20240207-pswj" src="https://github.com/Automattic/wp-calypso/assets/40267301/52d154a3-2a32-4d35-b7f3-729ef245ac56">

Most tablets should retain the existing scrolling-card interface.

I'm of the opinion that it probably makes sense to makes these same changes on the Traffic and Insights pages too but will check with the team first and tackled that in a later PR as needed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso Live branch.
* Navigate to the **Stats → Subscribers** page.
* Use the browser tools to test at different screen sizes. iPad mini and larger should get the standard Desktop UI with horizontal scrolling while smaller screens should get the vertically stacked cards.
* Confirm the highlight cards on the other pages have not changed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?