### PR TITLE
Like block: Add Help Center block guide

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/block-links-map.ts
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-description-links/src/block-links-map.ts
@@ -328,6 +328,10 @@ const blockInfoMapping: { [ key: string ]: { link: string; postId: number } } = 
 		link: 'https://wordpress.com/support/wordpress-editor/blocks/sharing-buttons-block/',
 		postId: 330003,
 	},
+	'jetpack/like': {
+		link: 'https://wordpress.com/support/likes/',
+		postId: 7294,
+	},
 };
 
 export const blockInfoWithVariations: {


### PR DESCRIPTION
Relate to https://github.com/Automattic/wp-calypso/issues/87340.

## Proposed Changes

* add Help Center block guide to the Like block

| Simple site | WoA site |
|--------|--------|
| ![Markup on 2024-02-14 at 10:33:51](https://github.com/Automattic/wp-calypso/assets/25105483/c2093561-72c9-45c6-834e-bb36f6481805) | ![Markup on 2024-02-14 at 10:39:59](https://github.com/Automattic/wp-calypso/assets/25105483/22e1c8e2-1c34-4666-beff-fc92dcf9a2fb) | 

## Testing Instructions

Please follow the steps outlined in PCYsg-ly5-p2 to test the changes on Simple and WoA sites.

1. To test on Simple sites, navigate to `apps/editing-toolkit` in your local Calypso and run `yarn dev --sync` there to sync the changes to your sandbox.
2. To test on WoA, download the `editing-toolkit.zip` from `Build Calypso Apps (WPCom Plugins)` TeamCity test → '\Artifacts` tab and upload and activate it on your site. Please note that the original Editing Toolkit plugin needs to be deactivated first.
3. When you add the Like block to any of your test site, the link in the sidebar should display as can be seen in the screenshots above. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?