### PR TITLE
My Home: Tidy Up Site Preview Card

### DIFF
--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -1,4 +1,4 @@
-import { Button, SiteThumbnail } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -9,6 +9,7 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { SiteUrl, Truncated } from 'calypso/sites-dashboard/components/sites-site-url';
 import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
+import { getWpComDomainBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import './style.scss';
 import { SitePreviewEllipsisMenu } from './site-preview-ellipsis-menu';
@@ -63,6 +64,7 @@ const SitePreview = ( {
 		canCurrentUser( state, selectedSite?.ID ?? 0, 'manage_options' )
 	);
 	const isMobile = useMobileBreakpoint();
+	const wpcomDomain = useSelector( ( state ) => getWpComDomainBySiteId( state, selectedSite?.ID ) );
 
 	if ( isMobile ) {
 		return <></>;
@@ -77,6 +79,11 @@ const SitePreview = ( {
 		  } )
 		: '#';
 
+	// We use an iframe rather than mShot to not cache changes.
+	const iframeSrcKeepHomepage = wpcomDomain
+		? `//${ wpcomDomain.domain }/?hide_banners=true&preview_overlay=true&preview=true`
+		: '#';
+
 	const selectedSiteURL = selectedSite ? selectedSite.URL : '#';
 	const selectedSiteSlug = selectedSite ? selectedSite.slug : '...';
 	const selectedSiteName = selectedSite ? selectedSite.name : '&nbsp;';
@@ -89,16 +96,18 @@ const SitePreview = ( {
 						{ __( 'Edit site' ) }
 					</Button>
 				) }
-				<SiteThumbnail
-					className="home-site-preview__thumbnail"
-					mShotsUrl={ addQueryArgs( selectedSite?.URL, {
-						iframe: true,
-						preview: true,
-						hide_banners: true,
-					} ) }
-					width={ 400 }
-					height={ 375 }
-				></SiteThumbnail>
+				<div className="home-site-preview__thumbnail">
+					{ wpcomDomain ? (
+						<iframe
+							scrolling="no"
+							loading="lazy"
+							title={ __( 'Site Preview' ) }
+							src={ iframeSrcKeepHomepage }
+						/>
+					) : (
+						<div className="home-site-preview__thumbnail-placeholder" />
+					) }
+				</div>
 			</ThumbnailWrapper>
 			{ showSiteDetails && (
 				<div className="home-site-preview__action-bar">

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -1,4 +1,4 @@
-import { Button } from '@automattic/components';
+import { Button, SiteThumbnail } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
@@ -9,10 +9,10 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { SiteUrl, Truncated } from 'calypso/sites-dashboard/components/sites-site-url';
 import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
-import { getWpComDomainBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import './style.scss';
 import { SitePreviewEllipsisMenu } from './site-preview-ellipsis-menu';
+
 interface ThumbnailWrapperProps {
 	showEditSite: boolean;
 	editSiteURL: string;
@@ -63,7 +63,6 @@ const SitePreview = ( {
 		canCurrentUser( state, selectedSite?.ID ?? 0, 'manage_options' )
 	);
 	const isMobile = useMobileBreakpoint();
-	const wpcomDomain = useSelector( ( state ) => getWpComDomainBySiteId( state, selectedSite?.ID ) );
 
 	if ( isMobile ) {
 		return <></>;
@@ -78,10 +77,6 @@ const SitePreview = ( {
 		  } )
 		: '#';
 
-	const iframeSrcKeepHomepage = wpcomDomain
-		? `//${ wpcomDomain.domain }/?hide_banners=true&preview_overlay=true&preview=true`
-		: '#';
-
 	const selectedSiteURL = selectedSite ? selectedSite.URL : '#';
 	const selectedSiteSlug = selectedSite ? selectedSite.slug : '...';
 	const selectedSiteName = selectedSite ? selectedSite.name : '&nbsp;';
@@ -94,18 +89,16 @@ const SitePreview = ( {
 						{ __( 'Edit site' ) }
 					</Button>
 				) }
-				<div className="home-site-preview__thumbnail">
-					{ wpcomDomain ? (
-						<iframe
-							scrolling="no"
-							loading="lazy"
-							title={ __( 'Site Preview' ) }
-							src={ iframeSrcKeepHomepage }
-						/>
-					) : (
-						<div className="home-site-preview__thumbnail-placeholder" />
-					) }
-				</div>
+				<SiteThumbnail
+					className="home-site-preview__thumbnail"
+					mShotsUrl={ addQueryArgs( selectedSite?.URL, {
+						iframe: true,
+						preview: true,
+						hide_banners: true,
+					} ) }
+					width={ 400 }
+					height={ 375 }
+				></SiteThumbnail>
 			</ThumbnailWrapper>
 			{ showSiteDetails && (
 				<div className="home-site-preview__action-bar">

--- a/client/my-sites/customer-home/cards/features/site-preview/index.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/index.tsx
@@ -13,7 +13,6 @@ import { getWpComDomainBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import './style.scss';
 import { SitePreviewEllipsisMenu } from './site-preview-ellipsis-menu';
-
 interface ThumbnailWrapperProps {
 	showEditSite: boolean;
 	editSiteURL: string;

--- a/client/my-sites/customer-home/cards/features/site-preview/site-preview-ellipsis-menu.tsx
+++ b/client/my-sites/customer-home/cards/features/site-preview/site-preview-ellipsis-menu.tsx
@@ -15,7 +15,9 @@ export const SitePreviewEllipsisMenu = () => {
 	const moreButtonRef = useRef( null );
 	const [ isShowingPopover, setIsShowingPopover ] = useState( false );
 
-	const classes = classNames( 'theme__more-button', { 'is-open': isShowingPopover } );
+	const classes = classNames( 'home-site-preview__ellipses-button', {
+		'is-open': isShowingPopover,
+	} );
 	const selectedSite = useSelector( getSelectedSite );
 
 	return (

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -32,22 +32,6 @@
 			height: 235px;
 			pointer-events: none;
 			width: 100%;
-			iframe {
-				// The idea is to zoom-out the iframe to get most of the content
-				// into the thumbnail and then we scale it down so it remains the
-				// size of the parent component (357% * 0.28 ~= 100%)
-				min-height: 375%;
-				width: 357%;
-				max-width: 357%;
-				transform: scale(0.28);
-				transform-origin: top left;
-				translate: 0 -10px;
-			}
-
-			.home-site-preview__thumbnail-placeholder {
-				height: 100%;
-				@include placeholder();
-			}
 		}
 
 		.home-site-preview__thumbnail-label {
@@ -74,13 +58,26 @@
 			max-width: calc(100% - 24px);
 
 			.home-site-preview__info-title {
-				color: var(--color-neutral-80);
+				color: var(--color-text);
 				flex: 1 1 auto;
 				font-family: inherit;
 				font-size: $font-body;
 				font-weight: 500;
 				line-height: 24px;
 			}
+		}
+	}
+
+	.home-site-preview__ellipses-button {
+		margin: auto 0;
+
+		.gridicon {
+			cursor: pointer;
+			fill: var(--color-neutral-light);
+		}
+
+		&.is-open .gridicon {
+			transform: rotate(90deg);
 		}
 	}
 }

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -73,7 +73,7 @@
 
 		.gridicon {
 			cursor: pointer;
-			fill: var(--color-neutral-light);
+			fill: var(--color-text-subtle);
 		}
 
 		&.is-open .gridicon {

--- a/client/my-sites/customer-home/cards/features/site-preview/style.scss
+++ b/client/my-sites/customer-home/cards/features/site-preview/style.scss
@@ -32,6 +32,22 @@
 			height: 235px;
 			pointer-events: none;
 			width: 100%;
+			iframe {
+				// The idea is to zoom-out the iframe to get most of the content
+				// into the thumbnail and then we scale it down so it remains the
+				// size of the parent component (357% * 0.28 ~= 100%)
+				min-height: 375%;
+				width: 357%;
+				max-width: 357%;
+				transform: scale(0.28);
+				transform-origin: top left;
+				translate: 0 -10px;
+			}
+
+			.home-site-preview__thumbnail-placeholder {
+				height: 100%;
+				@include placeholder();
+			}
 		}
 
 		.home-site-preview__thumbnail-label {


### PR DESCRIPTION
## Proposed Changes

There are two problems with the Site Preview card:

1) ~~Because it uses an iframe, it almost always gets obstructed by some sort of cookie consent form - either the Cookie Consent block or a third-party one. This seems like a perfect fit for the `SiteThumbnail` component that's used elsewhere in Calypso.~~ Removed - see discussion below. 
2) The styles are based on Theme styles, which isn't great. It doesn't lead to anything too outrageous, but it means the styles are different when the Themes stylesheet is loaded than if the page is loaded directly. If we want to reuse this, we should make a Component, but it's only a couple lines of CSS so it should be inserted here instead.

## Testing Instructions

(I've never really used TypeScript before, so go easy on me!) 

Compare the Site Preview card on My Home.

| Before | After |
|--------|--------|
| <img width="409" alt="Screenshot 2024-02-07 at 22 56 52" src="https://github.com/Automattic/wp-calypso/assets/43215253/9869f91e-1c85-4e28-8b83-7bd8a3445d75"> | <img width="383" alt="Screenshot 2024-02-07 at 23 19 46" src="https://github.com/Automattic/wp-calypso/assets/43215253/2d1c8152-ae3e-425c-803e-d9565df5572a"> |

That **Before** screenshot is taken when loading the page directly. If you go to the Themes page so that the other stylesheet loads and then My Home, the toggle will look more like the **After** screenshot. I've brought those styles into the relevant stylesheet. It's prettier, I think.  

cc @daledupreez, @sixhours, @andres-blanco
