### PR TITLE
Plans 2023: Account for siteId when updating storage add-ons UI state

### DIFF
--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -77,7 +77,7 @@ const usePricingMetaForGridPlans = ( {
 		purchaseId: currentPlan?.purchaseId,
 	} );
 	const selectedStorageOptions = useSelect(
-		( select ) => select( WpcomPlansUI.store ).getSelectedStorageOptions(),
+		( select ) => select( WpcomPlansUI.store ).getSelectedStorageOptions( selectedSiteId ?? 0 ),
 		[]
 	);
 

--- a/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
+++ b/packages/data-stores/src/plans/hooks/use-pricing-meta-for-grid-plans.ts
@@ -77,7 +77,7 @@ const usePricingMetaForGridPlans = ( {
 		purchaseId: currentPlan?.purchaseId,
 	} );
 	const selectedStorageOptions = useSelect(
-		( select ) => select( WpcomPlansUI.store ).getSelectedStorageOptions( selectedSiteId ?? 0 ),
+		( select ) => select( WpcomPlansUI.store ).getSelectedStorageOptions( selectedSiteId ),
 		[]
 	);
 

--- a/packages/data-stores/src/wpcom-plans-ui/actions.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/actions.ts
@@ -18,7 +18,7 @@ export const setSelectedStorageOptionForPlan = ( {
 }: {
 	addOnSlug: WPComStorageAddOnSlug;
 	planSlug: PlanSlug;
-	siteId: number;
+	siteId?: number | null;
 } ) =>
 	( {
 		type: 'WPCOM_PLANS_UI_SET_SELECTED_STORAGE_OPTION_FOR_PLAN',

--- a/packages/data-stores/src/wpcom-plans-ui/actions.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/actions.ts
@@ -14,14 +14,17 @@ export const resetStore = () =>
 export const setSelectedStorageOptionForPlan = ( {
 	addOnSlug,
 	planSlug,
+	siteId,
 }: {
 	addOnSlug: WPComStorageAddOnSlug;
 	planSlug: PlanSlug;
+	siteId: number;
 } ) =>
 	( {
 		type: 'WPCOM_PLANS_UI_SET_SELECTED_STORAGE_OPTION_FOR_PLAN',
 		addOnSlug,
 		planSlug,
+		siteId,
 	} ) as const;
 
 export type WpcomPlansUIAction = ReturnType<

--- a/packages/data-stores/src/wpcom-plans-ui/reducer.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/reducer.ts
@@ -20,9 +20,12 @@ const selectedStorageOptionForPlans: Reducer<
 	WpcomPlansUIAction
 > = ( state, action ) => {
 	if ( action.type === 'WPCOM_PLANS_UI_SET_SELECTED_STORAGE_OPTION_FOR_PLAN' ) {
-		// @ts-expect-error TS is unhappy if we index an object by a null or an undefined value. We, however,
-		// expect siteId to be null or undefined here before site creation ( Ex. during onboarding ).
-		return { ...state, [ action.siteId ]: { [ action.planSlug ]: action.addOnSlug } };
+		return {
+			...state,
+			// @ts-expect-error TS is unhappy if we index an object by a null or an undefined value. We, however,
+			// expect siteId to be null or undefined here before site creation ( Ex. during onboarding ).
+			[ action.siteId ]: { ...state?.[ action.siteId ], [ action.planSlug ]: action.addOnSlug },
+		};
 	}
 	return state;
 };

--- a/packages/data-stores/src/wpcom-plans-ui/reducer.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/reducer.ts
@@ -20,6 +20,8 @@ const selectedStorageOptionForPlans: Reducer<
 	WpcomPlansUIAction
 > = ( state, action ) => {
 	if ( action.type === 'WPCOM_PLANS_UI_SET_SELECTED_STORAGE_OPTION_FOR_PLAN' ) {
+		// @ts-expect-error TS is unhappy if we index by a null or undefined value. We, however
+		// expect siteId to be null here before site creation ( like during onboarding ).
 		return { ...state, [ action.siteId ]: { [ action.planSlug ]: action.addOnSlug } };
 	}
 	return state;

--- a/packages/data-stores/src/wpcom-plans-ui/reducer.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/reducer.ts
@@ -20,7 +20,7 @@ const selectedStorageOptionForPlans: Reducer<
 	WpcomPlansUIAction
 > = ( state, action ) => {
 	if ( action.type === 'WPCOM_PLANS_UI_SET_SELECTED_STORAGE_OPTION_FOR_PLAN' ) {
-		return { ...state, [ action.planSlug ]: action.addOnSlug };
+		return { ...state, [ action.siteId ]: { [ action.planSlug ]: action.addOnSlug } };
 	}
 	return state;
 };

--- a/packages/data-stores/src/wpcom-plans-ui/reducer.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/reducer.ts
@@ -20,8 +20,8 @@ const selectedStorageOptionForPlans: Reducer<
 	WpcomPlansUIAction
 > = ( state, action ) => {
 	if ( action.type === 'WPCOM_PLANS_UI_SET_SELECTED_STORAGE_OPTION_FOR_PLAN' ) {
-		// @ts-expect-error TS is unhappy if we index by a null or undefined value. We, however
-		// expect siteId to be null here before site creation ( like during onboarding ).
+		// @ts-expect-error TS is unhappy if we index an object by a null or an undefined value. We, however,
+		// expect siteId to be null or undefined here before site creation ( Ex. during onboarding ).
 		return { ...state, [ action.siteId ]: { [ action.planSlug ]: action.addOnSlug } };
 	}
 	return state;

--- a/packages/data-stores/src/wpcom-plans-ui/selectors.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/selectors.ts
@@ -5,7 +5,7 @@ export const isDomainUpsellDialogShown = ( state: State ) => !! state.showDomain
 export const getSelectedStorageOptionForPlan = (
 	state: State,
 	planSlug: PlanSlug,
-	siteId: number
-) => state.selectedStorageOptionForPlans?.[ siteId ]?.[ planSlug ];
-export const getSelectedStorageOptions = ( state: State, siteId: number ) =>
-	state.selectedStorageOptionForPlans?.[ siteId ];
+	siteId?: number | null
+) => ( siteId ? state.selectedStorageOptionForPlans?.[ siteId ]?.[ planSlug ] : null );
+export const getSelectedStorageOptions = ( state: State, siteId?: number | null ) =>
+	siteId ? state.selectedStorageOptionForPlans?.[ siteId ] : null;

--- a/packages/data-stores/src/wpcom-plans-ui/selectors.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/selectors.ts
@@ -6,6 +6,13 @@ export const getSelectedStorageOptionForPlan = (
 	state: State,
 	planSlug: PlanSlug,
 	siteId?: number | null
-) => ( siteId ? state.selectedStorageOptionForPlans?.[ siteId ]?.[ planSlug ] : null );
-export const getSelectedStorageOptions = ( state: State, siteId?: number | null ) =>
-	siteId ? state.selectedStorageOptionForPlans?.[ siteId ] : null;
+) => {
+	// @ts-expect-error TS is unhappy if we index an object by a null or an undefined value. We, however,
+	// expect siteId to be null or undefined here before site creation ( Ex. during onboarding ).
+	return state.selectedStorageOptionForPlans?.[ siteId ][ planSlug ];
+};
+export const getSelectedStorageOptions = ( state: State, siteId?: number | null ) => {
+	// @ts-expect-error TS is unhappy if we index an object by a null or an undefined value. We, however,
+	// expect siteId to be null or undefined here before site creation ( Ex. during onboarding ).
+	return state.selectedStorageOptionForPlans?.[ siteId ];
+};

--- a/packages/data-stores/src/wpcom-plans-ui/selectors.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/selectors.ts
@@ -2,6 +2,9 @@ import { PlanSlug } from '@automattic/calypso-products';
 import type { State } from './reducer';
 
 export const isDomainUpsellDialogShown = ( state: State ) => !! state.showDomainUpsellDialog;
-export const getSelectedStorageOptionForPlan = ( state: State, planSlug: PlanSlug ) =>
-	state.selectedStorageOptionForPlans?.[ planSlug ];
+export const getSelectedStorageOptionForPlan = (
+	state: State,
+	planSlug: PlanSlug,
+	siteId: number
+) => state.selectedStorageOptionForPlans?.[ siteId ]?.[ planSlug ];
 export const getSelectedStorageOptions = ( state: State ) => state.selectedStorageOptionForPlans;

--- a/packages/data-stores/src/wpcom-plans-ui/selectors.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/selectors.ts
@@ -7,4 +7,5 @@ export const getSelectedStorageOptionForPlan = (
 	planSlug: PlanSlug,
 	siteId: number
 ) => state.selectedStorageOptionForPlans?.[ siteId ]?.[ planSlug ];
-export const getSelectedStorageOptions = ( state: State ) => state.selectedStorageOptionForPlans;
+export const getSelectedStorageOptions = ( state: State, siteId: number ) =>
+	state.selectedStorageOptionForPlans?.[ siteId ];

--- a/packages/data-stores/src/wpcom-plans-ui/selectors.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/selectors.ts
@@ -9,7 +9,7 @@ export const getSelectedStorageOptionForPlan = (
 ) => {
 	// @ts-expect-error TS is unhappy if we index an object by a null or an undefined value. We, however,
 	// expect siteId to be null or undefined here before site creation ( Ex. during onboarding ).
-	return state.selectedStorageOptionForPlans?.[ siteId ][ planSlug ];
+	return state.selectedStorageOptionForPlans?.[ siteId ]?.[ planSlug ];
 };
 export const getSelectedStorageOptions = ( state: State, siteId?: number | null ) => {
 	// @ts-expect-error TS is unhappy if we index an object by a null or an undefined value. We, however,

--- a/packages/data-stores/src/wpcom-plans-ui/types.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/types.ts
@@ -4,8 +4,10 @@ export interface DomainUpsellDialog {
 	show: boolean;
 }
 
+type SiteId = string;
+
 export interface SelectedStorageOptionForPlans {
-	[ key: string ]: {
+	[ key: SiteId ]: {
 		[ key in PlanSlug ]: WPComStorageAddOnSlug;
 	};
 }

--- a/packages/data-stores/src/wpcom-plans-ui/types.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/types.ts
@@ -1,12 +1,11 @@
-import type { WPComStorageAddOnSlug } from '@automattic/calypso-products';
+import type { PlanSlug, WPComStorageAddOnSlug } from '@automattic/calypso-products';
 
 export interface DomainUpsellDialog {
 	show: boolean;
 }
 
 export interface SelectedStorageOptionForPlans {
-	// TODO: Review the types here
 	[ key: string ]: {
-		[ key: string ]: WPComStorageAddOnSlug;
+		[ key in PlanSlug ]: WPComStorageAddOnSlug;
 	};
 }

--- a/packages/data-stores/src/wpcom-plans-ui/types.ts
+++ b/packages/data-stores/src/wpcom-plans-ui/types.ts
@@ -5,5 +5,8 @@ export interface DomainUpsellDialog {
 }
 
 export interface SelectedStorageOptionForPlans {
-	[ key: string ]: WPComStorageAddOnSlug;
+	// TODO: Review the types here
+	[ key: string ]: {
+		[ key: string ]: WPComStorageAddOnSlug;
+	};
 }

--- a/packages/plans-grid-next/src/components/actions.tsx
+++ b/packages/plans-grid-next/src/components/actions.tsx
@@ -232,7 +232,7 @@ const LoggedInPlansFeatureActionButton = ( {
 	const { gridPlansIndex, selectedSiteId } = usePlansGridContext();
 	const selectedStorageOptionForPlan = useSelect(
 		( select ) =>
-			select( WpcomPlansUI.store ).getSelectedStorageOptionForPlan( planSlug, selectedSiteId ?? 0 ),
+			select( WpcomPlansUI.store ).getSelectedStorageOptionForPlan( planSlug, selectedSiteId ),
 		[ planSlug ]
 	);
 	const {

--- a/packages/plans-grid-next/src/components/actions.tsx
+++ b/packages/plans-grid-next/src/components/actions.tsx
@@ -229,9 +229,10 @@ const LoggedInPlansFeatureActionButton = ( {
 } ) => {
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
 	const translate = useTranslate();
-	const { gridPlansIndex } = usePlansGridContext();
+	const { gridPlansIndex, selectedSiteId } = usePlansGridContext();
 	const selectedStorageOptionForPlan = useSelect(
-		( select ) => select( WpcomPlansUI.store ).getSelectedStorageOptionForPlan( planSlug ),
+		( select ) =>
+			select( WpcomPlansUI.store ).getSelectedStorageOptionForPlan( planSlug, selectedSiteId ?? 0 ),
 		[ planSlug ]
 	);
 	const {

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -979,7 +979,7 @@ const ComparisonGrid = ( {
 	planUpgradeCreditsApplicable,
 	gridSize,
 }: ComparisonGridProps ) => {
-	const { gridPlans } = usePlansGridContext();
+	const { gridPlans, selectedSiteId } = usePlansGridContext();
 	const [ activeTooltipId, setActiveTooltipId ] = useManageTooltipToggle();
 
 	// Check to see if we have at least one Woo Express plan we're comparing.
@@ -1093,6 +1093,7 @@ const ComparisonGrid = ( {
 	const handleUpgradeClick = useUpgradeClickHandler( {
 		gridPlans,
 		onUpgradeClick,
+		selectedSiteId: selectedSiteId ?? 0,
 	} );
 
 	/**

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -1093,7 +1093,7 @@ const ComparisonGrid = ( {
 	const handleUpgradeClick = useUpgradeClickHandler( {
 		gridPlans,
 		onUpgradeClick,
-		selectedSiteId: selectedSiteId ?? 0,
+		selectedSiteId: selectedSiteId,
 	} );
 
 	/**

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -247,7 +247,7 @@ const FeaturesGrid = ( {
 	const handleUpgradeClick = useUpgradeClickHandler( {
 		gridPlans,
 		onUpgradeClick,
-		selectedSiteId: selectedSiteId ?? 0,
+		selectedSiteId: selectedSiteId,
 	} );
 
 	const spotlightPlanProps = {

--- a/packages/plans-grid-next/src/components/features-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/index.tsx
@@ -239,6 +239,7 @@ const FeaturesGrid = ( {
 	paidDomainName,
 	hideUnavailableFeatures,
 	selectedFeature,
+	selectedSiteId,
 	generatedWPComSubdomain,
 	isCustomDomainAllowedOnFreePlan,
 	gridSize,
@@ -246,6 +247,7 @@ const FeaturesGrid = ( {
 	const handleUpgradeClick = useUpgradeClickHandler( {
 		gridPlans,
 		onUpgradeClick,
+		selectedSiteId: selectedSiteId ?? 0,
 	} );
 
 	const spotlightPlanProps = {

--- a/packages/plans-grid-next/src/components/storage-add-on-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/storage-add-on-dropdown.tsx
@@ -81,7 +81,7 @@ export const StorageAddOnDropdown = ( {
 	priceOnSeparateLine = false,
 }: StorageAddOnDropdownProps ) => {
 	const translate = useTranslate();
-	const { gridPlansIndex } = usePlansGridContext();
+	const { gridPlansIndex, selectedSiteId } = usePlansGridContext();
 	const {
 		pricing: { currencyCode },
 		storageAddOnsForPlan,
@@ -97,7 +97,8 @@ export const StorageAddOnDropdown = ( {
 		currencyCode: currencyCode || 'USD',
 	} );
 	const selectedStorageOptionForPlan = useSelect(
-		( select ) => select( WpcomPlansUI.store ).getSelectedStorageOptionForPlan( planSlug ),
+		( select ) =>
+			select( WpcomPlansUI.store ).getSelectedStorageOptionForPlan( planSlug, selectedSiteId ?? 0 ),
 		[ planSlug ]
 	);
 	const defaultStorageOption = useDefaultStorageOption( {
@@ -107,7 +108,11 @@ export const StorageAddOnDropdown = ( {
 
 	useEffect( () => {
 		if ( storageAddOnsForPlan && defaultStorageOption && ! selectedStorageOptionForPlan ) {
-			setSelectedStorageOptionForPlan( { addOnSlug: defaultStorageOption, planSlug } );
+			setSelectedStorageOptionForPlan( {
+				addOnSlug: defaultStorageOption,
+				planSlug,
+				siteId: selectedSiteId ?? 0,
+			} );
 		}
 	}, [] );
 
@@ -146,7 +151,7 @@ export const StorageAddOnDropdown = ( {
 
 			if ( addOnSlug ) {
 				onStorageAddOnClick && onStorageAddOnClick( addOnSlug );
-				setSelectedStorageOptionForPlan( { addOnSlug, planSlug } );
+				setSelectedStorageOptionForPlan( { addOnSlug, planSlug, siteId: selectedSiteId ?? 0 } );
 			}
 		},
 		[ onStorageAddOnClick, planSlug, setSelectedStorageOptionForPlan ]

--- a/packages/plans-grid-next/src/components/storage-add-on-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/storage-add-on-dropdown.tsx
@@ -98,7 +98,7 @@ export const StorageAddOnDropdown = ( {
 	} );
 	const selectedStorageOptionForPlan = useSelect(
 		( select ) =>
-			select( WpcomPlansUI.store ).getSelectedStorageOptionForPlan( planSlug, selectedSiteId ?? 0 ),
+			select( WpcomPlansUI.store ).getSelectedStorageOptionForPlan( planSlug, selectedSiteId ),
 		[ planSlug ]
 	);
 	const defaultStorageOption = useDefaultStorageOption( {
@@ -111,7 +111,7 @@ export const StorageAddOnDropdown = ( {
 			setSelectedStorageOptionForPlan( {
 				addOnSlug: defaultStorageOption,
 				planSlug,
-				siteId: selectedSiteId ?? 0,
+				siteId: selectedSiteId,
 			} );
 		}
 	}, [] );
@@ -151,7 +151,7 @@ export const StorageAddOnDropdown = ( {
 
 			if ( addOnSlug ) {
 				onStorageAddOnClick && onStorageAddOnClick( addOnSlug );
-				setSelectedStorageOptionForPlan( { addOnSlug, planSlug, siteId: selectedSiteId ?? 0 } );
+				setSelectedStorageOptionForPlan( { addOnSlug, planSlug, siteId: selectedSiteId } );
 			}
 		},
 		[ onStorageAddOnClick, planSlug, setSelectedStorageOptionForPlan ]

--- a/packages/plans-grid-next/src/hooks/use-upgrade-click-handler.ts
+++ b/packages/plans-grid-next/src/hooks/use-upgrade-click-handler.ts
@@ -13,11 +13,12 @@ export type UpgradeClickHandler = (
 interface Props {
 	gridPlans: GridPlan[]; // TODO clk: to be removed, grabbed from context
 	onUpgradeClick?: UpgradeClickHandler;
+	selectedSiteId: number;
 }
 
-const useUpgradeClickHandler = ( { gridPlans, onUpgradeClick }: Props ) => {
+const useUpgradeClickHandler = ( { gridPlans, onUpgradeClick, selectedSiteId }: Props ) => {
 	const selectedStorageOptions = useSelect( ( select ) => {
-		return select( WpcomPlansUI.store ).getSelectedStorageOptions();
+		return select( WpcomPlansUI.store ).getSelectedStorageOptions( selectedSiteId );
 	}, [] );
 
 	return useCallback(

--- a/packages/plans-grid-next/src/hooks/use-upgrade-click-handler.ts
+++ b/packages/plans-grid-next/src/hooks/use-upgrade-click-handler.ts
@@ -13,7 +13,7 @@ export type UpgradeClickHandler = (
 interface Props {
 	gridPlans: GridPlan[]; // TODO clk: to be removed, grabbed from context
 	onUpgradeClick?: UpgradeClickHandler;
-	selectedSiteId: number;
+	selectedSiteId?: number | null;
 }
 
 const useUpgradeClickHandler = ( { gridPlans, onUpgradeClick, selectedSiteId }: Props ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/85773

## Proposed Changes

* Persist storage add-on UI state on a per site basis

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to /plans and select a non-standard storage add-on option
* Switch sites
* Verify that the storage add-on option has changed to the default

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?