### PR TITLE
Continue with GitHub: Add social login to `me/security/social-login`

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -114,7 +114,7 @@ class SocialLoginForm extends Component {
 		);
 	};
 
-	handleGitHubResponse = ( access_token, triggeredByUser = true ) => {
+	handleGitHubResponse = ( { access_token }, triggeredByUser = true ) => {
 		const { onSuccess, socialService } = this.props;
 		let redirectTo = this.props.redirectTo;
 

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -58,7 +58,7 @@ class SocialSignupForm extends Component {
 		} );
 	};
 
-	handleGitHubResponse = ( accessToken, triggeredByUser = true ) => {
+	handleGitHubResponse = ( { accessToken }, triggeredByUser = true ) => {
 		if ( ! triggeredByUser && this.props.socialService !== 'github' ) {
 			return;
 		}

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -128,7 +128,9 @@ const GitHubLoginButton = ( {
 
 		const clientId = config( 'github_oauth_client_id' );
 		const redirectEndpoint = encodeURIComponent(
-			`https://public-api.wordpress.com/wpcom/v2/hosting/github/app-callback?final_redirect_uri=${ redirectUri }`
+			`https://public-api.wordpress.com/wpcom/v2/hosting/github/app-callback?final_redirect_uri=${
+				redirectUri.split( '?' )[ 0 ]
+			}`
 		);
 		window.location.href = `https://github.com/login/oauth/authorize?client_id=${ clientId }&redirect_uri=${ redirectEndpoint }`;
 	};

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -127,12 +127,13 @@ const GitHubLoginButton = ( {
 		}
 
 		const clientId = config( 'github_oauth_client_id' );
+		const scope = encodeURIComponent( 'read:user,user:email' );
 		const redirectEndpoint = encodeURIComponent(
 			`https://public-api.wordpress.com/wpcom/v2/hosting/github/app-callback?final_redirect_uri=${
 				redirectUri.split( '?' )[ 0 ]
 			}`
 		);
-		window.location.href = `https://github.com/login/oauth/authorize?client_id=${ clientId }&redirect_uri=${ redirectEndpoint }`;
+		window.location.href = `https://github.com/login/oauth/authorize?client_id=${ clientId }&scope=${ scope }&redirect_uri=${ redirectEndpoint }`;
 	};
 
 	const eventHandlers = {

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -96,6 +96,11 @@ const GitHubLoginButton = ( {
 		responseHandler( { access_token } );
 	};
 
+	const stripQueryString = ( url: string ) => {
+		const urlParts = url.split( '?' );
+		return urlParts[ 0 ];
+	};
+
 	useEffect( () => {
 		// This feature is already gated inside client/blocks/authentication/social/index.tsx
 		// Adding an extra check here to prevent accidental inclusions in other parts of the app
@@ -129,9 +134,9 @@ const GitHubLoginButton = ( {
 		const clientId = config( 'github_oauth_client_id' );
 		const scope = encodeURIComponent( 'read:user,user:email' );
 		const redirectEndpoint = encodeURIComponent(
-			`https://public-api.wordpress.com/wpcom/v2/hosting/github/app-callback?final_redirect_uri=${
-				redirectUri.split( '?' )[ 0 ]
-			}`
+			`https://public-api.wordpress.com/wpcom/v2/hosting/github/app-callback?final_redirect_uri=${ stripQueryString(
+				redirectUri
+			) }`
 		);
 		window.location.href = `https://github.com/login/oauth/authorize?client_id=${ clientId }&scope=${ scope }&redirect_uri=${ redirectEndpoint }`;
 	};

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -93,7 +93,7 @@ const GitHubLoginButton = ( {
 		);
 
 		const { access_token } = response?.body?.data as ExchangeCodeForTokenResponse;
-		responseHandler( access_token, true );
+		responseHandler( { access_token } );
 	};
 
 	useEffect( () => {

--- a/client/me/social-login/action-button.jsx
+++ b/client/me/social-login/action-button.jsx
@@ -5,6 +5,7 @@ import { Component } from 'react';
 import { connect } from 'react-redux';
 import FormButton from 'calypso/components/forms/form-button';
 import AppleLoginButton from 'calypso/components/social-buttons/apple';
+import GithubLoginButton from 'calypso/components/social-buttons/github';
 import GoogleSocialButton from 'calypso/components/social-buttons/google';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { fetchCurrentUser } from 'calypso/state/current-user/actions';
@@ -158,6 +159,19 @@ class SocialLoginActionButton extends Component {
 				>
 					{ actionButton }
 				</AppleLoginButton>
+			);
+		}
+
+		if ( service === 'github' ) {
+			return (
+				<GithubLoginButton
+					onClick={ this.handleButtonClick }
+					responseHandler={ this.handleSocialServiceResponse }
+					redirectUri={ redirectUri }
+					socialServiceResponse={ this.props.socialServiceResponse }
+				>
+					{ actionButton }
+				</GithubLoginButton>
 			);
 		}
 

--- a/client/me/social-login/action-button.jsx
+++ b/client/me/social-login/action-button.jsx
@@ -101,6 +101,15 @@ class SocialLoginActionButton extends Component {
 			};
 		}
 
+		if ( service === 'github' ) {
+			this.recordLoginSuccess( service );
+
+			socialInfo = {
+				...socialInfo,
+				access_token: response.access_token,
+			};
+		}
+
 		return this.props.connectSocialUser( socialInfo ).then( this.refreshUser );
 	};
 

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -10,6 +10,7 @@ import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
 import AppleIcon from 'calypso/components/social-icons/apple';
+import GitHubIcon from 'calypso/components/social-icons/github';
 import GoogleIcon from 'calypso/components/social-icons/google';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
@@ -60,6 +61,17 @@ class SocialLogin extends Component {
 						redirectUri={ redirectUri }
 						socialServiceResponse={
 							this.props.socialService === 'apple' ? this.props.socialServiceResponse : null
+						}
+					/>
+				) }
+
+				{ config.isEnabled( 'login/github' ) && (
+					<SocialLoginService
+						service="github"
+						icon={ <GitHubIcon /> }
+						redirectUri={ redirectUri }
+						socialServiceResponse={
+							this.props.socialService === 'github' ? this.props.socialServiceResponse : null
 						}
 					/>
 				) }

--- a/client/me/social-login/service.jsx
+++ b/client/me/social-login/service.jsx
@@ -16,7 +16,7 @@ const SocialLoginService = ( {
 		<div className="social-login__header">
 			<div className="social-login__header-info">
 				<div className="social-login__header-icon">{ icon }</div>
-				<h3>{ service }</h3>
+				<h3>{ service === 'github' ? 'GitHub' : service }</h3>
 				{ socialConnectionEmail && <p>{ ' - ' + socialConnectionEmail }</p> }
 			</div>
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/wp-calypso/issues/87184.

ℹ️ This PR is based on https://github.com/Automattic/wp-calypso/pull/87300 and should be merged there once reviewed.
ℹ️ In order for the changes proposed in this PR to work, the following commit was added to our backend PR: D137543#2657171-code.

## Proposed Changes

* add GitHub social login to `me/security/social-login` 

| GitHub not connected | GitHub connected |
|--------|--------|
| ![Markup on 2024-02-13 at 14:04:06](https://github.com/Automattic/wp-calypso/assets/25105483/4d207c0c-d923-41f6-8357-d2b677e69a72) | ![Markup on 2024-02-13 at 14:02:42](https://github.com/Automattic/wp-calypso/assets/25105483/1c2e8515-2965-41b1-8f29-288dafe6984a) | 





## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build it.
2. Apply D137543-code to your sandbox; and sandbox `public-api.wordpress.com` and `wordpress.com`.
3. Log in to a test non-A8C WPCOM account.
4. Navigate to http://calypso.localhost:3000/me/security/social-login.
5. Click on the "Connect" button and go through GitHub login flow until you get back to Calypso again. Please note that the process can take some time due to sandboxed `public-api.wordpress.com` and `wordpress.com`.
6. Your GitHub account should be connected to your test WPCOM account.
7. Click on the "Disconnect" button.
8. Your GitHub account should get disconnected from your test WPCOM account.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?