### PR TITLE
Stats: Change mentioning of priority support for PWYW to Email support

### DIFF
--- a/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
+++ b/client/my-sites/stats/stats-notices/paid-plan-purchase-success-notice.tsx
@@ -6,6 +6,7 @@ import { PaidPlanPurchaseSuccessJetpackStatsNoticeProps } from './types';
 
 const PaidPlanPurchaseSuccessJetpackStatsNotice = ( {
 	isOdysseyStats,
+	isCommercial = false,
 }: PaidPlanPurchaseSuccessJetpackStatsNoticeProps ) => {
 	const translate = useTranslate();
 	const [ noticeDismissed, setNoticeDismissed ] = useState( false );
@@ -39,14 +40,23 @@ const PaidPlanPurchaseSuccessJetpackStatsNotice = ( {
 				title={ translate( 'Thank you for supporting Jetpack Stats!' ) }
 				onClose={ dismissNotice }
 			>
-				{ translate(
-					"{{p}}You'll now get instant access to upcoming features and priority support if applicable.{{/p}}",
-					{
-						components: {
-							p: <p />,
-						},
-					}
-				) }
+				{ isCommercial
+					? translate(
+							"{{p}}You'll now get instant access to upcoming features and priority support.{{/p}}",
+							{
+								components: {
+									p: <p />,
+								},
+							}
+					  )
+					: translate(
+							"{{p}}You'll stop seeing the upgrade banners and get Email support if applicable.{{/p}}",
+							{
+								components: {
+									p: <p />,
+								},
+							}
+					  ) }
 			</NoticeBanner>
 		</div>
 	);

--- a/client/my-sites/stats/stats-notices/types.ts
+++ b/client/my-sites/stats/stats-notices/types.ts
@@ -1,6 +1,7 @@
 export interface PaidPlanPurchaseSuccessJetpackStatsNoticeProps {
 	onNoticeViewed?: () => void;
 	isOdysseyStats: boolean;
+	isCommercial?: boolean;
 }
 
 export interface StatsNoticeProps {

--- a/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-personal.tsx
@@ -321,11 +321,11 @@ function StatsBenefitsListing( {
 				</li>
 				{ subscriptionValue >= defaultStartingValue ? (
 					<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--included` }>
-						{ translate( 'Priority support' ) }
+						{ translate( 'Email support' ) }
 					</li>
 				) : (
 					<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--not-included` }>
-						{ translate( 'No priority support' ) }
+						{ translate( 'No Email support' ) }
 					</li>
 				) }
 				<li className={ `${ COMPONENT_CLASS_NAME }__benefits-item--not-included` }>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -134,7 +134,7 @@ const StatsBenefitsPersonal = () => {
 				<li>{ translate( 'Detailed statistics about links leading to your site' ) }</li>
 				<li>{ translate( 'GDPR compliance' ) }</li>
 				{ /** TODO: check sub price for validation -  will need support added to use-stats-purchases hook */ }
-				<li>{ translate( 'Priority support' ) }</li>
+				<li>{ translate( 'Email support' ) }</li>
 			</ul>
 			<ul className={ `${ COMPONENT_CLASS_NAME }__benefits--not-included` }>
 				<li>{ translate( 'No commercial use' ) }</li>
@@ -156,7 +156,7 @@ const StatsBenefitsFree = () => {
 			</ul>
 			<ul className={ `${ COMPONENT_CLASS_NAME }__benefits--not-included` }>
 				<li>{ translate( 'No access to upcoming features' ) }</li>
-				<li>{ translate( 'No priority support' ) }</li>
+				<li>{ translate( 'Forum support' ) }</li>
 				<li>{ translate( 'No commercial use' ) }</li>
 			</ul>
 		</div>

--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -137,6 +137,7 @@ const StatsBenefitsPersonal = () => {
 				<li>{ translate( 'Email support' ) }</li>
 			</ul>
 			<ul className={ `${ COMPONENT_CLASS_NAME }__benefits--not-included` }>
+				<li>{ translate( 'No access to upcoming advanced features' ) }</li>
 				<li>{ translate( 'No commercial use' ) }</li>
 			</ul>
 		</div>
@@ -155,8 +156,8 @@ const StatsBenefitsFree = () => {
 				<li>{ translate( 'GDPR compliance' ) }</li>
 			</ul>
 			<ul className={ `${ COMPONENT_CLASS_NAME }__benefits--not-included` }>
-				<li>{ translate( 'No access to upcoming features' ) }</li>
-				<li>{ translate( 'Forum support' ) }</li>
+				<li>{ translate( 'No access to upcoming advanced features' ) }</li>
+				<li>{ translate( 'No Email support (supported by forum)' ) }</li>
 				<li>{ translate( 'No commercial use' ) }</li>
 			</ul>
 		</div>


### PR DESCRIPTION
Related: pejTkB-1aw-p2

## Proposed Changes

* Fix a couple of misses from https://github.com/Automattic/wp-calypso/pull/87372
* Tweaked wording for purchase success notice
* Changed 'priority support' to 'email support' for pwyw and free

cc @danjjohnson @foleynotrose 

## Testing Instructions

* Create a new JN site and connect it
* Open Calypso Live Branch
* Open `/stats/purchase/:siteSlug`
* Ensure you see 'Email support' instead of 'priority support' for purchase > ~$5
* Purchase PWYW
* Ensure you see the new purchase success messages
* Open `/stats/purchase/:siteSlug`again
* Ensure you see 'Email support' instead of 'priority support' for purchase > ~$5

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?