### PR TITLE
Checkout: Disable Pix for production

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -116,12 +116,15 @@ export function useCreateCreditCard( {
 }
 
 function useCreatePix(): PaymentMethod | null {
+	const isPixEnabled = isEnabled( 'checkout/ebanx-pix' );
 	return useMemo(
 		() =>
-			createPixPaymentMethod( {
-				submitButtonContent: <CheckoutSubmitButtonContent />,
-			} ),
-		[]
+			isPixEnabled
+				? createPixPaymentMethod( {
+						submitButtonContent: <CheckoutSubmitButtonContent />,
+				  } )
+				: null,
+		[ isPixEnabled ]
 	);
 }
 

--- a/config/development.json
+++ b/config/development.json
@@ -37,6 +37,7 @@
 		"calypso/help-center": true,
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,
+		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -17,6 +17,7 @@
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"catch-js-errors": true,
+		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": false,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -31,6 +31,7 @@
 	"features": {
 		"activity-log/v2": true,
 		"always_use_logout_url": true,
+		"checkout/ebanx-pix": false,
 		"checkout/google-pay": false,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -28,6 +28,7 @@
 	"features": {
 		"activity-log/v2": true,
 		"always_use_logout_url": false,
+		"checkout/ebanx-pix": false,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -30,6 +30,7 @@
 		"activity-log/v2": true,
 		"ad-tracking": true,
 		"always_use_logout_url": true,
+		"checkout/ebanx-pix": false,
 		"checkout/google-pay": false,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -30,6 +30,7 @@
 		"activity-log/v2": true,
 		"ad-tracking": false,
 		"always_use_logout_url": true,
+		"checkout/ebanx-pix": false,
 		"checkout/google-pay": false,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": false,

--- a/config/production.json
+++ b/config/production.json
@@ -28,6 +28,7 @@
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"catch-js-errors": true,
+		"checkout/ebanx-pix": false,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -25,6 +25,7 @@
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"catch-js-errors": true,
+		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": true,

--- a/config/test.json
+++ b/config/test.json
@@ -27,6 +27,7 @@
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"catch-js-errors": false,
+		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": false,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -25,6 +25,7 @@
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"catch-js-errors": false,
+		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": true,


### PR DESCRIPTION
## Proposed Changes

While we prepare to launch the Pix payment method for checkout, we need to feature-gate it to only run in certain environments. This PR creates a config variable so that Pix will only appear in horizon, wpcalypso, and development environments.

See https://github.com/Automattic/payments-shilling/issues/2417 for more information.

## Testing Instructions

None should be required.