### PR TITLE
Fix the sites table on tablets

### DIFF
--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -45,7 +45,7 @@ const Row = styled.tr`
 	border-block-end: 1px solid #eee;
 `;
 
-const Column = styled.td< { tabletHidden?: boolean } >`
+const Column = styled.td< { tabletHidden?: boolean; laptopHidden: boolean } >`
 	padding-block-start: 12px;
 	padding-block-end: 12px;
 	padding-inline-end: 24px;
@@ -58,9 +58,13 @@ const Column = styled.td< { tabletHidden?: boolean } >`
 	overflow: hidden;
 	text-overflow: ellipsis;
 
-	${ MEDIA_QUERIES.largeOrSmaller } {
+	${ MEDIA_QUERIES.hideTableRows } {
 		${ ( props ) => props.tabletHidden && 'display: none;' };
 		padding-inline-end: 0;
+	}
+
+	${ MEDIA_QUERIES.hideTableRows } {
+		${ ( props ) => props.laptopHidden && 'display: none;' };
 	}
 
 	.stats-sparkline__bar {
@@ -71,13 +75,13 @@ const Column = styled.td< { tabletHidden?: boolean } >`
 const SiteListTile = styled( ListTile )`
 	margin-inline-end: 0;
 
-	${ MEDIA_QUERIES.largeOrSmaller } {
+	${ MEDIA_QUERIES.hideTableRows } {
 		margin-inline-end: 12px;
 	}
 `;
 
 const ListTileLeading = styled( ThumbnailLink )`
-	${ MEDIA_QUERIES.largeOrSmaller } {
+	${ MEDIA_QUERIES.hideTableRows } {
 		margin-inline-end: 12px;
 	}
 `;

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -45,7 +45,7 @@ const Row = styled.tr`
 	border-block-end: 1px solid #eee;
 `;
 
-const Column = styled.td< { mobileHidden?: boolean } >`
+const Column = styled.td< { tabletHidden?: boolean } >`
 	padding-block-start: 12px;
 	padding-block-end: 12px;
 	padding-inline-end: 24px;
@@ -58,8 +58,8 @@ const Column = styled.td< { mobileHidden?: boolean } >`
 	overflow: hidden;
 	text-overflow: ellipsis;
 
-	${ MEDIA_QUERIES.mediumOrSmaller } {
-		${ ( props ) => props.mobileHidden && 'display: none;' };
+	${ MEDIA_QUERIES.largeOrSmaller } {
+		${ ( props ) => props.tabletHidden && 'display: none;' };
 		padding-inline-end: 0;
 	}
 
@@ -71,13 +71,13 @@ const Column = styled.td< { mobileHidden?: boolean } >`
 const SiteListTile = styled( ListTile )`
 	margin-inline-end: 0;
 
-	${ MEDIA_QUERIES.mediumOrSmaller } {
+	${ MEDIA_QUERIES.largeOrSmaller } {
 		margin-inline-end: 12px;
 	}
 `;
 
 const ListTileLeading = styled( ThumbnailLink )`
-	${ MEDIA_QUERIES.mediumOrSmaller } {
+	${ MEDIA_QUERIES.largeOrSmaller } {
 		margin-inline-end: 12px;
 	}
 `;
@@ -218,10 +218,10 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 					}
 				/>
 			</Column>
-			<Column mobileHidden>
+			<Column tabletHidden>
 				<SitePlan site={ site } userId={ userId } />
 			</Column>
-			<Column mobileHidden>
+			<Column tabletHidden>
 				<WithAtomicTransfer site={ site }>
 					{ ( result ) =>
 						result.wasTransferring ? (
@@ -235,10 +235,10 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 					}
 				</WithAtomicTransfer>
 			</Column>
-			<Column mobileHidden>
+			<Column tabletHidden>
 				{ site.options?.updated_at ? <TimeSince date={ site.options.updated_at } /> : '' }
 			</Column>
-			<StatsColumnStyled mobileHidden>
+			<StatsColumnStyled tabletHidden>
 				{ inView && (
 					<>
 						{ hasStatsLoadingError ? (

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -45,7 +45,7 @@ const Row = styled.tr`
 	border-block-end: 1px solid #eee;
 `;
 
-const Column = styled.td< { tabletHidden?: boolean; laptopHidden: boolean } >`
+const Column = styled.td< { tabletHidden?: boolean } >`
 	padding-block-start: 12px;
 	padding-block-end: 12px;
 	padding-inline-end: 24px;
@@ -61,10 +61,6 @@ const Column = styled.td< { tabletHidden?: boolean; laptopHidden: boolean } >`
 	${ MEDIA_QUERIES.hideTableRows } {
 		${ ( props ) => props.tabletHidden && 'display: none;' };
 		padding-inline-end: 0;
-	}
-
-	${ MEDIA_QUERIES.hideTableRows } {
-		${ ( props ) => props.laptopHidden && 'display: none;' };
 	}
 
 	.stats-sparkline__bar {

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -22,7 +22,7 @@ const Table = styled.table`
 `;
 
 const THead = styled.thead< { blockOffset: number } >( ( { blockOffset } ) => ( {
-	[ MEDIA_QUERIES.largeOrSmaller ]: {
+	[ MEDIA_QUERIES.hideTableRows ]: {
 		display: 'none',
 	},
 

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -22,7 +22,7 @@ const Table = styled.table`
 `;
 
 const THead = styled.thead< { blockOffset: number } >( ( { blockOffset } ) => ( {
-	[ MEDIA_QUERIES.mediumOrSmaller ]: {
+	[ MEDIA_QUERIES.largeOrSmaller ]: {
 		display: 'none',
 	},
 

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -111,6 +111,7 @@ export const MEDIA_QUERIES = {
 	small: `@media ${ SMALL_MEDIA_QUERY }`,
 	mediumOrSmaller: '@media screen and ( max-width: 781px )',
 	mediumOrLarger: '@media screen and ( min-width: 660px )',
+	largeOrSmaller: '@media screen and ( max-width: 960px )',
 	large: '@media screen and ( min-width: 960px )',
 	wide: '@media screen and ( min-width: 1280px )',
 };

--- a/client/sites-dashboard/utils.ts
+++ b/client/sites-dashboard/utils.ts
@@ -111,7 +111,7 @@ export const MEDIA_QUERIES = {
 	small: `@media ${ SMALL_MEDIA_QUERY }`,
 	mediumOrSmaller: '@media screen and ( max-width: 781px )',
 	mediumOrLarger: '@media screen and ( min-width: 660px )',
-	largeOrSmaller: '@media screen and ( max-width: 960px )',
+	hideTableRows: '@media screen and ( max-width: 1100px )',
 	large: '@media screen and ( min-width: 960px )',
 	wide: '@media screen and ( min-width: 1280px )',
 };


### PR DESCRIPTION
Fixes 5657-gh-Automattic/dotcom-forge 
Adjust sites table to work with the larger side bar on tablets.
I've noticed we don't seem to be showing the menu on mobile, but this diff is just to fix it for tablet sized screens.

**After:**
<img width="955" alt="Screenshot 2024-02-19 at 12 27 03 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/22102880-cdf6-4adb-80c6-8a92fd83f01c">

This does have a side effect when the flag is turned off, rather than add logic to handle the flag that we'll just have to remove. I think we should just allow this change, this is the worst it gets at 960px:

<img width="954" alt="Screenshot 2024-02-19 at 12 28 14 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/cfb60e5b-d57f-47df-a757-ac32192f7b7f">

### Testing instructions 
see 5657-gh-Automattic/dotcom-forge, set width to ~900px and view /sites page.