### PR TITLE
Site Monitoring: Add filter toggle on mobile web

### DIFF
--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
@@ -1,6 +1,5 @@
-import { SelectDropdown } from '@automattic/components';
+import { SelectDropdown, Gridicon, Badge } from '@automattic/components';
 import { Button } from '@wordpress/components';
-import { Icon, moreHorizontalMobile } from '@wordpress/icons';
 import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
@@ -131,8 +130,11 @@ export const SiteLogsToolbar = ( {
 					setIsMobileOpen( ! isMobileOpen );
 				} }
 			>
+				{ ( severity || requestType || requestStatus ) && (
+					<Badge className="site-logs-toolbar__badge" type="success"></Badge>
+				) }
 				{ translate( 'Filter' ) }
-				<Icon className="stats-icon" icon={ moreHorizontalMobile } size={ 22 } />
+				<Gridicon icon="filter" />
 			</Button>
 			<div
 				className={ classnames( 'site-logs-toolbar__top-row', { 'is-hidden': ! isMobileOpen } ) }
@@ -232,6 +234,7 @@ export const SiteLogsToolbar = ( {
 				) }
 
 				<Button
+					className="site-logs-toolbar__download"
 					disabled={ isDownloading }
 					isBusy={ isDownloading }
 					variant="primary"

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/index.tsx
@@ -1,6 +1,9 @@
 import { SelectDropdown } from '@automattic/components';
 import { Button } from '@wordpress/components';
+import { Icon, moreHorizontalMobile } from '@wordpress/icons';
+import classnames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { SiteLogsTab } from 'calypso/data/hosting/use-site-logs-query';
 import { useCurrentSiteGmtOffset } from '../../hooks/use-current-site-gmt-offset';
@@ -69,6 +72,7 @@ export const SiteLogsToolbar = ( {
 	const siteGmtOffset = useCurrentSiteGmtOffset();
 
 	const isDownloading = state.status === 'downloading';
+	const [ isMobileOpen, setIsMobileOpen ] = useState( false );
 
 	const handleTimeRangeChange = ( newStart: Moment | null, newEnd: Moment | null ) => {
 		if (
@@ -77,7 +81,7 @@ export const SiteLogsToolbar = ( {
 		) {
 			return;
 		}
-
+		setIsMobileOpen( false );
 		onDateTimeChange( newStart || startDateTime, newEnd || endDateTime );
 	};
 
@@ -121,7 +125,18 @@ export const SiteLogsToolbar = ( {
 
 	return (
 		<div className="site-logs-toolbar">
-			<div className="site-logs-toolbar__top-row">
+			<Button
+				className="site-logs-toolbar__filter"
+				onClick={ () => {
+					setIsMobileOpen( ! isMobileOpen );
+				} }
+			>
+				{ translate( 'Filter' ) }
+				<Icon className="stats-icon" icon={ moreHorizontalMobile } size={ 22 } />
+			</Button>
+			<div
+				className={ classnames( 'site-logs-toolbar__top-row', { 'is-hidden': ! isMobileOpen } ) }
+			>
 				<label htmlFor="from">{ translate( 'From' ) }</label>
 				<DateTimePicker
 					id="from"
@@ -152,7 +167,10 @@ export const SiteLogsToolbar = ( {
 							{ severities.map( ( option ) => (
 								<SelectDropdown.Item
 									key={ option.value }
-									onClick={ () => onSeverityChange( option.value ) }
+									onClick={ () => {
+										onSeverityChange( option.value );
+										setIsMobileOpen( false );
+									} }
 									ariaLabel={ option.label }
 									selected={ option.value === severity }
 								>
@@ -175,7 +193,10 @@ export const SiteLogsToolbar = ( {
 								{ requestTypes.map( ( option ) => (
 									<SelectDropdown.Item
 										key={ option.value }
-										onClick={ () => onRequestTypeChange( option.value ) }
+										onClick={ () => {
+											onRequestTypeChange( option.value );
+											setIsMobileOpen( false );
+										} }
 										ariaLabel={ option.label }
 										selected={ option.value === requestType }
 									>
@@ -195,7 +216,10 @@ export const SiteLogsToolbar = ( {
 								{ requestStatuses.map( ( option ) => (
 									<SelectDropdown.Item
 										key={ option.value }
-										onClick={ () => onRequestStatusChange( option.value ) }
+										onClick={ () => {
+											onRequestStatusChange( option.value );
+											setIsMobileOpen( false );
+										} }
 										ariaLabel={ option.label }
 										selected={ option.value === requestStatus }
 									>

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/style.scss
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/style.scss
@@ -71,6 +71,15 @@
 	}
 }
 
+.is-mobile-app-view .site-logs-toolbar__download {
+	display: none;
+}
+.site-logs-container .site-logs-toolbar .site-logs-toolbar__badge {
+	height: 8px;
+	width: 8px;
+	padding: 0;
+	margin-right: 4px;
+}
 .site-logs-toolbar__download-progress {
 	display: flex;
 	align-items: center;

--- a/client/my-sites/site-monitoring/components/site-logs-toolbar/style.scss
+++ b/client/my-sites/site-monitoring/components/site-logs-toolbar/style.scss
@@ -26,6 +26,7 @@
 		justify-content: flex-start;
 		gap: 16px;
 		padding-bottom: 16px;
+		clear: both;
 
 		.site-logs-toolbar-filter-element {
 			display: flex;
@@ -33,7 +34,10 @@
 			gap: 16px;
 		}
 	}
-
+	.site-logs-toolbar__filter {
+		display: none;
+		float: right;
+	}
 	@media screen and ( max-width: 600px ) {
 		.site-logs-toolbar__top-row {
 			flex-direction: column;
@@ -43,6 +47,13 @@
 				flex-direction: column;
 				align-items: stretch;
 			}
+
+			&.is-hidden {
+				display: none;
+			}
+		}
+		.site-logs-toolbar__filter {
+			display: flex;
 		}
 
 		.select-dropdown .select-dropdown__container {


### PR DESCRIPTION
This Pr updates the mobile web view to be more mobile web friendly by displaying the content instead of the the filtering form right away. 

This also updates 
## Proposed Changes
Before: (onload)
<img width="388" alt="Screenshot 2024-02-14 at 5 24 44 PM" src="https://github.com/Automattic/wp-calypso/assets/115071/882e33a1-e6de-4098-9ab2-cc4a5f7a5b8c">

After:
<img width="393" alt="Screenshot 2024-02-15 at 9 43 34 AM" src="https://github.com/Automattic/wp-calypso/assets/115071/db244fef-0bb1-4bc9-8f9f-56f399af15a5">

If the filter is active
<img width="385" alt="Screenshot 2024-02-15 at 9 43 43 AM" src="https://github.com/Automattic/wp-calypso/assets/115071/a755dad2-0070-47b0-85d9-41df13dbcacc">



When you click "Filter"
<img width="388" alt="Screenshot 2024-02-15 at 9 43 54 AM" src="https://github.com/Automattic/wp-calypso/assets/115071/0e269018-9340-48ff-b0dd-0c5b215057e6">


## Testing Instructions

Load this PR on a mobile device. 
Notice that the site-monitoring tools are much nicer to use. 

Load this PR on desktop. Notice that it works as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?