### PR TITLE
Jetpack Manage: Add progress bar screen when connecting url-only sites

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/connect-url/create-sites.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/connect-url/create-sites.tsx
@@ -1,4 +1,4 @@
-import { Gridicon } from '@automattic/components';
+import { Gridicon, ProgressBar } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import Spinner from './spinner';
 
@@ -12,26 +12,46 @@ export default function CreateSites( { processed, queue }: { processed: Site[]; 
 
 	return (
 		<div className="connect-url__create-sites">
-			<div className="connect-url__create-sites-quantity">
-				{ translate( 'Adding {{strong}}%(num)d sites{{/strong}}:', {
-					args: { num: processed.length + queue.length },
-					components: { strong: <strong /> },
-				} ) }
-			</div>
-			<ul className="connect-url__create-sites-list">
-				{ processed.map( ( site, index ) => (
-					<li className="connect-url__create-sites-row" key={ index }>
-						<Gridicon icon={ site.status === 'success' ? 'checkmark-circle' : 'cross-circle' } />
-						<div>{ site.url }</div>
-					</li>
-				) ) }
-				{ queue.map( ( site, index ) => (
-					<li className="connect-url__create-sites-row" key={ index }>
-						<Spinner />
-						<div>{ site.url }</div>
-					</li>
-				) ) }
-			</ul>
+			{ processed.length === processed.length + queue.length ? (
+				<>
+					<div className="connect-url__create-sites-quantity">
+						{ translate( 'Adding {{strong}}%(num)d sites{{/strong}}:', {
+							args: { num: processed.length + queue.length },
+							components: { strong: <strong /> },
+						} ) }
+					</div>
+					<ul className="connect-url__create-sites-list">
+						{ processed.map( ( site, index ) => (
+							<li className="connect-url__create-sites-row" key={ index }>
+								<Gridicon
+									icon={ site.status === 'success' ? 'checkmark-circle' : 'cross-circle' }
+								/>
+								<div>{ site.url }</div>
+							</li>
+						) ) }
+						{ queue.map( ( site, index ) => (
+							<li className="connect-url__create-sites-row" key={ index }>
+								<Spinner />
+								<div>{ site.url }</div>
+							</li>
+						) ) }
+					</ul>
+				</>
+			) : (
+				<div className="connect-url__create-sites-progress">
+					<h3 className="connect-url__create-sites-progress-title">
+						{ translate( 'Adding sites' ) }
+					</h3>
+					<span className="connect-url__create-sites-progress-subtitle">
+						{ translate( 'Please wait while we add all sites to your account.' ) }
+					</span>
+					<ProgressBar
+						value={ processed.length }
+						total={ processed.length + queue.length }
+						color="var(--studio-jetpack-green-50)"
+					/>
+				</div>
+			) }
 		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/connect-url/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/connect-url/style.scss
@@ -91,3 +91,21 @@
 .connect-url-csv-column-confirmation__column-picker {
 	display: flex;
 }
+
+.connect-url__create-sites-progress {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	padding: 24px;
+	min-height: 280px; // Not specified on, but trying to follow design
+
+	.connect-url__create-sites-progress-title {
+		margin-bottom: 0.5rem;
+		font-size: 2.25rem;
+	}
+
+	.connect-url__create-sites-progress-subtitle {
+		margin-bottom: 2rem;
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Adds progress bar for displaying progress when adding sites via url-only connection

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


* Go to http://jetpack.cloud.localhost:3000/dashboard/connect-url
* Load a CSV file ( sample below )
* Pick a column from the CSV, where the sites are at
* Clicking to "Add Sites" should take you to the progress bar view
* Followed by the progress bar view, the site list should appear with the proper statuses for each site

Use the following button to load a CSV with sites. Here's a sample CSV that I've been using:
```
domain,name
gameretro.tech,GameRetro.Tech
heyde.blog,Heyde Moura
www.gettech.com,Get Tech
propstech.com,Props Tech
mycooltechsite.lil.blog,MyCoolTechSite
```


https://github.com/Automattic/wp-calypso/assets/5550190/2cadadf8-6d67-4c46-af62-ab050e0a243b



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?