### PR TITLE
Remove icons and section labels from Global Site View sidebar

### DIFF
--- a/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
+++ b/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
@@ -2,7 +2,6 @@ import { translate } from 'i18n-calypso';
 
 /**
  * Menu items for the Global Site View sidebar.
- * TODO: Update all icons
  */
 export default function globalSiteSidebarMenu( {
 	shouldShowAddOns,
@@ -21,27 +20,7 @@ export default function globalSiteSidebarMenu( {
 			type: 'menu-item',
 			url: `/sites`,
 		},
-
 		{
-			type: 'separator',
-		},
-		{
-			icon: 'dashicons-admin-home',
-			slug: 'home',
-			title: translate( 'Home' ),
-			type: 'menu-item',
-			url: `/home/${ siteDomain }`,
-		},
-
-		/**
-		 * ACCOUNT section
-		 * TODO: We need to render the "ACCOUNT" label.
-		 */
-		{
-			type: 'separator',
-		},
-		{
-			icon: 'dashicons-admin-home',
 			slug: 'upgrades',
 			title: translate( 'Plans' ),
 			type: 'menu-item',
@@ -50,7 +29,6 @@ export default function globalSiteSidebarMenu( {
 		...( shouldShowAddOns
 			? [
 					{
-						icon: 'dashicons-admin-home',
 						slug: 'Add-Ons',
 						title: translate( 'Add-Ons' ),
 						type: 'menu-item',
@@ -59,7 +37,6 @@ export default function globalSiteSidebarMenu( {
 			  ]
 			: [] ),
 		{
-			icon: 'dashicons-admin-home',
 			slug: 'domains',
 			title: translate( 'Domains' ),
 			navigationLabel: translate( 'Manage all domains' ),
@@ -67,36 +44,24 @@ export default function globalSiteSidebarMenu( {
 			url: `/domains/manage/${ siteDomain }`,
 		},
 		{
-			icon: 'dashicons-admin-home',
 			slug: 'Emails',
 			title: translate( 'Emails' ),
 			type: 'menu-item',
 			url: `/email/${ siteDomain }`,
 		},
 		{
-			icon: 'dashicons-admin-home',
 			slug: 'Purchases',
 			title: translate( 'Purchases' ),
 			type: 'menu-item',
 			url: `/purchases/subscriptions/${ siteDomain }`,
 		},
-
-		/**
-		 * SITE section
-		 * TODO: We need to render the "SITE" label.
-		 */
 		{
-			type: 'separator',
-		},
-		{
-			icon: 'dashicons-admin-home',
 			slug: 'options-hosting-configuration-php',
 			title: translate( 'Hosting' ),
 			type: 'menu-item',
 			url: `/hosting-config/${ siteDomain }`,
 		},
 		{
-			icon: 'dashicons-admin-home',
 			slug: 'settings-site-tools',
 			title: translate( 'Tools' ),
 			type: 'menu-item',
@@ -105,7 +70,6 @@ export default function globalSiteSidebarMenu( {
 		...( showSiteMonitoring
 			? [
 					{
-						icon: 'dashicons-admin-home',
 						slug: 'tools-site-monitoring',
 						title: translate( 'Monitoring' ),
 						type: 'menu-item',
@@ -113,30 +77,19 @@ export default function globalSiteSidebarMenu( {
 					},
 			  ]
 			: [] ),
-
-		/**
-		 * GROW section
-		 * TODO: We need to render the "GROW" label.
-		 */
 		{
-			type: 'separator',
-		},
-		{
-			icon: 'dashicons-admin-home',
 			slug: 'tools-earn',
 			title: translate( 'Monetize' ),
 			type: 'menu-item',
 			url: `/earn/${ siteDomain }`,
 		},
 		{
-			icon: 'dashicons-admin-home',
 			slug: 'options-podcasting-php',
 			title: translate( 'Podcasting' ),
 			type: 'menu-item',
 			url: `/settings/podcasting/${ siteDomain }`,
 		},
 		{
-			icon: 'dashicons-admin-home',
 			slug: 'subscribers',
 			title: translate( 'Subscribers' ),
 			type: 'menu-item',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5626, https://github.com/Automattic/wp-calypso/pull/87477

## Proposed Changes

This PR removes icons and section labels from the Global Site View sidebar according to the new Nav Design Update: pfsHM7-aY-p2.

<img width="319" alt="Screenshot 2024-02-16 at 13 28 15" src="https://github.com/Automattic/wp-calypso/assets/5287479/4173b81c-425e-4f71-9962-a0295b8a1617">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live
* Prepare an Atomic site with the classic view
* Go to any site-specific Calypso page URL (e.g., /home/<your-site>, plans/<your-site>) 
* See how the sidebar looks like

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?