### PR TITLE
Launchpad: Improve focus style for accessibility

### DIFF
--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -38,8 +38,8 @@
 	}
 
 	&:focus {
-		box-shadow: none;
-		outline: none;
+		border-color: var(--color-primary);
+		box-shadow: 0 0 0 2px var(--color-primary-light);
 	}
 
 	.badge {

--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -23,6 +23,7 @@
 	outline: 0;
 	overflow: hidden;
 	text-decoration: none;
+	padding-left: 2px;
 
 	&:visited {
 		color: var(--color-neutral-100);
@@ -37,10 +38,9 @@
 		padding: 16px 0 16px 0;
 	}
 
-	&:focus {
-		border-color: var(--color-primary);
+	&:focus-visible {
+		outline: var(--color-primary);
 		box-shadow: 0 0 0 2px var(--color-primary-light);
-		text-indent: 2px;
 	}
 
 	.badge {

--- a/packages/launchpad/src/checklist-item/style.scss
+++ b/packages/launchpad/src/checklist-item/style.scss
@@ -40,6 +40,7 @@
 	&:focus {
 		border-color: var(--color-primary);
 		box-shadow: 0 0 0 2px var(--color-primary-light);
+		text-indent: 2px;
 	}
 
 	.badge {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87469 

## Proposed Changes

* Improve the focus state to follow accessibility requirements

### Customer Home
https://github.com/Automattic/wp-calypso/assets/38718/d2f302e3-2d5c-453f-9d78-8b91ee734240

### Tailored Onboarding
https://github.com/Automattic/wp-calypso/assets/38718/00c8af09-cdbb-44c4-a12d-5b68313a5199



## Testing Instructions
* Go to the customer's home and use the tab to navigate between the buttons
* Go to any onboarding flow, go to the launchpad page and use the tab to navigate between the buttons


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?