### PR TITLE
Jetpack Backup: Release on demand backups

### DIFF
--- a/client/components/jetpack/backup-actions-toolbar/index.tsx
+++ b/client/components/jetpack/backup-actions-toolbar/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button, Tooltip } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
@@ -47,7 +46,7 @@ const BackupActionsToolbar: FunctionComponent< Props > = ( { siteId, siteSlug } 
 	return (
 		<div className="jetpack-backup__actions-toolbar">
 			{ copySite }
-			{ config.isEnabled( 'jetpack/backup-on-demand' ) && backupNow }
+			{ backupNow }
 		</div>
 	);
 };

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -18,6 +18,7 @@ import QuerySiteProducts from 'calypso/components/data/query-site-products';
 import QuerySiteSettings from 'calypso/components/data/query-site-settings';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import BackupActionsToolbar from 'calypso/components/jetpack/backup-actions-toolbar';
+import BackupNowButton from 'calypso/components/jetpack/backup-now-button';
 import BackupPlaceholder from 'calypso/components/jetpack/backup-placeholder';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import Main from 'calypso/components/main';
@@ -96,7 +97,15 @@ const BackupPage = ( { queryDate } ) => {
 								},
 							}
 						) }
-					/>
+					>
+						<BackupNowButton
+							siteId={ siteId }
+							variant="primary"
+							trackEventName="calypso_jetpack_backup_now"
+						>
+							{ translate( 'Backup now' ) }
+						</BackupNowButton>
+					</NavigationHeader>
 				) }
 
 				<AdminContent selectedDate={ selectedDate } />

--- a/client/my-sites/backup/style.scss
+++ b/client/my-sites/backup/style.scss
@@ -3,7 +3,7 @@
 		display: flex;
 	}
 }
-.backup__page .components-button {
+.theme-jetpack-cloud .backup__page .components-button {
 	--color-accent: var(--color-jetpack);
 	--color-accent-60: var(--studio-jetpack-green-70);
 }

--- a/config/development.json
+++ b/config/development.json
@@ -89,7 +89,6 @@
 		"jetpack/api-cache": true,
 		"jetpack/backup-contents-page": true,
 		"jetpack/backup-messaging-i3": true,
-		"jetpack/backup-on-demand": true,
 		"jetpack/backup-restore-preflight-checks": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/cancel-through-main-flow": true,

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -45,7 +45,6 @@
 		"jetpack/activity-log-sharing": true,
 		"jetpack/agency-dashboard": true,
 		"jetpack/backup-messaging-i3": true,
-		"jetpack/backup-on-demand": true,
 		"jetpack/backup-restore-preflight-checks": true,
 		"jetpack/backup-retention-settings": true,
 		"jetpack/card-addition-improvements": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Remove `jetpack/backup-on-demand` feature flag
* Add `BackupNowButton` on the backup page in Calypso Blue

## Screenshots
| Jetpack Cloud | Calypso Blue |
|---|---|
| ![CleanShot 2024-02-12 at 16 08 39@2x](https://github.com/Automattic/wp-calypso/assets/1488641/7f2a654e-6e8b-420a-b174-9dee748a2323) | ![CleanShot 2024-02-12 at 16 05 42@2x](https://github.com/Automattic/wp-calypso/assets/1488641/8bd59d2a-ea91-404c-840a-04fe046a6e59) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Calypso Blue and Jetpack Cloud Live Branch
* Navigate to the Backup page
* Ensure you see the `Backup now` button on the top right of the page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?