### PR TITLE
Domains: Add comment in the glue records validation code

### DIFF
--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -164,7 +164,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		if ( ! nameserver ) {
 			return false;
 		}
-		// The hostname part of name servers in Key-Systems cannot be longer than 50 characters
+		// The subdomain part of name servers in Key-Systems cannot be longer than 50 characters
 		if (
 			nameserver.length > 50 ||
 			! nameserver.match(

--- a/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/glue-records-card.tsx
@@ -164,6 +164,7 @@ export default function GlueRecordsCard( { domain }: { domain: ResponseDomain } 
 		if ( ! nameserver ) {
 			return false;
 		}
+		// The hostname part of name servers in Key-Systems cannot be longer than 50 characters
 		if (
 			nameserver.length > 50 ||
 			! nameserver.match(


### PR DESCRIPTION
Related to #87191

## Proposed Changes

This PR just adds a comment explaining why there's a 50 character limit when adding a new glue record to a adomain.

## Testing Instructions

- N/A

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?