### PR TITLE
Jetpack Backup: Connect BackupNowButton to rewindBackupSite

### DIFF
--- a/client/components/jetpack/backup-now-button/index.tsx
+++ b/client/components/jetpack/backup-now-button/index.tsx
@@ -1,13 +1,14 @@
 import { Button, Tooltip } from '@wordpress/components';
 import { FunctionComponent, useCallback, useState } from 'react';
-import { useDispatch } from 'react-redux';
 import useTrackCallback from 'calypso/lib/jetpack/use-track-callback';
+import { useDispatch } from 'calypso/state';
 import { rewindBackupSite } from 'calypso/state/activity-log/actions';
 
 interface Props {
 	children?: React.ReactNode;
+	siteId: number;
 	tooltipText?: string;
-	trackEventName?: string;
+	trackEventName: string;
 	variant: 'primary' | 'secondary' | 'tertiary';
 }
 

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -176,6 +176,7 @@ function BackupStatus( { selectedDate, needCredentials, onDateChange } ) {
 	const isFetchingSiteFeatures = useSelectedSiteSelector( isRequestingSiteFeatures );
 	const isPoliciesInitialized = useSelectedSiteSelector( isRewindPoliciesInitialized );
 	const siteSlug = useSelector( getSelectedSiteSlug );
+	const siteId = useSelector( getSelectedSiteId );
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
@@ -218,7 +219,11 @@ function BackupStatus( { selectedDate, needCredentials, onDateChange } ) {
 										</Button>
 									</Tooltip>
 									{ config.isEnabled( 'jetpack/backup-on-demand' ) && (
-										<BackupNowButton variant="primary" trackEventName="calypso_jetpack_backup_now">
+										<BackupNowButton
+											variant="primary"
+											trackEventName="calypso_jetpack_backup_now"
+											siteId={ siteId }
+										>
 											{ translate( 'Backup Now' ) }
 										</BackupNowButton>
 									) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/jetpack-backup-team/issues/366

## Proposed Changes

* Adds the ability to start a backup when clicking the BackupNowButton
* Fixes the track event functionality
* Removes Disabled from props and uses disabled when the button is pressed
* Adds siteId as a prop
* Passes siteId from main backup class

https://github.com/Automattic/wp-calypso/assets/1992658/3b4e1591-1bc5-4867-9110-ef5ae20a0739


## Testing Instructions
* Open a live link for Cloud and navigate to a Jetpack Backup enabled site's backup page
* Add ?flags=jetpack/backup-on-demand to the end of the url
* Ensure the Backup Now button appears
* Click it and ensure the popup that the backup has been queued appears
* Ensure the button is disabled
* Ensure tracking pixel is sent after pressing the button - calypso_jetpack_backup_now
* Check the queue to find your site in it

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?