### PR TITLE
Jetpack Backup: Add backup actions toolbar

### DIFF
--- a/client/components/jetpack/backup-actions-toolbar/README.md
+++ b/client/components/jetpack/backup-actions-toolbar/README.md
@@ -1,0 +1,13 @@
+## Usage
+
+```jsx
+import BackupActionsToolbar from 'calypso/components/jetpack/backup-actions-toolbar';
+
+function render() {
+	return (
+		<div>
+			<BackupActionsToolbar />
+		</div>
+	);
+}
+```

--- a/client/components/jetpack/backup-actions-toolbar/README.md
+++ b/client/components/jetpack/backup-actions-toolbar/README.md
@@ -2,11 +2,16 @@
 
 ```jsx
 import BackupActionsToolbar from 'calypso/components/jetpack/backup-actions-toolbar';
+import { useSelector } from 'react-redux';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 function render() {
+    const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
 	return (
 		<div>
-			<BackupActionsToolbar />
+			<BackupActionsToolbar siteId={ siteId } siteSlug={ siteSlug } />
 		</div>
 	);
 }

--- a/client/components/jetpack/backup-actions-toolbar/index.tsx
+++ b/client/components/jetpack/backup-actions-toolbar/index.tsx
@@ -1,0 +1,18 @@
+import config from '@automattic/calypso-config';
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
+import BackupNowButton from '../backup-now-button';
+
+const BackupActionsToolbar: FunctionComponent = () => {
+	const translate = useTranslate();
+
+	const backupNow = (
+		<BackupNowButton variant="primary" trackEventName="calypso_jetpack_backup_now">
+			{ translate( 'Backup Now' ) }
+		</BackupNowButton>
+	);
+
+	return <>{ config.isEnabled( 'jetpack/backup-on-demand' ) && backupNow }</>;
+};
+
+export default BackupActionsToolbar;

--- a/client/components/jetpack/backup-actions-toolbar/index.tsx
+++ b/client/components/jetpack/backup-actions-toolbar/index.tsx
@@ -1,5 +1,4 @@
 import config from '@automattic/calypso-config';
-// import { Button } from '@automattic/components';
 import { Button, Tooltip } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';

--- a/client/components/jetpack/backup-actions-toolbar/index.tsx
+++ b/client/components/jetpack/backup-actions-toolbar/index.tsx
@@ -3,10 +3,11 @@ import config from '@automattic/calypso-config';
 import { Button, Tooltip } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
-import { useDispatch } from 'react-redux';
 import { backupClonePath } from 'calypso/my-sites/backup/paths';
+import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import BackupNowButton from '../backup-now-button';
+import './style.scss';
 
 interface Props {
 	siteSlug: 'string';
@@ -40,10 +41,10 @@ const BackupActionsToolbar: FunctionComponent< Props > = ( { siteSlug } ) => {
 	);
 
 	return (
-		<>
+		<div className="jetpack-backup__actions-toolbar">
 			{ copySite }
 			{ config.isEnabled( 'jetpack/backup-on-demand' ) && backupNow }
-		</>
+		</div>
 	);
 };
 

--- a/client/components/jetpack/backup-actions-toolbar/index.tsx
+++ b/client/components/jetpack/backup-actions-toolbar/index.tsx
@@ -1,10 +1,37 @@
 import config from '@automattic/calypso-config';
+// import { Button } from '@automattic/components';
+import { Button, Tooltip } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
+import { useDispatch } from 'react-redux';
+import { backupClonePath } from 'calypso/my-sites/backup/paths';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import BackupNowButton from '../backup-now-button';
 
-const BackupActionsToolbar: FunctionComponent = () => {
+interface Props {
+	siteSlug: 'string';
+}
+
+const BackupActionsToolbar: FunctionComponent< Props > = ( { siteSlug } ) => {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const copySite = (
+		<Tooltip
+			text={ translate(
+				'To test your site changes, migrate or keep your data safe in another site'
+			) }
+		>
+			<Button
+				className="backup__clone-button"
+				href={ backupClonePath( siteSlug ) }
+				onClick={ () => dispatch( recordTracksEvent( 'calypso_jetpack_backup_copy_site' ) ) }
+				variant="secondary"
+			>
+				{ translate( 'Copy site' ) }
+			</Button>
+		</Tooltip>
+	);
 
 	const backupNow = (
 		<BackupNowButton variant="primary" trackEventName="calypso_jetpack_backup_now">
@@ -12,7 +39,12 @@ const BackupActionsToolbar: FunctionComponent = () => {
 		</BackupNowButton>
 	);
 
-	return <>{ config.isEnabled( 'jetpack/backup-on-demand' ) && backupNow }</>;
+	return (
+		<>
+			{ copySite }
+			{ config.isEnabled( 'jetpack/backup-on-demand' ) && backupNow }
+		</>
+	);
 };
 
 export default BackupActionsToolbar;

--- a/client/components/jetpack/backup-actions-toolbar/index.tsx
+++ b/client/components/jetpack/backup-actions-toolbar/index.tsx
@@ -9,10 +9,11 @@ import BackupNowButton from '../backup-now-button';
 import './style.scss';
 
 interface Props {
-	siteSlug: 'string';
+	siteId: number;
+	siteSlug: string;
 }
 
-const BackupActionsToolbar: FunctionComponent< Props > = ( { siteSlug } ) => {
+const BackupActionsToolbar: FunctionComponent< Props > = ( { siteId, siteSlug } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -34,7 +35,11 @@ const BackupActionsToolbar: FunctionComponent< Props > = ( { siteSlug } ) => {
 	);
 
 	const backupNow = (
-		<BackupNowButton variant="primary" trackEventName="calypso_jetpack_backup_now">
+		<BackupNowButton
+			siteId={ siteId }
+			variant="primary"
+			trackEventName="calypso_jetpack_backup_now"
+		>
 			{ translate( 'Backup Now' ) }
 		</BackupNowButton>
 	);

--- a/client/components/jetpack/backup-actions-toolbar/style.scss
+++ b/client/components/jetpack/backup-actions-toolbar/style.scss
@@ -1,0 +1,4 @@
+.jetpack-backup__actions-toolbar {
+	display: flex;
+	gap: 10px;
+}

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -1,11 +1,10 @@
 import { WPCOM_FEATURES_REAL_TIME_BACKUPS } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
-import { Button } from '@automattic/components';
-import { ExternalLink, Tooltip } from '@wordpress/components';
+import { ExternalLink } from '@wordpress/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useSelector } from 'react-redux';
 import TimeMismatchWarning from 'calypso/blocks/time-mismatch-warning';
 import BackupStorageSpace from 'calypso/components/backup-storage-space';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -28,7 +27,6 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { INDEX_FORMAT } from 'calypso/lib/jetpack/backup-utils';
 import useDateWithOffset from 'calypso/lib/jetpack/hooks/use-date-with-offset';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import isRewindPoliciesInitialized from 'calypso/state/rewind/selectors/is-rewind-policies-initialized';
 import getActivityLogFilter from 'calypso/state/selectors/get-activity-log-filter';
 import getDoesRewindNeedCredentials from 'calypso/state/selectors/get-does-rewind-need-credentials';
@@ -41,7 +39,7 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 import BackupDatePicker from './backup-date-picker';
 import BackupsMadeRealtimeBanner from './banners/backups-made-realtime-banner';
 import EnableRestoresBanner from './banners/enable-restores-banner';
-import { backupMainPath, backupClonePath } from './paths';
+import { backupMainPath } from './paths';
 import SearchResults from './search-results';
 import { DailyStatus, RealtimeStatus } from './status';
 
@@ -176,7 +174,6 @@ function BackupStatus( { selectedDate, needCredentials, onDateChange } ) {
 	const isPoliciesInitialized = useSelectedSiteSelector( isRewindPoliciesInitialized );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const translate = useTranslate();
-	const dispatch = useDispatch();
 
 	const hasRealtimeBackups = useSelectedSiteSelector(
 		siteHasFeature,
@@ -201,22 +198,7 @@ function BackupStatus( { selectedDate, needCredentials, onDateChange } ) {
 						<div className="backup__header-right">
 							{ siteSlug && (
 								<>
-									<Tooltip
-										text={ translate(
-											'To test your site changes, migrate or keep your data safe in another site'
-										) }
-									>
-										<Button
-											className="backup__clone-button"
-											href={ backupClonePath( siteSlug ) }
-											onClick={ () =>
-												dispatch( recordTracksEvent( 'calypso_jetpack_backup_copy_site' ) )
-											}
-										>
-											{ translate( 'Copy site' ) }
-										</Button>
-									</Tooltip>
-									<BackupActionsToolbar />
+									<BackupActionsToolbar siteSlug={ siteSlug } />
 								</>
 							) }
 						</div>

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { WPCOM_FEATURES_REAL_TIME_BACKUPS } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { Button } from '@automattic/components';
@@ -19,7 +18,7 @@ import QuerySiteFeatures from 'calypso/components/data/query-site-features';
 import QuerySiteProducts from 'calypso/components/data/query-site-products';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import InlineSupportLink from 'calypso/components/inline-support-link';
-import BackupNowButton from 'calypso/components/jetpack/backup-now-button';
+import BackupActionsToolbar from 'calypso/components/jetpack/backup-actions-toolbar';
 import BackupPlaceholder from 'calypso/components/jetpack/backup-placeholder';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
@@ -217,11 +216,7 @@ function BackupStatus( { selectedDate, needCredentials, onDateChange } ) {
 											{ translate( 'Copy site' ) }
 										</Button>
 									</Tooltip>
-									{ config.isEnabled( 'jetpack/backup-on-demand' ) && (
-										<BackupNowButton variant="primary" trackEventName="calypso_jetpack_backup_now">
-											{ translate( 'Backup Now' ) }
-										</BackupNowButton>
-									) }
+									<BackupActionsToolbar />
 								</>
 							) }
 						</div>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves https://github.com/Automattic/jetpack-backup-team/issues/364

## Proposed Changes

* Add `BackupActionsToolbar` component that will be used to handle `Copy Site` and the new `Backup Now` button.
* Refactor the backup page to include the `BackupActionsToolbar`

## Screenshot

![CleanShot 2024-02-09 at 21 58 51@2x](https://github.com/Automattic/wp-calypso/assets/1488641/c0f22e31-ac60-4e33-b511-2f109f13b5c7)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Similar to https://github.com/Automattic/wp-calypso/pull/87352
- Spin up a Jetpack Cloud live branch.
- Navigate to the Backup page
- Ensure you don't see the Backup Now button.
- Now try passing the jetpack/backup-on-demand feature flag via URL, like `?flags=jetpack/backup-on-demand" and reload the page.
- Ensure you see the Backup Now button.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?