### PR TITLE
feat(developer): rollout new dev survey notice for all locales

### DIFF
--- a/client/me/developer/dev-survey-notice.tsx
+++ b/client/me/developer/dev-survey-notice.tsx
@@ -61,7 +61,7 @@ export const DeveloperSurveyNotice = ( {
 							className="developer-survey-notice__popup-content-buttons-cancel"
 							onClick={ () => onClose( ONE_DAY_IN_SECONDS, 'remind-later-button' ) }
 						>
-							{ hasTranslation( 'Maybe later' )
+							{ hasTranslation( 'Maybe later' ) || localeSlug === 'en'
 								? translate( 'Maybe later' )
 								: translate( 'Remind later' ) }
 						</Button>

--- a/client/me/developer/dev-survey-notice.tsx
+++ b/client/me/developer/dev-survey-notice.tsx
@@ -1,5 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import surveyImage from 'calypso/assets/images/illustrations/developer-survey.svg';
 
@@ -18,6 +19,7 @@ export const DeveloperSurveyNotice = ( {
 	localeSlug,
 }: DeveloperSurveyNoticeProps ) => {
 	const translate = useTranslate();
+	const { hasTranslation } = useI18n();
 
 	const href =
 		localeSlug === 'es'
@@ -59,7 +61,9 @@ export const DeveloperSurveyNotice = ( {
 							className="developer-survey-notice__popup-content-buttons-cancel"
 							onClick={ () => onClose( ONE_DAY_IN_SECONDS, 'remind-later-button' ) }
 						>
-							{ translate( 'Remind later' ) }
+							{ hasTranslation( 'Maybe later' )
+								? translate( 'Maybe later' )
+								: translate( 'Remind later' ) }
 						</Button>
 						<Button
 							className="developer-survey-notice__popup-content-buttons-ok"

--- a/client/me/developer/main.jsx
+++ b/client/me/developer/main.jsx
@@ -24,17 +24,6 @@ import { getIAmDeveloperCopy } from './get-i-am-a-developer-copy';
 import './style.scss';
 
 class Developer extends Component {
-	developerSurveyNoticeId = 'developer-survey';
-	getSurveyHref = () => {
-		const isES = this.props.currentUser.localeSlug === 'es';
-
-		if ( isES ) {
-			return 'https://wordpressdotcom.survey.fm/developer-survey-es';
-		}
-
-		return 'https://wordpressdotcom.survey.fm/developer-survey';
-	};
-
 	surveyNoticeWrapper = null;
 
 	constructor( props ) {
@@ -63,54 +52,18 @@ class Developer extends Component {
 	};
 
 	showDeveloperSurveyNotice = () => {
-		if ( this.props.currentUser.localeSlug === 'en' ) {
-			if ( ! this.surveyNoticeWrapper ) {
-				this.surveyNoticeWrapper = document.createElement( 'div' );
-				document.body.appendChild( this.surveyNoticeWrapper );
-			}
-
-			this.setState( { isDeveloperSurveyNoticeVisible: true } );
-		} else {
-			const noticeMessage = this.props.translate(
-				"Hey developer! How do {{i}}you{{/i}} use WordPress.com? Spare a moment? We'd love to hear what you think in a {{surveyLink}}quick survey{{/surveyLink}}.",
-				{
-					components: {
-						i: <i />,
-						surveyLink: (
-							<a
-								href={ this.getSurveyHref() }
-								target="_blank"
-								rel="noopener noreferrer"
-								onClick={ () => {
-									recordTracksEvent( 'calypso_me_developer_survey_clicked' );
-
-									this.hideDeveloperSurveyNotice();
-								} }
-							/>
-						),
-					},
-				}
-			);
-
-			const noticeProps = {
-				id: this.developerSurveyNoticeId,
-				isPersistent: true,
-				onDismissClick: () => {
-					recordTracksEvent( 'calypso_me_developer_survey_dismissed' );
-
-					this.setDeveloperSurveyCookie( 'dismissed', 24 * 60 * 60 ); // 1 day
-					this.props.removeNotice( this.developerSurveyNoticeId );
-				},
-			};
-			this.props.successNotice( noticeMessage, noticeProps );
+		if ( ! this.surveyNoticeWrapper ) {
+			this.surveyNoticeWrapper = document.createElement( 'div' );
+			document.body.appendChild( this.surveyNoticeWrapper );
 		}
+
+		this.setState( { isDeveloperSurveyNoticeVisible: true } );
 
 		recordTracksEvent( 'calypso_me_developer_survey_impression' );
 	};
 
 	hideDeveloperSurveyNotice = () => {
 		this.setState( { isDeveloperSurveyNoticeVisible: false } );
-		this.props.removeNotice( this.developerSurveyNoticeId );
 	};
 
 	handleToggleIsDevAccount = ( isDeveloperAccount ) => {


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/pull/87228#discussion_r1485946728

## Proposed Changes
Since all translations for this PR (https://github.com/Automattic/wp-calypso/pull/87228) are ready (https://github.com/Automattic/wp-calypso/pull/87228#issuecomment-1938500537), we can roll out it for all locales. 

## Testing Instructions
1. Open `http://calypso.localhost:3000/me/account`
2. Choose any language except "EN"
3. Open `http://calypso.localhost:3000/me/developer` NB: Before you should remove `developer_survey` cookie and "I am a developer" checkbox should be checked
4. Assert that you see translated notice <br /> ![Screenshot 2024-02-12 at 15 57 23](https://github.com/Automattic/wp-calypso/assets/5598437/a325120e-75fa-438a-8520-c64b664b8af6)
5. Also assert that there is used old translated copy for "Remind later"
6. Choose "EN" language in your setting and open again "Developer feature" page
7. Assert that you see the notice as previously, but with the button label "Maybe later" <br />  ![Screenshot 2024-02-12 at 16 00 57](https://github.com/Automattic/wp-calypso/assets/5598437/e4419964-5711-4805-838e-7f864a9300cf)

