### PR TITLE
Plans Next: Cleanup calls to `useUpgradeClickHandler`

### DIFF
--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -27,6 +27,7 @@ import { plansGridMediumLarge } from '../../css-mixins';
 import { usePlansGridContext } from '../../grid-context';
 import useHighlightAdjacencyMatrix from '../../hooks/use-highlight-adjacency-matrix';
 import { useManageTooltipToggle } from '../../hooks/use-manage-tooltip-toggle';
+import useUpgradeClickHandler from '../../hooks/use-upgrade-click-handler';
 import filterUnusedFeaturesObject from '../../lib/filter-unused-features-object';
 import getPlanFeaturesObject from '../../lib/get-plan-features-object';
 import { isStorageUpgradeableForPlan } from '../../lib/is-storage-upgradeable-for-plan';
@@ -1058,6 +1059,11 @@ const ComparisonGrid = ( {
 	// 100px is the padding of the footer row
 	const [ bottomHeaderRef, isBottomHeaderInView ] = useInView( { rootMargin: '-100px' } );
 
+	const handleUpgradeClick = useUpgradeClickHandler( {
+		gridPlans,
+		onUpgradeClick,
+	} );
+
 	return (
 		<div className="plan-comparison-grid">
 			<Grid isInSignup={ isInSignup }>
@@ -1075,7 +1081,7 @@ const ComparisonGrid = ( {
 							isLaunchPage={ isLaunchPage }
 							onPlanChange={ onPlanChange }
 							currentSitePlanSlug={ currentSitePlanSlug }
-							onUpgradeClick={ onUpgradeClick }
+							onUpgradeClick={ handleUpgradeClick }
 							planActionOverrides={ planActionOverrides }
 							selectedPlan={ selectedPlan }
 							showRefundPeriod={ showRefundPeriod }
@@ -1108,7 +1114,7 @@ const ComparisonGrid = ( {
 					isFooter={ true }
 					onPlanChange={ onPlanChange }
 					currentSitePlanSlug={ currentSitePlanSlug }
-					onUpgradeClick={ onUpgradeClick }
+					onUpgradeClick={ handleUpgradeClick }
 					planActionOverrides={ planActionOverrides }
 					selectedPlan={ selectedPlan }
 					showRefundPeriod={ showRefundPeriod }

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -8,6 +8,7 @@ import {
 import { FoldableCard } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import useUpgradeClickHandler from '../../hooks/use-upgrade-click-handler';
 import BillingTimeframes from './billing-timeframes';
 import MobileFreeDomain from './mobile-free-domain';
 import PlanFeaturesList from './plan-features-list';
@@ -242,6 +243,11 @@ const FeaturesGrid = ( {
 	isCustomDomainAllowedOnFreePlan,
 	gridSize,
 }: FeaturesGridProps ) => {
+	const handleUpgradeClick = useUpgradeClickHandler( {
+		gridPlans,
+		onUpgradeClick,
+	} );
+
 	const spotlightPlanProps = {
 		currentSitePlanSlug,
 		gridPlanForSpotlight,
@@ -249,7 +255,7 @@ const FeaturesGrid = ( {
 		isInSignup,
 		isLaunchPage,
 		onStorageAddOnClick,
-		onUpgradeClick,
+		onUpgradeClick: handleUpgradeClick,
 		planActionOverrides,
 		planUpgradeCreditsApplicable,
 		selectedFeature,

--- a/packages/plans-grid-next/src/hooks/use-upgrade-click-handler.ts
+++ b/packages/plans-grid-next/src/hooks/use-upgrade-click-handler.ts
@@ -5,12 +5,14 @@ import { useCallback } from '@wordpress/element';
 import type { GridPlan } from '../types';
 import type { MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
+export type UpgradeClickHandler = (
+	cartItems?: MinimalRequestCartProduct[] | null,
+	clickedPlanSlug?: PlanSlug
+) => void;
+
 interface Props {
 	gridPlans: GridPlan[]; // TODO clk: to be removed, grabbed from context
-	onUpgradeClick?: (
-		cartItems?: MinimalRequestCartProduct[] | null,
-		clickedPlanSlug?: PlanSlug
-	) => void;
+	onUpgradeClick?: UpgradeClickHandler;
 }
 
 const useUpgradeClickHandler = ( { gridPlans, onUpgradeClick }: Props ) => {

--- a/packages/plans-grid-next/src/index.tsx
+++ b/packages/plans-grid-next/src/index.tsx
@@ -11,7 +11,6 @@ import usePlanFeaturesForGridPlans from './hooks/data-store/use-plan-features-fo
 import useRestructuredPlanFeaturesForComparisonGrid from './hooks/data-store/use-restructured-plan-features-for-comparison-grid';
 import useGridSize from './hooks/use-grid-size';
 import { useManageTooltipToggle } from './hooks/use-manage-tooltip-toggle';
-import useUpgradeClickHandler from './hooks/use-upgrade-click-handler';
 import type { ComparisonGridExternalProps, FeaturesGridExternalProps } from './types';
 import './style.scss';
 
@@ -22,7 +21,6 @@ const WrappedComparisonGrid = ( {
 	useCheckPlanAvailabilityForPurchase,
 	recordTracksEvent,
 	allFeaturesList,
-	onUpgradeClick,
 	intervalType,
 	isInSignup,
 	isLaunchPage,
@@ -35,11 +33,6 @@ const WrappedComparisonGrid = ( {
 	coupon,
 	...otherProps
 }: ComparisonGridExternalProps ) => {
-	const handleUpgradeClick = useUpgradeClickHandler( {
-		gridPlans,
-		onUpgradeClick,
-	} );
-
 	const gridContainerRef = useRef< HTMLDivElement | null >( null );
 	const gridSize = useGridSize( {
 		containerRef: gridContainerRef,
@@ -77,7 +70,6 @@ const WrappedComparisonGrid = ( {
 					isInSignup={ isInSignup }
 					isLaunchPage={ isLaunchPage }
 					currentSitePlanSlug={ currentSitePlanSlug }
-					onUpgradeClick={ handleUpgradeClick }
 					selectedSiteId={ selectedSiteId }
 					selectedPlan={ selectedPlan }
 					selectedFeature={ selectedFeature }
@@ -100,14 +92,9 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 		useCheckPlanAvailabilityForPurchase,
 		recordTracksEvent,
 		allFeaturesList,
-		onUpgradeClick,
 		coupon,
 		isInAdmin,
 	} = props;
-	const handleUpgradeClick = useUpgradeClickHandler( {
-		gridPlans,
-		onUpgradeClick,
-	} );
 
 	const gridContainerRef = useRef< HTMLDivElement | null >( null );
 	const gridSize = useGridSize( {
@@ -137,11 +124,7 @@ const WrappedFeaturesGrid = ( props: FeaturesGridExternalProps ) => {
 				recordTracksEvent={ recordTracksEvent }
 				allFeaturesList={ allFeaturesList }
 			>
-				<FeaturesGrid
-					{ ...props }
-					onUpgradeClick={ handleUpgradeClick }
-					gridSize={ gridSize ?? undefined }
-				/>
+				<FeaturesGrid { ...props } gridSize={ gridSize ?? undefined } />
 			</PlansGridContextProvider>
 		</div>
 	);

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -1,4 +1,5 @@
 import { Plans, type AddOnMeta } from '@automattic/data-stores';
+import { UpgradeClickHandler } from './hooks/use-upgrade-click-handler';
 import type {
 	UrlFriendlyTermType,
 	PlanSlug,
@@ -116,7 +117,7 @@ export interface CommonGridProps {
 	showRefundPeriod?: boolean;
 	// only used for comparison grid
 	planTypeSelectorProps?: PlanTypeSelectorProps;
-	onUpgradeClick: ( planSlug: PlanSlug ) => void;
+	onUpgradeClick?: UpgradeClickHandler;
 	planUpgradeCreditsApplicable?: number | null;
 	gridContainerRef?: React.MutableRefObject< HTMLDivElement | null >;
 	gridSize?: string;


### PR DESCRIPTION
Fixes #86933

## Proposed Changes

As part of the ongoing cleanup work for `packages/plans-grid-next`, this moves the `useUpgradeClickHandler` hook usage down into `FeaturesGrid` and `ComparisonGrid`, rather than making the call in their respective wrappers.

## Testing Instructions

As this is a refactor there should be no functional changes. Verify that the click handler still works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?