### PR TITLE
Change the order direction of the campaigns list in calypso

### DIFF
--- a/client/data/promote-post/use-promote-post-campaigns-query-paged.ts
+++ b/client/data/promote-post/use-promote-post-campaigns-query-paged.ts
@@ -32,7 +32,7 @@ const useCampaignsQueryPaged = (
 	return useInfiniteQuery( {
 		queryKey: [ 'promote-post-campaigns', siteId, searchQueryParams ],
 		queryFn: async ( { pageParam } ) => {
-			const searchCampaignsUrl = `/search/campaigns/site/${ siteId }?order=asc&order_by=post_date&page=${ pageParam }${ searchQueryParams }`;
+			const searchCampaignsUrl = `/search/campaigns/site/${ siteId }?order=desc&order_by=created_at&page=${ pageParam }${ searchQueryParams }`;
 			const resultQuery = await requestDSPHandleErrors< CampaignQueryResult >(
 				siteId,
 				searchCampaignsUrl


### PR DESCRIPTION
Related to #

## Proposed Changes

* We are passing a wrong order direction to the campaigns endpoint. This PR aims to fix it

## Testing Instructions

Go to wordpress.com/advertising
Move to the campaigns list
You should be able to see campaigns ordered correctly by creation date in DESC order


- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
