### PR TITLE
Continue with GitHub: Update the button link to respect our new redirect logic

### DIFF
--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -67,7 +67,10 @@ const GitHubLoginButton = ( {
 		}
 
 		const clientId = config( 'github_oauth_client_id' );
-		window.location.href = `https://github.com/login/oauth/authorize?client_id=${ clientId }&redirect_uri=${ redirectUri }`;
+		const redirectEndpoint = encodeURIComponent(
+			`https://public-api.wordpress.com/wpcom/v2/hosting/github/app-callback?final_redirect_uri=${ redirectUri }`
+		);
+		window.location.href = `https://github.com/login/oauth/authorize?client_id=${ clientId }&redirect_uri=${ redirectEndpoint }`;
 	};
 
 	const eventHandlers = {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/87272.

## Proposed Changes

* utilize `public-api.wordpress.com/wpcom/v2/hosting/github/app-callback` endpoint introduced in D137372-code

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Navigate to http://calypso.localhost:3000/log-in or http://calypso.localhost:3000/start/user-social
2. Click on the "Continue with GitHub" button.
3. You should be directed to the GitHub "Sign In" page with the included `client_id` and `redirect_uri` URL parameters (depending on which page you are coming from). The `public-api.wordpress.com/wpcom/v2/hosting/github/app-callback` endpoint should be utilized.

`/log-in`:
![Markup on 2024-02-07 at 17:55:15](https://github.com/Automattic/wp-calypso/assets/25105483/7278cf81-bacb-4892-a4cc-c81a93aa4583)

`/start/user-social:`
![Markup on 2024-02-07 at 17:44:14](https://github.com/Automattic/wp-calypso/assets/25105483/aa88aad8-d9ee-4e62-9ed9-40733129da81)

ℹ️ Please note that the related `final-redirect-uri`s haven't been whitelisted yet - i.e. the actual redirect won't work until the following task is finished: https://github.com/Automattic/wp-calypso/issues/87278.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?