### PR TITLE
Add wp-admin link for atomic sites on /sites page.

### DIFF
--- a/client/sites-dashboard/components/test/__snapshots__/sites-grid-item.tsx.snap
+++ b/client/sites-dashboard/components/test/__snapshots__/sites-grid-item.tsx.snap
@@ -45,7 +45,7 @@ exports[`<SitesGridItem> Custom render 1`] = `
       </a>
     </div>
     <div
-      className="css-12bwudn-SitesGridItemSecondary eke2d2q1"
+      className="css-130wc7-SitesGridItemSecondary eke2d2q1"
     >
       <a
         className="components-external-link css-d9p5eo-SiteUrl ejzgyku1"
@@ -138,7 +138,7 @@ exports[`<SitesGridItem> Custom render 2 1`] = `
       </a>
     </div>
     <div
-      className="css-12bwudn-SitesGridItemSecondary eke2d2q1"
+      className="css-130wc7-SitesGridItemSecondary eke2d2q1"
     >
       <a
         className="components-external-link css-d9p5eo-SiteUrl ejzgyku1"
@@ -244,7 +244,7 @@ exports[`<SitesGridItem> Default render 1`] = `
       </div>
     </div>
     <div
-      className="css-12bwudn-SitesGridItemSecondary eke2d2q1"
+      className="css-130wc7-SitesGridItemSecondary eke2d2q1"
     >
       <a
         className="components-external-link css-d9p5eo-SiteUrl ejzgyku1"


### PR DESCRIPTION
simple PR to add a wp-admin link as shown in this mockup.
![cleanshot-2024-02-13-at-14 56 41402x-1](https://github.com/Automattic/wp-calypso/assets/22446385/851435cb-4d14-465a-abe2-c0fbebffe879)
project thread: pe7F0s-1Dj-p2
slack: p1707848599004499-slack-C03NLNTPZ2T

Link is only shown for atomic sites that have completed the launch checklist.

<img width="1093" alt="Screenshot 2024-02-14 at 3 06 44 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/5c9fa963-0e35-4220-8f3d-96585bcdf601">

I don't believe this change needs to be feature toggled, because it can stand alone.

### Testing instructions

With an atomic site that has completed the launch checklist, go to the /sites page.
Ensure grid view is selected (not table view)
There should be a functioning link to wp-admin

