### PR TITLE
Pattern Insertion: Fix the wpcom_pattern_inserted event isn't fired due to the incorrect pattern list

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/tracking.js
+++ b/apps/wpcom-block-editor/src/wpcom/features/tracking.js
@@ -326,10 +326,9 @@ const getBlocksTracker = ( eventName ) => ( blockIds, fromRootClientId, toRootCl
 const maybeTrackPatternInsertion = ( actionData, additionalData ) => {
 	const { rootClientId, blocks_replaced, insert_method, search_term } = additionalData;
 	const context = getBlockEventContextProperties( rootClientId );
-	const {
-		__experimentalBlockPatterns: patterns,
-		__experimentalBlockPatternCategories: patternCategories,
-	} = select( 'core/block-editor' ).getSettings();
+	const { __experimentalBlockPatternCategories: patternCategories } =
+		select( 'core/block-editor' ).getSettings();
+	const patterns = select( 'core/block-editor' ).__experimentalGetAllowedPatterns();
 
 	const meta = find( actionData, ( item ) => item?.patternName );
 	let patternName = meta?.patternName;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1708310144113639-slack-C029GN3KD

## Proposed Changes

* I'm unsure but the `__experimentalBlockPatterns` seems to become empty after https://github.com/WordPress/gutenberg/pull/57999 (or other changes from v17.6) so we cannot get the pattern name from the insertBlock/insertBlocks action when the pattern name is just directly used as a string instead of an object.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this change to your sandbox, and sandbox `widgets.wp.com`
* Go to the Site Editor
* Insert a pattern with a search term
  ![image](https://github.com/Automattic/wp-calypso/assets/13596067/f3a6a640-a50c-4524-8b23-5f84a92ef02e)
* Make sure the `wpcom_pattern_inserted` event is fired correctly
* Insert a pattern from the quick inserter
  ![image](https://github.com/Automattic/wp-calypso/assets/13596067/09b0c451-afe3-41ef-83d8-ae07006c2ace)
* Make sure the `wpcom_pattern_inserted` event is fired correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?