### PR TITLE
Checkout Bi-yearly Upsell: Show bi-yearly discount when no intro-offer involved.

### DIFF
--- a/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/jetpack-akismet-checkout-sidebar-plan-upsell/index.tsx
@@ -120,6 +120,12 @@ const useCalculatedDiscounts = () => {
 				isIntroductoryOffer: true,
 			} );
 		}
+	} else {
+		priceBreakdown.push( {
+			label: __( 'Multi-year discount*' ),
+			priceInteger: originalPrice - biennial.priceInteger,
+			isDiscount: true,
+		} );
 	}
 
 	// Coupon discount is added on top of other discounts


### PR DESCRIPTION
This PR fixes an issue where the multi-year discount was not being displayed in the Bi-yearly upsell, for Jetpack products that do not have an introductory offer (currently 2 Jetpack products: Jetpack Stats and Jetpack AI).

Fixes: https://github.com/Automattic/jetpack-marketing/issues/588

The PR trail (ordered historically from earliest to most recent):  https://github.com/Automattic/wp-calypso/pull/86353 --> https://github.com/Automattic/wp-calypso/issues/87194 --> https://github.com/Automattic/wp-calypso/pull/87243 --> https://github.com/Automattic/wp-calypso/pull/87266 --> (This PR)

Screenshots:

**BEFORE:**

![Markup 2024-02-18 at 12 32 32](https://github.com/Automattic/wp-calypso/assets/11078128/7ce2b03e-a2ae-42c5-b073-2f605ab6f67c)

.
**AFTER:**

![Markup 2024-02-18 at 12 35 48](https://github.com/Automattic/wp-calypso/assets/11078128/8a4cadbe-3d96-458b-951e-c12709e85e51)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Spin up Calypso blue locally or using the Calypso Live (direct link) below:
- Go to: `/checkout/jetpack/jetpack_stats_yearly` and verify the multi-year discount is showing correctly in the 2-year plan upsell box in the sidebar.  Same goes for `/checkout/jetpack/jetpack_ai_yearly`.
- Compare with production and see that the issue is fixed. 
- Also view the other products **with** introductory offers, and verify they are unaffected by this PR and they are still showing correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
- [ ] 