### PR TITLE
Untangle: Fix errors by moving `recordTracksEventForTrialNoticeClick` to `LaunchSiteTrialUpsellNotice`

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -574,14 +574,6 @@ export class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
-	recordTracksEventForTrialNoticeClick = () => {
-		const { recordTracksEvent, isSiteOnECommerceTrial } = this.props;
-		const eventName = isSiteOnECommerceTrial
-			? `calypso_ecommerce_trial_launch_banner_click`
-			: `calypso_migration_trial_launch_banner_click`;
-		recordTracksEvent( eventName );
-	};
-
 	privacySettings() {
 		const { isRequestingSettings, translate, handleSubmitForm, isSavingSettings, isP2HubSite } =
 			this.props;

--- a/client/my-sites/site-settings/site-visibility/launch-site-trial-notice.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site-trial-notice.jsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { translate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import {
@@ -16,6 +17,14 @@ export const LaunchSiteTrialUpsellNotice = () => {
 		getIsSiteOnMigrationTrial( state, siteId )
 	);
 	const isLaunchable = ! isSiteOnECommerceTrial && ! isSiteOnMigrationTrial;
+
+	const recordTracksEventForTrialNoticeClick = () => {
+		const eventName = isSiteOnECommerceTrial
+			? `calypso_ecommerce_trial_launch_banner_click`
+			: `calypso_migration_trial_launch_banner_click`;
+		recordTracksEvent( eventName );
+	};
+
 	if ( isLaunchable ) {
 		return null;
 	}
@@ -25,24 +34,14 @@ export const LaunchSiteTrialUpsellNotice = () => {
 			'Before you can share your store with the world, you need to {{a}}pick a plan{{/a}}.',
 			{
 				components: {
-					a: (
-						<a
-							href={ `/plans/${ siteSlug }` }
-							onClick={ this.recordTracksEventForTrialNoticeClick }
-						/>
-					),
+					a: <a href={ `/plans/${ siteSlug }` } onClick={ recordTracksEventForTrialNoticeClick } />,
 				},
 			}
 		);
 	} else if ( isSiteOnMigrationTrial ) {
 		noticeText = translate( 'Ready to launch your site? {{a}}Upgrade to a paid plan{{/a}}.', {
 			components: {
-				a: (
-					<a
-						href={ `/plans/${ siteSlug }` }
-						onClick={ this.recordTracksEventForTrialNoticeClick }
-					/>
-				),
+				a: <a href={ `/plans/${ siteSlug }` } onClick={ recordTracksEventForTrialNoticeClick } />,
 			},
 		} );
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Follow up to https://github.com/Automattic/wp-calypso/pull/87256

Related error messages:
p1707420584840419-slack-C04U5A26MJB
p1707406005822369-slack-C04U5A26MJB

## Proposed Changes

* This PR follows up on modularizing the Launch Site Component by moving `recordTracksEventForTrialNoticeClick` to `LaunchSiteTrialUpsellNotice` where it's needed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR locally
* Comment the testing code locally such that an upsell banner in `launch-site-trial-notice.jsx` will display. For example:
```
	if ( isLaunchable ) {
		// return null;
	}
	let noticeText;
	if ( ! isSiteOnECommerceTrial ) {
```
* Go to /settings/general/[site-slug]
* Click on the banner and notice the Tracks event is recorded properly and no errors are thrown.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?