### PR TITLE
Nav redesign: Fix /plans and /site-monitoring top paddings

### DIFF
--- a/client/my-sites/plans/style.scss
+++ b/client/my-sites/plans/style.scss
@@ -27,7 +27,8 @@
 body.is-section-plans {
 	.layout:not(.has-no-sidebar) .layout__content {
 		@media (min-width: $break-small) {
-			padding: 79px 0 0 0 !important;
+			padding-left: 0 !important;
+			padding-right: 0 !important;
 		}
 		@media (min-width: $break-medium) {
 			padding-left: calc(var(--sidebar-width-max) + 1px) !important;
@@ -56,6 +57,12 @@ body.is-section-plans {
 			.main {
 				padding: 17px max(calc(50% - 612px), 15px);
 			}
+		}
+	}
+
+	.layout:not(.has-no-sidebar):not(.has-no-masterbar) .layout__content {
+		@media (min-width: $break-small) {
+			padding-top: 79px !important;
 		}
 	}
 }

--- a/client/my-sites/site-monitoring/style.scss
+++ b/client/my-sites/site-monitoring/style.scss
@@ -19,8 +19,8 @@ $section-max-width: 1224px;
 	// this overrides the default .layout__content that adds unwanted padding
 	& .layout__content,
 	&.theme-default .focus-content .layout__content {
-		padding: 0;
-		padding-block-start: 79px;
+		padding-left: 0;
+		padding-right: 0;
 
 		@media (min-width: 1401px) {
 			padding-bottom: 88px;
@@ -29,6 +29,9 @@ $section-max-width: 1224px;
 		@media ( min-width: 782px ) {
 			padding-inline-start: calc(var(--sidebar-width-max) + 1px);
 		}
+	}
+	&:not(.has-no-masterbar) .layout__content {
+		padding-block-start: 79px;
 	}
 	.site-monitoring__formatted-header.formatted-header.modernized-header.is-left-align {
 		padding: 0 max(calc(50% - #{math.div( $section-max-width, 2 )}), 32px);


### PR DESCRIPTION
## Proposed Changes

After:

- https://github.com/Automattic/wp-calypso/pull/87623

was merged, `/plans` and `/site-monitoring` headers have bad top paddings, because they did not account for the missing top bar in the CSS.

This PR fixes that, using the same strategy as:

- https://github.com/Automattic/wp-calypso/pull/87622


Before

|<img width="970" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/dca5122d-64e3-45fd-b3e4-38d72412230a">|<img width="970" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/6b7bb0c9-e3ef-479d-8766-a0619bb33231">|
|-|-|

After

|<img width="970" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/84a3639b-d8b2-4eaa-8e08-260438dd9db8">|<img width="970" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/07491691-0f4c-4c73-810e-1750f403b8bc">|
|-|-|

## Testing Instructions

1. Open `/plans/:siteSlug` and `/site-monitoring/:siteSlug`, make sure they have the same header top padding as the rest of the menus.
1. Test without the flag and with various screen width.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?