### PR TITLE
Site Transfers: Update layout for confirm transfer screen

### DIFF
--- a/client/my-sites/site-settings/controller.js
+++ b/client/my-sites/site-settings/controller.js
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
 import { billingHistory } from 'calypso/me/purchases/paths';
 import SiteSettingsMain from 'calypso/my-sites/site-settings/main';
+import { ConfirmationTransfer } from 'calypso/my-sites/site-settings/site-owner-transfer/confirmation-transfer';
 import WpcomSiteTools from 'calypso/my-sites/site-settings/wpcom-site-tools';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -131,6 +132,16 @@ export function acceptSiteTransfer( context, next ) {
 			inviteKey={ context.params.invitation_key }
 			redirectTo={ context.query.nextStep }
 			dispatch={ context.store.dispatch }
+		/>
+	);
+	next();
+}
+
+export function renderConfirmTransferScreen( context, next ) {
+	context.primary = (
+		<ConfirmationTransfer
+			siteId={ context.params.site_id }
+			confirmationHash={ context.params.hash }
 		/>
 	);
 	next();

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -18,6 +18,7 @@ import {
 	startSiteOwnerTransfer,
 	renderSiteTransferredScreen,
 	wpcomSiteTools,
+	renderConfirmTransferScreen,
 } from 'calypso/my-sites/site-settings/controller';
 import { setScroll, siteSettings } from 'calypso/my-sites/site-settings/settings-controller';
 
@@ -118,6 +119,15 @@ export default function () {
 		'/settings/site-transferred/:site_id',
 		siteSelection,
 		renderSiteTransferredScreen,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/settings/site-transfer/:site_id/confirm/:hash',
+		siteSelection,
+		redirectIfCantStartSiteOwnerTransfer,
+		renderConfirmTransferScreen,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/site-settings/index.js
+++ b/client/my-sites/site-settings/index.js
@@ -124,7 +124,7 @@ export default function () {
 	);
 
 	page(
-		'/settings/site-transfer/:site_id/confirm/:hash',
+		'/settings/site-transfer/:hash/confirm/:site_id',
 		siteSelection,
 		redirectIfCantStartSiteOwnerTransfer,
 		renderConfirmTransferScreen,

--- a/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
@@ -1,30 +1,12 @@
-/* eslint-disable prettier/prettier */
-/* eslint-disable import/order */
-import styled from '@emotion/styled';
-import { useTranslate } from 'i18n-calypso';
-import ActionPanel from 'calypso/components/action-panel';
-import Main from 'calypso/components/main';
-import { navigate } from 'calypso/lib/navigate';
-import { acceptInvite } from 'calypso/state/invites/actions';
 import { useEffect } from '@wordpress/element';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import store from 'store';
+import { navigate } from 'calypso/lib/navigate';
 import wpcom from 'calypso/lib/wp';
 import normalizeInvite from 'calypso/my-sites/invites/invite-accept/utils/normalize-invite';
-import { LoadingBar } from 'calypso/components/loading-bar';
-import store from 'store';
-import DocumentHead from 'calypso/components/data/document-head';
-import { Global, css } from '@emotion/react';
-import MasterbarStyled from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled';
-import { useState } from 'react';
-import Notice from 'calypso/components/notice';
-
-const ActionPanelStyled = styled( ActionPanel )( {
-	fontSize: '14px',
-	margin: '20% 30px 0 30px',
-	fontWeight: 400,
-	'.action-panel__body': {
-		color: 'var(--studio-gray-70)',
-	},
-} );
+import { SiteTransferringLoadingCard } from 'calypso/my-sites/site-settings/site-owner-transfer/site-transferring-loading-card';
+import { acceptInvite } from 'calypso/state/invites/actions';
 
 export function AcceptSiteTransfer( props: any ) {
 	const translate = useTranslate();
@@ -57,40 +39,10 @@ export function AcceptSiteTransfer( props: any ) {
 		fetchAndAcceptInvite( props );
 	} );
 
-	const renderLoadingBar = () => {
-		return (
-			<>
-				<p>{ translate( 'Hold tight. We are making it happen!' ) }</p>
-				<LoadingBar key="transfer-site-loading-bar" progress={ progress } />
-			</>
-		);
-	};
-
-	const renderError = () => {
-		return (
-			<Notice status="is-error" showDismiss={ false }>
-				<div data-testid="error">
-					<p>{ error }</p>
-				</div>
-			</Notice>
-		);
-	};
-
 	return (
-		<>
-			<DocumentHead title={ translate( 'Site Transfer' ) } />
-			<Global
-				styles={ css`
-					body.is-section-settings,
-					body.is-section-settings .layout__content {
-						background: var( --studio-white );
-					}
-				` }
-			/>
-			<MasterbarStyled canGoBack={ false } />
-			<Main>
-				<ActionPanelStyled>{ ! error ? renderLoadingBar() : renderError() }</ActionPanelStyled>
-			</Main>
-		</>
+		<SiteTransferringLoadingCard
+			progress={ progress }
+			error={ error }
+		></SiteTransferringLoadingCard>
 	);
 }

--- a/client/my-sites/site-settings/site-owner-transfer/confirmation-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/confirmation-transfer.tsx
@@ -1,8 +1,7 @@
 import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useState } from 'react';
-import { LoadingBar } from 'calypso/components/loading-bar';
-import Notice from 'calypso/components/notice';
+import { SiteTransferringLoadingCard } from 'calypso/my-sites/site-settings/site-owner-transfer/site-transferring-loading-card';
 import { useConfirmTransfer } from './use-confirm-transfer';
 
 /**
@@ -34,31 +33,19 @@ export function ConfirmationTransfer( {
 		confirmTransfer( confirmationHash );
 	}, [ confirmTransfer, confirmationHash ] );
 
-	if ( error ) {
-		return (
-			<Notice status="is-error" showDismiss={ false }>
-				<div data-testid="error">
-					<p>
-						{ translate(
-							'There was an error confirming the site transfer. Please {{link}}contact our support team{{/link}} for help.',
-							{
-								components: {
-									link: <a href="/help" />,
-								},
-							}
-						) }
-					</p>
-				</div>
-			</Notice>
-		);
-	}
+	const customError = translate(
+		'There was an error confirming the site transfer. Please {{link}}contact our support team{{/link}} for help.',
+		{
+			components: {
+				link: <a href="/help" />,
+			},
+		}
+	);
 
 	return (
-		<>
-			<p>
-				<LoadingBar key="transfer-site-loading-bar" progress={ progress } />
-			</p>
-			<p>{ translate( 'We are transferring your site.' ) }</p>
-		</>
+		<SiteTransferringLoadingCard
+			progress={ progress }
+			error={ error ? customError : '' }
+		></SiteTransferringLoadingCard>
 	);
 }

--- a/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-owner-transfer.tsx
@@ -10,13 +10,11 @@ import { successNotice } from 'calypso/state/notices/actions';
 import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { getSettingsSource } from '../site-tools/utils';
-import { ConfirmationTransfer } from './confirmation-transfer';
 import PendingDomainTransfer from './pending-domain-transfer';
 import SiteOwnerTransferEligibility from './site-owner-user-search';
 import { SiteTransferCard } from './site-transfer-card';
 import StartSiteOwnerTransfer from './start-site-owner-transfer';
 import { User } from './use-administrators';
-import { useConfirmationTransferHash } from './use-confirmation-transfer-hash';
 
 const Strong = styled( 'strong' )( {
 	fontWeight: 500,
@@ -54,7 +52,6 @@ const SiteOwnerTransfer = () => {
 	const nonWpcomDomains = useSelector( ( state ) =>
 		getDomainsBySiteId( state, selectedSite?.ID )
 	)?.filter( ( domain ) => ! domain.isWPCOMDomain );
-	const confirmationHash = useConfirmationTransferHash();
 
 	const pendingDomain = nonWpcomDomains?.find(
 		( wpcomDomain: ResponseDomain ) => wpcomDomain.pendingTransfer
@@ -72,14 +69,6 @@ const SiteOwnerTransfer = () => {
 			page( `${ source }/${ selectedSite.slug }` );
 		}
 	};
-
-	if ( confirmationHash ) {
-		return (
-			<SiteTransferCard onClick={ onBackClick }>
-				<ConfirmationTransfer siteId={ selectedSite.ID } confirmationHash={ confirmationHash } />
-			</SiteTransferCard>
-		);
-	}
 
 	return (
 		<SiteTransferCard onClick={ onBackClick }>

--- a/client/my-sites/site-settings/site-owner-transfer/site-transferring-loading-card.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/site-transferring-loading-card.tsx
@@ -1,0 +1,65 @@
+import { css, Global } from '@emotion/react';
+import styled from '@emotion/styled';
+import { useTranslate } from 'i18n-calypso';
+import ActionPanel from 'calypso/components/action-panel';
+import DocumentHead from 'calypso/components/data/document-head';
+import { LoadingBar } from 'calypso/components/loading-bar';
+import Main from 'calypso/components/main';
+import Notice from 'calypso/components/notice';
+import MasterbarStyled from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled';
+
+const ActionPanelStyled = styled( ActionPanel )( {
+	fontSize: '14px',
+	margin: '20% 30px 0 30px',
+	fontWeight: 400,
+	'.action-panel__body': {
+		color: 'var(--studio-gray-70)',
+	},
+} );
+
+export function SiteTransferringLoadingCard( {
+	progress,
+	error,
+}: {
+	progress: number;
+	error: React.ReactNode | string;
+} ) {
+	const translate = useTranslate();
+
+	const renderLoadingBar = () => {
+		return (
+			<>
+				<p>{ translate( 'Hold tight. We are making it happen!' ) }</p>
+				<LoadingBar key="transfer-site-loading-bar" progress={ progress } />
+			</>
+		);
+	};
+
+	const renderError = () => {
+		return (
+			<Notice status="is-error" showDismiss={ false }>
+				<div data-testid="error">
+					<p>{ error }</p>
+				</div>
+			</Notice>
+		);
+	};
+
+	return (
+		<>
+			<DocumentHead title={ translate( 'Site Transfer' ) } />
+			<Global
+				styles={ css`
+					body.is-section-settings,
+					body.is-section-settings .layout__content {
+						background: var( --studio-white );
+					}
+				` }
+			/>
+			<MasterbarStyled canGoBack={ false } />
+			<Main>
+				<ActionPanelStyled>{ ! error ? renderLoadingBar() : renderError() }</ActionPanelStyled>
+			</Main>
+		</>
+	);
+}

--- a/client/state/selectors/can-current-user-start-site-owner-transfer.ts
+++ b/client/state/selectors/can-current-user-start-site-owner-transfer.ts
@@ -1,3 +1,4 @@
+import store from 'store';
 import { getCurrentUserEmail, getCurrentUserId } from 'calypso/state/current-user/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';

--- a/client/state/selectors/can-current-user-start-site-owner-transfer.ts
+++ b/client/state/selectors/can-current-user-start-site-owner-transfer.ts
@@ -1,4 +1,4 @@
-import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { getCurrentUserEmail, getCurrentUserId } from 'calypso/state/current-user/selectors';
 import isSiteAutomatedTransfer from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
@@ -19,6 +19,7 @@ export default function canCurrentUserStartSiteOwnerTransfer(
 	siteId: number | null
 ): boolean {
 	const userId = getCurrentUserId( state );
+	const userEmail = getCurrentUserEmail( state );
 	const siteOwnerId = getSelectedSite( state )?.site_owner;
 	if ( ! siteOwnerId || ! userId || ! siteId ) {
 		return false;
@@ -36,6 +37,16 @@ export default function canCurrentUserStartSiteOwnerTransfer(
 		isSiteWpcomStaging( state, siteId )
 	) {
 		return false;
+	}
+
+	const inviteCacheKey = 'accepted_site_transfer_invite';
+	const acceptedInvite = store.get( inviteCacheKey );
+
+	store.remove( inviteCacheKey );
+
+	// Allow user to accept the site transfer if they just have accepted the site transfer.
+	if ( acceptedInvite && acceptedInvite.sentTo === userEmail ) {
+		return true;
 	}
 
 	return siteOwnerId === userId;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Add new route to confirm site transfer with new design changes. 
* New route created for removing navigation from the layout and decoupling from existing site transfer functions. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* TBA

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?