### PR TITLE
Add global sidebar to Reader

### DIFF
--- a/client/layout/global-sidebar/index.jsx
+++ b/client/layout/global-sidebar/index.jsx
@@ -21,11 +21,13 @@ const GlobalSidebar = ( { children, onClick = undefined, className = '', ...prop
 		return <Spinner className="sidebar__menu-loading" />;
 	}
 
+	const { requireBackLink, ...sidebarProps } = props;
+
 	return (
 		<div className="global-sidebar">
 			<div className="sidebar__body">
-				<Sidebar className={ className } { ...props } onClick={ onClick }>
-					{ props.requireBackLink && (
+				<Sidebar className={ className } { ...sidebarProps } onClick={ onClick }>
+					{ requireBackLink && (
 						<div className="sidebar__back-link">
 							<a href="/sites">
 								<Gridicon icon="chevron-left" size={ 24 } />

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -21,11 +21,6 @@
 			display: flex;
 			gap: 6px;
 		}
-		.sidebar__menu:not(.is-togglable) {
-			display: flex;
-			flex-direction: column;
-			gap: 6px;
-		}
 		.sidebar__menu.is-togglable a.sidebar__heading {
 			padding: 8px 8px 8px 20px;
 		}

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -9,6 +9,9 @@ import { connect } from 'react-redux';
 import QueryReaderLists from 'calypso/components/data/query-reader-lists';
 import QueryReaderOrganizations from 'calypso/components/data/query-reader-organizations';
 import QueryReaderTeams from 'calypso/components/data/query-reader-teams';
+import { withCurrentRoute } from 'calypso/components/route';
+import GlobalSidebar from 'calypso/layout/global-sidebar';
+import { useGlobalSidebar } from 'calypso/layout/global-sidebar/hooks/use-global-sidebar';
 import Sidebar from 'calypso/layout/sidebar';
 import SidebarFooter from 'calypso/layout/sidebar/footer';
 import SidebarItem from 'calypso/layout/sidebar/item';
@@ -36,6 +39,7 @@ import {
 import { isListsOpen, isTagsOpen } from 'calypso/state/reader-ui/sidebar/selectors';
 import { getReaderTeams } from 'calypso/state/teams/selectors';
 import { setNextLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ReaderSidebarHelper from './helper';
 import ReaderSidebarPromo from './promo';
 import ReaderSidebarLists from './reader-sidebar-lists';
@@ -145,7 +149,7 @@ export class ReaderSidebar extends Component {
 		this.props.recordReaderTracksEvent( 'calypso_reader_sidebar_manage_subscriptions_clicked' );
 	};
 
-	renderSidebar() {
+	renderSidebarMenu() {
 		const { path, translate, teams, locale } = this.props;
 		const recentLabelTranslationReady = hasTranslation( 'Recent' ) || locale.startsWith( 'en' );
 		return (
@@ -269,12 +273,31 @@ export class ReaderSidebar extends Component {
 		);
 	}
 
-	render() {
+	renderGlobalSidebar() {
+		const asyncProps = {
+			placeholder: null,
+			path: this.props.path,
+			onClick: this.handleClick,
+			requireBackLink: true,
+		};
+		return (
+			<GlobalSidebar { ...asyncProps }>
+				<SidebarRegion>
+					<ReaderSidebarNudges />
+					{ this.renderSidebarMenu() }
+				</SidebarRegion>
+
+				<ReaderSidebarPromo />
+			</GlobalSidebar>
+		);
+	}
+
+	renderSidebar() {
 		return (
 			<Sidebar onClick={ this.handleClick }>
 				<SidebarRegion>
 					<ReaderSidebarNudges />
-					{ this.renderSidebar() }
+					{ this.renderSidebarMenu() }
 				</SidebarRegion>
 
 				<ReaderSidebarPromo />
@@ -283,22 +306,35 @@ export class ReaderSidebar extends Component {
 			</Sidebar>
 		);
 	}
+
+	render() {
+		if ( this.props.shouldShowGlobalSidebar ) {
+			return this.renderGlobalSidebar();
+		}
+		return this.renderSidebar();
+	}
 }
 
-export default connect(
-	( state ) => {
-		return {
-			isListsOpen: isListsOpen( state ),
-			isTagsOpen: isTagsOpen( state ),
-			subscribedLists: getSubscribedLists( state ),
-			teams: getReaderTeams( state ),
-			organizations: getReaderOrganizations( state ),
-		};
-	},
-	{
-		recordReaderTracksEvent,
-		setNextLayoutFocus,
-		toggleListsVisibility: toggleReaderSidebarLists,
-		toggleTagsVisibility: toggleReaderSidebarTags,
-	}
-)( localize( ReaderSidebar ) );
+export default withCurrentRoute(
+	connect(
+		( state, { currentSection } ) => {
+			const sectionGroup = currentSection?.group ?? null;
+			const siteId = getSelectedSiteId( state );
+			const { shouldShowGlobalSidebar } = useGlobalSidebar( siteId, sectionGroup );
+			return {
+				isListsOpen: isListsOpen( state ),
+				isTagsOpen: isTagsOpen( state ),
+				subscribedLists: getSubscribedLists( state ),
+				teams: getReaderTeams( state ),
+				organizations: getReaderOrganizations( state ),
+				shouldShowGlobalSidebar,
+			};
+		},
+		{
+			recordReaderTracksEvent,
+			setNextLayoutFocus,
+			toggleListsVisibility: toggleReaderSidebarLists,
+			toggleTagsVisibility: toggleReaderSidebarTags,
+		}
+	)( localize( ReaderSidebar ) )
+);

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -274,14 +274,13 @@ export class ReaderSidebar extends Component {
 	}
 
 	renderGlobalSidebar() {
-		const asyncProps = {
-			placeholder: null,
+		const props = {
 			path: this.props.path,
 			onClick: this.handleClick,
 			requireBackLink: true,
 		};
 		return (
-			<GlobalSidebar { ...asyncProps }>
+			<GlobalSidebar { ...props }>
 				<SidebarRegion>
 					<ReaderSidebarNudges />
 					{ this.renderSidebarMenu() }


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/87454

This adds the global sidebar to Reader. This sidebar is a simple version to roll out on various pages before we work on the layout/style of the global sidebar.

### Test

* Confirm global sidebar loads (you should see a back link that takes you to the my sites page) on Reader - https://container-hungry-keldysh.calypso.live/read
* Confirm no issues when loading the Reader with the feature flag disabled - https://container-hungry-keldysh.calypso.live/read?flags=-layout/dotcom-nav-redesign
