### PR TITLE
CheckoutV2: Fix Akismet 'site' dropdown styling

### DIFF
--- a/client/my-sites/checkout/src/components/akismet-pro-quantity-dropdown/index.tsx
+++ b/client/my-sites/checkout/src/components/akismet-pro-quantity-dropdown/index.tsx
@@ -6,6 +6,7 @@ import {
 import { Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { isMobile } from '@automattic/viewport';
+import { hasCheckoutVersion } from '@automattic/wpcom-checkout';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -117,6 +118,8 @@ const CurrentOptionContainer = styled.div`
 	width: 100%;
 	column-gap: 20px;
 	text-align: left;
+
+	${ hasCheckoutVersion( '2' ) ? `flex-direction: column; align-items: flex-start;` : null }
 `;
 
 const Price = styled.span`
@@ -126,6 +129,8 @@ const Price = styled.span`
 	> span {
 		font-size: calc( ${ ( props ) => props.theme.fontSize.small } - 1px );
 	}
+
+	${ hasCheckoutVersion( '2' ) ? `text-align: initial;` : `text-align: right;` }
 `;
 
 export const AkismetProQuantityDropDown: FunctionComponent< AkismetProQuantityDropDownProps > = ( {


### PR DESCRIPTION
As reported in pbOQVh-45k-p2#comment-5490 

Akismet includes a 'number of licenses' dropdown in checkout which hasn't been handled by the checkout v2 redesign yet:

| Before | After |
| ---- | ---- |
| ![image](https://github.com/Automattic/wp-calypso/assets/16580129/cc3ea95f-d6b5-4595-ac23-60e3e6ed9926) | ![image](https://github.com/Automattic/wp-calypso/assets/16580129/fddd7976-dd1f-4a01-a1ba-9f56712203fc) |

Related to https://github.com/Automattic/payments-shilling/issues/2436

## Proposed Changes

* This PR updates the Akismet specific styling to account for the new v2 sidebar changes

## Testing Instructions

* Go to `http://calypso.localhost:3000/checkout/akismet/ak_pro5h_yearly:-q-1?checkoutVersion=2`
* Ensure the 'Number of licenses' dropdown is legible and does not break outside the dropdown or in an awkward way

I am uncertain if there are any other use cases that modify this 'other' dropdown but it seems like it's only for selecting the number sites and doesn't include any other language or discount information.