### PR TITLE
Stats: Refactor Stats page elements layout distance

### DIFF
--- a/client/my-sites/stats/modernized-layout-styles.scss
+++ b/client/my-sites/stats/modernized-layout-styles.scss
@@ -26,7 +26,8 @@ $sidebar-appearance-break-point: 783px;
 	> .stats__all-time-views-section,
 	> .stats__post-detail-table-section,
 	> .stats__gmb-location-wrapper,
-	> .subscribers-page {
+	> .subscribers-page,
+	> .post-trends {
 		padding-top: $vertical-margin;
 		padding-bottom: $vertical-margin;
 	}

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -13,10 +13,6 @@ $lowestLevelColor: var(--color-neutral-5);
 	border-bottom: 1px solid var(--studio-gray-5);
 	border-top: 1px solid var(--studio-gray-5);
 
-	.stats-heat-map__legend {
-		margin-bottom: 48px;
-	}
-
 	.stats-heat-map__legend-item {
 		&.level-1 {
 			background-color: $lowestLevelColor;
@@ -34,7 +30,6 @@ $lowestLevelColor: var(--color-neutral-5);
 }
 
 .post-trends__heading {
-	margin-top: 48px;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;

--- a/client/my-sites/stats/post-trends/style.scss
+++ b/client/my-sites/stats/post-trends/style.scss
@@ -47,7 +47,7 @@ $lowestLevelColor: var(--color-neutral-5);
 }
 
 .post-trends__year {
-	margin-top: 16px;
+	margin-top: 1em;
 	padding: 16px 2px;
 	display: flex;
 	justify-content: space-between;

--- a/client/my-sites/stats/stats-heap-map/style.scss
+++ b/client/my-sites/stats/stats-heap-map/style.scss
@@ -1,7 +1,7 @@
 @import "@automattic/typography/styles/variables";
 
 .stats-heat-map__legend {
-	margin-top: 16px;
+	margin-top: 1em;
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/client/my-sites/stats/wordads/earnings.scss
+++ b/client/my-sites/stats/wordads/earnings.scss
@@ -1,5 +1,6 @@
 @import "@automattic/components/src/styles/mixins";
 @import "@automattic/typography/styles/variables";
+@import "@automattic/components/src/highlight-cards/variables.scss";
 
 
 .ads__table-header {
@@ -25,6 +26,7 @@
 
 .earnings_history {
 	border-radius: 4px;
+	margin-bottom: $vertical-margin;
 
 	table {
 		margin: 0;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Update the Posting activity padding with the existing shared pattern.
* Refactor the Posting activity element gaps with a relative unit.
* Update the Earnings history bottom gap with the shared design styling

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Live Calypso link.
* Navigate to Stats > `Insights` page.
* Ensure the `Posting activity` section layout looks reasonable.
* Navigate to Stats > `Ads` page.
* Ensure the margin at the bottom of the `Earnings history` section looks good.

|Before|After|
|-|-|
|<img width="1265" alt="截圖 2024-02-08 上午12 17 10" src="https://github.com/Automattic/wp-calypso/assets/6869813/ed58e8af-2c7c-4057-b66d-46257ab58624">|<img width="1290" alt="截圖 2024-02-08 上午12 08 06" src="https://github.com/Automattic/wp-calypso/assets/6869813/fb9b14ef-2eb2-47fc-9838-6a78031aff22">|

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?