### PR TITLE
Passwordless Invite: Fix disable button state

### DIFF
--- a/client/my-sites/invites/invite-accept-logged-out/style.scss
+++ b/client/my-sites/invites/invite-accept-logged-out/style.scss
@@ -73,6 +73,11 @@ body.is-section-accept-invite {
 				color: var(--color-text-inverted);
 				box-shadow: none;
 			}
+			&:disabled {
+				background: var(--studio-gray-20);
+				border: 1px solid var(--studio-gray-20);
+				color: var(--color-surface);
+			}
 		}
 		label.form-label {
 			color: var(--studio-gray-60, #50575e);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87427
Fixes #87427


## Proposed Changes

* Align buttons disabled style, more details https://github.com/Automattic/wp-calypso/issues/87427 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link or pull and apply this branch
* From your atomic site, Invite a user to your site
* Check your email and click on accept invitation
* Type an existing or invalid email to get the disabled state
* The button disabled state should match the disabled state from [login](https://wordpress.com/log-in)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?