### PR TITLE
Site Migration: Add test helper to test stepper flows

### DIFF
--- a/client/landing/stepper/declarative-flow/test/helpers/index.tsx
+++ b/client/landing/stepper/declarative-flow/test/helpers/index.tsx
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import React, { useEffect } from 'react';
+import { MemoryRouter, useNavigate, useLocation } from 'react-router';
+import { renderWithProvider } from '../../../../../test-helpers/testing-library';
+import type { Flow } from '../../internals/types';
+
+export const getFlowLocation = () => {
+	return {
+		path: screen.getByTestId( 'pathname' ).textContent,
+		state: JSON.parse( screen.getByTestId( 'state' ).textContent || '{}' ),
+	};
+};
+
+/** Utility to render a flow for testing purposes */
+export const renderFlow = ( flow: Flow ) => {
+	const FakeStepRender = ( { currentStep, dependencies } ) => {
+		const navigate = useNavigate();
+		const location = useLocation();
+		const fakeNavigate = ( pathname, state ) => navigate( pathname, { state } );
+		const { submit } = flow.useStepNavigation( currentStep, fakeNavigate );
+
+		useEffect( () => {
+			if ( submit ) {
+				submit( dependencies );
+			}
+		}, [] );
+
+		return (
+			<>
+				<p data-testid="pathname">{ `${ location.pathname }${ location.search }` }</p>
+				<p data-testid="search">{ location.search }</p>
+				<p data-testid="state">{ JSON.stringify( location.state ) }</p>
+			</>
+		);
+	};
+
+	// The Flow>useStepNavigation>submit function needs to be called from inside a component
+	const runUseStepNavigationSubmit = ( { currentStep, dependencies } ) => {
+		renderWithProvider(
+			<MemoryRouter initialEntries={ [ '/some-path?siteSlug=example.wordpress.com' ] }>
+				<FakeStepRender currentStep={ currentStep } dependencies={ dependencies } />
+			</MemoryRouter>
+		);
+	};
+
+	return {
+		runUseStepNavigationSubmit,
+	};
+};

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+import { renderWithProvider } from '../../../../test-helpers/testing-library';
+import siteMigrationFlow from '../site-migration-flow';
+
+const FakeStepRender = ( { currentStep, navigate, submitParams } ) => {
+	const { submit } = siteMigrationFlow.useStepNavigation( currentStep, navigate );
+
+	if ( submit ) {
+		submit( submitParams );
+	}
+	return null;
+};
+
+describe( 'Site Migration Flow', () => {
+	describe( 'navigation', () => {
+		const render = ( { currentStep, navigate }, submitParams = {} ) => {
+			renderWithProvider(
+				<MemoryRouter initialEntries={ [ '/some-path?siteSlug=example.wordpress.com' ] }>
+					<FakeStepRender
+						currentStep={ currentStep }
+						navigate={ navigate }
+						submitParams={ submitParams }
+					/>
+				</MemoryRouter>
+			);
+		};
+
+		it( 'navigates from import to waitForAtomic', () => {
+			const navigate = jest.fn();
+			render( { currentStep: 'import', navigate } );
+
+			expect( navigate ).toHaveBeenCalledWith( 'waitForAtomic', {
+				siteSlug: 'example.wordpress.com',
+			} );
+		} );
+
+		it( 'navigates from processing to waitForAtomic', () => {
+			const navigate = jest.fn();
+			render( { currentStep: 'waitForAtomic', navigate } );
+
+			expect( navigate ).toHaveBeenCalledWith( 'processing', {
+				currentStep: 'waitForAtomic',
+			} );
+		} );
+
+		it( 'navigates from processing to waitForPlugin when the atomic is ready', () => {
+			const navigate = jest.fn();
+			render( { currentStep: 'processing', navigate }, { finishedWaitingForAtomic: true } );
+
+			expect( navigate ).toHaveBeenCalledWith( 'waitForPluginInstall', {
+				siteSlug: 'example.wordpress.com',
+			} );
+		} );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -6,7 +6,7 @@ import { getFlowLocation, renderFlow } from './helpers';
 
 describe( 'Site Migration Flow', () => {
 	describe( 'navigation', () => {
-		it( 'navigates from import to waitForAtomic', async () => {
+		it( 'redirects from the import page to waitForAtomic page', async () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 
 			runUseStepNavigationSubmit( { currentStep: 'import' } );
@@ -17,7 +17,7 @@ describe( 'Site Migration Flow', () => {
 			} );
 		} );
 
-		it( 'navigates from processing to waitForPluginInstall when atomic is finished', () => {
+		it( 'redirect from the processing page to the waitForPluginInstall when atomic waiting is finished', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 
 			runUseStepNavigationSubmit( {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Add initial tests to cover the site-migration flow navigation.
* Add a utility to test the useStepNavigation method

### Context
Ideally, we should be able to render the whole flow with the steps on our test suite, but the component  `FlowRenderer` relays to a lot of global states, so I am proposition to use a lightweight version to enable us to test our flows without mocks or stubs.

This first version only supports "render" the `Flow>useStepNavigation`.

NOTE: It is just an initial structure, it is not testing all navigation code branches just because I would like to get feedback from the team.

## Testing instructions
- Write a test covering the transition between the 'processing' to the `site-migration-instructions' to see ensure the helper is easy to use. 

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?