### PR TITLE
Site migration: step placeholder for new instructions

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -160,8 +160,9 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	/**
 	 * Decide the render state based on the current component state
 	 */
+	const isNewMigrationFlowEnabled = config.isEnabled( 'stepper/site-migration-flow' );
 	useEffect( () => {
-		if ( config.isEnabled( 'stepper/site-migration-flow' ) ) {
+		if ( isNewMigrationFlowEnabled && isTargetSitePlanCompatible ) {
 			setRenderState( 'new-migration-flow' );
 		} else if (
 			! isInitFetchingDone &&

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { SiteDetails } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import React, { useEffect, useState, useMemo, useCallback } from 'react';
@@ -160,7 +161,9 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 	 * Decide the render state based on the current component state
 	 */
 	useEffect( () => {
-		if (
+		if ( config.isEnabled( 'stepper/site-migration-flow' ) ) {
+			setRenderState( 'new-migration-flow' );
+		} else if (
 			! isInitFetchingDone &&
 			( isFetchingMigrationData || isAddingTrial || queryTargetSitePlanStatus === 'fetched' )
 		) {
@@ -260,6 +263,9 @@ export const PreMigrationScreen: React.FunctionComponent< PreMigrationProps > = 
 					onProvideCredentialsClick={ toggleCredentialsForm }
 				/>
 			);
+
+		case 'new-migration-flow':
+			return <div>This is where instructions would go</div>;
 	}
 };
 

--- a/client/blocks/importer/wordpress/import-everything/pre-migration/types.ts
+++ b/client/blocks/importer/wordpress/import-everything/pre-migration/types.ts
@@ -9,6 +9,7 @@ export type CredentialsProtocol = 'ftp' | 'ssh';
 
 export type PreMigrationState =
 	| 'loading'
+	| 'new-migration-flow'
 	| 'not-authorized'
 	| 'credentials'
 	| 'upgrade-plan'

--- a/client/data/site-migration/use-migration-enabled.ts
+++ b/client/data/site-migration/use-migration-enabled.ts
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import type { MigrationEnabledResponse } from './types';
@@ -39,7 +38,6 @@ export const useMigrationEnabledInfoQuery = (
 			return {
 				...data,
 				can_migrate: !! (
-					config.isEnabled( 'stepper/site-migration-flow' ) ||
 					( data.migration_activated && data.migration_compatible ) ||
 					( data.jetpack_activated && data.jetpack_compatible )
 				),

--- a/client/data/site-migration/use-migration-enabled.ts
+++ b/client/data/site-migration/use-migration-enabled.ts
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import type { MigrationEnabledResponse } from './types';
@@ -38,6 +39,7 @@ export const useMigrationEnabledInfoQuery = (
 			return {
 				...data,
 				can_migrate: !! (
+					config.isEnabled( 'stepper/site-migration-flow' ) ||
 					( data.migration_activated && data.migration_compatible ) ||
 					( data.jetpack_activated && data.jetpack_compatible )
 				),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/87395
## Proposed Changes

The idea is that if the feature flag is enabled then a new component is rendered after a basic check for plans. More complex logic might be needed down the road to at least check that the source site is at least a WP site.

Related to https://github.com/Automattic/wp-calypso/issues/87393

## Testing Instructions
**Probably you will need to add the `flags=stepper/site-migration-flow` to the query param**
1. Create or set up an existing site that's not on WPCOM and that is not connected to JP. I used a Jurassic Ninja site.
2. Navigate to http://calypso.localhost:3000/start
3. Create a new site, choose a free plan and lastly, choose `Import my existing website content` as Goal.
4. Add dd the `flags=stepper/site-migration-flow` to the URL and refresh.
5. Enter the URL from your site.
6. You should see the `Upgrade your plan` screen.
7. Add the `flags=stepper/site-migration-flow` to the URL and refresh.
8. Select the free trial.
9. After that you should see this screen 
<img width="490" alt="image" src="https://github.com/Automattic/wp-calypso/assets/375980/9087a477-df91-4c45-b38f-a8a85c9ffb46">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?