### PR TITLE
Update Global sidebar selected menu items styles

### DIFF
--- a/client/layout/global-sidebar/index.jsx
+++ b/client/layout/global-sidebar/index.jsx
@@ -25,7 +25,8 @@ const GlobalSidebar = ( { children, onClick = undefined, className = '', ...prop
 		return <Spinner className="sidebar__menu-loading" />;
 	}
 
-	const { requireBackLink, ...sidebarProps } = props;
+	const { requireBackLink, backLinkText, ...sidebarProps } = props;
+	const sidebarBackLinkText = backLinkText ?? translate( 'Back' );
 
 	return (
 		<div className="global-sidebar">
@@ -36,7 +37,7 @@ const GlobalSidebar = ( { children, onClick = undefined, className = '', ...prop
 						<div className="sidebar__back-link">
 							<a href="/sites">
 								<Gridicon icon="chevron-left" size={ 24 } />
-								<span className="sidebar__back-link-text">{ translate( 'Back' ) }</span>
+								<span className="sidebar__back-link-text">{ sidebarBackLinkText }</span>
 							</a>
 						</div>
 					) }

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -116,7 +116,9 @@ $brand-text: "SF Pro Text", $sans;
 			display: none;
 		}
 
-
+		li.sidebar-streams__search {
+			margin: 0;
+		}
 	}
 
 	.sidebar__footer {

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -90,7 +90,6 @@
 	.sidebar__body {
 		flex: 1;
 		overflow-y: auto;
-		padding-top: 36px;
 
 		.sidebar {
 			display: flex;
@@ -100,17 +99,9 @@
 			padding: 8px 8px 8px 20px;
 		}
 		a.sidebar__menu-link {
-			padding: 8px 8px 8px 20px;
-
-			.menu-link-text {
-				font-size: rem(16px);
-				font-weight: 400;
-				padding: 0;
-				max-height: auto;
-			}
-		}
-		.sidebar__menu-item-title-text {
-			line-height: 32px;
+			padding: 12px 10px;
+			margin: 0 12px;
+			border-radius: 4px;
 		}
 
 		li.sidebar__separator {

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -1,3 +1,5 @@
+@import "@automattic/typography/styles/variables";
+$brand-text: "SF Pro Text", $sans;
 .global-sidebar {
 	bottom: 0;
 	display: flex;
@@ -9,7 +11,7 @@
 	transition: all 220ms ease-out;
 	background-color: var(--studio-black);
 
-	ul {
+	ul.sidebar__menu:not(.is-togglable) {
 		height: 100%;
 	}
 
@@ -91,34 +93,30 @@
 		flex: 1;
 		overflow-y: auto;
 
-		.sidebar {
+		.sidebar,
+		.sidebar__menu:not(.is-togglable) {
 			display: flex;
 			gap: 6px;
-		}
-		.sidebar__menu.is-togglable a.sidebar__heading {
-			padding: 8px 8px 8px 20px;
-		}
-		a.sidebar__menu-link {
-			padding: 12px 10px;
-			margin: 0 12px;
-			border-radius: 4px;
+			flex-direction: column;
 		}
 
 		li.sidebar__separator {
 			margin: 0 0 24px;
 		}
 
-		.selected {
-			.sidebar__heading,
-			.sidebar__menu-link {
-				.sidebar_svg-reader {
-					fill: var(--color-sidebar-menu-selected-background);
-					g path {
-						fill: var(--color-sidebar-menu-selected-text);
-					}
-				}
-			}
+		svg.sidebar__menu-icon {
+			display: none;
 		}
+
+		.sidebar__expandable-arrow {
+			fill: var(--studio-white);
+		}
+
+		.selected .sidebar__menu-link::after {
+			display: none;
+		}
+
+
 	}
 
 	.sidebar__footer {
@@ -163,11 +161,21 @@
 		a {
 			color: var(--nav-link);
 			text-decoration: none;
+			align-items: center;
+			display: inline-flex;
+			margin-bottom: 24px;
+			padding: 9px;
+			gap: 8px;
 		}
 
 		svg.gridicons-chevron-left {
 			vertical-align: top;
 			fill: var(--color-sidebar-gridicon-fill);
+		}
+
+		.sidebar__back-link-text {
+			font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			vertical-align: text-bottom;
 		}
 	}
 

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -392,6 +392,11 @@ $font-size: rem(14px);
 			}
 		}
 
+		.sidebar__expandable-content {
+			border-radius: 4px;
+			margin: 0 12px;
+		}
+
 		.sidebar__expandable-title {
 			padding: 0;
 			margin: 0;

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -350,13 +350,50 @@ $font-size: rem(14px);
 
 		.sidebar__menu-link-text {
 			font-family: $brand-text;
-			/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
-			font-size: 13px;
+			font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
 			font-style: normal;
 			font-weight: 400;
 			padding: 0;
 			margin: 0;
 			box-sizing: border-box;
+		}
+
+		.sidebar__menu-link,
+		.sidebar__menu.is-togglable .sidebar__heading {
+			padding: 12px 10px;
+			margin: 0 12px;
+			border-radius: 4px;
+		}
+
+		.sidebar__heading:not([tabindex="-1"]),
+		.sidebar__menu-link {
+			&:hover,
+			&:focus {
+				box-shadow: none;
+				transition: none;
+				color: var(--studio-white);
+			}
+		}
+
+		.sidebar__menu.is-togglable .sidebar__heading {
+			padding: 12px 10px;
+			margin: 0 12px;
+			border-radius: 4px;
+
+			&:hover {
+				background-color: var(--color-sidebar-menu-hover-background);
+				color: var(--studio-white);
+
+				.sidebar__menu-icon,
+				.sidebar__expandable-arrow {
+					fill: var(--studio-white);
+				}
+			}
+		}
+
+		.sidebar__expandable-title {
+			padding: 0;
+			margin: 0;
 		}
 	}
 

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -1,6 +1,9 @@
 @import "@wordpress/base-styles/breakpoints";
 // The following changes should be merged in their respective files before nav unification goes to production
 @import url( //s1.wp.com/wp-includes/css/dashicons.css?v=20150727 );
+@import "@automattic/typography/styles/variables";
+
+$brand-text: "SF Pro Text", $sans;
 
 // Override Global Vars
 .theme-default {
@@ -34,6 +37,7 @@
 		--sidebar-width-min: 314px;
 
 		--color-sidebar-background: var(--studio-black);
+		--color-sidebar-menu-selected-background: #3858e9;
 	}
 }
 
@@ -328,6 +332,32 @@ $font-size: rem(14px);
 
 	.global-sidebar .sidebar {
 		background-color: var(--studio-black);
+
+		.selected .sidebar__menu-link::after {
+			display: none;
+		}
+
+		.sidebar__menu-link {
+			line-height: 15px;
+
+			&:hover,
+			&:focus {
+				box-shadow: none;
+				transition: none;
+				color: var(--studio-white);
+			}
+		}
+
+		.sidebar__menu-link-text {
+			font-family: $brand-text;
+			/* stylelint-disable-next-line  declaration-property-unit-allowed-list */
+			font-size: 13px;
+			font-style: normal;
+			font-weight: 400;
+			padding: 0;
+			margin: 0;
+			box-sizing: border-box;
+		}
 	}
 
 	//client/components/site-selector/style.scss

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -32,7 +32,8 @@ $brand-text: "SF Pro Text", $sans;
 	--color-sidebar-submenu-selected-background: transparent;
 	--color-sidebar-submenu-selected-text: var(--color-text-inverted);
 
-	.is-global-sidebar-visible {
+	.is-global-sidebar-visible,
+	.is-global-site-sidebar-visible {
 		--sidebar-width-max: 314px;
 		--sidebar-width-min: 314px;
 

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -235,3 +235,14 @@ div.reader-notifications__panel {
 		}
 	}
 }
+
+// Adjust the where the notifications panel is positioned when the global sidebar is visible
+.is-global-sidebar-visible {
+	div.reader-notifications__panel {
+		#wpnc-panel.wpnc__main {
+			&.wpnt-open {
+				left: 314px;
+			}
+		}
+	}
+}

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -2,7 +2,7 @@ import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { hasTranslation } from '@wordpress/i18n';
 import closest from 'component-closest';
-import { localize } from 'i18n-calypso';
+import i18n, { localize } from 'i18n-calypso';
 import { defer, startsWith } from 'lodash';
 import { Component } from 'react';
 import { connect } from 'react-redux';
@@ -158,8 +158,6 @@ export class ReaderSidebar extends Component {
 				<QueryReaderTeams />
 				<QueryReaderOrganizations />
 
-				<SidebarSeparator />
-
 				<SidebarItem
 					label={ translate( 'Search' ) }
 					onNavigate={ this.handleReaderSidebarSearchClicked }
@@ -278,6 +276,7 @@ export class ReaderSidebar extends Component {
 			path: this.props.path,
 			onClick: this.handleClick,
 			requireBackLink: true,
+			backLinkText: i18n.translate( 'All sites' ),
 		};
 		return (
 			<GlobalSidebar { ...props }>

--- a/client/reader/sidebar/style.scss
+++ b/client/reader/sidebar/style.scss
@@ -1,5 +1,8 @@
 /* Overide very specific css on an attribute */
 .sidebar {
+	li.sidebar-streams__search {
+		margin-top: 8px;
+	}
 	li.reader-sidebar-tags__list {
 		margin-bottom: 8px;
 	}


### PR DESCRIPTION
This updates the selected (and hover) states for the sidebar menu items in the global sidebar;

### Before
<img width="416" alt="Screenshot 2024-02-19 at 11 51 51" src="https://github.com/Automattic/wp-calypso/assets/5560595/2062415f-4674-408c-a4ed-5ca25c8f8c81">

### After
<img width="405" alt="Screenshot 2024-02-19 at 11 52 03" src="https://github.com/Automattic/wp-calypso/assets/5560595/b56234c4-856b-49dc-b268-8ae282124f6c">

### Updates
* Updated the selected and hover styles for the global sidebar on my sites, domains, reader, profile and the sites level in classic view.
* Added optional prop to pass the back link text to the global sidebar component because it is `Back` from profile page and `All sites` from Reader.
* Removed top sidebar separator in Reader as added too much spacing

### Not done yet
* The toggle menus in Reader aren't styled yet as there is no mockup for them yet
<img width="321" alt="Screenshot 2024-02-19 at 19 20 07" src="https://github.com/Automattic/wp-calypso/assets/5560595/00d75915-69f1-475c-8ca8-aee1fa125783">

### Testing
* Apply patch and confirm sidebar looks in line with the prototype (version 4) 

