### PR TITLE
Settings: Fix toggle and support info alignment

### DIFF
--- a/client/my-sites/site-settings/custom-content-types/style.scss
+++ b/client/my-sites/site-settings/custom-content-types/style.scss
@@ -1,4 +1,5 @@
 .custom-content-types__module-settings {
+	flex-direction: column;
 	margin-bottom: 24px;
 
 	&:last-child {

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -795,3 +795,13 @@ button.site-settings__general-settings-set-guessed-timezone.button.is-borderless
 	font-size: $font-body-small;
 	font-style: italic;
 }
+
+.support-info + .jetpack-module-toggle,
+.support-info + .components-toggle-control,
+.support-info + .custom-content-types__module-settings {
+	display: flex;
+}
+
+.jetpack-module-toggle {
+	flex-direction: column;
+}


### PR DESCRIPTION
## Proposed Changes

Fixes an alignment issue with toggles and support info balloons in settings that was reported in https://github.com/Automattic/wp-calypso/pull/87350#issuecomment-1941815594

## Testing Instructions

Go through all settings pages for a simple and atomic site and verify they look good.

## Preview

Before:
![Screenshot 2024-02-14 at 13 16 42](https://github.com/Automattic/wp-calypso/assets/8436925/2454cf97-ceb6-482a-8690-42b39bf3fd0d)

After:
![Screenshot 2024-02-14 at 13 17 47](https://github.com/Automattic/wp-calypso/assets/8436925/cae4a3e2-2f04-4b14-a9fa-7810ae41cf72)