### PR TITLE
Downtime Monitoring: Fix for misleading error notice when activating a Jetpack module

### DIFF
--- a/client/state/checklist/reducer.js
+++ b/client/state/checklist/reducer.js
@@ -11,7 +11,7 @@ import { items as itemSchemas } from './schema';
 
 const setChecklistTaskCompletion = ( state, taskId, completed ) => ( {
 	...state,
-	tasks: state.tasks?.map( ( task ) =>
+	tasks: state?.tasks?.map( ( task ) =>
 		task.id === taskId ? { ...task, isCompleted: completed } : task
 	),
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/33710 https://github.com/Automattic/wp-calypso/pull/87525 https://github.com/Automattic/dotcom-forge/issues/5655


## Proposed Changes

* Fix for misleading error notice when activating a Jetpack module

https://github.com/Automattic/wp-calypso/assets/1881481/90f39166-977b-4d7a-a44a-18e1400758fd


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Connect a Jetpack site to WordPress.com
* Access Settings > Security from `wordpress.com/settings/security/{ SITE SLUG }
* Enable or disable the option `Get alerts if your site goes offline. We’ll let you know when it’s back up, too.`
* Verify there is a success notice and no errors 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?