### PR TITLE
Plans: Fix Layout for Site Selector

### DIFF
--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -25,7 +25,7 @@
 }
 
 body.is-section-plans {
-	.layout__content {
+	.layout:not(.has-no-sidebar) .layout__content {
 		@media (min-width: $break-small) {
 			padding: 79px 0 0 0 !important;
 		}


### PR DESCRIPTION
Defect of #84651

## Proposed Changes

Fix the layout for the Site Selector on Plans.

## Testing Instructions

Go to https://wordpress.com/plans/ when signed in. 

**Current:**
<img width="1670" alt="Screenshot 2024-02-14 at 12 07 46" src="https://github.com/Automattic/wp-calypso/assets/43215253/769f1a5d-8639-4acf-a2c3-2535c97fc593">

**Proposed:**
<img width="1667" alt="Screenshot 2024-02-14 at 12 08 38" src="https://github.com/Automattic/wp-calypso/assets/43215253/652b625c-8486-4980-b067-3b4112e74d9a">

cc @lupus2k, @chriskmnds