### PR TITLE
Jetpack Backup: Update backup button labels and catch in progress status when queuing a new backup

### DIFF
--- a/client/components/jetpack/backup-actions-toolbar/index.tsx
+++ b/client/components/jetpack/backup-actions-toolbar/index.tsx
@@ -40,7 +40,7 @@ const BackupActionsToolbar: FunctionComponent< Props > = ( { siteId, siteSlug } 
 			variant="primary"
 			trackEventName="calypso_jetpack_backup_now"
 		>
-			{ translate( 'Backup Now' ) }
+			{ translate( 'Backup now' ) }
 		</BackupNowButton>
 	);
 

--- a/client/components/jetpack/backup-now-button/README.md
+++ b/client/components/jetpack/backup-now-button/README.md
@@ -16,7 +16,7 @@ function render() {
 				tooltipText="Click here to backup your site now."
 				trackEventName="calypso_jetpack_backup_now"
 			>
-				Backup Now
+				Backup now
 			</BackupNowButton>
 		</div>
 	);

--- a/client/components/jetpack/backup-now-button/index.tsx
+++ b/client/components/jetpack/backup-now-button/index.tsx
@@ -67,12 +67,14 @@ const BackupNowButton: FunctionComponent< Props > = ( {
 		} else if ( backupCurrentlyInProgress ) {
 			setCurrentTooltip( statusTooltipTexts.IN_PROGRESS );
 			setButtonContent( statusLabels.IN_PROGRESS );
+			setEnqueued( false );
 		} else if ( enqueued ) {
 			setButtonContent( statusLabels.QUEUED );
 			setCurrentTooltip( statusTooltipTexts.QUEUED );
 		} else {
 			setButtonContent( children );
 			setCurrentTooltip( tooltipText );
+			setDisabled( false );
 		}
 	}, [ areBackupsStopped, backupCurrentlyInProgress, tooltipText, translate, enqueued, children ] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/87360

This PR aims to address these comments: https://github.com/Automattic/wp-calypso/pull/87360#pullrequestreview-1873638920

## Proposed Changes

* Update backup now button states:
  * Default state is now `Backup now` instead of `Backup Now`  
  * When backup is queued, display `Backup queued` instead of `Backup Queued`
  * When backup is in progress, display `Backup in progress` instead of `Backup Queued`
  * When backup is completed, switch it to `Backup now` and enable it again
* Fetch backup status every 1 second after queuing a backup so we could catch the `Backup in progress` status as soon as possible.

## Screenshots

| Scenario | Screenshot |
|---|---|
| Default state | ![CleanShot 2024-02-10 at 10 48 23@2x](https://github.com/Automattic/wp-calypso/assets/1488641/62e5e65f-eeba-4ca1-8467-1894a44fd854) |
| Backup queued | ![CleanShot 2024-02-10 at 10 47 12@2x](https://github.com/Automattic/wp-calypso/assets/1488641/c4934671-9a1e-4305-b69e-012f20664ef3) |
| Backup in progress | ![CleanShot 2024-02-10 at 10 45 19@2x](https://github.com/Automattic/wp-calypso/assets/1488641/3200e759-8492-421b-b6ae-9eb5341f6354) |

## Demo

https://github.com/Automattic/wp-calypso/assets/1488641/59dbdb53-8738-4812-884e-891981cc18a3


## Testing Instructions
* Open a live link for Cloud and navigate to a Jetpack Backup enabled site's backup page
* Add ?flags=jetpack/backup-on-demand to the end of the url
* Ensure the Backup Now button appears
* If there is no backup backlog, queue a backup and ensure the state of the button changes and has the proper hover based on the different scenarios provided above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?