### PR TITLE
Design Picker: Add Partner theme to cart based on the current plan

### DIFF
--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -19,6 +19,10 @@ import {
 	FEATURE_WAF_V2,
 	FEATURE_WORDADS,
 	PLAN_BUSINESS,
+	TERM_ANNUALLY,
+	TERM_BIENNIALLY,
+	TERM_MONTHLY,
+	TERM_TRIENNIALLY,
 	PLAN_ECOMMERCE,
 	PLAN_PERSONAL,
 	PLAN_PREMIUM,
@@ -52,6 +56,7 @@ interface UpgradeModalProps {
 	isOpen: boolean;
 	isMarketplaceThemeSubscriptionNeeded?: boolean;
 	isMarketplacePlanSubscriptionNeeeded?: boolean;
+	currentPlanTerm?: string;
 	marketplaceProduct?: ProductListItem;
 	closeModal: ( closedBy?: UpgradeModalClosedBy ) => void;
 	checkout: () => void;
@@ -75,6 +80,7 @@ export const ThemeUpgradeModal = ( {
 	isOpen,
 	isMarketplaceThemeSubscriptionNeeded,
 	isMarketplacePlanSubscriptionNeeeded,
+	currentPlanTerm,
 	marketplaceProduct,
 	closeModal,
 	checkout,
@@ -108,6 +114,14 @@ export const ThemeUpgradeModal = ( {
 	);
 	const monthlyBusinessPlanProduct = useSelect(
 		( select ) => select( ProductsList.store ).getProductBySlug( 'business-bundle-monthly' ),
+		[]
+	);
+	const biAnnualBusinessPlanProduct = useSelect(
+		( select ) => select( ProductsList.store ).getProductBySlug( 'business-bundle-2y' ),
+		[]
+	);
+	const triAnnualBusinessPlanProduct = useSelect(
+		( select ) => select( ProductsList.store ).getProductBySlug( 'business-bundle-3y' ),
 		[]
 	);
 
@@ -275,17 +289,43 @@ export const ThemeUpgradeModal = ( {
 	};
 
 	const getExternallyManagedPurchaseModalData = (): UpgradeModalContent => {
-		const businessPlan =
-			marketplaceProduct?.product_term === 'year'
-				? businessPlanProduct
-				: monthlyBusinessPlanProduct;
+		const getBusinessPlanByTerm = ( term: string ) => {
+			switch ( term ) {
+				case TERM_TRIENNIALLY:
+					return triAnnualBusinessPlanProduct;
+				case TERM_BIENNIALLY:
+					return biAnnualBusinessPlanProduct;
+				case TERM_ANNUALLY:
+					return businessPlanProduct;
+				case TERM_MONTHLY:
+				default:
+					return monthlyBusinessPlanProduct;
+			}
+		};
+
+		const getPlanTextByTerm = ( term: string, cost: string ) => {
+			switch ( term ) {
+				case TERM_TRIENNIALLY:
+					return translate( '%(cost)s per three years', { args: { cost } } );
+				case TERM_BIENNIALLY:
+					return translate( '%(cost)s per two years', { args: { cost } } );
+				case TERM_ANNUALLY:
+					return translate( '%(cost)s per year', { args: { cost } } );
+				case TERM_MONTHLY:
+				default:
+					return translate( '%(cost)s per month', { args: { cost } } );
+			}
+		};
+
+		const businessPlan = getBusinessPlanByTerm( currentPlanTerm || '' );
+
 		const businessPlanPrice = businessPlan?.combined_cost_display;
 		const productPrice = marketplaceProduct?.cost_display;
 
-		const businessPlanPriceText =
-			businessPlan?.product_term === 'year'
-				? translate( '%(cost)s per year', { args: { cost: businessPlanPrice || '' } } )
-				: translate( '%(cost)s per month', { args: { cost: businessPlanPrice || '' } } );
+		const businessPlanPriceText = getPlanTextByTerm(
+			currentPlanTerm || '',
+			businessPlanPrice || ''
+		);
 
 		const productPriceText =
 			marketplaceProduct?.product_term === 'year'

--- a/client/components/theme-upgrade-modal/index.tsx
+++ b/client/components/theme-upgrade-modal/index.tsx
@@ -275,11 +275,15 @@ export const ThemeUpgradeModal = ( {
 	};
 
 	const getExternallyManagedPurchaseModalData = (): UpgradeModalContent => {
-		const businessPlanPrice = monthlyBusinessPlanProduct?.combined_cost_display;
+		const businessPlan =
+			marketplaceProduct?.product_term === 'year'
+				? businessPlanProduct
+				: monthlyBusinessPlanProduct;
+		const businessPlanPrice = businessPlan?.combined_cost_display;
 		const productPrice = marketplaceProduct?.cost_display;
 
 		const businessPlanPriceText =
-			monthlyBusinessPlanProduct?.product_term === 'year'
+			businessPlan?.product_term === 'year'
 				? translate( '%(cost)s per year', { args: { cost: businessPlanPrice || '' } } )
 				: translate( '%(cost)s per month', { args: { cost: businessPlanPrice || '' } } );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -1,7 +1,9 @@
 import {
+	PLAN_BUSINESS,
 	PLAN_BUSINESS_MONTHLY,
 	PLAN_PERSONAL,
 	WPCOM_FEATURES_PREMIUM_THEMES_UNLIMITED,
+	isFreePlanProduct,
 } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import {
@@ -366,7 +368,10 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		) || [];
 	const marketplaceProductSlug =
 		marketplaceThemeProducts.length !== 0
-			? getPreferredBillingCycleProductSlug( marketplaceThemeProducts )
+			? getPreferredBillingCycleProductSlug(
+					marketplaceThemeProducts,
+					site?.plan && ! isFreePlanProduct( site?.plan ) ? site.plan : undefined
+			  )
 			: null;
 
 	const selectedMarketplaceProduct =
@@ -457,7 +462,9 @@ const UnifiedDesignPickerStep: Step = ( { navigation, flow, stepName } ) => {
 		if ( themeHasBundle ) {
 			plan = 'business-bundle';
 		} else if ( selectedDesign?.is_externally_managed ) {
-			plan = ! isExternallyManagedThemeAvailable ? PLAN_BUSINESS_MONTHLY : '';
+			const businessPlan =
+				selectedMarketplaceProduct.product_term === 'year' ? PLAN_BUSINESS : PLAN_BUSINESS_MONTHLY;
+			plan = ! isExternallyManagedThemeAvailable ? businessPlan : '';
 		} else if ( selectedDesign?.design_tier === PERSONAL_THEME ) {
 			plan = PLAN_PERSONAL;
 		} else {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/design-setup/unified-design-picker.tsx
@@ -68,7 +68,7 @@ import { useIsPluginBundleEligible } from '../../../../hooks/use-is-plugin-bundl
 import { useQuery } from '../../../../hooks/use-query';
 import { useSiteData } from '../../../../hooks/use-site-data';
 import { ONBOARD_STORE, SITE_STORE } from '../../../../stores';
-import { getBusinessPlanByTerm, goToCheckout } from '../../../../utils/checkout';
+import { goToCheckout } from '../../../../utils/checkout';
 import {
 	getDesignEventProps,
 	getDesignTypeProps,


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/87281

## Proposed Changes

On the Design Picker, for Partner Themes, define the billing period of the and plan (if needed) based on the current plan.

The added business plan should have the same billing period as the current plan, if the user doens't have a plan, the monthly version should be added.

## Testing Instructions

**Explorer Plan 3 years**

* Using a site with the above plan, go to the following URL `/setup/site-setup/designSetup?siteSlug=:SITE_URL`
* Select a  Partner theme (look for the `Partner` badge)
* Click to `Unlock Theme`
* A Modal will be shown with the Theme and the Creator Plan displayed. The plan should be triennial and the product should show the monthly version.
* Proceed to the checkout should display those items in the cart.

**Explorer Plan 2 years**

* Using a site with the above plan, go to the following URL `/setup/site-setup/designSetup?siteSlug=:SITE_URL`
* Select a  Partner theme (look for the `Partner` badge)
* Click to `Unlock Theme`
* A Modal will be shown with the Theme and the Creator Plan displayed. The plan should be biennial and the product should show the monthly version.
* Proceed to the checkout should display those items in the cart.


**Explorer Plan yearly**

* Using a site with the above plan, go to the following URL `/setup/site-setup/designSetup?siteSlug=:SITE_URL`
* Select a  Partner theme (look for the `Partner` badge)
* Click to `Unlock Theme`
* A Modal will be shown with the Theme and the Creator Plan displayed. The plan should be annual and the product should show the monthly version.
* Proceed to the checkout should display those items in the cart.


**Explorer Plan monthly**

* Using a site with the above plan, go to the following URL `/setup/site-setup/designSetup?siteSlug=:SITE_URL`
* Select a  Partner theme (look for the `Partner` badge)
* Click to `Unlock Theme`
* A Modal will be shown with the Theme and the Creator Plan displayed. Both should be displayed as monthly.
* Proceed to the checkout should display those items in the cart.

**Creator Plan**

* Using a site with the above plan, go to the following URL `/setup/site-setup/designSetup?siteSlug=:SITE_URL`
* Select a  Partner theme (look for the `Partner` badge)
* Click to `Unlock Theme`
* A Modal will be shown with the Theme.
* Proceed to the checkout should display those items in the cart.

**Free plan** 
* Go to `/start/free`
* You should follow the same flow as before
* Both products should be displayed as monthly on the modal and cart

| Explorer Plan monthly / Free | Explorer Plan yearly | Creator Plan |
| ------------- | ------------- | ------------- |
|![CleanShot 2024-02-08 at 16 09 02@2x](https://github.com/Automattic/wp-calypso/assets/5039531/e6544954-3e6c-4f6b-b565-40fab84d1741)|![CleanShot 2024-02-08 at 16 08 51@2x](https://github.com/Automattic/wp-calypso/assets/5039531/2bfcaa0d-a3ad-495e-8ed6-6458be5c2ab9)|![CleanShot 2024-02-08 at 16 15 07@2x](https://github.com/Automattic/wp-calypso/assets/5039531/7c169624-02e1-4326-b7af-171df6adebec)|



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?