### PR TITLE
Plans Next: Fix comparison grid stretching infinitely

### DIFF
--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -69,6 +69,9 @@ function DropdownIcon() {
 	);
 }
 
+const featureGroupRowTitleCellMaxWidth = 450;
+const rowCellMaxWidth = 290;
+
 const JetpackIconContainer = styled.div`
 	padding-inline-start: 6px;
 	display: inline-block;
@@ -106,11 +109,16 @@ const Title = styled.div< { isHiddenInMobile?: boolean } >`
 	` ) }
 `;
 
-const Grid = styled.div< { isInSignup?: boolean } >`
+const Grid = styled.div< { isInSignup?: boolean; visiblePlans: number } >`
 	display: grid;
-	margin-top: ${ ( props ) => ( props.isInSignup ? '90px' : '64px' ) };
+	margin: ${ ( props ) => ( props.isInSignup ? '90px auto 0' : '64px auto 0' ) };
 	background: #fff;
 	border: solid 1px #e0e0e0;
+	${ ( props ) =>
+		props.visiblePlans &&
+		css`
+			max-width: ${ rowCellMaxWidth * props.visiblePlans + featureGroupRowTitleCellMaxWidth }px;
+		` }
 
 	${ plansGridMediumLarge( css`
 		border-radius: 5px;
@@ -192,6 +200,7 @@ const Cell = styled.div< { textAlign?: 'start' | 'center' | 'end' } >`
 	align-items: center;
 	padding: 33px 20px 0;
 	border-right: solid 1px #e0e0e0;
+	max-width: ${ rowCellMaxWidth }px;
 
 	.gridicon {
 		fill: currentColor;
@@ -236,7 +245,10 @@ const Cell = styled.div< { textAlign?: 'start' | 'center' | 'end' } >`
 	` ) }
 `;
 
-const RowTitleCell = styled.div`
+const RowTitleCell = styled.div< {
+	isPlaceholderHeaderCell?: boolean;
+	isFeatureGroupRowTitleCell?: boolean;
+} >`
 	display: none;
 	font-size: 14px;
 	padding-right: 10px;
@@ -245,6 +257,12 @@ const RowTitleCell = styled.div`
 		flex: 1;
 		min-width: 290px;
 	` ) }
+	max-width: ${ ( props ) => {
+		if ( props.isPlaceholderHeaderCell || props.isFeatureGroupRowTitleCell ) {
+			return `${ featureGroupRowTitleCellMaxWidth }px`;
+		}
+		return `${ rowCellMaxWidth }px`;
+	} };
 `;
 
 const PlanSelector = styled.header`
@@ -493,6 +511,7 @@ const ComparisonGridHeader = forwardRef< HTMLDivElement, ComparisonGridHeaderPro
 				<RowTitleCell
 					key="feature-name"
 					className="plan-comparison-grid__header-cell is-placeholder-header-cell"
+					isPlaceholderHeaderCell={ true }
 				>
 					{ isStuck && planTypeSelectorProps && (
 						<PlanTypeSelectorWrapper>
@@ -737,7 +756,11 @@ const ComparisonGridFeatureGroupRow: React.FunctionComponent< {
 			className={ rowClasses }
 			isHighlighted={ isHighlighted }
 		>
-			<RowTitleCell key="feature-name" className="is-feature-group-row-title-cell">
+			<RowTitleCell
+				key="feature-name"
+				className="is-feature-group-row-title-cell"
+				isFeatureGroupRowTitleCell={ true }
+			>
 				{ isStorageFeature ? (
 					<Plans2023Tooltip
 						text={ translate( 'Space to store your photos, media, and more.' ) }
@@ -1060,7 +1083,7 @@ const ComparisonGrid = ( {
 
 	return (
 		<div className="plan-comparison-grid">
-			<Grid isInSignup={ isInSignup }>
+			<Grid isInSignup={ isInSignup } visiblePlans={ visiblePlans.length }>
 				<StickyContainer
 					disabled={ isBottomHeaderInView }
 					stickyClass="is-sticky-header-row"

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -109,16 +109,11 @@ const Title = styled.div< { isHiddenInMobile?: boolean } >`
 	` ) }
 `;
 
-const Grid = styled.div< { isInSignup?: boolean; visiblePlans: number } >`
+const Grid = styled.div< { isInSignup?: boolean } >`
 	display: grid;
 	margin: ${ ( props ) => ( props.isInSignup ? '90px auto 0' : '64px auto 0' ) };
 	background: #fff;
 	border: solid 1px #e0e0e0;
-	${ ( props ) =>
-		props.visiblePlans &&
-		css`
-			max-width: ${ rowCellMaxWidth * props.visiblePlans + featureGroupRowTitleCellMaxWidth }px;
-		` }
 
 	${ plansGridMediumLarge( css`
 		border-radius: 5px;
@@ -135,9 +130,7 @@ const Row = styled.div< {
 	className?: string;
 	isHighlighted?: boolean;
 } >`
-	justify-content: space-between;
 	margin-bottom: -1px;
-	align-items: stretch;
 	display: ${ ( props ) => ( props.isHiddenInMobile ? 'none' : 'flex' ) };
 
 	${ plansGridMediumLarge( css`
@@ -257,6 +250,10 @@ const RowTitleCell = styled.div< {
 		flex: 1;
 		min-width: 290px;
 	` ) }
+	/** 
+	 * max-width is set below primarily for sanity to avoid cells extending infinitely 
+	 * on change to container's layout. If it proves limiting, it can be removed.
+	 **/
 	max-width: ${ ( props ) => {
 		if ( props.isPlaceholderHeaderCell || props.isFeatureGroupRowTitleCell ) {
 			return `${ featureGroupRowTitleCellMaxWidth }px`;
@@ -1083,7 +1080,7 @@ const ComparisonGrid = ( {
 
 	return (
 		<div className="plan-comparison-grid">
-			<Grid isInSignup={ isInSignup } visiblePlans={ visiblePlans.length }>
+			<Grid isInSignup={ isInSignup }>
 				<StickyContainer
 					disabled={ isBottomHeaderInView }
 					stickyClass="is-sticky-header-row"

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -109,11 +109,16 @@ const Title = styled.div< { isHiddenInMobile?: boolean } >`
 	` ) }
 `;
 
-const Grid = styled.div< { isInSignup?: boolean } >`
+const Grid = styled.div< { isInSignup?: boolean; visiblePlans: number } >`
 	display: grid;
 	margin: ${ ( props ) => ( props.isInSignup ? '90px auto 0' : '64px auto 0' ) };
 	background: #fff;
 	border: solid 1px #e0e0e0;
+	${ ( props ) =>
+		props.visiblePlans &&
+		css`
+			max-width: ${ rowCellMaxWidth * props.visiblePlans + featureGroupRowTitleCellMaxWidth }px;
+		` }
 
 	${ plansGridMediumLarge( css`
 		border-radius: 5px;
@@ -130,7 +135,9 @@ const Row = styled.div< {
 	className?: string;
 	isHighlighted?: boolean;
 } >`
+	justify-content: space-between;
 	margin-bottom: -1px;
+	align-items: stretch;
 	display: ${ ( props ) => ( props.isHiddenInMobile ? 'none' : 'flex' ) };
 
 	${ plansGridMediumLarge( css`
@@ -250,10 +257,6 @@ const RowTitleCell = styled.div< {
 		flex: 1;
 		min-width: 290px;
 	` ) }
-	/** 
-	 * max-width is set below primarily for sanity to avoid cells extending infinitely 
-	 * on change to container's layout. If it proves limiting, it can be removed.
-	 **/
 	max-width: ${ ( props ) => {
 		if ( props.isPlaceholderHeaderCell || props.isFeatureGroupRowTitleCell ) {
 			return `${ featureGroupRowTitleCellMaxWidth }px`;
@@ -1080,7 +1083,7 @@ const ComparisonGrid = ( {
 
 	return (
 		<div className="plan-comparison-grid">
-			<Grid isInSignup={ isInSignup }>
+			<Grid isInSignup={ isInSignup } visiblePlans={ visiblePlans.length }>
 				<StickyContainer
 					disabled={ isBottomHeaderInView }
 					stickyClass="is-sticky-header-row"

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -736,6 +736,8 @@ body.is-section-signup.is-white-signup {
 }
 
 .plan-comparison-grid {
+	display: flex; // required to make grid not stretch with container
+
 	.plan-features-2023-gridrison__actions {
 		margin-bottom: auto;
 

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -736,8 +736,6 @@ body.is-section-signup.is-white-signup {
 }
 
 .plan-comparison-grid {
-	display: flex; // required to make grid not stretch with container
-
 	.plan-features-2023-gridrison__actions {
 		margin-bottom: auto;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Since merging https://github.com/Automattic/wp-calypso/pull/87003, the `ComparisonGrid` behaves more "fluidly" than expected i.e. it will stretch infinitely unless controlled via consuming-end media queries & max-width.

Controlling this behavior via media queries will probably needs knowledge of the grid-size (and/or other variables, like visible plans) from outside. It's one way, although feels a bit like extra complexity/layers towards reusing this component elsewhere.

The approach here, encodes max-width on the various elements in the grid and on the larger Grid container, which becomes a calculation of "plan columns + header column". The concept of "max column width" is something we have already for the `FeaturesGrid`, so this feels aligned.

We can adjust these constants easily and also move them to a better place later. I think they are only really meaningful in smaller/fewer-plan grids (2 or 3).

## Media

In `/start/hosting` (or `/setup/new-hosted-site`) flow:

**Before**

<img width="700" alt="Screenshot 2024-02-07 at 5 11 02 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/dba25f4d-2ba0-4fd1-8d38-6ed5a1133bdc">


**After**

<img width="700" alt="Screenshot 2024-02-07 at 5 12 21 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/a682cc51-8c71-41ae-a750-b151f4d0d2d7">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Confirm the comparison-grid in `/start/plans` and `/plans/[ any site ]` renders the correct number of plans on various screen sizes (it should render 2, 3, 4, 4+ on resizing)
- Confirm the grid doesn't keep expanding to eternity
- Confirm a comparison grid with fewer plans does not stretch to eternity. Confirm across all of `/plans/[ newsletter site ]`, `/plans/[ wooexpress site ]` and `/start/hosting` (testing the hosting flow brought this issue to the surface as it renders only 2 plans)
- Confirm borders, highlights, & sticky headers render fine

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?