### PR TITLE
Checkout: Update PixConfirmation to use the correct code for its QR code

### DIFF
--- a/client/my-sites/checkout/src/lib/pix-confirmation.tsx
+++ b/client/my-sites/checkout/src/lib/pix-confirmation.tsx
@@ -93,6 +93,7 @@ function CheckoutLogo( {
 
 export function PixConfirmation( {
 	redirectUrl,
+	qrCode,
 	priceInteger,
 	priceCurrency,
 	cancel,
@@ -100,6 +101,7 @@ export function PixConfirmation( {
 	isJetpackNotAtomic,
 }: {
 	redirectUrl: string;
+	qrCode: string;
 	priceInteger: number;
 	priceCurrency: string;
 	cancel: () => void;
@@ -136,7 +138,7 @@ export function PixConfirmation( {
 				</p>
 
 				<div className="pix-confirmation__qrcode">
-					<QRCodeSVG value={ redirectUrl } />
+					<QRCodeSVG value={ qrCode } />
 				</div>
 
 				<div className="pix-confirmation__manual-instructions">

--- a/client/my-sites/checkout/src/lib/pix-processor.ts
+++ b/client/my-sites/checkout/src/lib/pix-processor.ts
@@ -111,6 +111,12 @@ export async function pixProcessor(
 				throw new Error( genericErrorMessage );
 			}
 
+			if ( ! response?.qr_code ) {
+				// eslint-disable-next-line no-console
+				console.error( 'Transaction response was missing required qr code' );
+				throw new Error( genericErrorMessage );
+			}
+
 			if ( userAgent.isMobile && response.redirect_url ) {
 				return makeRedirectResponse( response?.redirect_url );
 			}
@@ -126,6 +132,7 @@ export async function pixProcessor(
 			displayModal( {
 				root,
 				redirectUrl: response.redirect_url,
+				qrCode: response.qr_code,
 				priceInteger: responseCart.total_cost_integer,
 				priceCurrency: responseCart.currency,
 				cancel: () => {
@@ -197,6 +204,7 @@ function hideModal( root: Root ): void {
 function displayModal( {
 	root,
 	redirectUrl,
+	qrCode,
 	priceInteger,
 	priceCurrency,
 	cancel,
@@ -206,6 +214,7 @@ function displayModal( {
 }: {
 	root: Root;
 	redirectUrl: string;
+	qrCode: string;
 	priceInteger: number;
 	priceCurrency: string;
 	cancel: () => void;
@@ -216,6 +225,7 @@ function displayModal( {
 	root.render(
 		createElement( PixConfirmation, {
 			redirectUrl,
+			qrCode,
 			priceInteger,
 			priceCurrency,
 			cancel,

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -10,6 +10,7 @@ export type WPCOMTransactionEndpointResponseSuccess = {
 	receipt_id: number;
 	order_id: number | '';
 	redirect_url?: string;
+	qr_code?: string;
 	is_gift_purchase: boolean;
 	display_price: string;
 	price_integer: number;
@@ -24,6 +25,7 @@ export type WPCOMTransactionEndpointResponseFailed = {
 	receipt_id: number;
 	order_id: number | '';
 	redirect_url?: string;
+	qr_code?: string;
 	is_gift_purchase: boolean;
 	display_price: string;
 	price_integer: number;
@@ -35,6 +37,7 @@ export type WPCOMTransactionEndpointResponseRedirect = {
 	message: { payment_intent_client_secret: string } | '';
 	order_id: number | '';
 	redirect_url: string;
+	qr_code?: string;
 	razorpay_order_id?: string;
 	razorpay_customer_id?: string;
 };


### PR DESCRIPTION
## Proposed Changes

The Pix payment method added in #86826 was using the wrong URL for its QR code. This PR fixes the code to have the right URL encoded.

Requires D137318-code

## Testing Instructions

- Apply D137318-code to your sandbox and sandbox the API.
- To use Pix as a payment method option in checkout, first you'll need to have BRL as your currency, and then you'll need to select "Brazil" as the country inside checkout (and a Brazilian postal code like `61919-230`).
- Use Ebanx [test customer info](https://developer.ebanx.com/docs/resources/testCustomerData/) to fill out the Pix form. "CEP" means "Postal code" and "CPF" means "Taxpayer Identification Number".
- Click to submit the payment.
- Scan the QR code with a phone and verify that the URL starts with something like `000555555555br.gov.bcb.pix1234fake-pix.com.br`.