### PR TITLE
Site Transfers: Verify ownership status before redirecting user to confirmation page

### DIFF
--- a/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
@@ -6,21 +6,21 @@ import ActionPanel from 'calypso/components/action-panel';
 import Main from 'calypso/components/main';
 import { navigate } from 'calypso/lib/navigate';
 import { acceptInvite } from 'calypso/state/invites/actions';
-import { useEffect } from '@wordpress/element';
 import wpcom from 'calypso/lib/wp';
 import normalizeInvite from 'calypso/my-sites/invites/invite-accept/utils/normalize-invite';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import DocumentHead from 'calypso/components/data/document-head';
 import { Global, css } from '@emotion/react';
 import MasterbarStyled from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Notice from 'calypso/components/notice';
 import { useInterval } from 'calypso/lib/interval';
 import { requestSite } from 'calypso/state/sites/actions';
 import { useSelector } from 'react-redux';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import * as React from 'react';
+import { PageViewTracker } from 'calypso/lib/analytics/page-view-tracker';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
 
 const ActionPanelStyled = styled( ActionPanel )( {
 	fontSize: '14px',
@@ -68,6 +68,13 @@ export function AcceptSiteTransfer( props: any ) {
 		},
 		[ dispatch, translate ]
 	);
+
+	// set the selected site id
+	useEffect( () => {
+		if ( site ) {
+			dispatch( setSelectedSiteId( site.ID ) );
+		}
+	}, [ site, dispatch ] );
 
 	// attempt to accept the invite
 	useEffect( () => {
@@ -141,6 +148,10 @@ export function AcceptSiteTransfer( props: any ) {
 	return (
 		<>
 			<DocumentHead title={ translate( 'Site Transfer' ) } />
+			<PageViewTracker
+				path="/settings/settings/site-transfer/:site"
+				title="Marketplace > Thank you"
+			/>
 			<Global
 				styles={ css`
 					body.is-section-settings,

--- a/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
@@ -41,7 +41,7 @@ export function AcceptSiteTransfer( props: any ) {
 	const userId = useSelector( ( state: object ) => getCurrentUserId( state ) );
 
 	const [ error, setError ] = useState< string | React.ReactNode >( '' );
-	const [ inviteAccepted, setInviteAccepted ] = useState< boolean >( true );
+	const [ inviteAccepted, setInviteAccepted ] = useState< boolean >( false );
 	const [ currentAttempt, setCurrentAttempt ] = React.useState( 0 );
 
 	const isSiteOwner = site && site.site_owner === userId;

--- a/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
@@ -40,7 +40,7 @@ export function AcceptSiteTransfer( props: any ) {
 	const userId = useSelector( ( state: object ) => getCurrentUserId( state ) );
 
 	const [ error, setError ] = useState< string | React.ReactNode >( '' );
-	const [ inviteAccepted, setInviteAccepted ] = useState< boolean >( true );
+	const [ inviteAccepted, setInviteAccepted ] = useState< boolean >( false );
 	const [ currentAttempt, setCurrentAttempt ] = useState< number >( 0 );
 
 	const isSiteOwner = site && site.site_owner === userId;

--- a/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
@@ -42,7 +42,7 @@ export function AcceptSiteTransfer( props: any ) {
 
 	const [ error, setError ] = useState< string | React.ReactNode >( '' );
 	const [ inviteAccepted, setInviteAccepted ] = useState< boolean >( false );
-	const [ currentAttempt, setCurrentAttempt ] = React.useState( 0 );
+	const [ currentAttempt, setCurrentAttempt ] = useState< number >( 0 );
 
 	const isSiteOwner = site && site.site_owner === userId;
 

--- a/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
@@ -114,7 +114,7 @@ export function AcceptSiteTransfer( props: any ) {
 	useInterval(
 		async () => {
 			dispatch( requestSite( props.siteId ) );
-			setCurrentAttempt( ( step ) => step + 1 );
+			setCurrentAttempt( ( attempt ) => attempt + 1 );
 		},
 		inviteAccepted && ! isSiteOwner && ! error ? 3000 : null
 	);

--- a/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
@@ -80,7 +80,7 @@ export function AcceptSiteTransfer( props: any ) {
 	useEffect( () => {
 		let redirect = props.redirectTo ?? null;
 
-		// If the redirect is not set and site is not set, redirect to the usual confirmation page
+		// If the redirect is not set and site is set, redirect to the usual confirmation page
 		if ( ! redirect && site ) {
 			redirect = '/settings/site-transferred/' + site.slug;
 		}

--- a/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
@@ -1,24 +1,22 @@
-/* eslint-disable prettier/prettier */
-/* eslint-disable import/order */
+import { Global, css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
-import ActionPanel from 'calypso/components/action-panel';
-import Main from 'calypso/components/main';
-import { navigate } from 'calypso/lib/navigate';
-import { acceptInvite } from 'calypso/state/invites/actions';
-import wpcom from 'calypso/lib/wp';
-import normalizeInvite from 'calypso/my-sites/invites/invite-accept/utils/normalize-invite';
-import { LoadingBar } from 'calypso/components/loading-bar';
-import DocumentHead from 'calypso/components/data/document-head';
-import { Global, css } from '@emotion/react';
-import MasterbarStyled from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled';
 import { useCallback, useEffect, useState } from 'react';
+import ActionPanel from 'calypso/components/action-panel';
+import DocumentHead from 'calypso/components/data/document-head';
+import { LoadingBar } from 'calypso/components/loading-bar';
+import Main from 'calypso/components/main';
 import Notice from 'calypso/components/notice';
 import { useInterval } from 'calypso/lib/interval';
-import { requestSite } from 'calypso/state/sites/actions';
-import { useSelector } from 'react-redux';
-import { getSite } from 'calypso/state/sites/selectors';
+import { navigate } from 'calypso/lib/navigate';
+import wpcom from 'calypso/lib/wp';
+import MasterbarStyled from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/masterbar-styled';
+import normalizeInvite from 'calypso/my-sites/invites/invite-accept/utils/normalize-invite';
+import { useSelector } from 'calypso/state';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
+import { acceptInvite } from 'calypso/state/invites/actions';
+import { requestSite } from 'calypso/state/sites/actions';
+import { getSite } from 'calypso/state/sites/selectors';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
@@ -42,7 +40,7 @@ export function AcceptSiteTransfer( props: any ) {
 	const userId = useSelector( ( state: object ) => getCurrentUserId( state ) );
 
 	const [ error, setError ] = useState< string | React.ReactNode >( '' );
-	const [ inviteAccepted, setInviteAccepted ] = useState< boolean >( false );
+	const [ inviteAccepted, setInviteAccepted ] = useState< boolean >( true );
 	const [ currentAttempt, setCurrentAttempt ] = useState< number >( 0 );
 
 	const isSiteOwner = site && site.site_owner === userId;

--- a/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
@@ -42,7 +42,7 @@ export function AcceptSiteTransfer( props: any ) {
 	const userId = useSelector( ( state: object ) => getCurrentUserId( state ) );
 
 	const [ error, setError ] = useState< string | React.ReactNode >( '' );
-	const [ inviteAccepted, setInviteAccepted ] = useState< boolean >( true );
+	const [ inviteAccepted, setInviteAccepted ] = useState< boolean >( false );
 	const [ currentAttempt, setCurrentAttempt ] = useState< number >( 0 );
 
 	const isSiteOwner = site && site.site_owner === userId;

--- a/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
@@ -19,9 +19,8 @@ import { requestSite } from 'calypso/state/sites/actions';
 import { useSelector } from 'react-redux';
 import { getSite } from 'calypso/state/sites/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
-import { PageViewTracker } from 'calypso/lib/analytics/page-view-tracker';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
-import { getSelectedSiteId as setCurrentSideId } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 const ActionPanelStyled = styled( ActionPanel )( {
 	fontSize: '14px',
@@ -38,12 +37,12 @@ export function AcceptSiteTransfer( props: any ) {
 	const progress = 0.15;
 	const maxAttempts = 10;
 
-	const selectedSiteId = useSelector( ( state: object ) => setCurrentSideId( state ) );
+	const selectedSiteId = useSelector( ( state: object ) => getSelectedSiteId( state ) );
 	const site = useSelector( ( state: object ) => getSite( state, props.siteId ) );
 	const userId = useSelector( ( state: object ) => getCurrentUserId( state ) );
 
 	const [ error, setError ] = useState< string | React.ReactNode >( '' );
-	const [ inviteAccepted, setInviteAccepted ] = useState< boolean >( false );
+	const [ inviteAccepted, setInviteAccepted ] = useState< boolean >( true );
 	const [ currentAttempt, setCurrentAttempt ] = useState< number >( 0 );
 
 	const isSiteOwner = site && site.site_owner === userId;
@@ -151,10 +150,6 @@ export function AcceptSiteTransfer( props: any ) {
 	return (
 		<>
 			<DocumentHead title={ translate( 'Site Transfer' ) } />
-			<PageViewTracker
-				path="/settings/settings/site-transfer/:site"
-				title="Marketplace > Thank you"
-			/>
 			<Global
 				styles={ css`
 					body.is-section-settings,

--- a/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
@@ -80,10 +80,12 @@ export function AcceptSiteTransfer( props: any ) {
 	useEffect( () => {
 		let redirect = props.redirectTo ?? null;
 
+		// If the redirect is not set and site is not set, redirect to the usual confirmation page
 		if ( ! redirect && site ) {
 			redirect = '/settings/site-transferred/' + site.slug;
 		}
 
+		// If the redirect is not set, redirect to the /sites page
 		if ( ! redirect ) {
 			redirect = '/sites';
 		}

--- a/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
@@ -76,7 +76,7 @@ export function AcceptSiteTransfer( props: any ) {
 		}
 	}, [ inviteAccepted, fetchAndAcceptInvite, props ] );
 
-	// redirect to the site settings page if the invite was accepted and the user is the site owner
+	// redirect to the site confirmation page if the invite was accepted and the user is the site owner
 	useEffect( () => {
 		let redirect = props.redirectTo ?? null;
 
@@ -95,7 +95,7 @@ export function AcceptSiteTransfer( props: any ) {
 		}
 	}, [ isSiteOwner, site, props ] );
 
-	// show an error message if the invite was not accepted and the user is not the site owner
+	// show an error message if the user is not the site owner
 	useEffect( () => {
 		if ( currentAttempt > maxAttempts ) {
 			setError(

--- a/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
@@ -21,6 +21,7 @@ import { getSite } from 'calypso/state/sites/selectors';
 import { getCurrentUserId } from 'calypso/state/current-user/selectors';
 import { PageViewTracker } from 'calypso/lib/analytics/page-view-tracker';
 import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import { getSelectedSiteId as setCurrentSideId } from 'calypso/state/ui/selectors';
 
 const ActionPanelStyled = styled( ActionPanel )( {
 	fontSize: '14px',
@@ -37,6 +38,7 @@ export function AcceptSiteTransfer( props: any ) {
 	const progress = 0.15;
 	const maxAttempts = 10;
 
+	const selectedSiteId = useSelector( ( state: object ) => setCurrentSideId( state ) );
 	const site = useSelector( ( state: object ) => getSite( state, props.siteId ) );
 	const userId = useSelector( ( state: object ) => getCurrentUserId( state ) );
 
@@ -69,12 +71,13 @@ export function AcceptSiteTransfer( props: any ) {
 		[ dispatch, translate ]
 	);
 
-	// set the selected site id
+	// set the selected site id if it's not set. This is needed to display masterbar correctly.
+	// This is happening because this route does not use `siteSelection` middleware.
 	useEffect( () => {
-		if ( site ) {
+		if ( site && selectedSiteId !== site.ID ) {
 			dispatch( setSelectedSiteId( site.ID ) );
 		}
-	}, [ site, dispatch ] );
+	}, [ selectedSiteId, site, dispatch ] );
 
 	// attempt to accept the invite
 	useEffect( () => {

--- a/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/accept-site-transfer.tsx
@@ -35,7 +35,7 @@ export function AcceptSiteTransfer( props: any ) {
 	const translate = useTranslate();
 	const dispatch = props.dispatch;
 	const progress = 0.15;
-	const maxAttempts = 10; // 1 minute
+	const maxAttempts = 10;
 
 	const site = useSelector( ( state: object ) => getSite( state, props.siteId ) );
 	const userId = useSelector( ( state: object ) => getCurrentUserId( state ) );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/dotcom-forge/issues/5365

## Proposed Changes

* Adds check for ownership status before redirecting user to confirmation page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/settings/site-transfer/{SITE_SLUG}/accept/S5kP9BiMSDQvBF68FjnhO1nB2Vtx2XWd`
* You should if following screen when you visit for the first time. When you don't own a site.
![CleanShot 2024-02-15 at 20 41 38@2x](https://github.com/Automattic/wp-calypso/assets/86406124/99005477-de9a-4c09-962f-3664f7fb1052)
* Change default value of `inviteAccepted` in useState. At some point you should be able to see following when you don't own the site. Open network tab to see its pooling site info. 
![CleanShot 2024-02-15 at 20 43 41@2x](https://github.com/Automattic/wp-calypso/assets/86406124/77b44212-7dde-43e4-9629-4402236dfbee)

* When you own site site, it should redirect you to `settings/site-transferred/{SITE_SLUG}`
![CleanShot 2024-02-15 at 20 45 47@2x](https://github.com/Automattic/wp-calypso/assets/86406124/0d42f054-4605-472a-9c90-eb76537a64d8)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?