### PR TITLE
Plans Next: Internalise plans-grid styles for covering highlight labels. Other layout isolation.

### DIFF
--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -39,7 +39,10 @@ $plan-features-header-banner-height: 20px;
 		margin: 0 20px;
 		padding: 0 0 10px;
 		overflow-x: visible;
-		padding-top: 35px; // enough to cover `plans-grid__popular-badge` repositioning (top: -35px)
+	}
+
+	.plans-grid-next__comparison-grid {
+		margin-top: 30px;
 	}
 }
 
@@ -129,7 +132,7 @@ $plan-features-header-banner-height: 20px;
 }
 
 .plans-features-main__group.is-wpcom.is-2023-pricing-grid {
-	margin-top: 24px;
+	padding-top: 24px;
 }
 
 /**

--- a/client/my-sites/plans-features-main/style.scss
+++ b/client/my-sites/plans-features-main/style.scss
@@ -24,6 +24,13 @@ $plan-features-header-banner-height: 20px;
 	}
 }
 
+.plans-features-main {
+	.plans-grid-next__features-grid,
+	.plans-grid-next__comparison-grid {
+		margin-top: 50px;
+	}
+}
+
 .is-2023-pricing-grid {
 	margin: 0 auto;
 
@@ -39,10 +46,6 @@ $plan-features-header-banner-height: 20px;
 		margin: 0 20px;
 		padding: 0 0 10px;
 		overflow-x: visible;
-	}
-
-	.plans-grid-next__comparison-grid {
-		margin-top: 30px;
 	}
 }
 
@@ -129,10 +132,6 @@ $plan-features-header-banner-height: 20px;
 .is-2023-pricing-grid .plan-features-2023-grid__content {
 	position: relative;
 	margin: auto;
-}
-
-.plans-features-main__group.is-wpcom.is-2023-pricing-grid {
-	padding-top: 24px;
 }
 
 /**

--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -110,9 +110,9 @@ const Title = styled.div< { isHiddenInMobile?: boolean } >`
 	` ) }
 `;
 
-const Grid = styled.div< { isInSignup?: boolean; visiblePlans: number } >`
+const Grid = styled.div< { visiblePlans: number } >`
 	display: grid;
-	margin: ${ ( props ) => ( props.isInSignup ? '90px auto 0' : '64px auto 0' ) };
+	margin: 0 auto;
 	background: #fff;
 	border: solid 1px #e0e0e0;
 	${ ( props ) =>
@@ -1087,9 +1087,19 @@ const ComparisonGrid = ( {
 		onUpgradeClick,
 	} );
 
+	/**
+	 * Search for "any" plan with a highlight label, not just the visible ones.
+	 * This will keep the grid static while user interacts (selects different plans to compare).
+	 * Some padding is applied in the stylesheet to cover the badges/labels.
+	 */
+	const hasHighlightedPlan = gridPlans.some( ( { highlightLabel } ) => !! highlightLabel );
+	const classes = classNames( 'plan-comparison-grid', {
+		'has-highlighted-plan': hasHighlightedPlan,
+	} );
+
 	return (
-		<div className="plan-comparison-grid">
-			<Grid isInSignup={ isInSignup } visiblePlans={ visiblePlans.length }>
+		<div className={ classes }>
+			<Grid visiblePlans={ visiblePlans.length }>
 				<StickyContainer
 					disabled={ isBottomHeaderInView }
 					stickyClass="is-sticky-header-row"

--- a/packages/plans-grid-next/src/components/features-grid/table.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/table.tsx
@@ -59,9 +59,19 @@ const Table = ( {
 	const gridPlansWithoutSpotlight = ! gridPlanForSpotlight
 		? renderedGridPlans
 		: renderedGridPlans.filter( ( { planSlug } ) => gridPlanForSpotlight.planSlug !== planSlug );
+	/**
+	 * Search for a plan with a highlight label.
+	 * Some margin is applied in the stylesheet to cover the badges/labels.
+	 */
+	const hasHighlightedPlan = gridPlansWithoutSpotlight.some(
+		( { highlightLabel } ) => !! highlightLabel
+	);
 	const tableClasses = classNames(
 		'plan-features-2023-grid__table',
-		`has-${ gridPlansWithoutSpotlight.length }-cols`
+		`has-${ gridPlansWithoutSpotlight.length }-cols`,
+		{
+			'has-highlighted-plan': hasHighlightedPlan,
+		}
 	);
 	const translate = useTranslate();
 

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -495,6 +495,11 @@ $mobile-card-max-width: 440px;
  * TODO clk consolidate with the rest above
  */
 .plans-grid-next {
+	// insignificant padding important to prevent parent/child margins from collapsing
+	// creates a barrier between parent/child elements
+	// the alternative (oveflow: auto) would break the sticky behavior
+	padding: 1px;
+
 	.plan-features-2023-grid__table-item {
 		border-right: none;
 		background-color: transparent;
@@ -528,16 +533,6 @@ $mobile-card-max-width: 440px;
 				background: #fff;
 				color: #fff;
 				padding: 0 0 17px;
-
-				.plan-grid-next & {
-					.foo & {
-						padding-top: 35px; // enough to cover `plans-grid__popular-badge` repositioning (top: -35px)
-					}
-				}
-
-				.plan-grid-next__comparison-grid & {
-					padding-top: 50px; // enough to cover `plans-grid__popular-badge` repositioning (top: -43px)
-				}
 
 				.plans-grid__plan-pill {
 					font-family: Inter, $sans;

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -497,7 +497,7 @@ $mobile-card-max-width: 440px;
 .plans-grid-next {
 	// insignificant padding important to prevent parent/child margins from collapsing
 	// creates a barrier between parent/child elements
-	// the alternative (oveflow: auto) would break the sticky behavior
+	// the alternative (oveflow: auto) would break the sticky behavior on the headers
 	padding: 1px;
 
 	.plan-features-2023-grid__table-item {

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -184,6 +184,11 @@ $mobile-card-max-width: 440px;
 	border-spacing: 0;
 	width: 100%;
 
+	&.has-highlighted-plan {
+		// margin (not padding) to not break internal borders/layout
+		margin-top: 35px; // enough to cover `plans-grid__popular-badge` repositioning (top: -35px)
+	}
+
 	&.has-1-cols {
 		max-width: $table-cell-max-width;
 	}
@@ -524,6 +529,16 @@ $mobile-card-max-width: 440px;
 				color: #fff;
 				padding: 0 0 17px;
 
+				.plan-grid-next & {
+					.foo & {
+						padding-top: 35px; // enough to cover `plans-grid__popular-badge` repositioning (top: -35px)
+					}
+				}
+
+				.plan-grid-next__comparison-grid & {
+					padding-top: 50px; // enough to cover `plans-grid__popular-badge` repositioning (top: -43px)
+				}
+
 				.plans-grid__plan-pill {
 					font-family: Inter, $sans;
 					font-size: 0.75rem;
@@ -693,6 +708,12 @@ $mobile-card-max-width: 440px;
 }
 
 .plan-comparison-grid {
+	&.has-highlighted-plan {
+		@include plans-grid-medium-large {
+			padding-top: 50px; // enough to cover `plans-grid__popular-badge` repositioning (top: -43px)
+		}
+	}
+
 	.plan-comparison-grid__feature-group-row.is-storage-feature {
 		align-items: flex-start;
 	}

--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -705,7 +705,7 @@ $mobile-card-max-width: 440px;
 .plan-comparison-grid {
 	&.has-highlighted-plan {
 		@include plans-grid-medium-large {
-			padding-top: 50px; // enough to cover `plans-grid__popular-badge` repositioning (top: -43px)
+			padding-top: 43px; // enough to cover `plans-grid__popular-badge` repositioning (top: -43px)
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/87332

## Proposed Changes

This PR continues with the CSS refactors for the plans-grid package. We decouple the grids from external/page layout, in effect making them more self-contained and portable to any rendering frame.

- Internalize into `plans-grid-next` the styles needed to make room for badges/labels shown when a plan is highlighted. Previously this was done on the `plans-wrapper` container. The grid now handles these internally respecting its render bounds.
- Remove margins added internally to position the `ComparisonGrid` further down the page. Page layout (e.g. margin between the term-toggle and features/comparison grid), is a consuming-end concern. Ultimately, these sorts of "wrapping" margins don't quite belong inside `plans-grid-next`, unless the whole page/bundle is served from there.
- More centralized and consistent margins across all views (these can be tailored further if/when needed)

## Media

### With highlight labels

#### Before (`.plans-grid-next`)

overflowing

<img width="700" alt="Screenshot 2024-02-14 at 2 09 57 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/496c2d72-3d60-4f5d-904b-2b1991720f53">

#### After (`.plans-grid-next`)

contained (outer top margin excluded for capture)

<img width="700" alt="Screenshot 2024-02-14 at 2 09 16 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/4217e796-4410-4986-81b0-2f5a9d3d95bc">

### Outer margins

Set to `50px` throughout all views & pages

| Comparison Grid | Features Grid |
|--------|--------|
| <img width="400" alt="Screenshot 2024-02-14 at 2 10 52 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/cf4f2984-44a7-4b5b-a636-9bb78b09a237"> | <img width="400" alt="Screenshot 2024-02-14 at 2 10 17 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/7821b829-2de5-4523-85ee-8c30acd3628c"> | 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Confirm across `/start/plans` and `/plans/[ site ]` things are not braking when resizing/scrolling

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?