### PR TITLE
Jetpack Manage: Add the 'Create a new Bluehost site' button.

### DIFF
--- a/client/components/bluehost-logo/index.tsx
+++ b/client/components/bluehost-logo/index.tsx
@@ -2,7 +2,7 @@ type Props = {
 	size?: number;
 };
 
-export default function BlueHostLogo( { size = 12 }: Props ) {
+export default function BluehostLogo( { size = 12 }: Props ) {
 	return (
 		<svg
 			className="gridicon bluehost-logo"

--- a/client/components/bluehost-logo/index.tsx
+++ b/client/components/bluehost-logo/index.tsx
@@ -1,0 +1,21 @@
+type Props = {
+	size?: number;
+};
+
+export default function BlueHostLogo( { size = 12 }: Props ) {
+	return (
+		<svg
+			className="gridicon bluehost-logo"
+			width={ `${ size }px` }
+			height={ `${ size }px` }
+			viewBox="0 0 1024 1024"
+			xmlns="http://www.w3.org/2000/svg"
+		>
+			<circle cx="512" cy="512" r="512" fill="#0076ff" />
+			<path
+				d="M303.9 303.4h116.2v116.2H303.9V303.4zm149.8 0h116.2v116.2H453.7V303.4zm150.2 0h116.2v116.2H603.9V303.4zm-300 150.5h116.2v116.2H303.9V453.9zm149.8 0h116.2v116.2H453.7V453.9zm150.2 0h116.2v116.2H603.9V453.9zm-300 150.5h116.2v116.2H303.9V604.4zm149.8 0h116.2v116.2H453.7V604.4zm150.2 0h116.2v116.2H603.9V604.4z"
+				fill="#fff"
+			/>
+		</svg>
+	);
+}

--- a/client/components/jetpack/add-new-site-button/index.tsx
+++ b/client/components/jetpack/add-new-site-button/index.tsx
@@ -34,7 +34,8 @@ const AddNewSiteButton = ( {
 
 	const jetpackConnectUrl = 'https://wordpress.com/jetpack/connect?source=jetpack-manage';
 
-	const bluehostCreateSiteUrl = ''; // TODO: Add Bluehost create site URL
+	const bluehostCreateSiteUrl =
+		'https://www.bluehost.com/hosting/cloud?utm_campaign=wordpresscloud_jetpack&utm_source=wordpresscom&utm_medium=referral&channelid=P61C46097236S625N0B2A151D0E0000V105';
 
 	return (
 		<SplitButton

--- a/client/components/jetpack/add-new-site-button/index.tsx
+++ b/client/components/jetpack/add-new-site-button/index.tsx
@@ -60,7 +60,7 @@ const AddNewSiteButton = ( {
 
 			<PopoverMenuItem onClick={ onClickBlueHostMenuItem } href={ bluehostCreateSiteUrl }>
 				<BlueHostLogo size={ 18 } />
-				<span>{ translate( 'Create a new Bluehost site' ) }</span>
+				<span>{ translate( 'Create a new BlueHost site' ) }</span>
 			</PopoverMenuItem>
 
 			{ isEnabled( 'jetpack/url-only-connection' ) && (

--- a/client/components/jetpack/add-new-site-button/index.tsx
+++ b/client/components/jetpack/add-new-site-button/index.tsx
@@ -1,7 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Gridicon, WordPressLogo } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
-import BlueHostLogo from 'calypso/components/bluehost-logo';
+import BluehostLogo from 'calypso/components/bluehost-logo';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SplitButton from 'calypso/components/split-button';
@@ -15,7 +15,7 @@ type Props = {
 	onClickAddNewSite?: () => void;
 	onClickWpcomMenuItem?: () => void;
 	onClickJetpackMenuItem?: () => void;
-	onClickBlueHostMenuItem?: () => void;
+	onClickBluehostMenuItem?: () => void;
 	onClickUrlMenuItem?: () => void;
 };
 
@@ -27,7 +27,7 @@ const AddNewSiteButton = ( {
 	onClickAddNewSite,
 	onClickWpcomMenuItem,
 	onClickJetpackMenuItem,
-	onClickBlueHostMenuItem,
+	onClickBluehostMenuItem,
 	onClickUrlMenuItem,
 }: Props ): JSX.Element => {
 	const translate = useTranslate();
@@ -58,9 +58,9 @@ const AddNewSiteButton = ( {
 				<span>{ translate( 'Connect a site to Jetpack' ) }</span>
 			</PopoverMenuItem>
 
-			<PopoverMenuItem onClick={ onClickBlueHostMenuItem } href={ bluehostCreateSiteUrl }>
-				<BlueHostLogo size={ 18 } />
-				<span>{ translate( 'Create a new BlueHost site' ) }</span>
+			<PopoverMenuItem onClick={ onClickBluehostMenuItem } href={ bluehostCreateSiteUrl }>
+				<BluehostLogo size={ 18 } />
+				<span>{ translate( 'Create a new Bluehost site' ) }</span>
 			</PopoverMenuItem>
 
 			{ isEnabled( 'jetpack/url-only-connection' ) && (

--- a/client/components/jetpack/add-new-site-button/index.tsx
+++ b/client/components/jetpack/add-new-site-button/index.tsx
@@ -1,6 +1,7 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { Gridicon, WordPressLogo } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import BlueHostLogo from 'calypso/components/bluehost-logo';
 import JetpackLogo from 'calypso/components/jetpack-logo';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
 import SplitButton from 'calypso/components/split-button';
@@ -14,6 +15,7 @@ type Props = {
 	onClickAddNewSite?: () => void;
 	onClickWpcomMenuItem?: () => void;
 	onClickJetpackMenuItem?: () => void;
+	onClickBlueHostMenuItem?: () => void;
 	onClickUrlMenuItem?: () => void;
 };
 
@@ -25,11 +27,14 @@ const AddNewSiteButton = ( {
 	onClickAddNewSite,
 	onClickWpcomMenuItem,
 	onClickJetpackMenuItem,
+	onClickBlueHostMenuItem,
 	onClickUrlMenuItem,
 }: Props ): JSX.Element => {
 	const translate = useTranslate();
 
 	const jetpackConnectUrl = 'https://wordpress.com/jetpack/connect?source=jetpack-manage';
+
+	const bluehostCreateSiteUrl = ''; // TODO: Add Bluehost create site URL
 
 	return (
 		<SplitButton
@@ -51,6 +56,11 @@ const AddNewSiteButton = ( {
 			<PopoverMenuItem onClick={ onClickJetpackMenuItem } href={ jetpackConnectUrl }>
 				<JetpackLogo className="gridicon" size={ 18 } />
 				<span>{ translate( 'Connect a site to Jetpack' ) }</span>
+			</PopoverMenuItem>
+
+			<PopoverMenuItem onClick={ onClickBlueHostMenuItem } href={ bluehostCreateSiteUrl }>
+				<BlueHostLogo size={ 18 } />
+				<span>{ translate( 'Create a new Bluehost site' ) }</span>
 			</PopoverMenuItem>
 
 			{ isEnabled( 'jetpack/url-only-connection' ) && (

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -503,6 +503,11 @@ export class SiteSelector extends Component {
 											'calypso_jetpack_agency_dashboard_sidebar_connect_jetpack_site_click'
 										)
 									}
+									onClickBlueHostMenuItem={ () =>
+										this.props.recordTracksEvent(
+											'calypso_jetpack_agency_dashboard_sidebar_create_bluehost_site_click'
+										)
+									}
 								/>
 							) : (
 								<SiteSelectorAddSite />

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -503,7 +503,7 @@ export class SiteSelector extends Component {
 											'calypso_jetpack_agency_dashboard_sidebar_connect_jetpack_site_click'
 										)
 									}
-									onClickBlueHostMenuItem={ () =>
+									onClickBluehostMenuItem={ () =>
 										this.props.recordTracksEvent(
 											'calypso_jetpack_agency_dashboard_sidebar_create_bluehost_site_click'
 										)

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
@@ -71,7 +71,7 @@ export default function SiteTopHeaderButtons() {
 								)
 							)
 						}
-						onClickBlueHostMenuItem={ () =>
+						onClickBluehostMenuItem={ () =>
 							dispatch(
 								recordTracksEvent(
 									'calypso_jetpack_agency_dashboard_sites_overview_create_bluehost_site_click'

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
@@ -71,6 +71,13 @@ export default function SiteTopHeaderButtons() {
 								)
 							)
 						}
+						onClickBlueHostMenuItem={ () =>
+							dispatch(
+								recordTracksEvent(
+									'calypso_jetpack_agency_dashboard_sites_overview_create_bluehost_site_click'
+								)
+							)
+						}
 						onClickUrlMenuItem={ () =>
 							dispatch(
 								recordTracksEvent(


### PR DESCRIPTION
This pull request includes the addition of a 'Create a new Bluehost site' button to Jetpack Manage.

**Dashboard**
<img width="434" alt="Screenshot 2024-02-08 at 2 55 31 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/c9b591d2-4fe2-4153-abe8-a02d6018ebf8">


**Sidebar**
<img width="760" alt="Screenshot 2024-02-08 at 2 58 50 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/ab92f3b3-ea2a-4e9d-b1b4-486718cbbaeb">



Related to https://github.com/Automattic/jetpack-roadmap/issues/1199

## Proposed Changes

* Add 'Create a new BlueHost site' button in the `AddNewSiteSplitButton` component.

## Testing Instructions
Since these changes are made specifically for agencies, you must set yourself(partner) as an agency - 2c49b-pb.

* Use the Jetpack cloud live link below and go to the Dashboard page (/dashboard)
* Click the dropdown button next to the **'Add new site'** button.
* Confirm that the button is visible and redirects to the correct Bluehost page.
* Similarly, click the Site selector in the sidebar and confirm the button is also visible when pressing the dropdown menu next to the **'Add new site'** button.


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?