### PR TITLE
Plans Next: Cleanse plans-grid-next pkg from remaining media queries and section styles

### DIFF
--- a/client/my-sites/plans-features-main/_media-queries.scss
+++ b/client/my-sites/plans-features-main/_media-queries.scss
@@ -1,0 +1,17 @@
+$plans-2023-small-breakpoint: 780px;
+
+/**
+ * @see client/my-sites/plans/modernized-layout.tsx
+ * This file introduces padding for the header on the plans page
+ * at a custom mobile breakpoint.
+ *
+ * This mixin can be use to target that particular breakpoint.
+ *
+ */
+@mixin plans-section-custom-mobile-breakpoint() {
+	.is-section-plans & {
+		@media ( min-width: $plans-2023-small-breakpoint ) {
+			@content;
+		}
+	}
+}

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -1,6 +1,7 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
+@import "@automattic/plans-grid-next/src/media-queries";
 @import "./media-queries";
 
 $plan-features-header-banner-height: 20px;

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -58,17 +58,6 @@ $plan-features-header-banner-height: 20px;
 	}
 }
 
-// Content group
-.plans-features-main__group {
-	& + & {
-		padding-top: 19px; // popular banner height adjustment
-	}
-
-	+ .faq {
-		margin-top: 20px;
-	}
-}
-
 .notice.plan-features-main__notice {
 	margin: 0 20px 24px;
 	width: unset;
@@ -140,7 +129,6 @@ $plan-features-header-banner-height: 20px;
 }
 
 .plans-features-main__group.is-wpcom.is-2023-pricing-grid {
-	// padding-top: 19px;
 	margin-top: 24px;
 }
 

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -361,3 +361,10 @@ body.is-section-plans .layout__content .main {
 		}
 	}
 }
+
+body.is-section-stepper,
+body.is-section-signup.is-white-signup {
+	.step-wrapper__header {
+		margin: 24px 20px 38px;
+	}
+}

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -36,10 +36,7 @@
 		margin: 0 20px;
 		padding: 0 0 10px;
 		overflow-x: visible;
-
-		@include plans-2023-break-small {
-			padding-top: 35px; // enough to cover `plans-grid__popular-badge` repositioning (top: -35px)
-		}
+		padding-top: 35px; // enough to cover `plans-grid__popular-badge` repositioning (top: -35px)
 	}
 }
 
@@ -137,39 +134,11 @@
 .is-2023-pricing-grid .plan-features-2023-grid__content {
 	position: relative;
 	margin: auto;
-
-	.is-section-stepper &,
-	.is-section-signup & {
-		@include pricing-grid-breakpoints;
-	}
-
-	.is-section-plans:not(.is-sidebar-collapsed) & {
-		@include pricing-grid-breakpoints-with-sidebar;
-
-	}
-
-	.is-section-plans.is-sidebar-collapsed.is-domain-plan-package-flow & {
-		@include pricing-grid-breakpoints-with-sidebar;
-
-	}
-
-	.is-section-plans.is-sidebar-collapsed:not(.is-domain-plan-package-flow) & {
-		@include pricing-grid-breakpoints;
-	}
-
 }
 
 .plans-features-main__group.is-wpcom.is-2023-pricing-grid {
-	padding-top: 19px;
+	// padding-top: 19px;
 	margin-top: 24px;
-}
-
-.plans-features-main__group.is-wpcom:not(.is-2023-pricing-grid) {
-	padding-top: 26px;
-
-	@media ( min-width: 880px ) {
-		padding-top: 19px;
-	}
 }
 
 // Required additional specificity

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -1,7 +1,9 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
-@import "@automattic/plans-grid-next/src/media-queries";
+@import "./media-queries";
+
+$plan-features-header-banner-height: 20px;
 
 :root {
 	--scss-font-body-small: #{$font-body-small};

--- a/client/my-sites/plans/modernized-layout.tsx
+++ b/client/my-sites/plans/modernized-layout.tsx
@@ -16,7 +16,7 @@ const ModernizedLayout: React.FunctionComponent = () => {
 	// ----------------------------------------------
 	// from @automattic/components/src/highlight-cards/variables.scss:
 	// ----------------------------------------------
-	// If changed, also change @plans-section-custom-mobile-breakpoint in client/my-sites/plans-grid/_media-queries.scss
+	// If changed, also change @plans-section-custom-mobile-breakpoint in client/my-sites/plans-features-main/_media-queries.scss
 	const customBreakpointSmall = '780px';
 	const verticalMargin = '32px';
 	// ----------------------------------------------

--- a/client/signup/steps/plans/style.scss
+++ b/client/signup/steps/plans/style.scss
@@ -1,18 +1,5 @@
 @import "@automattic/plans-grid-next/src/media-queries";
 
-.is-section-stepper .plans-features-main__group.is-2023-pricing-grid,
-.is-section-signup .is-2023-pricing-grid .plan-features-2023-grid__content {
-	@include pricing-grid-breakpoints;
-}
-
-.is-section-plans:not(.is-sidebar-collapsed) .is-2023-pricing-grid .plans-wrapper {
-	@include pricing-grid-breakpoints-with-sidebar;
-}
-
-.is-section-plans.is-sidebar-collapsed .is-2023-pricing-grid .plans-wrapper {
-	@include pricing-grid-breakpoints;
-}
-
 .plans-step {
 	margin: 0 auto;
 	max-width: 700px;

--- a/packages/plans-grid-next/src/_media-queries.scss
+++ b/packages/plans-grid-next/src/_media-queries.scss
@@ -1,68 +1,9 @@
 @import "@automattic/components/src/highlight-cards/variables.scss";
 
-$plan-features-sidebar-width: 272px;
 $plan-features-header-banner-height: 20px;
 
 // Plan Features Grid Breakpoints
 $plans-2023-small-breakpoint: 780px;
-
-$minWidthToGridWidthMap: (
-	780px: "668px",
-	1024px: "860px",
-	1200px: "100%",
-);
-
-/**
- * @deprecated
- * TODO clk used in plans-features-main / should migrate there
- *   - creates a bit of snapping effect on the various breakpoints
- *   - if it's not really necessary, we should remove it
- */
-@mixin pricing-grid-breakpoints {
-	width: 100%;
-
-	@each $screenMinWidth, $gridWidth in $minWidthToGridWidthMap {
-		@media ( min-width: #{$screenMinWidth} ) {
-			width: #{$gridWidth};
-		}
-	}
-}
-
-/**
- * Media queries for the plans grid on the /plans page.
- * This should stretch to fill it's container.
- *
- * @deprecated
- * TODO clk this should just be set as the default behavior for the grid
- */
-@mixin pricing-grid-breakpoints-with-sidebar {
-	width: 100%;
-}
-
-/**
- * @deprecated
- * TODO clk used in plans-features-main / should migrate there
- */
-@mixin plans-2023-break-small() {
-	body.is-section-stepper &,
-	body.is-section-signup.is-white-signup & {
-		@media ( min-width: $plans-2023-small-breakpoint ) {
-			@content;
-		}
-	}
-
-	.is-section-plans:not(.is-sidebar-collapsed) & {
-		@media ( min-width: $plans-2023-small-breakpoint + $plan-features-sidebar-width ) {
-			@content;
-		}
-	}
-
-	.is-section-plans.is-sidebar-collapsed & {
-		@media ( min-width: $plans-2023-small-breakpoint ) {
-			@content;
-		}
-	}
-}
 
 /**
  * @see client/my-sites/plans/modernized-layout.tsx

--- a/packages/plans-grid-next/src/_media-queries.scss
+++ b/packages/plans-grid-next/src/_media-queries.scss
@@ -1,30 +1,11 @@
-@import "@automattic/components/src/highlight-cards/variables.scss";
-
-// TODO clk used in plans-features-main / should migrate there
-$plan-features-header-banner-height: 20px;
-
 $plans-2023-small-breakpoint: 780px;
-
-/**
- * @see client/my-sites/plans/modernized-layout.tsx
- * This file introduces padding for the header on the plans page
- * at a custom mobile breakpoint.
- *
- * This mixin can be use to target that particular breakpoint.
- *
- * TODO clk used in plans-features-main / should migrate there
- */
-@mixin plans-section-custom-mobile-breakpoint() {
-	.is-section-plans & {
-		@media ( min-width: $plans-2023-small-breakpoint ) {
-			@content;
-		}
-	}
-}
 
 /**
  * @see @automattic/plans-grid-next/src/components/plan-type-selector/style.scss
  * This introduces mobile only sticky behavior for the plan type selector.
+ *
+ * @deprecated
+ * TODO clk This should migrate to use grid-size on the parent container. As done for features/comparison grid.
  */
 @mixin plan-type-selector-custom-mobile-breakpoint() {
 	@media ( max-width: $plans-2023-small-breakpoint ) {

--- a/packages/plans-grid-next/src/_media-queries.scss
+++ b/packages/plans-grid-next/src/_media-queries.scss
@@ -1,8 +1,8 @@
 @import "@automattic/components/src/highlight-cards/variables.scss";
 
+// TODO clk used in plans-features-main / should migrate there
 $plan-features-header-banner-height: 20px;
 
-// Plan Features Grid Breakpoints
 $plans-2023-small-breakpoint: 780px;
 
 /**
@@ -25,9 +25,6 @@ $plans-2023-small-breakpoint: 780px;
 /**
  * @see @automattic/plans-grid-next/src/components/plan-type-selector/style.scss
  * This introduces mobile only sticky behavior for the plan type selector.
- *
- * TODO clk need to update to use GridSize / container breakpoints
- *
  */
 @mixin plan-type-selector-custom-mobile-breakpoint() {
 	@media ( max-width: $plans-2023-small-breakpoint ) {

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -1012,10 +1012,3 @@ $mobile-card-max-width: 440px;
 		}
 	}
 }
-
-/**
- * TODO clk migrate out of plans-grid-next
- */
-.formatted-header {
-	margin-bottom: 0;
-}

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -715,7 +715,7 @@ $mobile-card-max-width: 440px;
 	.plan-features-2023-gridrison__actions-buttons {
 		min-height: 40px;
 	}
-	
+
 	.plan-comparison-grid__header-cell {
 		display: flex;
 		flex-direction: column;
@@ -1013,14 +1013,6 @@ $mobile-card-max-width: 440px;
 	}
 }
 
-
-/* Hosting onboarding flow */
-.is-hosting div.plan-features-2023-grid__content {
-	max-width: 768px;
-	margin-left: auto !important;
-	margin-right: auto !important;
-}
-
 /**
  * TODO clk migrate out of plans-grid-next
  */
@@ -1030,7 +1022,7 @@ body.is-section-signup.is-white-signup {
 		margin: 24px 20px 38px;
 	}
 }
- 
+
 /**
  * TODO clk migrate out of plans-grid-next
  */

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -703,39 +703,19 @@ $mobile-card-max-width: 440px;
 	}
 }
 
-/**
- * TODO clk migrate out of plans-grid-next
- */
-body.is-section-stepper,
-body.is-section-signup.is-white-signup {
-	.step-wrapper__header {
-		margin: 24px 20px 38px;
-	}
-}
-
-/**
- * TODO clk migrate out of plans-grid-next
- */
-.formatted-header {
-	margin-bottom: 0;
-}
-
-.plans-features-main__comparison-grid-container {
-	.plan-comparison-grid {
-		.plan-comparison-grid__feature-group-row.is-storage-feature {
-			align-items: flex-start;
-		}
-	}
-}
-
 .plan-comparison-grid {
+	.plan-comparison-grid__feature-group-row.is-storage-feature {
+		align-items: flex-start;
+	}
+
 	.plan-features-2023-gridrison__actions {
 		margin-bottom: auto;
-
-		&-buttons {
-			min-height: 40px;
-		}
 	}
+
+	.plan-features-2023-gridrison__actions-buttons {
+		min-height: 40px;
+	}
+	
 	.plan-comparison-grid__header-cell {
 		display: flex;
 		flex-direction: column;
@@ -1039,4 +1019,21 @@ body.is-section-signup.is-white-signup {
 	max-width: 768px;
 	margin-left: auto !important;
 	margin-right: auto !important;
+}
+
+/**
+ * TODO clk migrate out of plans-grid-next
+ */
+body.is-section-stepper,
+body.is-section-signup.is-white-signup {
+	.step-wrapper__header {
+		margin: 24px 20px 38px;
+	}
+}
+ 
+/**
+ * TODO clk migrate out of plans-grid-next
+ */
+.formatted-header {
+	margin-bottom: 0;
 }

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -477,10 +477,6 @@ $mobile-card-max-width: 440px;
 }
 
 .plan-features-2023-grid__content {
-	.plans-features-main__group.is-scrollable & {
-		padding-top: $plan-features-header-banner-height;
-	}
-
 	.plan-features-2023-grid__table-bottom {
 		margin-top: 54px;
 	}

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -714,9 +714,6 @@ body.is-section-stepper,
 body.is-section-signup.is-white-signup {
 	.step-wrapper__header {
 		margin: 24px 20px 38px;
-		@include plans-2023-break-small {
-			margin: 24px 20px;
-		}
 	}
 }
 

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -1016,16 +1016,6 @@ $mobile-card-max-width: 440px;
 /**
  * TODO clk migrate out of plans-grid-next
  */
-body.is-section-stepper,
-body.is-section-signup.is-white-signup {
-	.step-wrapper__header {
-		margin: 24px 20px 38px;
-	}
-}
-
-/**
- * TODO clk migrate out of plans-grid-next
- */
 .formatted-header {
 	margin-bottom: 0;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/79010

## Proposed Changes

This is part of a series of PRs for untangling the pricing grids/components from screen/media queries and any Calypso-dependent CSS context (such as sidebar width). The end goal is to (1) make the components responsive and reusable in any context, and (2) to be able to render the grids anywhere on a page (in a modal, sidebar, a half-page column, etc.). So pdgrnI-2uQ-p2 becomes relevant and this work should set the foundations for it.

In this PR:

- we follow from the work done in https://github.com/Automattic/wp-calypso/pull/86796 and https://github.com/Automattic/wp-calypso/pull/87003 to clean up remaining media queries and section styles
- migrate remaining media queries to Calypso (one left, except for the `PlanTypeSelector` which will be addressed in a follow-up)
- migrate section styles to Calypso
- remove media queries that were previously forcing the `FeaturesGrid` to snap into more condensed views at various breakpoints (see gifs below). I don't see the value in this behavior if we have enough space on the screen to fit a larger grid (respecting the max column widths). This also makes the `FeaturesGrid` behave similarly to `/pricing`, which also doesn't apply "snapping" across these breakpoints.

## Media

Features-grid Before

https://github.com/Automattic/wp-calypso/assets/1705499/ebc91dc5-cd50-4625-89b0-0e0c36bd4897

Features-grid After

https://github.com/Automattic/wp-calypso/assets/1705499/6cf0642f-54d5-46f4-aac2-3bec83fb0e7c

Features-grid on /pricing

https://github.com/Automattic/wp-calypso/assets/1705499/9b3d8787-90b0-42f7-866f-de15d17f8bc0

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- General testing across `/start/plans`, `/plans/[ any site ]`, `/setup/newsletter/plans`
- Confirm nothing broken visually on resizing (general layout, borders, highlight labels)
- Some styles were removed from `/start/hosting`. It doesn't look like they were ever applied or effective at all

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?