### PR TITLE
Theme Tiers: Fix pub/ Premium Themes in Onboarding

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -406,9 +406,7 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 	const isBundled = selectedDesign?.software_sets && selectedDesign.software_sets.length > 0;
 
 	const isLockedTheme =
-		( isEnabled( 'themes/tiers' ) &&
-			selectedDesign?.design_tier === PERSONAL_THEME &&
-			! canSiteActivateTheme ) ||
+		( isEnabled( 'themes/tiers' ) && ! canSiteActivateTheme ) ||
 		( selectedDesign?.is_premium && ! isPremiumThemeAvailable && ! didPurchaseSelectedTheme ) ||
 		( selectedDesign?.is_externally_managed &&
 			( ! isMarketplaceThemeSubscribed || ! isExternallyManagedThemeAvailable ) ) ||

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.ts
@@ -123,7 +123,7 @@ describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscripti
 			await page.getByText( 'Customize this design' ).waitFor();
 		} );
 
-		it.skip( 'Checks the active theme', async function () {
+		it( 'Checks the active theme', async function () {
 			const restAPIClient = new RestAPIClient(
 				{
 					username: testUser.username,
@@ -134,7 +134,7 @@ describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscripti
 
 			const theme = await restAPIClient.getActiveTheme( newSiteDetails.blog_details.blogid );
 
-			expect( theme ).toBe( `premium/${ themeSlug }` );
+			expect( theme ).toContain( themeSlug );
 		} );
 	} );
 

--- a/test/e2e/specs/onboarding/signup__with-theme-premium.ts
+++ b/test/e2e/specs/onboarding/signup__with-theme-premium.ts
@@ -123,7 +123,7 @@ describe( 'Lifecyle: Premium theme signup, onboard, launch and cancel subscripti
 			await page.getByText( 'Customize this design' ).waitFor();
 		} );
 
-		it( 'Checks the active theme', async function () {
+		it.skip( 'Checks the active theme', async function () {
 			const restAPIClient = new RestAPIClient(
 				{
 					username: testUser.username,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* Simplify the Theme Tiers check in onboarding to prevent breaking on Premium themes served from the `pub/` library.
* Also skip an obsolete test.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new Free site.
* Traverse onboarding until you get to the Design Picker: `/setup/site-setup/designSetup?siteSlug={ SITE }`.
* Try activating several types of themes, and ensure you can always complete the onboarding (upgrade needed in some cases) with the selected theme active.
  * Free theme.
  * Starter theme (e.g. Epi).
  * Premium theme served from `pub/` (e.g. Cakely).
  * Premium theme served from `premium/` (e.g. Annalee).
  * Free theme using a premium style variation (e.g. Bedrock).
  * Starter theme using a premium style variation (e.g. Blogorama).
  * Partner theme (e.g. STAX).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?