### PR TITLE
Continue with GitHub: Fix social disconnect error message bug

### DIFF
--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -28,6 +28,7 @@ type GithubLoginButtonProps = {
 	redirectUri: string;
 	onClick?: () => void;
 	socialServiceResponse?: string | null;
+	userHasDisconnected?: boolean;
 };
 
 type ExchangeCodeForTokenResponse = {
@@ -40,6 +41,7 @@ const GitHubLoginButton = ( {
 	redirectUri,
 	onClick,
 	socialServiceResponse,
+	userHasDisconnected,
 }: GithubLoginButtonProps ) => {
 	const translate = useTranslate();
 
@@ -116,10 +118,10 @@ const GitHubLoginButton = ( {
 	}, [ socialServiceResponse ] );
 
 	useEffect( () => {
-		if ( code && service === 'github' ) {
+		if ( code && service === 'github' && ! userHasDisconnected ) {
 			exchangeCodeForToken( code );
 		}
-	}, [ code, service ] );
+	}, [ code, service, userHasDisconnected ] );
 
 	const isDisabled = isFormDisabled || disabledState;
 

--- a/client/me/social-login/action-button.jsx
+++ b/client/me/social-login/action-button.jsx
@@ -26,6 +26,7 @@ class SocialLoginActionButton extends Component {
 
 	state = {
 		fetchingUser: false,
+		userHasDisconnected: false,
 	};
 
 	refreshUser = async () => {
@@ -115,13 +116,16 @@ class SocialLoginActionButton extends Component {
 
 	disconnectFromSocialService = () => {
 		const { service } = this.props;
-		return this.props.disconnectSocialUser( service ).then( this.refreshUser );
+		return this.props.disconnectSocialUser( service ).then( () => {
+			this.refreshUser();
+			this.setState( { userHasDisconnected: true } );
+		} );
 	};
 
 	render() {
 		const { service, isConnected, isUpdatingSocialConnection, redirectUri, translate } = this.props;
 
-		const { fetchingUser } = this.state;
+		const { fetchingUser, userHasDisconnected } = this.state;
 
 		const buttonLabel = isConnected ? translate( 'Disconnect' ) : translate( 'Connect' );
 		const disabled = isUpdatingSocialConnection || fetchingUser;
@@ -178,6 +182,7 @@ class SocialLoginActionButton extends Component {
 					responseHandler={ this.handleSocialServiceResponse }
 					redirectUri={ redirectUri }
 					socialServiceResponse={ this.props.socialServiceResponse }
+					userHasDisconnected={ userHasDisconnected }
 				>
 					{ actionButton }
 				</GithubLoginButton>


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/87534.

## Proposed Changes

* introduce new `userHasDisconnected` set to `true` when the user disconnects their social account
* pass this new prop to the `GithubLoginButton` component to prevent if from calling `exchangeCodeForToken`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Check out the PR branch and build it.
2. Apply D137543-code to your sandbox; and sandbox `public-api.wordpress.com` and `wordpress.com`.
3. Log in to a test non-A8C WPCOM account.
4. Navigate to http://calypso.localhost:3000/me/security/social-login
5. Click on the "Connect" button and go through the GitHub login flow until you get back to Calypso again. Please note that the process can take some time due to sandboxed `public-api.wordpress.com` and `wordpress.com`.
6. Your GitHub account should be connected to your test WPCOM account.
7. Click on the "Disconnect" button.
8. Your GitHub account should get disconnected from your test WPCOM account. There should be no error message displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?