### PR TITLE
Add global sidebar to the profile (me) page

### DIFF
--- a/client/layout/global-sidebar/index.jsx
+++ b/client/layout/global-sidebar/index.jsx
@@ -21,11 +21,13 @@ const GlobalSidebar = ( { children, onClick = undefined, className = '', ...prop
 		return <Spinner className="sidebar__menu-loading" />;
 	}
 
+	const { requireBackLink, ...sidebarProps } = props;
+
 	return (
 		<div className="global-sidebar">
 			<div className="sidebar__body">
-				<Sidebar className={ className } { ...props } onClick={ onClick }>
-					{ props.requireBackLink && (
+				<Sidebar className={ className } { ...sidebarProps } onClick={ onClick }>
+					{ requireBackLink && (
 						<div className="sidebar__back-link">
 							<a href="/sites">
 								<Gridicon icon="chevron-left" size={ 24 } />

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -62,12 +62,11 @@ class MeSidebar extends Component {
 	};
 
 	renderGlobalSidebar() {
-		const asyncProps = {
-			placeholder: null,
+		const props = {
 			path: this.props.path,
 			requireBackLink: true,
 		};
-		return <GlobalSidebar { ...asyncProps }>{ this.renderMenu() }</GlobalSidebar>;
+		return <GlobalSidebar { ...props }>{ this.renderMenu() }</GlobalSidebar>;
 	}
 
 	renderSidebar() {

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -4,6 +4,9 @@ import { englishLocales, localizeUrl } from '@automattic/i18n-utils';
 import i18n, { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
+import { withCurrentRoute } from 'calypso/components/route';
+import GlobalSidebar from 'calypso/layout/global-sidebar';
+import { useGlobalSidebar } from 'calypso/layout/global-sidebar/hooks/use-global-sidebar';
 import Sidebar from 'calypso/layout/sidebar';
 import CollapseSidebar from 'calypso/layout/sidebar/collapse-sidebar';
 import SidebarFooter from 'calypso/layout/sidebar/footer';
@@ -19,6 +22,7 @@ import { redirectToLogout } from 'calypso/state/current-user/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { logoutUser } from 'calypso/state/logout/actions';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 import './style.scss';
 import 'calypso/my-sites/sidebar/style.scss'; // Copy styles from the My Sites sidebar.
@@ -57,12 +61,32 @@ class MeSidebar extends Component {
 		this.props.recordGoogleEvent( 'Me', 'Clicked on Sidebar Sign Out Link' );
 	};
 
-	render() {
+	renderGlobalSidebar() {
+		const asyncProps = {
+			placeholder: null,
+			path: this.props.path,
+			requireBackLink: true,
+		};
+		return <GlobalSidebar { ...asyncProps }>{ this.renderMenu() }</GlobalSidebar>;
+	}
+
+	renderSidebar() {
+		const { translate } = this.props;
+		return (
+			<Sidebar>
+				{ this.renderMenu() }
+				<CollapseSidebar title={ translate( 'Collapse menu' ) } icon="dashicons-admin-collapse" />
+				<SidebarFooter />
+			</Sidebar>
+		);
+	}
+
+	renderMenu() {
 		const { context, locale, translate } = this.props;
 		const path = context.path.replace( '/me', '' ); // Remove base path.
 
 		return (
-			<Sidebar>
+			<>
 				<SidebarRegion>
 					<ProfileGravatar inSidebar user={ this.props.currentUser } />
 
@@ -175,21 +199,34 @@ class MeSidebar extends Component {
 						/>
 					</SidebarMenu>
 				</SidebarRegion>
-				<CollapseSidebar title={ translate( 'Collapse menu' ) } icon="dashicons-admin-collapse" />
-				<SidebarFooter />
-			</Sidebar>
+			</>
 		);
+	}
+
+	render() {
+		if ( this.props.shouldShowGlobalSidebar ) {
+			return this.renderGlobalSidebar();
+		}
+		return this.renderSidebar();
 	}
 }
 
-export default connect(
-	( state ) => ( {
-		currentUser: getCurrentUser( state ),
-	} ),
-	{
-		logoutUser,
-		recordGoogleEvent,
-		redirectToLogout,
-		setNextLayoutFocus,
-	}
-)( localize( MeSidebar ) );
+export default withCurrentRoute(
+	connect(
+		( state, { currentSection } ) => {
+			const sectionGroup = currentSection?.group ?? null;
+			const siteId = getSelectedSiteId( state );
+			const { shouldShowGlobalSidebar } = useGlobalSidebar( siteId, sectionGroup );
+			return {
+				currentUser: getCurrentUser( state ),
+				shouldShowGlobalSidebar,
+			};
+		},
+		{
+			logoutUser,
+			recordGoogleEvent,
+			redirectToLogout,
+			setNextLayoutFocus,
+		}
+	)( localize( MeSidebar ) )
+);


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/87454

This adds the global sidebar to the profile page. This sidebar is a simple version to roll out on various pages before we work on the layout/style of the global sidebar.

### Test

* Confirm global sidebar loads (you should see a back link that takes you to the my sites page) on the profile page - https://container-elastic-hawking.calypso.live/me
* Confirm no issues when loading the profile page with the feature flag disabled - https://container-elastic-hawking.calypso.live/me?flags=-layout/dotcom-nav-redesign
