### PR TITLE
Stats: add default query params

### DIFF
--- a/apps/odyssey-stats/src/components/odyssey-query-products.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-products.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { isError } from 'lodash';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import getDefaultQueryParams from 'calypso/my-sites/stats/hooks/default-query-params';
 import { PRODUCTS_LIST_REQUEST, PRODUCTS_LIST_REQUEST_FAILURE } from 'calypso/state/action-types';
 import { receiveProductsList } from 'calypso/state/products-list/actions';
 
@@ -17,13 +18,11 @@ function queryProductsList( currency = '', type = 'jetpack' ) {
 }
 function useQueryProductsList( currency = '', type = 'jetpack' ) {
 	return useQuery( {
+		...getDefaultQueryParams(),
 		queryKey: [ 'odyssey-stats', 'products', currency, type ],
 		queryFn: () => queryProductsList( currency, type ),
-		staleTime: 10 * 1000,
 		// If the module is not active, we don't want to retry the query.
 		retry: false,
-		retryOnMount: false,
-		refetchOnWindowFocus: false,
 	} );
 }
 

--- a/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
+++ b/apps/odyssey-stats/src/components/odyssey-query-site-purchases.ts
@@ -6,6 +6,7 @@ import { isError } from 'lodash';
 import { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import wpcom from 'calypso/lib/wp';
+import getDefaultQueryParams from 'calypso/my-sites/stats/hooks/default-query-params';
 import {
 	PURCHASES_SITE_FETCH,
 	PURCHASES_SITE_FETCH_COMPLETED,
@@ -28,13 +29,12 @@ async function queryOdysseyQuerySitePurchases( siteId: number | null ) {
 
 const useOdysseyQuerySitePurchases = ( siteId: number | null ) => {
 	return useQuery( {
+		...getDefaultQueryParams(),
 		queryKey: [ 'odyssey-stats', 'site-purchases', siteId ],
 		queryFn: () => queryOdysseyQuerySitePurchases( siteId ),
 		staleTime: 10 * 1000,
 		// If the module is not active, we don't want to retry the query.
 		retry: false,
-		retryOnMount: false,
-		refetchOnWindowFocus: false,
 	} );
 };
 
@@ -61,7 +61,7 @@ export default function OdysseyQuerySitePurchases( { siteId }: { siteId: number 
 			// Dispatch to the Purchases reducer for error status
 			reduxDispatch( {
 				type: PURCHASES_SITE_FETCH_FAILED,
-				error: purchases.message,
+				error: 'purchase_fetch_failed',
 			} );
 		} else {
 			// Dispatch to the Purchases reducer for consistent requesting status

--- a/apps/odyssey-stats/src/hooks/use-module-data-query.ts
+++ b/apps/odyssey-stats/src/hooks/use-module-data-query.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
+import getDefaultQueryParams from 'calypso/my-sites/stats/hooks/default-query-params';
 
 type Module = 'akismet' | 'protect' | 'vaultpress' | 'monitor' | 'stats' | 'verification-tools';
 type ModuleData = number | string | boolean;
@@ -38,13 +39,12 @@ function queryModuleData( module: Module ): Promise< ModuleData > {
 }
 
 export default function useModuleDataQuery( module: Module ) {
-	return useQuery< ModuleData, Error >( {
+	return useQuery( {
+		...getDefaultQueryParams(),
 		queryKey: [ 'stats-widget', 'module-data', module ],
 		queryFn: () => queryModuleData( module ),
 		staleTime: 5 * 60 * 1000,
 		// If the module is not active, we don't want to retry the query.
 		retry: false,
-		retryOnMount: false,
-		refetchOnWindowFocus: false,
 	} );
 }

--- a/apps/odyssey-stats/src/hooks/use-referrers-query.ts
+++ b/apps/odyssey-stats/src/hooks/use-referrers-query.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
+import getDefaultQueryParams from 'calypso/my-sites/stats/hooks/default-query-params';
 
 interface QueryReferrersParams {
 	period: string;
@@ -7,6 +8,10 @@ interface QueryReferrersParams {
 	date: string;
 	summarize?: number;
 	max?: number;
+}
+
+interface ReferresResponse {
+	summary: { groups: ( GroupWithChildren & GroupWithoutChildren )[] };
 }
 
 interface GroupWithChildren {
@@ -37,6 +42,7 @@ export default function useReferrersQuery(
 	max = 0
 ) {
 	return useQuery( {
+		...getDefaultQueryParams< ReferresResponse >(),
 		queryKey: [ 'stats-widget', 'referrers', siteId, period, num, date, summarize, max ],
 		queryFn: () => queryReferrers( siteId, { period, num, date, summarize, max } ),
 		select: ( data ) => {

--- a/apps/odyssey-stats/src/hooks/use-top-posts-query.ts
+++ b/apps/odyssey-stats/src/hooks/use-top-posts-query.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
+import getDefaultQueryParams from 'calypso/my-sites/stats/hooks/default-query-params';
 
 interface QueryTopPostsParams {
 	period: string;
@@ -7,6 +8,10 @@ interface QueryTopPostsParams {
 	date: string;
 	summarize?: number;
 	max?: number;
+}
+
+interface TopPostsResponse {
+	summary: { postviews: number | null };
 }
 
 function queryTopPosts( siteId: number, params: QueryTopPostsParams ) {
@@ -22,6 +27,7 @@ export default function useTopPostsQuery(
 	max = 0
 ) {
 	return useQuery( {
+		...getDefaultQueryParams< TopPostsResponse >(),
 		queryKey: [ 'stats-widget', 'top-posts', siteId, period, num, date, summarize, max ],
 		queryFn: () => queryTopPosts( siteId, { period, num, date, summarize, max } ),
 		select: ( data ) => data?.summary?.postviews,

--- a/apps/odyssey-stats/src/hooks/use-visits-query.ts
+++ b/apps/odyssey-stats/src/hooks/use-visits-query.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
+import getDefaultQueryParams from 'calypso/my-sites/stats/hooks/default-query-params';
 import { parseChartData } from 'calypso/state/stats/lists/utils';
 import { Unit } from '../typings';
 
@@ -22,6 +23,7 @@ export default function useVisitsQuery(
 	fields = [ 'views', 'visitors' ]
 ) {
 	return useQuery( {
+		...getDefaultQueryParams< Array< object > >(),
 		queryKey: [ 'stats-widget', 'visits', siteId, unit, quantity, date, fields ],
 		queryFn: () =>
 			queryStatsVisits( siteId, { unit, quantity, date, stat_fields: fields.join( ',' ) } ),

--- a/client/my-sites/stats/hooks/default-query-params.ts
+++ b/client/my-sites/stats/hooks/default-query-params.ts
@@ -1,0 +1,18 @@
+import { UseQueryOptions } from '@tanstack/react-query';
+
+const defaultQueryParams: Partial< UseQueryOptions > = {
+	staleTime: 1000 * 30, // 30 seconds
+	retry: 1,
+	retryDelay: 3 * 1000, // 3 seconds,
+	retryOnMount: false,
+	refetchOnWindowFocus: false,
+	refetchOnMount: false,
+	refetchInterval: false,
+	refetchIntervalInBackground: false,
+};
+
+const getDefaultQueyrParams = < T1 >() => {
+	return defaultQueryParams as UseQueryOptions< T1 >;
+};
+
+export default getDefaultQueyrParams;

--- a/client/my-sites/stats/hooks/use-notice-visibility-query.ts
+++ b/client/my-sites/stats/hooks/use-notice-visibility-query.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
+import getDefaultQueryParams from './default-query-params';
 
 const DEFAULT_SERVER_NOTICES_VISIBILITY = {
 	opt_in_new_stats: false,
@@ -75,12 +76,10 @@ const useNoticesVisibilityQueryRaw = function < T >(
 	enabled?: boolean
 ) {
 	return useQuery( {
+		...getDefaultQueryParams< Notices >(),
 		queryKey: [ 'stats', 'notices-visibility', 'raw', siteId ],
 		queryFn: () => queryNotices( siteId ),
 		select,
-		staleTime: 1000 * 30, // 30 seconds
-		retry: 1,
-		retryDelay: 3 * 1000, // 3 seconds,
 		enabled: enabled !== false,
 	} );
 };

--- a/client/my-sites/stats/hooks/use-plan-usage-query.ts
+++ b/client/my-sites/stats/hooks/use-plan-usage-query.ts
@@ -37,6 +37,6 @@ export default function usePlanUsageQuery(
 		queryKey: [ 'stats', 'usage', siteId ],
 		queryFn: () => queryPlanUsage( siteId ),
 		select: selectPlanUsage,
-		staleTime: 10 * 1000,
+		staleTime: 5 * 1000, // 5 seconds
 	} );
 }

--- a/client/my-sites/stats/hooks/use-plan-usage-query.ts
+++ b/client/my-sites/stats/hooks/use-plan-usage-query.ts
@@ -1,6 +1,7 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import { PriceTierListItemProps } from '../stats-purchase/types';
+import getDefaultQueryParams from './default-query-params';
 
 interface PeriodUsage {
 	current_start: string | null;
@@ -32,9 +33,10 @@ export default function usePlanUsageQuery(
 	siteId: number | null
 ): UseQueryResult< PlanUsage, unknown > {
 	return useQuery( {
+		...getDefaultQueryParams< PlanUsage >(),
 		queryKey: [ 'stats', 'usage', siteId ],
 		queryFn: () => queryPlanUsage( siteId ),
 		select: selectPlanUsage,
-		// staleTime: 1000 * 60 * 5, // 5 minutes
+		staleTime: 10 * 1000,
 	} );
 }

--- a/client/my-sites/stats/hooks/use-subscribers-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-query.tsx
@@ -1,6 +1,7 @@
 import { isValueTruthy } from '@automattic/wpcom-checkout';
 import { useQuery, useQueries, UseQueryResult } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
+import getDefaultQueryParams from './default-query-params';
 
 export interface SubscriberPayload {
 	date: string;
@@ -70,6 +71,7 @@ export default function useSubscribersQuery(
 	const queryDate = date ? date.toISOString() : new Date().toISOString();
 
 	return useQuery( {
+		...getDefaultQueryParams< SubscriberPayload >(),
 		queryKey: [ 'stats', 'subscribers', siteId, period, quantity, queryDate ],
 		queryFn: () => querySubscribers( siteId, period, quantity, queryDate ),
 		select: selectSubscribers,
@@ -90,10 +92,10 @@ export function useSubscribersQueries(
 		staleTime: 1000 * 60 * 5, // 5 minutes
 	} ) );
 
-	const results = useQueries( { queries: queryConfigs } ) as UseQueryResult<
-		SubscriberPayload,
-		unknown
-	>[];
+	const results = useQueries( {
+		...getDefaultQueryParams< SubscribersData[] >(),
+		queries: queryConfigs,
+	} );
 
 	const isLoading = results.some( ( result ) => result.isLoading );
 	const isError = results.some( ( result ) => result.isError );

--- a/client/my-sites/stats/hooks/use-subscribers-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-query.tsx
@@ -86,17 +86,14 @@ export function useSubscribersQueries(
 	dates: string[]
 ): { isLoading: boolean; isError: boolean; subscribersData: SubscribersData[] } {
 	const queryConfigs = dates.map( ( date, index ) => ( {
+		...getDefaultQueryParams< SubscriberPayload >(),
 		queryKey: [ 'stats', 'subscribers', index, siteId, period, quantity, date ],
 		queryFn: () => querySubscribers( siteId, period, quantity, date ),
 		select: selectSubscribers,
 		staleTime: 1000 * 60 * 5, // 5 minutes
 	} ) );
 
-	const results = useQueries( {
-		...getDefaultQueryParams< SubscribersData[] >(),
-		queries: queryConfigs,
-	} );
-
+	const results = useQueries( { queries: queryConfigs } );
 	const isLoading = results.some( ( result ) => result.isLoading );
 	const isError = results.some( ( result ) => result.isError );
 	const subscribersData = results.map( ( result ) => result.data ).filter( isValueTruthy );

--- a/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
+++ b/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx
@@ -1,5 +1,6 @@
 import { useQueries } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
+import getDefaultQueryParams from './default-query-params';
 
 const querySubscribersTotals = ( siteId: number | null, filterAdmin?: boolean ): Promise< any > => {
 	return wpcom.req.get(
@@ -57,12 +58,14 @@ function useSubscribersTotalsQueries( siteId: number | null, filterAdmin?: boole
 	const queries = useQueries( {
 		queries: [
 			{
+				...getDefaultQueryParams(),
 				queryKey: [ 'stats', 'totals', 'subscribers', siteId, filterAdmin ],
 				queryFn: () => querySubscribersTotals( siteId, filterAdmin ),
 				select: selectSubscribers,
 				staleTime: 1000 * 60 * 5, // 5 minutes
 			},
 			{
+				...getDefaultQueryParams(),
 				queryKey: [ 'stats', 'totals', 'paid', 'subscribers', siteId ],
 				queryFn: () => queryMore( siteId ),
 				select: selectPaidSubscribers,


### PR DESCRIPTION
Related to #87373

## Proposed Changes

This is another approach for https://github.com/Automattic/wp-calypso/pull/87407.

Add default params for React Query, where we,

- Don't `retryOnMount`
- Don't `refetchOnWindowFocus`
- Don't `refetchOnMount`
- Don't `refetchInterval`
- Don't `refetchIntervalInBackground`

Set a few default values:

```
	staleTime: 1000 * 30, // 30 seconds
	retry: 1,
	retryDelay: 3 * 1000, // 3 seconds,
```


## Testing Instructions

* Follow instructions in #87373
* Ensure pages don't reload anymore
* Ensure all Stats pages work okay
* Ensure the issue is gone for Odyssey as well

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?