### PR TITLE
Checkout: Remove custom multi-year discount from Jetpack plans

### DIFF
--- a/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
@@ -23,6 +23,7 @@ type PriceBreakdown = {
 	isBold?: boolean;
 	isDiscount?: boolean;
 	forceDisplay?: boolean;
+	isIntroductoryOffer?: boolean;
 };
 
 const debug = debugFactory( 'calypso:checkout-sidebar-plan-upsell' );
@@ -107,6 +108,7 @@ const useCalculatedDiscounts = () => {
 				label: __( 'Free trial*' ),
 				priceInteger: product.item_original_monthly_cost_integer,
 				isDiscount: true,
+				isIntroductoryOffer: true,
 			} );
 		} else if ( ! isProductFreeTrial ) {
 			// We don't show the discount for free trials (annual) in upsell if biennial plan doesn't have free trial.
@@ -114,6 +116,7 @@ const useCalculatedDiscounts = () => {
 				label: __( 'Introductory offer*' ),
 				priceInteger: current.priceBeforeDiscounts - current.priceInteger,
 				isDiscount: true,
+				isIntroductoryOffer: true,
 			} );
 		}
 	}
@@ -209,6 +212,10 @@ const JetpackAkismetCheckoutSidebarPlanUpsell: FC = () => {
 
 	const { percentSavings, priceBreakdown, finalBreakdown } = calculatedDiscounts;
 
+	const hasIntroductoryOffers = priceBreakdown.some(
+		( breakdown ) => breakdown.isIntroductoryOffer
+	);
+
 	const isLoading = FormStatus.READY !== formStatus;
 	const cardTitle = sprintf(
 		// translators: "percentSavings" is the savings percentage for the upgrade as a number, like '20' for '20%'.
@@ -232,6 +239,10 @@ const JetpackAkismetCheckoutSidebarPlanUpsell: FC = () => {
 				{ finalBreakdown.map( ( props ) => (
 					<UpsellEntry key={ props.label } { ...props } />
 				) ) }
+			</div>
+			<div>
+				{ hasIntroductoryOffers &&
+					__( '*Introductory offer first term only, renews at regular rate.' ) }
 			</div>
 			<PromoCardCTA
 				cta={ {


### PR DESCRIPTION
## Proposed Changes

The "multi-year discount" added by https://github.com/Automattic/wp-calypso/pull/86353 is misleading because the products it applies to do not have a multi-year discount except for the first year; displaying them in the way they are currently suggests that the introductory offer discount is smaller than it actually is and therefore that the amount that will need to be paid after the first term is smaller than it actually is (see https://github.com/Automattic/wp-calypso/issues/87194 for more details).

In this PR we remove the discount item from the discount section of checkout. This **does not** remove it from the 2 year upsell; we might want to do that too, but it's less of a concern because it's not referring to the current cart.

> [!NOTE]
> This does not remove the ability to show multi-year discounts for products which have an actual multi-year discount between their undiscounted prices. The function `canDisplayMultiYearDiscountForProduct()` can be used to identify products which should be considered for that feature.

Before             |  After
:-------------------------:|:-------------------------:
<img width="317" alt="Screenshot 2024-02-06 at 1 39 11 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/b82e3f08-72b3-45b3-a12a-2efedf99c2eb"> | <img width="307" alt="Screenshot 2024-02-06 at 1 39 16 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/83473c60-81ce-4f06-9801-3d5c22c6e9fa">
<img width="334" alt="Screenshot 2024-02-06 at 1 38 22 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/c11c7db8-ddfe-499f-9724-6fd057583098"> | <img width="323" alt="Screenshot 2024-02-06 at 1 38 34 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/47bee271-149a-4bf2-a5df-fb47620ce3c1">

## Testing Instructions

- Visit checkout with a Jetpack product in the cart (eg: `/checkout/jetpack/jetpack_complete`).
- Verify that the introductory offer for each product is shown as expected with its actual discount.
- Verify that the only mention of "Multi-year discount" is in the upsell.
- Select the biennial variant of the product and repeat the above steps.
- Verify that the introductory offer for each product is shown as expected with its actual discount.
- Verify that there's no mention of "Multi-year discount" in the list of discounts.