### PR TITLE
Remove "All Woo Stores powered by WordPress.com" copy in non-NUX screens

### DIFF
--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -423,9 +423,12 @@ class Login extends Component {
 				} else {
 					headerText = <h3>{ translate( "Let's get started" ) }</h3>;
 					const poweredByWpCom =
-						wccomFrom === 'nux'
-							? translate( 'All Woo Express stores are powered by WordPress.com!' )
-							: translate( 'All Woo stores are powered by WordPress.com!' );
+						wccomFrom === 'nux' ? (
+							<>
+								{ translate( 'All Woo Express stores are powered by WordPress.com!' ) }
+								<br />
+							</>
+						) : null;
 					const accountSelectionOrLoginToContinue = this.showContinueAsUser()
 						? translate( "First, select the account you'd like to use." )
 						: translate(
@@ -440,7 +443,6 @@ class Login extends Component {
 					postHeader = (
 						<p className="login__header-subtitle">
 							{ poweredByWpCom }
-							<br />
 							{ accountSelectionOrLoginToContinue }
 						</p>
 					);

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -48,6 +48,7 @@ import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import getPartnerSlugFromQuery from 'calypso/state/selectors/get-partner-slug-from-query';
+import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import isFetchingMagicLoginEmail from 'calypso/state/selectors/is-fetching-magic-login-email';
 import isMagicLoginEmailRequested from 'calypso/state/selectors/is-magic-login-email-requested';
 import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
@@ -883,7 +884,7 @@ export default connect(
 		isJetpackWooCommerceFlow:
 			'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
 		isWooCoreProfilerFlow: isWooCommerceCoreProfilerFlow( state ),
-		wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
+		wccomFrom: getWccomFrom( state ),
 		isAnchorFmSignup: getIsAnchorFmSignup(
 			get( getCurrentQueryArguments( state ), 'redirect_to' )
 		),

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -59,6 +59,7 @@ import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selector
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
+import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 import ErrorNotice from './error-notice';
 import SocialLoginForm from './social';
@@ -946,7 +947,7 @@ export default connect(
 				props.userEmail ||
 				getInitialQueryArguments( state )?.email_address ||
 				getCurrentQueryArguments( state )?.email_address,
-			wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
+			wccomFrom: getWccomFrom( state ),
 			currentQuery: getCurrentQueryArguments( state ),
 		};
 	},

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -57,6 +57,7 @@ import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import { createSocialUserFailed } from 'calypso/state/login/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 import { resetSignup } from 'calypso/state/signup/actions';
 import { getSectionName } from 'calypso/state/ui/selectors';
@@ -1352,7 +1353,7 @@ export default connect(
 				'woocommerce-onboarding' === get( getCurrentQueryArguments( state ), 'from' ),
 			isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
 			from: get( getCurrentQueryArguments( state ), 'from' ),
-			wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
+			wccomFrom: getWccomFrom( state ),
 			isWoo: isWooOAuth2Client( oauth2Client ) || isWooCoreProfilerFlow,
 			isWooCoreProfilerFlow,
 			isP2Flow:

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -25,6 +25,7 @@ import { resetMagicLoginRequestForm } from 'calypso/state/login/magic-login/acti
 import { isPartnerSignupQuery } from 'calypso/state/login/utils';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
+import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 
 export class LoginLinks extends Component {
 	static propTypes = {
@@ -296,7 +297,7 @@ export default connect(
 		isLoggedIn: Boolean( getCurrentUserId( state ) ),
 		query: getCurrentQueryArguments( state ),
 		isJetpackWooCommerceFlow: 'woocommerce-onboarding' === getCurrentQueryArguments( state ).from,
-		wccomFrom: getCurrentQueryArguments( state )[ 'wccom-from' ],
+		wccomFrom: getWccomFrom( state ),
 		isPartnerSignup: isPartnerSignupQuery( getCurrentQueryArguments( state ) ),
 	} ),
 	{

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -220,7 +220,7 @@ export class UserStep extends Component {
 						break;
 					default:
 						subHeaderText = translate(
-							'All Woo stores are powered by WordPress.com!{{br/}}Please create an account to continue. Already registered? {{a}}Log in{{/a}}',
+							'Please create an account to continue. Already registered? {{a}}Log in{{/a}}',
 							{
 								components: {
 									a: <a href={ loginUrl } />,
@@ -233,7 +233,7 @@ export class UserStep extends Component {
 				}
 			} else if ( isWooOAuth2Client( oauth2Client ) && ! wccomFrom ) {
 				subHeaderText = translate(
-					'All Woo stores are powered by WordPress.com!{{br/}}Please create an account to continue. Already registered? {{a}}Log in{{/a}}',
+					'Please create an account to continue. Already registered? {{a}}Log in{{/a}}',
 					{
 						components: {
 							a: <a href={ loginUrl } />,

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -730,19 +730,10 @@ export class UserStep extends Component {
 
 const ConnectedUser = connect(
 	( state ) => {
-		const queryOauth2Redirect = getCurrentQueryArguments( state ).oauth2_redirect;
-		let wccomFrom = null;
-		try {
-			const oauth2RedirectUrl = new URL( queryOauth2Redirect );
-			wccomFrom = oauth2RedirectUrl.searchParams.get( 'wccom-from' );
-		} catch ( e ) {
-			// Do nothing
-		}
-
 		return {
 			oauth2Client: getCurrentOAuth2Client( state ),
 			suggestedUsername: getSuggestedUsername( state ),
-			wccomFrom: wccomFrom,
+			wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
 			from: get( getCurrentQueryArguments( state ), 'from' ),
 			userLoggedIn: isUserLoggedIn( state ),
 		};

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -44,6 +44,7 @@ import { errorNotice } from 'calypso/state/notices/actions';
 import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
+import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
 import { getSuggestedUsername } from 'calypso/state/signup/optional-dependencies/selectors';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 
@@ -733,7 +734,7 @@ const ConnectedUser = connect(
 		return {
 			oauth2Client: getCurrentOAuth2Client( state ),
 			suggestedUsername: getSuggestedUsername( state ),
-			wccomFrom: get( getCurrentQueryArguments( state ), 'wccom-from' ),
+			wccomFrom: getWccomFrom( state ),
 			from: get( getCurrentQueryArguments( state ), 'from' ),
 			userLoggedIn: isUserLoggedIn( state ),
 		};

--- a/client/state/selectors/get-wccom-from.ts
+++ b/client/state/selectors/get-wccom-from.ts
@@ -1,0 +1,29 @@
+import { get } from 'lodash';
+import 'calypso/state/route/init';
+import getCurrentQueryArguments from './get-current-query-arguments';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Return the value of the `wccom-from` query argument.
+ *
+ * Login flow and signup flow use different query arguments to pass the `wccom-from` value.
+ * Login flow uses `wccom-from` directly, while signup flow uses `oauth2_redirect` to pass the `wccom-from` value.
+ */
+export default function getWccomFrom( state: AppState ): string | null {
+	const currentQuery = getCurrentQueryArguments( state );
+	const wccomFrom = get( currentQuery, 'wccom-from' ) as string | null;
+
+	if ( wccomFrom ) {
+		return wccomFrom;
+	}
+
+	try {
+		const queryOauth2Redirect = currentQuery?.oauth2_redirect;
+		const oauth2RedirectUrl = new URL( queryOauth2Redirect as string );
+		return oauth2RedirectUrl.searchParams.get( 'wccom-from' );
+	} catch ( e ) {
+		// ignore
+	}
+
+	return null;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Close https://github.com/Automattic/wp-calypso/issues/87443

It's confusing to see "All Woo Stores powered by WordPress.com" copy in non-NUX screens as it's not relevant to the user. This PR removes the copy from non-NUX screens. We use `wccomFrom` to determine if the user is on a NUX screen or not.
## Proposed Changes

* Remove All Woo stores are powered by WordPress.com! when not from NUX context

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**NUX flow**

1.  Log out from woo.com
2. Go to https://woo.com/start/#/installation
3. Click on "Try Woo Express for free"
4. Replace URL host with your local calypso or calypso live host
5. Observe there's `All Woo stores are powered by WordPress.com!`
6. Click on "Log in"
7.  Observe there's `All Woo stores are powered by WordPress.com!`

<img width="675" alt="Screenshot 2024-02-16 at 12 02 39" src="https://github.com/Automattic/wp-calypso/assets/4344253/d83182e8-0765-479a-aeb4-a5caba5ea473">

<img width="1344" alt="Screenshot 2024-02-16 at 11 58 25" src="https://github.com/Automattic/wp-calypso/assets/4344253/1ce78c6d-d9f6-41cd-8857-34b61174b193">


**non-NUX flow**

1.  Log out from woo.com
2. Go to https://woo.com/sso?next=%2F
3. Click on "Try Woo Express for free"
4. Replace URL host with your local calypso or calypso live host
5. Observe there's no `All Woo stores are powered by WordPress.com!`
6. Click on "Log in"
8.  Observe there's no `All Woo stores are powered by WordPress.com!`

<img width="644" alt="Screenshot 2024-02-16 at 12 04 40" src="https://github.com/Automattic/wp-calypso/assets/4344253/899ff294-42ef-4f30-9efa-2b90be0338bd">

<img width="1350" alt="Screenshot 2024-02-16 at 11 47 44" src="https://github.com/Automattic/wp-calypso/assets/4344253/96147894-a65c-463d-b820-566ff3ec3892">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?