### PR TITLE
Checkoutv2: Hide site preview in some cases

### DIFF
--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -150,6 +150,8 @@ export default function WPCheckoutOrderReview( {
 	const wpcomDomain = useSelector( ( state ) =>
 		getWpComDomainBySiteId( state, selectedSiteData?.ID )
 	);
+	const searchParams = new URLSearchParams( window.location.search );
+	const isSignupCheckout = searchParams.get( 'signup' ) === '1';
 
 	// This is what will be displayed at the top of checkout prefixed by "Site: ".
 	const domainUrl = getDomainToDisplayInCheckoutHeader( responseCart, selectedSiteData, siteUrl );
@@ -170,7 +172,7 @@ export default function WPCheckoutOrderReview( {
 	return (
 		<>
 			{ /** Only show the site preview for WPCOM domains that have a site connected to the site id **/ }
-			{ hasCheckoutVersion( '2' ) && selectedSiteData && wpcomDomain && (
+			{ hasCheckoutVersion( '2' ) && selectedSiteData && wpcomDomain && ! isSignupCheckout && (
 				<div className="checkout-site-preview">
 					<SitePreviewWrapper>
 						<SitePreview showEditSite={ false } showSiteDetails={ false } />

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -165,7 +165,7 @@ export default function WPCheckoutOrderReview( {
 
 	return (
 		<>
-			{ hasCheckoutVersion( '2' ) && (
+			{ hasCheckoutVersion( '2' ) && selectedSiteData && (
 				<div className="checkout-site-preview">
 					<SitePreviewWrapper>
 						<SitePreview showEditSite={ false } showSiteDetails={ false } />

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -16,6 +16,7 @@ import { useSelector, useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/constants';
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getWpComDomainBySiteId } from 'calypso/state/sites/domains/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import Coupon from './coupon';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
@@ -146,6 +147,9 @@ export default function WPCheckoutOrderReview( {
 	);
 
 	const selectedSiteData = useSelector( getSelectedSite );
+	const wpcomDomain = useSelector( ( state ) =>
+		getWpComDomainBySiteId( state, selectedSiteData?.ID )
+	);
 
 	// This is what will be displayed at the top of checkout prefixed by "Site: ".
 	const domainUrl = getDomainToDisplayInCheckoutHeader( responseCart, selectedSiteData, siteUrl );
@@ -165,7 +169,8 @@ export default function WPCheckoutOrderReview( {
 
 	return (
 		<>
-			{ hasCheckoutVersion( '2' ) && selectedSiteData && (
+			{ /** Only show the site preview for WPCOM domains that have a site connected to the site id **/ }
+			{ hasCheckoutVersion( '2' ) && selectedSiteData && wpcomDomain && (
 				<div className="checkout-site-preview">
 					<SitePreviewWrapper>
 						<SitePreview showEditSite={ false } showSiteDetails={ false } />


### PR DESCRIPTION
The Site Preview was added in the Checkout v2 redesign, but while testing it has been pointed out that the preview doesn't work for siteless checkouts or for non wpcom domain checkouts (i.e. Jetpack and Akismet sites).

This PR aims to hide the Site Preview component in those cases.

Related to https://github.com/Automattic/payments-shilling/issues/2435

## Testing Instructions

**Testing wpcom site/product**
* Add a wpcom plan or product and go to `/checkout/yoursite.com?checkoutVersion=2`
* Ensure that the site preview **_shows_**

**Test Jetpack site and product**
* Add a jetpack plan or product and go to the above query param url
* Ensure the site preview **_does not show_**
* Do the same for an akismet product

**Test siteless product**
* Go to a siteless checkout, such as `http://calypso.localhost:3000/checkout/jetpack/jetpack_backup_t1_yearly?checkoutVersion=2`
* Ensure the site preview **_does not show_**
