### PR TITLE
Headers: make heading and action buttons aligned at the top

### DIFF
--- a/client/components/navigation-header/style.scss
+++ b/client/components/navigation-header/style.scss
@@ -42,7 +42,7 @@
 .navigation-header__main {
 	display: flex;
 	justify-content: space-between;
-	align-items: center;
+	align-items: flex-start;
 	box-sizing: border-box;
 	column-gap: 10px;
 
@@ -104,4 +104,3 @@
 #primary header.navigation-header header.formatted-header {
 	margin: 0;
 }
-

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -80,7 +80,7 @@ const HeaderControls = styled.div( {
 	marginInline: 'auto',
 	display: 'flex',
 	flexDirection: 'row',
-	alignItems: 'center',
+	alignItems: 'flex-start',
 } );
 
 const DashboardHeading = styled.h1( {


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/5659

## Proposed Changes

This PR fixes the navigation header component(s) so that the heading and buttons are aligned-top, whether or not there are subheading.

With this, when we click around pages, the distance between heading and buttons from the top of the screen remains constant, so there's no janky experience.

|Before|After|
|-|-|
|<img width="668" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/b54147e6-a108-44ff-81de-788d8d3f4c47">|<img width="668" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/8fd2ceda-e656-48da-be3c-2a110ed065d1">|
|<img width="668" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/4c852da5-1953-4e78-8482-43d1514e64b2">|<img width="668" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/1bd5ee2e-8287-4c6f-a36f-1372eeadf083">|

Specifically requesting review from @candy02058912 as the original implementor of the navigation header.

## Testing Instructions

1. With the `layout/dotcom-nav-redesign` flag, click Sites and Domains repeatedly. Notice that you no longer notice "jumps" in the heading / buttons! Their distance from the top remain the same.
2. Test also with various pages, such as Theme Showcase (`/themes`). Verify that the heading and buttons still look good.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?