### PR TITLE
Show Default style as the default value of admin interface settings

### DIFF
--- a/client/my-sites/hosting/site-admin-interface-card/index.js
+++ b/client/my-sites/hosting/site-admin-interface-card/index.js
@@ -3,7 +3,7 @@ import { Card, FormLabel } from '@automattic/components';
 import { useHasEnTranslation } from '@automattic/i18n-utils';
 import styled from '@emotion/styled';
 import { useTranslate, localize } from 'i18n-calypso';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import CardHeading from 'calypso/components/card-heading';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -42,8 +42,8 @@ const SiteAdminInterfaceCard = ( { siteId } ) => {
 		dispatch( removeNotice( failureNoticeId ) );
 		dispatch( removeNotice( changeLoadingNoticeId ) );
 	};
-	const adminInterface = useSelector( ( state ) =>
-		getSiteOption( state, siteId, 'wpcom_admin_interface' )
+	const adminInterface = useSelector(
+		( state ) => getSiteOption( state, siteId, 'wpcom_admin_interface' ) || 'calypso'
 	);
 
 	const { setSiteInterface, isLoading: isUpdating } = useSiteInterfaceMutation( siteId, {
@@ -75,9 +75,7 @@ const SiteAdminInterfaceCard = ( { siteId } ) => {
 	} );
 
 	// Initialize the state with the value passed as a prop
-	const [ selectedAdminInterface, setSelectedAdminInterface ] = useState(
-		adminInterface ?? 'calypso'
-	);
+	const [ selectedAdminInterface, setSelectedAdminInterface ] = useState( adminInterface );
 
 	const handleInputChange = async ( value ) => {
 		dispatch(
@@ -88,12 +86,6 @@ const SiteAdminInterfaceCard = ( { siteId } ) => {
 		setSiteInterface( value );
 		setSelectedAdminInterface( value );
 	};
-
-	useEffect( () => {
-		if ( adminInterface ) {
-			setSelectedAdminInterface( adminInterface );
-		}
-	}, [ adminInterface ] );
 
 	return (
 		<Card>


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/5585

## Proposed Changes

This PR is a re-implementation of:

- https://github.com/Automattic/wp-calypso/pull/83494

, which was broken by:

- https://github.com/Automattic/wp-calypso/pull/86786

## Testing Instructions

- Create a new Business site and take it Atomic.
- Navigate to Hosting Configuration.
- Verify the 'Default style' radio option is checked by default.
- Verify that we can still click on the options, and the options can take effect as per usual.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?