### PR TITLE
Site Transfers: adds site trasnferred route / page.

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -17,6 +17,7 @@ import DisconnectSite from './disconnect-site';
 import ConfirmDisconnection from './disconnect-site/confirm';
 import ManageConnection from './manage-connection';
 import SiteOwnerTransfer from './site-owner-transfer/site-owner-transfer';
+import SiteTransferred from './site-owner-transfer/site-transferred';
 import StartOver from './start-over';
 
 function canDeleteSite( state, siteId ) {
@@ -114,6 +115,11 @@ export function manageConnection( context, next ) {
 
 export function startSiteOwnerTransfer( context, next ) {
 	context.primary = <SiteOwnerTransfer />;
+	next();
+}
+
+export function showSiteTransferredScreen( context, next ) {
+	context.primary = <SiteTransferred />;
 	next();
 }
 

--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -118,7 +118,7 @@ export function startSiteOwnerTransfer( context, next ) {
 	next();
 }
 
-export function showSiteTransferredScreen( context, next ) {
+export function renderSiteTransferredScreen( context, next ) {
 	context.primary = <SiteTransferred />;
 	next();
 }

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -15,6 +15,7 @@ import {
 	redirectToTraffic,
 	startOver,
 	startSiteOwnerTransfer,
+	showSiteTransferredScreen,
 	wpcomSiteTools,
 } from 'calypso/my-sites/site-settings/controller';
 import { setScroll, siteSettings } from 'calypso/my-sites/site-settings/settings-controller';
@@ -108,6 +109,15 @@ export default function () {
 		navigation,
 		setScroll,
 		startSiteOwnerTransfer,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/settings/site-transferred/:site_id',
+		siteSelection,
+		setScroll,
+		showSiteTransferredScreen,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -15,7 +15,7 @@ import {
 	redirectToTraffic,
 	startOver,
 	startSiteOwnerTransfer,
-	showSiteTransferredScreen,
+	renderSiteTransferredScreen,
 	wpcomSiteTools,
 } from 'calypso/my-sites/site-settings/controller';
 import { setScroll, siteSettings } from 'calypso/my-sites/site-settings/settings-controller';
@@ -116,8 +116,7 @@ export default function () {
 	page(
 		'/settings/site-transferred/:site_id',
 		siteSelection,
-		setScroll,
-		showSiteTransferredScreen,
+		renderSiteTransferredScreen,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/site-settings/site-owner-transfer/site-transferred.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-transferred.tsx
@@ -94,6 +94,7 @@ const SiteTransferred = () => {
 			<PageViewTracker path="/settings/site-transferred/:site" title="Marketplace > Thank you" />
 			<Global
 				styles={ css`
+					body.is-section-settings,
 					body.is-section-settings .layout__content {
 						background: var( --studio-white );
 					}

--- a/client/my-sites/site-settings/site-owner-transfer/site-transferred.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-transferred.tsx
@@ -1,4 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { PLAN_BUSINESS, PLAN_FREE } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
@@ -12,7 +13,11 @@ import Main from 'calypso/components/main';
 import ThankYouV2 from 'calypso/components/thank-you-v2';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import MasterbarStyled from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled';
+import { getAddNewPaymentMethodUrlFor } from 'calypso/my-sites/purchases/paths';
 import { useSelector } from 'calypso/state';
+import isPrivateSite from 'calypso/state/selectors/is-private-site';
+import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
+import { getSitePlanSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const Preview = styled.img`
@@ -20,18 +25,28 @@ const Preview = styled.img`
 	border-radius: 20px;
 `;
 
+const MainStyled = styled( Main )`
+	padding: 0 20px;
+`;
+
 const SiteTransferred = () => {
 	useQueryUserPurchases();
+	const translate = useTranslate();
 	const [ mShotUrl, setMShotUrl ] = useState( '' );
 	const siteId = useSelector( getSelectedSiteId );
+	const sitePlanSlug = useSelector( ( state ) => getSitePlanSlug( state, siteId ) ?? '' );
+	const siteSlug = useSelector( getSelectedSiteSlug ) || '';
+	const isPrivate = useSelector( ( state ) => ( siteId ? isPrivateSite( state, siteId ) : true ) );
+	const isComingSoon = useSelector( ( state ) =>
+		siteId ? isSiteComingSoon( state, siteId ) : true
+	);
+	const isPrivateOrComingSoon = isPrivate || isComingSoon;
+	const hasBillingPlan = sitePlanSlug !== PLAN_FREE;
 	const { width } = useWindowDimensions();
 	const mShotParams: MShotParams = {
 		scale: 2,
 		vpw: width <= 640 ? 640 : undefined,
 	};
-	const siteSlug = useSelector( getSelectedSiteSlug );
-	const translate = useTranslate();
-	const hasBillingPlan = true;
 
 	const sendTrackEvent = useCallback(
 		( name: string ) => {
@@ -61,28 +76,39 @@ const SiteTransferred = () => {
 		http.send();
 	};
 
-	checkScreenshot(
-		`https://s0.wp.com/mshots/v1/${ siteSlug }?${ Object.entries( mShotParams )
-			.filter( ( entry ) => !! entry[ 1 ] )
-			.map( ( [ key, val ] ) => key + '=' + val )
-			.join( '&' ) }`
-	);
+	if ( ! isPrivateOrComingSoon ) {
+		checkScreenshot(
+			`https://s0.wp.com/mshots/v1/${ siteSlug }?${ Object.entries( mShotParams )
+				.filter( ( entry ) => !! entry[ 1 ] )
+				.map( ( [ key, val ] ) => key + '=' + val )
+				.join( '&' ) }`
+		);
+	}
 
 	const thankYouHeaderAction = (
 		<Button
 			primary
-			href={ `https://${ siteSlug }/wp-admin/plugins.php` }
+			href={
+				hasBillingPlan
+					? getAddNewPaymentMethodUrlFor( siteSlug )
+					: `/checkout/${ siteSlug }/${ PLAN_BUSINESS }`
+			}
 			onClick={ () => {
-				sendTrackEvent( 'calypso_plugin_thank_you_setup_plugins_click' );
+				sendTrackEvent( 'calypso_transferred_site_next_step_click' );
 			} }
 		>
-			{ hasBillingPlan ? translate( 'Setup my billing details' ) : translate( 'Upgrade my plan' ) }
+			{ hasBillingPlan
+				? translate( 'Update billing details' )
+				: translate( 'Proceed to Checkout' ) }
 		</Button>
 	);
+	const title = hasBillingPlan
+		? translate( "You're now in charge." )
+		: translate( 'Your site is not on a plan.' );
 
 	const subtitle = hasBillingPlan
 		? translate(
-				"To ensure uninterrupted service, please update your billing details in the next step. After that, you're all set to explore and manage your site."
+				"Continue to full ownership by signing up for our exclusive plan. Enter your billing details and maintain your site's momentum!"
 		  )
 		: translate(
 				'To keep your site active and access all features, please upgrade your plan in the next step and enjoy the full experience of your site.'
@@ -101,14 +127,12 @@ const SiteTransferred = () => {
 				` }
 			/>
 			<MasterbarStyled canGoBack={ false } />
-			<Main>
-				<ThankYouV2
-					title={ translate( 'You now have full control' ) }
-					subtitle={ subtitle }
-					headerButtons={ thankYouHeaderAction }
-				/>
-				{ mShotUrl && <Preview src={ mShotUrl } alt="Website screenshot preview" /> }
-			</Main>
+			<MainStyled>
+				<ThankYouV2 title={ title } subtitle={ subtitle } headerButtons={ thankYouHeaderAction } />
+				{ ! isPrivateOrComingSoon && mShotUrl && (
+					<Preview src={ mShotUrl } alt="Website screenshot preview" />
+				) }
+			</MainStyled>
 		</>
 	);
 };

--- a/client/my-sites/site-settings/site-owner-transfer/site-transferred.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-transferred.tsx
@@ -1,0 +1,20 @@
+import { useTranslate } from 'i18n-calypso';
+import { useQueryUserPurchases } from 'calypso/components/data/query-user-purchases';
+import { useSelector } from 'calypso/state';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+const SiteTransferred = () => {
+	useQueryUserPurchases();
+	const selectedSite = useSelector( getSelectedSite );
+
+	const translate = useTranslate();
+
+	// ToDo: Implement onBackClick
+	// const onBackClick = () => {
+
+	// };
+
+	return <h1>Site Transferred screen</h1>;
+};
+
+export default SiteTransferred;

--- a/client/my-sites/site-settings/site-owner-transfer/site-transferred.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-transferred.tsx
@@ -1,20 +1,115 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
+import { Button } from '@automattic/components';
+import { Global, css } from '@emotion/react';
+import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
+import { useCallback, useState } from 'react';
+import { MShotParams } from 'calypso/blocks/import/types';
+import useWindowDimensions from 'calypso/blocks/import/windowDimensions.effect';
+import DocumentHead from 'calypso/components/data/document-head';
 import { useQueryUserPurchases } from 'calypso/components/data/query-user-purchases';
+import Main from 'calypso/components/main';
+import ThankYouV2 from 'calypso/components/thank-you-v2';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import MasterbarStyled from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled';
 import { useSelector } from 'calypso/state';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+const Preview = styled.img`
+	border: 8px solid var( --studio-gray-0 );
+	border-radius: 20px;
+`;
 
 const SiteTransferred = () => {
 	useQueryUserPurchases();
-	const selectedSite = useSelector( getSelectedSite );
-
+	const [ mShotUrl, setMShotUrl ] = useState( '' );
+	const siteId = useSelector( getSelectedSiteId );
+	const { width } = useWindowDimensions();
+	const mShotParams: MShotParams = {
+		scale: 2,
+		vpw: width <= 640 ? 640 : undefined,
+	};
+	const siteSlug = useSelector( getSelectedSiteSlug );
 	const translate = useTranslate();
+	const hasBillingPlan = true;
 
-	// ToDo: Implement onBackClick
-	// const onBackClick = () => {
+	const sendTrackEvent = useCallback(
+		( name: string ) => {
+			recordTracksEvent( name, {
+				site_id: siteId,
+			} );
+		},
+		[ siteId ]
+	);
 
-	// };
+	const checkScreenshot = ( screenShotUrl: string ) => {
+		const http = new XMLHttpRequest();
+		http.open( 'GET', screenShotUrl );
+		http.onreadystatechange = () => {
+			if ( http.readyState !== http.HEADERS_RECEIVED ) {
+				return;
+			}
 
-	return <h1>Site Transferred screen</h1>;
+			if ( http.getResponseHeader( 'Content-Type' ) !== 'image/jpeg' ) {
+				setTimeout( () => {
+					checkScreenshot( screenShotUrl );
+				}, 5000 );
+			} else {
+				setMShotUrl( screenShotUrl );
+			}
+		};
+		http.send();
+	};
+
+	checkScreenshot(
+		`https://s0.wp.com/mshots/v1/${ siteSlug }?${ Object.entries( mShotParams )
+			.filter( ( entry ) => !! entry[ 1 ] )
+			.map( ( [ key, val ] ) => key + '=' + val )
+			.join( '&' ) }`
+	);
+
+	const thankYouHeaderAction = (
+		<Button
+			primary
+			href={ `https://${ siteSlug }/wp-admin/plugins.php` }
+			onClick={ () => {
+				sendTrackEvent( 'calypso_plugin_thank_you_setup_plugins_click' );
+			} }
+		>
+			{ hasBillingPlan ? translate( 'Setup my billing details' ) : translate( 'Upgrade my plan' ) }
+		</Button>
+	);
+
+	const subtitle = hasBillingPlan
+		? translate(
+				"To ensure uninterrupted service, please update your billing details in the next step. After that, you're all set to explore and manage your site."
+		  )
+		: translate(
+				'To keep your site active and access all features, please upgrade your plan in the next step and enjoy the full experience of your site.'
+		  );
+
+	return (
+		<>
+			<DocumentHead title={ translate( 'Site Transferred' ) } />
+			<PageViewTracker path="/settings/site-transferred/:site" title="Marketplace > Thank you" />
+			<Global
+				styles={ css`
+					body.is-section-settings .layout__content {
+						background: var( --studio-white );
+					}
+				` }
+			/>
+			<MasterbarStyled canGoBack={ false } />
+			<Main>
+				<ThankYouV2
+					title={ translate( 'You now have full control' ) }
+					subtitle={ subtitle }
+					headerButtons={ thankYouHeaderAction }
+				/>
+				{ mShotUrl && <Preview src={ mShotUrl } alt="Website screenshot preview" /> }
+			</Main>
+		</>
+	);
 };
 
 export default SiteTransferred;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5450

## Proposed Changes

* Adds a new `/settings/site-transferred/:site_id` route
* Adds a new page for next actions for transferred sites: checkout with a plan or update billing details

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/settings/site-transferred/:domain` on a free site
* You should get the following screen
![CleanShot 2024-02-13 at 12 20 56@2x](https://github.com/Automattic/wp-calypso/assets/12430020/94045ce1-ef77-47a6-a073-25691b01d4b0)
* Clicking the CTA should land to checkout with the Creator plan

* Visit `/settings/site-transferred/:domain` on a site with a plan
* You should get the following screen
![CleanShot 2024-02-13 at 12 22 14@2x](https://github.com/Automattic/wp-calypso/assets/12430020/2b8cf302-4597-4d30-9aeb-773484600bbb)
* Clicking the CTA should land to update billing details screen

The site screenshot appears depending on whether the site is public or not.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?