### PR TITLE
Site Editor: Fix Top Bar Unclickable on Small Screens

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/editor.scss
+++ b/apps/wpcom-block-editor/src/wpcom/editor.scss
@@ -17,3 +17,10 @@
 		top: 0;
 	}
 }
+
+// Hotfix to prevent the site editor's W logo to cover the whole top bar on small screens.
+// @see https://github.com/Automattic/wp-calypso/issues/87247
+.edit-site-layout.is-full-canvas .edit-site-layout__hub {
+	padding-right: 0;
+	width: 60px;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/87247

## Proposed Changes

* Prevent the Site Editor's WP logo from expanding to the whole width, covering the top bar, and preventing click-throughs.

<img width="496" alt="Screenshot 2024-02-07 at 15 52 57" src="https://github.com/Automattic/wp-calypso/assets/2070010/8555b7ab-12ac-48fa-91b5-d80149cc1e73">

### Note

This hotfix should probably live in a (new) `default/editor.scss` file, so that it applies to any site type.

I chose to keep it in `wpcom` because otherwise, AFAICS, it would need a Jetpack release [to enqueue the new style](https://github.com/Automattic/jetpack/blob/9b0d6d052853ea7e1d5457bcf50d31d27dad5c9e/projects/plugins/jetpack/modules/wpcom-block-editor/class-jetpack-wpcom-block-editor.php#L309).

We could do it separately if needed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sync these changes to the sandbox.
* Sandbox a test site and `widgets.wp.com`.
* Open the site editor and enter canvas mode (`/wp-admin/site-editor.php?canvas=edit`).
* Ensure the top bar is all clickable.
* Resize the window to a phone-like width.
* Ensure the top bar is all clickable.
* Ensure the WP logo is clickable too.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?