### PR TITLE
Checkout and Payment Management: Centralize error boundary logging

### DIFF
--- a/client/me/purchases/controller.jsx
+++ b/client/me/purchases/controller.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import i18n, { getLocaleSlug, localize, useTranslate } from 'i18n-calypso';
@@ -11,7 +10,6 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import { makeLayout, render as clientRender } from 'calypso/controller';
 import { useGeoLocationQuery } from 'calypso/data/geo/use-geolocation-query';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { logToLogstash } from 'calypso/lib/logstash';
 import AddNewPaymentMethod from 'calypso/me/purchases/add-new-payment-method';
 import ChangePaymentMethod from 'calypso/me/purchases/manage-purchase/change-payment-method';
 import {
@@ -22,7 +20,7 @@ import {
 } from 'calypso/me/purchases/paths';
 import PurchasesNavigation from 'calypso/me/purchases/purchases-navigation';
 import { useTaxName } from 'calypso/my-sites/checkout/src/hooks/use-country-list';
-import { convertErrorToString } from 'calypso/my-sites/checkout/src/lib/analytics';
+import { logStashLoadErrorEvent } from 'calypso/my-sites/checkout/src/lib/analytics';
 import { getCurrentUserSiteCount } from 'calypso/state/current-user/selectors';
 import CancelPurchase from './cancel-purchase';
 import ConfirmCancelDomain from './confirm-cancel-domain';
@@ -36,16 +34,7 @@ import useVatDetails from './vat-info/use-vat-details';
 function useLogPurchasesError( message ) {
 	return useCallback(
 		( error ) => {
-			logToLogstash( {
-				feature: 'calypso_client',
-				message,
-				severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
-				extra: {
-					env: config( 'env_id' ),
-					type: 'account_level_purchases',
-					message: convertErrorToString( error ),
-				},
-			} );
+			logStashLoadErrorEvent( 'account_level_purchases', error, { message } );
 		},
 		[ message ]
 	);

--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -1,6 +1,5 @@
 import config from '@automattic/calypso-config';
 import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
-import { captureException } from '@automattic/calypso-sentry';
 import { StripeHookProvider } from '@automattic/calypso-stripe';
 import colorStudio from '@automattic/color-studio';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
@@ -16,21 +15,11 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 import CheckoutMain from './src/components/checkout-main';
 import PrePurchaseNotices from './src/components/prepurchase-notices';
-import { convertErrorToString } from './src/lib/analytics';
+import { logStashLoadErrorEvent } from './src/lib/analytics';
 import type { SitelessCheckoutType } from '@automattic/wpcom-checkout';
 
 const logCheckoutError = ( error: Error ) => {
-	captureException( error.cause ? error.cause : error );
-	logToLogstash( {
-		feature: 'calypso_client',
-		message: 'composite checkout load error',
-		severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
-		extra: {
-			env: config( 'env_id' ),
-			type: 'checkout_system_decider',
-			message: convertErrorToString( error ),
-		},
-	} );
+	logStashLoadErrorEvent( 'checkout_system_decider', error );
 };
 
 const CheckoutMainWrapperStyles = styled.div`

--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
@@ -9,7 +8,6 @@ import React, { useState, useEffect, useRef } from 'react';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
-import { logToLogstash } from 'calypso/lib/logstash';
 import { AUTO_RENEWAL } from 'calypso/lib/url/support';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import { getRedirectFromPendingPage } from 'calypso/my-sites/checkout/src/lib/pending-page';
@@ -22,7 +20,7 @@ import { fetchReceipt } from 'calypso/state/receipts/actions';
 import { getReceiptById } from 'calypso/state/receipts/selectors';
 import getOrderTransactionError from 'calypso/state/selectors/get-order-transaction-error';
 import usePurchaseOrder from '../../src/hooks/use-purchase-order';
-import { convertErrorToString } from '../../src/lib/analytics';
+import { logStashLoadErrorEvent } from '../../src/lib/analytics';
 import type { RedirectInstructions } from 'calypso/my-sites/checkout/src/lib/pending-page';
 import type { ReceiptState } from 'calypso/state/receipts/types';
 import type {
@@ -406,16 +404,7 @@ function displayRenewalSuccessNotice( {
 }
 
 const logCheckoutError = ( error: Error ) => {
-	logToLogstash( {
-		feature: 'calypso_client',
-		message: 'checkout pending load error',
-		severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
-		extra: {
-			env: config( 'env_id' ),
-			type: 'checkout_pending',
-			message: convertErrorToString( error ),
-		},
-	} );
+	logStashLoadErrorEvent( 'checkout_pending', error );
 };
 
 export default function CheckoutPendingWrapper( props: CheckoutPendingProps ) {

--- a/client/my-sites/checkout/src/lib/analytics.ts
+++ b/client/my-sites/checkout/src/lib/analytics.ts
@@ -25,7 +25,10 @@ export function logStashLoadErrorEvent(
 	return logStashEvent( 'composite checkout load error', {
 		...additionalData,
 		type: errorType,
-		message: convertErrorToString( error ),
+		message: additionalData.message
+			? String( additionalData.message )
+			: convertErrorToString( error ),
+		errorMessage: convertErrorToString( error ),
 		tags: [ 'checkout-error-boundary' ],
 	} );
 }

--- a/client/my-sites/checkout/src/lib/analytics.ts
+++ b/client/my-sites/checkout/src/lib/analytics.ts
@@ -26,6 +26,7 @@ export function logStashLoadErrorEvent(
 		...additionalData,
 		type: errorType,
 		message: convertErrorToString( error ),
+		tags: [ 'checkout-error-boundary' ],
 	} );
 }
 

--- a/client/my-sites/purchases/billing-history/index.tsx
+++ b/client/my-sites/purchases/billing-history/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { CompactCard } from '@automattic/components';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
@@ -12,7 +11,6 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { logToLogstash } from 'calypso/lib/logstash';
 import { BillingHistoryContent } from 'calypso/me/purchases/billing-history/main';
 import {
 	ReceiptBody,
@@ -20,7 +18,7 @@ import {
 	ReceiptTitle,
 } from 'calypso/me/purchases/billing-history/receipt';
 import titles from 'calypso/me/purchases/titles';
-import { convertErrorToString } from 'calypso/my-sites/checkout/src/lib/analytics';
+import { logStashLoadErrorEvent } from 'calypso/my-sites/checkout/src/lib/analytics';
 import PurchasesNavigation from 'calypso/my-sites/purchases/navigation';
 import { useSelector, useDispatch } from 'calypso/state';
 import { recordGoogleEvent } from 'calypso/state/analytics/actions';
@@ -36,16 +34,7 @@ import './style.scss';
 function useLogBillingHistoryError( message: string ) {
 	return useCallback(
 		( error: Error ) => {
-			logToLogstash( {
-				feature: 'calypso_client',
-				message,
-				severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
-				extra: {
-					env: config( 'env_id' ),
-					type: 'site_level_billing_history',
-					message: convertErrorToString( error ),
-				},
-			} );
+			logStashLoadErrorEvent( 'site_level_billing_history', error, { message } );
 		},
 		[ message ]
 	);

--- a/client/my-sites/purchases/main.tsx
+++ b/client/my-sites/purchases/main.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { CheckoutErrorBoundary } from '@automattic/composite-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
@@ -10,7 +9,6 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { logToLogstash } from 'calypso/lib/logstash';
 import CancelPurchase from 'calypso/me/purchases/cancel-purchase';
 import ConfirmCancelDomain from 'calypso/me/purchases/confirm-cancel-domain';
 import ManagePurchase from 'calypso/me/purchases/manage-purchase';
@@ -23,7 +21,7 @@ import getAvailableConciergeSessions from 'calypso/state/selectors/get-available
 import getConciergeNextAppointment from 'calypso/state/selectors/get-concierge-next-appointment';
 import getConciergeUserBlocked from 'calypso/state/selectors/get-concierge-user-blocked';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import { convertErrorToString } from '../checkout/src/lib/analytics';
+import { logStashLoadErrorEvent } from '../checkout/src/lib/analytics';
 import {
 	getPurchaseListUrlFor,
 	getCancelPurchaseUrlFor,
@@ -37,16 +35,7 @@ import { getChangeOrAddPaymentMethodUrlFor } from './utils';
 function useLogPurchasesError( message: string ) {
 	return useCallback(
 		( error: Error ) => {
-			logToLogstash( {
-				feature: 'calypso_client',
-				message,
-				severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
-				extra: {
-					env: config( 'env_id' ),
-					type: 'site_level_purchases',
-					message: convertErrorToString( error ),
-				},
-			} );
+			logStashLoadErrorEvent( 'site_level_purchases', error, { message } );
 		},
 		[ message ]
 	);

--- a/client/my-sites/purchases/payment-methods/index.tsx
+++ b/client/my-sites/purchases/payment-methods/index.tsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { RazorpayHookProvider } from '@automattic/calypso-razorpay';
 import page from '@automattic/calypso-router';
 import { StripeHookProvider, useStripe } from '@automattic/calypso-stripe';
@@ -16,7 +15,6 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
-import { logToLogstash } from 'calypso/lib/logstash';
 import { getRazorpayConfiguration, getStripeConfiguration } from 'calypso/lib/store-transactions';
 import PaymentMethodLoader from 'calypso/me/purchases/components/payment-method-loader';
 import PaymentMethodSidebar from 'calypso/me/purchases/components/payment-method-sidebar';
@@ -25,7 +23,7 @@ import { PaymentMethodSelectorSubmitButtonContent } from 'calypso/me/purchases/m
 import PaymentMethodList from 'calypso/me/purchases/payment-methods/payment-method-list';
 import titles from 'calypso/me/purchases/titles';
 import { useCreateCreditCard } from 'calypso/my-sites/checkout/src/hooks/use-create-payment-methods';
-import { convertErrorToString } from 'calypso/my-sites/checkout/src/lib/analytics';
+import { logStashLoadErrorEvent } from 'calypso/my-sites/checkout/src/lib/analytics';
 import PurchasesNavigation from 'calypso/my-sites/purchases/navigation';
 import { useDispatch, useSelector } from 'calypso/state';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
@@ -35,16 +33,7 @@ import { getAddNewPaymentMethodUrlFor, getPaymentMethodsUrlFor } from '../paths'
 function useLogPaymentMethodsError( message: string ) {
 	return useCallback(
 		( error: Error ) => {
-			logToLogstash( {
-				feature: 'calypso_client',
-				message,
-				severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
-				extra: {
-					env: config( 'env_id' ),
-					type: 'site_level_payment_methods',
-					message: convertErrorToString( error ),
-				},
-			} );
+			logStashLoadErrorEvent( 'site_level_payment_methods', error, { message } );
 		},
 		[ message ]
 	);


### PR DESCRIPTION
Many places within checkout and in payment management use a `CheckoutErrorBoundary` component, which is a React Error Boundary that catches fatal errors and prevents the page from becoming a blank screen, displaying an error message instead. These boundaries also record the fatal error using logstash so we can be aware of them. However, there are many different functions which do this work and some of them do it differently.

For example, some of these error boundaries also record the error to Sentry (see https://github.com/Automattic/wp-calypso/pull/63634 and https://github.com/Automattic/wp-calypso/pull/79712), but others do not (eg: the post-checkout "pending" page).

This disconnect also makes it difficult to make a change to all such error reporting. For example, it would be nice to have a single tag added to the logs.

## Proposed Changes

In this PR, we change all instances of `CheckoutErrorBoundary` to call `logStashLoadErrorEvent()` which is defined in `/checkout/src/lib/analytics`. That function will serve as the central place to call logstash for each error boundary.

This PR also modifies that function to include a new tag, `'checkout-error-boundary'`, to each message logged.

## Testing Instructions

- First you'll need a site with a complete order and you'll need to find that order ID.
- Apply the following changes on top of this diff to break the pending page redirect:

```diff
diff --git a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
index ef8ccf0e1d1..915805414cc 100644
--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -121,6 +121,7 @@ function isValidOrderId( orderId: number | ':orderId' ): orderId is number {
 }

 function performRedirect( url: string ): void {
+       throw new Error( 'testing error' );
        if ( url.startsWith( '/' ) ) {
                page( url );
                return;
```

- Start up this branch locally.
- Visit http://calypso.localhost:3000/checkout/thank-you/no-site/pending/584725 but replace the ID at the end with your real order ID.
- Open your browser Network traffic console.
- Verify that after loading briefly, the page displays `Sorry, there was an error loading this page.`.
- In the Network traffic console, make sure you see a POST request to `https://public-api.wordpress.com/rest/v1.1/logstash` with an encoded JSON block that contains `feature\":\"calypso_client\",\"message\":\"composite checkout load error\",\"severity\":\"debug\",\"extra\":{\"env\":\"development\",\"type\":\"checkout_pending\",\"message\":\"Error: Sorry, there was an error loading this page.; Cause: Error: testing error;` and also, `\"tags\":[\"checkout-error-boundary\"]`.