### PR TITLE
GitHub deployments: add feedback and navigation after creating new repo

### DIFF
--- a/client/my-sites/github-deployments/components/repositories/create-repository/create-repository-form.tsx
+++ b/client/my-sites/github-deployments/components/repositories/create-repository/create-repository-form.tsx
@@ -1,5 +1,5 @@
-import { FormLabel } from '@automattic/components';
-import { Button, FormToggle, Spinner } from '@wordpress/components';
+import { FormLabel, Button } from '@automattic/components';
+import { FormToggle, Spinner } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { ChangeEvent, useEffect, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -168,9 +168,9 @@ export const CreateRepositoryForm = ( {
 					</div>
 				</FormFieldset>
 				<Button
-					variant="primary"
-					disabled={ ! isFormValid || isPending }
+					primary
 					busy={ isPending }
+					disabled={ ! isFormValid }
 					onClick={ handleCreateRepository }
 				>
 					{ __( 'Create repository' ) }

--- a/client/my-sites/github-deployments/components/repositories/create-repository/create-repository-form.tsx
+++ b/client/my-sites/github-deployments/components/repositories/create-repository/create-repository-form.tsx
@@ -19,9 +19,13 @@ import './style.scss';
 
 type CreateRepositoryFormProps = {
 	onRepositoryCreated( args: MutationVariables ): void;
+	isPending?: boolean;
 };
 
-export const CreateRepositoryForm = ( { onRepositoryCreated }: CreateRepositoryFormProps ) => {
+export const CreateRepositoryForm = ( {
+	onRepositoryCreated,
+	isPending,
+}: CreateRepositoryFormProps ) => {
 	const { __ } = useI18n();
 	const {
 		account,
@@ -163,7 +167,12 @@ export const CreateRepositoryForm = ( { onRepositoryCreated }: CreateRepositoryF
 						<p style={ { margin: '0', marginLeft: '8px' } }>{ __( 'Deploy changes on push ' ) }</p>
 					</div>
 				</FormFieldset>
-				<Button variant="primary" disabled={ ! isFormValid } onClick={ handleCreateRepository }>
+				<Button
+					variant="primary"
+					disabled={ ! isFormValid || isPending }
+					busy={ isPending }
+					onClick={ handleCreateRepository }
+				>
 					{ __( 'Create repository' ) }
 				</Button>
 			</form>

--- a/client/my-sites/github-deployments/components/repositories/create-repository/create-repository-form.tsx
+++ b/client/my-sites/github-deployments/components/repositories/create-repository/create-repository-form.tsx
@@ -117,21 +117,21 @@ export const CreateRepositoryForm = ( {
 				<FormFieldset className="github-deployments-create-repository__project-type">
 					<FormLabel>{ __( 'What are you building ' ) }</FormLabel>
 					<FormRadioWithTemplateSelect
-						label={ __( 'A plugin' ) }
-						projectType="plugin"
-						isChecked={ projectType === 'plugin' }
-						onChange={ () => {
-							setProjectType( 'plugin' );
-						} }
-						onTemplateSelected={ setTemplate }
-						template={ template }
-					/>
-					<FormRadioWithTemplateSelect
 						label={ __( 'A theme' ) }
 						projectType="theme"
 						isChecked={ projectType === 'theme' }
 						onChange={ () => {
 							setProjectType( 'theme' );
+						} }
+						onTemplateSelected={ setTemplate }
+						template={ template }
+					/>
+					<FormRadioWithTemplateSelect
+						label={ __( 'A plugin' ) }
+						projectType="plugin"
+						isChecked={ projectType === 'plugin' }
+						onChange={ () => {
+							setProjectType( 'plugin' );
 						} }
 						onTemplateSelected={ setTemplate }
 						template={ template }

--- a/client/my-sites/github-deployments/components/repositories/create-repository/index.tsx
+++ b/client/my-sites/github-deployments/components/repositories/create-repository/index.tsx
@@ -1,23 +1,64 @@
+import page from '@automattic/calypso-router';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import ActionPanel from 'calypso/components/action-panel';
 import ActionPanelBody from 'calypso/components/action-panel/body';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
-import { useSelector } from 'calypso/state/index';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors/index';
+import { indexPage } from 'calypso/my-sites/github-deployments/routes';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { useDispatch, useSelector } from 'calypso/state/index';
+import { errorNotice, successNotice } from 'calypso/state/notices/actions';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors/index';
 import { CreateRepositoryForm } from './create-repository-form';
 import {
 	MutationVariables,
 	useCreateCodeDeploymentAndRepository,
 } from './use-create-code-deployment-and-repository';
+
 import './style.scss';
+
+const noticeOptions = {
+	duration: 3000,
+};
 
 export const CreateRepository = () => {
 	const { __ } = useI18n();
 	const siteId = useSelector( getSelectedSiteId );
+	const siteSlug = useSelector( getSelectedSiteSlug );
 
-	const { createDeploymentAndRepository } = useCreateCodeDeploymentAndRepository(
-		siteId as number
+	const goToDeployments = () => {
+		page( indexPage( siteSlug! ) );
+	};
+
+	const dispatch = useDispatch();
+
+	const { createDeploymentAndRepository, isPending } = useCreateCodeDeploymentAndRepository(
+		siteId as number,
+		{
+			onSuccess: () => {
+				goToDeployments();
+				dispatch( successNotice( __( 'Deployment created.' ), noticeOptions ) );
+			},
+			onError: ( error ) => {
+				dispatch(
+					errorNotice(
+						// translators: "reason" is why connecting the branch failed.
+						sprintf( __( 'Failed to create repository: %(reason)s' ), { reason: error.message } ),
+						{
+							...noticeOptions,
+						}
+					)
+				);
+			},
+			onSettled: ( _, error ) => {
+				dispatch(
+					recordTracksEvent( 'calypso_hosting_github_create_repository_success', {
+						connected: ! error,
+					} )
+				);
+			},
+		}
 	);
 
 	function handleCreateRepository( args: MutationVariables ) {
@@ -31,7 +72,10 @@ export const CreateRepository = () => {
 			</HeaderCake>
 			<ActionPanel>
 				<ActionPanelBody>
-					<CreateRepositoryForm onRepositoryCreated={ handleCreateRepository } />
+					<CreateRepositoryForm
+						onRepositoryCreated={ handleCreateRepository }
+						isPending={ isPending }
+					/>
 				</ActionPanelBody>
 			</ActionPanel>
 		</Main>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5253

<img width="1235" alt="Screenshot 2567-02-16 at 14 47 02" src="https://github.com/Automattic/wp-calypso/assets/6851384/0cc45940-ce34-4321-b215-eb875550ef18">

## Proposed Changes

* After creating a new repo, navigate to the index page
* Show feedback when request is in progress, and  for success and errors
* Reorders template picker items to match mockup

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Try creating a new repo
* Try with a repo name that doesn't exist in the account: success notification, plus navigates to the index page
* Try with a repo name that already exists - shows error notification


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?