### PR TITLE
Checkout: Remove unused query components

### DIFF
--- a/client/my-sites/checkout/checkout-main-wrapper.tsx
+++ b/client/my-sites/checkout/checkout-main-wrapper.tsx
@@ -14,7 +14,6 @@ import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import CalypsoShoppingCartProvider from './calypso-shopping-cart-provider';
 import CheckoutMain from './src/components/checkout-main';
-import PrePurchaseNotices from './src/components/prepurchase-notices';
 import { logStashLoadErrorEvent } from './src/lib/analytics';
 import type { SitelessCheckoutType } from '@automattic/wpcom-checkout';
 
@@ -78,8 +77,6 @@ export default function CheckoutMainWrapper( {
 	const locale = useSelector( getCurrentUserLocale );
 	const selectedSiteId = useSelector( getSelectedSiteId ) ?? undefined;
 
-	const prepurchaseNotices = <PrePurchaseNotices />;
-
 	useEffect( () => {
 		if ( productAliasFromUrl ) {
 			logToLogstash( {
@@ -126,7 +123,6 @@ export default function CheckoutMainWrapper( {
 								feature={ selectedFeature }
 								plan={ plan }
 								isComingFromUpsell={ isComingFromUpsell }
-								infoMessage={ prepurchaseNotices }
 								sitelessCheckoutType={ sitelessCheckoutType }
 								isLoggedOutCart={ isLoggedOutCart }
 								isNoSiteCart={ isNoSiteCart }

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -8,7 +8,6 @@ import { useSelect } from '@wordpress/data';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment, useCallback, useMemo } from 'react';
-import QueryContactDetailsCache from 'calypso/components/data/query-contact-details-cache';
 import { recordAddEvent } from 'calypso/lib/analytics/cart';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import useSiteDomains from 'calypso/my-sites/checkout/src/hooks/use-site-domains';
@@ -727,7 +726,6 @@ export default function CheckoutMain( {
 
 	return (
 		<Fragment>
-			<QueryContactDetailsCache />
 			<PageViewTracker
 				path={ analyticsPath }
 				title="Checkout"

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -1,4 +1,3 @@
-import { JETPACK_SEARCH_PRODUCTS } from '@automattic/calypso-products';
 import { useRazorpay } from '@automattic/calypso-razorpay';
 import { useStripe } from '@automattic/calypso-stripe';
 import colorStudio from '@automattic/color-studio';
@@ -10,13 +9,6 @@ import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment, useCallback, useMemo } from 'react';
 import QueryContactDetailsCache from 'calypso/components/data/query-contact-details-cache';
-import QueryJetpackSaleCoupon from 'calypso/components/data/query-jetpack-sale-coupon';
-import QueryPlans from 'calypso/components/data/query-plans';
-import QueryPostCounts from 'calypso/components/data/query-post-counts';
-import QueryProducts from 'calypso/components/data/query-products-list';
-import QuerySitePlans from 'calypso/components/data/query-site-plans';
-import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
-import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import { recordAddEvent } from 'calypso/lib/analytics/cart';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import useSiteDomains from 'calypso/my-sites/checkout/src/hooks/use-site-domains';
@@ -734,26 +726,9 @@ export default function CheckoutMain( {
 		reduxDispatch( infoNotice( translate( 'Redirecting to payment partner…' ) ) );
 	}, [ reduxDispatch, translate ] );
 
-	const cartHasSearchProduct = useMemo(
-		() =>
-			responseCart.products.some( ( { product_slug } ) =>
-				JETPACK_SEARCH_PRODUCTS.includes(
-					product_slug as ( typeof JETPACK_SEARCH_PRODUCTS )[ number ]
-				)
-			),
-		[ responseCart.products ]
-	);
-
 	return (
 		<Fragment>
-			<QueryJetpackSaleCoupon />
-			<QuerySitePlans siteId={ updatedSiteId } />
-			<QuerySitePurchases siteId={ updatedSiteId } />
-			{ isSiteless && <QueryUserPurchases /> }
-			<QueryPlans />
-			<QueryProducts />
 			<QueryContactDetailsCache />
-			{ cartHasSearchProduct && <QueryPostCounts siteId={ updatedSiteId || -1 } type="post" /> }
 			<PageViewTracker
 				path={ analyticsPath }
 				title="Checkout"

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -53,6 +53,7 @@ import { CHECKOUT_STORE } from '../lib/wpcom-store';
 import { CheckoutLoadingPlaceholder } from './checkout-loading-placeholder';
 import { OnChangeItemVariant } from './item-variation-picker';
 import JetpackProRedirectModal from './jetpack-pro-redirect-modal';
+import PrePurchaseNotices from './prepurchase-notices';
 import WPCheckout from './wp-checkout';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type {
@@ -85,7 +86,6 @@ export interface CheckoutMainProps {
 	isNoSiteCart?: boolean;
 	isGiftPurchase?: boolean;
 	isInModal?: boolean;
-	infoMessage?: JSX.Element;
 	// IMPORTANT NOTE: This will not be called for redirect payment methods like
 	// PayPal. They will redirect directly to the post-checkout page decided by
 	// `getThankYouUrl`.
@@ -125,7 +125,6 @@ export default function CheckoutMain( {
 	isLoggedOutCart,
 	isNoSiteCart,
 	isGiftPurchase,
-	infoMessage,
 	isInModal,
 	onAfterPaymentComplete,
 	disabledThankYouPage,
@@ -764,7 +763,7 @@ export default function CheckoutMain( {
 					changeSelection={ changeSelection }
 					countriesList={ countriesList }
 					createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
-					infoMessage={ infoMessage }
+					infoMessage={ <PrePurchaseNotices siteId={ updatedSiteId } isSiteless={ isSiteless } /> }
 					isLoggedOutCart={ !! isLoggedOutCart }
 					onPageLoadError={ onPageLoadError }
 					removeProductFromCart={ removeProductFromCartAndMaybeRedirect }

--- a/client/my-sites/checkout/src/components/prepurchase-notices/index.tsx
+++ b/client/my-sites/checkout/src/components/prepurchase-notices/index.tsx
@@ -22,6 +22,8 @@ import {
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
+import QueryUserPurchases from 'calypso/components/data/query-user-purchases';
 import Notice from 'calypso/components/notice';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { getSitePlan, isJetpackMinimumVersion, getSiteOption } from 'calypso/state/sites/selectors';
@@ -156,7 +158,7 @@ const PrePurchaseNotices = () => {
 	return null;
 };
 
-const Wrapper = () => {
+const PrePurchaseNoticesWrapper = () => {
 	const notice = PrePurchaseNotices();
 
 	return (
@@ -170,4 +172,20 @@ const Wrapper = () => {
 	);
 };
 
-export default Wrapper;
+function PrePurchaseNoticesQueryContainer( {
+	siteId,
+	isSiteless,
+}: {
+	siteId: number | undefined;
+	isSiteless: boolean;
+} ) {
+	return (
+		<>
+			<QuerySitePurchases siteId={ siteId } />
+			{ isSiteless && <QueryUserPurchases /> }
+			<PrePurchaseNoticesWrapper />
+		</>
+	);
+}
+
+export default PrePurchaseNoticesQueryContainer;

--- a/client/my-sites/checkout/src/test/checkout-contact-autocomplete.tsx
+++ b/client/my-sites/checkout/src/test/checkout-contact-autocomplete.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { dispatch } from '@wordpress/data';
 import nock from 'nock';
@@ -97,7 +97,9 @@ describe( 'Checkout contact step', () => {
 		const countryField = await screen.findByLabelText( 'Country' );
 
 		// Validate that fields are pre-filled
-		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'US' );
+		await waitFor( () => {
+			expect( countryField.selectedOptions[ 0 ].value ).toBe( 'US' );
+		} );
 		expect( await screen.findByLabelText( 'Postal code' ) ).toHaveValue( '10001' );
 
 		expect( await screen.findByTestId( 'payment-method-step--visible' ) ).toBeInTheDocument();

--- a/client/my-sites/checkout/src/test/checkout-vat-form.tsx
+++ b/client/my-sites/checkout/src/test/checkout-vat-form.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { convertResponseCartToRequestCart } from '@automattic/shopping-cart';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { dispatch } from '@wordpress/data';
 import nock from 'nock';
@@ -180,7 +180,9 @@ describe( 'Checkout contact step VAT form', () => {
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 		const countryField = await screen.findByLabelText( 'Country' );
 
-		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
+		await waitFor( () => {
+			expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
+		} );
 		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeChecked();
 		expect( await screen.findByLabelText( 'VAT ID' ) ).toBeInTheDocument();
 	} );
@@ -208,7 +210,9 @@ describe( 'Checkout contact step VAT form', () => {
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 		const countryField = await screen.findByLabelText( 'Country' );
 
-		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
+		await waitFor( () => {
+			expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
+		} );
 		expect( await screen.findByLabelText( 'VAT ID' ) ).toHaveValue( '12345' );
 		expect( await screen.findByLabelText( 'Organization for VAT' ) ).toHaveValue( 'Test company' );
 		expect( await screen.findByLabelText( 'Address for VAT' ) ).toHaveValue( '123 Main Street' );
@@ -237,7 +241,9 @@ describe( 'Checkout contact step VAT form', () => {
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 		const countryField = await screen.findByLabelText( 'Country' );
 
-		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
+		await waitFor( () => {
+			expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
+		} );
 		expect( await screen.findByLabelText( 'Is VAT for Northern Ireland?' ) ).toBeChecked();
 	} );
 
@@ -265,7 +271,9 @@ describe( 'Checkout contact step VAT form', () => {
 		await screen.findByLabelText( 'Continue with the entered contact details' );
 		const countryField = await screen.findByLabelText( 'Country' );
 
-		expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
+		await waitFor( () => {
+			expect( countryField.selectedOptions[ 0 ].value ).toBe( 'GB' );
+		} );
 		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeChecked();
 		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeDisabled();
 
@@ -524,7 +532,9 @@ describe( 'Checkout contact step VAT form', () => {
 		const countryField = await screen.findByLabelText( 'Country' );
 
 		// Make sure the form has the autocompleted data.
-		expect( countryField.selectedOptions[ 0 ].value ).toBe( cachedContactCountry );
+		await waitFor( () => {
+			expect( countryField.selectedOptions[ 0 ].value ).toBe( cachedContactCountry );
+		} );
 		expect( await screen.findByLabelText( 'Add VAT details' ) ).toBeChecked();
 		expect( await screen.findByLabelText( 'VAT ID' ) ).toHaveValue( vatId );
 		expect( await screen.findByLabelText( 'Organization for VAT' ) ).toHaveValue( vatName );


### PR DESCRIPTION
## Proposed Changes

This PR removes a collection of query components (a deprecated concept where a component is used to query an API endpoint and put the data into Redux) from checkout's main page because they are no longer used. They do not block checkout loading but they do cause unnecessary network traffic and processing and they have been piling up for years without any easy way to tell what uses them.

Details:

- `QueryJetpackSaleCoupon` was used for the coupon code automatically applied to some Jetpack products. That feature was added in https://github.com/Automattic/wp-calypso/pull/56523 and removed in https://github.com/Automattic/wp-calypso/pull/61546
- `QueryProducts` was used to find the product ID of products when adding them to the cart but was made unnecessary by https://github.com/Automattic/wp-calypso/pull/59365
- `QuerySitePlans` and `QueryPlans` were added in https://github.com/Automattic/wp-calypso/pull/42723, copying the logic from the previous version of checkout, intending to make sure that the post-checkout pages had the correct Redux state to display purchased plans, but this doesn't make a lot of sense anymore since on this page they will run _before_ checkout completes.
- `QueryPostCounts` was added by https://github.com/Automattic/wp-calypso/pull/63640 for calculations of the variant picker, but since https://github.com/Automattic/wp-calypso/pull/70452 the variant picker is populated only by the shopping cart.
- `QueryContactDetailsCache` was used to fetch the user's saved contact details to pre-populate the billing info step of checkout, but since https://github.com/Automattic/wp-calypso/pull/39997 the hook that pre-fills the contact details fields [has fetched that data itself](https://github.com/Automattic/wp-calypso/blob/24c438329ed50633225f717b0db9ddf3dd1dd6c1/client/my-sites/checkout/src/hooks/use-cached-domain-contact-details.ts#L29).

This leaves the following query components which are still required by pre-purchase notices, but this PR moves them to that component instead to prevent confusion.

- `QueryUserPurchases` was added in https://github.com/Automattic/wp-calypso/pull/75845 for the Akismet pre-purchases notice.
- `QuerySitePurchases` was added in https://github.com/Automattic/wp-calypso/pull/44587 / https://github.com/Automattic/wp-calypso/pull/44564 for the Jetpack pre-purchases notice.

## Testing Instructions

It's hard to be 100% sure that the data fetched by these components is not used anywhere, which is why they have not been removed before. However, given the research above I've fairly confident that they will not be missed. If they are, hopefully it will quickly become obvious and we can make sure to include the data in a way that is more closely tied to its use-case.

Read through the various PRs above which added these components and make sure that their test instructions still work as expected (or are no longer relevant).