### PR TITLE
Github Deployments: Force github deployments menu item for Cft

### DIFF
--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -77,31 +77,35 @@ const useSiteMenuItems = () => {
 
 	const hasUnifiedImporter = isEnabled( 'importer/unified' );
 
-	// Temporary fix to display the Newsletter menu item in the Settings menu for Jetpack sites.
-	// This can be removed once the code is released: https://github.com/Automattic/jetpack/pull/33065
-	const menuItemsWithNewsletterSettings = useMemo( () => {
-		if ( ! isJetpack || ! Array.isArray( menuItems ) || menuItems.length === 0 ) {
+	// Temporary patch to force display Github deployments menu item for testing (Cft).
+	// This can be removed once testing is complete.
+	const menuItemsWithGithubDeployments = useMemo( () => {
+		if (
+			! isJetpack ||
+			! Array.isArray( menuItems ) ||
+			menuItems.length === 0 ||
+			! isEnabled( 'github-deployments' )
+		) {
 			return menuItems;
 		}
 
 		return menuItems.map( ( menuItem ) => {
-			if ( menuItem.icon === 'dashicons-admin-settings' && Array.isArray( menuItem.children ) ) {
-				// Check if the 'Newsletter' submenu already exists.
-				const newsletterExists = menuItem.children.some(
-					( child ) => child.url && child.url.startsWith( '/settings/newsletter/' )
+			if ( menuItem.icon === 'dashicons-admin-tools' && Array.isArray( menuItem.children ) ) {
+				const githubDeploymentsExist = menuItem.children.some(
+					( child ) => child.url && child.url.startsWith( '/github-deployments/' )
 				);
 
-				if ( ! newsletterExists ) {
+				if ( ! githubDeploymentsExist ) {
 					return {
 						...menuItem,
 						children: [
 							...menuItem.children,
 							{
 								parent: menuItem.children[ 0 ].parent,
-								slug: 'newsletter',
-								title: translate( 'Newsletter' ),
+								slug: 'tools-github-deployments',
+								title: translate( 'GitHub Deployments' ),
 								type: 'submenu-item',
-								url: `/settings/newsletter/${ siteDomain }`,
+								url: `/github-deployments/${ siteDomain }`,
 							},
 						],
 					};
@@ -158,7 +162,7 @@ const useSiteMenuItems = () => {
 		showSiteMonitoring: isAtomic,
 	};
 
-	return menuItemsWithNewsletterSettings ?? buildFallbackResponse( fallbackDataOverrides );
+	return menuItemsWithGithubDeployments ?? buildFallbackResponse( fallbackDataOverrides );
 };
 
 export default useSiteMenuItems;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Repurpose function that force newsletter menu since version of jetpack it depends own was released months ago.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* have a user that is not apart of the github deployments dev team
* Have that user creates an atomic site and set `?flag=github-deployments` in the url
* Verify the `Github Deployments` menu is shown under tools section (never mind its position, its for testing)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?