### PR TITLE
Site Transfers: Display instructions for accepting site transfer to current user

### DIFF
--- a/client/my-sites/site-settings/site-owner-transfer/confirmation-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/confirmation-transfer.tsx
@@ -52,13 +52,11 @@ export function ConfirmationTransfer( {
 	if ( isEmailSent ) {
 		return (
 			<Notice status="is-success" showDismiss={ false }>
-				<div data-testid="email-sent">
-					<p>
-						{ translate(
-							'We have sent an email to the new site owner to accept the site transfer. They will need to click the link in the email to complete the transfer. The link in email will expire in 7 days.'
-						) }
-					</p>
-				</div>
+				<p>
+					{ translate(
+						'We have sent an email to the new site owner to accept the site transfer. They will need to click the link in the email to complete the transfer. The link in email will expire in 7 days.'
+					) }
+				</p>
 			</Notice>
 		);
 	}

--- a/client/my-sites/site-settings/site-owner-transfer/confirmation-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/confirmation-transfer.tsx
@@ -36,6 +36,7 @@ export function ConfirmationTransfer( {
 					recordTracksEvent( 'calypso_site_owner_transfer_confirm_success' );
 					page.redirect( `/sites?site-transfer-confirm=true` );
 				} else if ( email_sent ) {
+					recordTracksEvent( 'calypso_site_owner_transfer_pending_invitation_sent' );
 					setIsEmailSent( true );
 				}
 			},

--- a/client/my-sites/site-settings/site-owner-transfer/confirmation-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/confirmation-transfer.tsx
@@ -54,7 +54,7 @@ export function ConfirmationTransfer( {
 			<Notice status="is-success" showDismiss={ false }>
 				<p>
 					{ translate(
-						'We have sent an email to the new site owner to accept the site transfer. They will need to click the link in the email to complete the transfer. The link in email will expire in 7 days.'
+						'We have invited the new user to accept the site transfer. They will need to click the link included in the email invitation for the site transfer to complete. The invitation will expire in 7 days.'
 					) }
 				</p>
 			</Notice>

--- a/client/my-sites/site-settings/site-owner-transfer/confirmation-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/confirmation-transfer.tsx
@@ -6,6 +6,11 @@ import Notice from 'calypso/components/notice';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useConfirmTransfer } from './use-confirm-transfer';
 
+type SiteTransferResponse = {
+	transfer?: boolean;
+	email_sent?: boolean;
+};
+
 /**
  * Component to display the confirmation of the site transfer when the new owner clicks on the link in the email.
  * The confirmation hash. That URL is provided in the email.
@@ -19,19 +24,19 @@ export function ConfirmationTransfer( {
 } ) {
 	const translate = useTranslate();
 	const progress = 0.3;
-	const [ emailSent, setEmailSent ] = useState< boolean >( false );
+	const [ isEmailSent, setIsEmailSent ] = useState< boolean >( false );
 	const [ error, setError ] = useState< { message?: string } | null >( null );
 	const { confirmTransfer } = useConfirmTransfer(
 		{ siteId },
 		{
 			onSuccess: ( data ) => {
-				const { transfer, email_sent } = data as { transfer: boolean; email_sent: boolean };
+				const { transfer, email_sent } = data as SiteTransferResponse;
 
 				if ( transfer ) {
 					recordTracksEvent( 'calypso_site_owner_transfer_confirm_success' );
 					page.redirect( `/sites?site-transfer-confirm=true` );
 				} else if ( email_sent ) {
-					setEmailSent( true );
+					setIsEmailSent( true );
 				}
 			},
 			onError: ( error ) => {
@@ -43,7 +48,7 @@ export function ConfirmationTransfer( {
 		confirmTransfer( confirmationHash );
 	}, [ confirmTransfer, confirmationHash ] );
 
-	if ( emailSent ) {
+	if ( isEmailSent ) {
 		return (
 			<Notice status="is-success" showDismiss={ false }>
 				<div data-testid="email-sent">

--- a/client/my-sites/site-settings/site-owner-transfer/confirmation-transfer.tsx
+++ b/client/my-sites/site-settings/site-owner-transfer/confirmation-transfer.tsx
@@ -19,13 +19,20 @@ export function ConfirmationTransfer( {
 } ) {
 	const translate = useTranslate();
 	const progress = 0.3;
+	const [ emailSent, setEmailSent ] = useState< boolean >( false );
 	const [ error, setError ] = useState< { message?: string } | null >( null );
 	const { confirmTransfer } = useConfirmTransfer(
 		{ siteId },
 		{
-			onSuccess: () => {
-				recordTracksEvent( 'calypso_site_owner_transfer_confirm_success' );
-				page.redirect( `/sites?site-transfer-confirm=true` );
+			onSuccess: ( data ) => {
+				const { transfer, email_sent } = data as { transfer: boolean; email_sent: boolean };
+
+				if ( transfer ) {
+					recordTracksEvent( 'calypso_site_owner_transfer_confirm_success' );
+					page.redirect( `/sites?site-transfer-confirm=true` );
+				} else if ( email_sent ) {
+					setEmailSent( true );
+				}
 			},
 			onError: ( error ) => {
 				setError( error as Error );
@@ -35,6 +42,20 @@ export function ConfirmationTransfer( {
 	useEffect( () => {
 		confirmTransfer( confirmationHash );
 	}, [ confirmTransfer, confirmationHash ] );
+
+	if ( emailSent ) {
+		return (
+			<Notice status="is-success" showDismiss={ false }>
+				<div data-testid="email-sent">
+					<p>
+						{ translate(
+							'We have sent an email to the new site owner to accept the site transfer. They will need to click the link in the email to complete the transfer. The link in email will expire in 7 days.'
+						) }
+					</p>
+				</div>
+			</Notice>
+		);
+	}
 
 	if ( error ) {
 		return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/dotcom-forge/issues/5678

## Proposed Changes

* Uses server response to display instructions for accepting site transfer or redirect user to `/sites` route as usual. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

To mimic actual response, you can add following to early return from `confirm_transfer` in `WPCOM_REST_API_V2_Endpoint_Site_Owner_Transfer` endpoint.
```
`return [ 'transfer' => false, 'email_sent' => true ];`
```

#### Email Sent
* Make sure confirm transfer endpoint returns `email_sent` as true.
* Visit following route`/settings/start-site-transfer/[SITE_SLUG]?site-transfer-confirm=N3vHI5NMByDe4324`
* You should see following message message.
![CleanShot 2024-02-19 at 19 18 07@2x](https://github.com/Automattic/wp-calypso/assets/86406124/732c9b72-6d5e-4a38-bb4b-646a121acc64)

#### Site Transferred
* Make sure confirm transfer endpoint returns `transfer` as true.
* Visit following route`/settings/start-site-transfer/[SITE_SLUG]?site-transfer-confirm=N3vHI5NMByDe4324`
* Make sure you are redirected to `/sites?site-transfer-confirm=true`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?