### PR TITLE
Remove icons from Global Site sidebar

### DIFF
--- a/client/my-sites/sidebar/static-data/global-sidebar-menu.js
+++ b/client/my-sites/sidebar/static-data/global-sidebar-menu.js
@@ -6,7 +6,6 @@ import { translate } from 'i18n-calypso';
 export default function globalSidebarMenu() {
 	return [
 		{
-			icon: 'dashicons-admin-home',
 			slug: 'sites',
 			title: translate( 'Sites' ),
 			navigationLabel: translate( 'Manage all my sites' ),
@@ -14,7 +13,6 @@ export default function globalSidebarMenu() {
 			url: '/sites',
 		},
 		{
-			icon: 'dashicons-admin-site-alt3',
 			slug: 'domains',
 			title: translate( 'Domains' ),
 			navigationLabel: translate( 'Manage all domains' ),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5626, https://github.com/Automattic/wp-calypso/pull/87518

## Proposed Changes

This PR removes icons from the Global View sidebar according to the new Nav Design Update: pfsHM7-aY-p2.
<img width="299" alt="Screenshot 2024-02-16 at 15 59 45" src="https://github.com/Automattic/wp-calypso/assets/5287479/86ee6823-3d60-47f2-ac4c-73afbc52d705">

This PR should close https://github.com/Automattic/dotcom-forge/issues/5626.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live
* Go to /sites
* See how the sidebar looks like

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?