### PR TITLE
GitHub Deployments: Improve popup handling by listening for specific posted messages

### DIFF
--- a/client/my-sites/github-deployments/deployments/authorize-button.tsx
+++ b/client/my-sites/github-deployments/deployments/authorize-button.tsx
@@ -13,7 +13,7 @@ const AUTHORIZE_URL = addQueryArgs( 'https://github.com/login/oauth/authorize', 
 	client_id: config( 'github_oauth_client_id' ),
 } );
 
-const POPUP_ID = 'github-oauth-authorize';
+const POPUP_ID = 'github-app-authorize';
 
 export const GitHubAuthorizeButton = () => {
 	const { __ } = useI18n();
@@ -26,7 +26,7 @@ export const GitHubAuthorizeButton = () => {
 	const startAuthorization = () => {
 		setIsAuthorizing( true );
 
-		openPopup( { url: AUTHORIZE_URL, popupId: POPUP_ID } )
+		openPopup( { url: AUTHORIZE_URL, popupId: POPUP_ID, expectedEvent: 'github-app-authorized' } )
 			.then( () => refetch() )
 			.catch( () => dispatch( errorNotice( 'Failed to authorize GitHub. Please try again.' ) ) )
 			.finally( () => setIsAuthorizing( false ) );

--- a/client/my-sites/github-deployments/utils/open-popup.ts
+++ b/client/my-sites/github-deployments/utils/open-popup.ts
@@ -1,10 +1,11 @@
 interface OpenPopupOptions {
 	url: string;
 	popupId: string;
+	expectedEvent: string;
 }
 
-export const openPopup = ( { url, popupId }: OpenPopupOptions ) => {
-	return new Promise< void >( ( resolve, reject ) => {
+export const openPopup = < T = void >( { url, popupId, expectedEvent }: OpenPopupOptions ) => {
+	return new Promise< T >( ( resolve, reject ) => {
 		let popup: Window | null;
 
 		try {
@@ -14,14 +15,44 @@ export const openPopup = ( { url, popupId }: OpenPopupOptions ) => {
 		}
 
 		if ( ! popup ) {
-			reject();
+			return reject();
 		}
 
-		const interval = setInterval( (): void => {
-			if ( popup?.closed ) {
-				resolve();
+		let interval: number | null = null;
+		let handleMessage: Window[ 'onmessage' ] | null = null;
+		let hasResolved = false;
+
+		const clearListeners = () => {
+			if ( null !== interval ) {
 				clearInterval( interval );
 			}
+
+			if ( null !== handleMessage ) {
+				window.removeEventListener( 'message', handleMessage );
+			}
+		};
+
+		handleMessage = ( event: MessageEvent ) => {
+			const { data } = event;
+
+			if ( ! data ) {
+				return;
+			}
+
+			if ( expectedEvent === data.type ) {
+				clearListeners();
+				hasResolved = true;
+				resolve( data );
+			}
+		};
+
+		interval = window.setInterval( () => {
+			if ( popup?.closed && ! hasResolved ) {
+				clearListeners();
+				reject();
+			}
 		}, 500 );
+
+		window.addEventListener( 'message', handleMessage );
 	} );
 };


### PR DESCRIPTION
## Proposed Changes

Improves popup handling by listening for events dispatched from the popup. This means we can transmit data from the callback endpoint to WPCOM. This is useful in case we want to update the UI in response to certain events, using a new app installation as an example.

## Testing Instructions

- [Revoke app authorization](https://github.com/settings/apps/authorizations) inside GitHub and re-authorize yourself inside Calypso. Check that as soon as you press the button the popup closes and the connections are refetched.
- Enter the repository connection wizard and install the app into a new account. Verify that as soon as you install the app from the popup, it closes and the new account is preselected.