### PR TITLE
Checkoutv2: Style and functionality cleanup

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -43,6 +43,7 @@ export function CheckoutSidebarPlanUpsell() {
 		border-radius: 4px;
 		font-size: 12px;
 		font-weight: 500;
+		align-self: flex-end;
 
 		p {
 			margin: 0;

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -53,7 +53,7 @@ const CostOverridesListStyle = styled.div`
 
 const DeleteButton = styled( Button )< { theme?: Theme } >`
 	width: auto;
-	font-size: ${ hasCheckoutVersion( '2' ) ? '14px' : 'inherit' };
+	font-size: ${ hasCheckoutVersion( '2' ) ? '12px' : 'inherit' };
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 `;
 

--- a/client/my-sites/checkout/src/components/coupon.tsx
+++ b/client/my-sites/checkout/src/components/coupon.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@automattic/composite-checkout';
-import { Field, styled, joinClasses } from '@automattic/wpcom-checkout';
+import { Field, styled, joinClasses, hasCheckoutVersion } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
 import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -45,19 +45,38 @@ export default function Coupon( {
 				handleCouponSubmit();
 			} }
 		>
-			<Field
-				id={ id }
-				inputClassName="coupon-code"
-				value={ couponFieldValue }
-				disabled={ disabled || isPending }
-				placeholder={ String( translate( 'Enter your coupon code' ) ) }
-				isError={ hasCouponError && ! isFreshOrEdited }
-				errorMessage={ errorMessage }
-				onChange={ ( input ) => {
-					setIsFreshOrEdited( true );
-					setCouponFieldValue( input );
-				} }
-			/>
+			{ hasCheckoutVersion( '2' ) ? (
+				<>
+					<CouponLabel>Coupon code</CouponLabel>
+					<CouponField
+						id={ id }
+						inputClassName="coupon-code"
+						value={ couponFieldValue }
+						disabled={ disabled || isPending }
+						placeholder={ String( translate( 'Enter your coupon code' ) ) }
+						isError={ hasCouponError && ! isFreshOrEdited }
+						errorMessage={ errorMessage }
+						onChange={ ( input ) => {
+							setIsFreshOrEdited( true );
+							setCouponFieldValue( input );
+						} }
+					/>
+				</>
+			) : (
+				<Field
+					id={ id }
+					inputClassName="coupon-code"
+					value={ couponFieldValue }
+					disabled={ disabled || isPending }
+					placeholder={ String( translate( 'Enter your coupon code' ) ) }
+					isError={ hasCouponError && ! isFreshOrEdited }
+					errorMessage={ errorMessage }
+					onChange={ ( input ) => {
+						setIsFreshOrEdited( true );
+						setCouponFieldValue( input );
+					} }
+				/>
+			) }
 
 			{ isApplyButtonActive && (
 				<ApplyButton disabled={ isPending } buttonType="secondary">
@@ -102,16 +121,39 @@ const CouponWrapper = styled.form`
 	margin: 0;
 	padding-top: 0;
 	position: relative;
+
+	${ hasCheckoutVersion( '2' )
+		? `display: grid; 
+		align-items: center; 
+		justify-content: space-between; 
+		grid-template-columns: 1fr max-content; 
+		grid-template-areas: 
+		'label     .  '
+		'field  button';
+		gap: .5em;`
+		: null }
+`;
+
+const CouponLabel = styled.label`
+	font-size: 12px;
+	font-weight: 600;
+	grid-area: label;
+`;
+
+const CouponField = styled( Field )`
+	grid-area: field;
 `;
 
 const ApplyButton = styled( Button )`
-	position: absolute;
-	top: 3px;
-	right: 3px;
-	padding: 8px;
 	animation: ${ animateIn } 0.2s ease-out;
 	animation-fill-mode: backwards;
 	margin: 0;
+
+	${ hasCheckoutVersion( '2' )
+		? `position: relative; font-size: 14px; min-width: 70px; height: 37px; padding: 0 8px; grid-area: button; align-self: flex-start;`
+		: `position: absolute; padding: 8px;
+	top: 3px;
+	right: 3px;` }
 
 	.rtl & {
 		animation-name: ${ animateInRTL };

--- a/client/my-sites/checkout/src/components/coupon.tsx
+++ b/client/my-sites/checkout/src/components/coupon.tsx
@@ -47,7 +47,7 @@ export default function Coupon( {
 		>
 			{ hasCheckoutVersion( '2' ) ? (
 				<>
-					<CouponLabel>Coupon code</CouponLabel>
+					<CouponLabel>{ translate( 'Coupon code' ) }</CouponLabel>
 					<CouponField
 						id={ id }
 						inputClassName="coupon-code"

--- a/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
@@ -87,7 +87,7 @@ export const Discount = styled.span`
 	color: ${ ( props ) => props.theme.colors.discount };
 	margin-right: 8px;
 	${ hasCheckoutVersion( '2' )
-		? `align-items: left; font-size: 14px;`
+		? `align-items: left; font-size: 12px;`
 		: `align-items: center; font-size: 100%;` }
 
 	.rtl & {

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -46,7 +46,7 @@ const SiteSummary = styled.div`
 `;
 
 const CouponLinkWrapper = styled.div`
-	font-size: 14px;
+	${ hasCheckoutVersion( '2' ) ? `font-size: 12px;` : `font-size: 14px;` }
 `;
 
 const CouponAreaWrapper = styled.div`
@@ -59,8 +59,10 @@ const CouponEnableButton = styled.button`
 	cursor: pointer;
 	text-decoration: underline;
 	color: ${ ( props ) => props.theme.colors.highlight };
-	font-size: 14px;
 
+	&.wp-checkout-order-review__show-coupon-field-button {
+		${ hasCheckoutVersion( '2' ) ? `font-size: 12px` : `font-size: 14px;` }
+	}
 	:hover {
 		text-decoration: none;
 	}

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -209,7 +209,7 @@ function CheckoutSummaryPriceList() {
 				</CheckoutSubtotalSection>
 
 				<CheckoutSummaryTotal>
-					<span>{ translate( 'Total' ) }</span>
+					<span className="wp-checkout-order-summary__label">{ translate( 'Total' ) }</span>
 					<span className="wp-checkout-order-summary__total-price">
 						{ totalLineItem.formattedAmount }
 					</span>
@@ -945,10 +945,22 @@ const CheckoutSummaryLineItem = styled.div< { isDiscount?: boolean } >`
 
 const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )`
 	color: ${ ( props ) => props.theme.colors.textColorDark };
-	font-size: 20px;
 	font-weight: ${ ( props ) => props.theme.weights.bold };
 	line-height: 26px;
-	margin-bottom: 16px;
+	${ hasCheckoutVersion( '2' ) ? `margin-bottom: 0px;` : `margin-bottom: 16px;` }
+	font-size: 20px;
+
+	& span {
+		font-family: 'Recoleta', sans-serif;
+	}
+
+	& .wp-checkout-order-summary__label {
+		${ hasCheckoutVersion( '2' ) && 'font-size: 28px; line-height: 40px; ' }
+	}
+
+	& .wp-checkout-order-summary__total-price {
+		${ hasCheckoutVersion( '2' ) && 'font-size: 40px; line-height: 44px;' }
+	}
 `;
 
 const LoadingCopy = styled.p`

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -816,10 +816,16 @@ const pulse = keyframes`
 
 const CheckoutSummaryCard = styled.div`
 	border-bottom: none 0;
+	${ hasCheckoutVersion( '2' ) && `grid-area: summary` }
 `;
 
 const CheckoutSummaryFeatures = styled.div`
 	padding: 24px 0;
+	${ hasCheckoutVersion( '2' ) && `grid-area: features; justify-self: center;` }
+
+	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
+		${ hasCheckoutVersion( '2' ) && ` justify-self: flex-start;` }
+	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		padding: 24px 0;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -821,10 +821,10 @@ const CheckoutSummaryCard = styled.div`
 
 const CheckoutSummaryFeatures = styled.div`
 	padding: 24px 0;
-	${ hasCheckoutVersion( '2' ) && `grid-area: features; justify-self: center;` }
+	${ hasCheckoutVersion( '2' ) && `grid-area: features; justify-self: flex-start;` }
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		${ hasCheckoutVersion( '2' ) && ` justify-self: flex-start;` }
+		${ hasCheckoutVersion( '2' ) ? ` padding: 0 0 24px` : `padding: 24px 0;` }
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -957,7 +957,7 @@ const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )`
 	font-size: 20px;
 
 	& span {
-		font-family: 'Recoleta', sans-serif;
+		${ hasCheckoutVersion( '2' ) ? `font-family: 'Recoleta', sans-serif;` : null }
 	}
 
 	& .wp-checkout-order-summary__label {

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -772,24 +772,58 @@ const CheckoutSummaryTitlePrice = styled.span`
 
 const CheckoutSummaryBody = styled.div`
 	box-sizing: border-box;
-	display: none;
 	margin: 0 auto;
 	max-width: 600px;
 	width: 100%;
 	padding: 24px;
+	${ hasCheckoutVersion( '2' )
+		? `grid-template-areas: 
+			"preview"
+			"review"
+			"summary"
+			"nudge"
+			"features";
+			display: grid;
+			`
+		: `display: none` };
 
 	.is-visible & {
-		display: block;
+		${ hasCheckoutVersion( '2' ) ? ' display: grid' : 'display: block' };
+	}
+
+	& .checkout-site-preview {
+		grid-area: preview;
+	}
+
+	& .checkout-review-order {
+		grid-area: review;
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 		padding: 24px;
+
+		${ hasCheckoutVersion( '2' ) &&
+		`grid-template-areas: 
+			"review review"
+			"summary summary"
+			"features nudge"
+			` };
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-		display: block;
 		max-width: 328px;
 		padding: 0;
+
+		${ hasCheckoutVersion( '2' )
+			? `grid-template-areas: 
+			"preview"	
+			"review"
+			"summary"
+			"nudge"
+			"features";
+			display: grid;
+			`
+			: `display: block;` };
 
 		& .card {
 			box-shadow: none;
@@ -800,6 +834,7 @@ const CheckoutSummaryBody = styled.div`
 const CheckoutSidebarNudgeWrapper = styled.div`
 	display: flex;
 	flex-direction: column;
+	${ hasCheckoutVersion( '2' ) && `grid-area: nudge` };
 
 	& > * {
 		max-width: 288px;

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -775,24 +775,24 @@ const CheckoutSummaryBody = styled.div`
 	margin: 0 auto;
 	max-width: 600px;
 	width: 100%;
-	padding: 24px;
-	${ hasCheckoutVersion( '2' )
-		? `grid-template-areas: 
+	padding: 32px 24px 24px 24px;
+	display: none;
+
+	.is-visible & {
+		${ hasCheckoutVersion( '2' )
+			? ` display: grid;
+			grid-template-areas:
 			"preview"
 			"review"
 			"summary"
 			"nudge"
-			"features";
-			display: grid;
-			`
-		: `display: none` };
-
-	.is-visible & {
-		${ hasCheckoutVersion( '2' ) ? ' display: grid' : 'display: block' };
+			"features";`
+			: `display: block;` };
 	}
 
 	& .checkout-site-preview {
 		grid-area: preview;
+		display: none;
 	}
 
 	& .checkout-review-order {
@@ -800,33 +800,41 @@ const CheckoutSummaryBody = styled.div`
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		padding: 24px;
+		padding: 50px 24px 24px 24px;
 
-		${ hasCheckoutVersion( '2' ) &&
-		`grid-template-areas: 
+		.is-visible & {
+			${ hasCheckoutVersion( '2' ) &&
+			`grid-template-areas:
+			"preview preview"
 			"review review"
 			"summary summary"
 			"features nudge"
 			` };
+		}
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		max-width: 328px;
 		padding: 0;
 
-		${ hasCheckoutVersion( '2' )
-			? `grid-template-areas: 
-			"preview"	
-			"review"
-			"summary"
-			"nudge"
-			"features";
-			display: grid;
+		.is-visible & {
+			${ hasCheckoutVersion( '2' )
+				? `grid-template-areas:
+					"preview"
+					"review"
+					"summary"
+					"nudge"
+					"features";
+					display: grid;
 			`
-			: `display: block;` };
-
+				: `display: block;` };
+		}
 		& .card {
 			box-shadow: none;
+		}
+
+		& .checkout-site-preview {
+			display: block;
 		}
 	}
 `;

--- a/client/my-sites/checkout/src/components/wp-checkout.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout.tsx
@@ -775,8 +775,9 @@ const CheckoutSummaryBody = styled.div`
 	margin: 0 auto;
 	max-width: 600px;
 	width: 100%;
-	padding: 32px 24px 24px 24px;
 	display: none;
+
+	${ hasCheckoutVersion( '2' ) ? `padding: 32px 24px 24px 24px;` : 'padding: 24px;' }
 
 	.is-visible & {
 		${ hasCheckoutVersion( '2' )
@@ -800,7 +801,7 @@ const CheckoutSummaryBody = styled.div`
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		padding: 50px 24px 24px 24px;
+		${ hasCheckoutVersion( '2' ) ? `padding: 50px 24px 24px 24px;` : 'padding: 24px;' }
 
 		.is-visible & {
 			${ hasCheckoutVersion( '2' ) &&
@@ -817,7 +818,8 @@ const CheckoutSummaryBody = styled.div`
 		max-width: 328px;
 		padding: 0;
 
-		.is-visible & {
+		.is-visible &,
+		& {
 			${ hasCheckoutVersion( '2' )
 				? `grid-template-areas:
 					"preview"
@@ -829,6 +831,7 @@ const CheckoutSummaryBody = styled.div`
 			`
 				: `display: block;` };
 		}
+
 		& .card {
 			box-shadow: none;
 		}

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -244,7 +244,7 @@ const DeleteButtonWrapper = styled.div`
 
 const DeleteButton = styled( Button )< { theme?: Theme } >`
 	width: auto;
-	${ hasCheckoutVersion2 ? `font-size:  14px;` : `font-size: 0.75rem` };
+	${ hasCheckoutVersion2 ? `font-size:  12px;` : `font-size: 0.75rem` };
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 `;
 

--- a/packages/wpcom-checkout/src/field.tsx
+++ b/packages/wpcom-checkout/src/field.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
+import { hasCheckoutVersion } from './checkout-version-checker';
 import type { ReactNode } from 'react';
 
 // Disabling this to make migrating files easier
@@ -103,11 +104,12 @@ const Input = styled.input< { isError?: boolean; icon?: ReactNode } >`
 	display: block;
 	width: 100%;
 	box-sizing: border-box;
-	font-size: 16px;
 	border: 1px solid
 		${ ( props ) => ( props.isError ? props.theme.colors.error : props.theme.colors.borderColor ) };
 	padding: 7px ${ ( props ) => ( props.icon ? '60px' : '10px' ) } 7px 10px;
 	line-height: 1.5;
+
+	${ hasCheckoutVersion( '2' ) ? `font-size: 14px;` : `font-size: 16px;` }
 
 	.rtl & {
 		padding: 7px 10px 7px ${ ( props ) => ( props.icon ? '60px' : '10px' ) };


### PR DESCRIPTION
This PR handles a number of small tweaks and additions to v2 of the checkout redesign. This is meant as a final styling pass and encompasses a number of quick fixes.

Related to https://github.com/Automattic/payments-shilling/issues/1969

## Proposed Changes

See tracking post here pbOQVh-45k-p2#comment-5454

## Testing Instructions

- Go to `http://calypso.localhost:3000/checkout/yoursite.com?checkoutVersion=2` with items in your cart
- Also check the v1 checkout for any regressions
- To check a siteless checkout (such as is the case with testing the Site Preview item in the change list) you can use a URL like `http://calypso.localhost:3000/checkout/jetpack/jetpack_backup_t1_yearly?checkoutVersion=2`