### PR TITLE
Untangle: Update styles for the all sites menu item

### DIFF
--- a/client/my-sites/sidebar/item.jsx
+++ b/client/my-sites/sidebar/item.jsx
@@ -6,6 +6,7 @@
  * These two cases might be to be split up?
  */
 
+import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { memo } from 'react';
 import { useDispatch } from 'react-redux';
@@ -23,6 +24,7 @@ export const MySitesSidebarUnifiedItem = ( {
 	slug,
 	title,
 	url,
+	className = '',
 	shouldOpenExternalLinksInCurrentTab,
 	trackClickEvent,
 } ) => {
@@ -47,7 +49,10 @@ export const MySitesSidebarUnifiedItem = ( {
 			selected={ selected }
 			customIcon={ <SidebarCustomIcon icon={ icon } /> }
 			forceInternalLink={ shouldOpenExternalLinksInCurrentTab }
-			className={ isSubItem ? 'sidebar__menu-item--child' : 'sidebar__menu-item-parent' }
+			className={ classnames(
+				isSubItem ? 'sidebar__menu-item--child' : 'sidebar__menu-item-parent',
+				className
+			) }
 		>
 			<MySitesSidebarUnifiedStatsSparkline slug={ slug } />
 		</SidebarItem>

--- a/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
+++ b/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
@@ -19,6 +19,7 @@ export default function globalSiteSidebarMenu( {
 			title: translate( 'All sites' ),
 			type: 'menu-item',
 			url: `/sites`,
+			className: 'sidebar__menu-item-all-sites',
 		},
 		{
 			type: 'current-site',

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -340,13 +340,6 @@ $font-size: rem(14px);
 
 		.sidebar__menu-link {
 			line-height: 15px;
-
-			&:hover,
-			&:focus {
-				box-shadow: none;
-				transition: none;
-				color: var(--studio-white);
-			}
 		}
 
 		.sidebar__menu-link-text {
@@ -368,11 +361,37 @@ $font-size: rem(14px);
 
 		.sidebar__heading:not([tabindex="-1"]),
 		.sidebar__menu-link {
+			color: var(--studio-gray-5);
+
+			.sidebar__menu-icon {
+				color: inherit;
+
+				&::before {
+					transition: none;
+				}
+			}
+
 			&:hover,
 			&:focus {
 				box-shadow: none;
 				transition: none;
 				color: var(--studio-white);
+
+				.sidebar__menu-icon {
+					color: inherit;
+				}
+			}
+		}
+
+		// Custom styles for “< All sites”
+		.sidebar__menu-item-all-sites {
+			.sidebar__menu-link {
+				padding-left: 6px;
+			}
+
+			.sidebar__menu-link-text {
+				font-size: 16px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-weight: 600;
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Update the styles of the “< All sites” menu item to align the pRpvRJ8j0jvFa5l7adz1Ta-fi-2394_68254
  * padding-left
  * color
  * font-size
  * font-weight

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/f592db2e-72bd-4637-9c53-1e3fb46b8f08) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/786adc90-850f-4673-9a79-a7ec32528a9e) |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/3792c61f-b7ec-4824-a0e1-dbd8b3ab2e7a) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/1559ca5e-2c3d-43a0-b5b6-e860cfc3ae77) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the site with the global sidebar
* Make sure the styles of the “< All sites” menu item is aligned with the pRpvRJ8j0jvFa5l7adz1Ta-fi-2394_68254
  ![image](https://github.com/Automattic/wp-calypso/assets/13596067/e606d8dc-27f8-4b08-b472-693f80264690)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?