### PR TITLE
Stats: Query purchase for Calypso Stats too

### DIFF
--- a/client/my-sites/stats/stats-notices/index.tsx
+++ b/client/my-sites/stats/stats-notices/index.tsx
@@ -1,6 +1,5 @@
 import { FEATURE_STATS_PAID } from '@automattic/calypso-products';
 import { useState, useEffect } from 'react';
-import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import version_compare from 'calypso/lib/version-compare';
 import {
 	DEFAULT_NOTICES_VISIBILITY,
@@ -164,14 +163,10 @@ export default function StatsNotices( {
 	}
 
 	return (
-		<>
-			{ /* The component is replaced on build for Odyssey to query from Jetpack */ }
-			<QuerySitePurchases siteId={ siteId } />
-			<NewStatsNotices
-				siteId={ siteId }
-				isOdysseyStats={ isOdysseyStats }
-				statsPurchaseSuccess={ statsPurchaseSuccess }
-			/>
-		</>
+		<NewStatsNotices
+			siteId={ siteId }
+			isOdysseyStats={ isOdysseyStats }
+			statsPurchaseSuccess={ statsPurchaseSuccess }
+		/>
 	);
 }

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -53,7 +53,7 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 	);
 
 	// in Calypso `isRequestingSitePurchases` is constantly looping requesting and not requesting
-	const isFetching = ( isOdysseyStats && isRequestingSitePurchases ) || isRequestingNotices;
+	const isFetching = isRequestingSitePurchases || isRequestingNotices;
 	const hasPlan = isFreeOwned || isPWYWOwned || isCommercialOwned || supportCommercialUse;
 	const qualifiedUser =
 		siteCreatedTimeStamp && new Date( siteCreatedTimeStamp ) > new Date( '2024-01-31' );

--- a/client/my-sites/stats/stats-redirect/load-stats-page.tsx
+++ b/client/my-sites/stats/stats-redirect/load-stats-page.tsx
@@ -102,7 +102,7 @@ export default function LoadStatsPage( { children }: AsyncLoadProps ) {
 
 	return (
 		<>
-			{ isOdysseyStats && <QuerySitePurchases siteId={ siteId } /> }
+			<QuerySitePurchases siteId={ siteId } />
 			<StatsRedirectFlow>{ children }</StatsRedirectFlow>
 		</>
 	);


### PR DESCRIPTION
Related to #87315

## Proposed Changes

* Query purchase for Calypso Stats too
* Remove purchase query in children components to avoid dead loop

## Testing Instructions

* Create a new JN site and connect it
* Purchase a commercial license
* Open `http://calypso.localhost:3000/stats/day/:site`
* Refresh
* Ensure it doesn't redirect to the purchase page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?