### PR TITLE
JP Manage: Extract SitesViewState from SitesDataViews to SitesDashboardV2 parent component

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
@@ -29,7 +29,7 @@ import SiteContentHeader from './site-content-header';
 import SiteNotifications from './site-notifications';
 import SiteTopHeaderButtons from './site-top-header-buttons';
 import SitesDataViews from './sites-dataviews';
-import { ViewChangeProps } from './sites-dataviews/interfaces';
+import { SitesViewState } from './sites-dataviews/interfaces';
 
 import './style.scss';
 
@@ -62,27 +62,34 @@ export default function SitesDashboardV2() {
 		// setIsBulkManagementActive,
 	} = useContext( SitesOverviewContext );
 
-	const [ sitesViewData, setSitesViewData ] = useState< ViewChangeProps >( {
-		search: search,
-		sort: {},
-		filters: [],
-		selectedSite: undefined,
+	const [ sitesViewState, setSitesViewState ] = useState< SitesViewState >( {
+		type: 'table',
+		perPage: 50,
 		page: currentPage,
+		sort: {
+			field: 'site',
+			direction: 'desc',
+		},
+		search: search,
+		filters: [],
+		hiddenFields: [ 'status' ],
+		layout: {},
+		selectedSite: undefined,
 	} );
 
 	const { data, isError, isLoading, refetch } = useFetchDashboardSites(
 		isPartnerOAuthTokenLoaded,
-		sitesViewData.search,
-		sitesViewData.page,
+		sitesViewState.search,
+		sitesViewState.page,
 		filter,
 		sort
 	);
 
 	const onSitesViewChange = useCallback(
-		( sitesViewData: ViewChangeProps ) => {
-			setSitesViewData( sitesViewData );
+		( sitesViewData: SitesViewState ) => {
+			setSitesViewState( sitesViewData );
 		},
-		[ setSitesViewData ]
+		[ setSitesViewState ]
 	);
 
 	useEffect( () => {
@@ -253,7 +260,8 @@ export default function SitesDashboardV2() {
 					<SitesDataViews
 						data={ data }
 						isLoading={ isLoading }
-						onViewChange={ onSitesViewChange }
+						onSitesViewChange={ onSitesViewChange }
+						sitesViewState={ sitesViewState }
 					/>
 				</div>
 			</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -1,6 +1,6 @@
 import { DataViews } from '@wordpress/dataviews';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback } from 'react';
 import SiteActions from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions';
 import useFormattedSites from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites';
 import SiteStatusContent from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content';
@@ -10,33 +10,13 @@ import { SitesDataViewsProps } from './interfaces';
 
 import './style.scss';
 
-const SitesDataViews = ( { data, isLoading, onViewChange }: SitesDataViewsProps ) => {
+const SitesDataViews = ( {
+	data,
+	isLoading,
+	onSitesViewChange,
+	sitesViewState,
+}: SitesDataViewsProps ) => {
 	const translate = useTranslate();
-
-	const [ view, setView ] = useState( {
-		type: 'table',
-		perPage: 10,
-		page: 1,
-		sort: {
-			field: 'site',
-			direction: 'desc',
-		},
-		search: '',
-		filters: [ { field: 'status', operator: 'in', value: 'Needs attention' } ],
-		hiddenFields: [ 'status' ],
-		layout: {},
-		selectedSite: undefined,
-	} );
-
-	useEffect( () => {
-		onViewChange( {
-			search: view.search,
-			sort: view.sort,
-			filters: view.filters,
-			selectedSite: view.selectedSite,
-			page: view.page,
-		} );
-	}, [ view.search, view.sort, view.filters, view.selectedSite, view.page, onViewChange ] );
 
 	const sites = useFormattedSites( data?.sites ?? [] );
 
@@ -183,16 +163,16 @@ const SitesDataViews = ( { data, isLoading, onViewChange }: SitesDataViewsProps 
 				data={ sites }
 				paginationInfo={ { totalItems: 0, totalPages: 0 } }
 				fields={ fields }
-				view={ view }
+				view={ sitesViewState }
 				search={ true }
-				searchLabel="Search sites"
+				searchLabel={ translate( 'Search sites' ) }
 				getItemId={ ( item: SiteData ) => {
 					if ( isLoading ) {
 						return '';
 					}
 					return item.site.value.blog_id;
 				} }
-				onChangeView={ setView }
+				onChangeView={ onSitesViewChange }
 				supportedLayouts={ [ 'table' ] }
 				actions={ [] }
 				isLoading={ isLoading }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/interfaces.ts
@@ -1,17 +1,33 @@
 import { Site } from '../types';
 
-export interface ViewChangeProps {
-	search: string;
-	sort: any;
-	filters: any;
-	page: number;
-	selectedSite: Site | undefined;
-}
-
 export interface SitesDataViewsProps {
 	data:
 		| { sites: Array< Site >; total: number; perPage: number; totalFavorites: number }
 		| undefined;
 	isLoading: boolean;
-	onViewChange: ( view: ViewChangeProps ) => void;
+	onSitesViewChange: ( view: SitesViewState ) => void;
+	sitesViewState: SitesViewState;
+}
+
+export interface Sort {
+	field: string;
+	direction: 'asc' | 'desc';
+}
+
+export interface Filter {
+	field: string;
+	operator: string;
+	value: string;
+}
+
+export interface SitesViewState {
+	type: 'table' | 'list' | 'grid';
+	perPage: number;
+	page: number;
+	sort: Sort;
+	search: string;
+	filters: Filter[];
+	hiddenFields: string[];
+	layout: object;
+	selectedSite?: Site | undefined;
 }


### PR DESCRIPTION
## Proposed Changes

This PR moves the state logic from the child component SitesDataViews to its parent `SitesDashboardV2` component, which should manage the state (Lift State Up).

## Testing Instructions

- Check the code
- Everything should work as before: the filters on the Sites menu, the search textbox.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
