### PR TITLE
Stats: Fix for unwanted page refresh issue

### DIFF
--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -70,6 +70,11 @@ const queryNotices = async function ( siteId: number | null ): Promise< Notices 
 	return { ...DEFAULT_NOTICES_VISIBILITY, ...payload };
 };
 
+// Temporarily exposing queryNotices.
+export async function fetchNoticesAsync( siteId: number | null ): Promise< Notices > {
+	return queryNotices( siteId );
+}
+
 const useNoticesVisibilityQueryRaw = function < T >(
 	siteId: number | null,
 	select?: ( payload: Notices ) => T,

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -70,11 +70,6 @@ const queryNotices = async function ( siteId: number | null ): Promise< Notices 
 	return { ...DEFAULT_NOTICES_VISIBILITY, ...payload };
 };
 
-// Temporarily exposing queryNotices.
-export async function fetchNoticesAsync( siteId: number | null ): Promise< Notices > {
-	return queryNotices( siteId );
-}
-
 const useNoticesVisibilityQueryRaw = function < T >(
 	siteId: number | null,
 	select?: ( payload: Notices ) => T,

--- a/client/my-sites/stats/hooks/use-stats-purchases.ts
+++ b/client/my-sites/stats/hooks/use-stats-purchases.ts
@@ -8,7 +8,11 @@ import {
 } from '@automattic/calypso-products';
 import { useMemo } from 'react';
 import { useSelector } from 'calypso/state';
-import { isFetchingSitePurchases, getSitePurchases } from 'calypso/state/purchases/selectors';
+import {
+	isFetchingSitePurchases,
+	getSitePurchases,
+	hasLoadedSitePurchasesFromServer,
+} from 'calypso/state/purchases/selectors';
 import type { Purchase } from 'calypso/lib/purchases/types';
 
 const JETPACK_STATS_TIERED_BILLING_LIVE_DATE_2024_01_04 = '2024-01-04T05:30:00+00:00';
@@ -31,6 +35,7 @@ const isProductOwned = ( ownedPurchases: Purchase[], searchedProduct: string ) =
 export default function useStatsPurchases( siteId: number | null ) {
 	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, siteId ) );
 	const isRequestingSitePurchases = useSelector( isFetchingSitePurchases );
+	const hasLoadedSitePurchases = useSelector( hasLoadedSitePurchasesFromServer );
 
 	// Determine whether a product is owned.
 	// TODO we need to do plan check as well, because Stats products would be built into other plans.
@@ -77,5 +82,6 @@ export default function useStatsPurchases( siteId: number | null ) {
 		isCommercialOwned,
 		supportCommercialUse,
 		isLegacyCommercialLicense,
+		hasLoadedSitePurchases,
 	};
 }

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -3,7 +3,10 @@ import page from '@automattic/calypso-router';
 import { useEffect, useState, ReactNode } from 'react';
 import { useDispatch } from 'react-redux';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
-import { fetchNoticesAsync } from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
+import {
+	fetchNoticesAsync,
+	processConflictNotices,
+} from 'calypso/my-sites/stats/hooks/use-notice-visibility-query';
 import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { isJetpackSite, getSiteOption, getSiteSlug } from 'calypso/state/sites/selectors';
@@ -64,9 +67,11 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 		console.log( 'useEffect fetching notices...' );
 		async function fetchNotices() {
 			const data = await fetchNoticesAsync( siteId );
+			const payload = processConflictNotices( data );
 			console.log( 'data: ', data );
+			console.log( 'payload: ', payload );
 			setIsRequestingNotices( false );
-			setPurchaseNotPosponed( data?.focus_jetpack_purchase );
+			setPurchaseNotPosponed( payload?.focus_jetpack_purchase );
 		}
 		setIsRequestingNotices( true );
 		fetchNotices();

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -65,10 +65,10 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 	// Fetch notice state via direct API request.
 	useEffect( () => {
 		async function fetchNotices() {
-			const data = await fetchNoticesAsync( siteId );
-			const payload = processConflictNotices( data );
+			const notices = await fetchNoticesAsync( siteId );
+			const processedNotices = processConflictNotices( notices );
 			setIsRequestingNotices( false );
-			setPurchaseNotPosponed( payload?.focus_jetpack_purchase );
+			setPurchaseNotPosponed( processedNotices?.focus_jetpack_purchase );
 		}
 		setIsRequestingNotices( true );
 		fetchNotices();

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -24,7 +24,7 @@ interface StatsRedirectFlowProps {
 
 const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) => {
 	const [ isRequestingNotices, setIsRequestingNotices ] = useState( false );
-	const [ purchaseNotPosponed, setPurchaseNotPosponed ] = useState( false );
+	const [ purchaseNotPostponed, setPurchaseNotPostponed ] = useState( false );
 
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
@@ -55,7 +55,7 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 	// TODO: Investigate useNoticeVisibilityQuery.
 	// Tempoararily moved away from this to fix a page refresh bug.
 	/*
-	const { isFetching: isRequestingNotices, data: purchaseNotPosponed } = useNoticeVisibilityQuery(
+	const { isFetching: isRequestingNotices, data: purchaseNotPostponed } = useNoticeVisibilityQuery(
 		siteId,
 		'focus_jetpack_purchase',
 		canUserManageOptions
@@ -68,7 +68,7 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 			const notices = await fetchNoticesAsync( siteId );
 			const processedNotices = processConflictNotices( notices );
 			setIsRequestingNotices( false );
-			setPurchaseNotPosponed( processedNotices?.focus_jetpack_purchase );
+			setPurchaseNotPostponed( processedNotices?.focus_jetpack_purchase );
 		}
 		setIsRequestingNotices( true );
 		fetchNotices();
@@ -85,7 +85,7 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 		config.isEnabled( 'stats/checkout-flows-v2' ) &&
 		isSiteJetpackNotAtomic &&
 		! hasPlan &&
-		purchaseNotPosponed &&
+		purchaseNotPostponed &&
 		qualifiedUser;
 
 	const dispatch = useDispatch();
@@ -97,11 +97,11 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 		} else {
 			dispatch(
 				receiveStatNoticeSettings( siteId, {
-					focus_jetpack_purchase: purchaseNotPosponed,
+					focus_jetpack_purchase: purchaseNotPostponed,
 				} )
 			);
 		}
-	}, [ dispatch, redirectToPurchase, siteId, isFetching, purchaseNotPosponed ] );
+	}, [ dispatch, redirectToPurchase, siteId, isFetching, purchaseNotPostponed ] );
 
 	// render purchase flow for Jetpack sites created after February 2024
 	if ( ! isFetching && redirectToPurchase && siteSlug ) {

--- a/client/my-sites/stats/stats-redirect/index.tsx
+++ b/client/my-sites/stats/stats-redirect/index.tsx
@@ -64,12 +64,9 @@ const StatsRedirectFlow: React.FC< StatsRedirectFlowProps > = ( { children } ) =
 
 	// Fetch notice state via direct API request.
 	useEffect( () => {
-		console.log( 'useEffect fetching notices...' );
 		async function fetchNotices() {
 			const data = await fetchNoticesAsync( siteId );
 			const payload = processConflictNotices( data );
-			console.log( 'data: ', data );
-			console.log( 'payload: ', payload );
 			setIsRequestingNotices( false );
 			setPurchaseNotPosponed( payload?.focus_jetpack_purchase );
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87373.

## Proposed Changes

<strike>Move from TanStack to a direct API call for the `notices` endpoint to avoid a consistent page refresh issue. After some investigation, we aren't quite sure what is causing the refresh but these changes fix the issue in the meantime.</strike>

-------UPDATE------

Ended up depending on the 'right' flags to identify readiness to redirection.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

#### Confirm refresh is fixed
- Load up any top-level Stats page
- Switch to a new tab
- Wait 30 seconds (approx.) and revisit the Stats tab
- Confirm the page content doesn't reload

#### Confirm redirect still works
- Visit a new self-hosted site with Jetpack installed
- Visit the Stats page
- Confirm that you are redirected to the purchase flow

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?