### PR TITLE
Manage: Review dataview components

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
@@ -82,8 +82,8 @@ export default function SitesDashboardV2() {
 
 	const { data, isError, isLoading, refetch } = useFetchDashboardSites(
 		isPartnerOAuthTokenLoaded,
-		sitesViewState.search,
-		sitesViewState.page,
+		search,
+		currentPage,
 		filter,
 		sort
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -5,6 +5,7 @@ import SiteActions from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-o
 import useFormattedSites from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites';
 import SiteStatusContent from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
+import SiteSetFavorite from '../site-set-favorite';
 import { AllowedTypes, SiteData } from '../types';
 import { SitesDataViewsProps } from './interfaces';
 
@@ -134,7 +135,13 @@ const SitesDataViews = ( {
 				if ( isLoading ) {
 					return <TextPlaceholder />;
 				}
-				return <div>{ item.isFavorite ? '★' : '☆' }</div>;
+				return (
+					<SiteSetFavorite
+						isFavorite={ item.isFavorite || false }
+						siteId={ item.site.value.blog_id }
+						siteUrl={ item.site.value.url }
+					/>
+				);
 			},
 			enableHiding: false,
 			enableSorting: false,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -1,4 +1,5 @@
 import { DataViews } from '@wordpress/dataviews';
+import { Icon, starFilled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback } from 'react';
 import SiteActions from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions';
@@ -129,18 +130,20 @@ const SitesDataViews = ( {
 		},
 		{
 			id: 'favorite',
-			header: '★',
+			header: <Icon className="site-table__favorite-icon" size={ 24 } icon={ starFilled } />,
 			getValue: ( { item }: { item: SiteData } ) => item.isFavorite,
 			render: ( { item }: { item: SiteData } ) => {
 				if ( isLoading ) {
 					return <TextPlaceholder />;
 				}
 				return (
-					<SiteSetFavorite
-						isFavorite={ item.isFavorite || false }
-						siteId={ item.site.value.blog_id }
-						siteUrl={ item.site.value.url }
-					/>
+					<span className="sites-dataviews__favorite-btn-wrapper">
+						<SiteSetFavorite
+							isFavorite={ item.isFavorite || false }
+							siteId={ item.site.value.blog_id }
+							siteUrl={ item.site.value.url }
+						/>
+					</span>
 				);
 			},
 			enableHiding: false,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -578,3 +578,22 @@ a.sites-overview__boost-score {
 .margin-top-16 {
 	margin-top: 16px;
 }
+
+.sites-dataviews__favorite-btn-wrapper {
+	position: relative;
+
+	.site-set-favorite__favorite-icon {
+		visibility: hidden;
+		color: var(--color-primary);
+	}
+
+	button.site-set-favorite__favorite-icon {
+		position: unset;
+	}
+
+	&:hover {
+		.site-set-favorite__favorite-icon {
+			visibility: visible;
+		}
+	}
+}


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/301

## Proposed Changes

* This PR fixes two problems with the dataview components in SitesV2:
  * Favorites button: We weren't using the right component to render the favorite button, this has been fixed
  * Get Score link was not working due to a missing needed access to a shared context, more specifically to the list of products needed by the popup (`LicenseInfoModal`).

## Testing Instructions

* The first thing to test is if our current dashboard still works as intended (`/dashboard`)
* Then enable the new Sites Dashboard using the feature flag:
   * Feature Flag: jetpack/manage-sites-v2-menu To activate the Sites V2 menu. You can deactivate the feature flag using this query in the URL: ?flags=-jetpack/manage-sites-v2-menu
* Test the new Sites Dashboard components as described in https://github.com/Automattic/jetpack-manage/issues/301: 
  * Favorites button should work
  * Get Score link should work
  * All other components should work just as in the old dashboard  

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
