### PR TITLE
fix: explat client experiment name validation to match server side

### DIFF
--- a/packages/explat-client-react-helpers/CHANGELOG.md
+++ b/packages/explat-client-react-helpers/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.6
+
+- Bump explat-client version to latest that includes a fix for the experiment name validation to match server side validation: [a-z0-9_]*
+
 ## 0.0.5
 
 - Loosen the requirements around dependencies

--- a/packages/explat-client-react-helpers/package.json
+++ b/packages/explat-client-react-helpers/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/explat-client-react-helpers",
-	"version": "0.0.5",
+	"version": "0.0.6",
 	"description": "Standalone ExPlat Client: React Helpers.",
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"homepage": "https://github.com/Automattic/wp-calypso",

--- a/packages/explat-client/CHANGELOG.md
+++ b/packages/explat-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.0.5
+
+- Changed runtime experiment name validation to match server side validation: [a-z0-9_]*
+
 ## 0.0.4
 
 - Fix case where checking for localstorage throws an error.

--- a/packages/explat-client/package.json
+++ b/packages/explat-client/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/explat-client",
-	"version": "0.0.4",
+	"version": "0.0.5",
 	"description": "Standalone ExPlat Client.",
 	"bugs": "https://github.com/Automattic/wp-calypso/issues",
 	"homepage": "https://github.com/Automattic/wp-calypso",

--- a/packages/explat-client/src/internal/test/validations.ts
+++ b/packages/explat-client/src/internal/test/validations.ts
@@ -17,9 +17,12 @@ describe( 'isObject', () => {
 
 describe( 'isName', () => {
 	it( 'returns true for a valid name', () => {
+		expect( Validations.isName( 'a' ) ).toBe( true );
+		expect( Validations.isName( '1' ) ).toBe( true );
+		expect( Validations.isName( 'a1' ) ).toBe( true );
+		expect( Validations.isName( 'experiment' ) ).toBe( true );
 		expect( Validations.isName( 'experiment_name' ) ).toBe( true );
-		expect( Validations.isName( 'asdfkjhkjh09182lk_asdf[-123=@#$%^' ) ).toBe( true );
-		expect( Validations.isName( '!@#$%^&*(IO)_asdfkjn.;```' ) ).toBe( true );
+		expect( Validations.isName( 'experiment_name_v1' ) ).toBe( true );
 	} );
 	it( 'returns false for an invalid name', () => {
 		expect( Validations.isName( '' ) ).toBe( false );
@@ -27,6 +30,9 @@ describe( 'isName', () => {
 		expect( Validations.isName( {} ) ).toBe( false );
 		expect( Validations.isName( undefined ) ).toBe( false );
 		expect( Validations.isName( null ) ).toBe( false );
+		expect( Validations.isName( '!@#$%^&*(IO)_asdfkjn.;```' ) ).toBe( false );
+		expect( Validations.isName( 'asdfkjhkjh09182lk_asdf[-123=@#$%^' ) ).toBe( false );
+		expect( Validations.isName( 'experiment_V1' ) ).toBe( false );
 	} );
 } );
 

--- a/packages/explat-client/src/internal/validations.ts
+++ b/packages/explat-client/src/internal/validations.ts
@@ -9,7 +9,7 @@ export function isObject( x: unknown ): x is Record< string, unknown > {
  * @param name The data to test
  */
 export function isName( name: unknown ): name is string {
-	return typeof name === 'string' && name !== '' && /^[a-z0-9_,]*$/.test( name );
+	return typeof name === 'string' && name !== '' && /^[a-z0-9_]*$/.test( name );
 }
 
 /**

--- a/packages/explat-client/src/internal/validations.ts
+++ b/packages/explat-client/src/internal/validations.ts
@@ -9,7 +9,7 @@ export function isObject( x: unknown ): x is Record< string, unknown > {
  * @param name The data to test
  */
 export function isName( name: unknown ): name is string {
-	return typeof name === 'string' && name !== '';
+	return typeof name === 'string' && name !== '' && /^[a-z0-9_,]*$/.test( name );
 }
 
 /**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/woocommerce/woocommerce/issues/41854

## Proposed Changes

* Adjusted the experiment name validation in explat client to match the actual server side validation

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Analysis of the code and unit test should be sufficient

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?