### PR TITLE
Nav redesign: Fix footer hover state CSS

### DIFF
--- a/client/layout/global-sidebar/footer.tsx
+++ b/client/layout/global-sidebar/footer.tsx
@@ -34,7 +34,7 @@ export const GlobalSidebarFooter: FC< {
 		<SidebarFooter>
 			<a
 				href="/read"
-				className="sidebar__footer-link tooltip tooltip-top"
+				className="sidebar__footer-link sidebar__footer-reader tooltip tooltip-top"
 				title={ translate( 'Reader' ) }
 				data-tooltip={ translate( 'Reader' ) }
 			>
@@ -42,7 +42,7 @@ export const GlobalSidebarFooter: FC< {
 			</a>
 			<a
 				href="/me"
-				className="sidebar__footer-link tooltip tooltip-top"
+				className="sidebar__footer-link sidebar__footer-profile tooltip tooltip-top"
 				title={ translate( 'Profile' ) }
 				data-tooltip={ translate( 'Profile' ) }
 			>

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -165,6 +165,10 @@ $brand-text: "SF Pro Text", $sans;
 			display: flex;
 			flex-grow: 1;
 			align-items: center;
+			height: 16px;
+			padding: 8px 0;
+			font-size: 14px;  /* stylelint-disable-line declaration-property-unit-allowed-list */
+
 			svg {
 				&.wpicon {
 					margin-right: 10px;

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -129,6 +129,7 @@ $brand-text: "SF Pro Text", $sans;
 
 	.sidebar__footer {
 		display: flex;
+		gap: 8px;
 		align-items: center;
 		padding: 16px 24px 16px 24px;
 		border-color: var(--studio-gray-90);
@@ -140,39 +141,62 @@ $brand-text: "SF Pro Text", $sans;
 		.sidebar__footer-link {
 			display: flex;
 			align-items: center;
-			margin-left: 20px;
-			height: 40px;
-			&:first-child {
-				margin-left: 4px;
-			}
 		}
 		.sidebar__item-help {
 			display: flex;
 			align-items: center;
-			margin-left: 20px;
-			height: 40px;
+			padding: 4px;
 			cursor: pointer;
+
 			svg {
-				fill: var(--studio-white);
+				height: 24px;
+				width: 24px;
 			}
+		}
+		.sidebar__footer-reader {
+			padding: 4px;
+		}
+		.sidebar__footer-profile {
+			padding: 6px;
 		}
 		.sidebar__footer-wpadmin {
 			display: flex;
 			flex-grow: 1;
 			align-items: center;
-			color: var(--color-sidebar-text);
-			&:hover {
-				color: var(--color-sidebar-menu-hover-text);
-				text-decoration: underline;
-			}
 			svg {
-				fill: var(--studio-white);
 				&.wpicon {
 					margin-right: 10px;
 				}
 				&.external {
 					margin-left: auto;
 				}
+			}
+		}
+
+		.sidebar__item-help,
+		.sidebar__footer-link,
+		.sidebar__footer-wpadmin {
+			color: var(--studio-gray-5);
+
+			svg {
+				fill: var(--studio-gray-5);
+			}
+
+			&:hover {
+				color: var(--studio-white);
+				text-decoration: none;
+
+				svg {
+					fill: var(--studio-white);
+				}
+			}
+		}
+
+		.sidebar__footer-link,
+		.sidebar__item-help {
+			&:hover {
+				background-color: var(--color-sidebar-menu-hover-background);
+				border-radius: 4px;
 			}
 		}
 	}

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -19,6 +19,8 @@ $brand-text: "SF Pro Text", $sans;
 		position: relative;
 
 		&::after {
+			height: 20px;
+			line-height: 20px;
 			background: var(--studio-white);
 			border-radius: 4px;
 			bottom: -30px;
@@ -49,7 +51,7 @@ $brand-text: "SF Pro Text", $sans;
 			right: unset;
 			bottom: unset;
 			left: 0;
-			top: -30px;
+			top: -35px;
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

Apply the hover state CSS to the nav redesign footer as per pRpvRJ8j0jvFa5l7adz1Ta-fi-2394%3A80900.

|Before|After|
|-|-|
|<img width="316" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/0db97c0c-dc97-4cdb-bc24-bcc19dc464bd">|<img width="318" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/0a4c8a48-ff0e-44ca-b4a5-d6f51008c138">|<img width="311" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/9012da18-5757-41c4-9db5-ef7089e4661c">|
|<img width="312" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/9c692636-1387-4eee-bd8d-6c2ccd0eeec4">|<img width="310" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/78004b92-3525-4e06-8720-a359ff441c6c">|

## Testing Instructions

1. Open the Calypso Live and verify that the footer elements have the correct styles when hovered as above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?