### PR TITLE
composite-checkout: Remove makeManualResponse

### DIFF
--- a/packages/composite-checkout/README.md
+++ b/packages/composite-checkout/README.md
@@ -76,7 +76,7 @@ Within the components inside [CheckoutProvider](#CheckoutProvider), [usePaymentM
 
 When a payment method is ready to submit its data, it can use an appropriate "payment processor" function. These are functions passed to [CheckoutProvider](#CheckoutProvider) with the `paymentProcessors` prop and each one has a unique key. For convenience, the `submitButton` will be provided with an `onClick` function prop that will begin the transaction. The `onClick` function takes one argument, an object that contains the data needed by the payment processor function.
 
-The payment processor function's response will control what happens next. Each payment processor function must return a Promise that resolves to one of four results: [makeManualResponse](#makeManualResponse), [makeRedirectResponse](#makeRedirectResponse), [makeSuccessResponse](#makeSuccessResponse), or [makeErrorResponse](#makeErrorResponse).
+The payment processor function's response will control what happens next. Each payment processor function must return a Promise that resolves to one of three results: [makeRedirectResponse](#makeRedirectResponse), [makeSuccessResponse](#makeSuccessResponse), or [makeErrorResponse](#makeErrorResponse).
 
 ## API
 
@@ -212,7 +212,6 @@ An enum that holds the values of the [payment processor function return value's 
 
 - `.SUCCESS` (the payload will be an `unknown` object that is the server response).
 - `.REDIRECT` (the payload will be a `string` that is the redirect URL).
-- `.MANUAL` (the payload will be an `unknown` object that is determined by the payment processor function).
 - `.ERROR` (the payload will be a `string` that is the error message).
 
 ### TransactionStatus
@@ -236,10 +235,6 @@ A function to create a `CheckoutStepGroupStore` which can be passed to [Checkout
 ### makeErrorResponse
 
 An action creator function to be used by a [payment processor function](#payment-methods) for a [ERROR](#PaymentProcessorResponseType) response. It takes one string argument and will record the string as the error.
-
-### makeManualResponse
-
-An action creator function to be used by a [payment processor function](#payment-methods) for a [MANUAL](#PaymentProcessorResponseType) response; it will do nothing but pass along its argument as a `payload` property to the resolved Promise of the `onClick` function.
 
 ### makeRedirectResponse
 

--- a/packages/composite-checkout/src/components/use-process-payment.ts
+++ b/packages/composite-checkout/src/components/use-process-payment.ts
@@ -119,9 +119,6 @@ async function handlePaymentProcessorResponse(
 		setTransactionComplete( processorResponse.payload );
 		return processorResponse;
 	}
-	if ( processorResponse.type === PaymentProcessorResponseType.MANUAL ) {
-		return processorResponse;
-	}
 	throw new InvalidPaymentProcessorResponseError( paymentProcessorId );
 }
 

--- a/packages/composite-checkout/src/lib/invalid-payment-processor-response-error.ts
+++ b/packages/composite-checkout/src/lib/invalid-payment-processor-response-error.ts
@@ -1,6 +1,6 @@
 export default class InvalidPaymentProcessorResponseError extends Error {
 	constructor( paymentProcessorId: string ) {
-		const message = `Unknown payment processor response for processor "${ paymentProcessorId }". Payment processor functions should return one of makeManualResponse, makeSuccessResponse, makeRedirectResponse, or makeErrorResponse.`;
+		const message = `Unknown payment processor response for processor "${ paymentProcessorId }". Payment processor functions should return one of makeSuccessResponse, makeRedirectResponse, or makeErrorResponse.`;
 		super( message );
 		this.name = 'InvalidPaymentProcessorResponseError';
 	}

--- a/packages/composite-checkout/src/lib/payment-processors.ts
+++ b/packages/composite-checkout/src/lib/payment-processors.ts
@@ -5,7 +5,6 @@ import {
 	PaymentProcessorResponseData,
 	PaymentProcessorSuccess,
 	PaymentProcessorRedirect,
-	PaymentProcessorManual,
 	PaymentProcessorError,
 	PaymentProcessorResponseType,
 } from '../types';
@@ -45,8 +44,4 @@ export function makeSuccessResponse(
 
 export function makeRedirectResponse( url: string ): PaymentProcessorRedirect {
 	return { type: PaymentProcessorResponseType.REDIRECT, payload: url };
-}
-
-export function makeManualResponse( payload: unknown ): PaymentProcessorManual {
-	return { type: PaymentProcessorResponseType.MANUAL, payload };
 }

--- a/packages/composite-checkout/src/public-api.ts
+++ b/packages/composite-checkout/src/public-api.ts
@@ -26,7 +26,6 @@ import {
 import {
 	usePaymentProcessor,
 	usePaymentProcessors,
-	makeManualResponse,
 	makeSuccessResponse,
 	makeRedirectResponse,
 	makeErrorResponse,
@@ -54,7 +53,6 @@ export {
 	createCheckoutStepGroupStore,
 	makeErrorResponse,
 	isErrorResponse,
-	makeManualResponse,
 	makeRedirectResponse,
 	makeSuccessResponse,
 	useAllPaymentMethods,

--- a/packages/composite-checkout/src/types.ts
+++ b/packages/composite-checkout/src/types.ts
@@ -164,16 +164,11 @@ export type PaymentProcessorRedirect = {
 	type: PaymentProcessorResponseType.REDIRECT;
 	payload: string | undefined;
 };
-export type PaymentProcessorManual = {
-	type: PaymentProcessorResponseType.MANUAL;
-	payload: unknown;
-};
 
 export type PaymentProcessorResponse =
 	| PaymentProcessorError
 	| PaymentProcessorSuccess
-	| PaymentProcessorRedirect
-	| PaymentProcessorManual;
+	| PaymentProcessorRedirect;
 
 export type PaymentProcessorSubmitData = unknown;
 
@@ -184,7 +179,6 @@ export type PaymentProcessorFunction = (
 export enum PaymentProcessorResponseType {
 	SUCCESS = 'SUCCESS',
 	REDIRECT = 'REDIRECT',
-	MANUAL = 'MANUAL',
 	ERROR = 'ERROR',
 }
 

--- a/packages/composite-checkout/test/checkout.tsx
+++ b/packages/composite-checkout/test/checkout.tsx
@@ -18,8 +18,8 @@ import {
 	CheckoutFormSubmit,
 	CheckoutStepGroup,
 	useSetStepComplete,
-	makeManualResponse,
 	useTogglePaymentMethod,
+	makeErrorResponse,
 } from '../src/public-api';
 import { PaymentProcessorFunction, PaymentProcessorResponseType } from '../src/types';
 import { DefaultCheckoutSteps } from './utils/default-checkout-steps';
@@ -679,7 +679,7 @@ describe( 'Checkout', () => {
 		it( 'does not call the payment processor function if the validateForm callback is falsy', async () => {
 			const validateForm = jest.fn();
 			validateForm.mockResolvedValue( false );
-			const processor = jest.fn().mockResolvedValue( makeManualResponse( 'good' ) );
+			const processor = jest.fn().mockResolvedValue( makeErrorResponse( 'good' ) );
 			render(
 				<MyCheckout
 					steps={ [ steps[ 0 ] ] }
@@ -698,7 +698,7 @@ describe( 'Checkout', () => {
 		it( 'calls the payment processor function if the validateForm callback is truthy', async () => {
 			const validateForm = jest.fn();
 			validateForm.mockResolvedValue( true );
-			const processor = jest.fn().mockResolvedValue( makeManualResponse( 'good' ) );
+			const processor = jest.fn().mockResolvedValue( makeErrorResponse( 'good' ) );
 			render(
 				<MyCheckout
 					steps={ [ steps[ 0 ] ] }
@@ -715,7 +715,7 @@ describe( 'Checkout', () => {
 		} );
 
 		it( 'calls the payment processor function if the validateForm callback undefined', async () => {
-			const processor = jest.fn().mockResolvedValue( makeManualResponse( 'good' ) );
+			const processor = jest.fn().mockResolvedValue( makeErrorResponse( 'good' ) );
 			render( <MyCheckout steps={ [ steps[ 0 ] ] } paymentProcessor={ processor } /> );
 			const submitButton = screen.getByText( 'Pay Please' );
 


### PR DESCRIPTION
## Proposed Changes

Since https://github.com/Automattic/wp-calypso/pull/86775 refactored WeChatPay, we no longer have any payment processor functions that use the `makeManualResponse()` response type. That type was only implemented for WeChatPay and circumvents all the automated transaction systems used by the `CheckoutProvider`. I think we should remove it until such time as we decide something like that is absolutely needed. This will encourage new payment methods to use the existing response types (success, redirect, or error) which are significantly easier to use.

## Testing Instructions

TypeScript should cover all use-cases.