### PR TITLE
Continue with GitHub: Add button redirect to GitHub's OAuth

### DIFF
--- a/client/blocks/authentication/social/index.tsx
+++ b/client/blocks/authentication/social/index.tsx
@@ -133,6 +133,7 @@ const SocialAuthenticationForm = ( {
 						{ config.isEnabled( 'login/github' ) ? (
 							<GithubSocialButton
 								socialServiceResponse={ socialService === 'github' ? socialServiceResponse : null }
+								redirectUri={ getRedirectUri( 'github' ) }
 								responseHandler={ handleGitHubResponse }
 							/>
 						) : null }

--- a/client/blocks/authentication/social/index.tsx
+++ b/client/blocks/authentication/social/index.tsx
@@ -135,6 +135,9 @@ const SocialAuthenticationForm = ( {
 								socialServiceResponse={ socialService === 'github' ? socialServiceResponse : null }
 								redirectUri={ getRedirectUri( 'github' ) }
 								responseHandler={ handleGitHubResponse }
+								onClick={ () => {
+									trackLoginAndRememberRedirect( 'github' );
+								} }
 							/>
 						) : null }
 

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -21,6 +21,7 @@ type GithubLoginButtonProps = {
 	children?: ReactNode;
 	responseHandler: ( response: any ) => void;
 	redirectUri: string;
+	onClick?: () => void;
 	socialServiceResponse?: string | null;
 };
 
@@ -28,6 +29,7 @@ const GitHubLoginButton = ( {
 	children,
 	responseHandler,
 	redirectUri,
+	onClick,
 	socialServiceResponse,
 }: GithubLoginButtonProps ) => {
 	const translate = useTranslate();
@@ -62,6 +64,10 @@ const GitHubLoginButton = ( {
 		if ( isDisabled ) {
 			e.preventDefault();
 			return;
+		}
+
+		if ( onClick ) {
+			onClick();
 		}
 
 		const clientId = config( 'github_oauth_client_id' );

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -60,11 +60,7 @@ const GitHubLoginButton = ( {
 
 	const handleClick = ( e: MouseEvent< HTMLButtonElement > ) => {
 		errorRef.current = e.currentTarget;
-
-		if ( isDisabled ) {
-			e.preventDefault();
-			return;
-		}
+		e.preventDefault();
 
 		if ( onClick ) {
 			onClick();

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -20,12 +20,14 @@ import './style.scss';
 type GithubLoginButtonProps = {
 	children?: ReactNode;
 	responseHandler: ( response: any ) => void;
+	redirectUri: string;
 	socialServiceResponse?: string | null;
 };
 
 const GitHubLoginButton = ( {
 	children,
 	responseHandler,
+	redirectUri,
 	socialServiceResponse,
 }: GithubLoginButtonProps ) => {
 	const translate = useTranslate();
@@ -63,7 +65,6 @@ const GitHubLoginButton = ( {
 		}
 
 		const clientId = config( 'github_oauth_client_id' );
-		const redirectUri = encodeURIComponent( 'https://wordpress.com/start/user' );
 		window.location.href = `https://github.com/login/oauth/authorize?client_id=${ clientId }&redirect_uri=${ redirectUri }`;
 	};
 

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -52,11 +52,20 @@ const GitHubLoginButton = ( {
 		}
 	}, [ socialServiceResponse ] );
 
+	const isDisabled = isFormDisabled || disabledState;
+
 	const handleClick = ( e: MouseEvent< HTMLButtonElement > ) => {
 		errorRef.current = e.currentTarget;
-	};
 
-	const isDisabled = Boolean( disabledState || isFormDisabled || errorState );
+		if ( isDisabled ) {
+			e.preventDefault();
+			return;
+		}
+
+		const clientId = config( 'github_oauth_client_id' );
+		const redirectUri = encodeURIComponent( 'https://wordpress.com/start/user' );
+		window.location.href = `https://github.com/login/oauth/authorize?client_id=${ clientId }&redirect_uri=${ redirectUri }`;
+	};
 
 	const eventHandlers = {
 		onClick: handleClick,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/wp-calypso/issues/87226.

## Proposed Changes

* add button redirect to GitHub's OAuth
* include `trackLoginAndRememberRedirect()` `onClick`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to http://calypso.localhost:3000/log-in or http://calypso.localhost:3000/start/user-social
2. Click on the "Continue with GitHub" button.
3. You should be directed to the GitHub "Sign In" page with the included `client_id` and `redirect_uri` URL parameters (depending on which page you are coming from):

`/log-in`:
![Markup on 2024-02-07 at 12:49:52](https://github.com/Automattic/wp-calypso/assets/25105483/cc753655-55ab-4661-8d13-f661187f865e)

`/start/user-social`:
![Markup on 2024-02-07 at 12:49:04](https://github.com/Automattic/wp-calypso/assets/25105483/87654736-317c-4613-b79d-091d8069e22c)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?