### PR TITLE
Add product slug to products api call

### DIFF
--- a/client/components/data/query-products-list/index.jsx
+++ b/client/components/data/query-products-list/index.jsx
@@ -16,13 +16,18 @@ const request =
 		dispatch( requestProductsList( props ) );
 	};
 
-export function useQueryProductsList( { type = 'all', currency, persist } = {} ) {
+export function useQueryProductsList( {
+	type = 'all',
+	currency,
+	persist,
+	product_slug_list,
+} = {} ) {
 	const dispatch = useDispatch();
-
 	// Only runs on mount.
 	useEffect( () => {
-		dispatch( request( { type, currency, persist } ) );
-	}, [ dispatch, type, persist, currency ] );
+		const product_slugs = product_slug_list?.join( ',' );
+		dispatch( request( { type, currency, persist, product_slugs } ) );
+	}, [ dispatch, type, persist, currency, product_slug_list ] );
 
 	return null;
 }
@@ -34,8 +39,14 @@ export function useQueryProductsList( { type = 'all', currency, persist } = {} )
  *									"jetpack" for Jetpack products only, or undefined for all products.
  * @param {string} [props.currency] The currency code to override the currency used on the account.
  * @param {boolean} [props.persist] Set to true to persist the products list in the store.
+ * @param {string[]} [props.product_slug_list] Indicates the specific products being requested. Optional.
  * @returns {null} 					No visible output.
  */
-export default function QueryProductsList( { type = 'all', currency, persist } ) {
-	return useQueryProductsList( { type, currency, persist } );
+export default function QueryProductsList( {
+	type = 'all',
+	currency,
+	persist,
+	product_slug_list,
+} ) {
+	return useQueryProductsList( { type, currency, persist, product_slug_list } );
 }

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -744,6 +744,8 @@ export default function CheckoutMain( {
 		[ responseCart.products ]
 	);
 
+	const product_slug_list = responseCart?.products?.map( ( product ) => product.product_slug );
+
 	return (
 		<Fragment>
 			<QueryJetpackSaleCoupon />
@@ -751,7 +753,7 @@ export default function CheckoutMain( {
 			<QuerySitePurchases siteId={ updatedSiteId } />
 			{ isSiteless && <QueryUserPurchases /> }
 			<QueryPlans />
-			<QueryProducts />
+			<QueryProducts product_slug_list={ product_slug_list } />
 			<QueryContactDetailsCache />
 			{ cartHasSearchProduct && <QueryPostCounts siteId={ updatedSiteId || -1 } type="post" /> }
 			<PageViewTracker


### PR DESCRIPTION
Related to # https://github.com/Automattic/martech/issues/2722#issue-2137938101

## Proposed Changes

Add product_slug as a query parameter to the products endpoint call during the checkout process. 

## Testing Instructions

1. Checkout this branch 
2. Open Chrome
3. Open Developer tools and navigate to the Network Tab
4. Filter requests by product
5. Login to Calypso
6. Navigate to plans and select a plan that can be purchased (Starter, Creator etc.)
7. Click the back button in the top left to navigate back to the dashboard and leave the items in the cart
8. Go to add-ons and add the 50GB storage to the cart 
9. In the Network tab you should see a request being to the products endpoint, however, it should now include the product_slugs query parameter with the slugs for the selected products.
10. Only the requested products should be included in the endpoint response
11. The response time should be in the milliseconds.

![image](https://github.com/Automattic/wp-calypso/assets/25906001/c34424f6-3b30-412b-a03a-ca8341c28759)

