### PR TITLE
Untangle: Remove import-php URL override

### DIFF
--- a/client/state/data-layer/wpcom/sites/admin-menu/index.js
+++ b/client/state/data-layer/wpcom/sites/admin-menu/index.js
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { addQueryArgs } from 'calypso/lib/url';
 import { ADMIN_MENU_REQUEST } from 'calypso/state/action-types';
 import { receiveAdminMenu } from 'calypso/state/admin-menu/actions';
@@ -51,11 +50,6 @@ const sanitizeMenuItem = ( menuItem, siteSlug, wpAdminUrl ) => {
 		sanitizedChildren = menuItem.children.map( ( subMenuItem ) =>
 			sanitizeMenuItem( subMenuItem, siteSlug, wpAdminUrl )
 		);
-	}
-
-	// Enable the import page if the feature option is on.
-	if ( menuItem.slug === 'import-php' && isEnabled( 'importer/unified' ) ) {
-		menuItem.url = `/import/${ siteSlug }`;
 	}
 
 	return {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5262

## Proposed Changes

* This PR enables us to link the Import menu item to wp-admin/import.php from Calypso.
* By removing this code, the API endpoint URL value is honored, and we can link to wp-admin/import.php.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* In production
* Using an Atomic site with the global Classic wp-admin view enabled.
* Go to /hosting-config/[site_slug] (or any Calypso hosted page)
* Hover your mouse over Tools -> Import and notice it links (incorrectly) to the Calypso URL
* Apply this PR and refresh
* Using the same site as before with Classic wp-admin enabled.
* Go to /hosting-config/[site_slug] (or any Calypso hosted page)
* Hover your mouse over Tools -> Import and notice it links (correctly) to the wp-admin URL

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?