### PR TITLE
Signup: Add presales to DIFM (Built By) flows

### DIFF
--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -494,9 +494,10 @@ export function generateFlows( {
 			destination: getDIFMSignupDestination,
 			description: 'A flow for DIFM Lite leads',
 			excludeFromManageSiteFlows: true,
-			lastModified: '2023-10-11',
+			lastModified: '2024-02-09',
 			enableBranchSteps: true,
 			hideProgressIndicator: true,
+			enablePresales: true,
 		},
 		{
 			name: 'do-it-for-me-store',
@@ -512,9 +513,10 @@ export function generateFlows( {
 			destination: getDIFMSignupDestination,
 			description: 'The BBE store flow',
 			excludeFromManageSiteFlows: true,
-			lastModified: '2023-10-11',
+			lastModified: '2024-02-09',
 			enableBranchSteps: true,
 			hideProgressIndicator: true,
+			enablePresales: true,
 		},
 		{
 			name: 'website-design-services',
@@ -523,7 +525,8 @@ export function generateFlows( {
 			description: 'A flow for DIFM onboarding',
 			excludeFromManageSiteFlows: true,
 			providesDependenciesInQuery: [ 'siteSlug' ],
-			lastModified: '2022-05-02',
+			lastModified: '2024-02-09',
+			enablePresales: true,
 		},
 
 		{

--- a/client/signup/step-wrapper/index.jsx
+++ b/client/signup/step-wrapper/index.jsx
@@ -3,10 +3,19 @@ import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
+import { connect } from 'react-redux';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { usePresalesChat } from 'calypso/lib/presales-chat';
+import flows from 'calypso/signup/config/flows';
 import NavigationLink from 'calypso/signup/navigation-link';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { isReskinnedFlow } from '../is-flow';
 import './style.scss';
+
+function PresalesChat() {
+	usePresalesChat( 'wpcom' );
+	return null;
+}
 
 class StepWrapper extends Component {
 	static propTypes = {
@@ -34,6 +43,7 @@ class StepWrapper extends Component {
 		isHorizontalLayout: PropTypes.bool,
 		queryParams: PropTypes.object,
 		customizedActionButtons: PropTypes.element,
+		userLoggedIn: PropTypes.bool,
 	};
 
 	static defaultProps = {
@@ -198,6 +208,7 @@ class StepWrapper extends Component {
 			'is-large-skip-layout': isLargeSkipLayout,
 			'has-navigation': hasNavigation,
 		} );
+		const enablePresales = flows.getFlow( flowName, this.props.userLoggedIn )?.enablePresales;
 
 		let sticky = false;
 		if ( isSticky !== undefined ) {
@@ -247,9 +258,14 @@ class StepWrapper extends Component {
 						</div>
 					) }
 				</div>
+				{ enablePresales && <PresalesChat /> }
 			</>
 		);
 	}
 }
 
-export default localize( StepWrapper );
+export default connect( ( state ) => {
+	return {
+		userLoggedIn: isUserLoggedIn( state ),
+	};
+} )( localize( StepWrapper ) );


### PR DESCRIPTION
Implements peCdcN-lE-p2, adding presales chat to DIFM (Built By) flows.

## Proposed Changes

Opted to add a new flag at the level of flow declarations. This way we avoid a lot of duplicated code. The possible downside would be that we cannot enable it per step. But we don't have a use case for that, nor are we planning for it (either the whole flow has presales or not).

## Testing Instructions

* Visit DIFM flows directly to verify the presales chat shows up
    * http://calypso.localhost:3000/start/do-it-for-me/
    * http://calypso.localhost:3000/start/do-it-for-me-store/
* Visit other flows and verify there's no presales chat there. For example, https://calypso.localhost:3000/start/domains or https://calypso.localhost:3000/start/account

<img width="367" alt="Screenshot 2024-02-09 at 15 47 10" src="https://github.com/Automattic/wp-calypso/assets/3392497/d59787be-63c8-4bb0-b412-43a18e476ce6">

Possible issues preventing the presales chat from showing: the availability endpoint returns `false` (`https://public-api.wordpress.com/wpcom/v2/help/messaging/is-available?_envelope=1&group=wpcom_presales&environment=development`). Either sandbox the API and override that or log in to the sandboxed Zendesk environment and set yourself to available.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
