### PR TITLE
Update site card style in global nav

### DIFF
--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -160,6 +160,7 @@
 .site__domain {
 	overflow: hidden;
 	white-space: nowrap;
+	text-overflow: ellipsis;
 
 	&::after {
 		@include long-content-fade( $color: var( --color-surface-rgb ) );

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -240,11 +240,11 @@ $brand-text: "SF Pro Text", $sans;
 		background: var(--color-sidebar-menu-hover-background);
 		flex: unset;
 		padding: 0;
-		margin: 0 12px;
+		margin: 16px 12px;
 		border-radius: 4px;
 
 		a.site__content {
-			padding: 16px 12px;
+			padding: 12px;
 		}
 		&.is-selected,
 		&:hover {

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -246,6 +246,7 @@ $brand-text: "SF Pro Text", $sans;
 		a.site__content {
 			padding: 16px 12px;
 		}
+		&.is-selected,
 		&:hover {
 			background: var(--color-sidebar-menu-selected-background);
 

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -237,14 +237,21 @@ $brand-text: "SF Pro Text", $sans;
 	}
 
 	.site {
+		background: var(--color-sidebar-menu-hover-background);
 		flex: unset;
+		padding: 0;
+		margin: 0 12px;
+		border-radius: 4px;
 
-		&.is-selected {
-			background: var(--color-sidebar-menu-selected-background);
+		a.site__content {
+			padding: 16px 12px;
 		}
-
 		&:hover {
-			background: var(--color-sidebar-menu-hover-background);
+			background: var(--color-sidebar-menu-selected-background);
+
+			.site__domain {
+				color: var(--color-sidebar-menu-selected-text);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix up the site menu item so that it looks more like the prototype:

5681-gh-Automattic/dotcom-forge

Before:
<img width="316" alt="Screenshot 2024-02-20 at 1 59 03 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/6a81b6ed-9685-4bdf-9a9c-0d3b65b49f74">

After:

<img width="314" alt="Screenshot 2024-02-20 at 2 09 51 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/abf33bd8-8e4b-4ac1-8d7b-27b8cc2c2cef">

### Testing instructions.
Test with and without `?flags=-layout/dotcom-nav-redesign`