### PR TITLE
Site Migration: Add a placeholder site migration instructions step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -1,0 +1,38 @@
+import { StepContainer } from '@automattic/onboarding';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+
+const SiteMigrationInstructions: Step = function () {
+	const stepContent = (
+		<div>
+			<p>Site migration instructions go here.</p>
+		</div>
+	);
+
+	return (
+		<>
+			<DocumentHead title="Site migration instructions" />
+			<StepContainer
+				stepName="site-migration-instructions"
+				shouldHideNavButtons={ false }
+				className="is-step-site-migration-instructions"
+				hideSkip={ true }
+				hideBack={ true }
+				isHorizontalLayout
+				formattedHeader={
+					<FormattedHeader
+						id="site-migration-instructions-header"
+						headerText="Site migration instructions"
+						align="left"
+					/>
+				}
+				stepContent={ stepContent }
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		</>
+	);
+};
+
+export default SiteMigrationInstructions;

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -205,4 +205,9 @@ export const STEPS = {
 		slug: 'assignTrialPlan',
 		asyncComponent: () => import( './steps-repository/assign-trial-plan' ),
 	},
+
+	SITE_MIGRATION_INSTRUCTIONS: {
+		slug: 'site-migration-instructions',
+		asyncComponent: () => import( './steps-repository/site-migration-instructions' ),
+	},
 };

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -20,6 +20,7 @@ const siteMigration: Flow = {
 			STEPS.WAIT_FOR_ATOMIC,
 			STEPS.WAIT_FOR_PLUGIN_INSTALL,
 			STEPS.PROCESSING,
+			STEPS.SITE_MIGRATION_INSTRUCTIONS,
 			STEPS.ERROR,
 		];
 	},
@@ -143,8 +144,7 @@ const siteMigration: Flow = {
 					}
 
 					if ( providedDependencies?.pluginsInstalled ) {
-						//@TODO: Send users to the import instructions
-						return exitFlow( `/home/${ siteSlug }` );
+						return navigate( 'site-migration-instructions' );
 					}
 				}
 
@@ -156,6 +156,10 @@ const siteMigration: Flow = {
 
 				case 'waitForPluginInstall': {
 					return navigate( 'processing' );
+				}
+
+				case 'site-migration-instructions': {
+					return exitFlow( `/home/${ siteSlug }` );
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87393

## Proposed Changes

* Adds a new step for site migration instructions that can be used in the site migrations flow.
* There's no content or design here yet.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR and navigate to `/setup/site-migration/site-migration-instructions?flags=onboarding/new-migration-flow` and you should see the following beautiful screen:

<img width="1348" alt="Screenshot 2024-02-15 at 4 12 18 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/802c60ab-a680-4613-b409-22e4942330c7">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?