### PR TITLE
Checkout: Pre-fill Pix form from saved contact details

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-cached-domain-contact-details.ts
+++ b/client/my-sites/checkout/src/hooks/use-cached-domain-contact-details.ts
@@ -19,7 +19,7 @@ import type {
 
 const debug = debugFactory( 'calypso:use-cached-domain-contact-details' );
 
-function useCachedContactDetails(): PossiblyCompleteDomainContactDetails | null {
+export function useCachedContactDetails(): PossiblyCompleteDomainContactDetails | null {
 	const reduxDispatch = useReduxDispatch();
 	const haveRequestedCachedDetails = useRef< 'not-started' | 'pending' | 'done' >( 'not-started' );
 	const cachedContactDetails = useSelector( getContactDetailsCache );

--- a/client/my-sites/checkout/src/payment-methods/pix.tsx
+++ b/client/my-sites/checkout/src/payment-methods/pix.tsx
@@ -115,15 +115,20 @@ function usePrefillState( state: PixPaymentMethodState ): void {
 		state.change( 'phoneNumber', contactDetails.phone );
 	}
 
-	// Street number and address are separate in the Pix form but together in
-	// the tax form (where `contactDetails` comes from), so this attempts to
-	// split out the street number but it may be wrong.
+	// Street number and address are separate in the Pix form but joined
+	// together in the tax form (where `contactDetails` comes from), so this
+	// attempts to split out the street number so we can prefill both fields.
+	// Street numbers in Brazil seem to mostly follow the street name (eg: "Av.
+	// Foo, 1098"), so we look for a number at the end of the address. If this
+	// fails, we just fill the address field and leave the street number field
+	// blank. Other possible examples of entries: "Av. Xavier da Foo, 1773, apt
+	// 1000", or "Est. Terra Foo 700 c 4", or "rua Foo Bar 1975".
 	if ( contactDetails.address1 ) {
-		const regexpForStartingNumber = /^(\d+)\s+(.+)/;
-		const startingNumberSearch = contactDetails.address1.match( regexpForStartingNumber );
-		if ( startingNumberSearch && startingNumberSearch[ 1 ] && startingNumberSearch[ 2 ] ) {
-			state.change( 'streetNumber', startingNumberSearch[ 1 ] );
-			state.change( 'address', startingNumberSearch[ 2 ] );
+		const regexpForStreetNumber = /^(\D+?)[,\s]+(\d+|\d+[,\s]+\w+\s+\d+)$/;
+		const streetNumberSearch = contactDetails.address1.match( regexpForStreetNumber );
+		if ( streetNumberSearch && streetNumberSearch[ 1 ] && streetNumberSearch[ 2 ] ) {
+			state.change( 'address', streetNumberSearch[ 1 ] );
+			state.change( 'streetNumber', streetNumberSearch[ 2 ] );
 		} else {
 			state.change( 'address', contactDetails.address1 );
 		}


### PR DESCRIPTION
## Proposed Changes

This PR auto-completes the fields in the Pix payment method with saved contact details, if it can.

<img width="527" alt="Screenshot 2024-02-13 at 11 33 13 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/25edb5c0-047d-4c1f-9680-fef085509e1b">

> [!NOTE]
> At this time, changing the Pix fields and submitting the transaction will NOT save those fields for later. That would be a welcome improvement but this is a little tricky to do because they might differ from the user's tax or domain details and we only save one set. Which one should we keep? Solving this could be done in a later PR.

Fixes https://github.com/Automattic/payments-shilling/issues/2412

## Testing Instructions

- Use an account with saved payment details; ideally one which has purchased a domain so it has a full address saved.
- To use Pix as a payment method option in checkout, first you'll need to have BRL as your currency, and then you'll need to select "Brazil" as the country inside checkout (and a Brazilian postal code like `61919-230`).
- Select Pix as the payment method and verify that most of the fields are filled already except for "Name" and "CPF". Verify that you can edit and change the fields.