### PR TITLE
Manage: Update onboarding tour for new Sites Dashboard (SitesV2)

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -60,7 +60,7 @@ const SitesDataViews = ( {
 		},
 		{
 			id: 'site',
-			header: translate( 'SITE' ),
+			header: <span>{ translate( 'SITE' ) }</span>,
 			getValue: ( { item }: { item: SiteData } ) => item.site.value.url,
 			render: ( { item }: { item: SiteData } ) => {
 				if ( isLoading ) {
@@ -82,7 +82,7 @@ const SitesDataViews = ( {
 		},
 		{
 			id: 'stats',
-			header: 'STATS',
+			header: <span>STATS</span>,
 			getValue: () => 'Stats status',
 			render: ( { item }: { item: SiteData } ) => renderField( 'stats', item ),
 			enableHiding: false,
@@ -90,7 +90,7 @@ const SitesDataViews = ( {
 		},
 		{
 			id: 'boost',
-			header: 'BOOST',
+			header: <span>BOOST</span>,
 			getValue: ( { item }: { item: SiteData } ) => item.boost.status,
 			render: ( { item }: { item: SiteData } ) => renderField( 'boost', item ),
 			enableHiding: false,
@@ -98,7 +98,7 @@ const SitesDataViews = ( {
 		},
 		{
 			id: 'backup',
-			header: 'BACKUP',
+			header: <span>BACKUP</span>,
 			getValue: () => 'Backup status',
 			render: ( { item }: { item: SiteData } ) => renderField( 'backup', item ),
 			enableHiding: false,
@@ -106,7 +106,7 @@ const SitesDataViews = ( {
 		},
 		{
 			id: 'monitor',
-			header: 'MONITOR',
+			header: <span>MONITOR</span>,
 			getValue: () => 'Monitor status',
 			render: ( { item }: { item: SiteData } ) => renderField( 'monitor', item ),
 			enableHiding: false,
@@ -114,7 +114,7 @@ const SitesDataViews = ( {
 		},
 		{
 			id: 'scan',
-			header: 'SCAN',
+			header: <span>SCAN</span>,
 			getValue: () => 'Scan status',
 			render: ( { item }: { item: SiteData } ) => renderField( 'scan', item ),
 			enableHiding: false,
@@ -122,7 +122,7 @@ const SitesDataViews = ( {
 		},
 		{
 			id: 'plugins',
-			header: 'PLUGINS',
+			header: <span>PLUGINS</span>,
 			getValue: () => 'Plugins status',
 			render: ( { item }: { item: SiteData } ) => renderField( 'plugin', item ),
 			enableHiding: false,
@@ -151,7 +151,7 @@ const SitesDataViews = ( {
 		},
 		{
 			id: 'actions',
-			header: translate( 'ACTIONS' ),
+			header: <span>{ translate( 'ACTIONS' ) }</span>,
 			getValue: ( { item }: { item: SiteData } ) => item.isFavorite,
 			render: ( { item }: { item: SiteData } ) => {
 				if ( isLoading ) {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -60,7 +60,9 @@ const SitesDataViews = ( {
 		},
 		{
 			id: 'site',
-			header: <span>{ translate( 'SITE' ) }</span>,
+			header: (
+				<span className="sites-dataview__site-header">{ translate( 'Site' ).toUpperCase() }</span>
+			),
 			getValue: ( { item }: { item: SiteData } ) => item.site.value.url,
 			render: ( { item }: { item: SiteData } ) => {
 				if ( isLoading ) {
@@ -82,7 +84,7 @@ const SitesDataViews = ( {
 		},
 		{
 			id: 'stats',
-			header: <span>STATS</span>,
+			header: <span className="sites-dataview__stats-header">STATS</span>,
 			getValue: () => 'Stats status',
 			render: ( { item }: { item: SiteData } ) => renderField( 'stats', item ),
 			enableHiding: false,
@@ -90,7 +92,7 @@ const SitesDataViews = ( {
 		},
 		{
 			id: 'boost',
-			header: <span>BOOST</span>,
+			header: <span className="sites-dataview__boost-header">BOOST</span>,
 			getValue: ( { item }: { item: SiteData } ) => item.boost.status,
 			render: ( { item }: { item: SiteData } ) => renderField( 'boost', item ),
 			enableHiding: false,
@@ -98,7 +100,7 @@ const SitesDataViews = ( {
 		},
 		{
 			id: 'backup',
-			header: <span>BACKUP</span>,
+			header: <span className="sites-dataview__backup-header">BACKUP</span>,
 			getValue: () => 'Backup status',
 			render: ( { item }: { item: SiteData } ) => renderField( 'backup', item ),
 			enableHiding: false,
@@ -106,7 +108,7 @@ const SitesDataViews = ( {
 		},
 		{
 			id: 'monitor',
-			header: <span>MONITOR</span>,
+			header: <span className="sites-dataview__monitor-header">MONITOR</span>,
 			getValue: () => 'Monitor status',
 			render: ( { item }: { item: SiteData } ) => renderField( 'monitor', item ),
 			enableHiding: false,
@@ -114,7 +116,7 @@ const SitesDataViews = ( {
 		},
 		{
 			id: 'scan',
-			header: <span>SCAN</span>,
+			header: <span className="sites-dataview__scan-header">SCAN</span>,
 			getValue: () => 'Scan status',
 			render: ( { item }: { item: SiteData } ) => renderField( 'scan', item ),
 			enableHiding: false,
@@ -122,7 +124,7 @@ const SitesDataViews = ( {
 		},
 		{
 			id: 'plugins',
-			header: <span>PLUGINS</span>,
+			header: <span className="sites-dataview__plugins-header">PLUGINS</span>,
 			getValue: () => 'Plugins status',
 			render: ( { item }: { item: SiteData } ) => renderField( 'plugin', item ),
 			enableHiding: false,
@@ -130,7 +132,13 @@ const SitesDataViews = ( {
 		},
 		{
 			id: 'favorite',
-			header: <Icon className="site-table__favorite-icon" size={ 24 } icon={ starFilled } />,
+			header: (
+				<Icon
+					className="site-table__favorite-icon sites-dataview__favorites-header"
+					size={ 24 }
+					icon={ starFilled }
+				/>
+			),
 			getValue: ( { item }: { item: SiteData } ) => item.isFavorite,
 			render: ( { item }: { item: SiteData } ) => {
 				if ( isLoading ) {
@@ -151,7 +159,7 @@ const SitesDataViews = ( {
 		},
 		{
 			id: 'actions',
-			header: <span>{ translate( 'ACTIONS' ) }</span>,
+			header: <span className="sites-dataview__actions-header">{ translate( 'ACTIONS' ) }</span>,
 			getValue: ( { item }: { item: SiteData } ) => item.isFavorite,
 			render: ( { item }: { item: SiteData } ) => {
 				if ( isLoading ) {

--- a/client/jetpack-cloud/sections/onboarding-tours/dashboard-walkthrough-tour/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/dashboard-walkthrough-tour/index.tsx
@@ -10,35 +10,33 @@ export default function DashboardWalkthroughTour() {
 
 	const urlParams = new URLSearchParams( window.location.search );
 	const shouldRenderDashboardTour = urlParams.get( 'tour' ) === 'dashboard-walkthrough';
-	// TODO: As soon as v1 is no longer in use we should
+	// TODO: As soon as v1 is no longer in use we should delete it
 	// Define targets for both versions of the dashboard
-	const dashboardTargets = {
-		v1: {
-			site: "a.section-nav-tab__link[tabindex='0']",
-			stats: '.site-table__table tr:first-child td.jetpack-cloud-site-column__stats',
-			boost: '.site-table__table tr:first-child td.jetpack-cloud-site-column__boost',
-			backup: '.site-table__table tr:first-child td.jetpack-cloud-site-column__backup',
-			scan: '.site-table__table tr:first-child td.jetpack-cloud-site-column__scan',
-			uptimeMonitor:
-				'.site-table__table tr:first-child td.jetpack-cloud-site-column__monitor .toggle-activate-monitoring__toggle-button',
-			pluginUpdates: '.site-table__table tr:first-child td.jetpack-cloud-site-column__plugin',
-			detailedViews: '.site-table__table tr:first-child td.site-table__expand-row',
-		},
-		v2: {
-			site: "table.dataviews-view-table th[data-field-id='site'] button",
-			stats: "table.dataviews-view-table th[data-field-id='stats'] span",
-			boost: "table.dataviews-view-table th[data-field-id='boost'] span",
-			backup: "table.dataviews-view-table th[data-field-id='backup'] span",
-			scan: "table.dataviews-view-table th[data-field-id='scan'] span",
-			uptimeMonitor: "table.dataviews-view-table th[data-field-id='monitor'] span",
-			pluginUpdates: "table.dataviews-view-table th[data-field-id='plugins'] span",
-			detailedViews: "table.dataviews-view-table th[data-field-id='actions'] span",
-		},
+	const dashboardTargetsV1 = {
+		site: "a.section-nav-tab__link[tabindex='0']",
+		stats: '.site-table__table tr:first-child td.jetpack-cloud-site-column__stats',
+		boost: '.site-table__table tr:first-child td.jetpack-cloud-site-column__boost',
+		backup: '.site-table__table tr:first-child td.jetpack-cloud-site-column__backup',
+		scan: '.site-table__table tr:first-child td.jetpack-cloud-site-column__scan',
+		uptimeMonitor:
+			'.site-table__table tr:first-child td.jetpack-cloud-site-column__monitor .toggle-activate-monitoring__toggle-button',
+		pluginUpdates: '.site-table__table tr:first-child td.jetpack-cloud-site-column__plugin',
+		detailedViews: '.site-table__table tr:first-child td.site-table__expand-row',
+	};
+	const dashboardTargetsV2 = {
+		site: '.sites-dataview__site-header',
+		stats: '.sites-dataview__stats-header',
+		boost: '.sites-dataview__boost-header',
+		backup: '.sites-dataview__backup-header',
+		scan: '.sites-dataview__scan-header',
+		uptimeMonitor: '.sites-dataview__monitor-header',
+		pluginUpdates: '.sites-dataview__plugins-header',
+		detailedViews: '.sites-dataview__actions-header',
 	};
 
 	const activeDashboardTargets = isEnabled( 'jetpack/manage-sites-v2-menu' )
-		? dashboardTargets.v2
-		: dashboardTargets.v1;
+		? dashboardTargetsV2
+		: dashboardTargetsV1;
 
 	return (
 		shouldRenderDashboardTour && (

--- a/client/jetpack-cloud/sections/onboarding-tours/dashboard-walkthrough-tour/index.tsx
+++ b/client/jetpack-cloud/sections/onboarding-tours/dashboard-walkthrough-tour/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import GuidedTour from 'calypso/jetpack-cloud/components/guided-tour';
 import { JETPACK_MANAGE_ONBOARDING_TOURS_PREFERENCE_NAME } from '../constants';
@@ -9,6 +10,35 @@ export default function DashboardWalkthroughTour() {
 
 	const urlParams = new URLSearchParams( window.location.search );
 	const shouldRenderDashboardTour = urlParams.get( 'tour' ) === 'dashboard-walkthrough';
+	// TODO: As soon as v1 is no longer in use we should
+	// Define targets for both versions of the dashboard
+	const dashboardTargets = {
+		v1: {
+			site: "a.section-nav-tab__link[tabindex='0']",
+			stats: '.site-table__table tr:first-child td.jetpack-cloud-site-column__stats',
+			boost: '.site-table__table tr:first-child td.jetpack-cloud-site-column__boost',
+			backup: '.site-table__table tr:first-child td.jetpack-cloud-site-column__backup',
+			scan: '.site-table__table tr:first-child td.jetpack-cloud-site-column__scan',
+			uptimeMonitor:
+				'.site-table__table tr:first-child td.jetpack-cloud-site-column__monitor .toggle-activate-monitoring__toggle-button',
+			pluginUpdates: '.site-table__table tr:first-child td.jetpack-cloud-site-column__plugin',
+			detailedViews: '.site-table__table tr:first-child td.site-table__expand-row',
+		},
+		v2: {
+			site: "table.dataviews-view-table th[data-field-id='site'] button",
+			stats: "table.dataviews-view-table th[data-field-id='stats'] span",
+			boost: "table.dataviews-view-table th[data-field-id='boost'] span",
+			backup: "table.dataviews-view-table th[data-field-id='backup'] span",
+			scan: "table.dataviews-view-table th[data-field-id='scan'] span",
+			uptimeMonitor: "table.dataviews-view-table th[data-field-id='monitor'] span",
+			pluginUpdates: "table.dataviews-view-table th[data-field-id='plugins'] span",
+			detailedViews: "table.dataviews-view-table th[data-field-id='actions'] span",
+		},
+	};
+
+	const activeDashboardTargets = isEnabled( 'jetpack/manage-sites-v2-menu' )
+		? dashboardTargets.v2
+		: dashboardTargets.v1;
 
 	return (
 		shouldRenderDashboardTour && (
@@ -18,7 +48,7 @@ export default function DashboardWalkthroughTour() {
 				redirectAfterTourEnds="/overview"
 				tours={ [
 					{
-						target: "a.section-nav-tab__link[tabindex='0']",
+						target: activeDashboardTargets[ 'site' ],
 						popoverPosition: 'bottom right',
 						title: translate( 'Manage all your sites' ),
 						description: translate(
@@ -26,7 +56,7 @@ export default function DashboardWalkthroughTour() {
 						),
 					},
 					{
-						target: '.site-table__table tr:first-child td.jetpack-cloud-site-column__stats',
+						target: activeDashboardTargets[ 'stats' ],
 						popoverPosition: 'bottom right',
 						title: translate( '📊 Stats' ),
 						description: translate(
@@ -34,7 +64,7 @@ export default function DashboardWalkthroughTour() {
 						),
 					},
 					{
-						target: '.site-table__table tr:first-child td.jetpack-cloud-site-column__boost',
+						target: activeDashboardTargets[ 'boost' ],
 						popoverPosition: 'bottom right',
 						title: translate( '🚀 Boost score rating' ),
 						description: translate(
@@ -42,7 +72,7 @@ export default function DashboardWalkthroughTour() {
 						),
 					},
 					{
-						target: '.site-table__table tr:first-child td.jetpack-cloud-site-column__backup',
+						target: activeDashboardTargets[ 'backup' ],
 						popoverPosition: 'bottom right',
 						title: translate( '🛡️ Backups' ),
 						description: translate(
@@ -50,7 +80,7 @@ export default function DashboardWalkthroughTour() {
 						),
 					},
 					{
-						target: '.site-table__table tr:first-child td.jetpack-cloud-site-column__scan',
+						target: activeDashboardTargets[ 'scan' ],
 						popoverPosition: 'bottom right',
 						title: translate( '🔍 Scan' ),
 						description: translate(
@@ -58,8 +88,7 @@ export default function DashboardWalkthroughTour() {
 						),
 					},
 					{
-						target:
-							'.site-table__table tr:first-child td.jetpack-cloud-site-column__monitor .toggle-activate-monitoring__toggle-button',
+						target: activeDashboardTargets[ 'uptimeMonitor' ],
 						popoverPosition: 'bottom left',
 						title: translate( '⏲️ Uptime Monitor' ),
 						description: (
@@ -76,7 +105,7 @@ export default function DashboardWalkthroughTour() {
 						),
 					},
 					{
-						target: '.site-table__table tr:first-child td.jetpack-cloud-site-column__plugin',
+						target: activeDashboardTargets[ 'pluginUpdates' ],
 						popoverPosition: 'bottom right',
 						title: translate( '🔌 Plugin updates' ),
 						description: (
@@ -93,7 +122,7 @@ export default function DashboardWalkthroughTour() {
 						),
 					},
 					{
-						target: '.site-table__table tr:first-child td.site-table__expand-row',
+						target: activeDashboardTargets[ 'detailedViews' ],
 						popoverPosition: 'bottom right',
 						title: translate( '🔍 Detailed views' ),
 						description: translate(

--- a/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
+++ b/client/jetpack-cloud/sections/overview/primary/next-steps/index.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { CircularProgressBar } from '@automattic/components';
 import { Checklist, ChecklistItem, type Task } from '@automattic/launchpad';
 import { useTranslate } from 'i18n-calypso';
@@ -32,7 +33,9 @@ export default function NextSteps( { onDismiss = () => {} } ) {
 
 	const tasks: Task[] = [
 		{
-			calypso_path: '/dashboard?tour=dashboard-walkthrough',
+			calypso_path: isEnabled( 'jetpack/manage-sites-v2-menu' )
+				? '/sites?tour=dashboard-walkthrough'
+				: '/dashboard?tour=dashboard-walkthrough',
 			completed: checkTourCompletion( 'dashboardWalkthrough' ),
 			disabled: false,
 			actionDispatch: () => {


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/300

## Proposed Changes

* This PR updates the onboarding tour to the new Sites Dashboard (SitesV2) while keeping compatibility with the current dashboard.

## Testing Instructions

* The first thing to test is if our current dashboard still works, you can do so by following the instructions found in https://github.com/Automattic/wp-calypso/pull/85440
* Then enable the new Sites Dashboard using the feature flag:
   * Feature Flag: jetpack/manage-sites-v2-menu To activate the Sites V2 menu. You can deactivate the feature flag using this query in the URL: ?flags=-jetpack/manage-sites-v2-menu
* Test the tour in the new Sites Dashboard

NOTE: This PR only makes our current tour compatible, keeping all our current steps. Changing and adding new steps for our new sites dashboard will be addressed in a later PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
