### PR TITLE
Site Migration: Scaffolding for the new site migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/registered-flows.ts
+++ b/client/landing/stepper/declarative-flow/registered-flows.ts
@@ -13,6 +13,7 @@ import {
 	VIDEOPRESS_TV_PURCHASE_FLOW,
 	GOOGLE_TRANSFER,
 	REBLOGGING_FLOW,
+	SITE_MIGRATION_FLOW,
 } from '@automattic/onboarding';
 import type { Flow } from '../declarative-flow/internals/types';
 
@@ -148,4 +149,15 @@ const videoPressTvFlows: Record< string, () => Promise< { default: Flow } > > = 
 	  }
 	: {};
 
-export default { ...availableFlows, ...videoPressTvFlows };
+const siteMigrationFlow: Record< string, () => Promise< { default: Flow } > > = config.isEnabled(
+	'onboarding/new-migration-flow'
+)
+	? {
+			[ SITE_MIGRATION_FLOW ]: () =>
+				import(
+					/* webpackChunkName: "site-migration-flow" */ '../declarative-flow/site-migration-flow'
+				),
+	  }
+	: {};
+
+export default { ...availableFlows, ...videoPressTvFlows, ...siteMigrationFlow };

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -1,0 +1,140 @@
+import { useLocale } from '@automattic/i18n-utils';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
+import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
+import { useSiteSlugParam } from '../hooks/use-site-slug-param';
+import { USER_STORE, ONBOARD_STORE, SITE_STORE } from '../stores';
+import { getLoginUrl } from '../utils/path';
+import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import { STEPS } from './internals/steps';
+import { AssertConditionState } from './internals/types';
+import type { AssertConditionResult, Flow, ProvidedDependencies } from './internals/types';
+import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-stores';
+
+const siteMigration: Flow = {
+	name: 'site-migration',
+
+	useSteps() {
+		return [ STEPS.IMPORT, STEPS.ERROR ];
+	},
+	useAssertConditions(): AssertConditionResult {
+		const { setProfilerData } = useDispatch( ONBOARD_STORE );
+		const userIsLoggedIn = useSelect(
+			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
+			[]
+		);
+		let result: AssertConditionResult = { state: AssertConditionState.SUCCESS };
+
+		const flowName = this.name;
+
+		// There is a race condition where useLocale is reporting english,
+		// despite there being a locale in the URL so we need to look it up manually.
+		// We also need to support both query param and path suffix localized urls
+		// depending on where the user is coming from.
+		const useLocaleSlug = useLocale();
+		// Query param support can be removed after dotcom-forge/issues/2960 and 2961 are closed.
+		const queryLocaleSlug = getLocaleFromQueryParam();
+		const pathLocaleSlug = getLocaleFromPathname();
+		const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
+
+		const queryParams = new URLSearchParams( window.location.search );
+		const profilerData = queryParams.get( 'profilerdata' );
+		const aff = queryParams.get( 'aff' );
+		const vendorId = queryParams.get( 'vid' );
+
+		if ( profilerData ) {
+			try {
+				const decodedProfilerData = JSON.parse(
+					decodeURIComponent( escape( window.atob( profilerData ) ) )
+				);
+
+				setProfilerData( decodedProfilerData );
+				// Ignore any bad/invalid data and prevent it from causing downstream issues.
+			} catch {}
+		}
+
+		const getStartUrl = () => {
+			let hasFlowParams = false;
+			const flowParams = new URLSearchParams();
+			const queryParams = new URLSearchParams();
+
+			if ( vendorId ) {
+				queryParams.set( 'vid', vendorId );
+			}
+
+			if ( aff ) {
+				queryParams.set( 'aff', aff );
+			}
+
+			if ( locale && locale !== 'en' ) {
+				flowParams.set( 'locale', locale );
+				hasFlowParams = true;
+			}
+
+			const redirectTarget =
+				`/setup/site-migration` +
+				( hasFlowParams ? encodeURIComponent( '?' + flowParams.toString() ) : '' );
+
+			let queryString = `redirect_to=${ redirectTarget }`;
+
+			if ( queryParams.toString() ) {
+				queryString = `${ queryString }&${ queryParams.toString() }`;
+			}
+
+			const logInUrl = getLoginUrl( {
+				variationName: flowName,
+				locale,
+			} );
+
+			return `${ logInUrl }&${ queryString }`;
+		};
+
+		useEffect( () => {
+			if ( ! userIsLoggedIn ) {
+				const logInUrl = getStartUrl();
+				window.location.assign( logInUrl );
+			}
+		}, [] );
+
+		if ( ! userIsLoggedIn ) {
+			result = {
+				state: AssertConditionState.FAILURE,
+				message: 'site-migration requires a logged in user',
+			};
+		}
+
+		return result;
+	},
+	// TODO - We'll need to add the `navigate` argument back once we start adding more steps.
+	useStepNavigation( currentStep ) {
+		const flowName = this.name;
+		const intent = useSelect(
+			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getIntent(),
+			[]
+		);
+		const siteSlugParam = useSiteSlugParam();
+
+		const { getSiteIdBySlug } = useSelect( ( select ) => select( SITE_STORE ) as SiteSelect, [] );
+
+		const exitFlow = ( to: string ) => {
+			window.location.assign( to );
+		};
+
+		// TODO - We may need to add `...params: string[]` back once we start adding more steps.
+		function submit( providedDependencies: ProvidedDependencies = {} ) {
+			recordSubmitStep( providedDependencies, intent, flowName, currentStep );
+			const siteSlug = ( providedDependencies?.siteSlug as string ) || siteSlugParam || '';
+			const siteId = getSiteIdBySlug( siteSlug );
+
+			switch ( currentStep ) {
+				case 'import': {
+					return exitFlow( `/home/${ siteId ?? siteSlug }` );
+				}
+			}
+		}
+
+		return { submit, exitFlow };
+	},
+};
+
+export default siteMigration;

--- a/packages/onboarding/src/utils/flows.ts
+++ b/packages/onboarding/src/utils/flows.ts
@@ -22,6 +22,7 @@ export const WOOEXPRESS_FLOW = 'wooexpress';
 export const FREE_FLOW = 'free';
 export const FREE_POST_SETUP_FLOW = 'free-post-setup';
 export const MIGRATION_FLOW = 'import-focused';
+export const SITE_MIGRATION_FLOW = 'site-migration';
 export const COPY_SITE_FLOW = 'copy-site';
 export const BUILD_FLOW = 'build';
 export const WRITE_FLOW = 'write';
@@ -116,6 +117,10 @@ export const isCopySiteFlow = ( flowName: string | null ) => {
 
 export const isWooExpressFlow = ( flowName: string | null ) => {
 	return Boolean( flowName && [ WOOEXPRESS_FLOW ].includes( flowName ) );
+};
+
+export const isNewSiteMigrationFlow = ( flowName: string | null ) => {
+	return Boolean( flowName && [ SITE_MIGRATION_FLOW ].includes( flowName ) );
 };
 
 export const isBuildFlow = ( flowName: string | null ) => {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #87468

## Proposed Changes

This adds the scaffolding for the new site migration flow.

Context: paYKcK-45p-p2

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch locally or use the calypo.live url.
* Visit http://calypso.localhost:3000/setup/site-migration/import?flags=onboarding/new-migration-flow
* You should end up on the "Where will you import from?" step. (NOTE: This step will not be fully functional yet).
<img width="855" alt="CleanShot 2024-02-14 at 14 10 49" src="https://github.com/Automattic/wp-calypso/assets/917632/269df7f0-be43-4f83-849d-135a521295a6">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
