### PR TITLE
E2E: Fix Jetpack Related Posts block test

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/related-posts.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/related-posts.ts
@@ -35,20 +35,11 @@ export class RelatedPostsFlow implements BlockFlow {
 		await context.addedBlockLocator.waitFor();
 
 		if ( this.configurationData.headline ) {
-			await context.editorPage.openSettings();
-			await context.editorPage.clickSettingsTab( 'Block' );
-
-			const editorParent = await context.editorPage.getEditorParent();
-			// Toggle on the Headline text field.
-			await editorParent.getByLabel( 'Display headline' ).click();
-			// Fill the headline field.
-			await editorParent
-				.getByLabel( 'Headline', { exact: true } )
+			await context.addedBlockLocator
+				.getByRole( 'document', { name: 'Block: Related Posts' } )
+				.getByRole( 'document', { name: 'Block: Heading' } )
 				.fill( this.configurationData.headline );
 		}
-
-		// For mobile viewports, this block automatically opens the Block Settings sidebar.
-		await context.editorPage.closeSettings();
 	}
 
 	/**


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

In Automattic/jetpack#35353 the "display heading" setting was removed in favor of including a heading sub-block that users can configure directly. The test needs to fill that block now.

Note this does the minimum needed to get the existing test to pass. If someone wants to create a test for a block without a heading, they should add that in a separate PR.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up local Calypso E2E testing per [instructions](https://github.com/Automattic/wp-calypso/tree/trunk/test/e2e).
* Then something like `yarn workspace wp-e2e-tests build && ATOMIC_VARIATION=default TEST_ON_ATOMIC=true JETPACK_TARGET=wpcom-deployment yarn workspace wp-e2e-tests test -- test/e2e/specs/blocks/blocks__jetpack-other.ts` should do.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?