### PR TITLE
Jetpack Backup: Add BackupNowButton component scaffolding

### DIFF
--- a/client/components/jetpack/backup-now-button/README.md
+++ b/client/components/jetpack/backup-now-button/README.md
@@ -1,0 +1,19 @@
+## Usage
+
+```jsx
+import BackupNowButton from 'calypso/components/jetpack/backup-now-button';
+
+function render() {
+	return (
+		<div>
+			<BackupNowButton
+				variant="primary"
+				toolTipText="Click here to backup your site now."
+				trackEventName="calypso_jetpack_backup_now"
+			>
+				Backup Now
+			</BackupNowButton>
+		</div>
+	);
+}
+```

--- a/client/components/jetpack/backup-now-button/README.md
+++ b/client/components/jetpack/backup-now-button/README.md
@@ -8,7 +8,7 @@ function render() {
 		<div>
 			<BackupNowButton
 				variant="primary"
-				toolTipText="Click here to backup your site now."
+				tooltipText="Click here to backup your site now."
 				trackEventName="calypso_jetpack_backup_now"
 			>
 				Backup Now

--- a/client/components/jetpack/backup-now-button/index.tsx
+++ b/client/components/jetpack/backup-now-button/index.tsx
@@ -30,17 +30,7 @@ const BackupNowButton: FunctionComponent< Props > = ( {
 		</Button>
 	);
 
-	return (
-		<>
-			{ tooltipText ? (
-				<Tooltip text={ tooltipText }>{ button }</Tooltip>
-			) : (
-				<button onClick={ handleClick } disabled={ disabled }>
-					{ button }
-				</button>
-			) }
-		</>
-	);
+	return <>{ tooltipText ? <Tooltip text={ tooltipText }>{ button }</Tooltip> : button }</>;
 };
 
 export default BackupNowButton;

--- a/client/components/jetpack/backup-now-button/index.tsx
+++ b/client/components/jetpack/backup-now-button/index.tsx
@@ -5,7 +5,6 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 interface Props {
 	children?: React.ReactNode;
 	disabled?: boolean;
-	label?: string;
 	tooltipText?: string;
 	trackEventName?: string;
 	variant: 'primary' | 'secondary' | 'tertiary';

--- a/client/components/jetpack/backup-now-button/index.tsx
+++ b/client/components/jetpack/backup-now-button/index.tsx
@@ -1,0 +1,46 @@
+import { Button, Tooltip } from '@wordpress/components';
+import { FunctionComponent } from 'react';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+interface Props {
+	children?: React.ReactNode;
+	disabled?: boolean;
+	label?: string;
+	toolTipText?: string;
+	trackEventName?: string;
+	variant: 'primary' | 'secondary' | 'tertiary';
+}
+
+const BackupNowButton: FunctionComponent< Props > = ( {
+	children,
+	disabled = false,
+	toolTipText,
+	trackEventName,
+	variant,
+} ) => {
+	const handleClick = () => {
+		if ( trackEventName ) {
+			recordTracksEvent( trackEventName );
+		}
+	};
+
+	const button = (
+		<Button variant={ variant } onClick={ handleClick } disabled={ disabled }>
+			{ children }
+		</Button>
+	);
+
+	return (
+		<>
+			{ toolTipText ? (
+				<Tooltip text={ toolTipText }>{ button }</Tooltip>
+			) : (
+				<button onClick={ handleClick } disabled={ disabled }>
+					{ button }
+				</button>
+			) }
+		</>
+	);
+};
+
+export default BackupNowButton;

--- a/client/components/jetpack/backup-now-button/index.tsx
+++ b/client/components/jetpack/backup-now-button/index.tsx
@@ -6,7 +6,7 @@ interface Props {
 	children?: React.ReactNode;
 	disabled?: boolean;
 	label?: string;
-	toolTipText?: string;
+	tooltipText?: string;
 	trackEventName?: string;
 	variant: 'primary' | 'secondary' | 'tertiary';
 }
@@ -14,7 +14,7 @@ interface Props {
 const BackupNowButton: FunctionComponent< Props > = ( {
 	children,
 	disabled = false,
-	toolTipText,
+	tooltipText,
 	trackEventName,
 	variant,
 } ) => {
@@ -32,8 +32,8 @@ const BackupNowButton: FunctionComponent< Props > = ( {
 
 	return (
 		<>
-			{ toolTipText ? (
-				<Tooltip text={ toolTipText }>{ button }</Tooltip>
+			{ tooltipText ? (
+				<Tooltip text={ tooltipText }>{ button }</Tooltip>
 			) : (
 				<button onClick={ handleClick } disabled={ disabled }>
 					{ button }


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-backup-team/issues/363

## Proposed Changes

* Add a new `BackupNowButton` component that will be used to start a new backup for sites that have VaultPress Backup product.
  * If `tooltipText` is passed, we will wrap the button in <Tooltip>.
  * It is necessary to specify a variant (primary, secondary or tertiary). Excluding `link` as we don't expect this button to be a link.
  * Record a Track event with the custom `trackEventName` passed. This is because this button would be useful on Backup Warning page too.
* This is mostly initial code, so we can start iterating on adding more functionalities.
## Testing Instructions

N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?