### PR TITLE
GitHub deployments: connect "create new repository" UI

### DIFF
--- a/client/my-sites/github-deployments/components/accounts-dropdown/use-live-accounts.ts
+++ b/client/my-sites/github-deployments/components/accounts-dropdown/use-live-accounts.ts
@@ -16,7 +16,7 @@ const POPUP_ID = 'github-app-authorize';
 
 export const useLiveAccounts = ( { initialAccountId }: UseLiveAccountsParameters ) => {
 	const { __ } = useI18n();
-	const { data: accounts = [], refetch } = useGithubAccountsQuery();
+	const { data: accounts = [], refetch, isLoading: isLoadingAccounts } = useGithubAccountsQuery();
 	const dispatch = useDispatch();
 
 	const [ account, setAccount ] = useState< GitHubAccountData | undefined >( () => {
@@ -64,5 +64,6 @@ export const useLiveAccounts = ( { initialAccountId }: UseLiveAccountsParameters
 		onNewInstallationRequest,
 		setAccount,
 		accounts,
+		isLoadingAccounts,
 	};
 };

--- a/client/my-sites/github-deployments/components/repositories/browse-repositories.tsx
+++ b/client/my-sites/github-deployments/components/repositories/browse-repositories.tsx
@@ -1,11 +1,16 @@
-import { Card } from '@automattic/components';
+import page from '@automattic/calypso-router';
+import { Card, Button } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { ComponentProps, useState } from 'react';
+import { createRepositoryPage } from 'calypso/my-sites/github-deployments/routes';
+import { useSelector } from 'calypso/state/index';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors/index';
 import { GitHubAccountsDropdown } from '../accounts-dropdown';
 import { useLiveAccounts } from '../accounts-dropdown/use-live-accounts';
 import { GitHubLoadingPlaceholder } from '../loading-placeholder';
 import { GitHubBrowseRepositoriesList } from './repository-list';
 import { SearchRepos } from './search-repos';
+
 import './style.scss';
 
 type GitHubBrowseRepositoriesProps = {
@@ -16,12 +21,18 @@ export const GitHubBrowseRepositories = ( {
 	initialInstallationId,
 	onSelectRepository,
 }: GitHubBrowseRepositoriesProps ) => {
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
 	const { __ } = useI18n();
 	const { account, setAccount, accounts, onNewInstallationRequest } = useLiveAccounts( {
 		initialAccountId: initialInstallationId,
 	} );
 
 	const [ query, setQuery ] = useState( '' );
+
+	function handleCreateRepository() {
+		page( createRepositoryPage( siteSlug! ) );
+	}
 
 	function handleQueryChange( query: string ) {
 		setQuery( query );
@@ -59,6 +70,9 @@ export const GitHubBrowseRepositories = ( {
 					onChange={ setAccount }
 				/>
 				<SearchRepos value={ query } onChange={ handleQueryChange } />
+				<Button onClick={ handleCreateRepository } css={ { marginLeft: 'auto' } }>
+					{ __( 'Create new repository' ) }
+				</Button>
 			</div>
 			{ renderContent() }
 		</div>

--- a/client/my-sites/github-deployments/components/repositories/create-repository/create-repository-form.tsx
+++ b/client/my-sites/github-deployments/components/repositories/create-repository/create-repository-form.tsx
@@ -1,24 +1,55 @@
-import { FormLabel, SelectDropdown } from '@automattic/components';
-import { Button, FormToggle } from '@wordpress/components';
+import { FormLabel } from '@automattic/components';
+import { Button, FormToggle, Spinner } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormRadiosBar from 'calypso/components/forms/form-radios-bar';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import { FormRadioWithTemplateSelect } from './form-radio-with-template-select';
+import { GitHubAccountsDropdown } from 'calypso/my-sites/github-deployments/components/accounts-dropdown/index';
+import { useLiveAccounts } from 'calypso/my-sites/github-deployments/components/accounts-dropdown/use-live-accounts';
+import {
+	FormRadioWithTemplateSelect,
+	ProjectType,
+	RepositoryTemplate,
+} from './form-radio-with-template-select';
+import { repositoryTemplates } from './templates';
+import { MutationVariables } from './use-create-code-deployment-and-repository';
+
 import './style.scss';
 
 type CreateRepositoryFormProps = {
-	onRepositoryCreated?: () => void;
+	onRepositoryCreated( args: MutationVariables ): void;
 };
 
 export const CreateRepositoryForm = ( { onRepositoryCreated }: CreateRepositoryFormProps ) => {
 	const { __ } = useI18n();
+	const {
+		account,
+		setAccount,
+		accounts = [],
+		onNewInstallationRequest,
+		isLoadingAccounts,
+	} = useLiveAccounts( {} );
+	const [ repositoryName, setRepositoryName ] = useState( '' );
+	const [ type, setType ] = useState< ProjectType >( 'plugin' );
+	const [ isPrivate, setIsPrivate ] = useState( true );
+	const [ isAutomated, setIsAutomated ] = useState( false );
+	const [ template, setTemplate ] = useState< RepositoryTemplate >(
+		repositoryTemplates.plugin[ 0 ]
+	);
 
-	const [ selected, setSelected ] = useState( '' );
+	const isFormValid = repositoryName.trim() && ! isLoadingAccounts;
 
 	const handleCreateRepository = () => {
-		onRepositoryCreated?.();
+		const repositoryAccount = account || accounts[ 0 ];
+		onRepositoryCreated( {
+			installationId: repositoryAccount.external_id,
+			template: template.value,
+			accountName: repositoryAccount.account_name,
+			repositoryName,
+			isPrivate,
+			isAutomated,
+		} );
 	};
 
 	return (
@@ -27,72 +58,90 @@ export const CreateRepositoryForm = ( { onRepositoryCreated }: CreateRepositoryF
 				<div className="repository-name-formfieldset">
 					<FormFieldset style={ { flex: 0.5 } }>
 						<FormLabel htmlFor="githubAccount">{ __( 'Github account' ) }</FormLabel>
-						<SelectDropdown
-							id="githubAccount"
-							options={ [
-								{ label: 'Account 1', value: 'account1' },
-								{ label: 'Account 2', value: 'account2' },
-							] }
-						/>
+						{ isLoadingAccounts ? (
+							<Spinner />
+						) : (
+							<GitHubAccountsDropdown
+								onAddAccount={ onNewInstallationRequest }
+								accounts={ accounts }
+								value={ account || accounts[ 0 ] }
+								onChange={ setAccount }
+							/>
+						) }
 					</FormFieldset>
 					<FormFieldset style={ { flex: 1 } }>
 						<FormLabel htmlFor="repoName">{ __( 'Repository name' ) }</FormLabel>
-						<FormTextInput id="repoName" placeholder="my-amazing-project" />
+						<FormTextInput
+							id="repoName"
+							placehlder={ __( 'Repository name' ) }
+							value={ repositoryName }
+							onChange={ ( event: ChangeEvent< HTMLInputElement > ) =>
+								setRepositoryName( event.currentTarget.value )
+							}
+						/>
 					</FormFieldset>
 				</div>
 				<FormFieldset>
 					<FormLabel htmlFor="deploy">{ __( 'Privacy' ) }</FormLabel>
 					<div className="deploy-toggle">
-						<FormToggle id="deploy" checked={ false } onChange={ () => {} } />
+						<FormToggle
+							id="deploy"
+							checked={ isPrivate }
+							onChange={ () => setIsPrivate( ! isPrivate ) }
+						/>
 						<p style={ { margin: '0', marginLeft: '8px' } }>
 							{ __( 'Create private repository' ) }
 						</p>
 					</div>
 				</FormFieldset>
-				<FormFieldset>
+				<FormFieldset className="github-deployments-create-repository__project-type">
 					<FormLabel>{ __( 'What are you building ' ) }</FormLabel>
+					<FormRadioWithTemplateSelect
+						label={ __( 'A plugin' ) }
+						projectType="plugin"
+						isChecked={ type === 'plugin' }
+						onChange={ () => {
+							setType( 'plugin' );
+							setTemplate( repositoryTemplates.plugin[ 0 ] );
+						} }
+						onTemplateSelected={ setTemplate }
+						template={ template }
+					/>
 					<FormRadioWithTemplateSelect
 						label={ __( 'A theme' ) }
 						projectType="theme"
-						isChecked={ selected === 'theme' }
+						isChecked={ type === 'theme' }
 						onChange={ () => {
-							setSelected( 'theme' );
+							setType( 'theme' );
+							setTemplate( repositoryTemplates.theme[ 0 ] );
 						} }
-						onTemplateSelected={ () => {} }
+						onTemplateSelected={ setTemplate }
+						template={ template }
 					/>
 					<FormRadioWithTemplateSelect
-						style={ { marginTop: '8px' } }
-						label={ __( 'A plugin' ) }
-						projectType="plugin"
-						isChecked={ selected === 'plugin' }
-						onChange={ () => {
-							setSelected( 'plugin' );
-						} }
-						onTemplateSelected={ () => {} }
-					/>
-					<FormRadioWithTemplateSelect
-						style={ { marginTop: '8px' } }
 						label={ __( 'A site' ) }
 						projectType="site"
-						isChecked={ selected === 'site' }
+						isChecked={ type === 'site' }
 						onChange={ () => {
-							setSelected( 'site' );
+							setType( 'site' );
+							setTemplate( repositoryTemplates.site[ 0 ] );
 						} }
-						onTemplateSelected={ () => {} }
+						onTemplateSelected={ setTemplate }
+						template={ template }
 					/>
-				</FormFieldset>
-				<FormFieldset>
-					<FormLabel htmlFor="directory">{ __( 'Destination directory' ) }</FormLabel>
-					<FormTextInput id="directory" placeholder="/" />
 				</FormFieldset>
 				<FormFieldset>
 					<FormLabel htmlFor="deploy">{ __( 'Automatic deploys' ) }</FormLabel>
 					<div className="deploy-toggle">
-						<FormToggle id="deploy" checked={ true } onChange={ () => {} } />
+						<FormToggle
+							id="deploy"
+							checked={ isAutomated }
+							onChange={ () => setIsAutomated( ! isAutomated ) }
+						/>
 						<p style={ { margin: '0', marginLeft: '8px' } }>{ __( 'Deploy changes on push ' ) }</p>
 					</div>
 				</FormFieldset>
-				<Button variant="primary" onClick={ handleCreateRepository }>
+				<Button variant="primary" disabled={ ! isFormValid } onClick={ handleCreateRepository }>
 					{ __( 'Create repository' ) }
 				</Button>
 			</form>

--- a/client/my-sites/github-deployments/components/repositories/create-repository/form-radio-with-template-select.tsx
+++ b/client/my-sites/github-deployments/components/repositories/create-repository/form-radio-with-template-select.tsx
@@ -6,18 +6,19 @@ import FormRadio from 'calypso/components/forms/form-radio';
 import FormSelect from 'calypso/components/forms/form-select';
 import { getRepositoryTemplate } from './templates';
 
-type ProjectType = 'theme' | 'plugin' | 'site';
+export type ProjectType = 'theme' | 'plugin' | 'site';
 
 type FormRadioWithTemplateSelectProps = {
 	isChecked?: boolean;
 	label: string;
 	projectType: ProjectType;
 	onChange?: () => void;
-	onTemplateSelected?: ( template?: RepositoryTemplate ) => void;
+	onTemplateSelected: ( template: RepositoryTemplate ) => void;
+	template: RepositoryTemplate;
 	rest?: [ string, string ];
 } & React.HTMLProps< HTMLDivElement >;
 
-type RepositoryTemplate = {
+export type RepositoryTemplate = {
 	name: string;
 	value: string;
 	link: string;
@@ -29,12 +30,12 @@ export const FormRadioWithTemplateSelect = ( {
 	projectType,
 	onTemplateSelected,
 	onChange,
-	...rest
+	template,
 }: FormRadioWithTemplateSelectProps ) => {
 	const { __ } = useI18n();
 
 	const [ checked, setChecked ] = useState< boolean >( isChecked );
-	const [ selectedTemplate, setSelectedTemplate ] = useState< RepositoryTemplate | undefined >();
+	const [ selectedTemplate, setSelectedTemplate ] = useState< RepositoryTemplate >( template );
 
 	useEffect( () => {
 		setChecked( isChecked );
@@ -46,8 +47,10 @@ export const FormRadioWithTemplateSelect = ( {
 		const selectedTemplate = templates?.find(
 			( template: { value: string } ) => template.value === selectedValue
 		);
-		setSelectedTemplate( selectedTemplate );
-		onTemplateSelected?.( selectedTemplate );
+		if ( selectedTemplate ) {
+			setSelectedTemplate( selectedTemplate );
+			onTemplateSelected( selectedTemplate );
+		}
 	};
 
 	return (
@@ -55,7 +58,6 @@ export const FormRadioWithTemplateSelect = ( {
 			className={ classNames( 'form-radio__container', {
 				checked: checked,
 			} ) }
-			{ ...rest }
 		>
 			<FormRadio
 				checked={ checked }

--- a/client/my-sites/github-deployments/components/repositories/create-repository/index.tsx
+++ b/client/my-sites/github-deployments/components/repositories/create-repository/index.tsx
@@ -3,10 +3,26 @@ import ActionPanel from 'calypso/components/action-panel';
 import ActionPanelBody from 'calypso/components/action-panel/body';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
+import { useSelector } from 'calypso/state/index';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors/index';
 import { CreateRepositoryForm } from './create-repository-form';
+import {
+	MutationVariables,
+	useCreateCodeDeploymentAndRepository,
+} from './use-create-code-deployment-and-repository';
 import './style.scss';
+
 export const CreateRepository = () => {
 	const { __ } = useI18n();
+	const siteId = useSelector( getSelectedSiteId );
+
+	const { createDeploymentAndRepository } = useCreateCodeDeploymentAndRepository(
+		siteId as number
+	);
+
+	function handleCreateRepository( args: MutationVariables ) {
+		createDeploymentAndRepository( args );
+	}
 
 	return (
 		<Main fullWidthLayout>
@@ -15,7 +31,7 @@ export const CreateRepository = () => {
 			</HeaderCake>
 			<ActionPanel>
 				<ActionPanelBody>
-					<CreateRepositoryForm onRepositoryCreated={ () => {} } />
+					<CreateRepositoryForm onRepositoryCreated={ handleCreateRepository } />
 				</ActionPanelBody>
 			</ActionPanel>
 		</Main>

--- a/client/my-sites/github-deployments/components/repositories/create-repository/style.scss
+++ b/client/my-sites/github-deployments/components/repositories/create-repository/style.scss
@@ -5,6 +5,10 @@
 	gap: 24px;
 	color: var(--color-primary);
 
+	.form-label {
+		font-weight: 500;
+	}
+
 	.repository-name-formfieldset {
 		display: flex;
 		flex-direction: row;
@@ -28,6 +32,12 @@
 	.form-radio__container.checked .form-radio {
 		border: 1px solid var(--color-accent);
 		color: var(--color-accent);
+	}
+
+	&__project-type {
+		.form-radio__container:not(:first-child) {
+			margin-top: 8px;
+		}
 	}
 
 	.form-radio__container {

--- a/client/my-sites/github-deployments/components/repositories/create-repository/templates.ts
+++ b/client/my-sites/github-deployments/components/repositories/create-repository/templates.ts
@@ -1,26 +1,4 @@
-const REPOSITORY_TEMPLATES = {
-	theme: [
-		{
-			name: 'Underscores',
-			value: 'underscores',
-			link: 'https://underscores.me/',
-		},
-		{
-			name: 'Timber',
-			value: 'timber',
-			link: 'https://timber.github.io/docs/',
-		},
-		{
-			name: 'Sage',
-			value: 'sage',
-			link: 'https://roots.io/sage/docs/',
-		},
-		{
-			name: 'Understrap',
-			value: 'understrap',
-			link: 'https://understrap.com/',
-		},
-	],
+export const repositoryTemplates = {
 	plugin: [
 		{
 			name: 'WordPress Plugin Boilerplate',
@@ -41,6 +19,28 @@ const REPOSITORY_TEMPLATES = {
 			name: 'Team51',
 			value: 'team51',
 			link: 'https://example.com',
+		},
+	],
+	theme: [
+		{
+			name: 'Underscores',
+			value: 'underscores',
+			link: 'https://underscores.me/',
+		},
+		{
+			name: 'Timber',
+			value: 'timber',
+			link: 'https://timber.github.io/docs/',
+		},
+		{
+			name: 'Sage',
+			value: 'githubdeployments-theme-template3',
+			link: 'https://roots.io/sage/docs/',
+		},
+		{
+			name: 'Understrap',
+			value: 'understrap',
+			link: 'https://understrap.com/',
 		},
 	],
 	site: [
@@ -67,6 +67,8 @@ const REPOSITORY_TEMPLATES = {
 	],
 };
 
-export const getRepositoryTemplate = ( projectType: keyof typeof REPOSITORY_TEMPLATES ) => {
-	return REPOSITORY_TEMPLATES[ projectType ];
+export const defaultTemplate = repositoryTemplates.plugin[ 0 ];
+
+export const getRepositoryTemplate = ( projectType: keyof typeof repositoryTemplates ) => {
+	return repositoryTemplates[ projectType ];
 };

--- a/client/my-sites/github-deployments/components/repositories/create-repository/use-create-code-deployment-and-repository.ts
+++ b/client/my-sites/github-deployments/components/repositories/create-repository/use-create-code-deployment-and-repository.ts
@@ -1,0 +1,71 @@
+import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import wp from 'calypso/lib/wp';
+import { GITHUB_DEPLOYMENTS_QUERY_KEY } from 'calypso/my-sites/github-deployments/constants';
+import { CODE_DEPLOYMENTS_QUERY_KEY } from 'calypso/my-sites/github-deployments/deployments/use-code-deployments-query';
+
+export interface MutationVariables {
+	installationId: number;
+	template: string;
+	accountName: string;
+	repositoryName: string;
+	isPrivate?: boolean;
+	isAutomated?: boolean;
+}
+
+interface MutationResponse {
+	message: string;
+}
+
+interface MutationError {
+	code: string;
+	message: string;
+}
+
+export const useCreateCodeDeploymentAndRepository = (
+	siteId: number,
+	options: UseMutationOptions< MutationResponse, MutationError, MutationVariables > = {}
+) => {
+	const queryClient = useQueryClient();
+	const mutation = useMutation( {
+		mutationFn: async ( {
+			template,
+			installationId,
+			accountName,
+			repositoryName,
+			isPrivate,
+			isAutomated,
+		}: MutationVariables ) =>
+			wp.req.post(
+				{
+					path: `/hosting/github/repositories`,
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					template,
+					installation_id: installationId,
+					account_name: accountName,
+					repository_name: repositoryName,
+					is_private: isPrivate,
+					is_automated: isAutomated,
+					blog_id: siteId,
+				}
+			),
+		...options,
+		onSuccess: async ( ...args ) => {
+			await queryClient.invalidateQueries( {
+				queryKey: [ GITHUB_DEPLOYMENTS_QUERY_KEY, CODE_DEPLOYMENTS_QUERY_KEY, siteId ],
+			} );
+			options.onSuccess?.( ...args );
+		},
+	} );
+
+	const { mutateAsync, isPending } = mutation;
+
+	const createDeploymentAndRepository = useCallback(
+		( args: MutationVariables ) => mutateAsync( args ),
+		[ mutateAsync ]
+	);
+
+	return { createDeploymentAndRepository, isPending };
+};

--- a/client/my-sites/github-deployments/controller.tsx
+++ b/client/my-sites/github-deployments/controller.tsx
@@ -1,5 +1,6 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { PageViewTracker } from 'calypso/lib/analytics/page-view-tracker';
+import { CreateRepository } from 'calypso/my-sites/github-deployments/components/repositories/create-repository/index';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -53,6 +54,20 @@ export const deploymentManagement: Callback = ( context, next ) => {
 				delay={ 500 }
 			/>
 			<GitHubDeploymentManagement codeDeploymentId={ codeDeploymentId } />
+		</>
+	);
+	next();
+};
+
+export const createNewRepository: Callback = ( context, next ) => {
+	context.primary = (
+		<>
+			<PageViewTracker
+				path="/github-deployments/:site/create-new-repository"
+				title="Create Repository"
+				delay={ 500 }
+			/>
+			<CreateRepository />
 		</>
 	);
 	next();

--- a/client/my-sites/github-deployments/index.ts
+++ b/client/my-sites/github-deployments/index.ts
@@ -6,6 +6,7 @@ import {
 	deploymentsList,
 	deploymentCreation,
 	deploymentManagement,
+	createNewRepository,
 } from './controller';
 
 export default function () {
@@ -36,6 +37,16 @@ export default function () {
 		redirectHomeIfIneligible,
 		navigation,
 		deploymentManagement,
+		makeLayout,
+		clientRender
+	);
+
+	page(
+		'/github-deployments/:site/create-new-repository',
+		siteSelection,
+		redirectHomeIfIneligible,
+		navigation,
+		createNewRepository,
 		makeLayout,
 		clientRender
 	);

--- a/client/my-sites/github-deployments/routes.ts
+++ b/client/my-sites/github-deployments/routes.ts
@@ -1,15 +1,19 @@
 import { addQueryArgs } from 'calypso/lib/url';
 
-interface CreateRepositoryRouteParams {
+interface CreateDeploymentRouteParams {
 	installationId?: number;
 	repositoryId?: number;
+}
+
+interface CreateNewRepositoryRouteParams {
+	installationId?: number;
 }
 
 export const indexPage = ( siteSlug: string ) => `/github-deployments/${ siteSlug }`;
 
 export const createDeploymentPage = (
 	siteSlug: string,
-	{ installationId, repositoryId }: CreateRepositoryRouteParams = {}
+	{ installationId, repositoryId }: CreateDeploymentRouteParams = {}
 ) => {
 	return addQueryArgs(
 		{ installation_id: installationId, repository_id: repositoryId },
@@ -19,4 +23,14 @@ export const createDeploymentPage = (
 
 export const manageDeploymentPage = ( siteSlug: string, deploymentId: number ) => {
 	return `${ indexPage( siteSlug ) }/manage/${ deploymentId }`;
+};
+
+export const createRepositoryPage = (
+	siteSlug: string,
+	{ installationId }: CreateNewRepositoryRouteParams = {}
+) => {
+	return addQueryArgs(
+		{ installation_id: installationId },
+		`${ indexPage( siteSlug ) }/create-new-repository`
+	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5253

<img width="1212" alt="Screenshot 2567-02-15 at 17 52 15" src="https://github.com/Automattic/wp-calypso/assets/6851384/75444740-662d-4394-9ec4-2e00efe37d45">



## Proposed Changes

* Adds "Create new repository" button to the repositories view
* Finished most of the remaining stuff to get it working
* TODO back button, navigation on success, notice for error/success

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D138123-code
* Go to `/github-deployments/:site`
* Choose "connect repository" if you already have some deployments set up
* Click "Create new repository"
* Add a name
* Choose "Plugin" and "Sage" which is the only one set up currenty
* Hit "Create repository"
* Confirm payload looks ok
* The repo won't be created. I tried to debug D138123-code but couldn't. There is a problem fetching the zip of the template repo

Most things should be working but "Back" is not. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?