### PR TITLE
Nav redesign: Fix /sites top padding to match with /domains

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -833,7 +833,12 @@ $font-size: rem(14px);
 		}
 
 		.focus-content:not(.has-no-sidebar) .layout__content {
-			padding: 47px 0 0;
+			padding-left: 0;
+			padding-right: 0;
+		}
+
+		.focus-content:not(.has-no-sidebar):not(.has-no-masterbar) .layout__content {
+			padding-top: 47px;
 		}
 
 		// client/layout/sidebar/style.scss

--- a/client/sites-dashboard/components/hosting-command-palette-banner.tsx
+++ b/client/sites-dashboard/components/hosting-command-palette-banner.tsx
@@ -8,7 +8,9 @@ import DismissibleCard from 'calypso/blocks/dismissible-card';
 import { useCommandsArrayWpcom } from './wpcom-smp-commands';
 
 const HostingCommandPaletteBannerRoot = styled.div( {
-	marginBottom: 25,
+	'&:not(:empty)': {
+		marginBottom: 25,
+	},
 	'.hosting-command-palette-banner': {
 		background: 'linear-gradient(270deg, #E9EFF5 12.03%, rgba(233, 239, 245, 0) 40.39%)',
 		display: 'flex',

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -58,7 +58,6 @@ const PageHeader = styled.div( {
 
 	backgroundColor: 'var( --studio-white )',
 
-	paddingBlockStart: '24px',
 	paddingBlockEnd: '24px',
 
 	[ MEDIA_QUERIES.mediumOrSmaller ]: {

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -117,12 +117,7 @@ function sitesDashboard( context: PageJSContext, next: () => void ) {
 
 			.layout__content {
 				// The page header background extends all the way to the edge of the screen
-				padding-block: 32px;
 				padding-inline: 0;
-
-				${ MEDIA_QUERIES.mediumOrSmaller } {
-					padding-block-start: 46px;
-				}
 
 				// Prevents the status dropdown from being clipped when the page content
 				// isn't tall enough


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/5659

## Proposed Changes

This PR reduces the /sites top padding by doing the following:

- Unsets the padding overrides from the components in `/sites`.
- Fix the CSS of the command palette so that it only adds bottom margin when the component is visible.
- Fix the CSS when the width of the screen is small to account for whether the masterbar is visible or not.

Note that even with this, the action button from `/sites` and `/domains` are SLIGHTLY not aligned. This is because the header in `/domains` has subheading, while `/sites` does not.

I think we should be able to resolve this by using the new navigation header on the `/sites` route in the future. But, at least this PR does fix some CSS issues as above for now.

**Before**

|<img width="1171" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/c9d9573d-6400-4873-8fa0-7ad78ed917d5">|<img width="1171" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/f0662696-52c0-459a-8219-de34ad9ea5be">|
|-|-|

**After**

|<img width="1171" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/bc5793e0-ea2e-4226-ae52-09daa8d91958">|<img width="1171" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/f0662696-52c0-459a-8219-de34ad9ea5be">|
|-|-|


## Testing Instructions

1. Patch this PR
2. Test with and without the `?flags=layout/dotcom-nav-redesign` flag.
3. Test with wide and narrow viewport width
4. Test with random pages, make sure this PR does not break something in the header.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?