### PR TITLE
Stats: Hide Jetpack upsells on Atomic

### DIFF
--- a/client/my-sites/stats/site.jsx
+++ b/client/my-sites/stats/site.jsx
@@ -38,6 +38,7 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import getCurrentRouteParameterized from 'calypso/state/selectors/get-current-route-parameterized';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import isPrivateSite from 'calypso/state/selectors/is-private-site';
+import isAtomicSite from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { getJetpackStatsAdminVersion, isJetpackSite } from 'calypso/state/sites/selectors';
 import { requestModuleSettings } from 'calypso/state/stats/module-settings/actions';
 import { getModuleSettings } from 'calypso/state/stats/module-settings/selectors';
@@ -199,6 +200,7 @@ class StatsSite extends Component {
 			date,
 			siteId,
 			slug,
+			isAtomic,
 			isJetpack,
 			isSitePrivate,
 			isOdysseyStats,
@@ -208,6 +210,8 @@ class StatsSite extends Component {
 		} = this.props;
 
 		let defaultPeriod = PAST_SEVEN_DAYS;
+
+		const shouldShowUpsells = isOdysseyStats && ! isAtomic;
 
 		// Set the current period based on the module settings.
 		// @TODO: Introduce the loading state to avoid flickering due to slow module settings request.
@@ -477,8 +481,8 @@ class StatsSite extends Component {
 				{ isPlanUsageEnabled && (
 					<StatsPlanUsage siteId={ siteId } isOdysseyStats={ isOdysseyStats } />
 				) }
-				{ /* Only load Jetpack Upsell Section for Odyssey Stats */ }
-				{ ! isOdysseyStats ? null : (
+				{ /* Only load Jetpack Upsell Section for Odyssey Stats excluding Atomic */ }
+				{ ! shouldShowUpsells ? null : (
 					<AsyncLoad require="calypso/my-sites/stats/jetpack-upsell-section" />
 				) }
 				<PromoCards isOdysseyStats={ isOdysseyStats } pageSlug="traffic" slug={ slug } />
@@ -616,6 +620,7 @@ export default connect(
 
 		return {
 			canUserViewStats,
+			isAtomic: isAtomicSite( state, siteId ),
 			isJetpack,
 			isSitePrivate: isPrivateSite( state, siteId ),
 			siteId,


### PR DESCRIPTION

Related to #87397

## Proposed Changes

Adds a check for Atomic sites when determining if upsells component should be shown.

## Testing Instructions

* Create an Atomic dev blog following instructions at p9o2xV-1r2-p2
* Install Jetpack and Jetpack Beta plugin
* Install branch `update/enable-odyssey-for-woa-sites` on sandbox and sandbox `widgets.wp.com`
* Open `/wp-admin/admin.php?page=stats`
* Ensure the upsell section isn't showing up
* Ensure the pages works okay (a couple of failed api calls tho)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?