### PR TITLE
Untangle: Try adding toggle to pre AT warning for admin style

### DIFF
--- a/client/blocks/eligibility-warnings/warning-list.tsx
+++ b/client/blocks/eligibility-warnings/warning-list.tsx
@@ -1,8 +1,11 @@
 import { Card, Badge } from '@automattic/components';
+import { ToggleControl } from '@wordpress/components';
 import { localize, LocalizeProps, translate } from 'i18n-calypso';
-import { Fragment } from 'react';
+import React, { useState, Fragment } from 'react';
 import ActionPanelLink from 'calypso/components/action-panel/link';
 import ExternalLink from 'calypso/components/external-link';
+import { setAdminInterfaceStyle } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/sensei-launch/launch-completion-tasks';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { DomainNames, EligibilityWarning } from 'calypso/state/automated-transfer/selectors';
 
 interface ExternalProps {
@@ -13,54 +16,81 @@ interface ExternalProps {
 
 type Props = ExternalProps & LocalizeProps;
 
-export const WarningList = ( { context, translate, warnings, showContact = true }: Props ) => (
-	<div>
-		{ getWarningDescription( context, warnings.length, translate ) && (
-			<div className="eligibility-warnings__warning">
-				<div className="eligibility-warnings__message">
-					<span className="eligibility-warnings__message-description">
-						{ getWarningDescription( context, warnings.length, translate ) }
-					</span>
-				</div>
-			</div>
-		) }
+export const WarningList = ( { context, translate, warnings, showContact = true }: Props ) => {
+	const [ isAdminStyleEnabled, setAdminStyleEnabled ] = useState( true ); // State to track toggle
 
-		{ warnings.map( ( { name, description, supportUrl, domainNames }, index ) => (
-			<div className="eligibility-warnings__warning" key={ index }>
-				<div className="eligibility-warnings__message">
-					{ context !== 'plugin-details' && (
-						<Fragment>
-							<span className="eligibility-warnings__message-title">{ name }</span>:&nbsp;
-						</Fragment>
-					) }
-					<span className="eligibility-warnings__message-description">
-						<span>{ description } </span>
-						{ domainNames && displayDomainNames( domainNames ) }
-						{ supportUrl && (
-							<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">
-								{ translate( 'Learn more.' ) }
-							</ExternalLink>
+	// Function to handle toggle changes
+	const handleAdminStyleToggle = ( checkedValue: boolean ) => {
+		console.log( 'checkedValue', checkedValue );
+		setAdminStyleEnabled( checkedValue );
+		const siteId = getSelectedSiteId( getState() );
+		console.log( 'siteId', siteId );
+
+		if ( siteId !== null ) {
+			const adminStyle = checkedValue ? 'wp-admin' : 'calypso';
+			setAdminInterfaceStyle( siteId, adminStyle );
+		}
+	};
+
+	return (
+		<div>
+			{ getWarningDescription( context, warnings.length, translate ) && (
+				<div className="eligibility-warnings__warning">
+					<div className="eligibility-warnings__message">
+						<span className="eligibility-warnings__message-description">
+							{ getWarningDescription( context, warnings.length, translate ) }
+						</span>
+					</div>
+				</div>
+			) }
+
+			{ warnings.map( ( { id, name, description, supportUrl, domainNames }, index ) => (
+				<div className="eligibility-warnings__warning" key={ index }>
+					<div className="eligibility-warnings__message">
+						{ context !== 'plugin-details' && (
+							<Fragment>
+								<span className="eligibility-warnings__message-title">{ name }</span>:&nbsp;
+							</Fragment>
 						) }
-					</span>
+						<span className="eligibility-warnings__message-description">
+							<span>{ description } </span>
+							{ domainNames && displayDomainNames( domainNames ) }
+							{ supportUrl && (
+								<ExternalLink href={ supportUrl } target="_blank" rel="noopener noreferrer">
+									{ translate( 'Learn more.' ) }
+								</ExternalLink>
+							) }
+							{ id === 'wordpress_admin_style' && (
+								<div>
+									<ToggleControl
+										checked={ isAdminStyleEnabled }
+										onChange={ handleAdminStyleToggle }
+										disabled={ false }
+										label={ translate( 'Use the Classic WP-Admin style' ) }
+									/>
+								</div>
+							) }
+						</span>
+					</div>
 				</div>
-			</div>
-		) ) }
+			) ) }
 
-		{ showContact && (
-			<div className="eligibility-warnings__warning">
-				<div className="eligibility-warnings__message">
-					<span className="eligibility-warnings__message-description">
-						{ translate( '{{a}}Contact support{{/a}} for help and questions.', {
-							components: {
-								a: <ActionPanelLink href="/help/contact" />,
-							},
-						} ) }
-					</span>
+			{ showContact && (
+				<div className="eligibility-warnings__warning">
+					<div className="eligibility-warnings__message">
+						<span className="eligibility-warnings__message-description">
+							{ translate( '{{a}}Contact support{{/a}} for help and questions.', {
+								components: {
+									a: <ActionPanelLink href="/help/contact" />,
+								},
+							} ) }
+						</span>
+					</div>
 				</div>
-			</div>
-		) }
-	</div>
-);
+			) }
+		</div>
+	);
+};
 
 function displayDomainNames( domainNames: DomainNames ) {
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5458
Additional context: p1707173262804459-slack-C06DN6QQVAQ

## Proposed Changes

* This draft PR adds a toggle to the admin style warning when a site goes Atomic. The toggle allows users to opt-out of the style change.
* This approach is doable, but I recommend we complete https://github.com/Automattic/dotcom-forge/issues/5499 and https://github.com/Automattic/dotcom-forge/issues/5501 before proceeding. At which point we may wish to reconsider the addition of this toggle.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?