### PR TITLE
Plans 2023: Specify font size for storage add-on option in mobile

### DIFF
--- a/packages/plans-grid-next/src/style.scss
+++ b/packages/plans-grid-next/src/style.scss
@@ -139,6 +139,9 @@ $mobile-card-max-width: 440px;
 		}
 
 		.components-custom-select-control {
+			.storage-add-on-dropdown-option__title {
+				font-size: 0.875rem;
+			}
 			.components-custom-select-control__button {
 				height: 40px;
 			}
@@ -665,6 +668,8 @@ $mobile-card-max-width: 440px;
 			color: var(--studio-orange-40);
 		}
 	}
+
+	// test
 
 	.components-custom-select-control {
 		line-height: 0px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/87382#issuecomment-1939551808

## Proposed Changes

* Storage add-on options font-size styling wasn't being applied in mobile. We add a selector in this PR

## Screenshots
### Before
<img width="273" alt="Screenshot 2024-02-16 at 11 21 38 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/b3f4e287-b8f4-4774-8d8a-53d30abc3a7b">

### After
<img width="275" alt="Screenshot 2024-02-16 at 11 18 56 AM" src="https://github.com/Automattic/wp-calypso/assets/5414230/12624d75-e2ac-462b-b56a-b6d862e32c3e">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out PR
* Navigate to `/start/plans`
* Verify storage add-on option font-sizes are more size appropriate

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?