### PR TITLE
Site Transfer: Add new route to accept and initiate automated site transfer

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -16,6 +16,7 @@ import DeleteSite from './delete-site';
 import DisconnectSite from './disconnect-site';
 import ConfirmDisconnection from './disconnect-site/confirm';
 import ManageConnection from './manage-connection';
+import { AcceptSiteTransfer } from './site-owner-transfer/accept-site-transfer';
 import SiteOwnerTransfer from './site-owner-transfer/site-owner-transfer';
 import SiteTransferred from './site-owner-transfer/site-transferred';
 import StartOver from './start-over';
@@ -120,6 +121,18 @@ export function startSiteOwnerTransfer( context, next ) {
 
 export function renderSiteTransferredScreen( context, next ) {
 	context.primary = <SiteTransferred />;
+	next();
+}
+
+export function acceptSiteTransfer( context, next ) {
+	context.primary = (
+		<AcceptSiteTransfer
+			siteId={ context.params.site_id }
+			inviteKey={ context.params.invitation_key }
+			redirectTo={ context.query.nextStep }
+			dispatch={ context.store.dispatch }
+		/>
+	);
 	next();
 }
 

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -3,6 +3,7 @@ import { get } from 'lodash';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { navigation, siteSelection, sites } from 'calypso/my-sites/controller';
 import {
+	acceptSiteTransfer,
 	deleteSite,
 	disconnectSite,
 	disconnectSiteConfirm,
@@ -117,6 +118,13 @@ export default function () {
 		'/settings/site-transferred/:site_id',
 		siteSelection,
 		renderSiteTransferredScreen,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/settings/site-transfer/:site_id/accept/:invitation_key',
+		acceptSiteTransfer,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
@@ -1,0 +1,68 @@
+/* eslint-disable prettier/prettier */
+/* eslint-disable import/order */
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import ActionPanel from 'calypso/components/action-panel';
+import HeaderCake from 'calypso/components/header-cake';
+import Main from 'calypso/components/main';
+import NavigationHeader from 'calypso/components/navigation-header';
+import { navigate } from 'calypso/lib/navigate';
+import { acceptInvite } from 'calypso/state/invites/actions';
+import { useEffect } from '@wordpress/element';
+import wpcom from 'calypso/lib/wp';
+import normalizeInvite from 'calypso/my-sites/invites/invite-accept/utils/normalize-invite';
+import { LoadingBar } from 'calypso/components/loading-bar';
+import { errorNotice } from 'calypso/state/notices/actions';
+import store from 'store';
+
+const ActionPanelStyled = styled( ActionPanel )( {
+	fontSize: '14px',
+	fontWeight: 400,
+	'.action-panel__body': {
+		color: 'var(--studio-gray-70)',
+	},
+} );
+
+export function AcceptSiteTransfer( props: any ) {
+	const dispatch = props.dispatch;
+
+	const progress = 0.2;
+
+	const fetchAndAcceptInvite = async ( props: any ) => {
+		try {
+			const { siteId, inviteKey, redirectTo } = props;
+			const response = await wpcom.req.get( `/sites/${ siteId }/invites/${ inviteKey }` );
+			const invite = normalizeInvite( response );
+
+			invite.inviteKey = inviteKey;
+
+			await dispatch( acceptInvite( invite, null ) );
+
+			store.set( 'accepted_site_transfer_invite', invite );
+			navigate( redirectTo );
+		} catch {
+			dispatch( errorNotice( 'Failed to accept the transfer!' ) );
+			navigate( '/sites' );
+		}
+	};
+
+	useEffect( () => {
+		fetchAndAcceptInvite( props );
+	} );
+
+	const translate = useTranslate();
+	return (
+		<Main>
+			<NavigationHeader navigationItems={ [] } title={ translate( 'Site Transfer' ) } />
+			<HeaderCake isCompact={ true }>
+				<h1>{ translate( 'Site Transfer' ) }</h1>
+			</HeaderCake>
+			<ActionPanelStyled>
+				<p>
+					<LoadingBar key="transfer-site-loading-bar" progress={ progress } />
+				</p>
+				<p>{ translate( 'We are transferring your site.' ) }</p>
+			</ActionPanelStyled>
+		</Main>
+	);
+}

--- a/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
@@ -3,9 +3,7 @@
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import ActionPanel from 'calypso/components/action-panel';
-import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
-import NavigationHeader from 'calypso/components/navigation-header';
 import { navigate } from 'calypso/lib/navigate';
 import { acceptInvite } from 'calypso/state/invites/actions';
 import { useEffect } from '@wordpress/element';
@@ -14,9 +12,13 @@ import normalizeInvite from 'calypso/my-sites/invites/invite-accept/utils/normal
 import { LoadingBar } from 'calypso/components/loading-bar';
 import { errorNotice } from 'calypso/state/notices/actions';
 import store from 'store';
+import DocumentHead from 'calypso/components/data/document-head';
+import { Global, css } from '@emotion/react';
+import MasterbarStyled from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled';
 
 const ActionPanelStyled = styled( ActionPanel )( {
 	fontSize: '14px',
+	margin: '20% 30px 0 30px',
 	fontWeight: 400,
 	'.action-panel__body': {
 		color: 'var(--studio-gray-70)',
@@ -26,7 +28,7 @@ const ActionPanelStyled = styled( ActionPanel )( {
 export function AcceptSiteTransfer( props: any ) {
 	const dispatch = props.dispatch;
 
-	const progress = 0.2;
+	const progress = 0.15;
 
 	const fetchAndAcceptInvite = async ( props: any ) => {
 		try {
@@ -52,17 +54,25 @@ export function AcceptSiteTransfer( props: any ) {
 
 	const translate = useTranslate();
 	return (
-		<Main>
-			<NavigationHeader navigationItems={ [] } title={ translate( 'Site Transfer' ) } />
-			<HeaderCake isCompact={ true }>
-				<h1>{ translate( 'Site Transfer' ) }</h1>
-			</HeaderCake>
-			<ActionPanelStyled>
-				<p>
-					<LoadingBar key="transfer-site-loading-bar" progress={ progress } />
-				</p>
-				<p>{ translate( 'We are transferring your site.' ) }</p>
-			</ActionPanelStyled>
-		</Main>
+		<>
+			<DocumentHead title={ translate( 'Site Transfer' ) } />
+			<Global
+				styles={ css`
+					body.is-section-settings,
+					body.is-section-settings .layout__content {
+						background: var( --studio-white );
+					}
+				` }
+			/>
+			<MasterbarStyled canGoBack={ false } />
+			<Main>
+				<ActionPanelStyled>
+					<p>{ translate( 'Hold tight. We are making it happen!' ) }</p>
+					<p>
+						<LoadingBar key="transfer-site-loading-bar" progress={ progress } />
+					</p>
+				</ActionPanelStyled>
+			</Main>
+		</>
 	);
 }

--- a/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
@@ -35,14 +35,14 @@ export function AcceptSiteTransfer( props: any ) {
 	const fetchAndAcceptInvite = async ( props: any ) => {
 		try {
 			const { siteId, inviteKey, redirectTo } = props;
-			const response = await wpcom.req.get( `/sites/${ siteId }/invites/${ inviteKey }` );
-			const pendingInvite = normalizeInvite( response );
+			const pendingInvite = await wpcom.req.get( `/sites/${ siteId }/invites/${ inviteKey }` );
+			const invite = normalizeInvite( pendingInvite );
 
-			pendingInvite.inviteKey = inviteKey;
+			invite.inviteKey = inviteKey;
 
-			await dispatch( acceptInvite( pendingInvite, null ) );
+			await dispatch( acceptInvite( invite, null ) );
 
-			store.set( 'accepted_site_transfer_invite', pendingInvite );
+			store.set( 'accepted_site_transfer_invite', invite );
 			navigate( redirectTo );
 		} catch {
 			setError(

--- a/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
@@ -10,11 +10,12 @@ import { useEffect } from '@wordpress/element';
 import wpcom from 'calypso/lib/wp';
 import normalizeInvite from 'calypso/my-sites/invites/invite-accept/utils/normalize-invite';
 import { LoadingBar } from 'calypso/components/loading-bar';
-import { errorNotice } from 'calypso/state/notices/actions';
 import store from 'store';
 import DocumentHead from 'calypso/components/data/document-head';
 import { Global, css } from '@emotion/react';
 import MasterbarStyled from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled';
+import { useState } from 'react';
+import Notice from 'calypso/components/notice';
 
 const ActionPanelStyled = styled( ActionPanel )( {
 	fontSize: '14px',
@@ -26,9 +27,10 @@ const ActionPanelStyled = styled( ActionPanel )( {
 } );
 
 export function AcceptSiteTransfer( props: any ) {
+	const translate = useTranslate();
 	const dispatch = props.dispatch;
-
 	const progress = 0.15;
+	const [ error, setError ] = useState< string >( '' );
 
 	const fetchAndAcceptInvite = async ( props: any ) => {
 		try {
@@ -43,8 +45,11 @@ export function AcceptSiteTransfer( props: any ) {
 			store.set( 'accepted_site_transfer_invite', invite );
 			navigate( redirectTo );
 		} catch {
-			dispatch( errorNotice( 'Failed to accept the transfer!' ) );
-			navigate( '/sites' );
+			setError(
+				translate(
+					'Failed to add you as an administrator in the site. Please contact the original site owner to invite you as administrator first'
+				)
+			);
 		}
 	};
 
@@ -52,7 +57,25 @@ export function AcceptSiteTransfer( props: any ) {
 		fetchAndAcceptInvite( props );
 	} );
 
-	const translate = useTranslate();
+	const renderLoadingBar = () => {
+		return (
+			<>
+				<p>{ translate( 'Hold tight. We are making it happen!' ) }</p>
+				<LoadingBar key="transfer-site-loading-bar" progress={ progress } />
+			</>
+		);
+	};
+
+	const renderError = () => {
+		return (
+			<Notice status="is-error" showDismiss={ false }>
+				<div data-testid="error">
+					<p>{ error }</p>
+				</div>
+			</Notice>
+		);
+	};
+
 	return (
 		<>
 			<DocumentHead title={ translate( 'Site Transfer' ) } />
@@ -66,12 +89,7 @@ export function AcceptSiteTransfer( props: any ) {
 			/>
 			<MasterbarStyled canGoBack={ false } />
 			<Main>
-				<ActionPanelStyled>
-					<p>{ translate( 'Hold tight. We are making it happen!' ) }</p>
-					<p>
-						<LoadingBar key="transfer-site-loading-bar" progress={ progress } />
-					</p>
-				</ActionPanelStyled>
+				<ActionPanelStyled>{ ! error ? renderLoadingBar() : renderError() }</ActionPanelStyled>
 			</Main>
 		</>
 	);

--- a/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
@@ -47,7 +47,7 @@ export function AcceptSiteTransfer( props: any ) {
 		} catch {
 			setError(
 				translate(
-					'Failed to add you as an administrator in the site. Please contact the original site owner to invite you as administrator first'
+					'Failed to add you as an administrator in the site. Please contact the original site owner to invite you as administrator first.'
 				)
 			);
 		}

--- a/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
@@ -36,13 +36,13 @@ export function AcceptSiteTransfer( props: any ) {
 		try {
 			const { siteId, inviteKey, redirectTo } = props;
 			const response = await wpcom.req.get( `/sites/${ siteId }/invites/${ inviteKey }` );
-			const invite = normalizeInvite( response );
+			const pendingInvite = normalizeInvite( response );
 
-			invite.inviteKey = inviteKey;
+			pendingInvite.inviteKey = inviteKey;
 
-			await dispatch( acceptInvite( invite, null ) );
+			await dispatch( acceptInvite( pendingInvite, null ) );
 
-			store.set( 'accepted_site_transfer_invite', invite );
+			store.set( 'accepted_site_transfer_invite', pendingInvite );
 			navigate( redirectTo );
 		} catch {
 			setError(

--- a/client/state/selectors/can-current-user-start-site-owner-transfer.ts
+++ b/client/state/selectors/can-current-user-start-site-owner-transfer.ts
@@ -1,4 +1,5 @@
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import store from 'store';
+import { getCurrentUserEmail, getCurrentUserId } from 'calypso/state/current-user/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
@@ -19,6 +20,7 @@ export default function canCurrentUserStartSiteOwnerTransfer(
 	siteId: number | null
 ): boolean {
 	const userId = getCurrentUserId( state );
+	const userEmail = getCurrentUserEmail( state );
 	const siteOwnerId = getSelectedSite( state )?.site_owner;
 	if ( ! siteOwnerId || ! userId || ! siteId ) {
 		return false;
@@ -36,6 +38,16 @@ export default function canCurrentUserStartSiteOwnerTransfer(
 		isSiteWpcomStaging( state, siteId )
 	) {
 		return false;
+	}
+
+	const inviteCacheKey = 'accepted_site_transfer_invite';
+	const acceptedInvite = store.get( inviteCacheKey );
+
+	store.remove( inviteCacheKey );
+
+	// Allow user to accept the site transfer if they just have accepted the site transfer.
+	if ( acceptedInvite && acceptedInvite.sentTo === userEmail ) {
+		return true;
 	}
 
 	return siteOwnerId === userId;

--- a/client/state/selectors/can-current-user-start-site-owner-transfer.ts
+++ b/client/state/selectors/can-current-user-start-site-owner-transfer.ts
@@ -1,5 +1,3 @@
-import store from 'store';
-import { getCurrentUserEmail, getCurrentUserId } from 'calypso/state/current-user/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
@@ -20,7 +18,6 @@ export default function canCurrentUserStartSiteOwnerTransfer(
 	siteId: number | null
 ): boolean {
 	const userId = getCurrentUserId( state );
-	const userEmail = getCurrentUserEmail( state );
 	const siteOwnerId = getSelectedSite( state )?.site_owner;
 	if ( ! siteOwnerId || ! userId || ! siteId ) {
 		return false;
@@ -38,16 +35,6 @@ export default function canCurrentUserStartSiteOwnerTransfer(
 		isSiteWpcomStaging( state, siteId )
 	) {
 		return false;
-	}
-
-	const inviteCacheKey = 'accepted_site_transfer_invite';
-	const acceptedInvite = store.get( inviteCacheKey );
-
-	store.remove( inviteCacheKey );
-
-	// Allow user to accept the site transfer if they just have accepted the site transfer.
-	if ( acceptedInvite && acceptedInvite.sentTo === userEmail ) {
-		return true;
 	}
 
 	return siteOwnerId === userId;

--- a/client/state/selectors/can-current-user-start-site-owner-transfer.ts
+++ b/client/state/selectors/can-current-user-start-site-owner-transfer.ts
@@ -1,3 +1,4 @@
+import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5365

## Proposed Changes

* Adds new route to automatically accept admin role invite when user clicks on accept transfer link on email.
* Once user is added to the site, redirect user to actual transfer screen. 
* This screen is added to enforce 2 factor authentication while doing the transfer.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply patch D137375-code to your sandbox and sandbox public API.
* Update the calypso live or calypso local URL (of this branch for testing) in the `get_accept_transfer_link` function on the backend.
* Initiate a site transfer to the new email address on the branch https://github.com/Automattic/wp-calypso/pull/87001.
* When a new user clicks on "Sign up and accept transfer," make sure you are accessing this branch.
* Once the user clicks "Sign up and accept transfer," the following things should be happening:
    * The user is automatically logged in using a magic link.
    * Then, you are redirected to the site transfer screen where internally you are being added to the site as admin. The route is added in this branch.
    * Then, you are redirected to the confirm transfer screen to complete the actual site transfer.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?