### PR TITLE
Call fetchSitePlans in /plans to avoid WSOD with nav redesign

### DIFF
--- a/client/my-sites/plans/main.jsx
+++ b/client/my-sites/plans/main.jsx
@@ -167,9 +167,11 @@ class Plans extends Component {
 	};
 
 	componentDidMount() {
-		const { selectedSite } = this.props;
+		const { currentPlan, selectedSite } = this.props;
 		this.redirectIfInvalidPlanInterval();
-		this.props.fetchSitePlans( selectedSite.ID );
+		if ( ! currentPlan && selectedSite ) {
+			this.props.fetchSitePlans( selectedSite.ID );
+		}
 
 		if ( this.props.isDomainAndPlanPackageFlow ) {
 			document.body.classList.add( 'is-domain-plan-package-flow' );


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5635

## Proposed Changes

* Add fetchSitePlans API call to /plans, it was originally in CurrentSite as mentioned here https://github.com/Automattic/dotcom-forge/issues/5635#issuecomment-1951932253

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /plans/:site with and without the flag `?flags=layout/dotcom-nav-redesign` / `?flags=-layout/dotcom-nav-redesign`
* The page should render in both occasions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?