### PR TITLE
Show discounted plan price in `/plans`

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -288,6 +288,7 @@ const PlansFeaturesMain = ( {
 			: null
 	);
 	const getPlanTypeDestination = usePlanTypeDestinationCallback();
+	const couponCode = coupon || withDiscount;
 
 	const resolveModal = useModalResolutionCallback( {
 		isCustomDomainAllowedOnFreePlan,
@@ -378,7 +379,7 @@ const PlansFeaturesMain = ( {
 				: `/checkout/${ siteSlug }/${ planPath }`;
 
 			const checkoutUrlWithArgs = addQueryArgs(
-				{ ...( withDiscount && { coupon: withDiscount } ) },
+				{ ...( withDiscount && { coupon: couponCode } ) },
 				checkoutUrl
 			);
 
@@ -442,7 +443,7 @@ const PlansFeaturesMain = ( {
 		showLegacyStorageFeature,
 		isSubdomainNotGenerated: ! resolvedSubdomainName.result,
 		storageAddOns,
-		coupon,
+		coupon: couponCode,
 		selectedSiteId: siteId,
 	} );
 
@@ -553,7 +554,7 @@ const PlansFeaturesMain = ( {
 			currentSitePlanSlug: sitePlanSlug,
 			useCheckPlanAvailabilityForPurchase,
 			recordTracksEvent,
-			coupon,
+			coupon: couponCode,
 			selectedSiteId: siteId,
 			withDiscount,
 		};
@@ -610,7 +611,7 @@ const PlansFeaturesMain = ( {
 		planTypeSelector,
 		gridPlansForFeaturesGrid,
 		sitePlanSlug,
-		coupon,
+		couponCode,
 		siteId,
 		withDiscount,
 		getPlanTypeDestination,
@@ -798,7 +799,7 @@ const PlansFeaturesMain = ( {
 					'is-pricing-grid-2023-plans-features-main'
 				) }
 			>
-				<QueryPlans coupon={ coupon } />
+				<QueryPlans coupon={ couponCode } />
 				<QuerySites siteId={ siteId } />
 				<QuerySitePlans siteId={ siteId } />
 				<QueryActivePromotions />
@@ -868,7 +869,7 @@ const PlansFeaturesMain = ( {
 								layoutClassName="plans-features-main__plan-type-selector-layout"
 								enableStickyBehavior={ enablePlanTypeSelectorStickyBehavior }
 								stickyPlanTypeSelectorOffset={ masterbarHeight - 1 }
-								coupon={ coupon }
+								coupon={ couponCode }
 							/>
 						) }
 						<div
@@ -908,7 +909,7 @@ const PlansFeaturesMain = ( {
 									onStorageAddOnClick={ handleStorageAddOnClick }
 									showRefundPeriod={ isAnyHostingFlow( flowName ) }
 									recordTracksEvent={ recordTracksEvent }
-									coupon={ coupon }
+									coupon={ couponCode }
 									planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
 								/>
 								{ showEscapeHatch && hidePlansFeatureComparison && (
@@ -946,7 +947,7 @@ const PlansFeaturesMain = ( {
 												<PlanTypeSelector
 													{ ...planTypeSelectorProps }
 													layoutClassName="plans-features-main__plan-type-selector-layout"
-													coupon={ coupon }
+													coupon={ couponCode }
 												/>
 											) }
 											<ComparisonGrid
@@ -972,7 +973,7 @@ const PlansFeaturesMain = ( {
 												planTypeSelectorProps={
 													! hidePlanSelector ? planTypeSelectorProps : undefined
 												}
-												coupon={ coupon }
+												coupon={ couponCode }
 												recordTracksEvent={ recordTracksEvent }
 												planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
 											/>

--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -274,6 +274,7 @@ class Plans extends Component {
 				selectedPlan={ this.props.selectedPlan }
 				redirectTo={ this.props.redirectTo }
 				withDiscount={ this.props.withDiscount }
+				coupon={ this.props.withDiscount }
 				discountEndDate={ this.props.discountEndDate }
 				siteId={ selectedSite?.ID }
 				plansWithScroll={ false }
@@ -366,6 +367,7 @@ class Plans extends Component {
 			currentPlanIntervalType,
 			domainFromHomeUpsellFlow,
 			jetpackAppPlans,
+			withDiscount,
 		} = this.props;
 
 		if ( ! selectedSite || this.isInvalidPlanInterval() || ! currentPlan ) {
@@ -416,7 +418,7 @@ class Plans extends Component {
 				<DocumentHead title={ translate( 'Plans', { textOnly: true } ) } />
 				<PageViewTracker path="/plans/:site" title="Plans" />
 				<QueryContactDetailsCache />
-				<QueryPlans />
+				<QueryPlans coupon={ withDiscount } />
 				<TrackComponentView eventName="calypso_plans_view" />
 				{ ( isDomainUpsell || domainFromHomeUpsellFlow ) && (
 					<DomainUpsellDialog domain={ selectedSite.slug } />

--- a/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-toggle.tsx
+++ b/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-toggle.tsx
@@ -33,7 +33,8 @@ export const IntervalTypeToggle: React.FunctionComponent< IntervalTypeProps > = 
 	const maxDiscount = useMaxDiscount(
 		props.plans,
 		useCheckPlanAvailabilityForPurchase,
-		selectedSiteId
+		selectedSiteId,
+		coupon
 	);
 	const pricingMeta = Plans.usePricingMetaForGridPlans( {
 		planSlugs: currentSitePlanSlug ? [ currentSitePlanSlug ] : [],

--- a/packages/plans-grid-next/src/components/plan-type-selector/hooks/use-interval-options.tsx
+++ b/packages/plans-grid-next/src/components/plan-type-selector/hooks/use-interval-options.tsx
@@ -47,7 +47,7 @@ export default function useIntervalOptions( props: IntervalTypeProps ): Interval
 		},
 		'3yearly': {
 			key: '3yearly',
-			name: translate( 'Pay every 3 years' ),
+			name: translate( 'Pay every 33 years' ),
 			discountText: '',
 			termInMonths: 36,
 		},
@@ -69,7 +69,8 @@ export default function useIntervalOptions( props: IntervalTypeProps ): Interval
 		props.plans,
 		Object.keys( displayedOptionList ) as Array< SupportedUrlFriendlyTermType >,
 		props.useCheckPlanAvailabilityForPurchase,
-		props.selectedSiteId
+		props.selectedSiteId,
+		props.coupon
 	);
 
 	displayedOptionList = Object.fromEntries(

--- a/packages/plans-grid-next/src/components/plan-type-selector/hooks/use-max-discount.ts
+++ b/packages/plans-grid-next/src/components/plan-type-selector/hooks/use-max-discount.ts
@@ -11,7 +11,8 @@ import { useState } from '@wordpress/element';
 export default function useMaxDiscount(
 	plans: PlanSlug[],
 	useCheckPlanAvailabilityForPurchase: Plans.UseCheckPlanAvailabilityForPurchase,
-	selectedSiteId?: number | null
+	selectedSiteId?: number | null,
+	coupon?: string
 ): number {
 	const [ maxDiscount, setMaxDiscount ] = useState( 0 );
 	const wpcomMonthlyPlans = ( plans || [] ).filter( isWpComPlan ).filter( isMonthly );
@@ -22,7 +23,7 @@ export default function useMaxDiscount(
 		planSlugs: wpcomMonthlyPlans,
 		withoutPlanUpgradeCredits: true,
 		selectedSiteId,
-		coupon: undefined,
+		coupon,
 		useCheckPlanAvailabilityForPurchase,
 		storageAddOns: null,
 	} );
@@ -30,7 +31,7 @@ export default function useMaxDiscount(
 		planSlugs: yearlyVariantPlanSlugs,
 		withoutPlanUpgradeCredits: true,
 		selectedSiteId,
-		coupon: undefined,
+		coupon,
 		useCheckPlanAvailabilityForPurchase,
 		storageAddOns: null,
 	} );

--- a/packages/plans-grid-next/src/components/plan-type-selector/hooks/use-max-discounts-for-plan-terms.ts
+++ b/packages/plans-grid-next/src/components/plan-type-selector/hooks/use-max-discounts-for-plan-terms.ts
@@ -21,7 +21,8 @@ export default function useMaxDiscountsForPlanTerms(
 	plans: PlanSlug[],
 	urlFriendlyTerms: UrlFriendlyTermType[] = [],
 	useCheckPlanAvailabilityForPurchase: Plans.UseCheckPlanAvailabilityForPurchase,
-	selectedSiteId?: number | null
+	selectedSiteId?: number | null,
+	coupon?: string
 ): Record< UrlFriendlyTermType, number > {
 	const termDefinitionsMapping = urlFriendlyTerms.map( ( urlFriendlyTerm ) => ( {
 		urlFriendlyTerm,
@@ -51,7 +52,7 @@ export default function useMaxDiscountsForPlanTerms(
 		planSlugs: allRelatedPlanSlugs,
 		withoutPlanUpgradeCredits: true,
 		selectedSiteId,
-		coupon: undefined,
+		coupon,
 		useCheckPlanAvailabilityForPurchase,
 		storageAddOns: null,
 	} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
