### PR TITLE
Fix Jetpack menu item on Cloud sidebar menu

### DIFF
--- a/client/state/sites/selectors/get-site-admin-page.js
+++ b/client/state/sites/selectors/get-site-admin-page.js
@@ -2,14 +2,14 @@ import getSiteOption from './get-site-option';
 
 /**
  * Returns a site's wp-admin plugin page depending on which plugin is active.
- * @param  {Object}  state  Global state tree
- * @param  {?number}  siteId Site ID
- * @returns {string}        Plugin page name if a plugin is active. Defaults to `my-jetpack`
+ * @param   {Object}  state  Global state tree
+ * @param   {?number} siteId Site ID
+ * @returns {string}         Plugin page name if a plugin is active. Defaults to `my-jetpack`
  */
 export default function getSiteAdminPage( state, siteId ) {
 	const activeConnectedPlugins =
 		getSiteOption( state, siteId, 'jetpack_connection_active_plugins' ) ?? [];
-	const plugins = [ 'jetpack', 'jetpack-backup', 'jetpack-search', 'jetpack-social' ];
+	const plugins = [ 'jetpack-backup', 'jetpack-search', 'jetpack-social' ];
 
 	return plugins.find( ( plugin ) => activeConnectedPlugins.includes( plugin ) ) ?? 'my-jetpack';
 }

--- a/client/state/sites/selectors/get-site-admin-page.js
+++ b/client/state/sites/selectors/get-site-admin-page.js
@@ -4,12 +4,12 @@ import getSiteOption from './get-site-option';
  * Returns a site's wp-admin plugin page depending on which plugin is active.
  * @param  {Object}  state  Global state tree
  * @param  {?number}  siteId Site ID
- * @returns {string}        Jetpack or standalone plugin page name
+ * @returns {string}        Plugin page name if a plugin is active. Defaults to `my-jetpack`
  */
 export default function getSiteAdminPage( state, siteId ) {
 	const activeConnectedPlugins =
 		getSiteOption( state, siteId, 'jetpack_connection_active_plugins' ) ?? [];
 	const plugins = [ 'jetpack', 'jetpack-backup', 'jetpack-search', 'jetpack-social' ];
 
-	return plugins.find( ( plugin ) => activeConnectedPlugins.includes( plugin ) ) ?? 'jetpack';
+	return plugins.find( ( plugin ) => activeConnectedPlugins.includes( plugin ) ) ?? 'my-jetpack';
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

See linked issue

## Proposed Changes

* Update the default Jetpack admin URL to "My Jetpack". This will update the link on the sidebar on cloud.jetpack.com to point to My Jetpack, since that is now the main page in the plugin.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have a Jetpack-connected site (with no products)
* Visit the Calypso live link for Jetpack Cloud
* Select the site that is connected to Jetpack
* On the sidebar, confirm that "WP Admin" links to `my-jetpack` instead of `jetpack`

<img src="https://github.com/Automattic/wp-calypso/assets/5714212/13ddd202-c713-4875-bf1d-e9ffa8426bc3" height=500 />


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?