### PR TITLE
Congrats pages: rewrite approach for setting up Titan mailbox

### DIFF
--- a/client/my-sites/email/controller.js
+++ b/client/my-sites/email/controller.js
@@ -1,5 +1,4 @@
 import page from '@automattic/calypso-router';
-import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import CalypsoShoppingCartProvider from 'calypso/my-sites/checkout/calypso-shopping-cart-provider';
 import AddMailboxes from 'calypso/my-sites/email/add-mailboxes';
@@ -15,7 +14,6 @@ import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
 import MailboxesManagement from 'calypso/my-sites/email/mailboxes';
 import * as paths from 'calypso/my-sites/email/paths';
 import TitanSetUpMailbox from 'calypso/my-sites/email/titan-set-up-mailbox';
-import TitanSetUpThankYou from 'calypso/my-sites/email/titan-set-up-thank-you';
 
 export default {
 	emailManagementAddEmailForwards( pageContext, next ) {
@@ -186,24 +184,6 @@ export default {
 				domainName={ pageContext.params.domain }
 				siteSlug={ pageContext.params.site }
 			/>
-		);
-
-		next();
-	},
-
-	// Thank you page for when user sets up a mailbox after purchasing a Titan subscription.
-	emailManagementTitanSetUpThankYou( pageContext, next ) {
-		pageContext.primary = (
-			<Main className="checkout-thank-you is-redesign-v2">
-				<PageViewTracker
-					path={ paths.getTitanSetUpThankYouPath( ':site', ':domain' ) }
-					title="Checkout > Purchased Titan mailbox"
-				/>
-				<TitanSetUpThankYou
-					domainName={ pageContext.params.domain }
-					emailAddress={ pageContext.query.email }
-				/>
-			</Main>
 		);
 
 		next();

--- a/client/my-sites/email/index.js
+++ b/client/my-sites/email/index.js
@@ -185,24 +185,6 @@ export default function () {
 
 	registerMultiPage( {
 		paths: [
-			paths.getTitanSetUpThankYouPath(
-				':site',
-				':domain',
-				null,
-				paths.emailManagementAllSitesPrefix
-			),
-			paths.getTitanSetUpThankYouPath( ':site', ':domain' ),
-		],
-		handlers: [
-			...commonHandlers,
-			controller.emailManagementTitanSetUpThankYou,
-			makeLayout,
-			clientRender,
-		],
-	} );
-
-	registerMultiPage( {
-		paths: [
 			paths.getForwardingPath( ':site', ':domain', paths.emailManagementAllSitesPrefix ),
 			paths.getForwardingPath( ':site', ':domain' ),
 		],

--- a/client/my-sites/email/paths.ts
+++ b/client/my-sites/email/paths.ts
@@ -125,20 +125,6 @@ export const getTitanSetUpMailboxPath: EmailPathUtilityFunction = (
 	urlParameters
 ) => getPath( siteName, domainName, 'titan/set-up-mailbox', relativeTo, urlParameters );
 
-export const getTitanSetUpThankYouPath = (
-	siteName: string | null | undefined,
-	domainName: string | null | undefined,
-	emailAddress?: string | null,
-	relativeTo?: string
-) =>
-	getPath(
-		siteName,
-		domainName,
-		'titan/set-up-mailbox/thank-you',
-		relativeTo,
-		emailAddress ? { email: emailAddress } : {}
-	);
-
 export const getTitanControlPanelRedirectPath: EmailPathUtilityFunction = (
 	siteName,
 	domainName,
@@ -146,6 +132,7 @@ export const getTitanControlPanelRedirectPath: EmailPathUtilityFunction = (
 	urlParameters
 ) => getPath( siteName, domainName, 'titan/control-panel', relativeTo, urlParameters );
 
+// Generates URL: /email/:domain/manage/:site
 export const getEmailManagementPath: EmailPathUtilityFunction = (
 	siteName,
 	domainName,

--- a/client/my-sites/email/test/paths.ts
+++ b/client/my-sites/email/test/paths.ts
@@ -11,7 +11,6 @@ import {
 	getManageTitanMailboxesPath,
 	getNewTitanAccountPath,
 	getTitanSetUpMailboxPath,
-	getTitanSetUpThankYouPath,
 	getTitanControlPanelRedirectPath,
 	getEmailManagementPath,
 	getForwardingPath,
@@ -103,20 +102,6 @@ describe( 'path helper functions', () => {
 		);
 		expect( getTitanSetUpMailboxPath( siteName, null ) ).toEqual( `/email/${ siteName }` );
 		expect( getTitanSetUpMailboxPath( null, null ) ).toEqual( '/email' );
-	} );
-
-	it( 'getTitanSetUpThankYouPath', () => {
-		expect( getTitanSetUpThankYouPath( siteName, domainName, 'info@example.com' ) ).toEqual(
-			`/email/${ domainName }/titan/set-up-mailbox/thank-you/${ siteName }?email=info%40example.com`
-		);
-		expect( getTitanSetUpThankYouPath( siteName, domainName ) ).toEqual(
-			`/email/${ domainName }/titan/set-up-mailbox/thank-you/${ siteName }`
-		);
-		expect(
-			getTitanSetUpThankYouPath( ':site', ':domain', null, emailManagementAllSitesPrefix )
-		).toEqual( '/email/all/:domain/titan/set-up-mailbox/thank-you/:site' );
-		expect( getTitanSetUpThankYouPath( siteName, null ) ).toEqual( `/email/${ siteName }` );
-		expect( getTitanSetUpThankYouPath( null, null ) ).toEqual( '/email' );
 	} );
 
 	it( 'getTitanControlPanelRedirectPath', () => {

--- a/client/my-sites/email/titan-set-up-mailbox/titan-set-up-mailbox-form.tsx
+++ b/client/my-sites/email/titan-set-up-mailbox/titan-set-up-mailbox-form.tsx
@@ -14,11 +14,11 @@ import {
 	FIELD_PASSWORD_RESET_EMAIL,
 } from 'calypso/my-sites/email/form/mailboxes/constants';
 import { EmailProvider } from 'calypso/my-sites/email/form/mailboxes/types';
-import { getTitanSetUpThankYouPath } from 'calypso/my-sites/email/paths';
+import { getEmailManagementPath } from 'calypso/my-sites/email/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
-import { errorNotice } from 'calypso/state/notices/actions';
+import { successNotice, errorNotice } from 'calypso/state/notices/actions';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { MailboxForm } from 'calypso/my-sites/email/form/mailboxes';
 import type { MailboxOperations } from 'calypso/my-sites/email/form/mailboxes/components/utilities/mailbox-operations';
@@ -37,11 +37,6 @@ interface DispatchCompleteSetupClickProps {
 	domainName: string;
 	mailboxName: string;
 }
-
-const goToThankYouPage = ( siteSlug: string, selectedDomainName: string, mailboxName: string ) => {
-	const emailAddress = `${ mailboxName }@${ selectedDomainName }`;
-	page( getTitanSetUpThankYouPath( siteSlug, selectedDomainName, emailAddress ) );
-};
 
 const dispatchCompleteSetupClick = ( dispatchProps: DispatchCompleteSetupClickProps ) => {
 	const { canContinue, dispatch, domainName, mailboxName } = dispatchProps;
@@ -75,8 +70,8 @@ const useHandleCompleteSetup = (
 	};
 
 	const { isError, mutateAsync } = useCreateTitanMailboxMutation();
-	const selectedSite = useSelector( getSelectedSite );
 	const translate = useTranslate();
+	const selectedSite = useSelector( getSelectedSite );
 
 	return async ( mailboxOperations: MailboxOperations ) => {
 		const mailbox = mailboxOperations.mailboxes[ 0 ];
@@ -91,10 +86,17 @@ const useHandleCompleteSetup = (
 		try {
 			await mutateAsync( mailbox.getAsFlatObject() as TitanMailboxFields );
 
-			goToThankYouPage(
-				selectedSite?.slug as string,
-				selectedDomainName,
-				mailbox.formFields.mailbox.value
+			// The provision of new user (mailbox) is done through an async process, which means
+			// the new mailbox won't be immediately available. To account for this, we redirect
+			// users back to the Email Management page with a 5 seconds delay, to prevent
+			// users from seeing the "Set up mailbox" CTA again. There's a chance that the
+			// new mailbox is still unavailable after 5 seconds, but that is an edge case that we will
+			// cope with for the time being.
+			await new Promise( ( resolve ) => setTimeout( resolve, 5000 ) );
+
+			page( getEmailManagementPath( selectedSite?.slug, selectedDomainName ) );
+			dispatch(
+				successNotice( translate( 'Your email is now ready to use!' ), { duration: 5000 } )
 			);
 		} catch ( createError ) {
 			let message = translate( 'Unknown error' );


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/5870

## Proposed Changes
Currently, after setting up the mailbox, users will be taken to the Congrats Page within the dashboard experience, which is incorrect. Since the Congrats Page is meant to be shown in the checkout experience (without the sidebar and without the admin bar). 
With this PR we are redirecting user to the page with the list of mailboxes and show success notice.

## Testing Instructions
1. You need a domain with Titan subcription
2. Open in via `Upgrades` -> `Emails` -> Select if from the list
3. Remove mailboxes
4. You should see `Setup mailbox` button, click on it
5. Fill in fields and proceed
6. Assert that you are redirected to the previous page and see success notice (Previous approach - we were landed to congrats page)

![Screenshot 2024-02-16 at 16 24 50](https://github.com/Automattic/wp-calypso/assets/5598437/8b0c8624-dc15-4e81-bab0-2304a8258a46)

