### PR TITLE
Jetpack Manage: Fix the issue with Atomic sites showing managed plugins requiring updates.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites.ts
@@ -1,6 +1,12 @@
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
 import {
+	AUTOMOMANAGED_PLUGINS,
+	ECOMMERCE_BUNDLED_PLUGINS,
+	PREINSTALLED_PLUGINS,
+	PREINSTALLED_PREMIUM_PLUGINS,
+} from 'calypso/my-sites/plugins/constants';
+import {
 	BackupNode,
 	BoostNode,
 	MonitorNode,
@@ -149,7 +155,15 @@ const useFormatPluginData = () => {
 
 	return useCallback(
 		( site: Site ): PluginNode => {
-			const pluginUpdates = site.awaiting_plugin_updates;
+			const pluginUpdates = site.is_atomic
+				? site.awaiting_plugin_updates.filter(
+						( plugin ) =>
+							! PREINSTALLED_PLUGINS.includes( plugin ) &&
+							! AUTOMOMANAGED_PLUGINS.includes( plugin ) &&
+							! ECOMMERCE_BUNDLED_PLUGINS.includes( plugin ) &&
+							! Object.keys( PREINSTALLED_PREMIUM_PLUGINS ).includes( plugin )
+				  )
+				: site.awaiting_plugin_updates;
 
 			return {
 				value: `${ pluginUpdates?.length } ${ translate( 'Available' ) }`,


### PR DESCRIPTION
There are a few managed plugins for Atomic sites that don't need to be updated manually by the user. However, the dashboard doesn't take these plugins into account and mistakenly shows an item that needs attention in the UI. This PR fixes the issue by filtering out the managed plugins from the notification.

**Before**
<img width="1544" alt="Screenshot 2024-02-07 at 4 21 14 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/37533ffc-d1ea-4e07-940d-ab25bcf18c62">

**After**
<img width="1319" alt="Screenshot 2024-02-07 at 7 12 44 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/fcd03d7f-312e-4aa6-bfff-c2699857b624">


## Proposed Changes

* Filter plugins awaiting updates that are managed in WPCOM.

## Testing Instructions

Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Spin up some Atomic sites via the Site creation page (https://cloud.jetpack.com/partner-portal/create-site)
* Use the Jetpack cloud live link below and go to the Dashboard page (/dashboard)
* Wait until the sites appear on the page.
* Confirm that there are no plugins reported that require an update.

## Pre-merge Checklist



- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?