### PR TITLE
Nav redesign: add site card to the global site view sidebar

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -70,6 +70,14 @@
 
 	.site {
 		flex: unset;
+
+		&.is-selected {
+			background: var(--color-sidebar-menu-selected-background);
+		}
+
+		&:hover {
+			background: var(--color-sidebar-menu-hover-background);
+		}
 	}
 }
 

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -67,6 +67,10 @@
 			fill: var(--color-sidebar-gridicon-fill);
 		}
 	}
+
+	.site {
+		flex: unset;
+	}
 }
 
 .masterbar {

--- a/client/my-sites/sidebar/body.jsx
+++ b/client/my-sites/sidebar/body.jsx
@@ -1,8 +1,13 @@
 import { useSelector } from 'react-redux';
+import Site from 'calypso/blocks/site';
 import SidebarSeparator from 'calypso/layout/sidebar/separator';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
-import { getSidebarIsCollapsed, getSelectedSiteId } from 'calypso/state/ui/selectors';
+import {
+	getSidebarIsCollapsed,
+	getSelectedSiteId,
+	getSelectedSite,
+} from 'calypso/state/ui/selectors';
 import MySitesSidebarUnifiedItem from './item';
 import MySitesSidebarUnifiedMenu from './menu';
 import useSiteMenuItems from './use-site-menu-items';
@@ -14,6 +19,7 @@ import './style.scss';
 export const MySitesSidebarUnifiedBody = ( { path, children } ) => {
 	const menuItems = useSiteMenuItems();
 	const sidebarIsCollapsed = useSelector( getSidebarIsCollapsed );
+	const site = useSelector( getSelectedSite );
 	const siteId = useSelector( getSelectedSiteId );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 	const isSiteAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId ) );
@@ -27,6 +33,9 @@ export const MySitesSidebarUnifiedBody = ( { path, children } ) => {
 			{ menuItems.map( ( item, i ) => {
 				const isSelected = item?.url && itemLinkMatches( item.url, path );
 
+				if ( 'current-site' === item?.type ) {
+					return <Site site={ site } />;
+				}
 				if ( 'separator' === item?.type ) {
 					return <SidebarSeparator key={ i } />;
 				}

--- a/client/my-sites/sidebar/body.jsx
+++ b/client/my-sites/sidebar/body.jsx
@@ -34,7 +34,7 @@ export const MySitesSidebarUnifiedBody = ( { path, children } ) => {
 				const isSelected = item?.url && itemLinkMatches( item.url, path );
 
 				if ( 'current-site' === item?.type ) {
-					return <Site site={ site } />;
+					return <Site site={ site } href={ item?.url } isSelected={ isSelected } />;
 				}
 				if ( 'separator' === item?.type ) {
 					return <SidebarSeparator key={ i } />;

--- a/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
+++ b/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
@@ -22,6 +22,7 @@ export default function globalSiteSidebarMenu( {
 		},
 		{
 			type: 'current-site',
+			url: `/home/${ siteDomain }`,
 		},
 		{
 			slug: 'upgrades',

--- a/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
+++ b/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
@@ -21,6 +21,9 @@ export default function globalSiteSidebarMenu( {
 			url: `/sites`,
 		},
 		{
+			type: 'current-site',
+		},
+		{
 			slug: 'upgrades',
 			title: translate( 'Plans' ),
 			type: 'menu-item',


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/5624

## Proposed Changes

This PR adds back the site card, linking to My Home.

|Before|After|
|-|-|
|<img width="990" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/bd42836b-2306-492f-82a8-42838d5eb42e">|<img width="989" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/f0526922-652a-4e43-9d92-aced2912068c">|


## Testing Instructions

1. Using the Calypso live URL, go to `/home/:site` of an Atomic site with classic admin interface style.
2. Verify that you see the current site information in the sidebar as shown above.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?