### PR TITLE
Untangle: Update classic view site links on /sites

### DIFF
--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useSiteLaunchStatusLabel, getSiteLaunchStatus } from '@automattic/sites';
 import { css } from '@emotion/css';
@@ -125,7 +126,9 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 	const siteDashboardUrlProps = showThumbnailLink
 		? {
 				href:
-					isAtomicSite && siteDefaultInterface( site ) === 'wp-admin'
+					isAtomicSite &&
+					siteDefaultInterface( site ) === 'wp-admin' &&
+					! isEnabled( 'layout/dotcom-nav-redesign' )
 						? getSiteWpAdminUrl( site ) || getDashboardUrl( site.slug )
 						: getDashboardUrl( site.slug ),
 				title: __( 'Visit Dashboard' ),

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { ListTile, Popover } from '@automattic/components';
 import { useSiteLaunchStatusLabel } from '@automattic/sites';
 import { css } from '@emotion/css';
@@ -176,7 +177,9 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 					leading={
 						<ListTileLeading
 							href={
-								isAtomicSite && siteDefaultInterface( site ) === 'wp-admin'
+								isAtomicSite &&
+								siteDefaultInterface( site ) === 'wp-admin' &&
+								! isEnabled( 'layout/dotcom-nav-redesign' )
 									? getSiteWpAdminUrl( site ) || getDashboardUrl( site.slug )
 									: getDashboardUrl( site.slug )
 							}
@@ -189,7 +192,9 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 						<ListTileTitle>
 							<SiteName
 								href={
-									isAtomicSite && siteDefaultInterface( site ) === 'wp-admin'
+									isAtomicSite &&
+									siteDefaultInterface( site ) === 'wp-admin' &&
+									! isEnabled( 'layout/dotcom-nav-redesign' )
 										? getSiteWpAdminUrl( site ) || getDashboardUrl( site.slug )
 										: getDashboardUrl( site.slug )
 								}


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/5555

## Proposed Changes

Update site link on `/sites` when wp-admin interface is selected and flag `layout/dotcom-nav-redesign` is enabled.

## Testing Instructions

* Having a site with `wp-admin` interface selected at `/hosting-config/:site`
* Go to `/sites` (no site selected)
* The `wp-admin` site should link to `/wp-admin`
* Go to `/sites?flags=layout/dotcom-nav-redesign` (using the flag)
* Now the `wp-admin` sites should link to `/home/:site`
* Test it using list & grid views
* 