### PR TITLE
Revert "Untangle: Move Downtime monitoring from Security Settings to Site Tools"

### DIFF
--- a/client/my-sites/site-settings/wpcom-site-tools-settings/index.jsx
+++ b/client/my-sites/site-settings/wpcom-site-tools-settings/index.jsx
@@ -1,7 +1,5 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import JetpackMonitor from 'calypso/my-sites/site-settings/form-jetpack-monitor';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import getIsUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
@@ -19,7 +17,6 @@ const SiteSettingsGeneral = ( {
 	updateFields,
 	isRequestingSettings,
 	isSavingSettings,
-	isJetpack,
 
 	isWpcomStagingSite,
 	isAtomicAndEditingToolkitDeactivated,
@@ -37,7 +34,6 @@ const SiteSettingsGeneral = ( {
 				isSavingSettings={ isSavingSettings }
 			/>
 		) }
-		{ isJetpack && isEnabled( 'layout/dotcom-nav-redesign' ) && <JetpackMonitor /> }
 		{ ! isWpcomStagingSite && (
 			<SiteTools headerTitle={ translate( 'Other tools' ) } source={ SOURCE_SETTINGS_SITE_TOOLS } />
 		) }

--- a/client/my-sites/site-settings/wpcom-site-tools.jsx
+++ b/client/my-sites/site-settings/wpcom-site-tools.jsx
@@ -32,7 +32,7 @@ const WpcomSiteTools = ( { isJetpack, isPossibleJetpackConnectionProblem, siteId
 				title={ translate( 'Site Tools' ) }
 				subtitle={ translate( 'Manage your site settings, including site visibility, and more.' ) }
 			/>
-			<WpcomSiteToolsSettings isJetpack={ isJetpack } />
+			<WpcomSiteToolsSettings />
 		</Main>
 	);
 };

--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -11,7 +11,7 @@ import { items as itemSchemas } from './schema';
 
 const setChecklistTaskCompletion = ( state, taskId, completed ) => ( {
 	...state,
-	tasks: state?.tasks?.map( ( task ) =>
+	tasks: state.tasks?.map( ( task ) =>
 		task.id === taskId ? { ...task, isCompleted: completed } : task
 	),
 } );


### PR DESCRIPTION
Reverts Automattic/wp-calypso#87525

See https://github.com/Automattic/dotcom-forge/issues/5655#issuecomment-1953522431