### PR TITLE
Stats: Remove upcoming features wording for PWYW

### DIFF
--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -102,7 +102,7 @@ const DoYouLoveJetpackStatsNotice = ( {
 		? translate(
 				'Finesse your scaling-up strategy with detailed insights and data. Upgrade to an Explorer plan for a richer understanding and smarter decision-making.'
 		  )
-		: translate( 'Upgrade to get priority support and stop the upgrade notices.' );
+		: translate( 'Upgrade to support future development and stop the upgrade banners.' );
 
 	const CTAText = isWPCOMPaidStatsFlow ? translate( 'Upgrade' ) : translate( 'Upgrade my Stats' );
 

--- a/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
+++ b/client/my-sites/stats/stats-notices/do-you-love-jetpack-stats-notice.tsx
@@ -102,7 +102,7 @@ const DoYouLoveJetpackStatsNotice = ( {
 		? translate(
 				'Finesse your scaling-up strategy with detailed insights and data. Upgrade to an Explorer plan for a richer understanding and smarter decision-making.'
 		  )
-		: translate( 'Upgrade to get priority support and access to upcoming advanced features.' );
+		: translate( 'Upgrade to get priority support and stop the upgrade notices.' );
 
 	const CTAText = isWPCOMPaidStatsFlow ? translate( 'Upgrade' ) : translate( 'Upgrade my Stats' );
 

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -319,15 +319,6 @@ function StatsBenefitsListing( {
 				<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--included` }>
 					{ translate( 'GDPR compliance' ) }
 				</li>
-				{ subscriptionValue > 0 ? (
-					<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--included` }>
-						{ translate( 'Access to upcoming advanced features' ) }
-					</li>
-				) : (
-					<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--not-included` }>
-						{ translate( 'No access to upcoming advanced features' ) }
-					</li>
-				) }
 				{ subscriptionValue >= defaultStartingValue ? (
 					<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--included` }>
 						{ translate( 'Priority support' ) }
@@ -337,6 +328,9 @@ function StatsBenefitsListing( {
 						{ translate( 'No priority support' ) }
 					</li>
 				) }
+				<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--not-included` }>
+					{ translate( 'No access to upcoming advanced features' ) }
+				</li>
 			</ul>
 		</div>
 	);

--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -133,7 +133,6 @@ const StatsBenefitsPersonal = () => {
 				<li>{ translate( 'Traffic stats and trends for posts and pages' ) }</li>
 				<li>{ translate( 'Detailed statistics about links leading to your site' ) }</li>
 				<li>{ translate( 'GDPR compliance' ) }</li>
-				<li>{ translate( 'Access to upcoming advanced features' ) }</li>
 				{ /** TODO: check sub price for validation -  will need support added to use-stats-purchases hook */ }
 				<li>{ translate( 'Priority support' ) }</li>
 			</ul>


### PR DESCRIPTION
Related: pejTkB-1aw-p2

## Proposed Changes

We removing mentioning of access to upcoming feature from PWYW purchase page and/or feature highlights per the decision in the P2.

## Testing Instructions
* Ensure new wording sounds good and it builds okay

![IMG_6205](https://github.com/Automattic/wp-calypso/assets/1425433/f5aa999f-9d47-4aa7-8ccb-460148c44a0d)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?