### PR TITLE
Migration flow: Extend list of hosts with Pressable with support link

### DIFF
--- a/client/components/advanced-credentials/host-info.ts
+++ b/client/components/advanced-credentials/host-info.ts
@@ -328,6 +328,11 @@ export const topHosts: Host[] = [
 			ftp: 'https://www.siteground.com/kb/establish-ftp-connection-hosting-account/',
 		},
 	},
+	{
+		id: 'pressable',
+		name: 'Pressable',
+		supportLink: 'https://pressable.com/knowledgebase/connect-to-ssh-on-pressable/',
+	},
 ];
 
 export const genericInfo: Host = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/87237

## Proposed Changes

* Add Pressable to the list of hosts

## Testing Instructions

* Go to `/setup/import-focused?siteSlug={ATOM_SITE_SLUG}`
* Enter a jetpack connected self-hosted (ex. JN)
* Check if the dropdown in the right column has a Pressable option
* Select and check if the support link works

<img width="955" alt="Screenshot 2024-02-07 at 19 06 52" src="https://github.com/Automattic/wp-calypso/assets/1241413/bda2f893-0b62-4e83-8547-339fe18d7130">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?