### PR TITLE
Nav redesign: Restore the external link icon on the Global Site View sidebar

### DIFF
--- a/client/layout/global-sidebar/footer.tsx
+++ b/client/layout/global-sidebar/footer.tsx
@@ -1,4 +1,4 @@
-import { Icon, wordpress } from '@wordpress/icons';
+import { Icon, wordpress, external } from '@wordpress/icons';
 import { LocalizeProps } from 'i18n-calypso';
 import { FC } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
@@ -75,6 +75,7 @@ export const GlobalSiteSidebarFooter: FC< {
 			>
 				<Icon icon={ wordpress } className="wpicon" />
 				{ translate( 'WP Admin' ) }
+				<Icon icon={ external } className="external" />
 			</a>
 		</SidebarFooter>
 	);

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -164,6 +164,9 @@ $brand-text: "SF Pro Text", $sans;
 				&.wpicon {
 					margin-right: 10px;
 				}
+				&.external {
+					margin-left: auto;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/87584

## Proposed Changes

This PR restores the external link icon on the Global Site View sidebar.
The context: p1708397914488109-slack-C06DN6QQVAQ

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Open Calypso Live
- Go to any Calypso page (e.g., /home)
- See how the sidebar looks like

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?