### PR TITLE
Automattic for Agencies: Add layout components

### DIFF
--- a/client/a8c-for-agencies/components/layout/body.tsx
+++ b/client/a8c-for-agencies/components/layout/body.tsx
@@ -1,0 +1,13 @@
+import { ReactNode } from 'react';
+
+type Props = {
+	children: ReactNode;
+};
+
+export default function LayoutBody( { children }: Props ) {
+	return (
+		<div className="a4a-layout__body">
+			<div className="a4a-layout__body-wrapper">{ children }</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/components/layout/header.tsx
+++ b/client/a8c-for-agencies/components/layout/header.tsx
@@ -1,0 +1,107 @@
+import classNames from 'classnames';
+import { Children, ReactNode, useLayoutEffect, useState } from 'react';
+import Breadcrumb, { Item as BreadcrumbItem } from 'calypso/components/breadcrumb';
+import useDetectWindowBoundary from 'calypso/lib/detect-window-boundary';
+
+type Props = {
+	showStickyContent?: boolean;
+	children: ReactNode;
+};
+
+export function LayoutHeaderTitle( { children }: Props ) {
+	return <h1 className="a4a-layout__header-title">{ children }</h1>;
+}
+
+export function LayoutHeaderSubtitle( { children }: Props ) {
+	return <h2 className="a4a-layout__header-subtitle">{ children }</h2>;
+}
+
+export function LayoutHeaderActions( { children }: Props ) {
+	return <div className="a4a-layout__header-actions">{ children }</div>;
+}
+
+export function LayoutHeaderBreadcrumb( { items }: { items: BreadcrumbItem[] } ) {
+	return (
+		<div className="a4a-layout__header-breadcrumb">
+			<Breadcrumb items={ items } />
+		</div>
+	);
+}
+
+export default function LayoutHeader( { showStickyContent, children }: Props ) {
+	const headerBreadcrumb = Children.toArray( children ).find(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( child: any ) => child.type === LayoutHeaderBreadcrumb
+	);
+
+	const headerTitle = Children.toArray( children ).find(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( child: any ) => child.type === LayoutHeaderTitle
+	);
+
+	const headerSubtitle = Children.toArray( children ).find(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( child: any ) => child.type === LayoutHeaderSubtitle
+	);
+
+	const headerActions = Children.toArray( children ).find(
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		( child: any ) => child.type === LayoutHeaderActions
+	);
+
+	const [ divRef, hasCrossed ] = useDetectWindowBoundary();
+
+	const outerDivProps = divRef ? { ref: divRef as React.RefObject< HTMLDivElement > } : {};
+
+	const [ minHeaderHeight, setMinHeaderHeight ] = useState( 0 );
+
+	// To avoid shifting the layout when displaying sticky content,  we will need to
+	// keep track of our Header height and set it as the minimum viewport height.
+	useLayoutEffect(
+		() => {
+			const headerRef = outerDivProps?.ref?.current;
+
+			const updateMinHeaderHeight = () => {
+				setMinHeaderHeight( headerRef?.clientHeight ?? 0 );
+			};
+
+			window.addEventListener( 'resize', updateMinHeaderHeight );
+
+			updateMinHeaderHeight();
+
+			return () => {
+				window.removeEventListener( 'resize', updateMinHeaderHeight );
+			};
+		},
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+		[]
+	);
+
+	return (
+		<div
+			className="a4a-layout__viewport"
+			{ ...outerDivProps }
+			style={ showStickyContent ? { minHeight: `${ minHeaderHeight }px` } : {} }
+		>
+			<div
+				className={ classNames( {
+					'a4a-layout__sticky-header': showStickyContent && hasCrossed,
+				} ) }
+			>
+				<div
+					className={ classNames( 'a4a-layout__header', {
+						'has-actions': !! headerActions,
+					} ) }
+				>
+					<div className="a4a-layout__header-main">
+						{ headerBreadcrumb }
+						{ headerTitle }
+						{ headerSubtitle }
+					</div>
+
+					{ headerActions }
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/components/layout/index.tsx
+++ b/client/a8c-for-agencies/components/layout/index.tsx
@@ -1,0 +1,39 @@
+import classNames from 'classnames';
+import { ReactNode } from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
+import Main from 'calypso/components/main';
+
+import './style.scss';
+
+type Props = {
+	children: ReactNode;
+	sidebarNavigation?: ReactNode;
+	className?: string;
+	title: ReactNode;
+	wide?: boolean;
+	withBorder?: boolean;
+};
+
+export default function Layout( {
+	children,
+	className,
+	title,
+	wide = false,
+	withBorder = false,
+	sidebarNavigation,
+}: Props ) {
+	return (
+		<Main
+			className={ classNames( 'a4a-layout', className, {
+				'is-with-border': withBorder,
+			} ) }
+			fullWidthLayout={ wide }
+			wideLayout={ ! wide } // When we set to full width, we want to set this to false.
+		>
+			<DocumentHead title={ title } />
+			{ sidebarNavigation }
+
+			<div className="a4a-layout__container">{ children }</div>
+		</Main>
+	);
+}

--- a/client/a8c-for-agencies/components/layout/nav.tsx
+++ b/client/a8c-for-agencies/components/layout/nav.tsx
@@ -1,0 +1,74 @@
+import { Count } from '@automattic/components';
+import classNames from 'classnames';
+import { ReactNode } from 'react';
+import SectionNav from 'calypso/components/section-nav';
+import NavItem from 'calypso/components/section-nav/item';
+import NavTabs from 'calypso/components/section-nav/tabs';
+
+type LayoutNavigationProps = {
+	className?: string;
+	children: ReactNode;
+	selectedText: string;
+	selectedCount?: number;
+};
+
+type LayoutNavigationItemProps = {
+	label: string;
+	compactCount?: boolean;
+	onClick?: () => void;
+	path?: string;
+	count?: number;
+	selected?: boolean;
+};
+
+type LayoutNavigationTabsProps = {
+	selectedText: string;
+	selectedCount?: number;
+	items: LayoutNavigationItemProps[];
+};
+
+export function LayoutNavigationTabs( {
+	selectedText,
+	selectedCount,
+	items,
+}: LayoutNavigationTabsProps ) {
+	return (
+		<NavTabs selectedText={ selectedText } selectedCount={ selectedCount }>
+			{ items.map( ( { label, onClick, selected, count, path, compactCount = true } ) => (
+				<NavItem
+					key={ label.replace( /[^a-zA-Z0-9]/g, '' ).toLowerCase() }
+					compactCount={ compactCount }
+					count={ count }
+					path={ path }
+					onClick={ onClick }
+					selected={ selected }
+				>
+					{ label }
+				</NavItem>
+			) ) }
+		</NavTabs>
+	);
+}
+
+export default function LayoutNavigation( {
+	className,
+	selectedText,
+	selectedCount,
+	children,
+}: LayoutNavigationProps ) {
+	return (
+		<SectionNav
+			className={ classNames( 'a4a-layout__navigation', className ) }
+			applyUpdatedStyles
+			selectedText={
+				<span>
+					{ selectedText }
+					{ Number.isInteger( selectedCount ) && <Count count={ selectedCount } compact /> }
+				</span>
+			}
+			selectedCount={ selectedCount }
+		>
+			{ children }
+		</SectionNav>
+	);
+}

--- a/client/a8c-for-agencies/components/layout/stepper.tsx
+++ b/client/a8c-for-agencies/components/layout/stepper.tsx
@@ -1,0 +1,49 @@
+import { Gridicon } from '@automattic/components';
+import classnames from 'classnames';
+import { Fragment } from 'react';
+
+type Props = {
+	steps: string[];
+	current: number;
+};
+
+function getStepClassName( currentStep: number, step: number ): string {
+	return classnames( {
+		'is-current': currentStep === step,
+		'is-next': currentStep < step,
+		'is-complete': currentStep > step,
+	} );
+}
+
+function Marker( { currentStep, step }: { currentStep: number; step: number } ) {
+	if ( currentStep > step ) {
+		return (
+			<span className="a4a-layout__stepper-step-circle">
+				<Gridicon icon="checkmark" size={ 16 } />
+			</span>
+		);
+	}
+
+	return (
+		<span className="a4a-layout__stepper-step-circle">
+			<span>{ step }</span>
+		</span>
+	);
+}
+
+export default function LayoutStepper( { steps, current }: Props ) {
+	return (
+		<div className="a4a-layout__stepper">
+			{ steps.map( ( label, index ) => (
+				<Fragment key={ `step-${ index }` }>
+					<div className={ `a4a-layout__stepper-step ${ getStepClassName( current, index ) }` }>
+						<Marker currentStep={ current + 1 } step={ index + 1 } />
+						<span className="a4a-layout__stepper-step-name">{ label }</span>
+					</div>
+
+					{ index < steps.length - 1 && <div className="a4a-layout__stepper-step-separator" /> }
+				</Fragment>
+			) ) }
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -147,7 +147,7 @@
 
 .a4a-layout__header-subtitle {
 	font-size: 1rem;
-	color: var(--studio-gray-60);
+	color: var(--color-neutral-60);
 	margin: 0;
 	font-weight: 400;
 	line-height: 1.2;
@@ -239,20 +239,20 @@
 	}
 
 	&.is-current > .a4a-layout__stepper-step-circle {
-		background-color: var(--studio-gray-60);
-		border: 2px solid var(--studio-gray-60);
-		color: var(--studio-white);
+		background-color: var(--color-neutral-60);
+		border: 2px solid var(--color-neutral-60);
+		color: var(--color-text-inverted);
 	}
 
 	&.is-next > .a4a-layout__stepper-step-circle {
-		border: 2px solid var(--studio-gray-60);
-		color: var(--studio-gray-80);
+		border: 2px solid var(--color-neutral-60);
+		color: var(--color-neutral-80);
 	}
 
 	&.is-complete > .a4a-layout__stepper-step-circle {
 		background-color: var(--color-primary-50);
 		border: 2px solid var(--color-primary-50);
-		color: var(--studio-white);
+		color: var(--color-text-inverted);
 	}
 
 	&.is-next > .a4a-layout__stepper-step-name {
@@ -275,7 +275,7 @@
 }
 
 .a4a-layout__stepper-step-separator {
-	border: 1px solid var(--studio-gray-80);
+	border: 1px solid var(--color-neutral-80);
 	width: 20px;
 	height: 0;
 	margin: 0 0.75rem;

--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -1,0 +1,287 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.main.a4a-layout {
+	header.current-section {
+		button {
+			padding: 20px 8px;
+		}
+	}
+}
+
+.a4a-layout__container {
+	max-width: 100%;
+	min-height: calc(100vh - 123px);
+	display: flex;
+	flex-direction: column;
+	margin: auto;
+	padding: 0;
+}
+
+.a4a-layout__body {
+	width: 100%;
+	margin-block-end: -32px;
+	flex: 1 1 100%;
+
+	@include breakpoint-deprecated( ">660px" ) {
+		// We need these negative margin values because we want to make the container full-width,
+		// but our element is inside a limited-width parent.
+		margin-inline-start: -73px;
+		padding-inline: 73px;
+	}
+}
+
+.a4a-layout__top-wrapper,
+.a4a-layout__body-wrapper {
+	margin-inline: 0;
+
+	> * {
+		max-width: 1500px;
+		margin-inline: auto !important;
+	}
+}
+
+.main.a4a-layout.is-with-border {
+	@include breakpoint-deprecated( ">660px" ) {
+		.a4a-layout__top {
+			border-block-end: 1px solid var(--color-primary-5);
+		}
+
+		.a4a-layout__body {
+			background: rgba(255, 255, 255, 0.5);
+			padding-block: 16px;
+		}
+	}
+}
+
+.a4a-layout__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin: auto;
+	height: 100%;
+
+	> * + * {
+		margin-inline-start: 24px;
+	}
+
+	@include breakpoint-deprecated( "<1280px" ) {
+		flex-wrap: wrap;
+
+		> * {
+			width: 100%;
+		}
+
+		> * + * {
+			margin-inline-start: 0;
+		}
+	}
+}
+
+.a4a-layout__header.has-actions > .a4a-layout__header-main {
+	@include breakpoint-deprecated( "660px-1280px" ) {
+		margin-block-end: 16px;
+	}
+}
+
+.a4a-layout__sticky-header {
+	position: fixed;
+	width: calc(100%);
+	left: 0;
+	top: var(--masterbar-height);
+	background-color: rgba(246, 247, 247, 0.95);
+	box-shadow: 2px 2px 2px 0 rgb(0 0 0 / 8%);
+	z-index: 1001;
+	height: 74px;
+
+	.a4a-layout__header {
+		flex-wrap: nowrap;
+		max-width: 1500px;
+		padding-inline: 48px;
+
+		> * {
+			width: auto;
+		}
+	}
+
+	.a4a-layout__header-main,
+	.a4a-layout__header-actions {
+		margin: 0;
+	}
+
+	.a4a-layout__header-subtitle {
+		display: none;
+	}
+
+	.a4a-layout__header-title {
+		font-size: rem(24px);
+		margin-block-end: 0;
+		display: none;
+
+		@include break-large {
+			display: block;
+		}
+	}
+
+	@include breakpoint-deprecated( ">660px" ) {
+		width: calc(100% - var(--sidebar-width-min));
+		left: var(--sidebar-width-min);
+	}
+
+	@include breakpoint-deprecated( ">960px" ) {
+		width: calc(100% - var(--sidebar-width-max));
+		left: var(--sidebar-width-max);
+	}
+}
+
+.a4a-layout__header-breadcrumb {
+	margin-block-end: 4px;
+}
+
+.a4a-layout__header-title {
+	font-size: 2.25rem;
+	margin-block-end: 8px;
+	font-weight: 600;
+	line-height: 1.2;
+}
+
+.a4a-layout__header-subtitle {
+	font-size: 1rem;
+	color: var(--studio-gray-60);
+	margin: 0;
+	font-weight: 400;
+	line-height: 1.2;
+}
+
+.section-nav.a4a-layout__navigation {
+	margin-block-start: 16px;
+
+	.section-nav__mobile-header-text .count {
+		margin-inline-start: 8px;
+	}
+
+	.select-dropdown__item.is-selected .count {
+		color: var(--color-text);
+	}
+
+	.select-dropdown__header {
+		border-width: 0;
+
+		.count {
+			top: 12.5px;
+		}
+
+		@include breakpoint-deprecated( ">660px" ) {
+			border-width: 1px;
+		}
+	}
+
+	.section-nav-tabs.is-dropdown {
+		width: 100%;
+		margin: 0 0 1px 0;
+
+		@include breakpoint-deprecated( ">660px" ) {
+			margin-block-end: 12px;
+		}
+	}
+
+	.select-dropdown__options {
+		margin-inline: -1px;
+	}
+
+	.section-nav-tabs__dropdown .select-dropdown__container {
+		max-width: unset;
+		width: 100%;
+	}
+
+	.section-nav-tabs__dropdown {
+		// Since the search below the dropdown has z-index: 22,
+		// we need to make sure the dropdown is above it
+		z-index: 23;
+	}
+
+	@include breakpoint-deprecated( ">960px" ) {
+		margin-block-start: 32px;
+	}
+}
+
+
+.a4a-layout__stepper {
+	display: flex;
+	justify-content: flex-start;
+	align-items: center;
+	margin-block: 16px 32px;
+}
+
+.a4a-layout__stepper-step {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+
+	.a4a-layout__stepper-step-circle {
+		width: 20px;
+		height: 20px;
+		display: flex;
+		border-radius: 50%;
+		justify-content: center;
+		align-content: center;
+		align-items: center;
+		font-size: 0.75rem;
+	}
+
+	.a4a-layout__stepper-step-name {
+		margin-left: 0.5rem;
+		white-space: nowrap;
+	}
+
+	.a4a-layout__viewport {
+		margin-inline-start: 0;
+	}
+
+	&.is-current > .a4a-layout__stepper-step-circle {
+		background-color: var(--studio-gray-60);
+		border: 2px solid var(--studio-gray-60);
+		color: var(--studio-white);
+	}
+
+	&.is-next > .a4a-layout__stepper-step-circle {
+		border: 2px solid var(--studio-gray-60);
+		color: var(--studio-gray-80);
+	}
+
+	&.is-complete > .a4a-layout__stepper-step-circle {
+		background-color: var(--color-primary-50);
+		border: 2px solid var(--color-primary-50);
+		color: var(--studio-white);
+	}
+
+	&.is-next > .a4a-layout__stepper-step-name {
+		display: none;
+
+		@include break-medium {
+			display: flex;
+		}
+	}
+
+	&.is-complete > .a4a-layout__stepper-step-name,
+	&.is-complete > .a4a-layout__stepper-step-circle,
+	&.is-complete + .a4a-layout__stepper-step-separator {
+		display: none;
+
+		@include break-medium {
+			display: flex;
+		}
+	}
+}
+
+.a4a-layout__stepper-step-separator {
+	border: 1px solid var(--studio-gray-80);
+	width: 20px;
+	height: 0;
+	margin: 0 0.75rem;
+
+	@include break-medium {
+		width: 40px;
+		margin: 0 1.25rem;
+	}
+}

--- a/client/a8c-for-agencies/components/layout/top.tsx
+++ b/client/a8c-for-agencies/components/layout/top.tsx
@@ -1,0 +1,9 @@
+import { ReactNode } from 'react';
+
+type Props = {
+	children: ReactNode;
+};
+
+export default function LayoutTop( { children }: Props ) {
+	return <div className="a4a-layout__top-wrapper">{ children }</div>;
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/230

## Proposed Changes

This PR adds the layout components to A4A.

## Testing Instructions

- Switch to the branch `add/a4a-layout-components`.
- Start the server by running `start-a8c-for-agencies`.
- Go to the file: /client/a8c-for-agencies/sections/overview/controller.tsx.
- Set the below content as the primary content:

```

import Layout from 'calypso/a8c-for-agencies/components/layout';
import LayoutHeader, {
	LayoutHeaderSubtitle as Subtitle,
	LayoutHeaderTitle as Title,
} from 'calypso/a8c-for-agencies/components/layout/header';
import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';

context.primary = (
	<Layout wide title="Overview">
		<LayoutTop>
			<LayoutHeader>
				<Title> Overview </Title>
				<Subtitle> Overview page</Subtitle>
			</LayoutHeader>
		</LayoutTop>
	</Layout>
);
```

- Verify the code changes make sense(this is mostly a copy-paste of [jetpack-cloud layout](https://github.com/Automattic/wp-calypso/blob/29cac97979edf2d0d1b4184873b1ddc112a28d49/client/jetpack-cloud/components/layout)) 

- Verify the title and subtitle is loaded as below:

<img width="834" alt="Screenshot 2024-02-20 at 12 47 28 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/2bf9acad-9c3a-4213-8592-74a3becdaf55">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?