### PR TITLE
Jetpack Cloud: Add Atomic sites

### DIFF
--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -13,7 +13,6 @@ import { connect } from 'react-redux';
 import AllSites from 'calypso/blocks/all-sites';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
 import Search from 'calypso/components/search';
-import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import { addQueryArgs } from 'calypso/lib/url';
 import allSitesMenu from 'calypso/my-sites/sidebar/static-data/all-sites-menu';
@@ -323,14 +322,6 @@ export class SiteSelector extends Component {
 		// Eventually, we'll want to filter out domain-only sites at the API boundary instead.
 		sites = sites.filter( ( site ) => ! site?.options?.is_domain_only );
 
-		// For Jetpack Cloud, we filter only wp-admin interface Atomic sites
-		if ( isJetpackCloud() ) {
-			sites = sites.filter( ( site ) => {
-				return (
-					! site?.options?.is_wpcom_atomic || 'wp-admin' === site?.options?.wpcom_admin_interface
-				);
-			} );
-		}
 		return sites;
 	}
 

--- a/client/components/site-selector/index.jsx
+++ b/client/components/site-selector/index.jsx
@@ -13,6 +13,7 @@ import { connect } from 'react-redux';
 import AllSites from 'calypso/blocks/all-sites';
 import SitePlaceholder from 'calypso/blocks/site/placeholder';
 import Search from 'calypso/components/search';
+import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import scrollIntoViewport from 'calypso/lib/scroll-into-viewport';
 import { addQueryArgs } from 'calypso/lib/url';
 import allSitesMenu from 'calypso/my-sites/sidebar/static-data/all-sites-menu';
@@ -322,6 +323,14 @@ export class SiteSelector extends Component {
 		// Eventually, we'll want to filter out domain-only sites at the API boundary instead.
 		sites = sites.filter( ( site ) => ! site?.options?.is_domain_only );
 
+		// For Jetpack Cloud, we filter only wp-admin interface Atomic sites
+		if ( isJetpackCloud() ) {
+			sites = sites.filter( ( site ) => {
+				return (
+					! site?.options?.is_wpcom_atomic || 'wp-admin' === site?.options?.wpcom_admin_interface
+				);
+			} );
+		}
 		return sites;
 	}
 

--- a/client/jetpack-cloud/components/sidebar/site-selector.tsx
+++ b/client/jetpack-cloud/components/sidebar/site-selector.tsx
@@ -56,7 +56,6 @@ const SiteSelector = () => {
 			isJetpackAgencyDashboard={ canAccessJetpackManage }
 			allSitesPath="/dashboard"
 			siteBasePath="/landing"
-			wpcomSiteBasePath="https://wordpress.com/home"
 		/>
 	);
 };

--- a/client/jetpack-cloud/sections/landing/selectors.ts
+++ b/client/jetpack-cloud/sections/landing/selectors.ts
@@ -17,8 +17,8 @@ export const isSiteEligibleForJetpackCloud = ( state: AppState, siteId: number )
 	( isJetpackSite( state, siteId ) ||
 		isBackupPluginActive( state, siteId ) ||
 		isSearchPluginActive( state, siteId ) ) &&
-	( ( ! isSiteAtomic( state, siteId ) && ! isJetpackSiteMultiSite( state, siteId ) ) ||
-		isSiteAtomic( state, siteId ) );
+	( isSiteAtomic( state, siteId ) ||
+		( ! isSiteAtomic( state, siteId ) && ! isJetpackSiteMultiSite( state, siteId ) ) );
 
 export const getLandingPath = ( state: AppState, siteId: number | null ) => {
 	// Landing requires a site ID;

--- a/client/jetpack-cloud/sections/landing/selectors.ts
+++ b/client/jetpack-cloud/sections/landing/selectors.ts
@@ -17,8 +17,8 @@ export const isSiteEligibleForJetpackCloud = ( state: AppState, siteId: number )
 	( isJetpackSite( state, siteId ) ||
 		isBackupPluginActive( state, siteId ) ||
 		isSearchPluginActive( state, siteId ) ) &&
-	! isSiteAtomic( state, siteId ) &&
-	! isJetpackSiteMultiSite( state, siteId );
+	( ( ! isSiteAtomic( state, siteId ) && ! isJetpackSiteMultiSite( state, siteId ) ) ||
+		isSiteAtomic( state, siteId ) );
 
 export const getLandingPath = ( state: AppState, siteId: number | null ) => {
 	// Landing requires a site ID;

--- a/client/jetpack-cloud/sections/landing/test/selectors.js
+++ b/client/jetpack-cloud/sections/landing/test/selectors.js
@@ -8,7 +8,6 @@ import {
 	WPCOM_FEATURES_SCAN,
 	WPCOM_FEATURES_VIDEOPRESS,
 } from '@automattic/calypso-products';
-import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
 import getSiteSlug from 'calypso/state/sites/selectors/get-site-slug';
 import isBackupPluginActive from 'calypso/state/sites/selectors/is-backup-plugin-active';
@@ -165,13 +164,6 @@ describe( 'getLandingPath', () => {
 describe( 'isSiteEligibleForJetpackCloud', () => {
 	beforeEach( () => {
 		jest.resetAllMocks();
-	} );
-
-	it( 'should return false for Atomic sites', () => {
-		isJetpackSite.mockReturnValue( true );
-		isSiteAtomic.mockReturnValue( true );
-
-		expect( isSiteEligibleForJetpackCloud( {}, 0 ) ).toEqual( false );
 	} );
 
 	it( 'should return false for multisites', () => {

--- a/client/state/sites/selectors/get-jetpack-admin-url.js
+++ b/client/state/sites/selectors/get-jetpack-admin-url.js
@@ -1,4 +1,5 @@
 import { format as formatUrl, getUrlParts, getUrlFromParts } from '@automattic/calypso-url';
+import isSiteAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import getSiteAdminPage from './get-site-admin-page';
 import getSiteAdminUrl from './get-site-admin-url';
 
@@ -6,6 +7,9 @@ export default function getJetpackAdminUrl( state, siteId ) {
 	const siteAdminUrl = getSiteAdminUrl( state, siteId );
 	if ( siteAdminUrl === null ) {
 		return undefined;
+	}
+	if ( isSiteAtomic( state, siteId ) ) {
+		return siteAdminUrl;
 	}
 
 	const parts = getUrlParts( siteAdminUrl + 'admin.php' );

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -100,7 +100,7 @@
 		"scan": true,
 		"site-purchases": true
 	},
-	"site_filter": [ "jetpack" ],
+	"site_filter": [ "jetpack", "atomic" ],
 	"theme": "jetpack-cloud",
 	"restricted_me_access": false,
 	"theme_color": "#2fb41f",


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/5445

## Proposed Changes

We want to show Atomic sites on Jetpack Cloud.

- [ ] Atomic sites should show on Site selector.
- [ ] Check wp-admin link (on left sidebar) should link to wp-admin dashboard for Atomic sites.

## Testing Instructions

* Run `yarn start-jetpack-cloud`
* Go to http://jetpack.cloud.localhost:3000/
* You should see your Atomic sites.
* Check if everything is working as expected, and nothing is broken.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?