### PR TITLE
Automattic for Agencies: Add mobile sidebar navigation component

### DIFF
--- a/client/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation/index.tsx
@@ -1,0 +1,9 @@
+import SidebarNavigation from 'calypso/components/sidebar-navigation';
+import { useSelector } from 'calypso/state';
+import { getDocumentHeadTitle } from 'calypso/state/document-head/selectors/get-document-head-title';
+
+export default function MobileSidebarNavigation() {
+	const headerTitle = useSelector( getDocumentHeadTitle );
+
+	return <SidebarNavigation sectionTitle={ headerTitle } />;
+}


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/232

## Proposed Changes

This PR adds a component that renders the sidebar navigation for A4A on mobile devices.

## Testing Instructions

- Switch to the branch `add/a4a-mobile-sidebar-navigation`.
- Start the server by running `yarn start-a8c-for-agencies`.
- Go to the file: /client/a8c-for-agencies/sections/overview/controller.tsx.
- Set the below content as the primary content:

```
import Layout from 'calypso/a8c-for-agencies/components/layout';
import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';

context.primary = (
	<Layout wide title="Overview" sidebarNavigation={ <MobileSidebarNavigation /> }>
		<LayoutTop>Top</LayoutTop>
	</Layout>
);
```

- Switch to mobile view and verify that the UI looks like below:

<img width="371" alt="Screenshot 2024-02-20 at 4 46 49 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/488764a8-6b1d-44d9-a9c2-21724baada67">

<img width="395" alt="Screenshot 2024-02-20 at 4 47 17 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/99f4c566-b327-4c20-a3b2-d4ea49d9d8d8">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?