### PR TITLE
Site Migration: Basic steps for installing and activating the migration plugin.

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/index.tsx
@@ -1,0 +1,78 @@
+import { StepContainer } from '@automattic/onboarding';
+import { useI18n } from '@wordpress/react-i18n';
+import { useEffect } from 'react';
+import wpcomRequest from 'wpcom-proxy-request';
+import DocumentHead from 'calypso/components/data/document-head';
+import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+
+const SiteMigrationPluginInstall: Step = function SiteMigrationPluginInstall( {
+	navigation,
+	data,
+} ) {
+	const { submit } = navigation;
+	const siteId = data?.siteId;
+	const siteSlug = data?.siteSlug;
+	const { __ } = useI18n();
+
+	useEffect( () => {
+		if ( ! siteId || ! siteSlug ) {
+			return;
+		}
+
+		const installSiteMigrationPlugins = async () => {
+			try {
+				await wpcomRequest( {
+					path: `/sites/${ siteId }/plugins/install`,
+					method: 'POST',
+					apiVersion: '1.2',
+					body: {
+						slug: 'migrate-guru',
+					},
+				} );
+			} catch ( error ) {
+				submit?.( { error } );
+				return;
+			}
+
+			try {
+				await wpcomRequest( {
+					path: `/sites/${ siteId }/plugins/migrate-guru%2fmigrateguru`,
+					method: 'POST',
+					apiVersion: '1.2',
+					body: {
+						active: true,
+					},
+				} );
+			} catch ( error ) {
+				submit?.( { error } );
+				return;
+			}
+
+			submit?.();
+		};
+
+		installSiteMigrationPlugins();
+	}, [ siteId, siteSlug, submit ] );
+
+	return (
+		<>
+			<DocumentHead title={ __( 'Installing plugins' ) } />
+			<StepContainer
+				shouldHideNavButtons={ true }
+				hideFormattedHeader={ true }
+				stepName="processing-step"
+				stepContent={
+					<div className="processing-step">
+						<h1 className="processing-step__progress-step">{ __( 'Installing plugins' ) }</h1>
+						<LoadingEllipsis />
+					</div>
+				}
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		</>
+	);
+};
+
+export default SiteMigrationPluginInstall;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-site/index.tsx
@@ -1,0 +1,49 @@
+import { Button } from '@automattic/components';
+import { StepContainer } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
+import FormattedHeader from 'calypso/components/formatted-header';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import type { Step } from '../../types';
+
+const SiteMigrationSource: Step = function ( { navigation } ) {
+	const translate = useTranslate();
+
+	const handleSubmit = () => {
+		navigation.submit?.();
+	};
+
+	const stepContent = (
+		<div>
+			<p>Enter the url of the site you're migrating.</p>
+			<Button primary onClick={ handleSubmit }>
+				{ translate( 'Continue' ) }
+			</Button>
+		</div>
+	);
+
+	return (
+		<>
+			<DocumentHead title="Which site are you migrating?" />
+			<StepContainer
+				stepName="site-migration-instructions"
+				shouldHideNavButtons={ false }
+				className="is-step-site-migration-instructions"
+				hideSkip={ true }
+				hideBack={ true }
+				isHorizontalLayout
+				formattedHeader={
+					<FormattedHeader
+						id="site-migration-instructions-header"
+						headerText="Which site are you migrating?"
+						align="left"
+					/>
+				}
+				stepContent={ stepContent }
+				recordTracksEvent={ recordTracksEvent }
+			/>
+		</>
+	);
+};
+
+export default SiteMigrationSource;

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -210,4 +210,14 @@ export const STEPS = {
 		slug: 'site-migration-instructions',
 		asyncComponent: () => import( './steps-repository/site-migration-instructions' ),
 	},
+
+	SITE_MIGRATION_SOURCE: {
+		slug: 'site-migration-import-from',
+		asyncComponent: () => import( './steps-repository/site-migration-source-site' ),
+	},
+
+	SITE_MIGRATION_PLUGIN_INSTALL: {
+		slug: 'site-migration-plugin-install',
+		asyncComponent: () => import( './steps-repository/site-migration-plugin-install' ),
+	},
 };

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -1,6 +1,7 @@
 /**
  * @jest-environment jsdom
  */
+import { STEPS } from '../internals/steps';
 import siteMigrationFlow from '../site-migration-flow';
 import { getFlowLocation, renderFlow } from './helpers';
 
@@ -9,14 +10,15 @@ describe( 'Site Migration Flow', () => {
 		it( 'redirects from the import page to waitForAtomic page', async () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 
-			runUseStepNavigationSubmit( { currentStep: 'import' } );
+			runUseStepNavigationSubmit( { currentStep: STEPS.SITE_MIGRATION_SOURCE.slug } );
 
 			expect( getFlowLocation() ).toEqual( {
-				path: '/waitForAtomic',
+				path: '/site-migration-plugin-install',
 				state: { siteSlug: 'example.wordpress.com' },
 			} );
 		} );
 
+		// TODO - This will need to be updated once the flow has been updated to include these steps.
 		it( 'redirect from the processing page to the waitForPluginInstall when atomic waiting is finished', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #87498

## Proposed Changes

This adds a placeholder step for capturing the source site information. The step doesn't do anything at this point and implementation will be happening in #87604. Since the content of this step is placeholder-only, we're not doing any translation calls yet.

It's also worth noting that we still need to take into account upgrading the site plan (as needed) and waiting for the site to finish transferring to Atomic.

The main focus of this PR is the new `SiteMigrationPluginInstall` step which handles the actual plugin installation and activation. The step is also capable of redirecting to the `Error` step in the event plugin installation/activation fails.

Once the plugin is successfully installed, we navigate to the migration instructions step.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You can either check out this branch and run it locally or use the calypso.live link.
* First, visit https://wordpress.com/setup/free and continue the flow with or without launching the site.
* Once the site is created, upgrade the plan to 'Creator' and transfer the site to Atomic by activating "Hosting Configuration" in the settings.
* Now that you have a fully Atomic site that supports plugins, visit `http://calypso.localhost:3000/setup/site-migration?flags=onboarding/new-migration-flow&siteSlug=:siteSlug`
* You should see something like the following:
https://github.com/Automattic/wp-calypso/assets/917632/594b7152-8d3d-4c26-9252-cf0ba25f0fde
* Now go to the Plugins page in the wp-admin for the site and verify that MigrateGuru is installed and activated.

* You can also verify the error behavior by visiting `http://calypso.localhost:3000/setup/site-migration?flags=onboarding/new-migration-flow&siteSlug=:siteSlug` again now that the plugin is already installed.
* You should see something like the following:
https://github.com/Automattic/wp-calypso/assets/917632/4afe6dc5-79c8-4cf0-a751-acf5da199df4



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
