### PR TITLE
JP Manage: 281 - refine pricing page routing path

### DIFF
--- a/client/sections.js
+++ b/client/sections.js
@@ -576,15 +576,8 @@ const sections = [
 		enableLoggedOut: true,
 	},
 	{
-		name: 'jetpack-cloud-manage-pricing',
-		paths: [ '/manage/pricing' ],
-		module: 'calypso/jetpack-cloud/sections/manage/pricing',
-		group: 'jetpack-cloud',
-		enableLoggedOut: true,
-	},
-	{
 		name: 'jetpack-cloud-pricing',
-		paths: [ '/pricing', '/[^\\/]+/pricing', '/plans', '/[^\\/]+/plans' ],
+		paths: [ '/pricing', '/(?!manage)[^\\/]+/pricing', '/plans', '/[^\\/]+/plans' ],
 		module: 'calypso/jetpack-cloud/sections/pricing',
 		group: 'jetpack-cloud',
 		enableLoggedOut: true,
@@ -595,6 +588,13 @@ const sections = [
 				href: 'https://fonts.googleapis.com/css2?family=Noto+Sans:ital,wght@0,400;0,700;1,400;1,700&display=swap',
 			},
 		],
+	},
+	{
+		name: 'jetpack-cloud-manage-pricing',
+		paths: [ '/manage/pricing' ],
+		module: 'calypso/jetpack-cloud/sections/manage/pricing',
+		group: 'jetpack-cloud',
+		enableLoggedOut: true,
 	},
 	{
 		name: 'jetpack-cloud-features-comparison',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves Automattic/jetpack-manage#281 - refine pricing page routing path

## Proposed Changes

In #87201 we adjusted the routing logic for the Manage pricing page. This broke some styling, including the sticky bundle selector.

The styles broke because the `is-section` class on the page no longer was set to `is-section-jetpack-cloud-manage-pricing`.

As best I can tell, it seems the correct class is applied and then replaced with `is-section-jetpack-cloud-pricing`. Both operations were done by `BodySectionCssClass`. I suspect it went goes through each section path in order and applies a class generated from each matched path, and since we switched the order in #87201, the standard pricing page section was the last match and thus had priority. I did a fair amount of digging and found lots of evidence via `console.log` on paths and contexts and routes that supported this theory but couldn't find the missing piece to prove this.

The annoying part is this (terminology is a bit fuzzy, as I dug through a bunch of code):

* The path match seems to be ungreedy, stopping as soon as it finds a match (hence why the other PR mostly fixed things).
* The section associated with the route seems to be greedy, grabbing the last match.

As such, if there are two sections with competing paths, it will route to the first match and log the current section as the last match (resulting in improper classification in this case).

Ultimately I switched the section orders back to how they were when we originally shipped, and adjusted the normal pricing path regex to exclude `manage` (`/(?!manage)[^\\/]+/pricing`) so that the two pricing pages no longer have overlapping path matches.

## Testing Instructions

1. Go here: `http://jetpack.cloud.localhost:3000/pricing`
2. Go here: `http://jetpack.cloud.localhost:3000/es/pricing`
3. Go here: `http://jetpack.cloud.localhost:3000/manage/pricing`

In `trunk`, the English and Spanish pricing pages load correctly, but the Manage pricing page does not have the sticky header.

In the `fix/jp-manage/281-refine_pricing_page_routing_path` branch, all three pages load as expected, with the sticky header working well.

**Note:** I'm fairly certain this code change requires a Calypso restart no matter the setup.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
