### PR TITLE
Untangle: Move Downtime monitoring from Security Settings to Site Tools

### DIFF
--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -65,7 +65,7 @@ export const SiteSettingsSecurity = ( {
 			<SiteSettingsNavigation site={ site } section="security" />
 			{ showCredentials && <JetpackCredentials /> }
 			{ showJetpackBanner && <JetpackCredentialsBanner siteSlug={ site.slug } /> }
-			{ ! isEnabled( 'layout/dotcom-nav-redesign' ) && <JetpackMonitor /> }
+			<JetpackMonitor />
 			<FormSecurity />
 		</Main>
 	);

--- a/client/my-sites/site-settings/settings-security/main.jsx
+++ b/client/my-sites/site-settings/settings-security/main.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { FEATURE_SECURITY_SETTINGS, WPCOM_FEATURES_SCAN } from '@automattic/calypso-products';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -64,7 +65,7 @@ export const SiteSettingsSecurity = ( {
 			<SiteSettingsNavigation site={ site } section="security" />
 			{ showCredentials && <JetpackCredentials /> }
 			{ showJetpackBanner && <JetpackCredentialsBanner siteSlug={ site.slug } /> }
-			<JetpackMonitor />
+			{ ! isEnabled( 'layout/dotcom-nav-redesign' ) && <JetpackMonitor /> }
 			<FormSecurity />
 		</Main>
 	);

--- a/client/my-sites/site-settings/wpcom-site-tools-settings/index.jsx
+++ b/client/my-sites/site-settings/wpcom-site-tools-settings/index.jsx
@@ -19,6 +19,7 @@ const SiteSettingsGeneral = ( {
 	updateFields,
 	isRequestingSettings,
 	isSavingSettings,
+	isJetpack,
 
 	isWpcomStagingSite,
 	isAtomicAndEditingToolkitDeactivated,
@@ -36,7 +37,7 @@ const SiteSettingsGeneral = ( {
 				isSavingSettings={ isSavingSettings }
 			/>
 		) }
-		{ isEnabled( 'layout/dotcom-nav-redesign' ) && <JetpackMonitor /> }
+		{ isJetpack && isEnabled( 'layout/dotcom-nav-redesign' ) && <JetpackMonitor /> }
 		{ ! isWpcomStagingSite && (
 			<SiteTools headerTitle={ translate( 'Other tools' ) } source={ SOURCE_SETTINGS_SITE_TOOLS } />
 		) }

--- a/client/my-sites/site-settings/wpcom-site-tools-settings/index.jsx
+++ b/client/my-sites/site-settings/wpcom-site-tools-settings/index.jsx
@@ -1,5 +1,7 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
+import JetpackMonitor from 'calypso/my-sites/site-settings/form-jetpack-monitor';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import getIsUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
@@ -34,6 +36,7 @@ const SiteSettingsGeneral = ( {
 				isSavingSettings={ isSavingSettings }
 			/>
 		) }
+		{ isEnabled( 'layout/dotcom-nav-redesign' ) && <JetpackMonitor /> }
 		{ ! isWpcomStagingSite && (
 			<SiteTools headerTitle={ translate( 'Other tools' ) } source={ SOURCE_SETTINGS_SITE_TOOLS } />
 		) }

--- a/client/my-sites/site-settings/wpcom-site-tools.jsx
+++ b/client/my-sites/site-settings/wpcom-site-tools.jsx
@@ -32,7 +32,7 @@ const WpcomSiteTools = ( { isJetpack, isPossibleJetpackConnectionProblem, siteId
 				title={ translate( 'Site Tools' ) }
 				subtitle={ translate( 'Manage your site settings, including site visibility, and more.' ) }
 			/>
-			<WpcomSiteToolsSettings />
+			<WpcomSiteToolsSettings isJetpack={ isJetpack } />
 		</Main>
 	);
 };

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -11,7 +11,7 @@ import { items as itemSchemas } from './schema';
 
 const setChecklistTaskCompletion = ( state, taskId, completed ) => ( {
 	...state,
-	tasks: state.tasks?.map( ( task ) =>
+	tasks: state?.tasks?.map( ( task ) =>
 		task.id === taskId ? { ...task, isCompleted: completed } : task
 	),
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5325
Closes https://github.com/Automattic/dotcom-forge/issues/5378

## Proposed Changes

* Only for Atomic (& Jetpack), copy Downtime monitoring from Security settings to Site Tools when the flag `layout/dotcom-nav-redesign` is enabled

**On Atomic**

|Screen|BEFORE|AFTER|
|-|-|-|
|Site Tools|<img width="768" alt="Screenshot 2567-02-16 at 15 43 51" src="https://github.com/Automattic/wp-calypso/assets/1881481/0210dcab-ba3e-43cd-857d-424aac70e370">|<img width="769" alt="Screenshot 2567-02-16 at 15 43 23" src="https://github.com/Automattic/wp-calypso/assets/1881481/36d7beba-c711-4529-bdf6-01402cb914cd">|
|Security Settings (No changes)|<img width="773" alt="Screenshot 2567-02-16 at 15 44 25" src="https://github.com/Automattic/wp-calypso/assets/1881481/89e77aa0-1ac3-4f5d-b9f7-32707bad3039">|<img width="806" alt="Screenshot 2567-02-16 at 17 01 23" src="https://github.com/Automattic/wp-calypso/assets/1881481/214ef924-befb-409d-87d4-668f41d755f3">|

**On Simple**
|Screen|BEFORE|AFTER|
|-|-|-|
|Site Tools (No changes)|<img width="754" alt="Screenshot 2567-02-16 at 17 04 08" src="https://github.com/Automattic/wp-calypso/assets/1881481/806c5480-836a-4251-b7ab-80a1386ef09e">|<img width="754" alt="Screenshot 2567-02-16 at 17 04 08" src="https://github.com/Automattic/wp-calypso/assets/1881481/806c5480-836a-4251-b7ab-80a1386ef09e">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
From Calypso live:

* On Atomic, verify whether the "Downtime monitoring" section is in:
  * `/settings/site-tools/{ SITE }` to verify is there
  * `/settings/security/{ SITE }` to verify is still there
* On Simple, verify that the "Downtime monitoring" section is NOT in `/settings/site-tools/{ SITE }`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?