### PR TITLE
Import content onboarding flow: Fix the ProgressBar screen alignments

### DIFF
--- a/client/blocks/importer/components/progress-screen/index.tsx
+++ b/client/blocks/importer/components/progress-screen/index.tsx
@@ -40,13 +40,17 @@ const ProgressScreen: React.FunctionComponent< Props > = ( props ) => {
 		job?.importerFileType !== 'playground' ? __( 'Importing' ) : getPlaygroundImportTitle();
 
 	return (
-		<Progress>
-			<Title>{ title }...</Title>
-			<ProgressBar compact={ true } value={ progressValue } />
-			<SubTitle>
-				{ __( 'Feel free to close this window. We’ll email you when your new site is ready.' ) }
-			</SubTitle>
-		</Progress>
+		<div className="import-layout__center">
+			<Progress>
+				<div className="import__heading import__heading-center">
+					<Title>{ title }...</Title>
+					<ProgressBar compact={ true } value={ progressValue } />
+					<SubTitle>
+						{ __( 'Feel free to close this window. We’ll email you when your new site is ready.' ) }
+					</SubTitle>
+				</div>
+			</Progress>
+		</div>
 	);
 };
 

--- a/client/blocks/importer/wordpress/import-content-only/index.tsx
+++ b/client/blocks/importer/wordpress/import-content-only/index.tsx
@@ -148,11 +148,7 @@ const ImportContentOnly: React.FunctionComponent< Props > = ( props ) => {
 				'import__error-message': renderState === 'error',
 			} ) }
 		>
-			{ renderState === 'progress' && (
-				<div className="import-layout__center">
-					<ProgressScreen job={ job } />
-				</div>
-			) }
+			{ renderState === 'progress' && <ProgressScreen job={ job } /> }
 
 			{ renderState === 'error' && (
 				<ErrorMessage


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

- Center progress bar screen centrally to match the design applied on the import everything flow
- Center sub-title (regression introduced by recent changes)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/import-focused?siteSlug={SITE_SLUG}`
* Select "choose a content platform"
* Select WordPress
* Upload an XML/ZIP backup file
* Check if the progress bar is centrally position

| Header | Header |
|--------|--------|
| <img width="1011" alt="Screenshot 2024-02-08 at 13 08 51" src="https://github.com/Automattic/wp-calypso/assets/1241413/6a2c8848-0c51-4db8-a77a-04790bb3e3e8"> | <img width="1010" alt="Screenshot 2024-02-08 at 13 06 04" src="https://github.com/Automattic/wp-calypso/assets/1241413/444f808b-3f4d-4aad-9201-1b05e01d99ee"> | 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?