### PR TITLE
Recognize URL-only sites in Jetpack Manage

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions/use-site-actions.ts
@@ -37,27 +37,29 @@ export default function useSiteActions(
 		const isWPCOMAtomicSiteCreationEnabled =
 			isEnabled( 'jetpack/pro-dashboard-wpcom-atomic-hosting' ) && is_atomic;
 
+		const isUrlOnly = site?.value?.sticker?.includes( 'jetpack-manage-url-only-site' );
+
 		return [
 			{
 				name: translate( 'Set up site' ),
 				href: `https://wordpress.com/home/${ siteSlug }`,
 				onClick: () => handleClickMenuItem( 'set_up_site' ),
 				isExternalLink: true,
-				isEnabled: isWPCOMAtomicSiteCreationEnabled,
+				isEnabled: isWPCOMAtomicSiteCreationEnabled && ! isUrlOnly,
 			},
 			{
 				name: translate( 'Change domain' ),
 				href: `https://wordpress.com/domains/manage/${ siteSlug }`,
 				onClick: () => handleClickMenuItem( 'change_domain' ),
 				isExternalLink: true,
-				isEnabled: isWPCOMAtomicSiteCreationEnabled,
+				isEnabled: isWPCOMAtomicSiteCreationEnabled && ! isUrlOnly,
 			},
 			{
 				name: translate( 'Hosting configuration' ),
 				href: `https://wordpress.com/hosting-config/${ siteSlug }`,
 				onClick: () => handleClickMenuItem( 'hosting_configuration' ),
 				isExternalLink: true,
-				isEnabled: isWPCOMAtomicSiteCreationEnabled,
+				isEnabled: isWPCOMAtomicSiteCreationEnabled && ! isUrlOnly,
 			},
 			{
 				name: translate( 'Issue new license' ),
@@ -66,7 +68,7 @@ export default function useSiteActions(
 					: undefined,
 				onClick: () => handleClickMenuItem( 'issue_license' ),
 				isExternalLink: false,
-				isEnabled: partnerCanIssueLicense && ! siteError && ! is_atomic,
+				isEnabled: partnerCanIssueLicense && ! siteError && ! is_atomic && ! isUrlOnly,
 			},
 			{
 				name: translate( 'View activity' ),
@@ -75,7 +77,7 @@ export default function useSiteActions(
 					: `/activity-log/${ siteSlug }`,
 				onClick: () => handleClickMenuItem( 'view_activity' ),
 				isExternalLink: is_atomic,
-				isEnabled: ! siteError,
+				isEnabled: ! siteError && ! isUrlOnly,
 			},
 			{
 				name: translate( 'Copy this site' ),
@@ -84,7 +86,7 @@ export default function useSiteActions(
 					: `/backup/${ siteSlug }/clone`,
 				onClick: () => handleClickMenuItem( 'clone_site' ),
 				isExternalLink: is_atomic,
-				isEnabled: has_backup,
+				isEnabled: has_backup && ! isUrlOnly,
 			},
 			{
 				name: translate( 'Site settings' ),
@@ -93,7 +95,7 @@ export default function useSiteActions(
 					: `/settings/${ siteSlug }`,
 				onClick: () => handleClickMenuItem( 'site_settings' ),
 				isExternalLink: is_atomic,
-				isEnabled: has_backup,
+				isEnabled: has_backup && ! isUrlOnly,
 			},
 			{
 				name: translate( 'View site' ),
@@ -107,7 +109,7 @@ export default function useSiteActions(
 				href: `${ url_with_scheme }/wp-admin/admin.php?page=jetpack#/dashboard`,
 				onClick: () => handleClickMenuItem( 'visit_wp_admin' ),
 				isExternalLink: true,
-				isEnabled: true,
+				isEnabled: true && ! isUrlOnly,
 			},
 		];
 	}, [ dispatch, isLargeScreen, partnerCanIssueLicense, siteError, siteValue, translate ] );

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/index.tsx
@@ -1,4 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
+import { Icon, lineSolid } from '@wordpress/icons';
 import classNames from 'classnames';
 import { Fragment, useContext } from 'react';
 import useFetchTestConnection from 'calypso/data/agency-dashboard/use-fetch-test-connection';
@@ -19,7 +20,6 @@ import SitePhpVersion from '../site-expanded-content/site-php-version';
 import SiteStatusContent from '../site-status-content';
 import SiteTableExpand from '../site-table-expand';
 import type { SiteData, SiteColumns } from '../types';
-
 import './style.scss';
 
 interface Props {
@@ -62,6 +62,8 @@ export default function SiteTableRow( { index, columns, item, setExpanded, isExp
 	const hasSiteConnectionError = ! isConnected;
 	const siteError = item.monitor.error || hasSiteConnectionError;
 	const isMostRecentJetpackConnectedSite = mostRecentConnectedSite === site.value.url;
+	const isUrlOnly = site?.value?.sticker?.includes( 'jetpack-manage-url-only-site' );
+
 	return (
 		<Fragment>
 			<tr
@@ -88,6 +90,20 @@ export default function SiteTableRow( { index, columns, item, setExpanded, isExp
 					if ( hasSiteConnectionError && column.key !== 'site' ) {
 						return null;
 					}
+
+					if ( isUrlOnly && ! [ 'site', 'monitor' ].includes( column.key ) ) {
+						return (
+							<td
+								className={ classNames( column.className, {
+									'site-table__td-is-url-only': isUrlOnly,
+								} ) }
+								key={ `table-data-${ row.type }-${ blogId }` }
+							>
+								<Icon className="site-table__empty-icon" icon={ lineSolid } />
+							</td>
+						);
+					}
+
 					const isCritical = 'critical' === row.status;
 					if ( row.type ) {
 						return (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-table-row/style.scss
@@ -110,3 +110,7 @@ tr.site-table__table-row-expanded {
 		border-top: none;
 	}
 }
+
+.site-table__empty-icon {
+	opacity: 0.3;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -75,6 +75,7 @@ export interface BoostData {
 }
 
 export interface Site {
+	sticker: string[];
 	blog_id: number;
 	url: string;
 	url_with_scheme: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Adds a custom row-level view for sites stickered as URL-only sites in the JPM dashboard.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sticker one of your sites with `jetpack-manage-url-only-site` and ensure that it shows up without data in the JPM dashboard.
* Ensure that the options in the context menu are reduced to "View site" for all URL-only sites, and that the options in regular sites are unaffected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
