### PR TITLE
fix: eemoving empty node from dev feature page

### DIFF
--- a/client/me/developer/main.jsx
+++ b/client/me/developer/main.jsx
@@ -142,7 +142,7 @@ class Developer extends Component {
 	}
 
 	componentWillUnmount() {
-		document.body.removeChild( this.surveyNoticeWrapper );
+		this.surveyNoticeWrapper && document.body.removeChild( this.surveyNoticeWrapper );
 	}
 
 	componentDidUpdate( prevProps ) {


### PR DESCRIPTION
## Proposed Changes
There is an error for users with non-EN locale - we don’t create `this.surveyNoticeWrapper` for non-EN users, so we have error for removing `null` node.
