### PR TITLE
Help Center: Set Source URL ticket field when starting chat

### DIFF
--- a/client/lib/presales-chat/index.ts
+++ b/client/lib/presales-chat/index.ts
@@ -3,6 +3,7 @@ import {
 	useMessagingAvailability,
 	useZendeskMessaging,
 } from '@automattic/help-center/src/hooks';
+import { ZENDESK_SOURCE_URL_TICKET_FIELD_ID } from '@automattic/help-center/src/hooks/use-chat-widget';
 import { useIsEnglishLocale } from '@automattic/i18n-utils';
 import { useEffect } from 'react';
 import { useSelector } from 'react-redux';
@@ -17,7 +18,9 @@ declare global {
 		zE: (
 			action: string,
 			value: string,
-			handler?: ( callback: ( data: string | number ) => void ) => void
+			handler?:
+				| ( ( callback: ( data: string | number ) => void ) => void )
+				| { id: number; value: string }[]
 		) => void;
 	}
 }
@@ -81,6 +84,9 @@ export function usePresalesChat( keyType: KeyType, enabled = true, skipAvailabil
 		// presales chat is always shown by default
 		if ( enabled && isPresalesChatAvailable && isMessagingScriptLoaded ) {
 			window.zE( 'messenger', 'show' );
+			window.zE( 'messenger:set', 'conversationFields', [
+				{ id: ZENDESK_SOURCE_URL_TICKET_FIELD_ID, value: window.location.href },
+			] );
 		}
 	}, [ enabled, isMessagingScriptLoaded, isPresalesChatAvailable ] );
 

--- a/packages/help-center/src/components/types.d.ts
+++ b/packages/help-center/src/components/types.d.ts
@@ -5,7 +5,9 @@ interface Window {
 	zE?: (
 		action: string,
 		value: string,
-		handler?: ( callback: ( data: string | number ) => void ) => void
+		handler?:
+			| ( ( callback: ( data: string | number ) => void ) => void )
+			| { id: number; value: string }[]
 	) => void;
 }
 declare module '*.jpg';

--- a/packages/help-center/src/hooks/use-chat-widget.ts
+++ b/packages/help-center/src/hooks/use-chat-widget.ts
@@ -20,6 +20,8 @@ type ChatMetadata = {
 	onSuccess?: () => void;
 };
 
+export const ZENDESK_SOURCE_URL_TICKET_FIELD_ID = 23752099174548;
+
 export default function useChatWidget(
 	configName: ZendeskConfigName = 'zendesk_support_chat_key',
 	enabled = true
@@ -52,6 +54,9 @@ export default function useChatWidget(
 				if ( typeof window.zE === 'function' ) {
 					window.zE( 'messenger', 'open' );
 					window.zE( 'messenger', 'show' );
+					window.zE( 'messenger:set', 'conversationFields', [
+						{ id: ZENDESK_SOURCE_URL_TICKET_FIELD_ID, value: window.location.href },
+					] );
 				}
 			} )
 			.catch( () => {


### PR DESCRIPTION
This is useful context for Happiness Engineers to understand better the customer's journey.
It's also related to #87339, where this data will allow us to do custom routing in the backend to ensure best customer experience.

## Proposed Changes

* Set Source URL ticket field when starting chat.
  * I don't like the slightly duplicated code between use-chat-widget and presales-chat, but looks like in #81723 direct calls to the Zendesk API were added that circumvent some additional actions/safeguards we have 😞 We should fix that and use use-chat-widget there too, but that's a separate PR. So for now, I just opted to pull in the constant with the field ID from there, assuming that we'll refactor it in the future.

## Testing Instructions

Start a chat:
 - From Help Center: `?` -> Still need help, Live chat (might be disabled based on availability, log in to Zendesk Sandbox or [short circuit/disable the check](https://github.com/Automattic/wp-calypso/blob/075294caa21df063d4feae788152b9f695ef1945/packages/help-center/src/hooks/use-chat-status.ts#L26)) -> Still chat with us.
 - From presales: easiest is from Checkout (try upgrading your plan or buying a custom domain) or from http://calypso.localhost:3000/plugins _in private window_ (presales is only for logged out users there)
   - Same note about availability, [skip checking availability here](https://github.com/Automattic/wp-calypso/blob/075294caa21df063d4feae788152b9f695ef1945/client/lib/presales-chat/index.ts#L63).

Verify that there's no JS errors and the Zendesk Messaging widget shows up and can be used normally.
If you're testing on production, the Source URL field for the new chat should also be filled out with customer's current URL. However, Zendesk's API is finicky and has hidden rules about when a conversation is considered "new". So your conversation might not get the URL. For now, that's fine - I want to deploy this to production and see how it behaves for real users.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
