### PR TITLE
Nav redesign: Implement scroll sync

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -96,6 +96,7 @@ $brand-text: "SF Pro Text", $sans;
 		.sidebar,
 		.sidebar__menu:not(.is-togglable) {
 			display: flex;
+			min-height: unset;
 			gap: 6px;
 			flex-direction: column;
 		}

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -93,6 +93,11 @@ $brand-text: "SF Pro Text", $sans;
 		flex: 1;
 		overflow-y: auto;
 
+		scrollbar-width: none;
+		&::-webkit-scrollbar {
+			display: none;
+		}
+
 		.sidebar,
 		.sidebar__menu:not(.is-togglable) {
 			display: flex;

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -140,3 +140,21 @@ export const handleScroll = ( event: React.UIEvent< HTMLElement > ): void => {
 		ticking = true;
 	}
 };
+
+export const handleScrollGlobalSidebar = ( event: Event ): void => {
+	const globalSidebarBodyEl = document.querySelector( '.global-sidebar .sidebar__body' );
+	if ( ! globalSidebarBodyEl ) {
+		return;
+	}
+
+	if ( ! globalSidebarBodyEl.hasAttribute( 'data-scroll-initialized' ) ) {
+		globalSidebarBodyEl.setAttribute( 'data-scroll-initialized', 'true' );
+		globalSidebarBodyEl.addEventListener( 'scroll', handleScrollGlobalSidebar );
+	}
+
+	if ( event.currentTarget === globalSidebarBodyEl ) {
+		document.documentElement.scrollTop = globalSidebarBodyEl.scrollTop;
+	} else {
+		globalSidebarBodyEl.scrollTop = scrollY;
+	}
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5633

## Proposed Changes

This PR implements scroll sync for the nav redesign. See recording for reference:

https://github.com/Automattic/wp-calypso/assets/797888/4d469271-2e20-4ac4-8737-8e3204b549e3

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that the scrolling between the nav and the right-side content are in sync.
* Ensure that the sync makes sense when for both short and tall viewports.  
* Ensure that the nav in non-classic sites works as before. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?