### PR TITLE
Stats: Fix purchase recoganization on Odyssey

### DIFF
--- a/apps/odyssey-stats/src/components/odyssey-query-products.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-products.ts
@@ -1,8 +1,31 @@
+import { useQuery } from '@tanstack/react-query';
+import { isError } from 'lodash';
 import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { PRODUCTS_LIST_REQUEST, PRODUCTS_LIST_REQUEST_FAILURE } from 'calypso/state/action-types';
 import { receiveProductsList } from 'calypso/state/products-list/actions';
-import { isProductsListFetching } from 'calypso/state/products-list/selectors';
+
+function queryProductsList( currency = '', type = 'jetpack' ) {
+	// Calling the endpoint directly because jetpack/v4/products doesn't have tiers information (why?).
+	return globalThis
+		.fetch(
+			'https://public-api.wordpress.com/rest/v1.1/products?' +
+				new URLSearchParams( { currency: currency ?? '', type } )
+		)
+		.then( ( response ) => response.json() )
+		.catch( ( error: Error ) => error );
+}
+function useQueryProductsList( currency = '', type = 'jetpack' ) {
+	return useQuery( {
+		queryKey: [ 'odyssey-stats', 'products', currency, type ],
+		queryFn: () => queryProductsList( currency, type ),
+		staleTime: 10 * 1000,
+		// If the module is not active, we don't want to retry the query.
+		retry: false,
+		retryOnMount: false,
+		refetchOnWindowFocus: false,
+	} );
+}
 
 /**
  *
@@ -12,41 +35,37 @@ import { isProductsListFetching } from 'calypso/state/products-list/selectors';
  * @param {string} [props.currency] The currency code to override the currency used on the account.
  * @returns {null} 					No visible output.
  */
-export default function QueryProductsList( {
+export default function OdysseyQueryProductsList( {
 	type = 'jetpack',
 	currency,
 }: {
 	currency?: string;
 	type?: string;
 } ) {
-	const isRequesting = useSelector( ( state: object ) => isProductsListFetching( state ) );
+	const {
+		isFetching,
+		data: productsList,
+		isError: hasOtherErrors,
+	} = useQueryProductsList( currency, type );
 	const dispatch = useDispatch();
 
 	// Only runs on mount.
 	useEffect( () => {
-		if ( isRequesting ) {
+		if ( isFetching ) {
 			return;
 		}
 		dispatch( { type: PRODUCTS_LIST_REQUEST } );
-		// Calling the endpoint directly because jetpack/v4/products doesn't have tiers information (why?).
-		globalThis
-			.fetch(
-				'https://public-api.wordpress.com/rest/v1.1/products?' +
-					new URLSearchParams( { currency: currency ?? '', type } )
-			)
-			.then( ( response ) => response.json() )
-			.then( ( productsList: Array< object > ) =>
-				// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-				// @ts-ignore
-				dispatch( receiveProductsList( productsList, type ) )
-			)
-			.catch( ( error: Error ) =>
-				dispatch( {
-					type: PRODUCTS_LIST_REQUEST_FAILURE,
-					error,
-				} )
-			);
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ dispatch, type, currency ] );
+		if ( isError( productsList ) || hasOtherErrors ) {
+			dispatch( {
+				type: PRODUCTS_LIST_REQUEST_FAILURE,
+				productsList,
+			} );
+		} else {
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			dispatch( receiveProductsList( productsList, type ) );
+		}
+	}, [ dispatch, type, currency, productsList, hasOtherErrors, isFetching ] );
+
 	return null;
 }

--- a/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
@@ -1,59 +1,75 @@
 /**
  * This is a Odyssey implementation of 'calypso/components/data/query-site-purchases'.
  */
+import { useQuery } from '@tanstack/react-query';
+import { isError } from 'lodash';
 import { useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import wpcom from 'calypso/lib/wp';
 import {
 	PURCHASES_SITE_FETCH,
 	PURCHASES_SITE_FETCH_COMPLETED,
 	PURCHASES_SITE_FETCH_FAILED,
 } from 'calypso/state/action-types';
-import { isFetchingSitePurchases } from 'calypso/state/purchases/selectors';
-import type { RawPurchase } from 'calypso/lib/purchases/types';
 
+async function queryOdysseyQuerySitePurchases( siteId: number | null ) {
+	if ( ! siteId ) {
+		return;
+	}
+
+	return wpcom.req
+		.get( { path: '/site/purchases', apiNamespace: 'jetpack/v4' } )
+		.then( ( res: { data: string } ) => JSON.parse( res.data ) )
+		.catch( ( error: Error ) => error );
+}
 /**
  * Update site products in the Redux store by fetching purchases via API for Odyssey Stats.
  */
+
 const useOdysseyQuerySitePurchases = ( siteId: number | null ) => {
-	const isRequesting = useSelector( isFetchingSitePurchases );
+	return useQuery( {
+		queryKey: [ 'odyssey-stats', 'site-purchases', siteId ],
+		queryFn: () => queryOdysseyQuerySitePurchases( siteId ),
+		staleTime: 10 * 1000,
+		// If the module is not active, we don't want to retry the query.
+		retry: false,
+		retryOnMount: false,
+		refetchOnWindowFocus: false,
+	} );
+};
+
+export default function OdysseyQuerySitePurchases( { siteId }: { siteId: number | null } ) {
+	const {
+		data: purchases,
+		isFetching,
+		isError: hasOtherErrors,
+	} = useOdysseyQuerySitePurchases( siteId );
 	const reduxDispatch = useDispatch();
 
 	useEffect( () => {
-		if ( ! siteId || isRequesting ) {
+		if ( isFetching ) {
 			return;
 		}
-
 		// Dispatch evet marking as requesting
 		reduxDispatch( {
 			type: PURCHASES_SITE_FETCH,
 			siteId,
 		} );
-
-		wpcom.req
-			.get( { path: '/site/purchases', apiNamespace: 'jetpack/v4' } )
-			.then( ( res: { data: string } ) => JSON.parse( res.data ) )
-			.then( ( purchases: RawPurchase[] ) => {
-				// Dispatch to the Purchases reducer for consistent requesting status
-				reduxDispatch( {
-					type: PURCHASES_SITE_FETCH_COMPLETED,
-					siteId,
-					purchases: purchases,
-				} );
-			} )
-			.catch( ( error: Error ) => {
-				// Dispatch to the Purchases reducer for error status
-				reduxDispatch( {
-					type: PURCHASES_SITE_FETCH_FAILED,
-					error: error.message,
-				} );
+		if ( isError( purchases ) || hasOtherErrors ) {
+			// Dispatch to the Purchases reducer for error status
+			reduxDispatch( {
+				type: PURCHASES_SITE_FETCH_FAILED,
+				error: purchases.message,
 			} );
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ siteId, reduxDispatch ] );
-};
-
-export default function OdysseyQuerySitePurchases( { siteId }: { siteId: number | null } ) {
-	useOdysseyQuerySitePurchases( siteId );
+		} else {
+			// Dispatch to the Purchases reducer for consistent requesting status
+			reduxDispatch( {
+				type: PURCHASES_SITE_FETCH_COMPLETED,
+				siteId,
+				purchases: purchases,
+			} );
+		}
+	}, [ purchases, isFetching, reduxDispatch, hasOtherErrors ] );
 
 	return null;
 }

--- a/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
@@ -47,14 +47,16 @@ export default function OdysseyQuerySitePurchases( { siteId }: { siteId: number 
 	const reduxDispatch = useDispatch();
 
 	useEffect( () => {
-		if ( isFetching ) {
-			return;
-		}
 		// Dispatch evet marking as requesting
 		reduxDispatch( {
 			type: PURCHASES_SITE_FETCH,
 			siteId,
 		} );
+
+		if ( isFetching ) {
+			return;
+		}
+
 		if ( isError( purchases ) || hasOtherErrors ) {
 			// Dispatch to the Purchases reducer for error status
 			reduxDispatch( {
@@ -69,7 +71,7 @@ export default function OdysseyQuerySitePurchases( { siteId }: { siteId: number 
 				purchases: purchases,
 			} );
 		}
-	}, [ purchases, isFetching, reduxDispatch, hasOtherErrors ] );
+	}, [ purchases, isFetching, reduxDispatch, hasOtherErrors, siteId ] );
 
 	return null;
 }

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -52,7 +52,8 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 		canUserManageOptions
 	);
 
-	const isFetching = isRequestingSitePurchases || isRequestingNotices;
+	// in Calypso `isRequestingSitePurchases` is constantly looping requesting and not requesting
+	const isFetching = ( isOdysseyStats && isRequestingSitePurchases ) || isRequestingNotices;
 	const hasPlan = isFreeOwned || isPWYWOwned || isCommercialOwned || supportCommercialUse;
 	const qualifiedUser =
 		siteCreatedTimeStamp && new Date( siteCreatedTimeStamp ) > new Date( '2024-01-31' );

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -102,14 +102,14 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 			250
 		);
 
-		return <></>;
+		return null;
 	} else if ( ! isFetching || ( canUserViewStats && ! canUserManageOptions ) ) {
 		return <>{ children }</>;
 	} else if ( isFetching ) {
 		return <StatsLoader />;
 	}
 
-	return <></>;
+	return null;
 };
 
 export default StatsRedirectFlow;

--- a/client/my-sites/stats/stats-redirect/load-stats-page.tsx
+++ b/client/my-sites/stats/stats-redirect/load-stats-page.tsx
@@ -101,9 +101,9 @@ export default function LoadStatsPage( { children }: AsyncLoadProps ) {
 	}
 
 	return (
-		<StatsRedirectFlow>
+		<>
 			{ isOdysseyStats && <QuerySitePurchases siteId={ siteId } /> }
-			{ children }
-		</StatsRedirectFlow>
+			<StatsRedirectFlow>{ children }</StatsRedirectFlow>
+		</>
 	);
 }

--- a/client/my-sites/stats/stats-redirect/load-stats-page.tsx
+++ b/client/my-sites/stats/stats-redirect/load-stats-page.tsx
@@ -102,7 +102,7 @@ export default function LoadStatsPage( { children }: AsyncLoadProps ) {
 
 	return (
 		<StatsRedirectFlow>
-			<QuerySitePurchases siteId={ siteId } />
+			{ isOdysseyStats && <QuerySitePurchases siteId={ siteId } /> }
 			{ children }
 		</StatsRedirectFlow>
 	);

--- a/client/my-sites/stats/stats-redirect/load-stats-page.tsx
+++ b/client/my-sites/stats/stats-redirect/load-stats-page.tsx
@@ -102,7 +102,6 @@ export default function LoadStatsPage( { children }: AsyncLoadProps ) {
 
 	return (
 		<StatsRedirectFlow>
-			{ /* Only query site purchases on Calypso via existing data component */ }
 			<QuerySitePurchases siteId={ siteId } />
 			{ children }
 		</StatsRedirectFlow>

--- a/client/my-sites/stats/stats-redirect/load-stats-page.tsx
+++ b/client/my-sites/stats/stats-redirect/load-stats-page.tsx
@@ -3,6 +3,7 @@ import { useTranslate } from 'i18n-calypso';
 import { type ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 import illustration404 from 'calypso/assets/images/illustrations/illustration-404.svg';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import EmptyContent from 'calypso/components/empty-content';
 import { recordTracksEvent, withAnalytics } from 'calypso/state/analytics/actions';
 import { activateModule } from 'calypso/state/jetpack/modules/actions';
@@ -99,5 +100,11 @@ export default function LoadStatsPage( { children }: AsyncLoadProps ) {
 		return <EnableStatsModuleNotice siteId={ siteId } path={ path } />;
 	}
 
-	return <StatsRedirectFlow>{ children }</StatsRedirectFlow>;
+	return (
+		<StatsRedirectFlow>
+			{ /* Only query site purchases on Calypso via existing data component */ }
+			<QuerySitePurchases siteId={ siteId } />
+			{ children }
+		</StatsRedirectFlow>
+	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* update product and purchase fetching for Odyssey Stats to include Stats plans with tiers

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* setup Odyssey locally according to a FG guide
* make sure that you blog doesn't have any Stats plans
* purchase a plan and verify that you are redirected to the Traffic page instead of the purchase page again

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?