### PR TITLE
Standardize Plugins and Themes pages

### DIFF
--- a/client/my-sites/plugins/plugins-browser/index.jsx
+++ b/client/my-sites/plugins/plugins-browser/index.jsx
@@ -136,7 +136,7 @@ const PluginsBrowser = ( { trackPageViews = true, category, search, hideHeader }
 		return <NoPermissionsError title={ __( 'Plugins' ) } />;
 	}
 	return (
-		<MainComponent wideLayout isLoggedOut={ ! isLoggedIn }>
+		<MainComponent fullWidthLayout isLoggedOut={ ! isLoggedIn }>
 			<QueryProductsList persist />
 			<QueryPlugins siteId={ selectedSite?.ID } />
 			<QuerySitePurchases siteId={ selectedSite?.ID } />

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -88,7 +88,7 @@ body.is-section-plugins #primary .main.is-logged-out {
 		padding: 0 8px;
 
 		.responsive-toolbar-group__button-item {
-			padding: 0 16px;
+			padding: 4px 12px;
 		}
 		.responsive-toolbar-group__button-item:not([class*="is-pressed"]):hover::before {
 			background: rgba(6, 117, 196, 0.1);
@@ -97,8 +97,8 @@ body.is-section-plugins #primary .main.is-logged-out {
 
 	.components-button.is-pressed::before {
 		background: var(--studio-blue-50);
-		left: 4px;
-		right: 4px;
+		left: 0;
+		right: 0;
 	}
 }
 // Jetpack injects a banner on the /plugins page for jetpack sites

--- a/client/my-sites/plugins/plugins-browser/style.scss
+++ b/client/my-sites/plugins/plugins-browser/style.scss
@@ -95,7 +95,7 @@ body.is-section-plugins #primary .main.is-logged-out {
 		}
 	}
 
-	.components-button.is-pressed::before {
+	.responsive-toolbar-group__button-item.is-pressed::before {
 		background: var(--studio-blue-50);
 		left: 0;
 		right: 0;

--- a/client/my-sites/plugins/search-box-header/style.scss
+++ b/client/my-sites/plugins/search-box-header/style.scss
@@ -216,9 +216,15 @@ main.is-logged-out .search-box-header {
 				transform: scaleX(-1);
 				height: 33px;
 			}
+
 			input.search-component__input[type="search"],
 			input.search-component__input[type="search"]::placeholder {
 				color: var(--studio-gray-50);
+			}
+
+			&.has-focus {
+				border-color: var(--color-neutral-20);
+				box-shadow: none;
 			}
 		}
 	}

--- a/client/my-sites/themes/theme-showcase.scss
+++ b/client/my-sites/themes/theme-showcase.scss
@@ -33,7 +33,7 @@
 		position: relative;
 
 		@include breakpoint-deprecated( ">660px" ) {
-			padding: 64px 32px 16px;
+			padding: 88px 32px 8px;
 		}
 
 		h1 {
@@ -41,11 +41,10 @@
 			font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
 			font-size: 2.75rem;
 			line-height: 1.15;
-			margin-bottom: 16px;
+			margin-bottom: 15px;
 		}
 
 		.page-sub-header {
-			font-size: $font-body-large;
 			line-height: 26px;
 			margin-bottom: 8px;
 			max-width: 680px;
@@ -67,6 +66,7 @@
 	}
 
 	.search-themes-card {
+		background: none;
 
 		&.is-suggestions-open {
 			max-width: 100%;
@@ -83,6 +83,21 @@
 				0 16px 6px 0 rgba(38, 19, 19, 0),
 				0 25px 7px 0 rgba(38, 19, 19, 0);
 			margin: 0;
+		}
+
+		.search {
+			height: 55px;
+			border-radius: 4px;
+
+			.search__icon-navigation {
+				border-bottom-right-radius: 0;
+				border-top-right-radius: 0;
+			}
+
+			.search__input {
+				border-bottom-left-radius: 0;
+				border-top-left-radius: 0;
+			}
 		}
 
 		.keyed-suggestions__category {
@@ -130,7 +145,6 @@
 	}
 
 	.theme__search {
-
 		@include break-mobile {
 			width: 100%;
 		}
@@ -162,9 +176,21 @@
 				0 16px 6px 0 rgba(38, 19, 19, 0),
 				0 25px 7px 0 rgba(38, 19, 19, 0);
 
+			&.select-dropdown {
+				border-radius: 4px;
+				height: 55px;
+			}
+
+			&.is-open {
+				.select-dropdown__header {
+					border-radius: 4px;
+				}
+			}
+
 			.select-dropdown__header {
 				border-width: 0;
 				color: #575d63;
+				height: 55px;
 				line-height: 1.5;
 			}
 
@@ -184,10 +210,10 @@
 		}
 	}
 
-
 	.themes__filters {
-		margin-top: 66px;
-		padding-bottom: 18px;
+		margin-top: 50px;
+		padding-bottom: 25px;
+		padding-left: 1px;
 	}
 }
 
@@ -199,8 +225,14 @@
 	}
 }
 
-.theme-showcase {
+.search-themes-card {
+	.search {
+		height: 43px;
+		border-radius: 2px;
+	}
+}
 
+.theme-showcase {
 	.navigation-header {
 		@media (max-width: $break-small) {
 			padding-bottom: 16px;
@@ -235,13 +267,6 @@
 			}
 		}
 
-		.search-themes-card {
-			.search {
-				height: 43px;
-				border-radius: 2px;
-			}
-		}
-
 		.section-nav-tabs__dropdown .select-dropdown__container {
 			width: 100%;
 		}
@@ -249,6 +274,7 @@
 		.theme__search-input {
 			width: 100%;
 			padding: 0 0 10px 0;
+
 			@include break-mobile {
 				padding: 0 10px 0 0;
 			}
@@ -257,6 +283,7 @@
 		.section-nav-tabs__dropdown {
 			width: 100%;
 			flex-shrink: 0;
+
 			@include break-mobile {
 				width: auto;
 			}

--- a/client/my-sites/themes/themes-toolbar-group/style.scss
+++ b/client/my-sites/themes/themes-toolbar-group/style.scss
@@ -27,11 +27,9 @@
 	.components-toolbar {
 		background-color: transparent;
 		border: 0;
-		min-height: 28px;
 
 		.components-button {
 			color: var(--color-neutral-60);
-			height: 28px;
 			line-height: 24px;
 			padding: 4px 12px;
 
@@ -42,7 +40,6 @@
 			&::before {
 				transition: background-color 0.15s ease-in-out;
 				border-radius: 4px;
-				height: 28px;
 				left: 0;
 				right: 0;
 			}

--- a/client/my-sites/themes/use-theme-showcase-logged-out-seo-content.js
+++ b/client/my-sites/themes/use-theme-showcase-logged-out-seo-content.js
@@ -28,7 +28,7 @@ export default function useThemeShowcaseLoggedOutSeoContent( filter, tier ) {
 			recommended: {
 				all: {
 					title: translate( 'WordPress Themes' ),
-					header: translate( 'Find the perfect theme for your website.' ),
+					header: translate( 'Find the perfect theme for your website' ),
 					description: translate(
 						"Beautiful and responsive WordPress themes. Choose from free and premium options for all types of websites. Then, activate the one that's best for you."
 					),


### PR DESCRIPTION
This pull request seeks to align the look and feel of the `Plugins` and `Themes` pages for _logged out_ users. More specifically, it:
* Switches the `Plugins` page to a full layout
* Drops the shadow when the search field is focused on that page
* Fixes a small gap on the left of the list of filters
* Uses the same top margin on the `Themes` page than on the `Plugins` page
* Removes a trailing dot from the heading from the former
* Adds rounded corners to the search form elements
* Increases padding of filter buttons

##### `Plugins` page

Before | After
------ | -----
![image](https://github.com/Automattic/wp-calypso/assets/594356/8de2556b-59bf-418e-aee5-0b5e78340319)| ![image](https://github.com/Automattic/wp-calypso/assets/594356/b189479c-f9ef-4ea1-a5e3-f65befdef231)

##### `Themes` page

Before | After
------ | -----
![image](https://github.com/Automattic/wp-calypso/assets/594356/f768c5a2-afb8-4050-8734-990d16a87d8f) | ![image](https://github.com/Automattic/wp-calypso/assets/594356/adfffe7b-0a00-4b0b-a05f-3b56c606079d)

#### Testing instructions

You may want to also check how those pages look on small devices:

1. Run `git checkout fix/plugins-and-themes-page` and start your server, or access a [live branch](URL)
2. Compare the `Plugins` page from this [branch](http://calypso.localhost:3000/plugins) and [production](https://wordpress.com/plugins)
3. Compare the `Themes` page from this [branch](http://calypso.localhost:3000/themes) and [production](https://wordpress.com/themes)
4. Log into WordPress.com now
5. Assert that the `Plugins` page from this branch and production looks the same
6. Assert that the `Themes` page from this branch and production looks almost the same*

*: the search field is a bit longer, and the selected filter has more padding but I'm not sure we should fix that