### PR TITLE
Checkout: Update domain transfer promotional period TOS to indicate it begins when the transfer completes

### DIFF
--- a/client/me/purchases/purchase-item/index.jsx
+++ b/client/me/purchases/purchase-item/index.jsx
@@ -393,11 +393,35 @@ class PurchaseItem extends Component {
 			return translate( 'Included with Plan' );
 		}
 
-		if (
-			( isOneTimePurchase( purchase ) || isAkismetFreeProduct( purchase ) ) &&
-			! isDomainTransfer( purchase )
-		) {
-			return translate( 'Never Expires' );
+		if ( isOneTimePurchase( purchase ) || isAkismetFreeProduct( purchase ) ) {
+			if ( ! isDomainTransfer( purchase ) ) {
+				return translate( 'Never Expires' );
+			}
+			if ( isDomainTransfer( purchase ) ) {
+				const translateOptions = {
+					args: {
+						amount: formatCurrency( purchase.priceInteger, purchase.currencyCode, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ),
+						excludeTaxStringAbbreviation: excludeTaxStringAbbreviation,
+					},
+					components: {
+						abbr: <abbr title={ excludeTaxStringTitle } />,
+					},
+				};
+				if (
+					locale === 'en' ||
+					i18n.hasTranslation(
+						'After transfer completes, domain registration renews yearly at %(amount)s'
+					)
+				) {
+					return translate(
+						'After transfer completes, domain registration renews yearly at %(amount)s {{abbr}}%(excludeTaxStringAbbreviation)s{{/abbr}}',
+						translateOptions
+					);
+				}
+			}
 		}
 
 		return null;

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -385,10 +385,10 @@ function getMessageForTermsOfServiceRecordUnknown(
 	if (
 		args.product_meta &&
 		args.product_meta !== '' &&
-		args.product_slug === domainProductSlugs.TRANSFER_IN
+		args.domain_transfer_slug === domainProductSlugs.TRANSFER_IN
 	) {
 		return translate(
-			'The promotional period of your %(productName)s subscription for %(domainName)s will begin once the domain transfer is completed. At that time, you will be notified of the promotional period, renewal date, and renewal price (%(renewalPrice)s) via email.',
+			'The promotional period of your %(productName)s for %(domainName)s will begin once the domain transfer is completed. At that time, you will be notified of the promotional period, renewal date, and renewal price (%(renewalPrice)s) via email.',
 			{
 				args: {
 					...defaultRenewalArgs.args,

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -388,7 +388,7 @@ function getMessageForTermsOfServiceRecordUnknown(
 		args.domain_transfer_slug === domainProductSlugs.TRANSFER_IN
 	) {
 		return translate(
-			'The promotional period of your %(productName)s for %(domainName)s will begin once the domain transfer is completed. At that time, you will be notified of the promotional period, renewal date, and renewal price (%(renewalPrice)s) via email.',
+			'The promotional period of your %(productName)s for %(domainName)s will begin once the {{domainTransferSupportLink}}domain transfer is completed{{/domainTransferSupportLink}}. At that time, you will be notified of the promotional period, renewal date, and renewal price (%(renewalPrice)s) via email.',
 			{
 				args: {
 					...defaultRenewalArgs.args,
@@ -396,6 +396,13 @@ function getMessageForTermsOfServiceRecordUnknown(
 				},
 				components: {
 					...defaultRenewalArgs.components,
+					domainTransferSupportLink: (
+						<a
+							href="/support/domains/incoming-domain-transfer/"
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
 				},
 			}
 		);

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -381,6 +381,21 @@ function getMessageForTermsOfServiceRecordUnknown(
 		},
 	};
 
+	if ( args.product_meta && args.product_meta !== '' && 'Domain Transfer' === args.product_name ) {
+		return translate(
+			'The promotional period of your %(productName)s subscription for %(domainName)s will begin once the domain transfer is completed. At that time, you will be notified of the promotional period, renewal date, and renewal price (%(renewalPrice)s) via email.',
+			{
+				args: {
+					...defaultRenewalArgs.args,
+					domainName: args.product_meta,
+				},
+				components: {
+					...defaultRenewalArgs.components,
+				},
+			}
+		);
+	}
+
 	if ( args.product_meta && args.product_meta !== '' ) {
 		return translate(
 			'At the end of the promotional period your %(productName)s subscription for %(domainName)s will renew at the normal price of %(renewalPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -1,3 +1,4 @@
+import { domainProductSlugs } from '@automattic/calypso-products';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { TermsOfServiceRecord, useShoppingCart } from '@automattic/shopping-cart';
 import debugFactory from 'debug';
@@ -381,7 +382,11 @@ function getMessageForTermsOfServiceRecordUnknown(
 		},
 	};
 
-	if ( args.product_meta && args.product_meta !== '' && 'Domain Transfer' === args.product_name ) {
+	if (
+		args.product_meta &&
+		args.product_meta !== '' &&
+		args.product_slug === domainProductSlugs.TRANSFER_IN
+	) {
 		return translate(
 			'The promotional period of your %(productName)s subscription for %(domainName)s will begin once the domain transfer is completed. At that time, you will be notified of the promotional period, renewal date, and renewal price (%(renewalPrice)s) via email.',
 			{

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -727,6 +727,7 @@ export interface TermsOfServiceRecordArgsBase {
 	product_meta: string;
 	product_name: string;
 	product_slug: string;
+	domain_transfer_slug: string;
 	renewal_price: string;
 	renewal_price_integer: number;
 	is_renewal_price_prorated: boolean;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -723,8 +723,10 @@ export interface TermsOfServiceRecordArgsBase {
 	subscription_auto_renew_date?: string;
 	subscription_pre_renew_reminder_days?: string;
 	subscription_pre_renew_reminders_count?: number;
+	product_id: number;
 	product_meta: string;
 	product_name: string;
+	product_slug: string;
 	renewal_price: string;
 	renewal_price_integer: number;
 	is_renewal_price_prorated: boolean;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/payments-shilling/issues/1869

For compliance reasons, when a user makes a purchase that has a promotional discount AND the product is renewable, we need to inform the user of the length of the promotional period, the next renewal date, and what the renewal fee is. This has been particularly difficult to complete for domain transfers. Generally, all products renew 30 days before they expire. Since domain transfers carry over any time left on the registration, there is no way to soundly predict the expiration date without building another third-party call to WhoIs or waiting until the transfer completes.

This also becomes a moot point if, for whatever reason, the user never completes the transfer.

## Proposed Changes

* Make the checkout TOS explicit that domain transfers are a one-time purchase
* Explain that the user will receive information about the domain promotional period once the transfer is completed.
* Provide a link to the Domain Transfer support page

**Before**

![v2cropped-screencapture-calypso-localhost-3000-checkout-captivatinghomecom-wordpress-com-2024-02-11-17_19_43](https://github.com/Automattic/wp-calypso/assets/12505355/17eaf722-fe9c-4d10-bc1c-865efe54725d)


**After**

![v2cropped-screencapture-calypso-localhost-3000-checkout-wordpress-com-2024-02-11-17_05_50 ](https://github.com/Automattic/wp-calypso/assets/12505355/9f1bc8c8-9599-4557-b521-553a23a4e631)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* This PR is dependent on code-D137819
* The testing instructions are available there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?
