### PR TITLE
Attempt auto activate license after connect

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/licensing-thank-you-auto-activation.tsx
@@ -108,17 +108,13 @@ const LicensingActivationThankYou: FC< Props > = ( {
 		);
 	}, [ jetpackTemporarySiteId, productSlug, source, receiptId ] );
 
-	const onContinue = useCallback(
-		( e: React.MouseEvent ) => {
-			e.preventDefault();
+	const handleAutoActivate = useCallback(
+		( siteUrl: string ) => {
 			setError( false );
-			if ( selectedSite === 'activate-license-manually' ) {
-				return page( manualActivationUrl );
-			}
 			dispatch(
 				recordTracksEvent( 'calypso_siteless_checkout_submit_website_address', {
 					product_slug: productSlug,
-					site_url: selectedSite,
+					site_url: siteUrl,
 					receipt_id: receiptId,
 				} )
 			);
@@ -126,23 +122,35 @@ const LicensingActivationThankYou: FC< Props > = ( {
 			// transfer the temporary-site subscription to the user's selectedSite.
 			dispatch(
 				requestUpdateJetpackCheckoutSupportTicket(
-					selectedSite,
+					siteUrl,
 					receiptId,
 					source,
 					jetpackTemporarySiteId
 				)
 			);
 		},
-		[
-			dispatch,
-			manualActivationUrl,
-			jetpackTemporarySiteId,
-			productSlug,
-			receiptId,
-			selectedSite,
-			source,
-		]
+		[ dispatch, jetpackTemporarySiteId, productSlug, receiptId, source ]
 	);
+
+	const onContinue = useCallback(
+		( e: React.MouseEvent ) => {
+			e.preventDefault();
+			if ( selectedSite === 'activate-license-manually' ) {
+				return page( manualActivationUrl );
+			}
+			handleAutoActivate( selectedSite );
+		},
+		[ selectedSite, handleAutoActivate, manualActivationUrl ]
+	);
+
+	// Prevent auto-activation if it will fail at the initial attempt.
+	const [ attemptAutoActivate, setAttemptAutoActivate ] = useState( true );
+	useEffect( () => {
+		if ( attemptAutoActivate && fromSiteSlug && initialSelectedSite.includes( fromSiteSlug ) ) {
+			setAttemptAutoActivate( false );
+			handleAutoActivate( initialSelectedSite );
+		}
+	}, [ attemptAutoActivate, fromSiteSlug, handleAutoActivate, initialSelectedSite ] );
 
 	useEffect( () => {
 		if ( error || supportTicketRequestStatus === undefined ) {
@@ -224,8 +232,9 @@ const LicensingActivationThankYou: FC< Props > = ( {
 			.filter( ( site ) => ! site.is_wpcom_atomic )
 			.filter(
 				( site ) =>
-					! site.products.some( isProductActivatedOnSite ) &&
-					! isProductActivatedOnSite( site.plan )
+					( ! site.products.some( isProductActivatedOnSite ) &&
+						! isProductActivatedOnSite( site.plan ) ) ||
+					site.URL === initialSelectedSite
 			)
 			.map( ( site ) => ( {
 				value: site?.URL,
@@ -239,7 +248,7 @@ const LicensingActivationThankYou: FC< Props > = ( {
 					},
 				},
 			} ) );
-	}, [ jetpackSites, selectedSite, productSlug ] );
+	}, [ jetpackSites, productSlug, initialSelectedSite, selectedSite ] );
 
 	const lastSelectOption = {
 		value: 'activate-license-manually',


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-marketing/issues/526

## Proposed Changes

When we send a user through a siteless checkout and they connect after checkout, they need to manually assign their license key to their site. We should attach the license automatically after connection if they initiated the purchase from a specific site to reduce any potential confusion.

Probably the next step would be to change license activation in the backend. For now, this PR serves as quick fix for the situation described in the maintenance task.

## Testing Instructions

* Create new (JN) site that is not connected to Jetpack yet
* Go to interstitial e.g. /wp-admin/admin.php?page=my-jetpack#/add-jetpack-ai
* Continue with the flow and connect the site
* We should automatically be taken to the thank you page with CTA to return to WP Admin:
![CleanShot 2024-02-13 at 17 00 21@2x](https://github.com/Automattic/wp-calypso/assets/8419292/cb8d62a4-8428-4ef0-b06e-1358df4f803f)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?