### PR TITLE
Untangle: Add Subscribers to Jetpack Cloud

### DIFF
--- a/client/jetpack-cloud/sections/sidebar-navigation/lib/constants.ts
+++ b/client/jetpack-cloud/sections/sidebar-navigation/lib/constants.ts
@@ -6,6 +6,7 @@ export const JETPACK_MANAGE_PLUGINS_LINK = '/plugins/manage';
 export const JETPACK_CLOUD_ACTIVITY_LOG_LINK = '/activity-log';
 export const JETPACK_CLOUD_SEARCH_LINK = '/jetpack-search';
 export const JETPACK_CLOUD_SOCIAL_LINK = '/jetpack-social';
+export const JETPACK_CLOUD_SUBSCRIBERS_LINK = '/subscribers';
 export const JETPACK_MANAGE_OVERVIEW_LINK = '/overview';
 export const JETPACK_MANAGE_PARTNER_PORTAL_LINK = '/partner-portal';
 export const JETPACK_MANAGE_LICENCES_LINK = `${ JETPACK_MANAGE_PARTNER_PORTAL_LINK }/licenses`;

--- a/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/manage-selected-site.tsx
@@ -39,6 +39,7 @@ import {
 	JETPACK_CLOUD_ACTIVITY_LOG_LINK,
 	JETPACK_CLOUD_SEARCH_LINK,
 	JETPACK_CLOUD_SOCIAL_LINK,
+	JETPACK_CLOUD_SUBSCRIBERS_LINK,
 } from './lib/constants';
 
 const useMenuItems = ( {
@@ -130,6 +131,15 @@ const useMenuItems = ( {
 					trackEventName: 'calypso_jetpack_sidebar_social_clicked',
 					enabled: isAdmin && isSectionNameEnabled( 'jetpack-social' ) && ! isWPForTeamsSite,
 					isSelected: itemLinkMatches( path, `${ JETPACK_CLOUD_SOCIAL_LINK }/${ siteSlug }` ),
+				},
+				{
+					icon: <JetpackIcons icon="wordpress" size={ 24 } />,
+					path: '/',
+					link: `${ JETPACK_CLOUD_SUBSCRIBERS_LINK }/${ siteSlug }`,
+					title: translate( 'Subscribers' ),
+					trackEventName: 'calypso_jetpack_sidebar_subscribers_clicked',
+					enabled: isAdmin && isSectionNameEnabled( 'jetpack-subscribers' ) && ! isWPForTeamsSite,
+					isSelected: itemLinkMatches( path, `${ JETPACK_CLOUD_SUBSCRIBERS_LINK }/${ siteSlug }` ),
 				},
 				{
 					icon: settings,

--- a/client/sections.js
+++ b/client/sections.js
@@ -650,6 +650,12 @@ const sections = [
 		group: 'jetpack-cloud',
 	},
 	{
+		name: 'jetpack-subscribers',
+		paths: [ '/subscribers' ],
+		module: 'calypso/my-sites/subscribers',
+		group: 'jetpack-cloud',
+	},
+	{
 		name: 'woocommerce-installation',
 		paths: [ '/woocommerce-installation' ],
 		module: 'calypso/my-sites/woocommerce',

--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -99,6 +99,7 @@
 		"jetpack-cloud-golden-token": true,
 		"jetpack-search": true,
 		"jetpack-social": true,
+		"jetpack-subscribers": true,
 		"scan": true,
 		"site-purchases": true
 	},

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -90,6 +90,7 @@
 		"jetpack-cloud-golden-token": false,
 		"jetpack-search": true,
 		"jetpack-social": true,
+		"jetpack-subscribers": true,
 		"scan": true,
 		"site-purchases": true
 	},

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -95,6 +95,7 @@
 		"jetpack-cloud-golden-token": true,
 		"jetpack-search": true,
 		"jetpack-social": true,
+		"jetpack-subscribers": true,
 		"scan": true,
 		"site-purchases": true
 	},


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/5445

## Proposed Changes

Add Subscribers page to Jetpack Cloud.

#### TO-DO
- [ ] Import Endpoint responds `Invalid` (Related to fbhepr%2Skers%2Sjcpbz%2Sjc%2Qpbagrag%2Serfg%2Qncv%2Qcyhtvaf%2Sraqcbvagf%2Sfhofpevoref.cuc%3Se%3Qpnq3o86s%23360-og )
- [ ] Check Migrate from other WordPress sites.
 
## Testing Instructions

* Run yarn start-jetpack-cloud
* Go to http://jetpack.cloud.localhost:3000/
* Go to /subscribers
* Check if everything is working (except TO-DOs items)
* Test it on Jetpack Self hosted & Atomic sites.