### PR TITLE
Jetpack Backup: Improve actions toolbar on mobile resolutions

### DIFF
--- a/client/components/jetpack/backup-actions-toolbar/style.scss
+++ b/client/components/jetpack/backup-actions-toolbar/style.scss
@@ -1,4 +1,17 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
 .jetpack-backup__actions-toolbar {
 	display: flex;
 	gap: 10px;
+	flex-direction: column-reverse;
+
+	@include break-small {
+		flex-direction: row;
+	}
+
+	a {
+		justify-content: center;
+	}
 }
+


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack-backup-team/issues/364

## Proposed Changes

* Improve how the action toolbar looks on mobile resolutions
  * Switch the order so `Backup Now` becomes priority

| Before | After |
|---|---|
| ![CleanShot 2024-02-09 at 23 36 07@2x](https://github.com/Automattic/wp-calypso/assets/1488641/33d28bff-d043-4269-ad22-4966b613a1db) | ![CleanShot 2024-02-09 at 23 36 38@2x](https://github.com/Automattic/wp-calypso/assets/1488641/8feb14e4-7d9f-458a-9f68-182a8342d18e) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Spin up a Jetpack Cloud live branch.
- Navigate to the Backup page
- Pass the jetpack/backup-on-demand feature flag via URL, like `?flags=jetpack/backup-on-demand`
- Ensure the action toolbar (buttons in the right part of the header) looks as the screenshot provided below in mobile resolutions.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?