### PR TITLE
Unify Launch-site component on Settings and Site Tools (v2)

### DIFF
--- a/client/my-sites/site-settings/site-visibility/launch-site-trial-notice.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site-trial-notice.jsx
@@ -1,4 +1,7 @@
+<<<<<<< HEAD
 import { recordTracksEvent } from '@automattic/calypso-analytics';
+=======
+>>>>>>> a77fb4a2b5 (Modularize Launch Site and add Launch Site button to Site Tools)
 import { translate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import {
@@ -17,6 +20,7 @@ export const LaunchSiteTrialUpsellNotice = () => {
 		getIsSiteOnMigrationTrial( state, siteId )
 	);
 	const isLaunchable = ! isSiteOnECommerceTrial && ! isSiteOnMigrationTrial;
+<<<<<<< HEAD
 
 	const recordTracksEventForTrialNoticeClick = () => {
 		const eventName = isSiteOnECommerceTrial
@@ -25,6 +29,8 @@ export const LaunchSiteTrialUpsellNotice = () => {
 		recordTracksEvent( eventName );
 	};
 
+=======
+>>>>>>> a77fb4a2b5 (Modularize Launch Site and add Launch Site button to Site Tools)
 	if ( isLaunchable ) {
 		return null;
 	}
@@ -34,14 +40,32 @@ export const LaunchSiteTrialUpsellNotice = () => {
 			'Before you can share your store with the world, you need to {{a}}pick a plan{{/a}}.',
 			{
 				components: {
+<<<<<<< HEAD
 					a: <a href={ `/plans/${ siteSlug }` } onClick={ recordTracksEventForTrialNoticeClick } />,
+=======
+					a: (
+						<a
+							href={ `/plans/${ siteSlug }` }
+							onClick={ this.recordTracksEventForTrialNoticeClick }
+						/>
+					),
+>>>>>>> a77fb4a2b5 (Modularize Launch Site and add Launch Site button to Site Tools)
 				},
 			}
 		);
 	} else if ( isSiteOnMigrationTrial ) {
 		noticeText = translate( 'Ready to launch your site? {{a}}Upgrade to a paid plan{{/a}}.', {
 			components: {
+<<<<<<< HEAD
 				a: <a href={ `/plans/${ siteSlug }` } onClick={ recordTracksEventForTrialNoticeClick } />,
+=======
+				a: (
+					<a
+						href={ `/plans/${ siteSlug }` }
+						onClick={ this.recordTracksEventForTrialNoticeClick }
+					/>
+				),
+>>>>>>> a77fb4a2b5 (Modularize Launch Site and add Launch Site button to Site Tools)
 			},
 		} );
 	}

--- a/client/my-sites/site-settings/site-visibility/launch-site-trial-notice.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site-trial-notice.jsx
@@ -1,7 +1,4 @@
-<<<<<<< HEAD
 import { recordTracksEvent } from '@automattic/calypso-analytics';
-=======
->>>>>>> a77fb4a2b5 (Modularize Launch Site and add Launch Site button to Site Tools)
 import { translate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import {
@@ -20,7 +17,6 @@ export const LaunchSiteTrialUpsellNotice = () => {
 		getIsSiteOnMigrationTrial( state, siteId )
 	);
 	const isLaunchable = ! isSiteOnECommerceTrial && ! isSiteOnMigrationTrial;
-<<<<<<< HEAD
 
 	const recordTracksEventForTrialNoticeClick = () => {
 		const eventName = isSiteOnECommerceTrial
@@ -29,8 +25,6 @@ export const LaunchSiteTrialUpsellNotice = () => {
 		recordTracksEvent( eventName );
 	};
 
-=======
->>>>>>> a77fb4a2b5 (Modularize Launch Site and add Launch Site button to Site Tools)
 	if ( isLaunchable ) {
 		return null;
 	}
@@ -40,32 +34,14 @@ export const LaunchSiteTrialUpsellNotice = () => {
 			'Before you can share your store with the world, you need to {{a}}pick a plan{{/a}}.',
 			{
 				components: {
-<<<<<<< HEAD
 					a: <a href={ `/plans/${ siteSlug }` } onClick={ recordTracksEventForTrialNoticeClick } />,
-=======
-					a: (
-						<a
-							href={ `/plans/${ siteSlug }` }
-							onClick={ this.recordTracksEventForTrialNoticeClick }
-						/>
-					),
->>>>>>> a77fb4a2b5 (Modularize Launch Site and add Launch Site button to Site Tools)
 				},
 			}
 		);
 	} else if ( isSiteOnMigrationTrial ) {
 		noticeText = translate( 'Ready to launch your site? {{a}}Upgrade to a paid plan{{/a}}.', {
 			components: {
-<<<<<<< HEAD
 				a: <a href={ `/plans/${ siteSlug }` } onClick={ recordTracksEventForTrialNoticeClick } />,
-=======
-				a: (
-					<a
-						href={ `/plans/${ siteSlug }` }
-						onClick={ this.recordTracksEventForTrialNoticeClick }
-					/>
-				),
->>>>>>> a77fb4a2b5 (Modularize Launch Site and add Launch Site button to Site Tools)
 			},
 		} );
 	}

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -1,8 +1,8 @@
 import { WPCOM_FEATURES_SITE_PREVIEW_LINKS } from '@automattic/calypso-products';
 import { Card, CompactCard, Button } from '@automattic/components';
-import { dispatch } from '@wordpress/data';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
+import { connect } from 'react-redux';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import SitePreviewLink from 'calypso/components/site-preview-link';
 import { useSelector } from 'calypso/state';
@@ -27,7 +27,7 @@ import { LaunchSiteTrialUpsellNotice } from './launch-site-trial-notice';
 
 import './styles.scss';
 
-const LaunchSite = () => {
+const LaunchSite = ( { dispatchLaunchSite } ) => {
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSettings = useSelector( ( state ) => getSiteSettings( state, siteId ) );
@@ -50,7 +50,7 @@ const LaunchSite = () => {
 	} );
 	const btnText = translate( 'Launch site' );
 	const handleLaunchSite = () => {
-		dispatch( launchSite( site.ID ) );
+		dispatchLaunchSite( site.ID );
 	};
 	let querySiteDomainsComponent;
 	let btnComponent;
@@ -116,4 +116,10 @@ const LaunchSite = () => {
 	);
 };
 
-export default LaunchSite;
+const mapDispatchToProps = ( dispatch ) => {
+	return {
+		dispatchLaunchSite: ( siteID ) => dispatch( launchSite( siteID ) ),
+	};
+};
+
+export default connect( null, mapDispatchToProps )( LaunchSite );

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -2,10 +2,9 @@ import { WPCOM_FEATURES_SITE_PREVIEW_LINKS } from '@automattic/calypso-products'
 import { Card, CompactCard, Button } from '@automattic/components';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
-import { connect } from 'react-redux';
 import QuerySiteDomains from 'calypso/components/data/query-site-domains';
 import SitePreviewLink from 'calypso/components/site-preview-link';
-import { useSelector } from 'calypso/state';
+import { useSelector, useDispatch } from 'calypso/state';
 import isSiteComingSoon from 'calypso/state/selectors/is-site-coming-soon';
 import getIsUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
@@ -27,7 +26,8 @@ import { LaunchSiteTrialUpsellNotice } from './launch-site-trial-notice';
 
 import './styles.scss';
 
-const LaunchSite = ( { dispatchLaunchSite } ) => {
+const LaunchSite = () => {
+	const dispatch = useDispatch();
 	const site = useSelector( ( state ) => getSelectedSite( state ) );
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
 	const siteSettings = useSelector( ( state ) => getSiteSettings( state, siteId ) );
@@ -50,7 +50,7 @@ const LaunchSite = ( { dispatchLaunchSite } ) => {
 	} );
 	const btnText = translate( 'Launch site' );
 	const handleLaunchSite = () => {
-		dispatchLaunchSite( site.ID );
+		dispatch( launchSite( site.ID ) );
 	};
 	let querySiteDomainsComponent;
 	let btnComponent;
@@ -116,10 +116,4 @@ const LaunchSite = ( { dispatchLaunchSite } ) => {
 	);
 };
 
-const mapDispatchToProps = ( dispatch ) => {
-	return {
-		dispatchLaunchSite: ( siteID ) => dispatch( launchSite( siteID ) ),
-	};
-};
-
-export default connect( null, mapDispatchToProps )( LaunchSite );
+export default LaunchSite;

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -76,11 +76,7 @@ const LaunchSite = () => {
 		querySiteDomainsComponent = '';
 	}
 
-<<<<<<< HEAD
 	const blogPublic = parseInt( siteSettings && siteSettings.blog_public, 10 );
-=======
-	const blogPublic = parseInt( siteSettings.blog_public, 10 );
->>>>>>> a77fb4a2b5 (Modularize Launch Site and add Launch Site button to Site Tools)
 
 	// isPrivateAndUnlaunched means it is an unlaunched coming soon v1 site
 	const isPrivateAndUnlaunched = -1 === blogPublic && isUnlaunchedSite;

--- a/client/my-sites/site-settings/site-visibility/launch-site.jsx
+++ b/client/my-sites/site-settings/site-visibility/launch-site.jsx
@@ -76,7 +76,11 @@ const LaunchSite = () => {
 		querySiteDomainsComponent = '';
 	}
 
+<<<<<<< HEAD
 	const blogPublic = parseInt( siteSettings && siteSettings.blog_public, 10 );
+=======
+	const blogPublic = parseInt( siteSettings.blog_public, 10 );
+>>>>>>> a77fb4a2b5 (Modularize Launch Site and add Launch Site button to Site Tools)
 
 	// isPrivateAndUnlaunched means it is an unlaunched coming soon v1 site
 	const isPrivateAndUnlaunched = -1 === blogPublic && isUnlaunchedSite;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5539
Follow up of https://github.com/Automattic/wp-calypso/pull/87256 reverted https://github.com/Automattic/wp-calypso/pull/87317

## Proposed Changes

Unify 'Launch site' on `/settings/general/:site` and `/settings/site-tools/:site`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have a site that is unlaunched
* Go to `/settings/general/:site` and test SIte launch
* After site launch, should show privacy settings
* Prepare another site that is unlaunched
* Go to `/settings/site-tools/:site` and test Site launch
* After site launch, launch site component doesn't show
* Check p1707425040384579-slack-C02FMH4G8 to make sure it works fine now

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?