### PR TITLE
Move `adminInterface` check to `shouldShowGlobalSiteSidebar`

### DIFF
--- a/client/my-sites/navigation/index.jsx
+++ b/client/my-sites/navigation/index.jsx
@@ -4,10 +4,12 @@ import { connect } from 'react-redux';
 import AsyncLoad from 'calypso/components/async-load';
 import { withCurrentRoute } from 'calypso/components/route';
 import GlobalSidebar from 'calypso/layout/global-sidebar';
-import { useGlobalSidebar } from 'calypso/layout/global-sidebar/hooks/use-global-sidebar';
 import SitePicker from 'calypso/my-sites/picker';
 import MySitesSidebarUnifiedBody from 'calypso/my-sites/sidebar/body';
-import { getSiteOption } from 'calypso/state/sites/selectors';
+import {
+	getShouldShowGlobalSidebar,
+	getShouldShowGlobalSiteSidebar,
+} from 'calypso/state/global-sidebar/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 
 class MySitesNavigation extends Component {
@@ -105,15 +107,15 @@ export default withCurrentRoute(
 	connect( ( state, { currentSection } ) => {
 		const sectionGroup = currentSection?.group ?? null;
 		const siteId = getSelectedSiteId( state );
-		const adminInterface = getSiteOption( state, siteId, 'wpcom_admin_interface' );
-		const { shouldShowGlobalSidebar, shouldShowGlobalSiteSidebar } = useGlobalSidebar(
+		const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
+		const shouldShowGlobalSiteSidebar = getShouldShowGlobalSiteSidebar(
+			state,
 			siteId,
 			sectionGroup
 		);
 		return {
 			isGlobalSidebarVisible: shouldShowGlobalSidebar,
-			// Global Site View should be limited to classic interface users only for now.
-			isGlobalSiteSidebarVisible: shouldShowGlobalSiteSidebar && adminInterface === 'wp-admin',
+			isGlobalSiteSidebarVisible: shouldShowGlobalSiteSidebar,
 		};
 	}, null )( MySitesNavigation )
 );

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -4,9 +4,12 @@ import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { useCurrentRoute } from 'calypso/components/route';
-import { useGlobalSidebar } from 'calypso/layout/global-sidebar/hooks/use-global-sidebar';
 import domainOnlyFallbackMenu from 'calypso/my-sites/sidebar/static-data/domain-only-fallback-menu';
 import { getAdminMenu } from 'calypso/state/admin-menu/selectors';
+import {
+	getShouldShowGlobalSidebar,
+	getShouldShowGlobalSiteSidebar,
+} from 'calypso/state/global-sidebar/selectors';
 import { getPluginOnSite } from 'calypso/state/plugins/installed/selectors';
 import { canAnySiteHavePlugins } from 'calypso/state/selectors/can-any-site-have-plugins';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
@@ -17,7 +20,6 @@ import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getSiteDomain, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { requestAdminMenu } from '../../state/admin-menu/actions';
-import { getSiteOption } from '../../state/sites/selectors';
 import allSitesMenu from './static-data/all-sites-menu';
 import buildFallbackResponse from './static-data/fallback-menu';
 import globalSidebarMenu from './static-data/global-sidebar-menu';
@@ -36,13 +38,12 @@ const useSiteMenuItems = () => {
 	const locale = useLocale();
 	const isAllDomainsView = '/domains/manage' === currentRoute;
 	const { currentSection } = useCurrentRoute();
-	const adminInterface = useSelector( ( state ) =>
-		getSiteOption( state, selectedSiteId, 'wpcom_admin_interface' )
-	);
-	const { shouldShowGlobalSidebar, shouldShowGlobalSiteSidebar } = useGlobalSidebar(
-		selectedSiteId,
-		currentSection?.group
-	);
+	const shouldShowGlobalSidebar = useSelector( ( state ) => {
+		return getShouldShowGlobalSidebar( state, selectedSiteId, currentSection?.group );
+	} );
+	const shouldShowGlobalSiteSidebar = useSelector( ( state ) => {
+		return getShouldShowGlobalSiteSidebar( state, selectedSiteId, currentSection?.group );
+	} );
 
 	useEffect( () => {
 		if ( selectedSiteId && siteDomain ) {
@@ -114,8 +115,7 @@ const useSiteMenuItems = () => {
 	if ( shouldShowGlobalSidebar ) {
 		return globalSidebarMenu();
 	}
-	// Global Site View should be limited to classic interface users only for now.
-	if ( shouldShowGlobalSiteSidebar && adminInterface === 'wp-admin' ) {
+	if ( shouldShowGlobalSiteSidebar ) {
 		return globalSiteSidebarMenu( {
 			siteDomain,
 			shouldShowAddOns: shouldShowAddOnsInFallbackMenu,

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -1,0 +1,30 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { getSiteOption } from '../sites/selectors';
+import type { AppState } from 'calypso/types';
+
+export const getShouldShowGlobalSidebar = ( _: AppState, siteId: number, sectionGroup: string ) => {
+	let shouldShowGlobalSidebar = false;
+	if ( isEnabled( 'layout/dotcom-nav-redesign' ) ) {
+		shouldShowGlobalSidebar =
+			sectionGroup === 'me' ||
+			sectionGroup === 'reader' ||
+			sectionGroup === 'sites-dashboard' ||
+			( sectionGroup === 'sites' && ! siteId );
+	}
+	return shouldShowGlobalSidebar;
+};
+
+export const getShouldShowGlobalSiteSidebar = (
+	state: AppState,
+	siteId: number,
+	sectionGroup: string
+) => {
+	let shouldShowGlobalSiteSidebar = false;
+	if ( isEnabled( 'layout/dotcom-nav-redesign' ) ) {
+		// Global Site View should be limited to classic interface users only for now.
+		const adminInterface = getSiteOption( state, siteId, 'wpcom_admin_interface' );
+		shouldShowGlobalSiteSidebar =
+			adminInterface === 'wp-admin' && sectionGroup === 'sites' && !! siteId;
+	}
+	return shouldShowGlobalSiteSidebar;
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thehttps://github.com/Automattic/dotcom-forge/issues/5609linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5609

## Proposed Changes

This pull request refactors the location of the `adminInterface` check, moving it into the `shouldShowGlobalSiteSidebar` function. 
This change aims to streamline code by reducing the number of code seams. Previously implemented as a hook, the `adminInterface` check has been transformed into a selector, so it can now be utilized within both functional and connected components.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live
* Go to /sites, /read, /me and verify it shows Global View sidebar
* Prepare a site with the classic view, and then go to a Calypso page (e.g., /home/your-site), verify it shows Global Site View sidebar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?