### PR TITLE
help center - update loading check for jetpack to support jetpack beta tester plugin

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/full-site-editing-plugin.php
@@ -304,9 +304,9 @@ function load_help_center() {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
-		// This doesn't work if Jetpack is an mu-plugin.
+		// This should still work if Jetpack is an mu-plugin.
 		// Since this isn't running in WPCOM this shouldn't matter.
-		if ( ! is_plugin_active( 'jetpack/jetpack.php' ) ) {
+		if ( ! defined( 'JETPACK__VERSION' ) ) {
 			return false;
 		}
 	}


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #  p1707847387926519-slack-CDLH4C1UZ

## Proposed Changes

* We found that when running a branch in the jetpack-beta-tester plugin, that the help center doesn't load.
* This change should allow the help center to load in this environment as well, as proposed by @ebinnion 

![Screenshot 2024-02-13 at 1 57 31 PM](https://github.com/Automattic/wp-calypso/assets/28742426/a9895b99-125d-4406-8f0b-cf24ecad4cd5)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sync this ETK build to your sandbox. Smoke test simple sites (calypso, wp-admin, in editor).
* Install this build of ETK on an Atomic test site. You can get the build from the "Build calypso apps" checks link to TC, and select the "Artifacts" tab.
* Verify the help center is still available and there are no regressions.
* Install the jetpack-beta-tester plugin, and activate any branch outside the last stable release.
* Verify that the help center is still present in the toolbar.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?