### PR TITLE
fix: woo signup page primary button hover font color

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -104,6 +104,7 @@
 
 		&:hover {
 			background-color: $woo-purple-40;
+			color: #fff;
 		}
 
 		&:disabled {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Reported by GlobalStep testing: p1707722398685899-slack-C011ENB20Q1

https://github.com/Automattic/wp-calypso/assets/27843274/9f6d0b14-1b6a-4ef5-bab4-942e0c6912c7


## Proposed Changes

* Changed hover font color for primary button on woo signup pages to white

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run calypso live or localhost dev
* Go to woo.com/start in a incognito window that isn't logged in and then step through until reaching the wordpress.com signup page, then replace it with calypso.live or calypso.localhost:3000 or use this [link](http://calypso.localhost:3000/start/wpcc/oauth2-user?ref=oauth2&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3D6376f19e2e6e144be8f4868ca9839945ecc1ae35e4d7fe5779668f3f5c27cf72%26redirect_uri%3Dhttps%253A%252F%252Fwoo.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252Fstart%25252F%252523%25252Finstallation%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%3Dnux%26calypso_env%3Dproduction%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login%26from-calypso%3D1&oauth2_client_id=50916)

https://github.com/Automattic/wp-calypso/assets/27843274/cdd20abd-d639-4a94-a99f-92ff30f54fb1



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?