### PR TITLE
GitHub Deployments: Authorize with the social connection mechanism

### DIFF
--- a/client/my-sites/github-deployments/deployments/authorize-button.tsx
+++ b/client/my-sites/github-deployments/deployments/authorize-button.tsx
@@ -5,11 +5,11 @@ import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
 import SocialLogo from 'calypso/components/social-logo';
 import { useDispatch } from 'calypso/state';
-import { connectSocialUser } from 'calypso/state/login/actions';
 import { postLoginRequest } from 'calypso/state/login/utils';
 import { errorNotice } from 'calypso/state/notices/actions';
 import { useGithubAccountsQuery } from '../use-github-accounts-query';
 import { openPopup } from '../utils/open-popup';
+import { useSaveGitHubCredentialsMutation } from './use-save-github-credentials-mutation';
 
 const AUTHORIZE_URL = addQueryArgs( 'https://github.com/login/oauth/authorize', {
 	client_id: config( 'github_oauth_client_id' ),
@@ -22,6 +22,7 @@ export const GitHubAuthorizeButton = () => {
 	const dispatch = useDispatch();
 
 	const { isLoading, isRefetching, refetch } = useGithubAccountsQuery();
+	const { saveGitHubCredentials } = useSaveGitHubCredentialsMutation();
 
 	const [ isAuthorizing, setIsAuthorizing ] = useState( false );
 
@@ -46,12 +47,7 @@ export const GitHubAuthorizeButton = () => {
 					throw new Error( 'Access token not included in the response.' );
 				}
 
-				return dispatch(
-					connectSocialUser( {
-						service: 'github',
-						access_token: response.body.data.access_token,
-					} )
-				);
+				return saveGitHubCredentials( { accessToken: response.body.data.access_token } );
 			} )
 			.then( () => refetch() )
 			.catch( () => dispatch( errorNotice( 'Failed to authorize GitHub. Please try again.' ) ) )

--- a/client/my-sites/github-deployments/deployments/use-save-github-credentials-mutation.ts
+++ b/client/my-sites/github-deployments/deployments/use-save-github-credentials-mutation.ts
@@ -1,0 +1,31 @@
+import { useMutation } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import wp from 'calypso/lib/wp';
+
+interface MutationVariables {
+	accessToken: string;
+}
+
+export const useSaveGitHubCredentialsMutation = () => {
+	const mutation = useMutation( {
+		mutationFn: async ( { accessToken }: MutationVariables ) =>
+			wp.req.post(
+				{
+					path: '/hosting/github/accounts',
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					access_token: accessToken,
+				}
+			),
+	} );
+
+	const { mutateAsync, isPending } = mutation;
+
+	const saveGitHubCredentials = useCallback(
+		( args: MutationVariables ) => mutateAsync( args ),
+		[ mutateAsync ]
+	);
+
+	return { saveGitHubCredentials, isPending };
+};

--- a/client/my-sites/github-deployments/use-github-accounts-query.ts
+++ b/client/my-sites/github-deployments/use-github-accounts-query.ts
@@ -4,11 +4,14 @@ import { GITHUB_DEPLOYMENTS_QUERY_KEY } from './constants';
 
 const fetchAccounts = (): GitHubAccountData[] =>
 	wp.req.get( {
-		path: `/hosting/github/accounts`,
+		path: `/hosting/github/installations`, // @todo Change the references to this endpoint
 		apiNamespace: 'wpcom/v2',
 	} );
 
-const GITHUB_DEPLOYMENTS_ACCOUNTS_QUERY_KEY = [ GITHUB_DEPLOYMENTS_QUERY_KEY, 'github-accounts' ];
+const GITHUB_DEPLOYMENTS_ACCOUNTS_QUERY_KEY = [
+	GITHUB_DEPLOYMENTS_QUERY_KEY,
+	'github-installations',
+];
 
 export interface GitHubAccountData {
 	account_name: string;

--- a/client/state/login/actions/connect-social-user.js
+++ b/client/state/login/actions/connect-social-user.js
@@ -12,13 +12,13 @@ import 'calypso/state/login/init';
 
 /**
  * Connects the current WordPress.com account with a third-party social account (Google ...).
- * @param {Object} socialInfo              Object containing the social service config data
- * @param {string} socialInfo.service      Social service associated with token, e.g. google.
- * @param {string} socialInfo.access_token OAuth2 Token returned from service.
- * @param {string} socialInfo.id_token     (Optional) OpenID Connect Token returned from service.
- * @param {string} socialInfo.user_name    (Optional) The user name associated with this connection, in case it's not part of id_token.
- * @param {string} socialInfo.user_email   (Optional) The user email associated with this connection, in case it's not part of id_token.
- * @param {string} redirectTo              Url to redirect the user to upon successful login
+ * @param {Object}  socialInfo              Object containing the social service config data
+ * @param {string}  socialInfo.service      Social service associated with token, e.g. google.
+ * @param {string}  socialInfo.access_token OAuth2 Token returned from service.
+ * @param {string=} socialInfo.id_token     (Optional) OpenID Connect Token returned from service.
+ * @param {string=} socialInfo.user_name    (Optional) The user name associated with this connection, in case it's not part of id_token.
+ * @param {string=} socialInfo.user_email   (Optional) The user email associated with this connection, in case it's not part of id_token.
+ * @param {string=} redirectTo              Url to redirect the user to upon successful login
  * @returns {Function} A thunk that can be dispatched
  */
 export const connectSocialUser =


### PR DESCRIPTION
## Proposed Changes

Relies on the `exchange-social-auth-code` endpoint to exchange the GitHub OAuth code for an access token, and saves this access token to an endpoint. The alternative was passing a `state` string, which doesn't sound ideal since our other OAuth mechanisms are not relying on it (and it also serves a different purpose.)

## Testing Instructions

See D138680-code.