### PR TITLE
Live Preview: Remove the redundant tooltip

### DIFF
--- a/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-override-save-button.ts
+++ b/apps/wpcom-block-editor/src/wpcom/features/live-preview/hooks/use-override-save-button.ts
@@ -72,7 +72,7 @@ export const useOverrideSaveButton = ( {
 					if ( node.nodeType === Node.ELEMENT_NODE ) {
 						const tooltip = ( node as Element ).querySelector( '.components-tooltip' );
 						if ( tooltip ) {
-							tooltip.textContent = __( 'Upgrade now', 'wpcom-live-preview' );
+							tooltip.remove();
 						}
 					}
 				} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

This PR removes the tooltip initially added for accessibility purposes. Given that its purpose overlaps with the button, we think it might be beneficial to remove this tooltip to avoid confusion temporarily. https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/tooltip_role#accessibility_concerns

We'll explore alternative ways to display the shortcut key when we have the bandwidth. https://github.com/Automattic/wp-calypso/issues/87619

The accessibility tree:
<img width="320" alt="Screenshot 2024-02-20 at 11 01 17" src="https://github.com/Automattic/wp-calypso/assets/5287479/6fe46558-3c45-44ba-8ac3-24429a4ca909">

Related:
https://github.com/Automattic/wp-calypso/pull/85013#discussion_r1426197065
https://github.com/Automattic/wp-calypso/pull/87584#discussion_r1494144830

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Patch this PR
* Sandbox your site and widgets.wp.com
* Prepare a free site
* Live-preview a premium plan
* Mouseover the Upgrade button

| before | after |
|--------|--------|
| <img width="355" alt="Screenshot 2024-02-20 at 11 12 40" src="https://github.com/Automattic/wp-calypso/assets/5287479/ed3f9dab-09ce-48af-ac76-7cf1acc6063d"> | <img width="351" alt="Screenshot 2024-02-20 at 11 10 13" src="https://github.com/Automattic/wp-calypso/assets/5287479/6ba0081e-ea55-4d80-9a11-8ff92efaf244"> | 


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?