### PR TITLE
Add special handling for Jetpack legacy upgrade errors

### DIFF
--- a/client/my-sites/checkout/cart/cart-messages.tsx
+++ b/client/my-sites/checkout/cart/cart-messages.tsx
@@ -3,7 +3,7 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import { useDisplayCartMessages } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
-import { JETPACK_SUPPORT } from 'calypso/lib/url/support';
+import { JETPACK_CONTACT_SUPPORT, JETPACK_SUPPORT } from 'calypso/lib/url/support';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useDispatch, useSelector } from 'calypso/state';
 import { errorNotice, successNotice, removeNotice } from 'calypso/state/notices/actions';
@@ -131,6 +131,33 @@ function getInvalidMultisitePurchaseErrorMessage( {
 	);
 }
 
+function getJetpackLegacyUpgradeErrorMessage( {
+	translate,
+	message,
+	selectedSiteSlug,
+}: {
+	translate: ReturnType< typeof useTranslate >;
+	message: string;
+	selectedSiteSlug: string | null | undefined;
+} ) {
+	return (
+		<div style={ { maxWidth: '500px' } }>
+			{ message }&nbsp;
+			<a
+				href={
+					localizeUrl( JETPACK_CONTACT_SUPPORT ) +
+					'&assistant=false&subject=legacy-upgrade' +
+					( selectedSiteSlug ? '&url=' + selectedSiteSlug : '' )
+				}
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				{ translate( 'Contact Support' ) }
+			</a>
+		</div>
+	);
+}
+
 // Use this to transform message strings into React components
 function getMessagePrettifier(
 	translate: ReturnType< typeof useTranslate >,
@@ -146,6 +173,13 @@ function getMessagePrettifier(
 
 			case 'invalid-product-multisite':
 				return getInvalidMultisitePurchaseErrorMessage( { translate, message: message.message } );
+
+			case 'invalid-jetpack-legacy-upgrade':
+				return getJetpackLegacyUpgradeErrorMessage( {
+					translate,
+					message: message.message,
+					selectedSiteSlug,
+				} );
 
 			default:
 				return message.message;

--- a/client/my-sites/checkout/cart/cart-messages.tsx
+++ b/client/my-sites/checkout/cart/cart-messages.tsx
@@ -146,7 +146,8 @@ function getJetpackLegacyUpgradeErrorMessage( {
 			<a
 				href={
 					localizeUrl( JETPACK_CONTACT_SUPPORT ) +
-					'&assistant=false&subject=legacy-upgrade' +
+					'&assistant=false&subject=' +
+					encodeURIComponent( 'Help with Jetpack Legacy Upgrade' ) +
 					( selectedSiteSlug ? '&url=' + selectedSiteSlug : '' )
 				}
 				target="_blank"


### PR DESCRIPTION
## Proposed Changes

* This diff adds special message handling for a Jetpack legacy upgrade message
* It adds a "contact support" link to the message

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You will need to test with D138280-code
* Using a site that has a legacy Jetpack plan (ie Jetpack Personal) navigate to /me/purchases and select the plan
* On the plan management page, select "Upgrade"
* Choose Jetpack Complete or Jetpack Security as the upgrade
* You should be redirected to the cart and see the warning message
![Screenshot 2024-02-14 at 2 33 27 PM](https://github.com/Automattic/wp-calypso/assets/18016357/ba12921a-97ae-437d-94b4-2ba47be1afef)
* Clicking on "Contact Support" should take you to jetpack.com/contact-support, the site you were trying to upgrade should be pre-selected in the form

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?