### PR TITLE
GitHub deployments/update deployments table

### DIFF
--- a/client/my-sites/github-deployments/components/repositories/repository-list-item.tsx
+++ b/client/my-sites/github-deployments/components/repositories/repository-list-item.tsx
@@ -2,6 +2,8 @@ import { Button } from '@automattic/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, lock } from '@wordpress/icons';
 import { GitHubRepositoryData } from '../../use-github-repositories-query';
+import { formatDate } from 'calypso/my-sites/github-deployments/utils/Dates';
+import { useLocale } from '@automattic/i18n-utils';
 
 interface GitHubRepositoryListItemProps {
 	repository: GitHubRepositoryData;
@@ -12,6 +14,7 @@ export const GitHubRepositoryListItem = ( {
 	repository,
 	onSelect,
 }: GitHubRepositoryListItemProps ) => {
+	const locale = useLocale();
 	return (
 		<tr>
 			<td>
@@ -19,7 +22,7 @@ export const GitHubRepositoryListItem = ( {
 					{ repository.name } { repository.private && <Icon icon={ lock } size={ 16 } /> }
 				</div>
 			</td>
-			<td>{ new Date( repository.updated_at ).toLocaleDateString() }</td>
+			<td>{ formatDate( locale, new Date( repository.updated_at ) ) }</td>
 			<td>
 				<Button compact onClick={ onSelect }>
 					{ __( 'Select' ) }

--- a/client/my-sites/github-deployments/components/repositories/repository-list-item.tsx
+++ b/client/my-sites/github-deployments/components/repositories/repository-list-item.tsx
@@ -1,9 +1,9 @@
 import { Button } from '@automattic/components';
+import { useLocale } from '@automattic/i18n-utils';
 import { __ } from '@wordpress/i18n';
 import { Icon, lock } from '@wordpress/icons';
+import { formatDate } from 'calypso/my-sites/github-deployments/utils/dates';
 import { GitHubRepositoryData } from '../../use-github-repositories-query';
-import { formatDate } from 'calypso/my-sites/github-deployments/utils/Dates';
-import { useLocale } from '@automattic/i18n-utils';
 
 interface GitHubRepositoryListItemProps {
 	repository: GitHubRepositoryData;

--- a/client/my-sites/github-deployments/components/repositories/repository-list.tsx
+++ b/client/my-sites/github-deployments/components/repositories/repository-list.tsx
@@ -21,7 +21,7 @@ export const GitHubBrowseRepositoriesList = ( {
 	query,
 	onSelectRepository,
 }: RepositoriesListProps ) => {
-	const [ sort, setSort ] = useState< SortOption >( 'name_desc' );
+	const [ sort, setSort ] = useState< SortOption >( 'name_asc' );
 	const [ page, setPage ] = useState( 1 );
 
 	useLayoutEffect( () => {

--- a/client/my-sites/github-deployments/components/repositories/style.scss
+++ b/client/my-sites/github-deployments/components/repositories/style.scss
@@ -57,7 +57,7 @@
 		display: flex;
 		flex-direction: column;
 		span {
-			color: var(--Gray-Gray-40, #787C82);
+			color: var(--Gray-Gray-40, #787c82);
 			font-size: $font-body-small;
 		}
 	}

--- a/client/my-sites/github-deployments/components/repositories/style.scss
+++ b/client/my-sites/github-deployments/components/repositories/style.scss
@@ -55,7 +55,7 @@
 
 	&__account {
 		display: flex;
-		flex-direction: column;
+		align-items: center;
 		span {
 			color: var(--Gray-Gray-40, #787c82);
 			font-size: $font-body-small;

--- a/client/my-sites/github-deployments/components/repositories/style.scss
+++ b/client/my-sites/github-deployments/components/repositories/style.scss
@@ -55,8 +55,11 @@
 
 	&__account {
 		display: flex;
-		align-items: center;
-		gap: 4px;
+		flex-direction: column;
+		span {
+			color: var(--Gray-Gray-40, #787C82);
+			font-size: $font-body-small;
+		}
 	}
 
 	tr td:last-child {

--- a/client/my-sites/github-deployments/deployments/deployment-status.tsx
+++ b/client/my-sites/github-deployments/deployments/deployment-status.tsx
@@ -1,0 +1,66 @@
+import { __ } from '@wordpress/i18n';
+
+export const DeployStatus = {
+	STATUS_PENDING: 0,
+	STATUS_QUEUED: 1,
+	STATUS_RUNNING: 2,
+	STATUS_SUCCESS: 3,
+	STATUS_FAILED: 4,
+	STATUS_BUILDING: 5,
+} as const;
+
+type ValueOf< T > = T[ keyof T ];
+
+interface DeploymentStatusProps {
+	status: ValueOf< typeof DeployStatus >;
+}
+
+const getStatusText = ( status: ValueOf< typeof DeployStatus > ) => {
+	switch ( status ) {
+		case DeployStatus.STATUS_PENDING:
+			return __( 'Pending' );
+		case DeployStatus.STATUS_QUEUED:
+			return __( 'Queued' );
+		case DeployStatus.STATUS_RUNNING:
+			return __( 'Running' );
+		case DeployStatus.STATUS_SUCCESS:
+			return __( 'Success' );
+		case DeployStatus.STATUS_FAILED:
+			return __( 'Failed' );
+		case DeployStatus.STATUS_BUILDING:
+			return __( 'Building' );
+		default:
+			return __( 'Unknown' );
+	}
+};
+
+const getClassname = ( status: ValueOf< typeof DeployStatus > ) => {
+	switch ( status ) {
+		case DeployStatus.STATUS_PENDING:
+			return 'pending';
+		case DeployStatus.STATUS_QUEUED:
+			return 'queued';
+		case DeployStatus.STATUS_RUNNING:
+			return 'running';
+		case DeployStatus.STATUS_SUCCESS:
+			return 'success';
+		case DeployStatus.STATUS_FAILED:
+			return 'failed';
+		case DeployStatus.STATUS_BUILDING:
+			return 'building';
+		default:
+			return '';
+	}
+};
+
+export const DeploymentStatus = ( { status }: DeploymentStatusProps ) => {
+	return (
+		<div
+			className={ `github-deployments-status github-deployments-status__${ getClassname(
+				status
+			) }` }
+		>
+			<span>{ getStatusText( status ) }</span>
+		</div>
+	);
+};

--- a/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
+++ b/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
@@ -8,6 +8,8 @@ import { useSelector } from '../../../state';
 import { manageDeploymentPage } from '../routes';
 import { CodeDeploymentData } from './use-code-deployments-query';
 import { useDeleteCodeDeployment } from './use-delete-code-deployment';
+import { formatDate } from 'calypso/my-sites/github-deployments/utils/Dates';
+import { useLocale } from '@automattic/i18n-utils';
 
 interface GitHubRepositoryListItemProps {
 	deployment: CodeDeploymentData;
@@ -15,6 +17,7 @@ interface GitHubRepositoryListItemProps {
 
 export const DeploymentsListItem = ( { deployment }: GitHubRepositoryListItemProps ) => {
 	const siteSlug = useSelector( getSelectedSiteSlug );
+	const locale = useLocale();
 
 	const { deleteDeployment, isPending } = useDeleteCodeDeployment(
 		deployment.blog_id,
@@ -35,7 +38,7 @@ export const DeploymentsListItem = ( { deployment }: GitHubRepositoryListItemPro
 				<span>Status</span>
 			</td>
 			<td>
-				<span>{ new Date( deployment.updated_on ).toLocaleDateString() }</span>
+				<span>{ formatDate( locale, new Date( deployment.updated_on ) ) }</span>
 			</td>
 			<td>
 				<span>Duration</span>
@@ -48,6 +51,14 @@ export const DeploymentsListItem = ( { deployment }: GitHubRepositoryListItemPro
 						{ ( { onClose } ) => (
 							<Fragment>
 								<MenuGroup>
+									<MenuItem
+										onClick={ () => {
+											page( manageDeploymentPage( siteSlug!, deployment.id ) );
+											onClose();
+										} }
+									>
+										{ __( 'Trigger manual deploy' ) }
+									</MenuItem>
 									<MenuItem
 										onClick={ () => {
 											page( manageDeploymentPage( siteSlug!, deployment.id ) );

--- a/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
+++ b/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
@@ -1,21 +1,24 @@
 import page from '@automattic/calypso-router';
 import { Gridicon } from '@automattic/components';
+import { useLocale } from '@automattic/i18n-utils';
 import { DropdownMenu, MenuGroup, MenuItem, Spinner } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Icon, linkOff } from '@wordpress/icons';
+import { DeploymentStatus } from 'calypso/my-sites/github-deployments/deployments/deployment-status';
+import { useCreateCodeDeploymentRun } from 'calypso/my-sites/github-deployments/deployments/use-create-code-deployment-run';
+import { formatDate } from 'calypso/my-sites/github-deployments/utils/dates';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { useSelector } from '../../../state';
 import { manageDeploymentPage } from '../routes';
 import { CodeDeploymentData } from './use-code-deployments-query';
 import { useDeleteCodeDeployment } from './use-delete-code-deployment';
-import { formatDate } from 'calypso/my-sites/github-deployments/utils/Dates';
-import { useLocale } from '@automattic/i18n-utils';
 
-interface GitHubRepositoryListItemProps {
+interface DeploymentsListItemProps {
 	deployment: CodeDeploymentData;
 }
 
-export const DeploymentsListItem = ( { deployment }: GitHubRepositoryListItemProps ) => {
+export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) => {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const locale = useLocale();
 
@@ -24,24 +27,60 @@ export const DeploymentsListItem = ( { deployment }: GitHubRepositoryListItemPro
 		deployment.id
 	);
 
+	const { triggerManualDeployment } = useCreateCodeDeploymentRun(
+		deployment.blog_id,
+		deployment.id
+	);
+
+	const [ account, repo ] = deployment.repository_name.split( '/' );
+
 	return (
 		<tr>
 			<td>
-				<div className="github-deployments-repository-list__account">
-					{ deployment.repository_name }
+				<div className="github-deployments-list__repository-details">
+					{ repo }
+					<span>{ account }</span>
 				</div>
 			</td>
 			<td>
-				<span>Last commit</span>
+				<div className="github-deployments-list__commit-details">
+					This is the commit message
+					<div>
+						<a href="https://github.com/{deployment.repository_name}">44d4fa1</a>
+						<span>
+							<svg
+								width="16"
+								height="16"
+								viewBox="0 0 16 16"
+								fill="none"
+								xmlns="http://www.w3.org/2000/svg"
+							>
+								<path
+									d="M10.0001 3.16667C10.0001 2.59203 10.2284 2.04093 10.6347 1.6346C11.041 1.22827 11.5921 1 12.1667 1C12.7414 1 13.2925 1.22827 13.6988 1.6346C14.1051 2.04093 14.3334 2.59203 14.3334 3.16667C14.3334 3.7413 14.1051 4.2924 13.6988 4.69873C13.2925 5.10506 12.7414 5.33333 12.1667 5.33333C11.5921 5.33333 11.041 5.10506 10.6347 4.69873C10.2284 4.2924 10.0001 3.7413 10.0001 3.16667ZM1.66675 12.8333C1.66675 12.2587 1.89502 11.7076 2.30135 11.3013C2.70768 10.8949 3.25878 10.6667 3.83341 10.6667C4.40805 10.6667 4.95915 10.8949 5.36548 11.3013C5.77181 11.7076 6.00008 12.2587 6.00008 12.8333C6.00008 13.408 5.77181 13.9591 5.36548 14.3654C4.95915 14.7717 4.40805 15 3.83341 15C3.25878 15 2.70768 14.7717 2.30135 14.3654C1.89502 13.9591 1.66675 13.408 1.66675 12.8333ZM1.66675 3.16667C1.66675 2.59203 1.89502 2.04093 2.30135 1.6346C2.70768 1.22827 3.25878 1 3.83341 1C4.40805 1 4.95915 1.22827 5.36548 1.6346C5.77181 2.04093 6.00008 2.59203 6.00008 3.16667C6.00008 3.7413 5.77181 4.2924 5.36548 4.69873C4.95915 5.10506 4.40805 5.33333 3.83341 5.33333C3.25878 5.33333 2.70768 5.10506 2.30135 4.69873C1.89502 4.2924 1.66675 3.7413 1.66675 3.16667ZM3.83341 4.33333C4.14292 4.33325 4.43972 4.21021 4.65851 3.99129C4.8773 3.77237 5.00017 3.47551 5.00008 3.166C4.99999 2.85649 4.87696 2.5597 4.65804 2.3409C4.43912 2.12211 4.14226 1.99924 3.83275 1.99933C3.6795 1.99938 3.52775 2.02961 3.38618 2.08829C3.24461 2.14698 3.11599 2.23298 3.00765 2.34138C2.78886 2.56029 2.66599 2.85716 2.66608 3.16667C2.66617 3.47617 2.78921 3.77297 3.00812 3.99176C3.22704 4.21056 3.52391 4.33342 3.83341 4.33333ZM3.83341 14C3.98667 14 4.13841 13.9697 4.27998 13.911C4.42155 13.8524 4.55018 13.7664 4.65851 13.658C4.76685 13.5496 4.85277 13.4209 4.91138 13.2793C4.96998 13.1377 5.00013 12.9859 5.00008 12.8327C5.00004 12.6794 4.96981 12.5277 4.91112 12.3861C4.85243 12.2445 4.76644 12.1159 4.65804 12.0076C4.54964 11.8992 4.42097 11.8133 4.27937 11.7547C4.13776 11.6961 3.986 11.666 3.83275 11.666C3.52324 11.6661 3.22644 11.7891 3.00765 12.008C2.78886 12.227 2.66599 12.5238 2.66608 12.8333C2.66617 13.1428 2.78921 13.4396 3.00812 13.6584C3.22704 13.8772 3.52391 14.0001 3.83341 14ZM12.1667 4.33333C12.4763 4.33325 12.7731 4.21021 12.9918 3.99129C13.2106 3.77237 13.3335 3.47551 13.3334 3.166C13.3333 2.85649 13.2103 2.5597 12.9914 2.3409C12.7725 2.12211 12.4756 1.99924 12.1661 1.99933C12.0128 1.99938 11.8611 2.02961 11.7195 2.08829C11.5779 2.14698 11.4493 2.23298 11.341 2.34138C11.2327 2.44977 11.1467 2.57845 11.0881 2.72005C11.0295 2.86165 10.9994 3.01341 10.9994 3.16667C10.9995 3.31992 11.0297 3.47166 11.0884 3.61323C11.1471 3.7548 11.2331 3.88343 11.3415 3.99176C11.4499 4.1001 11.5785 4.18602 11.7201 4.24463C11.8617 4.30324 12.0135 4.33338 12.1667 4.33333Z"
+									fill="black"
+								/>
+								<path
+									d="M3.83325 11.1668C3.70064 11.1668 3.57347 11.1142 3.4797 11.0204C3.38593 10.9266 3.33325 10.7994 3.33325 10.6668V5.3335C3.33325 5.20089 3.38593 5.07371 3.4797 4.97994C3.57347 4.88617 3.70064 4.8335 3.83325 4.8335C3.96586 4.8335 4.09304 4.88617 4.18681 4.97994C4.28057 5.07371 4.33325 5.20089 4.33325 5.3335V10.6668C4.33325 10.7994 4.28057 10.9266 4.18681 11.0204C4.09304 11.1142 3.96586 11.1668 3.83325 11.1668Z"
+									fill="black"
+								/>
+								<path
+									d="M11.6666 5.83317V5.1665H12.6666V5.83317C12.6666 6.49621 12.4032 7.1321 11.9344 7.60094C11.4655 8.06978 10.8296 8.33317 10.1666 8.33317H5.49992C5.1905 8.33317 4.89375 8.45609 4.67496 8.67488C4.45617 8.89367 4.33325 9.19042 4.33325 9.49984H3.33325C3.33325 8.9252 3.56153 8.3741 3.96785 7.96777C4.37418 7.56144 4.92528 7.33317 5.49992 7.33317H10.1666C10.5644 7.33317 10.9459 7.17514 11.2272 6.89383C11.5085 6.61253 11.6666 6.231 11.6666 5.83317Z"
+									fill="black"
+								/>
+							</svg>
+							<span>Main</span>
+						</span>
+					</div>
+				</div>
 			</td>
 			<td>
-				<span>Status</span>
+				<DeploymentStatus status={ 2 } />
 			</td>
 			<td>
 				<span>{ formatDate( locale, new Date( deployment.updated_on ) ) }</span>
 			</td>
 			<td>
-				<span>Duration</span>
+				<span>30s</span>
 			</td>
 			<td>
 				{ isPending ? (
@@ -53,7 +92,7 @@ export const DeploymentsListItem = ( { deployment }: GitHubRepositoryListItemPro
 								<MenuGroup>
 									<MenuItem
 										onClick={ () => {
-											page( manageDeploymentPage( siteSlug!, deployment.id ) );
+											triggerManualDeployment();
 											onClose();
 										} }
 									>
@@ -70,11 +109,13 @@ export const DeploymentsListItem = ( { deployment }: GitHubRepositoryListItemPro
 								</MenuGroup>
 								<MenuGroup>
 									<MenuItem
+										className="github-deployments-list__menu-item-danger"
 										onClick={ () => {
 											deleteDeployment();
 											onClose();
 										} }
 									>
+										<Icon icon={ linkOff } />
 										{ __( 'Disconnect repository ' ) }
 									</MenuItem>
 								</MenuGroup>

--- a/client/my-sites/github-deployments/deployments/styles.scss
+++ b/client/my-sites/github-deployments/deployments/styles.scss
@@ -49,7 +49,7 @@
 		display: flex;
 		flex-direction: column;
 		span {
-			color: var(--Gray-Gray-40, #787C82);
+			color: var(--Gray-Gray-40, #787c82);
 			font-size: $font-body-small;
 		}
 	}
@@ -73,37 +73,40 @@
 .github-deployments-status {
 	display: inline-flex;
 	min-height: 24px;
-	padding: 0px 8px;
+	padding-left: 8px;
+	padding-right: 8px;
 	justify-content: center;
 	align-items: center;
 	gap: 4px;
+	/* stylelint-disable-next-line scales/radii */
 	border-radius: 12px;
 
 	&__pending {
-		background-color: var(--Green-Green-5, #B8E6BF);
+		background-color: var(--Green-Green-5, #b8e6bf);
 	}
 
 	&__queued {
-		background-color: var(--Yellow-Yellow-5, #F5E6B3);
+		background-color: var(--Yellow-Yellow-5, #f5e6b3);
 	}
 
 	&__running {
-		background-color: var(--Green-Green-5, #B8E6BF);
+		background-color: var(--Green-Green-5, #b8e6bf);
 	}
 
 	&__success {
-		background-color: var(--Green-Green-5, #B8E6BF);
+		background-color: var(--Green-Green-5, #b8e6bf);
 	}
 
 	&__failed {
-		background-color: var(--Red-Red-5, #FACFD2);
+		background-color: var(--Red-Red-5, #facfd2);
 	}
 
 	&__building {
-		background-color: var(--Blue-Blue-5, #BBE0FA);
+		background-color: var(--Blue-Blue-5, #bbe0fa);
 	}
 
 	span {
+		/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 		font-size: 13px;
 		font-style: normal;
 		font-weight: 400;

--- a/client/my-sites/github-deployments/deployments/styles.scss
+++ b/client/my-sites/github-deployments/deployments/styles.scss
@@ -45,4 +45,68 @@
 		text-align: right;
 	}
 
+	&__repository-details {
+		display: flex;
+		flex-direction: column;
+		span {
+			color: var(--Gray-Gray-40, #787C82);
+			font-size: $font-body-small;
+		}
+	}
+
+	&__commit-details {
+		display: flex;
+		flex-direction: column;
+		> div {
+			display: flex;
+			gap: 8px;
+			font-size: $font-body-small;
+		}
+	}
+
+	&__menu-item-danger {
+		color: var(--color-error);
+	}
+}
+
+
+.github-deployments-status {
+	display: inline-flex;
+	min-height: 24px;
+	padding: 0px 8px;
+	justify-content: center;
+	align-items: center;
+	gap: 4px;
+	border-radius: 12px;
+
+	&__pending {
+		background-color: var(--Green-Green-5, #B8E6BF);
+	}
+
+	&__queued {
+		background-color: var(--Yellow-Yellow-5, #F5E6B3);
+	}
+
+	&__running {
+		background-color: var(--Green-Green-5, #B8E6BF);
+	}
+
+	&__success {
+		background-color: var(--Green-Green-5, #B8E6BF);
+	}
+
+	&__failed {
+		background-color: var(--Red-Red-5, #FACFD2);
+	}
+
+	&__building {
+		background-color: var(--Blue-Blue-5, #BBE0FA);
+	}
+
+	span {
+		font-size: 13px;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 20px; /* 153.846% */
+	}
 }

--- a/client/my-sites/github-deployments/deployments/use-create-code-deployment-run.ts
+++ b/client/my-sites/github-deployments/deployments/use-create-code-deployment-run.ts
@@ -1,0 +1,39 @@
+import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+import { GITHUB_DEPLOYMENTS_QUERY_KEY } from 'calypso/my-sites/github-deployments/constants';
+import { CODE_DEPLOYMENTS_QUERY_KEY } from 'calypso/my-sites/github-deployments/deployments/use-code-deployments-query';
+
+interface MutationResponse {
+	message: string;
+}
+
+interface MutationError {
+	code: string;
+	message: string;
+}
+
+export const useCreateCodeDeploymentRun = (
+	siteId: number,
+	deploymentId: number,
+	options: UseMutationOptions< MutationResponse, MutationError > = {}
+) => {
+	const queryClient = useQueryClient();
+	const mutation = useMutation( {
+		mutationFn: async () =>
+			wp.req.post( {
+				path: `/sites/${ siteId }/hosting/code-deployments/${ deploymentId }/runs`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		...options,
+		onSuccess: async ( ...args ) => {
+			await queryClient.invalidateQueries( {
+				queryKey: [ GITHUB_DEPLOYMENTS_QUERY_KEY, CODE_DEPLOYMENTS_QUERY_KEY, siteId ],
+			} );
+			options.onSuccess?.( ...args );
+		},
+	} );
+
+	const { mutate, isPending } = mutation;
+
+	return { triggerManualDeployment: mutate, isPending };
+};

--- a/client/my-sites/github-deployments/utils/dates.ts
+++ b/client/my-sites/github-deployments/utils/dates.ts
@@ -1,0 +1,3 @@
+export const formatDate = ( locale: string, date: Date ) => {
+	return Intl.DateTimeFormat( locale, { dateStyle: 'medium' } ).format( date );
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5332

<img width="1225" alt="Screenshot 2567-02-14 at 15 30 47" src="https://github.com/Automattic/wp-calypso/assets/6851384/e92623ef-0e8d-4fdb-a3bf-1e42ce460499">

## Proposed Changes

* Make the table rows look closer to the mockup
* Support "trigger manual deployment" 
* Some minor tweaks to date formatting and sorting

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* No backend patches are need now. :
* Use Calypso Live
* Visit `/github-deployments/:atomic-site` and take a look at the deployments table
* You can use the "trigger manual deployment", and it works, but the deployment details don't come back yet. That is being worked on. I hardcoded some of the stuff for now. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?