### PR TITLE
Help Center: Remove right offset for classic view

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.scss
@@ -48,12 +48,16 @@
 	}
 }
 
+body.is-nav-unification {
+	#wpadminbar #wp-toolbar #wp-admin-bar-help-center {
+		margin-right: 5px;
+	}
+}
+
 #wpadminbar #wp-toolbar {
 	#wp-admin-bar-help-center {
-		position: relative;
 		padding: 0;
 		width: 36px;
-		right: 5px;
 		display: none;
 
 		@include breakpoint-deprecated( ">960px" ) {


### PR DESCRIPTION
## Proposed Changes

When nav unification is disabled, the right offset results in an awkward space to the right of help center. It appears that this space is desired when nav unification is enabled and the new post (write) button is to the right of help center.

The `right: 5px` also causes some issues with overlapping other menu items. In this screenshot, note the overlap with the debug bar.

<img width="190" alt="304902101-5dec1d71-dfb0-4bd5-981f-50b4869a40e7" src="https://github.com/Automattic/wp-calypso/assets/1126811/4990d646-4afa-48d4-bd24-5ef876918f9a">

This PR proposes using `margin-right: 5px` which is similar to the approach the `/me` menu item uses and also to only apply this when nav unification is enabled (when the write button expects to be used)

It was considered whether the margin should be removed from help center and the `/me` menu item, putting margin on either side of the new post button instead. But, with us potentially removing the masterbar in wp-admin for all sites, it didn't seem worth taking this approach right now.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open wp-admin on a simple site and observe that there is margin to the right of the help center.
- Upload the plugin to an atomic site, turn on classic view in hosting configuration, and load wp-admin proxied. Observe no padding to the right of help center.
- Turn off classic view
- Observe padding to the right of help center

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?