### PR TITLE
Meta: Add workflow for notifying on triaged high priority issues

### DIFF
--- a/.github/workflows/notify-high-priority-triaged-issues.yml
+++ b/.github/workflows/notify-high-priority-triaged-issues.yml
@@ -1,0 +1,51 @@
+name: 'Notify on High Priority Triaged Items'
+on:
+  issues:
+    types: [labeled]
+  # This commented out section is useful for testing the workflow in the context of a pull request before merging.
+  # pull_request:
+  #   types: [labeled]
+
+jobs:
+  notify-on-label:
+    runs-on: ubuntu-latest
+    if: >
+      ( github.event.label.name == '[Pri] High' ||
+      github.event.label.name == '[Pri] Blocker' ||
+      github.event.label.name == 'Triaged' )
+    steps:
+      - name: Set variables based on event type
+        id: set-vars
+        run: |
+          if [ "${{ github.event_name }}" = "issues" ]; then
+            echo "::set-output name=item_type::Issue"
+            echo "::set-output name=item_url::https://github.com/${{ github.repository }}/issues/${{ github.event.issue.number }}"
+            echo "::set-output name=item_title::${{ github.event.issue.title }}"
+            echo "::set-output name=item_number::${{ github.event.issue.number }}"
+          else
+            echo "::set-output name=item_type::PR"
+            echo "::set-output name=item_url::https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
+            echo "::set-output name=item_title::${{ github.event.pull_request.title }}"
+            echo "::set-output name=item_number::${{ github.event.pull_request.number }}"
+          fi
+      - name: Notify Slack
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          channel-id: 'C02FMH4G8'
+          payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "A high priority ${{ steps.set-vars.outputs.item_type }} labeled '${{ github.event.label.name }}' has been triaged and needs attention:\n*<${{ steps.set-vars.outputs.item_url }}|${{ steps.set-vars.outputs.item_type }} #${{ steps.set-vars.outputs.item_number }}: ${{ steps.set-vars.outputs.item_title }}>*"
+                  }
+                }
+              ],
+              "text": "A high priority triaged item needs attention",
+              "unfurl_links": false,
+              "unfurl_media": false
+            }
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_TOKEN }}


### PR DESCRIPTION
## Proposed Changes

* Add a workflow that will trigger in our escalations channel in Slack when high priority or block issues have been triaged.

## Testing Instructions

- Uncomment the `on` trigger to include pull requests
- Ensure this PR gets the expected labels
- Check escalations channel.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?