### PR TITLE
deactivate bloganuary in dev

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -31,7 +31,6 @@
 	"features": {
 		"ad-tracking": false,
 		"akismet/checkout-quantity-dropdown": true,
-		"bloganuary": true,
 		"calypso/ai-blogging-prompts": true,
 		"calypso/ai-assembler": true,
 		"calypso/help-center": true,


### PR DESCRIPTION
disable bloganuary testing flag so that developers will no longer see bloganuary cards etc.
The flag only exists for developers.