### PR TITLE
Checkout: Prevent calling window.postMessage in pending page with invalid URL

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/pending/index.tsx
@@ -133,10 +133,11 @@ function performRedirect( url: string ): void {
 // If the current page is in the pop-up, notify to the opener and delay the redirection.
 // Otherwise, do the redirection immediately.
 function notifyAndPerformRedirect(
-	siteSlug: string = '',
+	siteSlug: string | undefined,
 	{ isError, isUnknown, url }: RedirectInstructions
 ): void {
 	if (
+		siteSlug &&
 		sendMessageToOpener( siteSlug, isError || isUnknown ? 'checkoutFailed' : 'checkoutCompleted' )
 	) {
 		window.setTimeout( () => performRedirect( url ), 3000 );

--- a/client/my-sites/checkout/src/lib/leave-checkout.ts
+++ b/client/my-sites/checkout/src/lib/leave-checkout.ts
@@ -38,7 +38,7 @@ export const leaveCheckout = ( {
 	const launchpadURLRegex = /^\/setup\/[a-z][a-z\-_]*[a-z]\/launchpad\b/g;
 	const launchpadURLRegexMatch = redirectToParam?.toString().match( launchpadURLRegex );
 
-	if ( sendMessageToOpener( siteSlug, 'checkoutCancelled' ) ) {
+	if ( siteSlug && sendMessageToOpener( siteSlug, 'checkoutCancelled' ) ) {
 		return;
 	}
 

--- a/client/my-sites/checkout/src/lib/popup.ts
+++ b/client/my-sites/checkout/src/lib/popup.ts
@@ -4,6 +4,16 @@ type MessageAction = 'checkoutCompleted' | 'checkoutFailed' | 'checkoutCancelled
 export const isPopup = () =>
 	typeof window !== 'undefined' && window.opener && window.opener !== window;
 
+function isValidHttpUrl( data: string ): boolean {
+	let url;
+	try {
+		url = new URL( data );
+	} catch ( error ) {
+		return false;
+	}
+	return url.protocol === 'http:' || url.protocol === 'https:';
+}
+
 // Send the message to the opener.
 export const sendMessageToOpener = ( siteSlug: string, action: MessageAction ) => {
 	if ( ! isPopup() ) {
@@ -12,7 +22,11 @@ export const sendMessageToOpener = ( siteSlug: string, action: MessageAction ) =
 	if ( ! siteSlug ) {
 		return false;
 	}
+	const targetOrigin = `https://${ siteSlug }`;
+	if ( ! isValidHttpUrl( targetOrigin ) ) {
+		return false;
+	}
 
-	window.opener.postMessage( { action }, `https://${ siteSlug }` );
+	window.opener.postMessage( { action }, targetOrigin );
 	return true;
 };

--- a/client/my-sites/checkout/src/lib/popup.ts
+++ b/client/my-sites/checkout/src/lib/popup.ts
@@ -27,6 +27,12 @@ export const sendMessageToOpener = ( siteSlug: string, action: MessageAction ) =
 		return false;
 	}
 
-	window.opener.postMessage( { action }, targetOrigin );
+	try {
+		window.opener.postMessage( { action }, targetOrigin );
+	} catch ( error ) {
+		// eslint-disable-next-line no-console
+		console.error( `Sending action '${ action }' to window.opener failed: ${ error }` );
+		return false;
+	}
 	return true;
 };

--- a/client/my-sites/checkout/src/lib/popup.ts
+++ b/client/my-sites/checkout/src/lib/popup.ts
@@ -5,8 +5,11 @@ export const isPopup = () =>
 	typeof window !== 'undefined' && window.opener && window.opener !== window;
 
 // Send the message to the opener.
-export const sendMessageToOpener = ( siteSlug: string = '', action: MessageAction ) => {
+export const sendMessageToOpener = ( siteSlug: string, action: MessageAction ) => {
 	if ( ! isPopup() ) {
+		return false;
+	}
+	if ( ! siteSlug ) {
 		return false;
 	}
 


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/85771 added a special case for the post-checkout "pending" page. When the page detects that the order is complete and the user reached it via a link (which sets the `window.opener` property), it calls `window.opener.postMessage()` with the `targetOrigin` argument set to `https://${siteSlug}`.

However, the siteSlug can easily be empty, undefined, or something else invalid. `postMessage` can also fail for other reasons. This may cause a fatal error that breaks the pending page. See p1707998782039109-slack-C096PD42U for more information on these errors.

## Proposed Changes

In this PR we alter the `window.opener` logic so that it guards against invalid URLs and other fatals that could occur with the `window.opener.postMessage()` call. If there are any problems, the redirect will ignore that call and redirect as normal.

## Testing Instructions

I can't find a way to test this effectively. Static analysis may be the only option.