### PR TITLE
Redirect to My Jetpack after license activation

### DIFF
--- a/client/components/jetpack/sidebar/index.jsx
+++ b/client/components/jetpack/sidebar/index.jsx
@@ -9,7 +9,7 @@ import SidebarMenu from 'calypso/layout/sidebar/menu';
 import SidebarRegion from 'calypso/layout/sidebar/region';
 import CurrentSite from 'calypso/my-sites/current-site';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import getJetpackAdminUrl from 'calypso/state/sites/selectors/get-jetpack-admin-url';
+import { getJetpackAdminUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import JetpackCloudSidebarMenuItems from './menu-items/jetpack-cloud';
 import JetpackIcons from './menu-items/jetpack-icons';

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -13,7 +13,7 @@ import Sidebar, {
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { isAgencyUser } from 'calypso/state/partner-portal/partner/selectors';
-import getJetpackAdminUrl from 'calypso/state/sites/selectors/get-jetpack-admin-url';
+import { getJetpackAdminUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import UserFeedbackModalForm from '../user-feedback-modal-form';
 import SidebarHeader from './header';

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content/site-boost-column/index.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useContext, useState } from 'react';
 import { useSelector } from 'calypso/state';
-import getJetpackAdminUrl from 'calypso/state/sites/selectors/get-jetpack-admin-url';
+import { getJetpackAdminUrl } from 'calypso/state/sites/selectors';
 import { useJetpackAgencyDashboardRecordTrackEvent } from '../../../hooks';
 import DashboardDataContext from '../../dashboard-data-context';
 import { getBoostRating, getBoostRatingClass } from '../../lib/boost';

--- a/client/my-sites/checkout/checkout-thank-you/use-get-jetpack-activation-confirmation-info.ts
+++ b/client/my-sites/checkout/checkout-thank-you/use-get-jetpack-activation-confirmation-info.ts
@@ -15,7 +15,7 @@ import successImageDefault from 'calypso/assets/images/jetpack/licensing-activat
 import successImageScan from 'calypso/assets/images/jetpack/licensing-activation-success-Scan.png';
 import successImageSearch from 'calypso/assets/images/jetpack/licensing-activation-success-Search.png';
 import { useSelector } from 'calypso/state';
-import { getSiteAdminUrl, getSiteSlug } from 'calypso/state/sites/selectors';
+import { getSiteSlug, getJetpackAdminUrl } from 'calypso/state/sites/selectors';
 
 type ActivationConfirmationInfo = {
 	image: string;
@@ -29,7 +29,7 @@ const useGetJetpackActivationConfirmationInfo = (
 ): ActivationConfirmationInfo => {
 	const translate = useTranslate();
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
-	const wpAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
+	const jetpackAdminUrl = useSelector( ( state ) => getJetpackAdminUrl( state, siteId ) );
 
 	const baseJetpackCloudUrl = 'https://cloud.jetpack.com';
 
@@ -39,7 +39,7 @@ const useGetJetpackActivationConfirmationInfo = (
 			text: translate(
 				"We'll take care of everything from here. Now you can enjoy a spam-free site!"
 			),
-			buttonUrl: wpAdminUrl || baseJetpackCloudUrl,
+			buttonUrl: jetpackAdminUrl || baseJetpackCloudUrl,
 		},
 		jetpack_backup: {
 			image: successImageDefault,
@@ -104,12 +104,12 @@ const useGetJetpackActivationConfirmationInfo = (
 		jetpack_videopress: {
 			image: successImageDefault,
 			text: translate( 'Experience high-quality, ad-free video built specifically for WordPress.' ),
-			buttonUrl: wpAdminUrl || baseJetpackCloudUrl,
+			buttonUrl: jetpackAdminUrl || baseJetpackCloudUrl,
 		},
 		default: {
 			image: successImageDefault,
 			text: translate( "You're all set!" ),
-			buttonUrl: wpAdminUrl || baseJetpackCloudUrl,
+			buttonUrl: jetpackAdminUrl || baseJetpackCloudUrl,
 		},
 	};
 

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -70,6 +70,7 @@ export { default as getSiteWooCommerceUrl } from './get-site-woocommerce-url';
 export { default as getJetpackSearchCustomizeUrl } from './get-jetpack-search-customize-url';
 export { default as getJetpackSearchDashboardUrl } from './get-jetpack-search-dashboard-url';
 export { default as getJetpackVersion } from './get-jetpack-version';
+export { default as getJetpackAdminUrl } from './get-jetpack-admin-url';
 export { default as isSimpleSite } from './is-simple-site';
 export { default as getJetpackStatsAdminVersion } from './get-jetpack-stats-admin-version';
 export { default as isWooCYSEligibleSite } from './is-woo-cys-eligible-site';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* This PR updates the behavior of the redirect after activating a license to redirect to My Jetpack.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Start this process on any Jetpack site that you have. Make sure it's not connected when you start this
* Go to My Jetpack, click on "Learn More" on the Boost card
* Complete the checkout process and connect your site after the checkout
* On the site selection screen, you can replace the WordPress.com domain with the Calypso live domain for this PR
* Attach the license to your site and you'll be redirected to a URL like this: https://{...}.calypso.live/checkout/jetpack/thank-you/licensing-auto-activate-completed/jetpack_boost_monthly?destinationSiteId={siteID}
* Click on "Go to Dashboard" and confirm you're redirected to My Jetpack

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?