### PR TITLE
Automattic for Agencies: Implement OAuth Authentication

### DIFF
--- a/client/a8c-for-agencies/sections/auth/connect/index.tsx
+++ b/client/a8c-for-agencies/sections/auth/connect/index.tsx
@@ -1,0 +1,33 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { FunctionComponent } from 'react';
+import Main from 'calypso/components/main';
+import './style.scss';
+
+interface Props {
+	authUrl: string;
+}
+
+const Connect: FunctionComponent< Props > = ( { authUrl } ) => {
+	const translate = useTranslate();
+
+	return (
+		<Main className="connect">
+			<div className="connect__content">
+				{
+					// TODO: Add logo here
+				 }
+				<p>
+					{ translate(
+						'Welcome to Automattic for Agencies. Authorize with your WordPress.com credentials to get started.'
+					) }
+				</p>
+				<Button primary href={ authUrl }>
+					{ translate( 'Authorize Automattic for Agencies' ) }
+				</Button>
+			</div>
+		</Main>
+	);
+};
+
+export default Connect;

--- a/client/a8c-for-agencies/sections/auth/connect/style.scss
+++ b/client/a8c-for-agencies/sections/auth/connect/style.scss
@@ -1,0 +1,16 @@
+.connect.main {
+	margin: auto;
+	max-width: 480px;
+}
+
+.connect__content {
+	align-items: center;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	text-align: center;
+
+	& > * {
+		margin-block-end: 32px;
+	}
+}

--- a/client/a8c-for-agencies/sections/auth/controller.tsx
+++ b/client/a8c-for-agencies/sections/auth/controller.tsx
@@ -1,0 +1,69 @@
+import config from '@automattic/calypso-config';
+import debugFactory from 'debug';
+import store from 'store';
+import Connect from './connect';
+import type { Callback, Context } from '@automattic/calypso-router';
+
+const WP_AUTHORIZE_ENDPOINT = 'https://public-api.wordpress.com/oauth2/authorize';
+const debug = debugFactory( 'calypso:a8c-for-agencies-connect' );
+
+const DEFAULT_NEXT_LOCATION = '/';
+
+export const connect: Callback = ( context, next ) => {
+	if ( config.isEnabled( 'oauth' ) && config( 'oauth_client_id' ) ) {
+		const redirectUri = new URL( '/connect/oauth/token', window.location.origin );
+
+		const authUrl = new URL( WP_AUTHORIZE_ENDPOINT );
+		authUrl.search = new URLSearchParams( {
+			response_type: 'token',
+			client_id: config( 'oauth_client_id' ),
+			redirect_uri: redirectUri.toString(),
+			scope: 'global',
+		} ).toString();
+
+		debug( `authUrl: ${ authUrl }` );
+
+		window.location.replace( authUrl.toString() );
+	} else {
+		context.primary = <p>Oauth un-enabled or client id missing!</p>;
+	}
+	next();
+};
+
+// The type of `Context.hash` is `string`, but here it is being used as
+// an object. Assuming the types are wrong, here we override them to fix TS
+// errors until the types can be corrected.
+type OverriddenPageContext = Context & { hash?: Record< string, string > };
+
+export const tokenRedirect: Callback = ( ctx, next ) => {
+	const context = ctx as OverriddenPageContext;
+	// We didn't get an auth token; take a step back
+	// and ask for authorization from the user again
+	if ( context.hash?.error ) {
+		context.primary = <Connect authUrl="/connect/oauth/token" />;
+		return next();
+	}
+
+	if ( context.hash?.access_token ) {
+		debug( 'setting user token' );
+		store.set( 'wpcom_token', context.hash.access_token );
+	}
+
+	if ( context.hash?.expires_in ) {
+		debug( 'setting user token_expires_in' );
+		store.set( 'wpcom_token_expires_in', context.hash.expires_in );
+	}
+
+	try {
+		const nextUrl = new URL(
+			context?.query.next ?? DEFAULT_NEXT_LOCATION,
+			new URL( window.location.origin )
+		);
+		document.location.replace(
+			nextUrl.host === window.location.host ? nextUrl.toString() : DEFAULT_NEXT_LOCATION
+		);
+	} catch ( error ) {
+		// if something is fundamentally wrong with context.query.next we just go to root.
+		document.location.replace( DEFAULT_NEXT_LOCATION );
+	}
+};

--- a/client/a8c-for-agencies/sections/auth/index.ts
+++ b/client/a8c-for-agencies/sections/auth/index.ts
@@ -1,0 +1,11 @@
+import config from '@automattic/calypso-config';
+import page from '@automattic/calypso-router';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { connect, tokenRedirect } from './controller';
+
+export default (): void => {
+	if ( config.isEnabled( 'a8c-for-agencies' ) ) {
+		page( '/connect', connect, makeLayout, clientRender );
+		page( '/connect/oauth/token', tokenRedirect, makeLayout, clientRender );
+	}
+};

--- a/client/boot/common.js
+++ b/client/boot/common.js
@@ -51,6 +51,8 @@ import { setupLocale } from './locale';
 
 const debug = debugFactory( 'calypso' );
 
+const isA8CForAgenciesEnabled = config.isEnabled( 'a8c-for-agencies' );
+
 const setupContextMiddleware = ( reduxStore, reactQueryClient ) => {
 	page( '*', ( context, next ) => {
 		const parsed = getUrlParts( context.canonicalPath );
@@ -134,7 +136,7 @@ function saveOauthFlags() {
 
 function authorizePath() {
 	const redirectUri = new URL(
-		isJetpackCloud() ? '/connect/oauth/token' : '/api/oauth/token',
+		isJetpackCloud() || isA8CForAgenciesEnabled ? '/connect/oauth/token' : '/api/oauth/token',
 		window.location
 	);
 	redirectUri.search = new URLSearchParams( {

--- a/client/sections.js
+++ b/client/sections.js
@@ -680,6 +680,13 @@ const sections = [
 		group: 'a8c-for-agencies',
 		enableLoggedOut: true,
 	},
+	{
+		name: 'a8c-for-agencies-auth',
+		paths: [ '/connect', '/connect/oauth/token' ],
+		module: 'calypso/a8c-for-agencies/sections/auth',
+		group: 'a8c-for-agencies',
+		enableLoggedOut: true,
+	},
 ];
 
 module.exports = sections;

--- a/client/state/oauth2-clients/reducer.js
+++ b/client/state/oauth2-clients/reducer.js
@@ -75,6 +75,21 @@ export const initialClientsData = {
 		name: 'jetpack-cloud',
 		title: 'Jetpack Cloud',
 	},
+	95928: {
+		id: 95928,
+		name: 'a8c-for-agencies',
+		title: 'A8C for Agencies',
+	},
+	95931: {
+		id: 95931,
+		name: 'a8c-for-agencies',
+		title: 'A8C for Agencies',
+	},
+	95932: {
+		id: 95932,
+		name: 'a8c-for-agencies',
+		title: 'A8C for Agencies',
+	},
 };
 
 export function clients( state = initialClientsData, action ) {

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -8,15 +8,18 @@
 	"i18n_default_locale_slug": "en",
 	"port": 3000,
 	"site_name": "Automattic For Agencies",
+	"oauth_client_id": 95928,
 	"features": {
 		"a8c-for-agencies": true,
 		"always_use_logout_url": true,
 		"dev/auth-helper": true,
-		"dev/preferences-helper": true
+		"dev/preferences-helper": true,
+		"oauth": true
 	},
 	"enable_all_sections": false,
 	"sections": {
-		"a8c-for-agencies": true
+		"a8c-for-agencies": true,
+		"a8c-for-agencies-auth": true
 	},
 	"site_filter": [],
 	"theme": "jetpack-cloud",

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -7,8 +7,10 @@
 	"hostname": "agencies.automattic.com",
 	"i18n_default_locale_slug": "en",
 	"site_name": "Automattic For Agencies",
+	"oauth_client_id": 95932,
 	"features": {
-		"a8c-for-agencies": true
+		"a8c-for-agencies": true,
+		"oauth": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -7,8 +7,10 @@
 	"hostname": "agencies.automattic.com",
 	"i18n_default_locale_slug": "en",
 	"site_name": "Automattic For Agencies",
+	"oauth_client_id": 95931,
 	"features": {
-		"a8c-for-agencies": true
+		"a8c-for-agencies": true,
+		"oauth": true
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/215

## Proposed Changes

- Adds the oauth_client_id. More details: https://github.com/Automattic/jetpack-genesis/issues/216
- Enables Oauth 
- Adds auth routes & pages
- Adds auth sections

## Testing Instructions


Note: None of the links work on the masterbar. So, please ignore it for now

- Switch to the branch `add/implement-oauth-authentication`.
- Start the server by running `start-a8c-for-agencies`.
- You will be redirected to a `https://public-api.wordpress.com/oauth2/authorize` page > Click Approve and verify you are redirected to "/" and `Hello, World!` text is shown along with `Secondary` text on the left nav and a default masterbar. Please note this will be updated in upcoming PRs. 

<img width="1728" alt="Screenshot 2024-02-12 at 5 20 06 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/25cb3ac8-7667-4acc-8108-be5b8ab00de8">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?