### PR TITLE
A4A: Add the 'Main' and 'Sites' sidebar menu items.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -1,0 +1,5 @@
+export const A4A_OVERVIEW_LINK = '/overview';
+export const A4A_SITES_LINK = '/sites';
+export const A4A_SITES_LINK_NEEDS_ATTENTION = '/sites?issue_types=all_issues';
+export const A4A_SITES_LINK_FAVORITE = '/sites/favorite';
+export const A4A_PLUGINS_LINK = '/plugins';

--- a/client/a8c-for-agencies/components/sidebar-menu/lib/utils.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/utils.ts
@@ -1,0 +1,21 @@
+import { itemLinkMatches } from 'calypso/my-sites/sidebar/utils';
+import { A4A_SITES_LINK } from './constants';
+
+type MenuItemProps = {
+	id?: string;
+	icon: JSX.Element;
+	link: string;
+	path: string;
+	title: string;
+	withChevron?: boolean;
+	isExternalLink?: boolean;
+	trackEventProps?: { [ key: string ]: string };
+};
+
+export const createItem = ( props: MenuItemProps, path: string ) => ( {
+	...props,
+	trackEventName: 'calypso_a4a_sidebar_menu_click',
+	isSelected: props.link.startsWith( A4A_SITES_LINK )
+		? props.link === path
+		: itemLinkMatches( props.link, path ),
+} );

--- a/client/a8c-for-agencies/components/sidebar-menu/main.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/main.tsx
@@ -44,5 +44,5 @@ export default function ( { path }: Props ) {
 		].map( ( item ) => createItem( item, path ) );
 	}, [ path, translate ] );
 
-	return <Sidebar path="" menuItems={ menuItems } />;
+	return <Sidebar path="" menuItems={ menuItems } withUserProfileFooter />;
 }

--- a/client/a8c-for-agencies/components/sidebar-menu/main.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/main.tsx
@@ -1,0 +1,48 @@
+import { category, home, plugins } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import Sidebar from '../sidebar';
+import { A4A_OVERVIEW_LINK, A4A_PLUGINS_LINK, A4A_SITES_LINK } from './lib/constants';
+import { createItem } from './lib/utils';
+
+type Props = {
+	path: string;
+};
+
+export default function ( { path }: Props ) {
+	const translate = useTranslate();
+	const menuItems = useMemo( () => {
+		return [
+			{
+				icon: home,
+				path: '/',
+				link: A4A_OVERVIEW_LINK,
+				title: translate( 'Overview' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Overview',
+				},
+			},
+			{
+				icon: category,
+				path: '/',
+				link: A4A_SITES_LINK,
+				title: translate( 'Sites' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Dashboard',
+				},
+				withChevron: true,
+			},
+			{
+				icon: plugins,
+				path: '/',
+				link: A4A_PLUGINS_LINK,
+				title: translate( 'Plugins' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Plugins',
+				},
+			},
+		].map( ( item ) => createItem( item, path ) );
+	}, [ path, translate ] );
+
+	return <Sidebar path="" menuItems={ menuItems } />;
+}

--- a/client/a8c-for-agencies/components/sidebar-menu/sites.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/sites.tsx
@@ -1,0 +1,78 @@
+import page from '@automattic/calypso-router';
+import { category, chevronLeft, formatListBulletsRTL, starEmpty } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import Sidebar from '../sidebar';
+import {
+	A4A_OVERVIEW_LINK,
+	A4A_SITES_LINK,
+	A4A_SITES_LINK_FAVORITE,
+	A4A_SITES_LINK_NEEDS_ATTENTION,
+} from './lib/constants';
+import { createItem } from './lib/utils';
+
+type Props = {
+	path: string;
+};
+
+export default function ( { path }: Props ) {
+	const translate = useTranslate();
+
+	const menuItems = useMemo( () => {
+		return [
+			createItem(
+				{
+					icon: formatListBulletsRTL,
+					path: A4A_SITES_LINK,
+					link: A4A_SITES_LINK_NEEDS_ATTENTION,
+					title: translate( 'Needs Attention' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Sites / Needs Attention',
+					},
+				},
+				path
+			),
+			createItem(
+				{
+					icon: starEmpty,
+					path: A4A_SITES_LINK,
+					link: A4A_SITES_LINK_FAVORITE,
+					title: translate( 'Favorites' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Sites / Favorites',
+					},
+				},
+				path
+			),
+			createItem(
+				{
+					id: 'sites-all-menu-item',
+					icon: category,
+					path: A4A_SITES_LINK,
+					link: A4A_SITES_LINK,
+					title: translate( 'All' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Sites / All',
+					},
+				},
+				path
+			),
+		].map( ( item ) => createItem( item, path ) );
+	}, [ path, translate ] );
+
+	return (
+		<Sidebar
+			path={ A4A_SITES_LINK }
+			title={ translate( 'Sites' ) }
+			description={ translate( 'Manage all your sites and Jetpack services from one place.' ) }
+			backButtonProps={ {
+				label: translate( 'Back to overview' ),
+				icon: chevronLeft,
+				onClick: () => {
+					page( A4A_OVERVIEW_LINK );
+				},
+			} }
+			menuItems={ menuItems }
+		/>
+	);
+}

--- a/client/a8c-for-agencies/components/sidebar-menu/sites.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/sites.tsx
@@ -73,6 +73,8 @@ export default function ( { path }: Props ) {
 				},
 			} }
 			menuItems={ menuItems }
+			withSiteSelector
+			withGetHelpLink
 		/>
 	);
 }

--- a/client/a8c-for-agencies/sections/overview/controller.tsx
+++ b/client/a8c-for-agencies/sections/overview/controller.tsx
@@ -1,37 +1,9 @@
 import { type Callback } from '@automattic/calypso-router';
-import { category, home } from '@wordpress/icons';
-import Sidebar from '../../components/sidebar';
+import MainSidebar from '../../components/sidebar-menu/main';
 
 export const overviewContext: Callback = ( context, next ) => {
 	context.header = <div>Header</div>;
-	context.secondary = (
-		<Sidebar
-			path="/"
-			menuItems={ [
-				{
-					icon: home,
-					path: '/',
-					link: '/overview',
-					title: 'Overview',
-					trackEventProps: {
-						menu_item: 'A4A / Overview',
-					},
-					isSelected: true,
-				},
-				{
-					icon: category,
-					path: '/',
-					link: '/sites',
-					title: 'Sites',
-					trackEventProps: {
-						menu_item: 'Sites / Overview',
-					},
-					isSelected: false,
-				},
-			] }
-			withUserProfileFooter
-		/>
-	);
+	context.secondary = <MainSidebar path={ context.path } />;
 	context.primary = <div>Overview</div>;
 
 	next();

--- a/client/a8c-for-agencies/sections/plugins/controller.tsx
+++ b/client/a8c-for-agencies/sections/plugins/controller.tsx
@@ -1,8 +1,9 @@
 import { type Callback } from '@automattic/calypso-router';
+import MainSidebar from '../../components/sidebar-menu/main';
 
 export const pluginsContext: Callback = ( context, next ) => {
 	context.header = <div>Header</div>;
-	context.secondary = <div>Secondary</div>;
+	context.secondary = <MainSidebar path={ context.path } />;
 	context.primary = <div>plugins</div>;
 
 	next();

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -1,37 +1,9 @@
-import page, { type Callback } from '@automattic/calypso-router';
-import { category, chevronLeft } from '@wordpress/icons';
-import Sidebar from '../../components/sidebar';
+import { type Callback } from '@automattic/calypso-router';
+import SitesSidebar from '../../components/sidebar-menu/sites';
 
 export const sitesContext: Callback = ( context, next ) => {
 	context.header = <div>Header</div>;
-	context.secondary = (
-		<Sidebar
-			path="/"
-			title="Sites"
-			description="sample text"
-			backButtonProps={ {
-				label: 'Back to overview',
-				icon: chevronLeft,
-				onClick: () => {
-					page( '/overview' );
-				},
-			} }
-			menuItems={ [
-				{
-					icon: category,
-					path: '/',
-					link: '/sites',
-					title: 'Needs attention',
-					trackEventProps: {
-						menu_item: 'Sites / Overview',
-					},
-					isSelected: false,
-				},
-			] }
-			withSiteSelector
-			withGetHelpLink
-		/>
-	);
+	context.secondary = <SitesSidebar path={ context.path } />;
 	context.primary = <div>sites</div>;
 
 	next();
@@ -39,7 +11,7 @@ export const sitesContext: Callback = ( context, next ) => {
 
 export const sitesFavoriteContext: Callback = ( context, next ) => {
 	context.header = <div>Header</div>;
-	context.secondary = <div>Secondary</div>;
+	context.secondary = <SitesSidebar path={ context.path } />;
 	context.primary = <div>sites favorite</div>;
 
 	next();

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -388,7 +388,8 @@ export default withCurrentRoute(
 			isWpMobileApp() ||
 			isWcMobileApp() ||
 			shouldShowGlobalSidebar ||
-			isJetpackCloud();
+			isJetpackCloud() ||
+			config.isEnabled( 'a8c-for-agencies' );
 		const isJetpackMobileFlow = 'jetpack-connect' === sectionName && !! retrieveMobileRedirect();
 		const isJetpackWooCommerceFlow =
 			[ 'jetpack-connect', 'login' ].includes( sectionName ) &&


### PR DESCRIPTION
This pull request includes the official list of menu items for the Main and Sites sidebars in A4A.

<img width="481" alt="Screenshot 2024-02-19 at 4 20 47 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/124d430c-7228-4c04-b90c-32597aa1ebe5">
<img width="442" alt="Screenshot 2024-02-19 at 4 20 53 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/7167eda6-82e7-4337-9b48-6407370da583">

Closes https://github.com/Automattic/jetpack-genesis/issues/221
Closes https://github.com/Automattic/jetpack-genesis/issues/224
Closes https://github.com/Automattic/jetpack-genesis/issues/225

## Proposed Changes

* Add new `SidebarMain` and `SidebarSites` components containing predefined Sidebar properties.
* Update controllers to use the new components.
* Hide the masterbar from the layout when loading in the A4A environment.

## Testing Instructions
* Checkout this branch
* Spin up the environment using the command `yarn start-a8c-for-agencies`.
* Test if the sidebar menu works and is correct for all pages.
* **Additionally, please test Calypso Blue and Green existing URLs (/sites,/plugins,/overview) if it is not broken.**

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?