### PR TITLE
Stepper: Add constants for Atomic, wait for plugins, and assign trial plan steps

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -190,4 +190,19 @@ export const STEPS = {
 		slug: 'bundleTransfer',
 		asyncComponent: () => import( './steps-repository/bundle-transfer' ),
 	},
+
+	WAIT_FOR_ATOMIC: {
+		slug: 'waitForAtomic',
+		asyncComponent: () => import( './steps-repository/wait-for-atomic' ),
+	},
+
+	WAIT_FOR_PLUGIN_INSTALL: {
+		slug: 'waitForPluginInstall',
+		asyncComponent: () => import( './steps-repository/wait-for-plugin-install' ),
+	},
+
+	ASSIGN_TRIAL_PLAN: {
+		slug: 'assignTrialPlan',
+		asyncComponent: () => import( './steps-repository/assign-trial-plan' ),
+	},
 };

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -9,6 +9,7 @@ import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { USER_STORE, ONBOARD_STORE, SITE_STORE } from '../stores';
 import { getLoginUrl } from '../utils/path';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
+import { STEPS } from './internals/steps';
 import { AssignTrialResult } from './internals/steps-repository/assign-trial-plan/constants';
 import { ProcessingResult } from './internals/steps-repository/processing-step/constants';
 import { AssertConditionState } from './internals/types';
@@ -20,27 +21,12 @@ const wooexpress: Flow = {
 
 	useSteps() {
 		return [
-			{
-				slug: 'createSite',
-				asyncComponent: () => import( './internals/steps-repository/create-site' ),
-			},
-			{
-				slug: 'processing',
-				asyncComponent: () => import( './internals/steps-repository/processing-step' ),
-			},
-			{
-				slug: 'assignTrialPlan',
-				asyncComponent: () => import( './internals/steps-repository/assign-trial-plan' ),
-			},
-			{
-				slug: 'waitForAtomic',
-				asyncComponent: () => import( './internals/steps-repository/wait-for-atomic' ),
-			},
-			{
-				slug: 'waitForPluginInstall',
-				asyncComponent: () => import( './internals/steps-repository/wait-for-plugin-install' ),
-			},
-			{ slug: 'error', asyncComponent: () => import( './internals/steps-repository/error-step' ) },
+			STEPS.SITE_CREATION_STEP,
+			STEPS.PROCESSING,
+			STEPS.ASSIGN_TRIAL_PLAN,
+			STEPS.WAIT_FOR_ATOMIC,
+			STEPS.WAIT_FOR_PLUGIN_INSTALL,
+			STEPS.ERROR,
 		];
 	},
 	useAssertConditions(): AssertConditionResult {

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -102,9 +102,9 @@ const wooexpress: Flow = {
 		};
 
 		// Despite sending a CHECKING state, this function gets called again with the
-		// /setup/wooexpress/createSite route which has no locale in the path so we need to
+		// /setup/wooexpress/create-site route which has no locale in the path so we need to
 		// redirect off of the first render.
-		// This effects both /setup/wooexpress/<locale> starting points and /setup/wooexpress/createSite/<locale> urls.
+		// This effects both /setup/wooexpress/<locale> starting points and /setup/wooexpress/create-site/<locale> urls.
 		// The double call also hapens on urls without locale.
 		useEffect( () => {
 			// Log when profiler data does not contain valid data.
@@ -173,7 +173,7 @@ const wooexpress: Flow = {
 			const adminUrl = siteId && getSiteOption( siteId, 'admin_url' );
 
 			switch ( currentStep ) {
-				case 'createSite': {
+				case 'create-site': {
 					return navigate( 'processing', {
 						currentStep,
 					} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

I noticed in https://github.com/Automattic/wp-calypso/issues/87468 that we've moved some steps into constants rather than hard-coding them directly in the flow. We'll likely need to reuse the Wait for Atomic and possibly Wait for Plugins steps for the site migration flow.

This refactors the WooExpress flow to move its steps into step constants to DRY things up and allow us to more easily re-use these steps in the site migration flow if need be.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR, navigate to `/setup/wooexpress`
* Make sure your WooExpress trial site is still created as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?