### PR TITLE
New User Survey: Adds a new user survey for new user signups right after they signup

### DIFF
--- a/client/components/forms/form-checkbox/index.tsx
+++ b/client/components/forms/form-checkbox/index.tsx
@@ -1,12 +1,19 @@
 import classnames from 'classnames';
-import { FunctionComponent, InputHTMLAttributes } from 'react';
+import { InputHTMLAttributes, forwardRef } from 'react';
 
 import './style.scss';
 
 type CheckboxProps = InputHTMLAttributes< HTMLInputElement >;
 
-const FormInputCheckbox: FunctionComponent< CheckboxProps > = ( { className, ...otherProps } ) => (
-	<input { ...otherProps } type="checkbox" className={ classnames( className, 'form-checkbox' ) } />
+const FormInputCheckbox = forwardRef< HTMLInputElement | null, CheckboxProps >(
+	( { className, ...otherProps }, ref ) => (
+		<input
+			ref={ ref }
+			{ ...otherProps }
+			type="checkbox"
+			className={ classnames( className, 'form-checkbox' ) }
+		/>
+	)
 );
 
 export default FormInputCheckbox;

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1209,6 +1209,12 @@ export function excludeStepIfEmailVerified( stepName, defaultDependencies, nextP
 	flows.excludeStep( stepName );
 }
 
+export function excludeSurveyStepIfInactive( stepName, defaultDependencies, nextProps ) {
+	if ( nextProps.initialContext?.isSignupSurveyActive === false ) {
+		flows.excludeStep( stepName );
+	}
+}
+
 export function excludeStepIfProfileComplete( stepName, defaultDependencies, nextProps ) {
 	if ( includes( flows.excludedSteps, stepName ) ) {
 		return;

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -141,8 +141,8 @@ export function generateFlows( {
 		{
 			name: 'onboarding',
 			steps: isEnabled( 'signup/professional-email-step' )
-				? [ userSocialStep, 'domains', 'emails', 'plans' ]
-				: [ userSocialStep, 'domains', 'plans' ],
+				? [ userSocialStep, 'new-user-survey', 'domains', 'emails', 'plans' ]
+				: [ userSocialStep, 'new-user-survey', 'domains', 'plans' ],
 			destination: getSignupDestination,
 			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pau2Xa-Vs.',
 			lastModified: '2023-10-11',

--- a/client/signup/config/step-components.js
+++ b/client/signup/config/step-components.js
@@ -20,6 +20,7 @@ const stepNameToModuleName = {
 	emails: 'emails',
 	mailbox: 'emails',
 	launch: 'launch-site',
+	'new-user-survey': 'new-user-survey',
 	'mailbox-plan': 'plans',
 	plans: 'plans',
 	'plans-new': 'plans',

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -43,6 +43,7 @@ export function generateSteps( {
 	excludeStepIfEmailVerified = noop,
 	excludeStepIfProfileComplete = noop,
 	submitWebsiteContent = noop,
+	excludeSurveyStepIfInactive = noop,
 } = {} ) {
 	return {
 		// `themes` does not update the theme for an existing site as we normally
@@ -244,7 +245,10 @@ export function generateSteps( {
 		test: {
 			stepName: 'test',
 		},
-
+		'new-user-survey': {
+			stepName: 'new-user-survey',
+			fulfilledStepCallback: excludeSurveyStepIfInactive,
+		},
 		plans: {
 			stepName: 'plans',
 			apiRequestFunction: addPlanToCart,

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -22,6 +22,7 @@ import {
 	excludeStepIfEmailVerified,
 	submitWebsiteContent,
 	excludeStepIfProfileComplete,
+	excludeSurveyStepIfInactive,
 } from 'calypso/lib/signup/step-actions';
 import { generateSteps } from './steps-pure';
 
@@ -49,4 +50,5 @@ export default generateSteps( {
 	excludeStepIfEmailVerified,
 	excludeStepIfProfileComplete,
 	submitWebsiteContent,
+	excludeSurveyStepIfInactive,
 } );

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -247,7 +247,12 @@ export default {
 			const experiment = await loadExperimentAssignment(
 				'calypso_signup_onboarding_site_goals_survey'
 			);
-			initialContext.isSignupSurveyActive = experiment.variationName === 'treatment';
+
+			/**
+			 * TODO: DISABLE BEFORE SHIPPING !!!!!!
+			 * ==============================================================================> \_/ SHORT CIRCUITING NOW TO MAKE TESTING EASIER
+			 */
+			initialContext.isSignupSurveyActive = experiment.variationName === 'treatment' || true;
 		}
 		next();
 	},

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -251,7 +251,7 @@ export default {
 		}
 
 		if ( config.isEnabled( 'onboarding/new-user-survey' ) ) {
-			// Force display of the interval dropdown for the onboarding flow
+			// Force display of the new user survey for the onboarding flow
 			initialContext.isSignupSurveyActive = true;
 		}
 		next();

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -5,10 +5,11 @@ import { createElement } from 'react';
 import store from 'store';
 import { notFound } from 'calypso/controller';
 import { recordPageView } from 'calypso/lib/analytics/page-view';
+import { loadExperimentAssignment } from 'calypso/lib/explat';
 import { login } from 'calypso/lib/paths';
 import { sectionify } from 'calypso/lib/route';
 import flows from 'calypso/signup/config/flows';
-import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { updateDependencies } from 'calypso/state/signup/actions';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
 import { setCurrentFlowName, setPreviousFlowName } from 'calypso/state/signup/flow/actions';
@@ -160,7 +161,7 @@ export default {
 		next();
 	},
 
-	redirectToFlow( context, next ) {
+	async redirectToFlow( context, next ) {
 		const userLoggedIn = isUserLoggedIn( context.store.getState() );
 		const flowName = getFlowName( context.params, userLoggedIn );
 		const localeFromParams = context.params.lang;
@@ -233,6 +234,21 @@ export default {
 
 		store.set( 'signup-locale', localeFromParams );
 
+		/**
+		 * The experiment is only loaded on the onboarding flow
+		 * If user is logged out we load the experiment
+		 * If user is logged in we load the experiment only if the user has no sites
+		 * More info: pbxNRc-3xO-p2
+		 */
+		const isNewUser = ! getCurrentUserSiteCount( context.store.getState() );
+		initialContext.isSignupSurveyActive = false;
+		const isOnboardingFlow = flowName === 'onboarding';
+		if ( isOnboardingFlow && ( ! userLoggedIn || ( userLoggedIn && isNewUser ) ) ) {
+			const experiment = await loadExperimentAssignment(
+				'calypso_signup_onboarding_site_goals_survey'
+			);
+			initialContext.isSignupSurveyActive = experiment.variationName === 'treatment';
+		}
 		next();
 	},
 

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -247,7 +247,8 @@ export default {
 			const experiment = await loadExperimentAssignment(
 				'calypso_signup_onboarding_site_goals_survey'
 			);
-			initialContext.isSignupSurveyActive = experiment.variationName === 'treatment';
+			initialContext.isSignupSurveyActive = experiment.variationName === 'treatment' || experiment.variationName === 'treatment_scrambled';
+
 		}
 
 		if ( config.isEnabled( 'onboarding/new-user-survey' ) ) {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -247,12 +247,12 @@ export default {
 			const experiment = await loadExperimentAssignment(
 				'calypso_signup_onboarding_site_goals_survey'
 			);
+			initialContext.isSignupSurveyActive = experiment.variationName === 'treatment';
+		}
 
-			/**
-			 * TODO: DISABLE BEFORE SHIPPING !!!!!!
-			 * ==============================================================================> \_/ SHORT CIRCUITING NOW TO MAKE TESTING EASIER
-			 */
-			initialContext.isSignupSurveyActive = experiment.variationName === 'treatment' || true;
+		if ( config.isEnabled( 'onboarding/new-user-survey' ) ) {
+			// Force display of the interval dropdown for the onboarding flow
+			initialContext.isSignupSurveyActive = true;
 		}
 		next();
 	},

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -247,11 +247,15 @@ export default {
 			const experiment = await loadExperimentAssignment(
 				'calypso_signup_onboarding_site_goals_survey'
 			);
-			initialContext.isSignupSurveyActive = experiment.variationName === 'treatment' || experiment.variationName === 'treatment_scrambled';
-
+			initialContext.isSignupSurveyActive =
+				experiment.variationName === 'treatment' ||
+				experiment.variationName === 'treatment_scrambled';
 		}
 
-		if ( config.isEnabled( 'onboarding/new-user-survey' ) ) {
+		if (
+			config.isEnabled( 'onboarding/new-user-survey' ) ||
+			config.isEnabled( 'onboarding/new-user-survey-scrambled' )
+		) {
 			// Force display of the new user survey for the onboarding flow
 			initialContext.isSignupSurveyActive = true;
 		}

--- a/client/signup/steps/new-user-survey/components.tsx
+++ b/client/signup/steps/new-user-survey/components.tsx
@@ -1,6 +1,6 @@
 import { Card, FormLabel } from '@automattic/components';
 import styled from '@emotion/styled';
-import { ReactNode, useMemo } from 'react';
+import { Children, ReactNode, isValidElement, useEffect } from 'react';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 
 export type Viewport = 'desktop' | 'mobile' | 'tablet';
@@ -55,18 +55,77 @@ export const ButtonContainer = styled.div`
 	padding-top: 10px;
 `;
 
+export const getCheckboxKey = ( child: ReactNode ): string => {
+	if ( ! isValidElement( child ) || ! child.props.children ) {
+		return '';
+	}
+	const shuffledChildren = Children.toArray( child.props.children );
+	const [ checkboxNode ] = shuffledChildren;
+
+	if ( isValidElement( checkboxNode ) && checkboxNode.props.name ) {
+		return checkboxNode.props.name;
+	}
+	return '';
+};
+
+type ShuffleProps = {
+	/**
+	 * An array of ReactNode elements, representing the children to be shuffled.
+	 */
+	children: Array< ReactNode >;
+
+	/**
+	 * An array of strings or null, indicating the current order of children.
+	 * If null, the children will be shuffled initially.
+	 */
+	childOrder: string[] | null;
+
+	/**
+	 * A state setter function responsible for updating the child order.
+	 * @param {string[] | null} value - The new child order or null to shuffle the children.
+	 */
+	setChildOrder: React.Dispatch< React.SetStateAction< string[] | null > >;
+
+	/**
+	 * A function that extracts a unique key from each child element, used for maintaining consistent order.
+	 * @param {ReactNode} child - The child element for which the key is to be extracted.
+	 * @returns {string} The key extracted from the child element.
+	 */
+	getChildKey: ( child: ReactNode ) => string;
+};
 /**
- *	Shuffle the children so that element order is randomized
+ * A controlled component which shuffles children by random order based on provided keys.
+ * It ensures the order of children remains consistent when specified keys are provided.
+ * @param {ShuffleProps} props - The props for the Shuffle component.
+ * @returns {ReactNode} The shuffled children.
  */
-export const Shuffle = ( props: { children: Array< ReactNode > } ) => {
-	const { children } = props;
+export const Shuffle = ( props: ShuffleProps ) => {
+	const { children, setChildOrder, childOrder, getChildKey } = props;
 
-	const shuffledChildren = useMemo( () => {
-		const clonedChildren = [ ...children ];
-		clonedChildren.sort( () => Math.random() - Math.random() );
-		return clonedChildren;
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ children.length ] );
+	useEffect( () => {
+		setChildOrder( ( prevChildOrder ) => {
+			// If the previous child order is null, shuffle the children based on provided keys
+			if ( prevChildOrder === null || prevChildOrder.length !== Children.count( children ) ) {
+				const newChildOrder = Children.toArray( children ).map( ( child ) => {
+					return getChildKey( child );
+				} );
+				newChildOrder.sort( () => Math.random() - Math.random() );
+				return newChildOrder;
+			}
+			// If the previous child order exists, maintain it
+			return prevChildOrder;
+		} );
+	}, [ children, setChildOrder, getChildKey ] );
 
-	return shuffledChildren;
+	// If a child order exists, sort the children based on that order
+	let sortedChildrenClone = children;
+	if ( childOrder !== null ) {
+		sortedChildrenClone = [ ...children ];
+		sortedChildrenClone.sort( ( child1, child2 ) => {
+			return (
+				childOrder.indexOf( getChildKey( child1 ) ) - childOrder.indexOf( getChildKey( child2 ) )
+			);
+		} );
+	}
+	return sortedChildrenClone;
 };

--- a/client/signup/steps/new-user-survey/components.tsx
+++ b/client/signup/steps/new-user-survey/components.tsx
@@ -27,7 +27,7 @@ export const StyledCard = styled( Card )`
 
 export const StyledLabel = styled( FormLabel )`
 	&.form-label.form-label {
-		min-height: 30px;
+		min-height: 32px;
 		display: flex;
 		align-items: center;
 	}
@@ -36,8 +36,8 @@ export const StyledLabel = styled( FormLabel )`
 export const StyledFormTextInput = styled< any >( FormTextInput )`
 	&.form-text-input.form-text-input {
 		margin-left: 24px;
-		font-size: 0.75rem;
-		max-width: 311px;
+		max-width: 385px;
+		font-size: 100%;
 	}
 `;
 

--- a/client/signup/steps/new-user-survey/components.tsx
+++ b/client/signup/steps/new-user-survey/components.tsx
@@ -1,5 +1,6 @@
 import { Card, FormLabel } from '@automattic/components';
 import styled from '@emotion/styled';
+import { ReactNode } from 'react';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 
 export type Viewport = 'desktop' | 'mobile' | 'tablet';
@@ -53,3 +54,13 @@ export const ButtonContainer = styled.div`
 	padding-bottom: 10px;
 	padding-top: 10px;
 `;
+
+/**
+ *	Shuffle the children so that element order is randomized
+ */
+export const Shuffle = ( props: { children: Array< ReactNode > } ) => {
+	const { children } = props;
+	const clonedChildren = [ ...children ];
+	clonedChildren.sort( () => Math.random() - Math.random() );
+	return clonedChildren;
+};

--- a/client/signup/steps/new-user-survey/components.tsx
+++ b/client/signup/steps/new-user-survey/components.tsx
@@ -1,0 +1,55 @@
+import { Card, FormLabel } from '@automattic/components';
+import styled from '@emotion/styled';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+
+export type Viewport = 'desktop' | 'mobile' | 'tablet';
+type PropsWithViewport = { currentViewport: Viewport };
+export const SurveyFormContainer = styled.div`
+	margin: 0
+		${ ( { currentViewport }: PropsWithViewport ) =>
+			currentViewport === 'desktop' ? 'auto' : '10px' };
+`;
+
+export const StyledCard = styled( Card )`
+	margin: 0 auto;
+	padding: 25px 30px;
+	display: flex;
+	justify-content: center;
+	width: ${ ( props: PropsWithViewport ) =>
+		props.currentViewport === 'mobile' ? '100%' : 'fit-content' };
+	min-width: ${ ( props: PropsWithViewport ) =>
+		props.currentViewport === 'mobile' ? 'unset' : '452px' };
+	&&&&& {
+		margin-bottom: 15px;
+	}
+`;
+
+export const StyledLabel = styled( FormLabel )`
+	&.form-label.form-label {
+		min-height: 30px;
+		display: flex;
+		align-items: center;
+	}
+`;
+
+export const StyledFormTextInput = styled< any >( FormTextInput )`
+	&.form-text-input.form-text-input {
+		margin-left: 24px;
+		font-size: 0.75rem;
+		max-width: 311px;
+	}
+`;
+
+export const CardContent = styled.div`
+	width: 100%;
+`;
+
+export const OptionsContainer = styled.div`
+	padding: 0 20px;
+`;
+
+export const ButtonContainer = styled.div`
+	text-align: center;
+	padding-bottom: 10px;
+	padding-top: 10px;
+`;

--- a/client/signup/steps/new-user-survey/components.tsx
+++ b/client/signup/steps/new-user-survey/components.tsx
@@ -1,6 +1,6 @@
 import { Card, FormLabel } from '@automattic/components';
 import styled from '@emotion/styled';
-import { ReactNode } from 'react';
+import { ReactNode, useMemo } from 'react';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 
 export type Viewport = 'desktop' | 'mobile' | 'tablet';
@@ -19,7 +19,7 @@ export const StyledCard = styled( Card )`
 	width: ${ ( props: PropsWithViewport ) =>
 		props.currentViewport === 'mobile' ? '100%' : 'fit-content' };
 	min-width: ${ ( props: PropsWithViewport ) =>
-		props.currentViewport === 'mobile' ? 'unset' : '452px' };
+		props.currentViewport === 'mobile' ? 'unset' : '459px' };
 	&&&&& {
 		margin-bottom: 15px;
 	}
@@ -60,7 +60,13 @@ export const ButtonContainer = styled.div`
  */
 export const Shuffle = ( props: { children: Array< ReactNode > } ) => {
 	const { children } = props;
-	const clonedChildren = [ ...children ];
-	clonedChildren.sort( () => Math.random() - Math.random() );
-	return clonedChildren;
+
+	const shuffledChildren = useMemo( () => {
+		const clonedChildren = [ ...children ];
+		clonedChildren.sort( () => Math.random() - Math.random() );
+		return clonedChildren;
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ children.length ] );
+
+	return shuffledChildren;
 };

--- a/client/signup/steps/new-user-survey/components/Shuffle/index.tsx
+++ b/client/signup/steps/new-user-survey/components/Shuffle/index.tsx
@@ -50,7 +50,7 @@ type ShuffleProps = {
  * @returns {ReactNode} The shuffled children.
  */
 const Shuffle = ( props: ShuffleProps ) => {
-	const { children, setChildOrder, childOrder, getChildKey, isShuffleActive = true } = props;
+	const { children, setChildOrder, childOrder, getChildKey, isShuffleActive = false } = props;
 
 	useEffect( () => {
 		setChildOrder( ( prevChildOrder ) => {

--- a/client/signup/steps/new-user-survey/components/Shuffle/index.tsx
+++ b/client/signup/steps/new-user-survey/components/Shuffle/index.tsx
@@ -37,6 +37,11 @@ type ShuffleProps = {
 	 * @returns {string} The key extracted from the child element.
 	 */
 	getChildKey: ( child: ReactNode ) => string;
+
+	/**
+	 * A boolean indicating whether the Shuffling of elements is active is active.
+	 */
+	isActive?: boolean;
 };
 /**
  * A controlled component which shuffles children by random order based on provided keys.
@@ -45,26 +50,28 @@ type ShuffleProps = {
  * @returns {ReactNode} The shuffled children.
  */
 const Shuffle = ( props: ShuffleProps ) => {
-	const { children, setChildOrder, childOrder, getChildKey } = props;
+	const { children, setChildOrder, childOrder, getChildKey, isActive } = props;
 
 	useEffect( () => {
-		setChildOrder( ( prevChildOrder ) => {
-			// If the previous child order is null, shuffle the children based on provided keys
-			if ( prevChildOrder === null || prevChildOrder.length !== Children.count( children ) ) {
-				const newChildOrder = Children.toArray( children ).map( ( child ) => {
-					return getChildKey( child );
-				} );
-				newChildOrder.sort( () => Math.random() - Math.random() );
-				return newChildOrder;
-			}
-			// If the previous child order exists, maintain it
-			return prevChildOrder;
-		} );
-	}, [ children, setChildOrder, getChildKey ] );
+		if ( isActive ) {
+			setChildOrder( ( prevChildOrder ) => {
+				// If the previous child order is null, shuffle the children based on provided keys
+				if ( prevChildOrder === null || prevChildOrder.length !== Children.count( children ) ) {
+					const newChildOrder = Children.toArray( children ).map( ( child ) => {
+						return getChildKey( child );
+					} );
+					newChildOrder.sort( () => Math.random() - Math.random() );
+					return newChildOrder;
+				}
+				// If the previous child order exists, maintain it
+				return prevChildOrder;
+			} );
+		}
+	}, [ children, setChildOrder, getChildKey, isActive ] );
 
 	// If a child order exists, sort the children based on that order
 	let sortedChildrenClone = children;
-	if ( childOrder !== null ) {
+	if ( isActive && childOrder !== null ) {
 		sortedChildrenClone = [ ...children ];
 		sortedChildrenClone.sort( ( child1, child2 ) => {
 			return (

--- a/client/signup/steps/new-user-survey/components/Shuffle/index.tsx
+++ b/client/signup/steps/new-user-survey/components/Shuffle/index.tsx
@@ -1,61 +1,6 @@
-import { Card, FormLabel } from '@automattic/components';
-import styled from '@emotion/styled';
-import { Children, ReactNode, isValidElement, useEffect } from 'react';
-import FormTextInput from 'calypso/components/forms/form-text-input';
+import React, { Children, ReactNode, isValidElement, useEffect } from 'react';
 
-export type Viewport = 'desktop' | 'mobile' | 'tablet';
-type PropsWithViewport = { currentViewport: Viewport };
-export const SurveyFormContainer = styled.div`
-	margin: 0
-		${ ( { currentViewport }: PropsWithViewport ) =>
-			currentViewport === 'desktop' ? 'auto' : '10px' };
-`;
-
-export const StyledCard = styled( Card )`
-	margin: 0 auto;
-	padding: 25px 30px;
-	display: flex;
-	justify-content: center;
-	width: ${ ( props: PropsWithViewport ) =>
-		props.currentViewport === 'mobile' ? '100%' : 'fit-content' };
-	min-width: ${ ( props: PropsWithViewport ) =>
-		props.currentViewport === 'mobile' ? 'unset' : '459px' };
-	&&&&& {
-		margin-bottom: 15px;
-	}
-`;
-
-export const StyledLabel = styled( FormLabel )`
-	&.form-label.form-label {
-		min-height: 32px;
-		display: flex;
-		align-items: center;
-	}
-`;
-
-export const StyledFormTextInput = styled< any >( FormTextInput )`
-	&.form-text-input.form-text-input {
-		margin-left: 24px;
-		max-width: 385px;
-		font-size: 100%;
-	}
-`;
-
-export const CardContent = styled.div`
-	width: 100%;
-`;
-
-export const OptionsContainer = styled.div`
-	padding: 0 20px;
-`;
-
-export const ButtonContainer = styled.div`
-	text-align: center;
-	padding-bottom: 10px;
-	padding-top: 10px;
-`;
-
-export const getCheckboxKey = ( child: ReactNode ): string => {
+export const getCheckBoxKey = ( child: ReactNode ): string => {
 	if ( ! isValidElement( child ) || ! child.props.children ) {
 		return '';
 	}
@@ -99,7 +44,7 @@ type ShuffleProps = {
  * @param {ShuffleProps} props - The props for the Shuffle component.
  * @returns {ReactNode} The shuffled children.
  */
-export const Shuffle = ( props: ShuffleProps ) => {
+const Shuffle = ( props: ShuffleProps ) => {
 	const { children, setChildOrder, childOrder, getChildKey } = props;
 
 	useEffect( () => {
@@ -126,6 +71,16 @@ export const Shuffle = ( props: ShuffleProps ) => {
 				childOrder.indexOf( getChildKey( child1 ) ) - childOrder.indexOf( getChildKey( child2 ) )
 			);
 		} );
+
+		sortedChildrenClone =
+			sortedChildrenClone.map( ( child, i ) => {
+				if ( isValidElement( child ) ) {
+					return React.cloneElement< any >( child, { ...child.props, 'data-testid': i + 1 } );
+				}
+				return child;
+			} ) ?? [];
 	}
 	return sortedChildrenClone;
 };
+
+export default Shuffle;

--- a/client/signup/steps/new-user-survey/components/Shuffle/index.tsx
+++ b/client/signup/steps/new-user-survey/components/Shuffle/index.tsx
@@ -41,7 +41,7 @@ type ShuffleProps = {
 	/**
 	 * A boolean indicating whether the Shuffling of elements is active is active.
 	 */
-	isActive?: boolean;
+	isShuffleActive?: boolean;
 };
 /**
  * A controlled component which shuffles children by random order based on provided keys.
@@ -50,43 +50,43 @@ type ShuffleProps = {
  * @returns {ReactNode} The shuffled children.
  */
 const Shuffle = ( props: ShuffleProps ) => {
-	const { children, setChildOrder, childOrder, getChildKey, isActive } = props;
+	const { children, setChildOrder, childOrder, getChildKey, isShuffleActive = true } = props;
 
 	useEffect( () => {
-		if ( isActive ) {
-			setChildOrder( ( prevChildOrder ) => {
-				// If the previous child order is null, shuffle the children based on provided keys
-				if ( prevChildOrder === null || prevChildOrder.length !== Children.count( children ) ) {
-					const newChildOrder = Children.toArray( children ).map( ( child ) => {
-						return getChildKey( child );
-					} );
+		setChildOrder( ( prevChildOrder ) => {
+			// If the previous child order is null, shuffle the children based on provided keys
+			if ( prevChildOrder === null || prevChildOrder.length !== Children.count( children ) ) {
+				const newChildOrder = Children.toArray( children ).map( ( child ) => {
+					return getChildKey( child );
+				} );
+				if ( isShuffleActive ) {
 					newChildOrder.sort( () => Math.random() - Math.random() );
-					return newChildOrder;
 				}
-				// If the previous child order exists, maintain it
-				return prevChildOrder;
-			} );
-		}
-	}, [ children, setChildOrder, getChildKey, isActive ] );
+				return newChildOrder;
+			}
+			// If the previous child order exists, maintain it
+			return prevChildOrder;
+		} );
+	}, [ children, setChildOrder, getChildKey, isShuffleActive ] );
 
 	// If a child order exists, sort the children based on that order
 	let sortedChildrenClone = children;
-	if ( isActive && childOrder !== null ) {
+	if ( isShuffleActive && childOrder !== null ) {
 		sortedChildrenClone = [ ...children ];
 		sortedChildrenClone.sort( ( child1, child2 ) => {
 			return (
 				childOrder.indexOf( getChildKey( child1 ) ) - childOrder.indexOf( getChildKey( child2 ) )
 			);
 		} );
-
-		sortedChildrenClone =
-			sortedChildrenClone.map( ( child, i ) => {
-				if ( isValidElement( child ) ) {
-					return React.cloneElement< any >( child, { ...child.props, 'data-testid': i + 1 } );
-				}
-				return child;
-			} ) ?? [];
 	}
+	/*** Testing helper */
+	sortedChildrenClone =
+		sortedChildrenClone.map( ( child, i ) => {
+			if ( isValidElement( child ) ) {
+				return React.cloneElement< any >( child, { ...child.props, 'data-testid': i + 1 } );
+			}
+			return child;
+		} ) ?? [];
 	return sortedChildrenClone;
 };
 

--- a/client/signup/steps/new-user-survey/components/Shuffle/test/index.tsx
+++ b/client/signup/steps/new-user-survey/components/Shuffle/test/index.tsx
@@ -1,0 +1,90 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import React, { ReactNode, useState } from 'react';
+import Shuffle from '../index';
+interface MockComponentProps {
+	children?: ReactNode[];
+	childOrderOverride?: string[] | null;
+	ref?: React.Ref< any >;
+}
+const DEBUG_PRINT_DIV_ID = 'render-order-print';
+function MockComponent( { children, childOrderOverride }: MockComponentProps ) {
+	const [ childOrder, setChildOrder ] = useState< string[] | null >( childOrderOverride ?? null );
+	if ( children ) {
+		return (
+			<>
+				<div data-testid={ DEBUG_PRINT_DIV_ID }>{ childOrder?.join( ',' ) }</div>
+				<Shuffle
+					childOrder={ childOrder }
+					getChildKey={ ( child: React.ReactNode ) => {
+						// @ts-expect-error - Resolver does not have to have proper form
+						return child.props.children[ 1 ].props.name ?? '';
+					} }
+					setChildOrder={ setChildOrder }
+				>
+					{ children }
+				</Shuffle>
+			</>
+		);
+	}
+	return (
+		<>
+			<div data-testid={ DEBUG_PRINT_DIV_ID }>{ childOrder?.join( ',' ) }</div>
+			<Shuffle
+				childOrder={ childOrder }
+				setChildOrder={ setChildOrder }
+				getChildKey={ ( child: any ) => {
+					return child.props.children[ 1 ].props.name;
+				} }
+			>
+				<label key={ 1 }>
+					<span>Child 1</span>
+					<input name="1" />
+				</label>
+				<label key={ 2 }>
+					<span>Child 2</span>
+					<input name="2" />
+				</label>
+				<label key={ 3 }>
+					<span>Child 3</span>
+					<input name="3" />
+				</label>
+				<label key={ 4 }>
+					<span>Child 4</span>
+					<input name="4" />
+				</label>
+				<label key={ 5 }>
+					<span>Child 5</span>
+					<input name="5" />
+				</label>
+			</Shuffle>
+		</>
+	);
+}
+
+describe( 'Shuffle Component', () => {
+	test( 'Given an order of ids renders according to the given order', () => {
+		const { getByTestId } = render(
+			<MockComponent childOrderOverride={ [ '5', '4', '3', '2', '1' ] } />
+		);
+		screen.debug();
+		expect( getByTestId( '1' ) ).toHaveTextContent( 'Child 5' );
+		expect( getByTestId( '2' ) ).toHaveTextContent( 'Child 4' );
+		expect( getByTestId( '3' ) ).toHaveTextContent( 'Child 3' );
+		expect( getByTestId( '4' ) ).toHaveTextContent( 'Child 2' );
+		expect( getByTestId( '5' ) ).toHaveTextContent( 'Child 1' );
+	} );
+
+	test( 'Given no order renders a random order accurately', () => {
+		const { getByTestId } = render( <MockComponent /> );
+		const debugPrint = getByTestId( DEBUG_PRINT_DIV_ID );
+		const finalOrder = debugPrint.textContent?.split( ',' ) ?? [];
+
+		finalOrder.forEach( ( id, i ) => {
+			expect( getByTestId( String( i + 1 ) ) ).toHaveTextContent( `Child ${ id }` );
+		} );
+	} );
+} );

--- a/client/signup/steps/new-user-survey/components/Shuffle/test/index.tsx
+++ b/client/signup/steps/new-user-survey/components/Shuffle/test/index.tsx
@@ -19,6 +19,7 @@ function MockComponent( { children, childOrderOverride, isShuffleActive }: MockC
 			<>
 				<div data-testid={ DEBUG_PRINT_DIV_ID }>{ childOrder?.join( ',' ) }</div>
 				<Shuffle
+					isShuffleActive={ isShuffleActive }
 					childOrder={ childOrder }
 					getChildKey={ ( child: React.ReactNode ) => {
 						// @ts-expect-error - Resolver does not have to have proper form
@@ -70,7 +71,7 @@ function MockComponent( { children, childOrderOverride, isShuffleActive }: MockC
 describe( 'Shuffle Component', () => {
 	test( 'Given an order of ids renders according to the given order', () => {
 		const { getByTestId } = render(
-			<MockComponent childOrderOverride={ [ '5', '4', '3', '2', '1' ] } />
+			<MockComponent childOrderOverride={ [ '5', '4', '3', '2', '1' ] } isShuffleActive={ true } />
 		);
 		expect( getByTestId( '1' ) ).toHaveTextContent( 'Child 5' );
 		expect( getByTestId( '2' ) ).toHaveTextContent( 'Child 4' );
@@ -80,7 +81,7 @@ describe( 'Shuffle Component', () => {
 	} );
 
 	test( 'Given no order renders a random order accurately', () => {
-		const { getByTestId } = render( <MockComponent /> );
+		const { getByTestId } = render( <MockComponent isShuffleActive={ true } /> );
 		const debugPrint = getByTestId( DEBUG_PRINT_DIV_ID );
 		const finalOrder = debugPrint.textContent?.split( ',' ) ?? [];
 
@@ -89,7 +90,7 @@ describe( 'Shuffle Component', () => {
 		} );
 	} );
 
-	test( 'If shuffle flag is disabled no scrambling will occur', () => {
+	test( 'If shuffle flag is disabled no change in order will occur', () => {
 		const { getByTestId } = render( <MockComponent isShuffleActive={ false } /> );
 		const debugPrint = getByTestId( DEBUG_PRINT_DIV_ID );
 

--- a/client/signup/steps/new-user-survey/components/Shuffle/test/index.tsx
+++ b/client/signup/steps/new-user-survey/components/Shuffle/test/index.tsx
@@ -2,16 +2,17 @@
  * @jest-environment jsdom
  */
 
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React, { ReactNode, useState } from 'react';
 import Shuffle from '../index';
 interface MockComponentProps {
 	children?: ReactNode[];
 	childOrderOverride?: string[] | null;
 	ref?: React.Ref< any >;
+	isShuffleActive?: boolean;
 }
 const DEBUG_PRINT_DIV_ID = 'render-order-print';
-function MockComponent( { children, childOrderOverride }: MockComponentProps ) {
+function MockComponent( { children, childOrderOverride, isShuffleActive }: MockComponentProps ) {
 	const [ childOrder, setChildOrder ] = useState< string[] | null >( childOrderOverride ?? null );
 	if ( children ) {
 		return (
@@ -39,6 +40,7 @@ function MockComponent( { children, childOrderOverride }: MockComponentProps ) {
 				getChildKey={ ( child: any ) => {
 					return child.props.children[ 1 ].props.name;
 				} }
+				isShuffleActive={ isShuffleActive }
 			>
 				<label key={ 1 }>
 					<span>Child 1</span>
@@ -70,7 +72,6 @@ describe( 'Shuffle Component', () => {
 		const { getByTestId } = render(
 			<MockComponent childOrderOverride={ [ '5', '4', '3', '2', '1' ] } />
 		);
-		screen.debug();
 		expect( getByTestId( '1' ) ).toHaveTextContent( 'Child 5' );
 		expect( getByTestId( '2' ) ).toHaveTextContent( 'Child 4' );
 		expect( getByTestId( '3' ) ).toHaveTextContent( 'Child 3' );
@@ -86,5 +87,17 @@ describe( 'Shuffle Component', () => {
 		finalOrder.forEach( ( id, i ) => {
 			expect( getByTestId( String( i + 1 ) ) ).toHaveTextContent( `Child ${ id }` );
 		} );
+	} );
+
+	test( 'If shuffle flag is disabled no scrambling will occur', () => {
+		const { getByTestId } = render( <MockComponent isShuffleActive={ false } /> );
+		const debugPrint = getByTestId( DEBUG_PRINT_DIV_ID );
+
+		expect( debugPrint.innerHTML ).toEqual( '1,2,3,4,5' );
+		expect( getByTestId( '1' ) ).toHaveTextContent( 'Child 1' );
+		expect( getByTestId( '2' ) ).toHaveTextContent( 'Child 2' );
+		expect( getByTestId( '3' ) ).toHaveTextContent( 'Child 3' );
+		expect( getByTestId( '4' ) ).toHaveTextContent( 'Child 4' );
+		expect( getByTestId( '5' ) ).toHaveTextContent( 'Child 5' );
 	} );
 } );

--- a/client/signup/steps/new-user-survey/components/index.tsx
+++ b/client/signup/steps/new-user-survey/components/index.tsx
@@ -1,0 +1,55 @@
+import { Card, FormLabel } from '@automattic/components';
+import styled from '@emotion/styled';
+import FormTextInput from 'calypso/components/forms/form-text-input';
+
+export type Viewport = 'desktop' | 'mobile' | 'tablet';
+type PropsWithViewport = { currentViewport: Viewport };
+export const SurveyFormContainer = styled.div`
+	margin: 0
+		${ ( { currentViewport }: PropsWithViewport ) =>
+			currentViewport === 'desktop' ? 'auto' : '10px' };
+`;
+
+export const StyledCard = styled( Card )`
+	margin: 0 auto;
+	padding: 25px 30px;
+	display: flex;
+	justify-content: center;
+	width: ${ ( props: PropsWithViewport ) =>
+		props.currentViewport === 'mobile' ? '100%' : 'fit-content' };
+	min-width: ${ ( props: PropsWithViewport ) =>
+		props.currentViewport === 'mobile' ? 'unset' : '459px' };
+	&&&&& {
+		margin-bottom: 15px;
+	}
+`;
+
+export const StyledLabel = styled( FormLabel )`
+	&.form-label.form-label {
+		min-height: 32px;
+		display: flex;
+		align-items: center;
+	}
+`;
+
+export const StyledFormTextInput = styled< any >( FormTextInput )`
+	&.form-text-input.form-text-input {
+		margin-left: 24px;
+		max-width: 385px;
+		font-size: 100%;
+	}
+`;
+
+export const CardContent = styled.div`
+	width: 100%;
+`;
+
+export const OptionsContainer = styled.div`
+	padding: 0 20px;
+`;
+
+export const ButtonContainer = styled.div`
+	text-align: center;
+	padding-bottom: 10px;
+	padding-top: 10px;
+`;

--- a/client/signup/steps/new-user-survey/index.tsx
+++ b/client/signup/steps/new-user-survey/index.tsx
@@ -10,6 +10,7 @@ import {
 	ButtonContainer,
 	CardContent,
 	OptionsContainer,
+	Shuffle,
 	StyledCard,
 	StyledFormTextInput,
 	StyledLabel,
@@ -46,6 +47,7 @@ interface Props {
 	flowName: string;
 	stepName: string;
 }
+
 function SurveyForm( props: Props ) {
 	const [ formState, setFormState ] = useState< FormState >( defaultFormState );
 	const translate = useTranslate();
@@ -129,22 +131,30 @@ function SurveyForm( props: Props ) {
 								  ) }
 						</CardHeading>
 						<OptionsContainer>
-							<StyledLabel>
-								<FormInputCheckbox
-									checked={ formState.survey_goals_blogging }
-									name="survey_goals_blogging"
-									onChange={ handleChange }
-								/>
-								<span>{ translate( 'Blogging' ) }</span>
-							</StyledLabel>
-							<StyledLabel>
-								<FormInputCheckbox name="survey_goals_website_building" onChange={ handleChange } />
-								<span>{ translate( 'Website building' ) }</span>
-							</StyledLabel>
-							<StyledLabel>
-								<FormInputCheckbox name="survey_goals_website_hosting" onChange={ handleChange } />
-								<span>{ translate( 'WordPress hosting' ) }</span>
-							</StyledLabel>
+							<Shuffle>
+								<StyledLabel>
+									<FormInputCheckbox
+										checked={ formState.survey_goals_blogging }
+										name="survey_goals_blogging"
+										onChange={ handleChange }
+									/>
+									<span>{ translate( 'Blogging' ) }</span>
+								</StyledLabel>
+								<StyledLabel>
+									<FormInputCheckbox
+										name="survey_goals_website_building"
+										onChange={ handleChange }
+									/>
+									<span>{ translate( 'Website building' ) }</span>
+								</StyledLabel>
+								<StyledLabel>
+									<FormInputCheckbox
+										name="survey_goals_website_hosting"
+										onChange={ handleChange }
+									/>
+									<span>{ translate( 'WordPress hosting' ) }</span>
+								</StyledLabel>
+							</Shuffle>
 							<StyledLabel>
 								<FormInputCheckbox
 									checked={ formState.survey_goals_custom_check }
@@ -165,61 +175,63 @@ function SurveyForm( props: Props ) {
 							{ translate( 'What best describes you?' ) }
 						</CardHeading>
 						<OptionsContainer>
-							<StyledLabel>
-								<FormInputCheckbox
-									name="survey_describe_yourself_creator"
-									onChange={ handleChange }
-								/>
-								<span>{ translate( 'Personal site creator' ) }</span>
-							</StyledLabel>
-							<StyledLabel>
-								<FormInputCheckbox
-									name="survey_describe_yourself_business"
-									onChange={ handleChange }
-								/>
-								<span>{ translate( 'Business' ) }</span>
-							</StyledLabel>
-							<StyledLabel>
-								<FormInputCheckbox
-									name="survey_describe_yourself_ecommerce"
-									onChange={ handleChange }
-								/>
-								<span>{ translate( 'eCommerce store' ) }</span>
-							</StyledLabel>
-							<StyledLabel>
-								<FormInputCheckbox
-									name="survey_describe_yourself_enterprise"
-									onChange={ handleChange }
-								/>
-								<span>{ translate( 'Enterprise' ) }</span>
-							</StyledLabel>
-							<StyledLabel>
-								<FormInputCheckbox
-									name="survey_describe_yourself_developer"
-									onChange={ handleChange }
-								/>
-								<span>{ translate( 'Developer' ) }</span>
-							</StyledLabel>
-							<StyledLabel>
-								<FormInputCheckbox
-									name="survey_describe_yourself_agency"
-									onChange={ handleChange }
-								/>
-								<span>{ translate( 'Agency' ) }</span>
-							</StyledLabel>
-							<StyledLabel>
-								<FormInputCheckbox
-									onChange={ handleChange }
-									checked={ formState.survey_describe_yourself_custom_check }
-									name="survey_describe_yourself_custom_check"
-								/>
-								<StyledFormTextInput
-									name="survey_describe_yourself_custom_text"
-									onChange={ handleChange }
-									value={ formState.survey_describe_yourself_custom_text }
-									placeholder={ placeholder }
-								/>
-							</StyledLabel>
+							<Shuffle>
+								<StyledLabel>
+									<FormInputCheckbox
+										name="survey_describe_yourself_creator"
+										onChange={ handleChange }
+									/>
+									<span>{ translate( 'Personal site creator' ) }</span>
+								</StyledLabel>
+								<StyledLabel>
+									<FormInputCheckbox
+										name="survey_describe_yourself_business"
+										onChange={ handleChange }
+									/>
+									<span>{ translate( 'Business' ) }</span>
+								</StyledLabel>
+								<StyledLabel>
+									<FormInputCheckbox
+										name="survey_describe_yourself_ecommerce"
+										onChange={ handleChange }
+									/>
+									<span>{ translate( 'eCommerce store' ) }</span>
+								</StyledLabel>
+								<StyledLabel>
+									<FormInputCheckbox
+										name="survey_describe_yourself_enterprise"
+										onChange={ handleChange }
+									/>
+									<span>{ translate( 'Enterprise' ) }</span>
+								</StyledLabel>
+								<StyledLabel>
+									<FormInputCheckbox
+										name="survey_describe_yourself_developer"
+										onChange={ handleChange }
+									/>
+									<span>{ translate( 'Developer' ) }</span>
+								</StyledLabel>
+								<StyledLabel>
+									<FormInputCheckbox
+										name="survey_describe_yourself_agency"
+										onChange={ handleChange }
+									/>
+									<span>{ translate( 'Agency' ) }</span>
+								</StyledLabel>
+								<StyledLabel>
+									<FormInputCheckbox
+										onChange={ handleChange }
+										checked={ formState.survey_describe_yourself_custom_check }
+										name="survey_describe_yourself_custom_check"
+									/>
+									<StyledFormTextInput
+										name="survey_describe_yourself_custom_text"
+										onChange={ handleChange }
+										value={ formState.survey_describe_yourself_custom_text }
+										placeholder={ placeholder }
+									/>
+								</StyledLabel>
+							</Shuffle>
 						</OptionsContainer>
 					</FormFieldset>
 					<ButtonContainer>

--- a/client/signup/steps/new-user-survey/index.tsx
+++ b/client/signup/steps/new-user-survey/index.tsx
@@ -5,6 +5,7 @@ import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
+import { useExperiment } from 'calypso/lib/explat';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import {
 	ButtonContainer,
@@ -69,12 +70,21 @@ function ControlledCheckbox( props: {
 }
 
 function SurveyForm( props: Props ) {
+	const [ isExperimentLoading, experimentAssignment ] = useExperiment(
+		'calypso_signup_onboarding_site_goals_survey'
+	);
+	const isScrambled = experimentAssignment?.variationName === 'treatment_scrambled';
+
 	const [ formState, setFormState ] = useState< FormState >( defaultFormState );
 	const [ orderGoals, setOrderGoals ] = useState< string[] | null >( [] );
 	const [ orderDescribeYourself, setOrderDescribeYourself ] = useState< string[] | null >( [] );
 	const translate = useTranslate();
 	const isMobileViewport = useMobileBreakpoint();
 	const isDesktopViewport = useDesktopBreakpoint();
+
+	if ( isExperimentLoading ) {
+		return null;
+	}
 
 	const handleChange = ( e: ChangeEvent< HTMLInputElement > ) => {
 		const { name, value } = e.target as { name: keyof FormState; value: string | 'on' };
@@ -158,6 +168,7 @@ function SurveyForm( props: Props ) {
 						</CardHeading>
 						<OptionsContainer>
 							<Shuffle
+								isActive={ isScrambled }
 								getChildKey={ getCheckBoxKey }
 								childOrder={ orderGoals }
 								setChildOrder={ setOrderGoals }
@@ -202,6 +213,7 @@ function SurveyForm( props: Props ) {
 						</CardHeading>
 						<OptionsContainer>
 							<Shuffle
+								isActive={ isScrambled }
 								getChildKey={ getCheckBoxKey }
 								childOrder={ orderDescribeYourself }
 								setChildOrder={ setOrderDescribeYourself }

--- a/client/signup/steps/new-user-survey/index.tsx
+++ b/client/signup/steps/new-user-survey/index.tsx
@@ -73,7 +73,7 @@ function SurveyForm( props: Props ) {
 	const [ isExperimentLoading, experimentAssignment ] = useExperiment(
 		'calypso_signup_onboarding_site_goals_survey'
 	);
-	const isScrambled = experimentAssignment?.variationName === 'treatment_scrambled';
+	const isScrambled = experimentAssignment?.variationName === 'treatment_scrambled' || true;
 
 	const [ formState, setFormState ] = useState< FormState >( defaultFormState );
 	const [ orderGoals, setOrderGoals ] = useState< string[] | null >( [] );
@@ -168,7 +168,7 @@ function SurveyForm( props: Props ) {
 						</CardHeading>
 						<OptionsContainer>
 							<Shuffle
-								isActive={ isScrambled }
+								isShuffleActive={ isScrambled }
 								getChildKey={ getCheckBoxKey }
 								childOrder={ orderGoals }
 								setChildOrder={ setOrderGoals }
@@ -213,7 +213,7 @@ function SurveyForm( props: Props ) {
 						</CardHeading>
 						<OptionsContainer>
 							<Shuffle
-								isActive={ isScrambled }
+								isShuffleActive={ isScrambled }
 								getChildKey={ getCheckBoxKey }
 								childOrder={ orderDescribeYourself }
 								setChildOrder={ setOrderDescribeYourself }

--- a/client/signup/steps/new-user-survey/index.tsx
+++ b/client/signup/steps/new-user-survey/index.tsx
@@ -128,10 +128,7 @@ function SurveyForm( props: Props ) {
 		currentViewport = 'desktop';
 	}
 
-	const placeholder =
-		currentViewport === 'mobile'
-			? translate( 'Please fill in your own answer' )
-			: translate( 'None of the above? (Please fill in your own answer)' );
+	const placeholder = translate( 'Something else?' );
 
 	return (
 		<SurveyFormContainer currentViewport={ currentViewport }>

--- a/client/signup/steps/new-user-survey/index.tsx
+++ b/client/signup/steps/new-user-survey/index.tsx
@@ -10,14 +10,13 @@ import {
 	ButtonContainer,
 	CardContent,
 	OptionsContainer,
-	Shuffle,
 	StyledCard,
 	StyledFormTextInput,
 	StyledLabel,
 	SurveyFormContainer,
 	Viewport,
-	getCheckboxKey,
 } from './components';
+import Shuffle, { getCheckBoxKey } from './components/Shuffle';
 
 const defaultFormState = {
 	survey_goals_blogging: null,
@@ -159,7 +158,7 @@ function SurveyForm( props: Props ) {
 						</CardHeading>
 						<OptionsContainer>
 							<Shuffle
-								getChildKey={ getCheckboxKey }
+								getChildKey={ getCheckBoxKey }
 								childOrder={ orderGoals }
 								setChildOrder={ setOrderGoals }
 							>
@@ -203,7 +202,7 @@ function SurveyForm( props: Props ) {
 						</CardHeading>
 						<OptionsContainer>
 							<Shuffle
-								getChildKey={ getCheckboxKey }
+								getChildKey={ getCheckBoxKey }
 								childOrder={ orderDescribeYourself }
 								setChildOrder={ setOrderDescribeYourself }
 							>

--- a/client/signup/steps/new-user-survey/index.tsx
+++ b/client/signup/steps/new-user-survey/index.tsx
@@ -1,0 +1,266 @@
+import { Button } from '@automattic/components';
+import { useDesktopBreakpoint, useMobileBreakpoint } from '@automattic/viewport-react';
+import { useTranslate } from 'i18n-calypso';
+import { ChangeEvent, useState } from 'react';
+import CardHeading from 'calypso/components/card-heading';
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+import StepWrapper from 'calypso/signup/step-wrapper';
+import {
+	ButtonContainer,
+	CardContent,
+	OptionsContainer,
+	StyledCard,
+	StyledFormTextInput,
+	StyledLabel,
+	SurveyFormContainer,
+	Viewport,
+} from './components';
+
+const defaultFormState = {
+	survey_goals_blogging: false,
+	survey_goals_website_building: false,
+	survey_goals_wordpress_hosting: false,
+	survey_goals_custom_check: false,
+	survey_goals_custom_text: '',
+	survey_describe_yourself_creator: false,
+	survey_describe_yourself_business: false,
+	survey_describe_yourself_ecommerce: false,
+	survey_describe_yourself_enterprise: false,
+	survey_describe_yourself_developer: false,
+	survey_describe_yourself_agency: false,
+	survey_describe_yourself_custom_check: false,
+	survey_describe_yourself_custom_text: '',
+};
+type FormState = typeof defaultFormState;
+
+type SubmitSignupStepType = (
+	step: { stepName: string; wasSkipped?: boolean },
+	providedDependencies?: object,
+	optionalProps?: any
+) => void;
+interface Props {
+	goToNextStep: () => void;
+	submitSignupStep: SubmitSignupStepType;
+	goToStep: ( stepName: string ) => void;
+	flowName: string;
+	stepName: string;
+}
+function SurveyForm( props: Props ) {
+	const [ formState, setFormState ] = useState< FormState >( defaultFormState );
+	const translate = useTranslate();
+	const isMobileViewport = useMobileBreakpoint();
+	const isDesktopViewport = useDesktopBreakpoint();
+
+	const handleChange = ( e: ChangeEvent< HTMLInputElement > ) => {
+		const { name, value } = e.target as { name: keyof FormState; value: string | 'on' };
+		if ( name.includes( 'custom_text' ) ) {
+			let updatedData: Partial< FormState > = { [ name ]: value };
+			if ( name.includes( 'goals' ) ) {
+				updatedData = { ...updatedData, survey_goals_custom_check: !! value };
+			} else {
+				updatedData = { ...updatedData, survey_describe_yourself_custom_check: !! value };
+			}
+			setFormState( ( prev: FormState ) => ( {
+				...prev,
+				...updatedData,
+			} ) );
+		} else if ( name.includes( 'custom_check' ) ) {
+			const newCheckedValue = ! formState[ name ];
+			let updatedData: Partial< FormState > = { [ name ]: newCheckedValue };
+			if ( name.includes( 'goals' ) ) {
+				updatedData = {
+					...updatedData,
+					survey_goals_custom_text: newCheckedValue ? formState.survey_goals_custom_text : '',
+				};
+			} else {
+				updatedData = {
+					...updatedData,
+					survey_describe_yourself_custom_text: newCheckedValue
+						? formState.survey_describe_yourself_custom_text
+						: '',
+				};
+			}
+			setFormState( ( prev: FormState ) => ( {
+				...prev,
+				...updatedData,
+			} ) );
+		} else {
+			setFormState( ( prev: FormState ) => ( {
+				...prev,
+				[ name ]: ! formState[ name ],
+			} ) );
+		}
+	};
+
+	const handleContinue = () => {
+		const { stepName, goToNextStep, submitSignupStep } = props;
+		submitSignupStep( { stepName }, {}, { ...formState } );
+		goToNextStep();
+	};
+
+	let currentViewport: Viewport = 'tablet';
+	if ( isMobileViewport ) {
+		currentViewport = 'mobile';
+	} else if ( isDesktopViewport ) {
+		currentViewport = 'desktop';
+	}
+
+	const placeholder =
+		currentViewport === 'mobile'
+			? translate( 'Please fill in your own answer' )
+			: translate( 'None of the above (Please fill in your own answer)' );
+
+	return (
+		<SurveyFormContainer currentViewport={ currentViewport }>
+			<StyledCard currentViewport={ currentViewport }>
+				<CardContent>
+					<FormFieldset>
+						<CardHeading tagName="h5" isBold={ true } size={ 18 }>
+							{ currentViewport === 'mobile'
+								? translate( 'What are your top goals?' )
+								: translate(
+										'What are your top goals? {{s}}(You can check multiple boxes.){{/s}}',
+										{
+											components: {
+												s: <small />,
+											},
+										}
+								  ) }
+						</CardHeading>
+						<OptionsContainer>
+							<StyledLabel>
+								<FormInputCheckbox
+									checked={ formState.survey_goals_blogging }
+									name="survey_goals_blogging"
+									onChange={ handleChange }
+								/>
+								<span>{ translate( 'Blogging' ) }</span>
+							</StyledLabel>
+							<StyledLabel>
+								<FormInputCheckbox name="survey_goals_website_building" onChange={ handleChange } />
+								<span>{ translate( 'Website building' ) }</span>
+							</StyledLabel>
+							<StyledLabel>
+								<FormInputCheckbox name="survey_goals_website_hosting" onChange={ handleChange } />
+								<span>{ translate( 'WordPress hosting' ) }</span>
+							</StyledLabel>
+							<StyledLabel>
+								<FormInputCheckbox
+									checked={ formState.survey_goals_custom_check }
+									name="survey_goals_custom_check"
+									onChange={ handleChange }
+								/>
+								<StyledFormTextInput
+									name="survey_goals_custom_text"
+									value={ formState.survey_goals_custom_text }
+									placeholder={ placeholder }
+									onChange={ handleChange }
+								/>
+							</StyledLabel>
+						</OptionsContainer>
+					</FormFieldset>
+					<FormFieldset>
+						<CardHeading tagName="h5" isBold={ true } size={ 18 }>
+							{ translate( 'What best describes you?' ) }
+						</CardHeading>
+						<OptionsContainer>
+							<StyledLabel>
+								<FormInputCheckbox
+									name="survey_describe_yourself_creator"
+									onChange={ handleChange }
+								/>
+								<span>{ translate( 'Personal site creator' ) }</span>
+							</StyledLabel>
+							<StyledLabel>
+								<FormInputCheckbox
+									name="survey_describe_yourself_business"
+									onChange={ handleChange }
+								/>
+								<span>{ translate( 'Business' ) }</span>
+							</StyledLabel>
+							<StyledLabel>
+								<FormInputCheckbox
+									name="survey_describe_yourself_ecommerce"
+									onChange={ handleChange }
+								/>
+								<span>{ translate( 'eCommerce store' ) }</span>
+							</StyledLabel>
+							<StyledLabel>
+								<FormInputCheckbox
+									name="survey_describe_yourself_enterprise"
+									onChange={ handleChange }
+								/>
+								<span>{ translate( 'Enterprise' ) }</span>
+							</StyledLabel>
+							<StyledLabel>
+								<FormInputCheckbox
+									name="survey_describe_yourself_developer"
+									onChange={ handleChange }
+								/>
+								<span>{ translate( 'Developer' ) }</span>
+							</StyledLabel>
+							<StyledLabel>
+								<FormInputCheckbox
+									name="survey_describe_yourself_agency"
+									onChange={ handleChange }
+								/>
+								<span>{ translate( 'Agency' ) }</span>
+							</StyledLabel>
+							<StyledLabel>
+								<FormInputCheckbox
+									onChange={ handleChange }
+									checked={ formState.survey_describe_yourself_custom_check }
+									name="survey_describe_yourself_custom_check"
+								/>
+								<StyledFormTextInput
+									name="survey_describe_yourself_custom_text"
+									onChange={ handleChange }
+									value={ formState.survey_describe_yourself_custom_text }
+									placeholder={ placeholder }
+								/>
+							</StyledLabel>
+						</OptionsContainer>
+					</FormFieldset>
+					<ButtonContainer>
+						<Button primary onClick={ handleContinue }>
+							{ translate( 'Continue' ) }
+						</Button>
+					</ButtonContainer>
+				</CardContent>
+			</StyledCard>
+		</SurveyFormContainer>
+	);
+}
+
+export default function NewUserSurvey( props: Props ) {
+	const { flowName, stepName } = props;
+	const translate = useTranslate();
+
+	const headerText = translate( 'Please tell us about yourself.' );
+	const subHeaderText = translate(
+		'We will use the aggregated survey results to learn about our users and improve our services.'
+	);
+
+	const handleSkip = () => {
+		const { stepName, goToNextStep, submitSignupStep } = props;
+		submitSignupStep( { stepName, wasSkipped: true } );
+		goToNextStep();
+	};
+	return (
+		<StepWrapper
+			flowName={ flowName }
+			stepName={ stepName }
+			stepContent={ <SurveyForm { ...props } /> }
+			headerText={ headerText }
+			fallbackHeaderText={ headerText }
+			subHeaderText={ subHeaderText }
+			fallbackSubHeaderText={ subHeaderText }
+			isWideLayout={ false }
+			isExtraWideLayout={ true }
+			hideSkip={ false }
+			skipButtonAlign="top"
+			goToNextStep={ handleSkip }
+		/>
+	);
+}

--- a/client/signup/steps/new-user-survey/index.tsx
+++ b/client/signup/steps/new-user-survey/index.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@automattic/components';
 import { useDesktopBreakpoint, useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -46,6 +46,26 @@ interface Props {
 	goToStep: ( stepName: string ) => void;
 	flowName: string;
 	stepName: string;
+}
+
+function ControlledCheckbox( props: {
+	name: string;
+	value: string | boolean | null | undefined;
+	onChange: ( e: ChangeEvent< HTMLInputElement > ) => void;
+} ) {
+	const inputRef = useRef< HTMLInputElement >( null );
+
+	useEffect( () => {
+		if ( inputRef.current ) {
+			if ( props.value ) {
+				inputRef.current.checked = true;
+			} else {
+				inputRef.current.checked = false;
+			}
+		}
+	}, [ props.value ] );
+
+	return <FormInputCheckbox onChange={ props.onChange } name={ props.name } ref={ inputRef } />;
 }
 
 function SurveyForm( props: Props ) {
@@ -152,7 +172,11 @@ function SurveyForm( props: Props ) {
 								</StyledLabel>
 							</Shuffle>
 							<StyledLabel>
-								<FormInputCheckbox name="survey_goals_custom_check" onChange={ handleChange } />
+								<ControlledCheckbox
+									name="survey_goals_custom_check"
+									onChange={ handleChange }
+									value={ formState.survey_goals_custom_check }
+								/>
 								<StyledFormTextInput
 									name="survey_goals_custom_text"
 									value={ formState.survey_goals_custom_text }
@@ -212,9 +236,10 @@ function SurveyForm( props: Props ) {
 								</StyledLabel>
 							</Shuffle>
 							<StyledLabel>
-								<FormInputCheckbox
+								<ControlledCheckbox
 									onChange={ handleChange }
 									name="survey_describe_yourself_custom_check"
+									value={ formState.survey_describe_yourself_custom_check }
 								/>
 								<StyledFormTextInput
 									name="survey_describe_yourself_custom_text"

--- a/client/signup/steps/new-user-survey/index.tsx
+++ b/client/signup/steps/new-user-survey/index.tsx
@@ -19,21 +19,21 @@ import {
 } from './components';
 
 const defaultFormState = {
-	survey_goals_blogging: false,
-	survey_goals_website_building: false,
-	survey_goals_wordpress_hosting: false,
-	survey_goals_custom_check: false,
+	survey_goals_blogging: null,
+	survey_goals_website_building: null,
+	survey_goals_wordpress_hosting: null,
+	survey_goals_custom_check: null,
 	survey_goals_custom_text: '',
-	survey_describe_yourself_creator: false,
-	survey_describe_yourself_business: false,
-	survey_describe_yourself_ecommerce: false,
-	survey_describe_yourself_enterprise: false,
-	survey_describe_yourself_developer: false,
-	survey_describe_yourself_agency: false,
-	survey_describe_yourself_custom_check: false,
+	survey_describe_yourself_creator: null,
+	survey_describe_yourself_business: null,
+	survey_describe_yourself_ecommerce: null,
+	survey_describe_yourself_enterprise: null,
+	survey_describe_yourself_developer: null,
+	survey_describe_yourself_agency: null,
+	survey_describe_yourself_custom_check: null,
 	survey_describe_yourself_custom_text: '',
 };
-type FormState = typeof defaultFormState;
+type FormState = Record< keyof typeof defaultFormState, null | undefined | string | boolean >;
 
 type SubmitSignupStepType = (
 	step: { stepName: string; wasSkipped?: boolean },
@@ -111,7 +111,7 @@ function SurveyForm( props: Props ) {
 	const placeholder =
 		currentViewport === 'mobile'
 			? translate( 'Please fill in your own answer' )
-			: translate( 'None of the above (Please fill in your own answer)' );
+			: translate( 'None of the above? (Please fill in your own answer)' );
 
 	return (
 		<SurveyFormContainer currentViewport={ currentViewport }>
@@ -133,11 +133,7 @@ function SurveyForm( props: Props ) {
 						<OptionsContainer>
 							<Shuffle>
 								<StyledLabel>
-									<FormInputCheckbox
-										checked={ formState.survey_goals_blogging }
-										name="survey_goals_blogging"
-										onChange={ handleChange }
-									/>
+									<FormInputCheckbox name="survey_goals_blogging" onChange={ handleChange } />
 									<span>{ translate( 'Blogging' ) }</span>
 								</StyledLabel>
 								<StyledLabel>
@@ -156,11 +152,7 @@ function SurveyForm( props: Props ) {
 								</StyledLabel>
 							</Shuffle>
 							<StyledLabel>
-								<FormInputCheckbox
-									checked={ formState.survey_goals_custom_check }
-									name="survey_goals_custom_check"
-									onChange={ handleChange }
-								/>
+								<FormInputCheckbox name="survey_goals_custom_check" onChange={ handleChange } />
 								<StyledFormTextInput
 									name="survey_goals_custom_text"
 									value={ formState.survey_goals_custom_text }
@@ -218,20 +210,19 @@ function SurveyForm( props: Props ) {
 									/>
 									<span>{ translate( 'Agency' ) }</span>
 								</StyledLabel>
-								<StyledLabel>
-									<FormInputCheckbox
-										onChange={ handleChange }
-										checked={ formState.survey_describe_yourself_custom_check }
-										name="survey_describe_yourself_custom_check"
-									/>
-									<StyledFormTextInput
-										name="survey_describe_yourself_custom_text"
-										onChange={ handleChange }
-										value={ formState.survey_describe_yourself_custom_text }
-										placeholder={ placeholder }
-									/>
-								</StyledLabel>
 							</Shuffle>
+							<StyledLabel>
+								<FormInputCheckbox
+									onChange={ handleChange }
+									name="survey_describe_yourself_custom_check"
+								/>
+								<StyledFormTextInput
+									name="survey_describe_yourself_custom_text"
+									onChange={ handleChange }
+									value={ formState.survey_describe_yourself_custom_text }
+									placeholder={ placeholder }
+								/>
+							</StyledLabel>
 						</OptionsContainer>
 					</FormFieldset>
 					<ButtonContainer>

--- a/client/signup/steps/new-user-survey/index.tsx
+++ b/client/signup/steps/new-user-survey/index.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useDesktopBreakpoint, useMobileBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
@@ -73,7 +74,9 @@ function SurveyForm( props: Props ) {
 	const [ isExperimentLoading, experimentAssignment ] = useExperiment(
 		'calypso_signup_onboarding_site_goals_survey'
 	);
-	const isScrambled = experimentAssignment?.variationName === 'treatment_scrambled' || true;
+	const isScrambled =
+		experimentAssignment?.variationName === 'treatment_scrambled' ||
+		config.isEnabled( 'onboarding/new-user-survey-scrambled' );
 
 	const [ formState, setFormState ] = useState< FormState >( defaultFormState );
 	const [ orderGoals, setOrderGoals ] = useState< string[] | null >( [] );

--- a/client/signup/steps/new-user-survey/index.tsx
+++ b/client/signup/steps/new-user-survey/index.tsx
@@ -16,6 +16,7 @@ import {
 	StyledLabel,
 	SurveyFormContainer,
 	Viewport,
+	getCheckboxKey,
 } from './components';
 
 const defaultFormState = {
@@ -70,6 +71,8 @@ function ControlledCheckbox( props: {
 
 function SurveyForm( props: Props ) {
 	const [ formState, setFormState ] = useState< FormState >( defaultFormState );
+	const [ orderGoals, setOrderGoals ] = useState< string[] | null >( [] );
+	const [ orderDescribeYourself, setOrderDescribeYourself ] = useState< string[] | null >( [] );
 	const translate = useTranslate();
 	const isMobileViewport = useMobileBreakpoint();
 	const isDesktopViewport = useDesktopBreakpoint();
@@ -117,7 +120,15 @@ function SurveyForm( props: Props ) {
 
 	const handleContinue = () => {
 		const { stepName, goToNextStep, submitSignupStep } = props;
-		submitSignupStep( { stepName }, {}, { ...formState } );
+		submitSignupStep(
+			{ stepName },
+			{},
+			{
+				...formState,
+				survey_field_order_goals: orderGoals?.join( ', ' ),
+				survey_field_order_describe_yourself: orderDescribeYourself?.join( ', ' ),
+			}
+		);
 		goToNextStep();
 	};
 
@@ -147,7 +158,11 @@ function SurveyForm( props: Props ) {
 								  ) }
 						</CardHeading>
 						<OptionsContainer>
-							<Shuffle>
+							<Shuffle
+								getChildKey={ getCheckboxKey }
+								childOrder={ orderGoals }
+								setChildOrder={ setOrderGoals }
+							>
 								<StyledLabel>
 									<FormInputCheckbox name="survey_goals_blogging" onChange={ handleChange } />
 									<span>{ translate( 'Blogging' ) }</span>
@@ -187,7 +202,11 @@ function SurveyForm( props: Props ) {
 							{ translate( 'What best describes you?' ) }
 						</CardHeading>
 						<OptionsContainer>
-							<Shuffle>
+							<Shuffle
+								getChildKey={ getCheckboxKey }
+								childOrder={ orderDescribeYourself }
+								setChildOrder={ setOrderDescribeYourself }
+							>
 								<StyledLabel>
 									<FormInputCheckbox
 										name="survey_describe_yourself_creator"

--- a/client/signup/steps/new-user-survey/index.tsx
+++ b/client/signup/steps/new-user-survey/index.tsx
@@ -110,7 +110,7 @@ function SurveyForm( props: Props ) {
 		} else {
 			setFormState( ( prev: FormState ) => ( {
 				...prev,
-				[ name ]: ! formState[ name ],
+				[ name ]: ! prev[ name ],
 			} ) );
 		}
 	};
@@ -129,7 +129,6 @@ function SurveyForm( props: Props ) {
 	}
 
 	const placeholder = translate( 'Something else?' );
-
 	return (
 		<SurveyFormContainer currentViewport={ currentViewport }>
 			<StyledCard currentViewport={ currentViewport }>

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -345,7 +345,7 @@ export class UserStep extends Component {
 		} );
 	};
 
-	submit = async ( data ) => {
+	submit = ( data ) => {
 		const { flowName, stepName, oauth2Signup } = this.props;
 		const dependencies = {};
 		if ( oauth2Signup ) {

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -1,11 +1,11 @@
 import config from '@automattic/calypso-config';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { isNewsletterFlow, isHostingSignupFlow } from '@automattic/onboarding';
+import { isHostingSignupFlow, isNewsletterFlow } from '@automattic/onboarding';
 import { isMobile } from '@automattic/viewport';
 import { Button } from '@wordpress/components';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
-import { isEmpty, omit, get } from 'lodash';
+import { get, isEmpty, omit } from 'lodash';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -17,11 +17,11 @@ import { initGoogleRecaptcha, recordGoogleRecaptchaAction } from 'calypso/lib/an
 import detectHistoryNavigation from 'calypso/lib/detect-history-navigation';
 import { getSocialServiceFromClientId } from 'calypso/lib/login';
 import {
-	isCrowdsignalOAuth2Client,
-	isWooOAuth2Client,
-	isJetpackCloudOAuth2Client,
 	isA4AOAuth2Client,
+	isCrowdsignalOAuth2Client,
 	isGravatarOAuth2Client,
+	isJetpackCloudOAuth2Client,
+	isWooOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
 import { WPCC } from 'calypso/lib/url/support';
@@ -345,7 +345,7 @@ export class UserStep extends Component {
 		} );
 	};
 
-	submit = ( data ) => {
+	submit = async ( data ) => {
 		const { flowName, stepName, oauth2Signup } = this.props;
 		const dependencies = {};
 		if ( oauth2Signup ) {

--- a/config/development.json
+++ b/config/development.json
@@ -153,6 +153,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
 		"onboarding/new-user-survey": false,
+		"onboarding/new-user-survey-scrambled": false,
 		"p2/p2-plus": true,
 		"page/export": true,
 		"pattern-assembler/v2": true,

--- a/config/development.json
+++ b/config/development.json
@@ -152,7 +152,7 @@
 		"onboarding/import-light": false,
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
-		"onboarding/new-user-survey": true,
+		"onboarding/new-user-survey": false,
 		"p2/p2-plus": true,
 		"page/export": true,
 		"pattern-assembler/v2": true,

--- a/config/development.json
+++ b/config/development.json
@@ -152,6 +152,7 @@
 		"onboarding/import-light": false,
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
+		"onboarding/new-user-survey": true,
 		"p2/p2-plus": true,
 		"page/export": true,
 		"pattern-assembler/v2": true,

--- a/config/production.json
+++ b/config/production.json
@@ -123,7 +123,7 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
-		"onboarding/new-user-survey": true,
+		"onboarding/new-user-survey": false,
 		"p2/p2-plus": true,
 		"pattern-assembler/v2": true,
 		"plans/hosting-trial": true,

--- a/config/production.json
+++ b/config/production.json
@@ -124,6 +124,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
 		"onboarding/new-user-survey": false,
+		"onboarding/new-user-survey-scrambled": false,
 		"p2/p2-plus": true,
 		"pattern-assembler/v2": true,
 		"plans/hosting-trial": true,

--- a/config/production.json
+++ b/config/production.json
@@ -123,6 +123,7 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
+		"onboarding/new-user-survey": true,
 		"p2/p2-plus": true,
 		"pattern-assembler/v2": true,
 		"plans/hosting-trial": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -119,6 +119,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
 		"onboarding/new-user-survey": false,
+		"onboarding/new-user-survey-scrambled": false,
 		"p2/p2-plus": true,
 		"page/export": true,
 		"pattern-assembler/v2": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -118,7 +118,7 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
-		"onboarding/new-user-survey": true,
+		"onboarding/new-user-survey": false,
 		"p2/p2-plus": true,
 		"page/export": true,
 		"pattern-assembler/v2": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -118,6 +118,7 @@
 		"onboarding/import-from-wordpress": true,
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
+		"onboarding/new-user-survey": true,
 		"p2/p2-plus": true,
 		"page/export": true,
 		"pattern-assembler/v2": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -119,6 +119,7 @@
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
 		"onboarding/new-user-survey": false,
+		"onboarding/new-user-survey-scrambled": false,
 		"p2/p2-plus": true,
 		"pattern-assembler/v2": true,
 		"plans/hosting-trial": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -118,6 +118,7 @@
 		"onboarding/import-light": false,
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
+		"onboarding/new-user-survey": true,
 		"p2/p2-plus": true,
 		"pattern-assembler/v2": true,
 		"plans/hosting-trial": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -118,7 +118,7 @@
 		"onboarding/import-light": false,
 		"onboarding/import-redirect-to-themes": true,
 		"onboarding/interval-dropdown": true,
-		"onboarding/new-user-survey": true,
+		"onboarding/new-user-survey": false,
 		"p2/p2-plus": true,
 		"pattern-assembler/v2": true,
 		"plans/hosting-trial": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to pau2Xa-5AZ-p2

## Proposed Changes 

### Show a post signup survey

* Adds a new user survey as an experiment to fulfil a customer data gathering exercise
* The experiment is loaded on load of the `start` page. The experiment is loaded only if the flow is `onboarding` and the user is not currently signed up. 
https://github.com/Automattic/wp-calypso/blob/4c61fe774e6cfa3a197243f2e5488ba48079cec3/client/signup/controller.js#L237-L248

* The survey will be excluded in all other instances and the `control` variant.
* The data will be submitted as tracks props

<img width="1381" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/d71d7690-c533-41bd-9c58-4980c6add8d3">

### Shuffle options logic

When the form is visible, we shuffle options if the variant is `treatment_scramble`. If not the order will remain static. When shuffling the order we record it in state and provide this information as a tracks prop for data analysis.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
Assign yourself to the variant in  21652-explat-experiment
* Try with a fresh user on the onboarding flow `/start` the survey view should be visible
* Try with a fresh user on the any other signup flow `/start` the survey view should NOT be visible
* Try with an existing user (user with at least 1 active site) start logged out and go to `/start` survey should not be visible
* With a fresh user fill the survey make sure they are accurately reflected when submitted.

Assign yourself to the control in  21652-explat-experiment
* Try with a fresh user on the onboarding flow `/start` the survey view should NOT be visible

Use feature flag 

* This can also be tested via the feature flags onboarding/new-user-survey, onboarding/new-user-survey-scrambled. 
Eg: ...
   - `/start?flags="onboarding/new-user-survey"` 
   - `/start?flags="onboarding/new-user-survey-scrambled"`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?