### PR TITLE
GitHub deployments: Connecting deployment style to backend

### DIFF
--- a/client/my-sites/github-deployments/components/github-connection-form.tsx
+++ b/client/my-sites/github-deployments/components/github-connection-form.tsx
@@ -119,6 +119,10 @@ export const GitHubConnectionForm = ( {
 			<div className="github-deployments-connect-repository__deployment-style">
 				<FormFieldset>
 					<DeploymentStyle
+						branchName={ branch }
+						installationId={ account.external_id }
+						repositoryId={ repository.id }
+						onChooseWorkflow={ () => {} }
 						onValidationChange={ ( status ) => {
 							if ( status === 'success' ) {
 								setSubmitDisabled( false );

--- a/client/my-sites/github-deployments/components/github-connection-form.tsx
+++ b/client/my-sites/github-deployments/components/github-connection-form.tsx
@@ -16,12 +16,14 @@ interface CodeDeploymentData {
 	targetDir: string;
 	installationId: number;
 	isAutomated: boolean;
+	workflowPath?: string;
 }
 
 interface InitialValues {
 	branch: string;
 	destPath: string;
 	isAutomated: boolean;
+	workflowPath?: string;
 }
 
 interface ConnectRepositoryDialogProps {
@@ -37,13 +39,21 @@ export const GitHubConnectionForm = ( {
 	repository,
 	installation,
 	ctaLabel,
-	initialValues = { branch: repository.default_branch, destPath: '/', isAutomated: false },
+	initialValues = {
+		branch: repository.default_branch,
+		destPath: '/',
+		isAutomated: false,
+		workflowPath: undefined,
+	},
 	changeRepository,
 	onSubmit,
 }: ConnectRepositoryDialogProps ) => {
 	const [ branch, setBranch ] = useState( initialValues.branch );
 	const [ destPath, setDestPath ] = useState( initialValues.destPath );
 	const [ isAutoDeploy, setIsAutoDeploy ] = useState( initialValues.isAutomated );
+	const [ workflowPath, setWorkflowPath ] = useState< string | undefined >(
+		initialValues.workflowPath
+	);
 
 	const { data: branches = [ branch ], isLoading: isFetchingBranches } =
 		useGithubRepositoryBranchesQuery( installation.external_id, repository.owner, repository.name );
@@ -68,6 +78,7 @@ export const GitHubConnectionForm = ( {
 						targetDir: destPath,
 						installationId: installation.external_id,
 						isAutomated: isAutoDeploy,
+						workflowPath: workflowPath,
 					} );
 				} finally {
 					setIsPending( false );
@@ -120,9 +131,10 @@ export const GitHubConnectionForm = ( {
 				<FormFieldset>
 					<DeploymentStyle
 						branchName={ branch }
-						installationId={ account.external_id }
+						installationId={ installation.external_id }
 						repository={ repository }
-						onChooseWorkflow={ () => {} }
+						workflowPath={ workflowPath }
+						onChooseWorkflow={ ( item ) => setWorkflowPath( item ) }
 						onValidationChange={ ( status ) => {
 							if ( status === 'success' ) {
 								setSubmitDisabled( false );

--- a/client/my-sites/github-deployments/components/github-connection-form.tsx
+++ b/client/my-sites/github-deployments/components/github-connection-form.tsx
@@ -121,7 +121,7 @@ export const GitHubConnectionForm = ( {
 					<DeploymentStyle
 						branchName={ branch }
 						installationId={ account.external_id }
-						repositoryId={ repository.id }
+						repository={ repository }
 						onChooseWorkflow={ () => {} }
 						onValidationChange={ ( status ) => {
 							if ( status === 'success' ) {

--- a/client/my-sites/github-deployments/components/repositories/create-repository/create-repository-form.tsx
+++ b/client/my-sites/github-deployments/components/repositories/create-repository/create-repository-form.tsx
@@ -6,7 +6,6 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { GitHubInstallationsDropdown } from 'calypso/my-sites/github-deployments/components/installations-dropdown';
 import { useLiveInstallations } from 'calypso/my-sites/github-deployments/components/installations-dropdown/use-live-installations';
-import { DeploymentStyle } from '../deployment-style/deployment-style';
 import {
 	FormRadioWithTemplateSelect,
 	ProjectType,
@@ -179,9 +178,7 @@ export const CreateRepositoryForm = ( {
 					{ __( 'Create repository' ) }
 				</Button>
 			</form>
-			<div className="github-deployments-create-repository__deployment-style">
-				<DeploymentStyle />
-			</div>
+			<div className="github-deployments-create-repository__deployment-style"></div>
 		</div>
 	);
 };

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/deployment-style.tsx
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/deployment-style.tsx
@@ -15,6 +15,7 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormRadiosBar from 'calypso/components/forms/form-radios-bar';
 import SupportInfo from 'calypso/components/support-info';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { GitHubRepositoryData } from 'calypso/my-sites/github-deployments/use-github-repositories-query';
 import { useDispatch } from 'calypso/state';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { useCreateWorkflow } from './use-create-workflow';
@@ -28,7 +29,7 @@ import './style.scss';
 
 interface DeploymentStyleProps {
 	installationId: number;
-	repositoryId: number;
+	repository: GitHubRepositoryData;
 	branchName: string;
 	onChooseWorkflow?( workflowFilename: string ): void;
 	onValidationChange?( status: WorkFlowStates ): void;
@@ -44,7 +45,7 @@ type DeploymentStyle = 'simple' | 'custom';
 
 export const DeploymentStyle = ( {
 	installationId,
-	repositoryId,
+	repository,
 	branchName,
 	onChooseWorkflow,
 	onValidationChange,
@@ -58,7 +59,8 @@ export const DeploymentStyle = ( {
 
 	const { data: workflows, isLoading: isFetchingWorkflows } = useDeploymentWorkflowsQuery(
 		installationId,
-		repositoryId,
+		repository.name,
+		repository.owner,
 		branchName,
 		deploymentStyle
 	);
@@ -76,7 +78,7 @@ export const DeploymentStyle = ( {
 
 	const { isLoading: isCheckingWorkflowFile, data: workflowCheckResult } = useCheckWorkflowQuery(
 		installationId,
-		repositoryId,
+		repository.id,
 		branchName,
 		selectedWorkflow
 	);
@@ -177,7 +179,7 @@ export const DeploymentStyle = ( {
 
 	useEffect( () => {
 		const workflowsValidationsChanged = workflowsValidations.map( ( validation ) => {
-			const item = workflowCheckResult?.checked_items.find( ( checkedItem ) => {
+			const item = workflowCheckResult?.checked_items?.find( ( checkedItem ) => {
 				return checkedItem.validation_name === validation.key;
 			} );
 

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/deployment-style.tsx
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/deployment-style.tsx
@@ -78,7 +78,8 @@ export const DeploymentStyle = ( {
 
 	const { isLoading: isCheckingWorkflowFile, data: workflowCheckResult } = useCheckWorkflowQuery(
 		installationId,
-		repository.id,
+		repository.name,
+		repository.owner,
 		branchName,
 		selectedWorkflow
 	);
@@ -161,7 +162,7 @@ export const DeploymentStyle = ( {
 
 	const installWorkflow = async () => {
 		createDeployment( {
-			repositoryId,
+			repositoryId: repository.id,
 			branchName: 'main',
 			installationId,
 			fileName: '.github/workflows/wpcom.yml',

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/deployment-style.tsx
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/deployment-style.tsx
@@ -10,10 +10,11 @@ import { check, closeSmall } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormRadiosBar from 'calypso/components/forms/form-radios-bar';
 import SupportInfo from 'calypso/components/support-info';
+import { useDeploymentWorkflowsQuery } from './use-deployment-workflows-query';
 
 import './style.scss';
 
@@ -28,8 +29,25 @@ type WorkFlowStates = 'loading' | 'success' | 'error';
 export const DeploymentStyle = ( { onDefineStyle, onValidationChange }: DeploymentStyleProps ) => {
 	const { __ } = useI18n();
 
+	const installationId = 123;
+	const repositoryId = 123;
+	const { data: workflows, isLoading: isFetchingWorkflows } = useDeploymentWorkflowsQuery(
+		installationId,
+		repositoryId
+	);
+
+	const workflowsForRendering = useMemo( () => {
+		const mappedValues = [ { value: 'none', label: __( 'Deployment workflows' ) } ].concat(
+			workflows?.map( ( workflow ) => ( {
+				value: workflow.file_name,
+				label: workflow.file_name,
+			} ) ) || []
+		);
+
+		return mappedValues.concat( { value: 'create-new', label: __( 'Create new workflow' ) } );
+	}, [ workflows ] );
+
 	const [ deploymentStyle, setDeploymentStyle ] = useState< DeploymentStyle >( 'simple' );
-	const [ isFetchingWorkflows, setFechingWorkflows ] = useState( true );
 	const [ selectedWorkflow, setSelectedWorkflow ] = useState( 'none' );
 	const [ isCreatingNewWorkflow, setIsCreatingNewWorkflow ] = useState( false );
 	const [ validationTriggered, setValidationTriggered ] = useState( false );
@@ -57,13 +75,6 @@ export const DeploymentStyle = ( { onDefineStyle, onValidationChange }: Deployme
 	const installWorkflow = () => {
 		alert( 'TODO: installWorkflow' );
 	};
-
-	const workflows = [
-		{ value: 'none', label: __( 'Deployment workflows' ) },
-		{ value: 'deploy-live', label: 'deploy-live.yml' },
-		{ value: 'test', label: 'test.yml' },
-		{ value: 'create-new', label: __( 'Create new workflow' ) },
-	];
 
 	const RenderIcon = ( { state }: { state: WorkFlowStates } ) => {
 		if ( state === 'loading' ) {
@@ -104,7 +115,6 @@ export const DeploymentStyle = ( { onDefineStyle, onValidationChange }: Deployme
 				setTimeout( () => {
 					setValidationTriggered( true );
 				}, 1000 );
-				setFechingWorkflows( true );
 				if ( status === 'error' ) {
 					setErrorMesseage( 'Please fix this error' );
 				}
@@ -143,7 +153,7 @@ export const DeploymentStyle = ( { onDefineStyle, onValidationChange }: Deployme
 					<div className="github-deployments-connect-repository__automatic-deploys">
 						<SelectControl
 							value={ selectedWorkflow }
-							options={ workflows }
+							options={ workflowsForRendering }
 							onChange={ handleWorkflowChange }
 						/>
 						{ isFetchingWorkflows && <Spinner /> }

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/use-create-workflow.tsx
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/use-create-workflow.tsx
@@ -1,0 +1,64 @@
+import { useMutation, UseMutationOptions, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import wp from 'calypso/lib/wp';
+import { GITHUB_DEPLOYMENTS_QUERY_KEY } from 'calypso/my-sites/github-deployments/constants';
+import { CODE_DEPLOYMENTS_QUERY_KEY } from 'calypso/my-sites/github-deployments/deployments/use-code-deployments-query';
+
+interface MutationVariables {
+	repositoryId: number;
+	branchName: string;
+	installationId: number;
+	fileName: string;
+}
+
+interface MutationResponse {
+	message: string;
+}
+
+interface MutationError {
+	code: string;
+	message: string;
+}
+
+export const useCreateWorkflow = (
+	options: UseMutationOptions< MutationResponse, MutationError, MutationVariables > = {}
+) => {
+	const queryClient = useQueryClient();
+	const path = `/hosting/github/workflows`;
+	const mutation = useMutation( {
+		mutationFn: async ( {
+			repositoryId,
+			branchName,
+			installationId,
+			fileName,
+		}: MutationVariables ) =>
+			wp.req.post(
+				{
+					path,
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					repository_id: repositoryId,
+					branch_name: branchName,
+					installation_id: installationId,
+					file_name: fileName,
+				}
+			),
+		...options,
+		onSuccess: async ( ...args ) => {
+			await queryClient.invalidateQueries( {
+				queryKey: [ GITHUB_DEPLOYMENTS_QUERY_KEY, CODE_DEPLOYMENTS_QUERY_KEY, path ],
+			} );
+			options.onSuccess?.( ...args );
+		},
+	} );
+
+	const { mutateAsync, isPending } = mutation;
+
+	const createDeployment = useCallback(
+		( args: MutationVariables ) => mutateAsync( args ),
+		[ mutateAsync ]
+	);
+
+	return { createDeployment, isPending };
+};

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/use-deployment-workflows-query.ts
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/use-deployment-workflows-query.ts
@@ -52,14 +52,16 @@ export const useDeploymentWorkflowsQuery = (
 
 export const useCheckWorkflowQuery = (
 	installationId: number,
-	repositoryId: number,
+	repositoryName: string,
+	repositoryOwner: string,
 	branchName: string,
 	workflowFilename: string
 ) => {
 	const invalidFilenames = [ 'none', 'create-new' ];
 	const path = addQueryArgs( '/hosting/github/workflows/checks', {
 		installation_id: installationId,
-		repository_id: repositoryId,
+		repository_name: repositoryName,
+		repository_owner: repositoryOwner,
 		branch_name: branchName,
 		workflow_filename: workflowFilename,
 	} );

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/use-deployment-workflows-query.ts
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/use-deployment-workflows-query.ts
@@ -23,15 +23,19 @@ export interface WorkflowsValidation {
 export const useDeploymentWorkflowsQuery = (
 	installationId: number,
 	repositoryId: number,
+	branchName: string,
+	deploymentStyle: string,
 	options?: Partial< UseQueryOptions< Workflows[] > >
 ) => {
 	const path = addQueryArgs( '/hosting/github/workflows', {
 		installation_id: installationId,
 		repository_id: repositoryId,
+		branch_name: branchName,
 	} );
 
 	return useQuery< Workflows[] >( {
 		queryKey: [ GITHUB_DEPLOYMENTS_QUERY_KEY, CODE_DEPLOYMENTS_QUERY_KEY, path ],
+		enabled: !! installationId && !! repositoryId && !! branchName && deploymentStyle !== 'simple',
 		queryFn: (): Workflows[] =>
 			wp.req.get( {
 				path,
@@ -47,12 +51,14 @@ export const useDeploymentWorkflowsQuery = (
 export const useCheckWorkflowQuery = (
 	installationId: number,
 	repositoryId: number,
+	branchName: string,
 	workflowFilename: string
 ) => {
 	const invalidFilenames = [ 'none', 'create-new' ];
 	const path = addQueryArgs( '/hosting/github/workflows/checks', {
 		installation_id: installationId,
 		repository_id: repositoryId,
+		branch_name: branchName,
 		workflow_filename: workflowFilename,
 	} );
 

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/use-deployment-workflows-query.ts
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/use-deployment-workflows-query.ts
@@ -22,20 +22,22 @@ export interface WorkflowsValidation {
 
 export const useDeploymentWorkflowsQuery = (
 	installationId: number,
-	repositoryId: number,
+	repositoryName: string,
+	repositoryOwner: string,
 	branchName: string,
 	deploymentStyle: string,
 	options?: Partial< UseQueryOptions< Workflows[] > >
 ) => {
 	const path = addQueryArgs( '/hosting/github/workflows', {
 		installation_id: installationId,
-		repository_id: repositoryId,
+		repository_name: repositoryName,
+		repository_owner: repositoryOwner,
 		branch_name: branchName,
 	} );
 
 	return useQuery< Workflows[] >( {
 		queryKey: [ GITHUB_DEPLOYMENTS_QUERY_KEY, CODE_DEPLOYMENTS_QUERY_KEY, path ],
-		enabled: !! installationId && !! repositoryId && !! branchName && deploymentStyle !== 'simple',
+		enabled: !! installationId && deploymentStyle !== 'simple',
 		queryFn: (): Workflows[] =>
 			wp.req.get( {
 				path,

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/use-deployment-workflows-query.ts
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/use-deployment-workflows-query.ts
@@ -7,6 +7,7 @@ export const CODE_DEPLOYMENTS_QUERY_KEY = 'code-deployments';
 
 export interface Workflows {
 	file_name: string;
+	workflow_path: string;
 }
 export type WorkFlowStates = 'loading' | 'success' | 'error';
 

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/use-deployment-workflows-query.ts
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/use-deployment-workflows-query.ts
@@ -1,0 +1,34 @@
+import { UseQueryOptions, useQuery } from '@tanstack/react-query';
+import { addQueryArgs } from '@wordpress/url';
+import wp from 'calypso/lib/wp';
+import { GITHUB_DEPLOYMENTS_QUERY_KEY } from 'calypso/my-sites/github-deployments/constants';
+
+export const CODE_DEPLOYMENTS_QUERY_KEY = 'code-deployments';
+
+export interface Workflows {
+	file_name: string;
+}
+
+export const useDeploymentWorkflowsQuery = (
+	installationId: number,
+	repositoryId: number,
+	options?: Partial< UseQueryOptions< Workflows[] > >
+) => {
+	const path = addQueryArgs( '/hosting/github/workflows', {
+		installation_id: installationId,
+		repository_id: repositoryId,
+	} );
+
+	return useQuery< Workflows[] >( {
+		queryKey: [ GITHUB_DEPLOYMENTS_QUERY_KEY, CODE_DEPLOYMENTS_QUERY_KEY, repositoryId ],
+		queryFn: (): Workflows[] =>
+			wp.req.get( {
+				path,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		meta: {
+			persist: false,
+		},
+		...options,
+	} );
+};

--- a/client/my-sites/github-deployments/deployment-management/deployment-management-form.tsx
+++ b/client/my-sites/github-deployments/deployment-management/deployment-management-form.tsx
@@ -65,6 +65,7 @@ export const GitHubDeploymentManagementForm = ( {
 			branch: codeDeployment.branch_name,
 			destPath: codeDeployment.target_dir,
 			isAutomated: codeDeployment.is_automated,
+			workflowPath: codeDeployment.workflow_path,
 		};
 	}, [ codeDeployment ] );
 
@@ -78,13 +79,21 @@ export const GitHubDeploymentManagementForm = ( {
 			ctaLabel={ __( 'Update connection' ) }
 			repository={ repository }
 			initialValues={ initialValues }
-			onSubmit={ ( { externalRepositoryId, branchName, targetDir, installationId, isAutomated } ) =>
+			onSubmit={ ( {
+				externalRepositoryId,
+				branchName,
+				targetDir,
+				installationId,
+				isAutomated,
+				workflowPath,
+			} ) =>
 				updateDeployment( {
 					externalRepositoryId,
 					branchName,
 					targetDir,
 					installationId,
 					isAutomated,
+					workflowPath,
 				} )
 			}
 		/>

--- a/client/my-sites/github-deployments/deployment-management/use-code-deployment-query.ts
+++ b/client/my-sites/github-deployments/deployment-management/use-code-deployment-query.ts
@@ -1,23 +1,9 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 import { GITHUB_DEPLOYMENTS_QUERY_KEY } from '../constants';
+import { CodeDeploymentData } from '../deployments/use-code-deployments-query';
 
 export const CODE_DEPLOYMENTS_QUERY_KEY = 'code-deployments';
-
-export interface CodeDeploymentData {
-	id: number;
-	blog_id: number;
-	created_by_user_id: number;
-	created_on: string;
-	updated_on: string;
-	external_repository_id: number;
-	repository_name: string;
-	branch_name: string;
-	target_dir: string;
-	is_automated: boolean;
-	installation_id: number;
-	created_by: CreatedBy;
-}
 
 export interface CreatedBy {
 	id: number;

--- a/client/my-sites/github-deployments/deployment-management/use-update-code-deployment.ts
+++ b/client/my-sites/github-deployments/deployment-management/use-update-code-deployment.ts
@@ -10,6 +10,7 @@ interface MutationVariables {
 	targetDir: string;
 	installationId: number;
 	isAutomated?: boolean;
+	workflowPath?: string;
 }
 
 interface MutationResponse {
@@ -34,6 +35,7 @@ export const useUpdateCodeDeployment = (
 			branchName,
 			installationId,
 			isAutomated,
+			workflowPath,
 		}: MutationVariables ) =>
 			wp.req.put(
 				{
@@ -46,6 +48,7 @@ export const useUpdateCodeDeployment = (
 					target_dir: targetDir,
 					installation_id: installationId,
 					is_automated: isAutomated,
+					workflow_path: workflowPath,
 				}
 			),
 		...options,

--- a/client/my-sites/github-deployments/deployments/use-code-deployments-query.ts
+++ b/client/my-sites/github-deployments/deployments/use-code-deployments-query.ts
@@ -14,6 +14,7 @@ export interface CodeDeploymentData {
 	repository_name: string;
 	branch_name: string;
 	target_dir: string;
+	workflow_path: string;
 	is_automated: boolean;
 	installation_id: number;
 	created_by: CreatedBy;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5334

<img width="1346" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/0d0aa5eb-486c-4e21-a3f4-ca0e35c600ee">



## Proposed Changes

* Obtaining repository workflows from the backend API
* Perform backend check of workflow validations
* Workflow validations are dynamic, so we can increase them as we need
* Workflow creation CTA is connected to the backend API
* Obtaining workflow files from GitHub API
* Validating workflow files by parsing the YAML file content
* Connected the `Verify workflow` button to retrigger the validation

TODO: 
* Show real workflow.yml examples with the `YAML` format
* Create a new workflow file 
* Create the `Fix workflow for me` actions
* Bug: Being in a repo that has workflow files and seeing them with `Customizable`, after switching to a branch without workflow files, the validation still shows and generates errors.
* Improve user feedback when no workflow was found in the repo on that branch
* Connect DeploymentStyle at the create repository screen using template parameters instead of repository parameters

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this diff: D138800-code
* Go to `/github-deployments` and play with the `customizable` deployment style

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?