### PR TITLE
Disable /home to wc-admin redirect when nav redesign is enabled

### DIFF
--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -8,7 +8,11 @@ import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
 import isJetpackModuleActive from 'calypso/state/selectors/is-jetpack-module-active';
 import { isSiteOnWooExpressEcommerceTrial } from 'calypso/state/sites/plans/selectors';
-import { canCurrentUserUseCustomerHome, getSiteUrl } from 'calypso/state/sites/selectors';
+import {
+	canCurrentUserUseCustomerHome,
+	getSiteOption,
+	getSiteUrl,
+} from 'calypso/state/sites/selectors';
 import {
 	getSelectedSiteSlug,
 	getSelectedSiteId,
@@ -42,12 +46,14 @@ export async function maybeRedirect( context, next ) {
 
 	const siteId = getSelectedSiteId( state );
 	const site = getSelectedSite( state );
+	const adminInterface = getSiteOption( state, siteId, 'wpcom_admin_interface' );
+
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
 	let fetchPromise;
 
 	if (
 		isSiteOnWooExpressEcommerceTrial( state, siteId ) &&
-		! isEnabled( 'layout/dotcom-nav-redesign' )
+		! ( isEnabled( 'layout/dotcom-nav-redesign' ) && adminInterface === 'wp-admin' )
 	) {
 		// Pre-fetch plugins and modules to avoid flashing content prior deciding whether to redirect.
 		fetchPromise = Promise.allSettled( [

--- a/client/my-sites/customer-home/controller.jsx
+++ b/client/my-sites/customer-home/controller.jsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { fetchLaunchpad } from '@automattic/data-stores';
 import { areLaunchpadTasksCompleted } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/launchpad/task-helper';
@@ -44,7 +45,10 @@ export async function maybeRedirect( context, next ) {
 	const isSiteLaunched = site?.launch_status === 'launched' || false;
 	let fetchPromise;
 
-	if ( isSiteOnWooExpressEcommerceTrial( state, siteId ) ) {
+	if (
+		isSiteOnWooExpressEcommerceTrial( state, siteId ) &&
+		! isEnabled( 'layout/dotcom-nav-redesign' )
+	) {
 		// Pre-fetch plugins and modules to avoid flashing content prior deciding whether to redirect.
 		fetchPromise = Promise.allSettled( [
 			context.store.dispatch( fetchSitePlugins( siteId ) ),


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5584

## Proposed Changes

* When the nav redesign is enabled, the /home redirect to wc-admin will be disabled as it prevents users returning to calypso from wp-admin using the new WordPress.com/home/:site link in wp-admin.
* ~Note this doesn't need to restrict to classic view only as all ecom plans are running classic view~ we're restricting to classic view as per https://github.com/Automattic/dotcom-forge/issues/5584#issuecomment-1952197361

## Testing Instructions

* With an ecommerce plan
* Access the sites /home page with the flag enabled 
  * http://calypso.localhost:3000/home/testingtesterson517.wpcomstaging.com?flags=layout/dotcom-nav-redesign
  * You should **not** be redirected to wc-admin
* And with the flag disabled
  * http://calypso.localhost:3000/home/testingtesterson517.wpcomstaging.com?flags=-layout/dotcom-nav-redesign
  * You should be redirected to wc-admin
