### PR TITLE
E2E: Fix Jetpack Related Posts block test again

### DIFF
--- a/packages/calypso-e2e/src/lib/blocks/block-flows/related-posts.ts
+++ b/packages/calypso-e2e/src/lib/blocks/block-flows/related-posts.ts
@@ -36,7 +36,6 @@ export class RelatedPostsFlow implements BlockFlow {
 
 		if ( this.configurationData.headline ) {
 			await context.addedBlockLocator
-				.getByRole( 'document', { name: 'Block: Related Posts' } )
 				.getByRole( 'document', { name: 'Block: Heading' } )
 				.fill( this.configurationData.headline );
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

The fix in #87388 was accidentally looking for a related post block inside of another related post block (because `context.addedBlockLocator` already points at the just-added block, then `.getByRole()` was looking inside of that). That normally wouldn't work, but due to a bug in Automattic/jetpack#35353, that's exactly the DOM structure that existed in the page. 😀

Now that we're fixing that bug with Automattic/jetpack#35686, the test needs fixing too.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Same as for #87388. Ideally run it against a site that has Automattic/jetpack#35686 already too (is there an easy way to do that?)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?