### PR TITLE
Localize the support links on Developer Features page

### DIFF
--- a/client/me/developer/features/use-features-list.tsx
+++ b/client/me/developer/features/use-features-list.tsx
@@ -18,7 +18,7 @@ export const useFeaturesList = () => {
 					comment: 'Feature description',
 				}
 			),
-			linkLearnMore: localizeUrl( '/support/connect-to-ssh-on-wordpress-com' ),
+			linkLearnMore: localizeUrl( 'https://wordpress.com/support/connect-to-ssh-on-wordpress-com' ),
 		},
 		{
 			id: 'staging-sites',
@@ -31,7 +31,7 @@ export const useFeaturesList = () => {
 					comment: 'Feature description',
 				}
 			),
-			linkLearnMore: localizeUrl( '/support/how-to-create-a-staging-site/' ),
+			linkLearnMore: localizeUrl( 'https://wordpress.com/support/how-to-create-a-staging-site/' ),
 		},
 		{
 			id: 'custom-code',
@@ -44,7 +44,7 @@ export const useFeaturesList = () => {
 					comment: 'Feature description',
 				}
 			),
-			linkLearnMore: localizeUrl( '/support/code' ),
+			linkLearnMore: localizeUrl( 'https://wordpress.com/support/code' ),
 		},
 		{
 			id: 'free-ssl-certificates',
@@ -57,7 +57,7 @@ export const useFeaturesList = () => {
 					comment: 'Feature description',
 				}
 			),
-			linkLearnMore: localizeUrl( '/support/domains/https-ssl' ),
+			linkLearnMore: localizeUrl( 'https://wordpress.com/support/domains/https-ssl' ),
 		},
 		{
 			id: 'expert-support',
@@ -70,7 +70,7 @@ export const useFeaturesList = () => {
 					comment: 'Feature description',
 				}
 			),
-			linkLearnMore: localizeUrl( '/support/help-support-options' ),
+			linkLearnMore: localizeUrl( 'https://wordpress.com/support/help-support-options' ),
 		},
 		{
 			id: 'malware-scanning-removal',
@@ -84,7 +84,7 @@ export const useFeaturesList = () => {
 					components: {
 						backupsLink: (
 							<a
-								href={ localizeUrl( '/support/restore' ) }
+								href={ localizeUrl( 'https://wordpress.com/support/restore' ) }
 								target="_blank"
 								rel="noopener noreferrer"
 								onClick={ handleClickLink }
@@ -92,7 +92,7 @@ export const useFeaturesList = () => {
 						),
 						malwareScanningLink: (
 							<a
-								href={ localizeUrl( '/support/malware-and-site-security' ) }
+								href={ localizeUrl( 'https://wordpress.com/support/malware-and-site-security' ) }
 								target="_blank"
 								rel="noopener noreferrer"
 								onClick={ handleClickLink }
@@ -100,7 +100,7 @@ export const useFeaturesList = () => {
 						),
 						siteMonitoringLink: (
 							<a
-								href={ localizeUrl( '/support/site-monitoring' ) }
+								href={ localizeUrl( 'https://wordpress.com/support/site-monitoring' ) }
 								target="_blank"
 								rel="noopener noreferrer"
 								onClick={ handleClickLink }

--- a/client/me/developer/features/use-handle-click-link.tsx
+++ b/client/me/developer/features/use-handle-click-link.tsx
@@ -13,7 +13,7 @@ export const useHandleClickLink = () => {
 			if ( pathIndex !== -1 ) {
 				featureSlug = featureSlug.substring( pathIndex + prefixToRemove.length );
 			}
-
+			featureSlug = featureSlug.replace( /^\/|\/$/g, '' );
 			recordTracksEventWithUserIsDevAccount( 'calypso_me_developer_learn_more', {
 				feature: featureSlug,
 			} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Localize the links on /me/developer Developer Features page by switching to absolute URLs, which can be handled by `localizeUrl`.

## Testing Instructions

1. Go to /me and switch to a Mag-16 locale, like Spanish, German, Korean etc.
2. Navigate to /me/developer and confirm that all the links to support pages are localized there.

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
