### PR TITLE
Plans Next: Relocate header price component into shared

### DIFF
--- a/packages/plans-grid-next/src/components/comparison-grid/index.tsx
+++ b/packages/plans-grid-next/src/components/comparison-grid/index.tsx
@@ -34,11 +34,11 @@ import { isStorageUpgradeableForPlan } from '../../lib/is-storage-upgradeable-fo
 import { sortPlans } from '../../lib/sort-plan-properties';
 import { getStorageStringFromFeature } from '../../util';
 import PlanFeatures2023GridActions from '../actions';
-import PlanFeatures2023GridHeaderPrice from '../header-price';
 import PlanTypeSelector from '../plan-type-selector';
 import { Plans2023Tooltip } from '../plans-2023-tooltip';
 import PopularBadge from '../popular-badge';
 import BillingTimeframe from '../shared/billing-timeframe';
+import HeaderPrice from '../shared/header-price';
 import { StickyContainer } from '../sticky-container';
 import StorageAddOnDropdown from '../storage-add-on-dropdown';
 import type {
@@ -450,7 +450,7 @@ const ComparisonGridHeaderCell = ( {
 					{ showPlanSelect && <DropdownIcon /> }
 				</h4>
 			</PlanSelector>
-			<PlanFeatures2023GridHeaderPrice
+			<HeaderPrice
 				planSlug={ planSlug }
 				planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
 				currentSitePlanSlug={ currentSitePlanSlug }

--- a/packages/plans-grid-next/src/components/features-grid/plan-price.tsx
+++ b/packages/plans-grid-next/src/components/features-grid/plan-price.tsx
@@ -1,6 +1,6 @@
 import { GridPlan } from '../../types';
-import PlanFeatures2023GridHeaderPrice from '../header-price';
 import PlanDivOrTdContainer from '../plan-div-td-container';
+import HeaderPrice from '../shared/header-price';
 
 type PlanPriceProps = {
 	currentSitePlanSlug?: string | null;
@@ -25,7 +25,7 @@ const PlanPrice = ( {
 				className="plan-features-2023-grid__table-item plan-price"
 				isTableCell={ options?.isTableCell }
 			>
-				<PlanFeatures2023GridHeaderPrice
+				<HeaderPrice
 					planSlug={ planSlug }
 					planUpgradeCreditsApplicable={ planUpgradeCreditsApplicable }
 					currentSitePlanSlug={ currentSitePlanSlug }

--- a/packages/plans-grid-next/src/components/shared/header-price.tsx
+++ b/packages/plans-grid-next/src/components/shared/header-price.tsx
@@ -2,12 +2,12 @@ import { isWpcomEnterpriseGridPlan, type PlanSlug } from '@automattic/calypso-pr
 import { PlanPrice } from '@automattic/components';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import { usePlansGridContext } from '../grid-context';
-import useIsLargeCurrency from '../hooks/use-is-large-currency';
-import { usePlanPricingInfoFromGridPlans } from '../hooks/use-plan-pricing-info-from-grid-plans';
-import type { GridPlan } from '../types';
+import { usePlansGridContext } from '../../grid-context';
+import useIsLargeCurrency from '../../hooks/use-is-large-currency';
+import { usePlanPricingInfoFromGridPlans } from '../../hooks/use-plan-pricing-info-from-grid-plans';
+import type { GridPlan } from '../../types';
 
-interface PlanFeatures2023GridHeaderPriceProps {
+interface HeaderPrice {
 	planSlug: PlanSlug;
 	planUpgradeCreditsApplicable?: number | null;
 	currentSitePlanSlug?: string | null;
@@ -131,11 +131,11 @@ const HeaderPriceContainer = styled.div`
 	}
 `;
 
-const PlanFeatures2023GridHeaderPrice = ( {
+const HeaderPrice = ( {
 	planSlug,
 	planUpgradeCreditsApplicable,
 	visibleGridPlans,
-}: PlanFeatures2023GridHeaderPriceProps ) => {
+}: HeaderPrice ) => {
 	const translate = useTranslate();
 	const { gridPlansIndex } = usePlansGridContext();
 	const {
@@ -301,4 +301,4 @@ const PlanFeatures2023GridHeaderPrice = ( {
 	);
 };
 
-export default PlanFeatures2023GridHeaderPrice;
+export default HeaderPrice;

--- a/packages/plans-grid-next/src/components/shared/test/header-price.tsx
+++ b/packages/plans-grid-next/src/components/shared/test/header-price.tsx
@@ -12,15 +12,15 @@ jest.mock( 'react-redux', () => ( {
 	...jest.requireActual( 'react-redux' ),
 	useSelector: jest.fn(),
 } ) );
-jest.mock( '../../grid-context', () => ( { usePlansGridContext: jest.fn() } ) );
+jest.mock( '../../../grid-context', () => ( { usePlansGridContext: jest.fn() } ) );
 
 import { type PlanSlug, PLAN_ANNUAL_PERIOD, PLAN_PERSONAL } from '@automattic/calypso-products';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { usePlansGridContext } from '../../grid-context';
-import PlanFeatures2023GridHeaderPrice from '../header-price';
+import { usePlansGridContext } from '../../../grid-context';
+import HeaderPrice from '../header-price';
 
-describe( 'PlanFeatures2023GridHeaderPrice', () => {
+describe( 'HeaderPrice', () => {
 	const defaultProps = {
 		isLargeCurrency: false,
 		planSlug: PLAN_PERSONAL as PlanSlug,
@@ -49,7 +49,7 @@ describe( 'PlanFeatures2023GridHeaderPrice', () => {
 			},
 		} ) );
 
-		const { container } = render( <PlanFeatures2023GridHeaderPrice { ...defaultProps } /> );
+		const { container } = render( <HeaderPrice { ...defaultProps } /> );
 		const rawPrice = container.querySelector( '.plan-price.is-original' );
 		const discountedPrice = container.querySelector( '.plan-price.is-discounted' );
 
@@ -74,7 +74,7 @@ describe( 'PlanFeatures2023GridHeaderPrice', () => {
 			},
 		} ) );
 
-		const { container } = render( <PlanFeatures2023GridHeaderPrice { ...defaultProps } /> );
+		const { container } = render( <HeaderPrice { ...defaultProps } /> );
 		const rawPrice = container.querySelector( '.plan-price' );
 		const discountedPrice = container.querySelector( '.plan-price.is-discounted' );
 


### PR DESCRIPTION
Resolves #86936

## Proposed Changes

Renames `PlanFeatures2023GridHeaderPrice` to `HeaderPrice` and moves it into `.../shared/header-price.tsx`.

## Testing Instructions

No functional changes, so please just smoke test `/plans/:site` paying attention to instances of `HeaderPrice`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?