### PR TITLE
Fix expiry date on purchases page

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -218,11 +218,11 @@ function renderRenewsOrExpiresOn( {
 	}
 
 	if ( isExpiring( purchase ) || isExpired( purchase ) ) {
-		return <>{ moment( purchase.expiryDate ).format( 'LL' ) }</>;
+		return <>{ moment.utc( purchase.expiryDate ).format( 'LL' ) }</>;
 	}
 
 	if ( isRenewing( purchase ) ) {
-		return <>{ moment( purchase.renewDate ).format( 'LL' ) }</>;
+		return <>{ moment.utc( purchase.renewDate ).format( 'LL' ) }</>;
 	}
 
 	if ( isOneTimePurchase( purchase ) ) {


### PR DESCRIPTION
## Proposed Changes

* Moment was formatting dates incorrectly because it wasn't using UTC time. This caused the expiry date to sometimes be 1 day earlier than the actual expiry date
* Use moment.utc to get the correct date when formatting expiry date

## Testing Instructions

1. Before checking out this branch, on a test site, make a jetpack purchase. Doesn't matter what product
2. Go to the Store Admin and update the expiry date to be Feb 3, 2024
![image](https://github.com/Automattic/wp-calypso/assets/65001528/2ce4e278-5d4c-4fe3-8f94-b0b18c2a77a2)
3. Go to wordpress.com/me/purchases and confirm that the expiry date on that purchase says February 2nd instead
![image](https://github.com/Automattic/wp-calypso/assets/65001528/aa93d285-b2c2-435a-94e6-761405f6142f)
4. Now use the calypso live link or your local environment with this branch checked out and go to `/me/purchases`. Make sure the date is now correct
![image](https://github.com/Automattic/wp-calypso/assets/65001528/721aae8b-268e-497a-9e43-22b60c345c73)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?