### PR TITLE
Untangle: Update My Home Header Action buttons

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -152,12 +152,7 @@ const Home = ( {
 				<Button href={ site.URL } onClick={ trackViewSiteAction } target="_blank">
 					{ translate( 'View site' ) }
 				</Button>
-				<Button
-					href={ site.URL + '/wp-admin' }
-					onClick={ trackOpenWPAdminAction }
-					target="_blank"
-					primary
-				>
+				<Button href={ site.URL + '/wp-admin' } onClick={ trackOpenWPAdminAction } primary>
 					{ translate( 'Open WP Admin' ) }
 				</Button>
 			</>

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useQueryClient } from '@tanstack/react-query';
@@ -65,6 +66,7 @@ const Home = ( {
 	site,
 	siteId,
 	trackViewSiteAction,
+	trackOpenWPAdminAction,
 	isSiteWooExpressEcommerceTrial,
 	ssoModuleActive,
 	fetchingJetpackModules,
@@ -143,6 +145,29 @@ const Home = ( {
 		return <WooCommerceHomePlaceholder />;
 	}
 
+	const headerActions =
+		config.isEnabled( 'layout/dotcom-nav-redesign' ) &&
+		'wp-admin' === site?.options?.wpcom_admin_interface ? (
+			<>
+				<Button href={ site.URL } onClick={ trackViewSiteAction } target="_blank">
+					{ translate( 'View site' ) }
+				</Button>
+				<Button
+					href={ site.URL + '/wp-admin' }
+					onClick={ trackOpenWPAdminAction }
+					target="_blank"
+					primary
+				>
+					{ translate( 'Open WP Admin' ) }
+				</Button>
+			</>
+		) : (
+			<>
+				<Button href={ site.URL } onClick={ trackViewSiteAction } target="_blank">
+					{ translate( 'Visit site' ) }
+				</Button>
+			</>
+		);
 	const header = (
 		<div className="customer-home__heading">
 			<NavigationHeader
@@ -152,9 +177,7 @@ const Home = ( {
 				title={ translate( 'My Home' ) }
 				subtitle={ translate( 'Your hub for posting, editing, and growing your site.' ) }
 			>
-				<Button href={ site.URL } onClick={ trackViewSiteAction } target="_blank">
-					{ translate( 'Visit site' ) }
-				</Button>
+				{ headerActions }
 			</NavigationHeader>
 
 			<div className="customer-home__site-content">
@@ -315,9 +338,16 @@ const trackViewSiteAction = ( isStaticHomePage ) =>
 		bumpStat( 'calypso_customer_home', 'my_site_view_site' )
 	);
 
+const trackOpenWPAdminAction = () =>
+	composeAnalytics(
+		recordTracksEvent( 'calypso_customer_home_my_site_open_wpadmin_click', {} ),
+		bumpStat( 'calypso_customer_home', 'my_site_open_wpadmin' )
+	);
+
 const mapDispatchToProps = {
 	trackViewSiteAction,
 	verifyIcannEmail,
+	trackOpenWPAdminAction,
 };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
@@ -326,6 +356,7 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 		...ownProps,
 		...stateProps,
 		trackViewSiteAction: () => dispatchProps.trackViewSiteAction( isStaticHomePage ),
+		trackOpenWPAdminAction: () => dispatchProps.trackOpenWPAdminAction(),
 		handleVerifyIcannEmail: dispatchProps.verifyIcannEmail,
 	};
 };


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5551
P2: pfsHM7-aY-p2#comment-249

## Proposed Changes

Update My home header action buttons for `wp-admin` interface with `layout/dotcom-nav-redesign` flag

- [ ] Rename `Visit site` to `View site`
- [ ] Add `Open WP Admin` button (with primary color)
- [ ] Add Tracking event for `Open WP Admin` button

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/14741c89-8d27-4b3e-8283-0516e78fda13) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/36f2e0f0-a941-45be-88e3-9779d111a0a7) |

## Testing Instructions

* Go to `/home/:your-site:?flags=layout/dotcom-nav-redesign` using a site with `wp-admin` interface
* Check header buttons as mentioned before
* Check `calypso_customer_home_my_site_open_wpadmin_click` tracking event
* Using a non-wp-admin site, everything should look as before.
