### PR TITLE
Jetpack Sale Banner: get sale_description from backend

### DIFF
--- a/client/jetpack-cloud/sections/pricing/sale-banner/index.tsx
+++ b/client/jetpack-cloud/sections/pricing/sale-banner/index.tsx
@@ -30,6 +30,7 @@ const SaleBanner: React.FC< Props > = ( { coupon } ) => {
 	const moment = useLocalizedMoment();
 	const [ isClosed, setIsClosed ] = useState( false );
 	const saleTitle = coupon.sale_title;
+	const saleDescription = coupon.sale_description;
 	const now = moment.utc().unix();
 	const expiryDate = moment.utc( coupon?.expiry_date ).unix();
 	const isBeforeExpiry = coupon && now <= expiryDate;
@@ -62,13 +63,7 @@ const SaleBanner: React.FC< Props > = ( { coupon } ) => {
 						<div>
 							<b>{ saleTitle }</b>
 							&nbsp;
-							{ translate(
-								'Take up to %(discount)d%% off all annual Jetpack bundles and products.',
-								{
-									args: { discount: coupon.final_discount },
-									comment: '%(discount)d%% is discount amount in percentage, e.g. 65%',
-								}
-							) }
+							{ saleDescription }
 						</div>
 						<span className="sale-banner__countdown-timer">
 							{ translate( 'Sale ends in: %(days)dd %(hours)dh %(minutes)dm %(seconds)ss', {

--- a/client/state/marketing/selectors.ts
+++ b/client/state/marketing/selectors.ts
@@ -6,6 +6,7 @@ export interface JetpackSaleCoupon {
 	start_date: string;
 	expiry_date: string;
 	sale_title: string;
+	sale_description: string;
 	final_discount: number;
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-marketing/issues/430

## Proposed Changes

* Use sale_description instead of hardcoding the description on Jetpack Sale Banner

## Testing Instructions

* Point public-api.wordpress.com to your sandbox (apply diff D137584-code)
* Run jetpack cloud live link
* Make sure the following sale banner displays:
![CleanShot 2024-02-08 at 18 33 30@2x](https://github.com/Automattic/wp-calypso/assets/8419292/e0dcb346-ef7a-496e-86d5-8a8cc47514d2)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?