### PR TITLE
Checkout: fix chargeback-only display issues

### DIFF
--- a/client/my-sites/checkout/src/components/CheckoutMoneyBackGuarantee.jsx
+++ b/client/my-sites/checkout/src/components/CheckoutMoneyBackGuarantee.jsx
@@ -1,3 +1,4 @@
+import { isChargeback } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import { Icon, reusableBlock } from '@wordpress/icons';
 import { CheckoutSummaryRefundWindows } from './wp-checkout-order-summary';
@@ -33,6 +34,11 @@ const StyledIcon = styled( Icon )`
 `;
 
 export function CheckoutMoneyBackGuarantee( { cart } ) {
+	// Return early if the cart is only Chargebacks fees
+	if ( cart.products.every( isChargeback ) ) {
+		return null;
+	}
+
 	const allCartItemsAreDomains = cart.products.every(
 		( product ) => product.is_domain_registration === true
 	);

--- a/client/my-sites/checkout/src/components/CheckoutMoneyBackGuarantee.jsx
+++ b/client/my-sites/checkout/src/components/CheckoutMoneyBackGuarantee.jsx
@@ -1,4 +1,4 @@
-import { isChargeback } from '@automattic/calypso-products';
+import { isChargeback, isCredits } from '@automattic/calypso-products';
 import styled from '@emotion/styled';
 import { Icon, reusableBlock } from '@wordpress/icons';
 import { CheckoutSummaryRefundWindows } from './wp-checkout-order-summary';
@@ -35,7 +35,7 @@ const StyledIcon = styled( Icon )`
 
 export function CheckoutMoneyBackGuarantee( { cart } ) {
 	// Return early if the cart is only Chargebacks fees
-	if ( cart.products.every( isChargeback ) ) {
+	if ( cart.products.every( isChargeback || isCredits ) ) {
 		return null;
 	}
 

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -2,6 +2,7 @@ import {
 	getPlan,
 	getYearlyPlanByMonthly,
 	isChargeback,
+	isCredits,
 	isDomainProduct,
 	isDomainTransfer,
 	isGoogleWorkspace,
@@ -118,7 +119,7 @@ export function CheckoutSummaryFeaturedList( {
 	const translate = useTranslate();
 
 	// Return early if the cart is only Chargebacks fees
-	if ( responseCart.products.every( isChargeback ) ) {
+	if ( responseCart.products.every( isChargeback || isCredits ) ) {
 		return null;
 	}
 

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -1,6 +1,7 @@
 import {
 	getPlan,
 	getYearlyPlanByMonthly,
+	isChargeback,
 	isDomainProduct,
 	isDomainTransfer,
 	isGoogleWorkspace,
@@ -115,6 +116,12 @@ export function CheckoutSummaryFeaturedList( {
 	) => void;
 } ) {
 	const translate = useTranslate();
+
+	// Return early if the cart is only Chargebacks fees
+	if ( responseCart.products.every( isChargeback ) ) {
+		return null;
+	}
+
 	const hasRenewalInCart = responseCart.products.some(
 		( product ) => product.extra.purchaseType === 'renewal'
 	);

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -807,9 +807,11 @@ const CheckoutSidebarNudgeWrapper = styled.div`
 `;
 
 const CheckoutTermsAndCheckboxesWrapper = styled.div`
+	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
 	padding: 32px 20px 0 24px;
+	width: 100%;
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		padding: 32px 20px 0 40px;
 	}


### PR DESCRIPTION
This makes a few small updates to the way Checkout handles a cart that's only Chargeback fees.

Fixes: https://github.com/Automattic/wp-calypso/issues/64203

| Before      | After |
| ----------- | ----------- |
|   ![wordpress com_checkout_cainsnuxtest2401135335 wordpress com](https://github.com/Automattic/wp-calypso/assets/942359/9008db95-acda-429f-832a-228aadb342e9)   |    ![calypso localhost_3000_checkout_cainsnuxtest2401135335 wordpress com](https://github.com/Automattic/wp-calypso/assets/942359/1b29f1d8-4fff-42e6-8067-38ff9b1e0f7e)    |

**To test:**
- Testing a chargeback is difficult - I'll create a guide. The easiest way to test this is probably to SU `cainstesting` and then visit https://wordpress.com/checkout/cainsnuxtest2401135335.wordpress.com
- Verify that the changes look correct
- Visit Checkout for any other site/product combination
- Verify that there haven't been visual regressions