### PR TITLE
Nav redesign: make site switcher links to /sites

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -42,6 +42,38 @@ class CurrentSite extends Component {
 		this.props.recordTracksEvent( 'calypso_sidebar_all_sites_click' );
 	};
 
+	renderSiteSwitcher = () => {
+		const { translate, isRtl } = this.props;
+		const arrowDirection = isRtl ? 'right' : 'left';
+
+		if ( isEnabled( 'layout/dotcom-nav-redesign' ) ) {
+			return (
+				<span className="current-site__switch-sites">
+					<Button borderless href="/sites">
+						<span
+							// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+							className={ `gridicon dashicons-before dashicons-arrow-${ arrowDirection }-alt2` }
+						></span>
+						<span className="current-site__switch-sites-label">{ translate( 'All sites' ) }</span>
+					</Button>
+				</span>
+			);
+		}
+		return (
+			this.props.siteCount > 1 && (
+				<span className="current-site__switch-sites">
+					<Button borderless onClick={ this.switchSites }>
+						<span
+							// eslint-disable-next-line wpcalypso/jsx-classname-namespace
+							className={ `gridicon dashicons-before dashicons-arrow-${ arrowDirection }-alt2` }
+						></span>
+						<span className="current-site__switch-sites-label">{ translate( 'Switch site' ) }</span>
+					</Button>
+				</span>
+			)
+		);
+	};
+
 	render() {
 		const { selectedSite, translate, anySiteSelected } = this.props;
 
@@ -70,24 +102,10 @@ class CurrentSite extends Component {
 			/* eslint-enable wpcalypso/jsx-classname-namespace, jsx-a11y/anchor-is-valid */
 		}
 
-		const arrowDirection = this.props.isRtl ? 'right' : 'left';
-
 		return (
 			<Card className="current-site">
 				<div role="button" tabIndex="0" aria-hidden="true" onClick={ this.expandUnifiedNavSidebar }>
-					{ this.props.siteCount > 1 && (
-						<span className="current-site__switch-sites">
-							<Button borderless onClick={ this.switchSites }>
-								<span
-									// eslint-disable-next-line wpcalypso/jsx-classname-namespace
-									className={ `gridicon dashicons-before dashicons-arrow-${ arrowDirection }-alt2` }
-								></span>
-								<span className="current-site__switch-sites-label">
-									{ translate( 'Switch site' ) }
-								</span>
-							</Button>
-						</span>
-					) }
+					{ this.renderSiteSwitcher() }
 
 					{ selectedSite ? (
 						<div>

--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -49,7 +49,7 @@ class CurrentSite extends Component {
 		if ( isEnabled( 'layout/dotcom-nav-redesign' ) ) {
 			return (
 				<span className="current-site__switch-sites">
-					<Button borderless href="/sites">
+					<Button borderless href="/sites" onClick={ this.onAllSitesClick }>
 						<span
 							// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 							className={ `gridicon dashicons-before dashicons-arrow-${ arrowDirection }-alt2` }


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/5640

## Proposed Changes

This PR makes so that the site switcher links back to `/sites` when the nav redesign flag is true.

In that case, this PR also renames the link to `All sites`, to align with the Global Site View sidebar.

|Before|After
|-|-|
|<img width="272" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/52fdd48e-8a0b-407b-a8f3-2153a9b8a571">|<img width="277" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/9f6e18a6-4d91-4c62-ab94-a426339a8dbc">|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Go to `/home/:siteSlug` on a Free site
2. Verify that the button takes us to `/sites` upon clicked
3. Repeat with the flag disabled `?flags=-layout/dotcom-nav-redesign`, verify that the original site switcher behavior is there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)