### PR TITLE
Github Deployments: wire-up back button

### DIFF
--- a/client/my-sites/github-deployments/components/repositories/create-repository/index.tsx
+++ b/client/my-sites/github-deployments/components/repositories/create-repository/index.tsx
@@ -5,7 +5,7 @@ import ActionPanel from 'calypso/components/action-panel';
 import ActionPanelBody from 'calypso/components/action-panel/body';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
-import { indexPage } from 'calypso/my-sites/github-deployments/routes';
+import { createPage, indexPage } from 'calypso/my-sites/github-deployments/routes';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useDispatch, useSelector } from 'calypso/state/index';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
@@ -26,7 +26,7 @@ export const CreateRepository = () => {
 	const { __ } = useI18n();
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
-
+	const createPath = createPage( siteSlug! );
 	const goToDeployments = () => {
 		page( indexPage( siteSlug! ) );
 	};
@@ -67,7 +67,7 @@ export const CreateRepository = () => {
 
 	return (
 		<Main fullWidthLayout>
-			<HeaderCake backHref="#">
+			<HeaderCake backHref={ createPath }>
 				<h1>{ __( 'Create repository' ) }</h1>
 			</HeaderCake>
 			<ActionPanel>

--- a/client/my-sites/github-deployments/routes.ts
+++ b/client/my-sites/github-deployments/routes.ts
@@ -11,6 +11,8 @@ interface CreateNewRepositoryRouteParams {
 
 export const indexPage = ( siteSlug: string ) => `/github-deployments/${ siteSlug }`;
 
+export const createPage = ( siteSlug: string ) => `/github-deployments/${ siteSlug }/create`;
+
 export const createDeploymentPage = (
 	siteSlug: string,
 	{ installationId, repositoryId }: CreateDeploymentRouteParams = {}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5253

## Proposed Changes

* Title - allow navigating back from "Create repository" screen

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?