### PR TITLE
Nav redesign: Hide the top bar in the Global Site view

### DIFF
--- a/client/layout/global-sidebar/hooks/use-global-sidebar.js
+++ b/client/layout/global-sidebar/hooks/use-global-sidebar.js
@@ -2,14 +2,12 @@ import { isEnabled } from '@automattic/calypso-config';
 
 export const useGlobalSidebar = ( siteId, sectionGroup ) => {
 	let shouldShowGlobalSidebar = false;
-	let shouldShowGlobalSiteSidebar = false;
 	if ( isEnabled( 'layout/dotcom-nav-redesign' ) ) {
 		shouldShowGlobalSidebar =
 			sectionGroup === 'me' ||
 			sectionGroup === 'reader' ||
 			sectionGroup === 'sites-dashboard' ||
 			( sectionGroup === 'sites' && ! siteId );
-		shouldShowGlobalSiteSidebar = sectionGroup === 'sites' && !! siteId;
 	}
-	return { shouldShowGlobalSidebar, shouldShowGlobalSiteSidebar };
+	return { shouldShowGlobalSidebar };
 };

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -19,7 +19,6 @@ import { withCurrentRoute } from 'calypso/components/route';
 import SympathyDevWarning from 'calypso/components/sympathy-dev-warning';
 import { retrieveMobileRedirect } from 'calypso/jetpack-connect/persistence-utils';
 import wooDnaConfig from 'calypso/jetpack-connect/woo-dna-config';
-import { useGlobalSidebar } from 'calypso/layout/global-sidebar/hooks/use-global-sidebar';
 import HtmlIsIframeClassname from 'calypso/layout/html-is-iframe-classname';
 import EmptyMasterbar from 'calypso/layout/masterbar/empty';
 import MasterbarLoggedIn from 'calypso/layout/masterbar/logged-in';
@@ -32,12 +31,16 @@ import { getMessagePathForJITM } from 'calypso/lib/route';
 import UserVerificationChecker from 'calypso/lib/user/verification-checker';
 import { isOffline } from 'calypso/state/application/selectors';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import {
+	getShouldShowGlobalSidebar,
+	getShouldShowGlobalSiteSidebar,
+} from 'calypso/state/global-sidebar/selectors';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import { getPreference } from 'calypso/state/preferences/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
-import { getSiteOption, isJetpackSite } from 'calypso/state/sites/selectors';
+import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { isSupportSession } from 'calypso/state/support/selectors';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import {
@@ -377,8 +380,9 @@ export default withCurrentRoute(
 		const isWooCoreProfilerFlow =
 			[ 'jetpack-connect', 'login' ].includes( sectionName ) &&
 			isWooCommerceCoreProfilerFlow( state );
-		const adminInterface = getSiteOption( state, siteId, 'wpcom_admin_interface' );
-		const { shouldShowGlobalSidebar, shouldShowGlobalSiteSidebar } = useGlobalSidebar(
+		const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
+		const shouldShowGlobalSiteSidebar = getShouldShowGlobalSiteSidebar(
+			state,
 			siteId,
 			sectionGroup
 		);
@@ -452,8 +456,7 @@ export default withCurrentRoute(
 			userAllowedToHelpCenter,
 			currentRoute,
 			isGlobalSidebarVisible: shouldShowGlobalSidebar,
-			// Global Site View should be limited to classic interface users only for now.
-			isGlobalSiteSidebarVisible: shouldShowGlobalSiteSidebar && adminInterface === 'wp-admin',
+			isGlobalSiteSidebarVisible: shouldShowGlobalSiteSidebar,
 		};
 	} )( Layout )
 );

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -402,6 +402,7 @@ export default withCurrentRoute(
 			isWpMobileApp() ||
 			isWcMobileApp() ||
 			shouldShowGlobalSidebar ||
+			shouldShowGlobalSiteSidebar ||
 			isJetpackCloud() ||
 			config.isEnabled( 'a8c-for-agencies' );
 		const isJetpackMobileFlow = 'jetpack-connect' === sectionName && !! retrieveMobileRedirect();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 
- close https://github.com/Automattic/dotcom-forge/issues/5684
- https://github.com/Automattic/wp-calypso/pull/87583, https://github.com/Automattic/wp-calypso/pull/87542

## Proposed Changes

This PR hides the top bar in the Global Site view.

| before | after |
|--------|--------|
| <img width="1439" alt="Screenshot 2024-02-20 at 15 05 00" src="https://github.com/Automattic/wp-calypso/assets/5287479/bb51ed95-93a9-4951-882c-b07213e90eec"> | <img width="1436" alt="Screenshot 2024-02-20 at 15 03 01" src="https://github.com/Automattic/wp-calypso/assets/5287479/6be81ec7-5e4a-43de-8fa0-1a68e4681346"> | 


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live
* Prepare a site with the classic view, and then go to a Calypso page (e.g., /home/your-site)
* Verify it hide the top bar


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?