### PR TITLE
Assembler: Hot fix for pattern rendering while use-in-view is not working

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/pattern-list-renderer.tsx
@@ -42,7 +42,7 @@ const PatternListItem = ( {
 	onSelect,
 }: PatternListItemProps ) => {
 	const ref = useRef< HTMLButtonElement >();
-	const { ref: inViewRef, inView: inViewOnce } = useInView( {
+	const { ref: inViewRef } = useInView( {
 		triggerOnce: true,
 	} );
 
@@ -75,7 +75,7 @@ const PatternListItem = ( {
 				aria-current={ isSelected }
 				onClick={ () => onSelect( pattern ) }
 			>
-				{ isShown && inViewOnce ? (
+				{ isShown ? (
 					<PatternRenderer
 						key={ pattern.ID }
 						patternId={ encodePatternId( pattern.ID ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/87409 #87409

## Proposed Changes

* Remove `inViewOnce` from the condition to render a pattern because the use-in-view hook is not working

|BEFORE|AFTER|
|-|-|
|<img width="694" alt="Screenshot 2567-02-13 at 13 53 04" src="https://github.com/Automattic/wp-calypso/assets/1881481/9c68c4b8-f8fc-44eb-83a0-fde8053d8072">|<img width="694" alt="Screenshot 2567-02-13 at 13 55 07" src="https://github.com/Automattic/wp-calypso/assets/1881481/32a5c76c-7708-4190-ac09-a23a71aaf5da">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the Assembler to confirm patterns are rendered in the sidebar and the performance is not affected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-ajp-p2)?