### PR TITLE
GitHub Deployments: Add authorization

### DIFF
--- a/client/my-sites/github-deployments/authorize/authorize-button.tsx
+++ b/client/my-sites/github-deployments/authorize/authorize-button.tsx
@@ -1,24 +1,73 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
-import { __ } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import { addQueryArgs } from '@wordpress/url';
+import { useState } from 'react';
+import SocialLogo from 'calypso/components/social-logo';
+import { useDispatch } from 'calypso/state';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { useGithubAccountsQuery } from '../use-github-accounts-query';
 
-import './style.scss';
+const AUTHORIZE_URL = addQueryArgs( 'https://github.com/login/oauth/authorize', {
+	client_id: config( 'github_oauth_client_id' ),
+} );
 
-interface GitHubAuthorizeProps {
-	buttonText?: string;
-}
+const POPUP_ID = 'github-oauth-authorize';
 
-const isAuthorizing = false;
+const authorizeGitHub = () => {
+	return new Promise< void >( ( resolve, reject ) => {
+		let popup: Window | null;
 
-export const GitHubAuthorizeButton = ( props: GitHubAuthorizeProps ) => {
-	const { buttonText = __( 'Authorize access to GitHub' ) } = props;
+		try {
+			popup = window.open( AUTHORIZE_URL, POPUP_ID, 'height=600,width=700' );
+		} catch {
+			return reject();
+		}
 
-	function authoriseGitHub() {
-		//coming soon
+		if ( ! popup ) {
+			reject();
+		}
+
+		const interval = setInterval( (): void => {
+			if ( popup?.closed ) {
+				resolve();
+				clearInterval( interval );
+			}
+		}, 500 );
+	} );
+};
+
+export const GitHubAuthorizeButton = () => {
+	const { __ } = useI18n();
+	const dispatch = useDispatch();
+
+	const { isLoading, isRefetching, refetch } = useGithubAccountsQuery();
+
+	const [ isAuthorizing, setIsAuthorizing ] = useState( false );
+
+	const startAuthorization = () => {
+		setIsAuthorizing( true );
+
+		authorizeGitHub()
+			.then( () => refetch() )
+			.catch( () => dispatch( errorNotice( 'Failed to authorize GitHub. Please try again.' ) ) )
+			.finally( () => setIsAuthorizing( false ) );
+	};
+
+	if ( isLoading && ! isRefetching ) {
+		return null;
 	}
 
 	return (
-		<Button primary busy={ isAuthorizing } disabled={ isAuthorizing } onClick={ authoriseGitHub }>
-			{ buttonText }
+		<Button
+			primary
+			css={ { display: 'flex', alignItems: 'center' } }
+			busy={ isLoading || isAuthorizing }
+			disabled={ isLoading || isAuthorizing }
+			onClick={ startAuthorization }
+		>
+			<SocialLogo icon="github" size={ 18 } css={ { marginRight: '4px' } } />
+			{ __( 'Authorize GitHub' ) }
 		</Button>
 	);
 };

--- a/client/my-sites/github-deployments/connection-wizard-button.tsx
+++ b/client/my-sites/github-deployments/connection-wizard-button.tsx
@@ -1,0 +1,12 @@
+import { Button } from '@automattic/components';
+import { useI18n } from '@wordpress/react-i18n';
+
+export const ConnectionWizardButton = ( { onClick }: { onClick(): void } ) => {
+	const { __ } = useI18n();
+
+	return (
+		<Button primary css={ { display: 'flex', alignItems: 'center' } } onClick={ onClick }>
+			{ __( 'Connect repository' ) }
+		</Button>
+	);
+};

--- a/client/my-sites/github-deployments/controller.tsx
+++ b/client/my-sites/github-deployments/controller.tsx
@@ -1,6 +1,4 @@
 import { isEnabled } from '@automattic/calypso-config';
-import QueryKeyringConnections from 'calypso/components/data/query-keyring-connections';
-import QueryKeyringServices from 'calypso/components/data/query-keyring-services';
 import { PageViewTracker } from 'calypso/lib/analytics/page-view-tracker';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
@@ -12,8 +10,6 @@ export const githubDeployments: Callback = ( context, next ) => {
 	context.primary = (
 		<>
 			<PageViewTracker path="/github-deployments/:site" title="GitHub Deployments" delay={ 500 } />
-			<QueryKeyringServices />
-			<QueryKeyringConnections />
 			<GitHubDeployments />
 		</>
 	);

--- a/client/my-sites/github-deployments/main.tsx
+++ b/client/my-sites/github-deployments/main.tsx
@@ -1,28 +1,26 @@
-import { Button } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
-import { CodeDeployments } from 'calypso/my-sites/github-deployments/deployments/index';
+import NavigationHeader from 'calypso/components/navigation-header';
 import { useSelector } from 'calypso/state/index';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors/index';
 import { GitHubAuthorize } from './authorize';
+import { GitHubAuthorizeButton } from './authorize/authorize-button';
 import { GitHubConnect } from './connect';
+import { ConnectionWizardButton } from './connection-wizard-button';
+import { CodeDeployments } from './deployments';
 import { GitHubLoadingPlaceholder } from './loading-placeholder';
 import { useCodeDeploymentsQuery } from './use-code-deployments-query';
 import { useGithubAccountsQuery } from './use-github-accounts-query';
-
 import './style.scss';
-
-// Follow test plan at D137459 to add your token for testing.
 
 type Tab = 'list' | 'connect';
 
 export function GitHubDeployments() {
 	const titleHeader = translate( 'GitHub Deployments' );
-	const siteId = useSelector( getSelectedSiteId ) as number;
+	const siteId = useSelector( getSelectedSiteId );
 	const [ tab, setTab ] = useState< Tab >( 'list' );
 
 	const { data: accounts = [], isLoading: isLoadingAccounts } = useGithubAccountsQuery();
@@ -40,8 +38,24 @@ export function GitHubDeployments() {
 		setTab( 'list' );
 	};
 
+	const renderTopRightButton = () => {
+		if ( isLoadingDeployments || isLoadingAccounts ) {
+			return null;
+		}
+
+		if ( showConnectButton ) {
+			return <ConnectionWizardButton onClick={ handleConnect } />;
+		}
+
+		if ( deployments && ! accounts ) {
+			return <GitHubAuthorizeButton />;
+		}
+
+		return null;
+	};
+
 	const renderContent = () => {
-		if ( isLoadingAccounts || isLoadingDeployments ) {
+		if ( isLoadingDeployments || isLoadingAccounts ) {
 			return <GitHubLoadingPlaceholder />;
 		}
 
@@ -58,30 +72,23 @@ export function GitHubDeployments() {
 
 	return (
 		<Main className="github-deployments" fullWidthLayout>
-			<div className="github-deployments__page-header">
-				<DocumentHead title={ titleHeader } />
-				<FormattedHeader
-					align="left"
-					headerText={ titleHeader }
-					subHeaderText={ translate(
-						"Changes pushed to the selected branch's repos will be automatically deployed. {{learnMoreLink}}Learn more{{/learnMoreLink}}.",
-						{
-							components: {
-								learnMoreLink: (
-									<InlineSupportLink supportContext="site-monitoring" showIcon={ false } />
-								),
-							},
-						}
-					) }
-				></FormattedHeader>
-				{ showConnectButton && (
-					<div>
-						<Button primary onClick={ handleConnect }>
-							{ translate( 'Connect repository' ) }
-						</Button>
-					</div>
+			<DocumentHead title={ titleHeader } />
+			<NavigationHeader
+				compactBreadcrumb
+				title={ titleHeader }
+				subtitle={ translate(
+					"Changes pushed to the selected branch's repos will be automatically deployed. {{learnMoreLink}}Learn more{{/learnMoreLink}}.",
+					{
+						components: {
+							learnMoreLink: (
+								<InlineSupportLink supportContext="site-monitoring" showIcon={ false } />
+							),
+						},
+					}
 				) }
-			</div>
+			>
+				{ renderTopRightButton() }
+			</NavigationHeader>
 			{ renderContent() }
 		</Main>
 	);

--- a/client/my-sites/github-deployments/use-code-deployments-query.ts
+++ b/client/my-sites/github-deployments/use-code-deployments-query.ts
@@ -25,10 +25,11 @@ export interface CreatedBy {
 }
 
 export const useCodeDeploymentsQuery = (
-	siteId: number,
+	siteId: number | null,
 	options?: UseQueryOptions< CodeDeploymentData[] >
 ) => {
 	return useQuery< CodeDeploymentData[] >( {
+		enabled: !! siteId,
 		queryKey: [ GITHUB_DEPLOYMENTS_QUERY_KEY, CODE_DEPLOYMENTS_QUERY_KEY, siteId ],
 		queryFn: (): CodeDeploymentData[] =>
 			wp.req.get( {

--- a/client/my-sites/github-deployments/use-github-accounts-query.ts
+++ b/client/my-sites/github-deployments/use-github-accounts-query.ts
@@ -2,7 +2,13 @@ import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 import { GITHUB_DEPLOYMENTS_QUERY_KEY } from './constants';
 
-export const GITHUB_ACCOUNTS_QUERY_KEY = 'github-accounts';
+const fetchAccounts = (): GitHubAccountData[] =>
+	wp.req.get( {
+		path: `/hosting/github/accounts`,
+		apiNamespace: 'wpcom/v2',
+	} );
+
+const GITHUB_DEPLOYMENTS_ACCOUNTS_QUERY_KEY = [ GITHUB_DEPLOYMENTS_QUERY_KEY, 'github-accounts' ];
 
 export interface GitHubAccountData {
 	account_name: string;
@@ -10,17 +16,16 @@ export interface GitHubAccountData {
 	external_name: string;
 }
 
-export const useGithubAccountsQuery = ( options?: UseQueryOptions< GitHubAccountData[] > ) => {
+export const useGithubAccountsQuery = (
+	options?: Partial< UseQueryOptions< GitHubAccountData[] > >
+) => {
 	return useQuery< GitHubAccountData[] >( {
-		queryKey: [ GITHUB_DEPLOYMENTS_QUERY_KEY, GITHUB_ACCOUNTS_QUERY_KEY ],
-		queryFn: (): GitHubAccountData[] =>
-			wp.req.get( {
-				path: `/hosting/github/accounts`,
-				apiNamespace: 'wpcom/v2',
-			} ),
-		meta: {
-			persist: false,
-		},
+		queryKey: GITHUB_DEPLOYMENTS_ACCOUNTS_QUERY_KEY,
+		queryFn: fetchAccounts,
+		retry: false,
+		retryOnMount: false,
+		refetchOnMount: false,
+		meta: { persist: false },
 		...options,
 	} );
 };


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/5249.

## Proposed Changes

When the user browses `/github-deployments/%s` without having authorized WPCOM to see their GitHub account, we display the "Authorize GitHub" button.

https://github.com/Automattic/wp-calypso/assets/26530524/d7d86086-9080-43f6-a102-6937be375521

## Testing Instructions

1. Apply D137982-code to your sandbox;
2. Run this branch locally;
3. Go to `/github-deployments/%s`;
4. Click "Authorize GitHub", and verify that you can authorize your account, or the popup closes if the account already has the app authorized;
5. Check that the button now says "Connect repository".

If you want to retry the process, run `wp shell` in your sandbox and type the following command: `delete_user_meta(<wpcom_user_id>, 'github_access_token');`