### PR TITLE
Add support for `currency` URL param on `/plans/:site`

### DIFF
--- a/packages/data-stores/src/plans/queries/use-plans.ts
+++ b/packages/data-stores/src/plans/queries/use-plans.ts
@@ -1,6 +1,7 @@
 import { calculateMonthlyPriceForPlan } from '@automattic/calypso-products';
 import { useLocale } from '@automattic/i18n-utils';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { getQueryArg } from '@wordpress/url';
 import wpcomRequest from 'wpcom-proxy-request';
 import unpackIntroOffer from './lib/unpack-intro-offer';
 import useQueryKeysFactory from './lib/use-query-keys-factory';
@@ -26,6 +27,13 @@ function usePlans( {
 	const params = new URLSearchParams();
 	coupon && params.append( 'coupon_code', coupon );
 	params.append( 'locale', locale );
+
+	if ( typeof window !== 'undefined' ) {
+		const currency = getQueryArg( window.location.search, 'currency' );
+		if ( typeof currency === 'string' ) {
+			params.append( 'currency', currency );
+		}
+	}
 
 	return useQuery( {
 		queryKey: queryKeys.plans( coupon ),


### PR DESCRIPTION
Resolves #87402

## Proposed Changes

Adds support for passing a `?currency=xx` param when viewing `/plans/:site`. Allows for quickly switching the currency in the spotlight, features & comparison grids.

![CleanShot 2024-02-13 at 16 49 51@2x](https://github.com/Automattic/wp-calypso/assets/69198925/a4b18d58-9d79-4ea4-9c2b-48dfd65c3efa)


## Testing Instructions

1. Load `/plans/:site?currency=xx` using different values for the `currency` param eg. USD, INR, AUD
2. Verify that the prices shown in the grids & spotlight are displayed in the expected currency
3. Remove the `currency` param and verify that the grids & spotlight use the store admin* currency

* Store admin is available here: `/wp-admin/network/admin.php?page=store-admin`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?