### PR TITLE
Theme Tiers: Add Sensei and Community Tiers

### DIFF
--- a/client/components/theme-tier/constants.js
+++ b/client/components/theme-tier/constants.js
@@ -31,32 +31,44 @@ const getIncludedWithLabel = ( planSlug ) => {
  * @typedef {Object} tier
  * @property {string} label The translated label of the theme tier.
  * @property {string} minimumUpsellPlan The minimum plan required to activate a theme belonging to the tier. Used for upselling purposes.
+ * @property {boolean} isFilterable Whether the tier can be used to filter the Theme Showcase.
  */
 export const THEME_TIERS = {
 	free: {
 		label: translate( 'Free' ),
 		minimumUpsellPlan: PLAN_FREE,
+		isFilterable: true,
 	},
 	personal: {
 		label: getIncludedWithLabel( PLAN_PERSONAL ),
 		minimumUpsellPlan: PLAN_PERSONAL,
+		isFilterable: true,
 	},
 	premium: {
 		label: getIncludedWithLabel( PLAN_PREMIUM ),
 		minimumUpsellPlan: PLAN_PREMIUM,
+		isFilterable: true,
 	},
 	partner: {
 		label: translate( 'Partner', {
 			context: 'This theme is developed and supported by a theme partner',
 		} ),
 		minimumUpsellPlan: PLAN_BUSINESS,
+		isFilterable: true,
 	},
 	woocommerce: {
 		label: translate( 'WooCommerce' ),
 		minimumUpsellPlan: PLAN_BUSINESS,
+		isFilterable: true,
 	},
 	sensei: {
-		label: translate( 'Sensei' ),
+		label: translate( 'Sensei LMS' ),
 		minimumUpsellPlan: PLAN_BUSINESS,
+		isFilterable: false,
+	},
+	community: {
+		label: translate( 'Community' ),
+		minimumUpsellPlan: PLAN_BUSINESS,
+		isFilterable: false,
 	},
 };

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -201,13 +201,20 @@ class ThemeShowcase extends Component {
 		const { isSiteWooExpressOrEcomFreeTrial, themeTiers } = this.props;
 
 		if ( config.isEnabled( 'themes/tiers' ) ) {
-			return [
-				{ value: 'all', label: translate( 'All' ) },
-				...Object.keys( themeTiers ).map( ( tier ) => ( {
-					value: tier,
-					label: THEME_TIERS[ tier ]?.label || tier,
-				} ) ),
-			];
+			const tiers = Object.keys( themeTiers ).reduce( ( availableTiers, tier ) => {
+				if ( ! THEME_TIERS[ tier ]?.isFilterable ) {
+					return availableTiers;
+				}
+				return [
+					...availableTiers,
+					{
+						value: tier,
+						label: THEME_TIERS[ tier ].label,
+					},
+				];
+			}, [] );
+
+			return [ { value: 'all', label: translate( 'All' ) }, ...tiers ];
 		}
 
 		const tiers = [

--- a/client/state/themes/selectors/get-theme-tier-for-theme.tsx
+++ b/client/state/themes/selectors/get-theme-tier-for-theme.tsx
@@ -2,6 +2,6 @@ import { getTheme } from 'calypso/state/themes/selectors';
 import type { AppState } from 'calypso/types';
 
 export function getThemeTierForTheme( state: AppState, themeId: string ) {
-	const theme = getTheme( state, 'wpcom', themeId );
+	const theme = getTheme( state, 'wpcom', themeId ) || getTheme( state, 'wporg', themeId );
 	return theme?.theme_tier || {};
 }

--- a/client/state/themes/test/utils.js
+++ b/client/state/themes/test/utils.js
@@ -145,6 +145,7 @@ describe( 'utils', () => {
 						{ slug: 'two-columns', name: 'Two Columns' },
 					],
 				},
+				theme_tier: { slug: 'community' },
 			} );
 		} );
 	} );

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -105,6 +105,10 @@ export function normalizeWporgTheme( theme ) {
 		normalizedTheme.author = author;
 	}
 
+	// Manually add the theme_tier for tracking purposes.
+	// @TODO: Replace this with the real tier definition from a new endpoint.
+	normalizedTheme.theme_tier = { slug: 'community' };
+
 	if ( ! normalizedTheme.tags ) {
 		return normalizedTheme;
 	}

--- a/client/state/themes/utils.js
+++ b/client/state/themes/utils.js
@@ -81,6 +81,10 @@ export function normalizeWpcomTheme( theme ) {
  * @returns {Object}        Normalized theme object
  */
 export function normalizeWporgTheme( theme ) {
+	if ( ! theme ) {
+		return {};
+	}
+
 	const attributesMap = {
 		slug: 'id',
 		preview_url: 'demo_uri',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to D138731-code

## Proposed Changes

This PR introduces the Sensei and Community theme tiers already added to the Showcase site and added to the API in D138731-code.

To ensure the new tiers are not used in the Showcase filtering system, we are inverting how the filters are built: instead of using the API as source of truth, we are using the Calypso counterpart, allowing for a granular control over which tiers are displayed as filters, and which are there for other reasons (badges, feature checks, event tracking, or even simply consistency).

### The Sensei Tier

This change aims to track the engagement and revenue of all themes. Currently, the Sensei tier is not provisioned by the API, and Sensei themes (only one for now: Course) are not tracked correctly, recording a `null` tier.

### The Community Tier

The Community tier, for example, is added for consistency and future-proofing. Since Dotorg themes are retrieved via the Dotorg API, Calypso might not have the tier definitions in state (which is provided by the Dotcom themes API). I've hardcoded a barebone tier information to the normalized Dotorg theme objects, so that it can at least be used for tracking.

In the future, we should update how tiers are added to the Calypso state. Instead of piggybacking from other existing `/themes` and `/theme` endpoints, we should have a standalone endpoint for this purpose only.
For the sake of simplicity, let's start with a hardcode.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply D138731-code and sandbox the API.
* Select a free test site for convenience.
* Enter the Theme Showcase (`/themes`) and search for a Sensei theme (e.g Course).
* Open the theme and click on the upsell banner.
* Ensure the `calypso_theme_upsell_plan_click` event is recorded with `theme_tier: "sensei"`.
* Now search for a Community theme (e.g. Astra), open the theme and click on the upsell banner.
* Ensure the `calypso_theme_upsell_plan_click` event is recorded with `theme_tier: "community"`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?