### PR TITLE
Launchpad: Move the onboarding tasks click tracking to Launchpad internal

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/sidebar.tsx
@@ -274,6 +274,7 @@ const Sidebar = ( {
 						</div>
 					) }
 					<LaunchpadInternal
+						flow={ flow }
 						site={ site }
 						siteSlug={ launchpadKey }
 						checklistSlug={ checklistSlug }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/bio/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/bio/index.tsx
@@ -5,7 +5,6 @@ import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { getSiteIdOrSlug } from '../../task-helper';
-import { recordTaskClickTracksEvent } from '../../tracking';
 import { type TaskAction } from '../../types';
 
 export const getSetupLinkInBioTask: TaskAction = ( task, flow, context ) => {
@@ -13,7 +12,6 @@ export const getSetupLinkInBioTask: TaskAction = ( task, flow, context ) => {
 
 	return {
 		...task,
-		actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
 		calypso_path: addQueryArgs( `/setup/link-in-bio-post-setup/linkInBioPostSetup`, {
 			...getSiteIdOrSlug( flow, site, siteSlug ),
 		} ),
@@ -21,7 +19,7 @@ export const getSetupLinkInBioTask: TaskAction = ( task, flow, context ) => {
 	};
 };
 
-export const getLinkInBioLaunchedTask: TaskAction = ( task, flow, context ) => {
+export const getLinkInBioLaunchedTask: TaskAction = ( task, _, context ) => {
 	const { siteSlug, site, submit } = context;
 	return {
 		...task,
@@ -37,7 +35,6 @@ export const getLinkInBioLaunchedTask: TaskAction = ( task, flow, context ) => {
 
 					// Waits for half a second so that the loading screen doesn't flash away too quickly
 					await new Promise( ( res ) => setTimeout( res, 500 ) );
-					recordTaskClickTracksEvent( task, flow, context );
 					return { goToHome: true, siteSlug };
 				} );
 
@@ -47,10 +44,9 @@ export const getLinkInBioLaunchedTask: TaskAction = ( task, flow, context ) => {
 	};
 };
 
-export const getLinksAddedTask: TaskAction = ( task, flow, context ) => {
+export const getLinksAddedTask: TaskAction = ( task ) => {
 	return {
 		...task,
-		actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
 		calyso_path: addQueryArgs( task.calypso_path, { canvas: 'edit' } ),
 		useCalypsoPath: true,
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/content/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/content/index.tsx
@@ -1,6 +1,5 @@
 import { updateLaunchpadSettings } from '@automattic/data-stores/src/queries/use-launchpad';
 import { isNewsletterFlow } from '@automattic/onboarding';
-import { recordTaskClickTracksEvent } from '../../tracking';
 import { TaskAction } from '../../types';
 
 const completeMigrateContentTask = async ( siteSlug: string | null ) => {
@@ -18,7 +17,6 @@ export const getMigrateContentTask: TaskAction = ( task, flow, context ) => {
 		...task,
 		disabled: mustVerifyEmailBeforePosting || false,
 		actionDispatch: () => {
-			recordTaskClickTracksEvent( task, flow, context );
 			completeMigrateContentTask( siteSlug );
 		},
 		useCalypsoPath: true,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/design/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/design/index.tsx
@@ -1,7 +1,6 @@
 import { Task } from '@automattic/launchpad';
 import { addQueryArgs } from '@wordpress/url';
 import { getSiteIdOrSlug } from '../../task-helper';
-import { recordTaskClickTracksEvent } from '../../tracking';
 import { TaskAction } from '../../types';
 
 export const getDesignSelectedTask: TaskAction = ( task, flow, context ): Task => {
@@ -9,7 +8,6 @@ export const getDesignSelectedTask: TaskAction = ( task, flow, context ): Task =
 
 	return {
 		...task,
-		actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
 		calypso_path: addQueryArgs( task.calypso_path, {
 			...getSiteIdOrSlug( flow, site, siteSlug ),
 			flowToReturnTo: flow,
@@ -22,10 +20,9 @@ export const getDesignCompletedTask = getDesignSelectedTask;
 
 export const getDesignEditedTask: TaskAction = ( task, flow, context ) => {
 	const { site, siteSlug } = context;
-  
+
 	return {
 		...task,
-		actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
 		calypso_path: addQueryArgs( task.calypso_path, {
 			...getSiteIdOrSlug( flow, site, siteSlug ),
 			canvas: 'edit',

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/domain/index.tsx
@@ -2,8 +2,7 @@ import { Task } from '@automattic/launchpad';
 import { isBlogOnboardingFlow, isSiteAssemblerFlow } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
-import { getSiteIdOrSlug, isDomainUpsellCompleted } from '../../task-helper';
-import { recordTaskClickTracksEvent } from '../../tracking';
+import { isDomainUpsellCompleted, getSiteIdOrSlug } from '../../task-helper';
 import { TaskAction } from '../../types';
 
 export const getDomainUpSellTask: TaskAction = ( task, flow, context ): Task => {
@@ -32,8 +31,6 @@ export const getDomainUpSellTask: TaskAction = ( task, flow, context ): Task => 
 	return {
 		...task,
 		completed: domainUpsellCompleted,
-		actionDispatch: () =>
-			recordTaskClickTracksEvent( { ...task, completed: domainUpsellCompleted }, flow, context ),
 		calypso_path: getDestionationUrl(),
 		badge_text:
 			domainUpsellCompleted || isBlogOnboardingFlow( flow ) || isSiteAssemblerFlow( flow )

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/email/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/email/index.tsx
@@ -1,5 +1,4 @@
 import { Task } from '@automattic/launchpad';
-import { recordTaskClickTracksEvent } from '../../tracking';
 import { TaskAction } from '../../types';
 
 export const getVerifyEmail: TaskAction = ( task, flow, context ): Task => {
@@ -8,7 +7,6 @@ export const getVerifyEmail: TaskAction = ( task, flow, context ): Task => {
 	return {
 		...task,
 		completed: isEmailVerified || false,
-		actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
 		useCalypsoPath: true,
 	};
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/payments/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/payments/index.tsx
@@ -1,5 +1,4 @@
 import { translate } from 'i18n-calypso';
-import { recordTaskClickTracksEvent } from '../../tracking';
 import { type TaskAction } from '../../types';
 
 export const getSetupPaymentsTask: TaskAction = ( task, flow, context ) => {
@@ -8,7 +7,6 @@ export const getSetupPaymentsTask: TaskAction = ( task, flow, context ) => {
 	return {
 		...task,
 		badge_text: task.completed ? translate( 'Connected' ) : null,
-		actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
 		calypso_path: stripeConnectUrl ? stripeConnectUrl : `/earn/payments/${ siteSlug }#launchpad`,
 		useCalypsoPath: true,
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/plan/index.tsx
@@ -14,10 +14,7 @@ import { addQueryArgs } from '@wordpress/url';
 import { translate } from 'i18n-calypso';
 import { ADD_TIER_PLAN_HASH } from 'calypso/my-sites/earn/memberships/constants';
 import { getSiteIdOrSlug } from '../../task-helper';
-import {
-	recordGlobalStylesGattingPlanSelectedResetStylesEvent,
-	recordTaskClickTracksEvent,
-} from '../../tracking';
+import { recordGlobalStylesGattingPlanSelectedResetStylesEvent } from '../../tracking';
 import { TaskAction, TaskContext } from '../../types';
 
 const getPlanTaskSubtitle = (
@@ -68,7 +65,6 @@ export const getPlanSelectedTask: TaskAction = ( task, flow, context ): Task => 
 	return {
 		...task,
 		actionDispatch: () => {
-			recordTaskClickTracksEvent( task, flow, context );
 			if ( displayGlobalStylesWarning ) {
 				recordGlobalStylesGattingPlanSelectedResetStylesEvent( task, flow, context, {
 					displayGlobalStylesWarning,
@@ -96,7 +92,6 @@ const getPlanCompletedTask: TaskAction = ( task, flow, context ) => {
 
 	return {
 		...task,
-		actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
 		calypso_path: addQueryArgs( `/setup/${ flow }/plans`, {
 			...getSiteIdOrSlug( flow, site, siteSlug ),
 		} ),
@@ -123,7 +118,6 @@ const getNewsLetterPlanCreated: TaskAction = ( task, flow, context ) => {
 	return {
 		...task,
 		actionDispatch: () => {
-			recordTaskClickTracksEvent( task, flow, context );
 			completePaidNewsletterTask( siteSlug, queryClient );
 			site?.ID
 				? setShowPlansModal( true )

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/post/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/post/index.tsx
@@ -1,9 +1,7 @@
 import { Task } from '@automattic/launchpad';
 import { isBlogOnboardingFlow, isNewsletterFlow } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
-import { recordTaskClickTracksEvent } from '../../tracking';
 import { TaskAction } from '../../types';
-
 
 export const getFirstPostPublished: TaskAction = ( task, flow, context ): Task => {
 	const { siteSlug, isEmailVerified } = context;
@@ -11,14 +9,15 @@ export const getFirstPostPublished: TaskAction = ( task, flow, context ): Task =
 
 	return {
 		...task,
-		disabled: mustVerifyEmailBeforePosting || ( task.completed && isBlogOnboardingFlow( flow || null ) ) ||
+		disabled:
+			mustVerifyEmailBeforePosting ||
+			( task.completed && isBlogOnboardingFlow( flow || null ) ) ||
 			false,
 		calypso_path: ! isBlogOnboardingFlow( flow || null )
 			? `/post/${ siteSlug }`
 			: addQueryArgs( `https://${ siteSlug }/wp-admin/post-new.php`, {
 					origin: window.location.origin,
-			 } ),
-		actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
+			  } ),
 		useCalypsoPath: true,
 	};
 };
@@ -31,7 +30,6 @@ const getFirstPostPublishedNewsletterTask: TaskAction = ( task, flow, context ):
 		...task,
 		isLaunchTask: true,
 		disabled: mustVerifyEmailBeforePosting || false,
-		actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
 		useCalypsoPath: true,
 	};
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/setup/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/setup/index.tsx
@@ -2,7 +2,6 @@ import { type Task } from '@automattic/launchpad';
 import { isBlogOnboardingFlow } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
 import { getSiteIdOrSlug } from '../../task-helper';
-import { recordTaskClickTracksEvent } from '../../tracking';
 import { type TaskAction } from '../../types';
 
 export const getSetupFreeTask: TaskAction = ( task, flow, context ): Task => {
@@ -10,7 +9,6 @@ export const getSetupFreeTask: TaskAction = ( task, flow, context ): Task => {
 
 	return {
 		...task,
-		actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
 		calypso_path: addQueryArgs( `/setup/${ flow }/freePostSetup`, {
 			...getSiteIdOrSlug( flow, site, siteSlug ),
 		} ),
@@ -23,7 +21,6 @@ export const getSetupBlogTask: TaskAction = ( task, flow, context ): Task => {
 
 	return {
 		...task,
-		actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
 		calypso_path: addQueryArgs( task.calypso_path, { ...getSiteIdOrSlug( flow, site, siteSlug ) } ),
 		disabled: task.completed && ! isBlogOnboardingFlow( flow ),
 		useCalypsoPath: true,
@@ -35,7 +32,6 @@ export const getSetupNewsletterTask: TaskAction = ( task, flow, context ): Task 
 
 	return {
 		...task,
-		actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
 		calypso_path: addQueryArgs( task.calypso_path, {
 			...getSiteIdOrSlug( flow, site, siteSlug ),
 			flowToReturnTo: flow,
@@ -49,7 +45,6 @@ export const getSetupVideoPressTask: TaskAction = ( task, flow, context ): Task 
 
 	return {
 		...task,
-		actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
 		calypso_path: addQueryArgs( task.calypso_path, { ...getSiteIdOrSlug( flow, site, siteSlug ) } ),
 		useCalypsoPath: true,
 	};
@@ -61,7 +56,6 @@ export const getSetupGeneralTask: TaskAction = ( task, flow, context ): Task => 
 	return {
 		...task,
 		disabled: false,
-		actionDispatch: () => recordTaskClickTracksEvent( task, flow, context ),
 		calypso_path: addQueryArgs( `/setup/update-options/options`, {
 			...getSiteIdOrSlug( flow, site, siteSlug ),
 			flowToReturnTo: flow,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/site/index.tsx
@@ -15,7 +15,6 @@ import { translate } from 'i18n-calypso';
 import { ONBOARD_STORE, SITE_STORE } from 'calypso/landing/stepper/stores';
 import { goToCheckout } from 'calypso/landing/stepper/utils/checkout';
 import { isDomainUpsellCompleted } from '../../task-helper';
-import { recordTaskClickTracksEvent } from '../../tracking';
 import { TaskAction, TaskContext } from '../../types';
 
 const getCompletedTasks = ( tasks: Task[] ): Record< string, boolean > =>
@@ -112,7 +111,6 @@ const completeLaunchSiteTask = async ( task: Task, flow: string, context: TaskCo
 		await launchSite( site.ID );
 		// Waits for half a second so that the loading screen doesn't flash away too quickly
 		await new Promise( ( res ) => setTimeout( res, 500 ) );
-		recordTaskClickTracksEvent( task, flow, context );
 
 		return {
 			siteSlug,

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/site/index.tsx
@@ -172,7 +172,6 @@ export const getVideopressLaunchedTask: TaskAction = ( task, flow, context ): Ta
 						} )
 					);
 				} );
-				recordTaskClickTracksEvent( task, flow, context );
 				submit?.();
 			}
 		},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/subscribers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/subscribers/index.tsx
@@ -1,5 +1,4 @@
 import { isNewsletterFlow } from '@automattic/onboarding';
-import { recordTaskClickTracksEvent } from '../../tracking';
 import { type TaskAction } from '../../types';
 
 const getSubscribersTask: TaskAction = ( task, flow, context ) => {
@@ -11,7 +10,6 @@ const getSubscribersTask: TaskAction = ( task, flow, context ) => {
 		disabled: mustVerifyEmailBeforePosting || false,
 		actionDispatch: () => {
 			if ( goToStep ) {
-				recordTaskClickTracksEvent( task, flow, context );
 				goToStep( 'subscribers' );
 			}
 		},

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/videopress/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-definitions/videopress/index.tsx
@@ -1,7 +1,6 @@
 import { FEATURE_VIDEO_UPLOADS, planHasFeature } from '@automattic/calypso-products';
 import { isVideoPressFlow } from '@automattic/onboarding';
 import { addQueryArgs } from '@wordpress/url';
-import { recordTaskClickTracksEvent } from '../../tracking';
 import { TaskAction } from '../../types';
 
 export const getVideoPressUploadTask: TaskAction = ( task, flow, context ) => {
@@ -32,9 +31,6 @@ export const getVideoPressUploadTask: TaskAction = ( task, flow, context ) => {
 		...task,
 		actionUrl: launchpadUploadVideoLink,
 		disabled: isVideoPressFlowWithUnsupportedPlan || videoPressUploadCompleted,
-		actionDispatch: () => {
-			recordTaskClickTracksEvent( task, flow, context );
-		},
 		calypso_path: launchpadUploadVideoLink,
 		useCalypsoPath: true,
 	};

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tracking.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/launchpad/tracking.ts
@@ -31,5 +31,3 @@ const buildEventTracker =
 export const recordGlobalStylesGattingPlanSelectedResetStylesEvent = buildEventTracker(
 	'calypso_launchpad_global_styles_gating_plan_selected_reset_styles'
 );
-
-export const recordTaskClickTracksEvent = buildEventTracker( 'calypso_launchpad_task_clicked' );

--- a/packages/launchpad/src/launchpad-internal.tsx
+++ b/packages/launchpad/src/launchpad-internal.tsx
@@ -14,8 +14,7 @@ interface Props {
 	taskFilter?: ( tasks: Task[] ) => Task[];
 	useLaunchpadOptions?: UseLaunchpadOptions;
 	launchpadContext: string;
-	// Temporary flag to control the auto tracking of click events
-	enableAutoTracking?: boolean;
+	flow?: string;
 }
 
 /**
@@ -23,6 +22,7 @@ interface Props {
  * Please use the main Launchpad component whenever possible.
  */
 const LaunchpadInternal: FC< Props > = ( {
+	flow,
 	site,
 	siteSlug,
 	checklistSlug,
@@ -30,7 +30,6 @@ const LaunchpadInternal: FC< Props > = ( {
 	makeLastTaskPrimaryAction,
 	useLaunchpadOptions = {},
 	launchpadContext,
-	enableAutoTracking = false,
 } ) => {
 	const launchpadData = useLaunchpad(
 		siteSlug || '',
@@ -56,12 +55,11 @@ const LaunchpadInternal: FC< Props > = ( {
 		checklistSlug,
 		site,
 		context: launchpadContext,
+		flow,
 	} );
 
 	const itemClickHandler = ( task: Task ) => {
-		if ( enableAutoTracking ) {
-			trackTaskClick( task );
-		}
+		trackTaskClick( task );
 		task?.actionDispatch?.();
 	};
 

--- a/packages/launchpad/src/launchpad.tsx
+++ b/packages/launchpad/src/launchpad.tsx
@@ -87,7 +87,6 @@ const Launchpad = ( {
 				taskFilter={ taskFilter }
 				useLaunchpadOptions={ launchpadOptions }
 				launchpadContext={ launchpadContext }
-				enableAutoTracking
 			/>
 		</>
 	);

--- a/packages/launchpad/src/test/launchpad.tsx
+++ b/packages/launchpad/src/test/launchpad.tsx
@@ -42,8 +42,8 @@ describe( 'LaunchpadInternal', () => {
 		expect( checklistItems.length ).toBe( 3 );
 	} );
 
-	it( 'records the checklist item click when autoTracking is enabled', async () => {
-		renderComponent( { enableAutoTracking: true } );
+	it( 'records the checklist item click', async () => {
+		renderComponent();
 
 		jest.clearAllMocks();
 		await userEvent.click( screen.getByRole( 'button', { name: /Task 1/ } ) );

--- a/packages/launchpad/src/use-tracking/index.tsx
+++ b/packages/launchpad/src/use-tracking/index.tsx
@@ -8,6 +8,7 @@ interface Params {
 	checklistSlug: string | null;
 	context: string;
 	site: SiteDetails | null | undefined;
+	flow?: string;
 }
 
 const stringifyTasks = ( tasks: Task[] ) => {
@@ -20,7 +21,7 @@ const stringifyTasks = ( tasks: Task[] ) => {
 };
 
 export const useTracking = ( params: Params ) => {
-	const { tasks, checklistSlug, context, site } = params;
+	const { tasks, checklistSlug, context, site, flow } = params;
 	const completedSteps = useMemo( () => tasks.filter( ( task ) => task.completed ), [ tasks ] );
 	const taskNames = useMemo( () => stringifyTasks( tasks ), [ tasks ] );
 	const numberOfSteps = tasks.length;
@@ -47,6 +48,7 @@ export const useTracking = ( params: Params ) => {
 			checklist_slug: checklistSlug,
 			context: context,
 			site_intent: siteIntent,
+			flow,
 		} );
 
 		tasks.forEach( ( task: Task ) => {
@@ -57,6 +59,7 @@ export const useTracking = ( params: Params ) => {
 				context: context,
 				order: task.order,
 				site_intent: siteIntent,
+				flow,
 			} );
 		} );
 		// Array of tasks requires deep comparison
@@ -70,6 +73,7 @@ export const useTracking = ( params: Params ) => {
 			checklist_slug: checklistSlug,
 			context: context,
 			task_id: task.id,
+			flow,
 			order: task.order,
 		} );
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Related to #87175

## Context
We are currently adding the code to track the user clicking on the launchpad tasks in each definition. It is error-prone and requires more work and validation.  The overall goal of this PR is to move all tracking management to the LaunchpadInternal component. 

## Proposed changes
* Remove the click tracking from the task definitions
* Enable the auto-tracking on the onboarding internal launchpad 
* Add the optional  flow attribute on the tracking events


The attribute 'flow' is new from this PR you can use it to check if the events are using the new structure

## Testing Instructions
**Onboarding**
* Go to any onboarding flow E.g (setup/free)
* Follow the instructions until you are redirected to the launchpad page (setup/free/launchpad)
* Reload the page 
* Opens again the Tracks Vigilante 
* Click on any task and check if we are tracking the click with the follow attributes

```
blog_id: XXXX
blog_lang: en
checklist_completed: false
checklist_slug: free
client: browser
context: onboarding
environment: development
environment_id: development
flow: free
is_completed: true
number_of_completed_steps: 3
number_of_steps: 7
order: 1
site_count: 259
site_id_label: wpcom
site_intent: free
site_plan_id: 1
task_id: setup_free
vph: 1319
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?