### PR TITLE
A4A: Add the initial theme for the new environment.

### DIFF
--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -13,12 +13,8 @@
 
 	.main {
 		box-sizing: border-box;
-		padding-left: 16px;
-		padding-right: 16px;
-	}
-
-	input::placeholder {
-		color: var(--color-neutral-10) !important;
+		padding-inline-start: 16px;
+		padding-inline-end: 16px;
 	}
 }
 
@@ -30,16 +26,16 @@
 	// On mobile views this accommodates the masterbar, but we don't have one;
 	// so, we can remove it by default and re-add it when our width is >660px.
 	.layout__content {
-		padding-top: initial;
+		padding-block-start: initial;
 	}
 
 	@include breakpoint-deprecated( ">660px" ) {
-		padding-top: 32px;
+		padding-block-start: 32px;
 	}
 }
 
 .theme-a8c-for-agencies .layout__secondary {
-	border-right: initial;
+	border-inline-end: initial;
 
 	// Allow visible overflow, so the profile dropdown menu can be displayed
 	overflow: initial;
@@ -67,8 +63,6 @@
 
 		.all-sites,
 		.site {
-			--color-sidebar-menu-selected-background: #e3f0e4;
-
 			margin: 4px 4px 0 4px;
 
 			&.is-selected,
@@ -80,7 +74,6 @@
 }
 
 // Universal Text Styles
-
 html {
 	h2 {
 		font-size: $font-title-small;
@@ -115,18 +108,8 @@ html {
 	}
 }
 
-.theme-a8c-for-agencies .ReactModalPortal {
-	.dialog.card {
-		box-shadow: 0 0 0 1px var(--color-border-subtle), 0 4px 12px var(--color-neutral-10);
-	}
-
-	.dialog__action-buttons {
-		border-radius: 0 0 var(--a4a-corners-soft) var(--a4a-corners-soft);
-	}
-}
-
 .layout__secondary {
-	border-right: 1px solid var(--color-sidebar-border);
+	border-inline-end: 1px solid var(--color-sidebar-border);
 }
 
 .layout.focus-content .layout__secondary {

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -1,0 +1,149 @@
+// custom properties for a8c-for-agencies
+:root {
+	// border-radius
+	--a4a-corners-sharp: 0;
+	--a4a-corners-soft: 4px;
+}
+
+.theme-a8c-for-agencies {
+	background-color: var(--studio-wordpress-blue-90);
+
+	// Masterbar
+	@media only screen and ( min-width: 782px ) {
+		--masterbar-height: 46px;
+	}
+
+	.main {
+		box-sizing: border-box;
+		padding-left: 16px;
+		padding-right: 16px;
+	}
+
+	input::placeholder {
+		color: var(--color-neutral-10) !important;
+	}
+}
+
+// New navigation will not include a masterbar
+.theme-a8c-for-agencies .layout.has-no-masterbar {
+	--masterbar-height: 0;
+
+	// By default, there's 32px of top padding on the layout component.
+	// On mobile views this accommodates the masterbar, but we don't have one;
+	// so, we can remove it by default and re-add it when our width is >660px.
+	.layout__content {
+		padding-top: initial;
+	}
+
+	@include breakpoint-deprecated( ">660px" ) {
+		padding-top: 32px;
+	}
+}
+
+.theme-a8c-for-agencies .layout__secondary {
+	background-color: var(--studio-wordpress-blue-90);
+
+	border-right: initial;
+
+	// Allow visible overflow, so the profile dropdown menu can be displayed
+	overflow: initial;
+
+	// Make the selected-site navigation full-height
+	.my-sites__navigation {
+		height: 100%;
+	}
+
+	.site-selector {
+		top: 80px;
+
+		.site-selector__sites {
+			border-top: initial;
+		}
+
+		.all-sites {
+			border-bottom: initial;
+
+			// Remove the long-content fade if All Sites is selected
+			.all-sites__title::after {
+				display: none;
+			}
+		}
+
+		.all-sites,
+		.site {
+			--color-sidebar-menu-selected-background: #e3f0e4;
+
+			margin: 4px 4px 0 4px;
+
+			&.is-selected,
+			&:hover {
+				border-radius: 4px;
+			}
+		}
+	}
+}
+
+// Universal Text Styles
+
+html {
+	h2 {
+		font-size: $font-title-small;
+		font-weight: 600;
+		line-height: 32px;
+
+		@include breakpoint-deprecated( ">660px" ) {
+			font-size: $font-headline-small;
+			line-height: 40px;
+		}
+	}
+
+	h3 {
+		font-size: $font-body;
+		font-weight: 600;
+		line-height: 23px;
+
+		@include breakpoint-deprecated( ">660px" ) {
+			font-size: $font-title-small;
+			line-height: 23px;
+		}
+	}
+
+	p {
+		font-size: $font-body;
+		line-height: 24px;
+
+		@include breakpoint-deprecated( ">660px" ) {
+			font-size: $font-title-small;
+			line-height: 24px;
+		}
+	}
+}
+
+.theme-a8c-for-agencies .ReactModalPortal {
+	.dialog.card {
+		box-shadow: 0 0 0 1px var(--color-border-subtle), 0 4px 12px var(--color-neutral-10);
+	}
+
+	.dialog__action-buttons {
+		border-radius: 0 0 var(--a4a-corners-soft) var(--a4a-corners-soft);
+	}
+}
+
+.layout__secondary {
+	border-right: 1px solid var(--color-sidebar-border);
+}
+
+.layout.focus-content .layout__secondary {
+	@media only screen and ( max-width: 782px ) and ( min-width: 660px ) {
+		transform: none;
+		padding: 0;
+	}
+}
+
+.masterbar {
+	font-size: $font-body;
+}
+
+.site-selector .site-selector__actions {
+	padding: 16px;
+}

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -6,8 +6,6 @@
 }
 
 .theme-a8c-for-agencies {
-	background-color: var(--studio-wordpress-blue-90);
-
 	// Masterbar
 	@media only screen and ( min-width: 782px ) {
 		--masterbar-height: 46px;
@@ -41,8 +39,6 @@
 }
 
 .theme-a8c-for-agencies .layout__secondary {
-	background-color: var(--studio-wordpress-blue-90);
-
 	border-right: initial;
 
 	// Allow visible overflow, so the profile dropdown menu can be displayed

--- a/client/a8c-for-agencies/style.tsx
+++ b/client/a8c-for-agencies/style.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+import 'calypso/a8c-for-agencies/style.scss';
+
+const StyleImporter: React.FC = () => null;
+
+export default StyleImporter;

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -296,6 +296,9 @@ class Layout extends Component {
 				{ isJetpackCloud() && (
 					<AsyncLoad require="calypso/jetpack-cloud/style" placeholder={ null } />
 				) }
+				{ config.isEnabled( 'a8c-for-agencies' ) && (
+					<AsyncLoad require="calypso/a8c-for-agencies/style" placeholder={ null } />
+				) }
 				{ this.props.isOffline && <OfflineStatus /> }
 				<div id="content" className="layout__content">
 					{ config.isEnabled( 'jitms' ) && this.props.isEligibleForJITM && (

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -221,6 +221,9 @@ const LayoutLoggedOut = ( {
 			{ isJetpackCloud() && (
 				<AsyncLoad require="calypso/jetpack-cloud/style" placeholder={ null } />
 			) }
+			{ config.isEnabled( 'a8c-for-agencies' ) && (
+				<AsyncLoad require="calypso/a8c-for-agencies/style" placeholder={ null } />
+			) }
 			<div id="content" className="layout__content">
 				<AsyncLoad require="calypso/components/global-notices" placeholder={ null } id="notices" />
 				<div id="primary" className="layout__primary">

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -19,7 +19,7 @@
 		"a8c-for-agencies": true
 	},
 	"site_filter": [],
-	"theme": "jetpack-cloud",
+	"theme": "a8c-for-agencies",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f",
 	"hotjar_enabled": true

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -15,7 +15,7 @@
 		"a8c-for-agencies": true
 	},
 	"site_filter": [],
-	"theme": "jetpack-cloud",
+	"theme": "a8c-for-agencies",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f",
 	"hotjar_enabled": true

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -15,7 +15,7 @@
 		"a8c-for-agencies": true
 	},
 	"site_filter": [],
-	"theme": "jetpack-cloud",
+	"theme": "a8c-for-agencies",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f",
 	"hotjar_enabled": true


### PR DESCRIPTION
This PR adds the theme for A4A environment.

Closes https://github.com/Automattic/jetpack-genesis/issues/220

## Proposed Changes

* Add a new `a8c-for-agencies/style.scss` file to contain all global styling. Note that the majority of the style was copied from the Jetpack cloud.
* Add style imported and asynchronously load it.
* Update the environment config to use the `a8c-for-agencies` theme.

## Testing Instructions

* Checkout to this branch.
* Spin up the environment using the command `yarn start-a8c-for-agencies`.
* Goto http://agencies.localhost:3000
* Confirm that the Global style was loaded properly.
<img width="1709" alt="Screenshot 2024-02-13 at 5 50 08 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/136490e5-0806-45fd-8f53-d7bc844111fa">


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?