### PR TITLE
Help Center: Remove tab component tablist

### DIFF
--- a/packages/help-center/src/components/help-center-article-content.scss
+++ b/packages/help-center/src/components/help-center-article-content.scss
@@ -237,4 +237,10 @@
 			display: none;
 		}
 	}
+
+	// Hide the tablist for the WP Support 3 tab component
+	// Context: https://github.com/Automattic/wp-calypso/issues/87340#issuecomment-1937424710
+	.wpsupport3-tab__tablist {
+		display: none;
+	}
 }


### PR DESCRIPTION
Context: https://github.com/Automattic/wp-calypso/issues/87340#issuecomment-1938334732

## Problem

The tab component is not rendering well in the Help Center
![Screenshot 2024-02-13 at 18 08 01](https://github.com/Automattic/wp-calypso/assets/52076348/d765a2e5-2436-4bd4-a894-b2d8ce0b9803)

https://wordpress.com/support/likes/#tab-block-themes

## Solution

We should make the tab component work in the Help Center, meanwhile this PR hides the tab list.

## Testing

1. Go to HC and search for the `Add a Like Button` guide
2. There shouldn't be any tablist