### PR TITLE
JP-Manage: Remove unnecessary dependency and wrap function with useCallback hook.

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
@@ -3,7 +3,7 @@ import { Button } from '@automattic/components';
 import { isWithinBreakpoint } from '@automattic/viewport';
 import { getQueryArg, removeQueryArgs, addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useContext, useEffect, useState, useMemo } from 'react';
+import { useContext, useEffect, useState, useMemo, useCallback } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import Notice from 'calypso/components/notice';
 import SidebarNavigation from 'calypso/components/sidebar-navigation';
@@ -78,9 +78,12 @@ export default function SitesDashboardV2() {
 		sort
 	);
 
-	const onSitesViewChange = ( sitesViewData: ViewChangeProps ) => {
-		setSitesViewData( sitesViewData );
-	};
+	const onSitesViewChange = useCallback(
+		( sitesViewData: ViewChangeProps ) => {
+			setSitesViewData( sitesViewData );
+		},
+		[ setSitesViewData ]
+	);
 
 	useEffect( () => {
 		if ( jetpackSiteDisconnected ) {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -58,7 +58,7 @@ const SitesDataViews = ( { data, isLoading, onViewChange }: SitesDataViewsProps 
 				);
 			}
 		},
-		[ sites, isLoading ]
+		[ isLoading ]
 	);
 
 	const fields = [


### PR DESCRIPTION
Fixes: https://github.com/Automattic/jetpack-manage/issues/309

## Proposed Changes

This PR fixes an issue with a React hook and console warning message: `Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render`

The issue was fixed wrapping the `onSitesViewChange` function with a useCallback hook.

Also, it removes an unnecessary dependency, `sites`.

## Testing Instructions

- Check that the warning message

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
