### PR TITLE
Back buttons goes back to correct settings page for transfer, reset, delete site pages

### DIFF
--- a/client/my-sites/site-settings/delete-site/index.jsx
+++ b/client/my-sites/site-settings/delete-site/index.jsx
@@ -24,6 +24,7 @@ import { getSite, getSiteDomain } from 'calypso/state/sites/selectors';
 import { hasSitesAsLandingPage } from 'calypso/state/sites/selectors/has-sites-as-landing-page';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSettingsSource } from '../site-tools/utils';
 
 import './style.scss';
 
@@ -91,7 +92,8 @@ class DeleteSite extends Component {
 
 	_goBack = () => {
 		const { siteSlug } = this.props;
-		page( '/settings/general/' + siteSlug );
+		const source = getSettingsSource();
+		page( `${ source }/${ siteSlug }` );
 	};
 
 	componentDidUpdate( prevProps ) {

--- a/client/my-sites/site-settings/section-general.jsx
+++ b/client/my-sites/site-settings/section-general.jsx
@@ -7,12 +7,15 @@ import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
 import P2PreapprovedDomainsForm from './settings-p2/preapproved-domains';
 import SiteTools from './site-tools';
+import { SOURCE_SETTINGS_GENERAL } from './site-tools/utils';
 
 const SiteSettingsGeneral = ( { site, isWPForTeamsSite, isP2Hub, isWpcomStagingSite } ) => (
 	<div className="site-settings__main general-settings">
 		<GeneralForm site={ site } />
 		{ isWPForTeamsSite && isP2Hub && <P2PreapprovedDomainsForm siteId={ site?.ID } /> }
-		{ ! isWpcomStagingSite && <SiteTools headerTitle={ translate( 'Site tools' ) } /> }
+		{ ! isWpcomStagingSite && (
+			<SiteTools headerTitle={ translate( 'Site tools' ) } source={ SOURCE_SETTINGS_GENERAL } />
+		) }
 	</div>
 );
 

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
@@ -9,6 +9,7 @@ import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import { successNotice } from 'calypso/state/notices/actions';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import { getSettingsSource } from '../site-tools/utils';
 import { ConfirmationTransfer } from './confirmation-transfer';
 import PendingDomainTransfer from './pending-domain-transfer';
 import SiteOwnerTransferEligibility from './site-owner-user-search';
@@ -67,7 +68,8 @@ const SiteOwnerTransfer = () => {
 		if ( ! pendingDomain && newSiteOwner && ! transferSiteSuccess ) {
 			setNewSiteOwner( null );
 		} else {
-			page( '/settings/general/' + selectedSite.slug );
+			const source = getSettingsSource();
+			page( `${ source }/${ selectedSite.slug }` );
 		}
 	};
 

--- a/client/my-sites/site-settings/site-tools/index.jsx
+++ b/client/my-sites/site-settings/site-tools/index.jsx
@@ -60,13 +60,14 @@ class SiteTools extends Component {
 			showStartSiteTransfer,
 			siteId,
 			headerTitle,
+			source,
 		} = this.props;
 
-		const changeAddressLink = `/domains/manage/${ siteSlug }`;
-		const startOverLink = `/settings/start-over/${ siteSlug }`;
-		const startSiteTransferLink = `/settings/start-site-transfer/${ siteSlug }`;
-		const deleteSiteLink = `/settings/delete-site/${ siteSlug }`;
-		const manageConnectionLink = `/settings/manage-connection/${ siteSlug }`;
+		const changeAddressLink = `/domains/manage/${ siteSlug }?source=${ source }`;
+		const startOverLink = `/settings/start-over/${ siteSlug }?source=${ source }`;
+		const startSiteTransferLink = `/settings/start-site-transfer/${ siteSlug }?source=${ source }`;
+		const deleteSiteLink = `/settings/delete-site/${ siteSlug }?source=${ source }`;
+		const manageConnectionLink = `/settings/manage-connection/${ siteSlug }?source=${ source }`;
 
 		const changeSiteAddress = translate( 'Change your site address' );
 

--- a/client/my-sites/site-settings/site-tools/utils.ts
+++ b/client/my-sites/site-settings/site-tools/utils.ts
@@ -1,0 +1,13 @@
+export const SOURCE_SETTINGS_GENERAL = '/settings/general';
+export const SOURCE_SETTINGS_SITE_TOOLS = '/settings/site-tools';
+
+const allowedSources = [ SOURCE_SETTINGS_GENERAL, SOURCE_SETTINGS_SITE_TOOLS ];
+export const getSettingsSource = () => {
+	let source = new URLSearchParams( window.location.search ).get( 'source' ) || '';
+	if ( ! allowedSources.includes( source ) ) {
+		// TODO: change the default to /settings/site-tools
+		// after we default all sites to the classic style for the wpcom untangle project.
+		source = '/settings/general';
+	}
+	return source;
+};

--- a/client/my-sites/site-settings/start-over.jsx
+++ b/client/my-sites/site-settings/start-over.jsx
@@ -26,6 +26,7 @@ import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import { getSite, getSiteDomain, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { BuiltByUpsell } from './built-by-upsell-banner';
+import { getSettingsSource } from './site-tools/utils';
 
 function SiteResetCard( {
 	translate,
@@ -43,6 +44,8 @@ function SiteResetCard( {
 	const { data: status, refetch: refetchResetStatus } = useSiteResetStatusQuery( siteId );
 	const [ isDomainConfirmed, setDomainConfirmed ] = useState( false );
 	const [ resetComplete, setResetComplete ] = useState( false );
+
+	const source = getSettingsSource();
 
 	const checkStatus = async () => {
 		if ( status?.status !== 'completed' && isAtomic ) {
@@ -304,7 +307,7 @@ function SiteResetCard( {
 				) }
 			/>
 			<PageViewTracker path="/settings/start-reset/:site" title="Settings > Site Reset" />
-			<HeaderCake backHref={ '/settings/general/' + selectedSiteSlug }>
+			<HeaderCake backHref={ `${ source }/${ selectedSiteSlug }` }>
 				<h1>{ translate( 'Site Reset' ) }</h1>
 			</HeaderCake>
 			{ renderBody() }

--- a/client/my-sites/site-settings/wpcom-site-tools-settings/index.jsx
+++ b/client/my-sites/site-settings/wpcom-site-tools-settings/index.jsx
@@ -3,10 +3,13 @@ import { connect } from 'react-redux';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import SiteTools from '../site-tools';
+import { SOURCE_SETTINGS_SITE_TOOLS } from '../site-tools/utils';
 
 const SiteSettingsGeneral = ( { isWpcomStagingSite } ) => (
 	<div className="site-settings__main general-settings">
-		{ ! isWpcomStagingSite && <SiteTools headerTitle={ translate( 'Other tools' ) } /> }
+		{ ! isWpcomStagingSite && (
+			<SiteTools headerTitle={ translate( 'Other tools' ) } source={ SOURCE_SETTINGS_SITE_TOOLS } />
+		) }
 	</div>
 );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5490

## Proposed Changes

* Add source reference to transfer, reset, delete site pages
* Back button redirects to the correct source according to the source reference

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test for both `/settings/site-tools/:site` and `/settings/general/:site`
* Transfer site back button goes to correct source
* Reset site back button goes to correct source
* Delete site back button goes to correct source

https://github.com/Automattic/wp-calypso/assets/6586048/f0076c41-d9cc-499e-8d82-5d890845597d


https://github.com/Automattic/wp-calypso/assets/6586048/acffcb39-19d1-4e12-a8f6-a00d7c35ac95




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?