### PR TITLE
Continue with GitHub: GitHub authentication

### DIFF
--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -114,8 +114,30 @@ class SocialLoginForm extends Component {
 		);
 	};
 
-	// eslint-disable-next-line no-unused-vars
-	handleGitHubResponse = ( response ) => {};
+	handleGitHubResponse = ( { access_token } ) => {
+		const { onSuccess, socialService } = this.props;
+		const redirectTo = this.props.redirectTo;
+
+		if ( socialService !== 'github' ) {
+			return;
+		}
+
+		const socialInfo = {
+			service: 'github',
+			access_token: access_token,
+		};
+
+		this.props.loginSocialUser( socialInfo, redirectTo ).then(
+			() => {
+				this.recordEvent( 'calypso_login_social_login_success', 'github' );
+
+				onSuccess();
+			},
+			( error ) => {
+				this.reportSocialLoginFailure( { service: 'github', socialInfo, error } );
+			}
+		);
+	};
 
 	recordEvent = ( eventName, service, params ) =>
 		this.props.recordTracksEvent( eventName, {
@@ -133,6 +155,9 @@ class SocialLoginForm extends Component {
 
 	getRedirectUri = ( service ) => {
 		const host = typeof window !== 'undefined' && window.location.host;
+		if ( window.location.hostname === 'calypso.localhost' ) {
+			return `http://${ host }${ login( { socialService: service } ) }`;
+		}
 		return `https://${ host }${ login( { socialService: service } ) }`;
 	};
 

--- a/client/blocks/login/social.jsx
+++ b/client/blocks/login/social.jsx
@@ -155,7 +155,7 @@ class SocialLoginForm extends Component {
 
 	getRedirectUri = ( service ) => {
 		const host = typeof window !== 'undefined' && window.location.host;
-		if ( window.location.hostname === 'calypso.localhost' ) {
+		if ( typeof window !== 'undefined' && window.location.hostname === 'calypso.localhost' ) {
 			return `http://${ host }${ login( { socialService: service } ) }`;
 		}
 		return `https://${ host }${ login( { socialService: service } ) }`;

--- a/client/blocks/signup-form/social.jsx
+++ b/client/blocks/signup-form/social.jsx
@@ -58,8 +58,20 @@ class SocialSignupForm extends Component {
 		} );
 	};
 
-	// eslint-disable-next-line no-unused-vars
-	handleGitHubResponse = ( response ) => {};
+	handleGitHubResponse = ( { access_token }, triggeredByUser = true ) => {
+		if ( ! triggeredByUser && this.props.socialService !== 'github' ) {
+			return;
+		}
+
+		this.props.recordTracksEvent( 'calypso_signup_social_button_success', {
+			social_account_type: 'github',
+		} );
+
+		this.props.handleResponse( 'github', access_token, null, {
+			// Make accounts signed up via GitHub as dev accounts
+			is_dev_account: true,
+		} );
+	};
 
 	trackSocialSignup = ( service ) => {
 		this.props.recordTracksEvent( 'calypso_signup_social_button_click', {

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -103,14 +103,6 @@ const GitHubLoginButton = ( {
 	};
 
 	useEffect( () => {
-		// This feature is already gated inside client/blocks/authentication/social/index.tsx
-		// Adding an extra check here to prevent accidental inclusions in other parts of the app
-		if ( ! config.isEnabled( 'login/github' ) ) {
-			return;
-		}
-	} );
-
-	useEffect( () => {
 		if ( socialServiceResponse ) {
 			responseHandler( socialServiceResponse );
 		}
@@ -156,6 +148,12 @@ const GitHubLoginButton = ( {
 		};
 
 		customButton = cloneElement( children as ReactElement, childProps );
+	}
+
+	// This feature is already gated inside client/blocks/authentication/social/index.tsx
+	// Adding an extra check here to prevent accidental inclusions in other parts of the app
+	if ( ! config.isEnabled( 'login/github' ) ) {
+		return;
 	}
 
 	return (

--- a/client/components/social-buttons/google.js
+++ b/client/components/social-buttons/google.js
@@ -56,7 +56,7 @@ class GoogleSocialButton extends Component {
 	}
 
 	componentDidMount() {
-		if ( this.props.authCodeFromRedirect ) {
+		if ( this.props.authCodeFromRedirect && this.props.serviceFromRedirect !== 'github' ) {
 			this.handleAuthorizationCode( {
 				auth_code: this.props.authCodeFromRedirect,
 				redirect_uri: this.props.redirectUri,
@@ -115,7 +115,6 @@ class GoogleSocialButton extends Component {
 
 	async handleAuthorizationCode( { auth_code, redirect_uri } ) {
 		let response;
-
 		try {
 			response = await postLoginRequest( 'exchange-social-auth-code', {
 				service: 'google',
@@ -263,6 +262,7 @@ export default connect(
 	( state ) => ( {
 		isFormDisabled: isFormDisabled( state ),
 		authCodeFromRedirect: getInitialQueryArguments( state ).code,
+		serviceFromRedirect: getInitialQueryArguments( state ).service,
 	} ),
 	{
 		recordTracksEvent,

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -93,7 +93,7 @@ export default ( router ) => {
 		[
 			`/log-in/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
 			`/log-in/:flow(social-connect|private-site)/${ lang }`,
-			`/log-in/:socialService(google|apple)/callback/${ lang }`,
+			`/log-in/:socialService(google|apple|github)/callback/${ lang }`,
 			`/log-in/:isJetpack(jetpack)/${ lang }`,
 			`/log-in/:isJetpack(jetpack)/:twoFactorAuthType(authenticator|backup|sms|push|webauthn)/${ lang }`,
 			`/log-in/:isJetpack(jetpack)/:action(lostpassword)/${ lang }`,

--- a/client/me/social-login/index.jsx
+++ b/client/me/social-login/index.jsx
@@ -10,6 +10,7 @@ import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import Notice from 'calypso/components/notice';
 import AppleIcon from 'calypso/components/social-icons/apple';
+import GitHubIcon from 'calypso/components/social-icons/github';
 import GoogleIcon from 'calypso/components/social-icons/google';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import twoStepAuthorization from 'calypso/lib/two-step-authorization';
@@ -60,6 +61,17 @@ class SocialLogin extends Component {
 						redirectUri={ redirectUri }
 						socialServiceResponse={
 							this.props.socialService === 'apple' ? this.props.socialServiceResponse : null
+						}
+					/>
+				) }
+
+				{ config.isEnabled( 'login/github' ) && (
+					<SocialLoginService
+						service="github"
+						icon={ <GitHubIcon /> }
+						redirectUri={ redirectUri }
+						socialServiceResponse={
+							this.props.socialService === 'github' ? this.props.socialServiceResponse : null
 						}
 					/>
 				) }

--- a/client/me/social-login/service.jsx
+++ b/client/me/social-login/service.jsx
@@ -16,7 +16,7 @@ const SocialLoginService = ( {
 		<div className="social-login__header">
 			<div className="social-login__header-info">
 				<div className="social-login__header-icon">{ icon }</div>
-				<h3>{ service }</h3>
+				<h3>{ service === 'github' ? 'GitHub' : service }</h3>
 				{ socialConnectionEmail && <p>{ ' - ' + socialConnectionEmail }</p> }
 			</div>
 

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -353,7 +353,6 @@ export class UserStep extends Component {
 		} else if ( data.queryArgs.redirect_to ) {
 			dependencies.redirect = data.queryArgs.redirect_to;
 		}
-
 		this.props.submitSignupStep(
 			{
 				flowName,
@@ -434,7 +433,6 @@ export class UserStep extends Component {
 			query.redirect_to = window.sessionStorage.getItem( 'signup_redirect_to' );
 			window.sessionStorage.removeItem( 'signup_redirect_to' );
 		}
-
 		this.submit( {
 			service,
 			access_token,


### PR DESCRIPTION
## Proposed Changes

- Log in with GitHub
- Sign up with GitHub
- Connect GitHub social account to an existing account with the same email address.

| | |
|-|-|
| ![CleanShot 2024-02-20 at 14 24 08@2x](https://github.com/Automattic/wp-calypso/assets/528287/d641b9d1-cddd-4a7f-a638-785a7d70d94f) |  ![CleanShot 2024-02-20 at 14 24 20@2x](https://github.com/Automattic/wp-calypso/assets/528287/03dfb69b-82df-4fdd-a94e-ff12271da44e) |



## Testing Instructions

- Apply this PR
- In an incognito tab, check these scenarios

### Sign up
1. Sign up with a GitHub account (which email is not already a registered WPCOM account)  at http://calypso.localhost:3000/start/user-social

### Sign in
1. Sign in with the GitHub account from above at http://calypso.localhost:3000/log-in

### Connect GH
(This might be a tricky one to test)
1. Set your GitHub email address to an existing WP.com account
2. Try to log in using GitHub at http://calypso.localhost:3000/log-in
3. You will be notified that an account already exists for that email adress, and will be asked to log in
4. After logging in the GitHub account should be linked


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?