### PR TITLE
Revert modularize launch from general settings

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -22,6 +22,7 @@ import { Component, Fragment } from 'react';
 import { connect } from 'react-redux';
 import fiverrLogo from 'calypso/assets/images/customer-home/fiverr-logo.svg';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -48,6 +49,7 @@ import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { useSiteGlobalStylesStatus } from 'calypso/state/sites/hooks/use-site-global-styles-status';
+import { launchSite } from 'calypso/state/sites/launch/actions';
 import {
 	isSiteOnECommerceTrial as getIsSiteOnECommerceTrial,
 	isSiteOnMigrationTrial as getIsSiteOnMigrationTrial,
@@ -66,7 +68,7 @@ import {
 import { BuiltByUpsell } from './built-by-upsell-banner';
 import Masterbar from './masterbar';
 import SiteIconSetting from './site-icon-setting';
-import LaunchSite from './site-visibility/launch-site';
+import TrialUpsellNotice from './trial-upsell-notice';
 import wrapSettingsForm from './wrap-settings-form';
 
 export class SiteSettingsFormGeneral extends Component {
@@ -574,6 +576,132 @@ export class SiteSettingsFormGeneral extends Component {
 		);
 	}
 
+	recordTracksEventForTrialNoticeClick = () => {
+		const { recordTracksEvent, isSiteOnECommerceTrial } = this.props;
+		const eventName = isSiteOnECommerceTrial
+			? `calypso_ecommerce_trial_launch_banner_click`
+			: `calypso_migration_trial_launch_banner_click`;
+		recordTracksEvent( eventName );
+	};
+
+	getTrialUpsellNotice() {
+		const { translate, siteSlug, isSiteOnECommerceTrial, isSiteOnMigrationTrial, isLaunchable } =
+			this.props;
+		if ( isLaunchable ) {
+			return null;
+		}
+		let noticeText;
+		if ( isSiteOnECommerceTrial ) {
+			noticeText = translate(
+				'Before you can share your store with the world, you need to {{a}}pick a plan{{/a}}.',
+				{
+					components: {
+						a: (
+							<a
+								href={ `/plans/${ siteSlug }` }
+								onClick={ this.recordTracksEventForTrialNoticeClick }
+							/>
+						),
+					},
+				}
+			);
+		} else if ( isSiteOnMigrationTrial ) {
+			noticeText = translate( 'Ready to launch your site? {{a}}Upgrade to a paid plan{{/a}}.', {
+				components: {
+					a: (
+						<a
+							href={ `/plans/${ siteSlug }` }
+							onClick={ this.recordTracksEventForTrialNoticeClick }
+						/>
+					),
+				},
+			} );
+		}
+
+		return noticeText && <TrialUpsellNotice text={ noticeText } />;
+	}
+
+	renderLaunchSite() {
+		const {
+			translate,
+			siteDomains,
+			siteSlug,
+			siteId,
+			isPaidPlan,
+			isComingSoon,
+			fields,
+			hasSitePreviewLink,
+			site,
+			isLaunchable,
+		} = this.props;
+
+		const launchSiteClasses = classNames( 'site-settings__general-settings-launch-site-button', {
+			'site-settings__disable-privacy-settings': ! siteDomains.length,
+		} );
+		const btnText = translate( 'Launch site' );
+		let querySiteDomainsComponent;
+		let btnComponent;
+
+		if ( 0 === siteDomains.length ) {
+			querySiteDomainsComponent = <QuerySiteDomains siteId={ siteId } />;
+			btnComponent = <Button>{ btnText }</Button>;
+		} else if ( isPaidPlan && siteDomains.length > 1 ) {
+			btnComponent = (
+				<Button onClick={ this.props.launchSite } disabled={ ! isLaunchable }>
+					{ btnText }
+				</Button>
+			);
+			querySiteDomainsComponent = '';
+		} else {
+			btnComponent = (
+				<Button
+					href={ `/start/launch-site?siteSlug=${ siteSlug }&source=general-settings&new=${ site.title }&search=yes` }
+				>
+					{ btnText }
+				</Button>
+			);
+			querySiteDomainsComponent = '';
+		}
+
+		const blogPublic = parseInt( fields.blog_public, 10 );
+		// isPrivateAndUnlaunched means it is an unlaunched coming soon v1 site
+		const isPrivateAndUnlaunched = -1 === blogPublic && this.props.isUnlaunchedSite;
+
+		const showPreviewLink = isComingSoon && hasSitePreviewLink;
+
+		const LaunchCard = showPreviewLink ? CompactCard : Card;
+
+		return (
+			<>
+				<SettingsSectionHeader title={ translate( 'Launch site' ) } />
+				<LaunchCard>
+					{ this.getTrialUpsellNotice() }
+					<div className="site-settings__general-settings-launch-site">
+						<div className="site-settings__general-settings-launch-site-text">
+							<p>
+								{ isComingSoon || isPrivateAndUnlaunched
+									? translate(
+											'Your site hasn\'t been launched yet. It is hidden from visitors behind a "Coming Soon" notice until it is launched.'
+									  )
+									: translate(
+											"Your site hasn't been launched yet. It's private; only you can see it until it is launched."
+									  ) }
+							</p>
+						</div>
+						<div className={ launchSiteClasses }>{ btnComponent }</div>
+					</div>
+				</LaunchCard>
+				{ showPreviewLink && (
+					<Card>
+						<SitePreviewLink siteUrl={ site.URL } siteId={ siteId } source="launch-settings" />
+					</Card>
+				) }
+
+				{ querySiteDomainsComponent }
+			</>
+		);
+	}
+
 	privacySettings() {
 		const { isRequestingSettings, translate, handleSubmitForm, isSavingSettings, isP2HubSite } =
 			this.props;
@@ -793,11 +921,9 @@ export class SiteSettingsFormGeneral extends Component {
 
 				{ this.props.isUnlaunchedSite &&
 				! isAtomicAndEditingToolkitDeactivated &&
-				! isWpcomStagingSite ? (
-					<LaunchSite />
-				) : (
-					this.privacySettings()
-				) }
+				! isWpcomStagingSite
+					? this.renderLaunchSite()
+					: this.privacySettings() }
 				{ this.enhancedOwnershipSettings() }
 				<BuiltByUpsell
 					site={ site }
@@ -889,6 +1015,14 @@ export class SiteSettingsFormGeneral extends Component {
 	}
 }
 
+const mapDispatchToProps = ( dispatch, ownProps ) => {
+	const { site } = ownProps;
+
+	return {
+		launchSite: () => dispatch( launchSite( site.ID ) ),
+	};
+};
+
 const connectComponent = connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	return {
@@ -916,7 +1050,7 @@ const connectComponent = connect( ( state ) => {
 		isLaunchable:
 			! getIsSiteOnECommerceTrial( state, siteId ) && ! getIsSiteOnMigrationTrial( state, siteId ),
 	};
-} );
+}, mapDispatchToProps );
 
 const getFormSettings = ( settings ) => {
 	const defaultSettings = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/87256

## Proposed Changes

* This PR reverts https://github.com/Automattic/wp-calypso/pull/87256 changes to the Settings -> General form Launch site setting.
* An intermittent issue is documented here that needs to be worked out. p1707425040384579-slack-C02FMH4G8

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Create a new site and launch it using the Settings > General > Launch site

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?