### PR TITLE
[Continue with GitHub] response handler scaffolding

### DIFF
--- a/client/blocks/authentication/social/index.tsx
+++ b/client/blocks/authentication/social/index.tsx
@@ -21,6 +21,7 @@ interface SocialAuthenticationFormProps {
 	compact?: boolean;
 	handleGoogleResponse: ( response: any ) => void;
 	handleAppleResponse: ( response: any ) => void;
+	handleGitHubResponse: ( response: any ) => void;
 	getRedirectUri: ( service: string ) => string;
 	trackLoginAndRememberRedirect: ( service: string ) => void;
 	socialService: string;
@@ -35,6 +36,7 @@ interface SocialAuthenticationFormProps {
 const SocialAuthenticationForm = ( {
 	compact,
 	handleGoogleResponse,
+	handleGitHubResponse,
 	handleAppleResponse,
 	getRedirectUri,
 	trackLoginAndRememberRedirect,
@@ -128,7 +130,12 @@ const SocialAuthenticationForm = ( {
 							}
 						/>
 
-						{ config.isEnabled( 'login/github' ) ? <GithubSocialButton /> : null }
+						{ config.isEnabled( 'login/github' ) ? (
+							<GithubSocialButton
+								socialServiceResponse={ socialService === 'github' ? socialServiceResponse : null }
+								responseHandler={ handleGitHubResponse }
+							/>
+						) : null }
 
 						{ children }
 					</div>

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -114,6 +114,9 @@ class SocialLoginForm extends Component {
 		);
 	};
 
+	// eslint-disable-next-line no-unused-vars
+	handleGitHubResponse = ( response ) => {};
+
 	recordEvent = ( eventName, service, params ) =>
 		this.props.recordTracksEvent( eventName, {
 			social_account_type: service,
@@ -139,6 +142,7 @@ class SocialLoginForm extends Component {
 				compact={ this.props.compact }
 				handleGoogleResponse={ this.handleGoogleResponse }
 				handleAppleResponse={ this.handleAppleResponse }
+				handleGitHubResponse={ this.handleGitHubResponse }
 				getRedirectUri={ this.getRedirectUri }
 				trackLoginAndRememberRedirect={ this.trackLoginAndRememberRedirect }
 				socialService={ this.props.socialService }

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -58,6 +58,9 @@ class SocialSignupForm extends Component {
 		} );
 	};
 
+	// eslint-disable-next-line no-unused-vars
+	handleGitHubResponse = ( response ) => {};
+
 	trackSocialSignup = ( service ) => {
 		this.props.recordTracksEvent( 'calypso_signup_social_button_click', {
 			social_account_type: service,
@@ -103,6 +106,7 @@ class SocialSignupForm extends Component {
 			<SocialAuthenticationForm
 				compact={ this.props.compact }
 				handleGoogleResponse={ this.handleGoogleResponse }
+				handleGitHubResponse={ this.handleGitHubResponse }
 				handleAppleResponse={ this.handleAppleResponse }
 				getRedirectUri={ this.getRedirectUri }
 				trackLoginAndRememberRedirect={ this.trackLoginAndRememberRedirect }

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -19,9 +19,15 @@ import './style.scss';
 
 type GithubLoginButtonProps = {
 	children?: ReactNode;
+	responseHandler: ( response: any ) => void;
+	socialServiceResponse?: string | null;
 };
 
-const GitHubLoginButton = ( { children }: GithubLoginButtonProps ) => {
+const GitHubLoginButton = ( {
+	children,
+	responseHandler,
+	socialServiceResponse,
+}: GithubLoginButtonProps ) => {
 	const translate = useTranslate();
 
 	const isFormDisabled = useSelector( isFormDisabledSelector );
@@ -39,6 +45,12 @@ const GitHubLoginButton = ( { children }: GithubLoginButtonProps ) => {
 			return;
 		}
 	} );
+
+	useEffect( () => {
+		if ( socialServiceResponse ) {
+			responseHandler( socialServiceResponse );
+		}
+	}, [ socialServiceResponse ] );
 
 	const handleClick = ( e: MouseEvent< HTMLButtonElement > ) => {
 		errorRef.current = e.currentTarget;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87183

## Proposed Changes

This PR adds some scaffolding to intercept the response sent by the callback.

## Testing Instructions

Just test for regressions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?