### PR TITLE
Stats: Avoid fetching notice flag for non-admins

### DIFF
--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -65,7 +65,8 @@ const queryNotices = async function ( siteId: number | null ): Promise< Notices 
 
 const useNoticesVisibilityQueryRaw = function < T >(
 	siteId: number | null,
-	select?: ( payload: Notices ) => T
+	select?: ( payload: Notices ) => T,
+	enabled?: boolean
 ) {
 	return useQuery( {
 		queryKey: [ 'stats', 'notices-visibility', 'raw', siteId ],
@@ -74,15 +75,24 @@ const useNoticesVisibilityQueryRaw = function < T >(
 		staleTime: 1000 * 30, // 30 seconds
 		retry: 1,
 		retryDelay: 3 * 1000, // 3 seconds,
+		enabled: enabled === false ? false : true,
 	} );
 };
 
-export function useNoticeVisibilityQuery( siteId: number | null, noticeId: NoticeIdType ) {
+export function useNoticeVisibilityQuery(
+	siteId: number | null,
+	noticeId: NoticeIdType,
+	enabled?: boolean
+) {
 	const selectVisibilityForSingleNotice = ( payload: Notices ) => {
 		payload = processConflictNotices( payload );
 		return !! payload?.[ noticeId ];
 	};
-	return useNoticesVisibilityQueryRaw< boolean >( siteId, selectVisibilityForSingleNotice );
+	return useNoticesVisibilityQueryRaw< boolean >(
+		siteId,
+		selectVisibilityForSingleNotice,
+		enabled
+	);
 }
 
 export function useNoticesVisibilityQuery( siteId: number | null ) {

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -54,11 +54,17 @@ export const processConflictNotices = ( notices: Notices ): Notices => {
 };
 
 const queryNotices = async function ( siteId: number | null ): Promise< Notices > {
-	const payload = await wpcom.req.get( {
-		method: 'GET',
-		apiNamespace: 'wpcom/v2',
-		path: `/sites/${ siteId }/jetpack-stats-dashboard/notices`,
-	} );
+	let payload;
+
+	try {
+		payload = await wpcom.req.get( {
+			method: 'GET',
+			apiNamespace: 'wpcom/v2',
+			path: `/sites/${ siteId }/jetpack-stats-dashboard/notices`,
+		} );
+	} catch ( error ) {
+		return DEFAULT_NOTICES_VISIBILITY;
+	}
 
 	return { ...DEFAULT_NOTICES_VISIBILITY, ...payload };
 };

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -81,7 +81,7 @@ const useNoticesVisibilityQueryRaw = function < T >(
 		staleTime: 1000 * 30, // 30 seconds
 		retry: 1,
 		retryDelay: 3 * 1000, // 3 seconds,
-		enabled: enabled === false ? false : true,
+		enabled: enabled !== false,
 	} );
 };
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87135

## Proposed Changes

* iterating on the hotfix #87242
* avoid attempting to fetch a notice when the user is not an admin

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Be logged into an account that has non-admin access to a simple site (for example, Author access)
* Visit `http://calypso.localhost:3000/stats/day/<sitename>`
* No longer see endless white screen

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?