### PR TITLE
Congrats pages: Refactor Google Workspace page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -48,6 +48,7 @@ import {
 	domainManagementList,
 	domainManagementTransferInPrecheck,
 } from 'calypso/my-sites/domains/paths';
+import { GoogleWorkspaceSetUpThankYou } from 'calypso/my-sites/email/google-workspace-set-up-thank-you';
 import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
 import TitanSetUpThankYou from 'calypso/my-sites/email/titan-set-up-thank-you';
 import { fetchAtomicTransfer } from 'calypso/state/atomic-transfer/actions';
@@ -87,7 +88,6 @@ import DomainThankYou from './domains/domain-thank-you';
 import EcommercePlanDetails from './ecommerce-plan-details';
 import FailedPurchaseDetails from './failed-purchase-details';
 import CheckoutThankYouFeaturesHeader from './features-header';
-import GoogleAppsDetails from './google-apps-details';
 import CheckoutThankYouHeader from './header';
 import JetpackPlanDetails from './jetpack-plan-details';
 import PersonalPlanDetails from './personal-plan-details';
@@ -576,6 +576,9 @@ export class CheckoutThankYou extends Component<
 		if ( isRefactoredForThankYouV2( this.props ) ) {
 			let pageContent = null;
 			const domainPurchase = getDomainPurchase( purchases );
+			const gSuiteOrExtraLicenseOrGoogleWorkspace = purchases.find(
+				isGSuiteOrExtraLicenseOrGoogleWorkspace
+			);
 
 			if ( wasBulkDomainTransfer ) {
 				pageContent = (
@@ -607,6 +610,10 @@ export class CheckoutThankYou extends Component<
 						domainName={ domainPurchase.meta }
 						isDomainOnlySite={ this.props.domainOnlySiteFlow }
 					/>
+				);
+			} else if ( gSuiteOrExtraLicenseOrGoogleWorkspace ) {
+				pageContent = (
+					<GoogleWorkspaceSetUpThankYou purchase={ gSuiteOrExtraLicenseOrGoogleWorkspace } />
 				);
 			}
 
@@ -1096,9 +1103,6 @@ function PurchaseDetailsWrapper(
 				selectedSite={ props.selectedSite }
 			/>
 		);
-	}
-	if ( purchases.some( isGSuiteOrExtraLicenseOrGoogleWorkspace ) ) {
-		return <GoogleAppsDetails purchases={ purchases } />;
 	}
 	if ( purchases.some( isDomainMapping ) ) {
 		return <DomainMappingDetails domain={ domain } isRootDomainWithUs={ isRootDomainWithUs } />;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/google-workspace-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/google-workspace-product.tsx
@@ -1,0 +1,47 @@
+import { Button } from '@wordpress/components';
+import { useTranslate } from 'i18n-calypso';
+import ThankYouProduct from 'calypso/components/thank-you-v2/product';
+import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
+
+export type ThankYouGoogleWorkspaceProductProps = {
+	productFamily: string;
+	numberOfMailboxesPurchased?: number;
+	domainName: string;
+	siteSlug?: string;
+};
+
+export function ThankYouGoogleWorkspaceProduct( {
+	productFamily,
+	domainName,
+	numberOfMailboxesPurchased,
+	siteSlug,
+}: ThankYouGoogleWorkspaceProductProps ) {
+	const translate = useTranslate();
+	const emailManagementPath = getEmailManagementPath( siteSlug, domainName );
+
+	let details;
+	if ( numberOfMailboxesPurchased && numberOfMailboxesPurchased > 1 ) {
+		details = translate( '%(quantity)s mailboxes for %(domainName)s', {
+			args: { quantity: numberOfMailboxesPurchased, domainName },
+		} );
+	} else {
+		details = translate( 'Mailbox for %(domainName)s', {
+			args: { domainName },
+		} );
+	}
+
+	const actions = [
+		<Button variant="primary" href={ emailManagementPath } key="manage-email">
+			{ translate( 'Manage email' ) }
+		</Button>,
+	];
+
+	return (
+		<ThankYouProduct
+			name={ productFamily }
+			key={ productFamily + domainName }
+			details={ details }
+			actions={ actions }
+		/>
+	);
+}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
@@ -1,4 +1,9 @@
-import { isWpComPlan, isP2Plus, isTitanMail } from '@automattic/calypso-products';
+import {
+	isGSuiteOrExtraLicenseOrGoogleWorkspace,
+	isP2Plus,
+	isTitanMail,
+	isWpComPlan,
+} from '@automattic/calypso-products';
 import { CheckoutThankYouCombinedProps, getFailedPurchases, getPurchases } from '..';
 import {
 	getDomainPurchase,
@@ -28,6 +33,10 @@ export const isRefactoredForThankYouV2 = ( props: CheckoutThankYouCombinedProps 
 	}
 
 	if ( isDomainOnly( purchases ) ) {
+		return true;
+	}
+
+	if ( purchases.some( isGSuiteOrExtraLicenseOrGoogleWorkspace ) ) {
 		return true;
 	}
 

--- a/client/my-sites/email/google-workspace-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/google-workspace-set-up-thank-you/index.tsx
@@ -1,0 +1,89 @@
+import {
+	isGoogleWorkspaceExtraLicence,
+	isGSuiteExtraLicenseProductSlug,
+} from '@automattic/calypso-products';
+import { useTranslate } from 'i18n-calypso';
+import ThankYouV2 from 'calypso/components/thank-you-v2';
+import { getGoogleMailServiceFamily } from 'calypso/lib/gsuite';
+import { CONTACT } from 'calypso/lib/url/support';
+import { ThankYouGoogleWorkspaceProduct } from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/products/google-workspace-product';
+import { useSelector } from 'calypso/state';
+import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import type { ReceiptPurchase } from 'calypso/state/receipts/types';
+
+type GoogleWorkspaceSetUpThankYouProps = {
+	purchase: ReceiptPurchase;
+};
+
+export const GoogleWorkspaceSetUpThankYou = ( { purchase }: GoogleWorkspaceSetUpThankYouProps ) => {
+	const domainName = purchase.meta;
+	const productFamily = getGoogleMailServiceFamily( purchase?.productSlug );
+	const selectedSite = useSelector( getSelectedSite );
+	const translate = useTranslate();
+	const email = useSelector( getCurrentUserEmail );
+
+	const footerDetails = [
+		{
+			key: 'footer-extra-info',
+			title: translate( 'Everything you need to know' ),
+			description: translate( 'Explore our support guides and find an answer to every question.' ),
+			buttonText: translate( 'Explore support resources' ),
+			buttonHref: '/support/',
+		},
+		{
+			key: 'footer-email',
+			title: translate( 'Email questions? We have the answers' ),
+			description: translate(
+				'Explore our comprehensive support guides and find solutions to all your email-related questions.'
+			),
+			buttonText: translate( 'Email support resources' ),
+			buttonHref: '/support/add-email/adding-google-workspace-to-your-site/',
+		},
+	];
+
+	let title;
+	let subtitle;
+
+	if (
+		isGoogleWorkspaceExtraLicence( purchase ) ||
+		isGSuiteExtraLicenseProductSlug( purchase.productSlug )
+	) {
+		title = translate( 'Say hello to your new email address' );
+		subtitle = translate( "All set! Now it's time to update your contact details." );
+	} else {
+		title = translate( 'Congratulations on your purchase!' );
+		subtitle = translate(
+			"{{strong}}Keep an eye on your email to finish setting up your new email addresses.{{/strong}} We are setting up your new Google Workspace users but this process can take several minutes. We will email you at %(email)s with login information once they are ready but if you still haven't received anything after a few hours, do not hesitate to {{link}}contact support{{/link}}.",
+			{
+				components: {
+					strong: <strong />,
+					link: <a href={ CONTACT } rel="noopener noreferrer" target="_blank" />,
+				},
+				args: {
+					email,
+				},
+			}
+		);
+	}
+
+	const products = (
+		<ThankYouGoogleWorkspaceProduct
+			productFamily={ productFamily }
+			domainName={ domainName }
+			siteSlug={ selectedSite?.slug }
+			numberOfMailboxesPurchased={ purchase.newQuantity }
+		/>
+	);
+
+	return (
+		<>
+			<ThankYouV2
+				title={ title }
+				subtitle={ subtitle }
+				products={ products }
+				footerDetails={ footerDetails }
+			/>
+		</>
+	);
+};


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/2727

## Proposed Changes

This is a redesign of Google Workspace congrats page, as part of the project to redesign all congrats pages (pb5gDS-38y-p2).
Design: https://href.li/?https://www.figma.com/file/VLoPHWqcewxNKZYjjkDu3O/?node-id=2887-2591

## Testing Instructions
1. Open `Upgrades` -> `Domains`
2. Purchase domain with Google Workspace subscription
3. Assert that you see the next screen, with product as `Google Workspace For <DOMAIN_NAME>` <br /> ![Screenshot 2024-02-16 at 16 31 35](https://github.com/Automattic/wp-calypso/assets/5598437/a109903f-f46e-4775-8fca-51234d99bea4)
5. Open `Upgrades` -> `Emails`
6. Select your GW subscription from previous steps
7. You should see button `Finish setup`, click on it and proceed
8. After finishing setup the button `Add new mailboxes` should be enabled and click on it
9. Add a few mailboxes and purchase them
10. Assert that you see the same congrats page but with another product info (quantity of mailboxes should be displayed) <br /> ![Screenshot 2024-02-16 at 16 32 13](https://github.com/Automattic/wp-calypso/assets/5598437/999d0548-23bd-4e5f-bac9-9b0142289708)
