### PR TITLE
Patterns: Add skeleton of new `Patterns` page

### DIFF
--- a/client/components/main/README.md
+++ b/client/components/main/README.md
@@ -1,4 +1,4 @@
-# Main (jsx)
+# Main
 
 Component used to declare the main area of any given section —- it's the main wrapper that gets rendered first inside `#primary`.
 

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -177,9 +177,15 @@ const LayoutLoggedOut = ( {
 	) {
 		masterbar = null;
 	} else if (
-		[ 'plugins', 'themes', 'theme', 'reader', 'subscriptions', 'site-profiler' ].includes(
-			sectionName
-		) &&
+		[
+			'patterns',
+			'plugins',
+			'reader',
+			'site-profiler',
+			'subscriptions',
+			'theme',
+			'themes',
+		].includes( sectionName ) &&
 		! isReaderTagPage &&
 		! isReaderSearchPage &&
 		! isReaderDiscoverPage
@@ -255,16 +261,17 @@ const LayoutLoggedOut = ( {
 				</>
 			) }
 
-			{ [ 'themes', 'theme', 'reader' ].includes( sectionName ) && ! isReaderTagEmbed && (
-				<UniversalNavbarFooter
-					onLanguageChange={ ( e ) => {
-						navigate( `/${ e.target.value + pathNameWithoutLocale }` );
-						window.location.reload();
-					} }
-					currentRoute={ currentRoute }
-					isLoggedIn={ isLoggedIn }
-				/>
-			) }
+			{ [ 'patterns', 'reader', 'theme', 'themes' ].includes( sectionName ) &&
+				! isReaderTagEmbed && (
+					<UniversalNavbarFooter
+						onLanguageChange={ ( e ) => {
+							navigate( `/${ e.target.value + pathNameWithoutLocale }` );
+							window.location.reload();
+						} }
+						currentRoute={ currentRoute }
+						isLoggedIn={ isLoggedIn }
+					/>
+				) }
 
 			{ ! isLoggedIn && ! isReaderTagEmbed && (
 				<ReaderJoinConversationDialog

--- a/client/my-sites/patterns/README.md
+++ b/client/my-sites/patterns/README.md
@@ -1,0 +1,3 @@
+# Patterns
+
+Displays a showcase of WordPress.com patterns, which resides on `/patterns`.

--- a/client/my-sites/patterns/controller.tsx
+++ b/client/my-sites/patterns/controller.tsx
@@ -1,0 +1,10 @@
+import Patterns from 'calypso/my-sites/patterns/patterns';
+import type { Context as PageJSContext } from '@automattic/calypso-router';
+
+type Next = ( error?: Error ) => void;
+
+export function renderPatterns( context: PageJSContext, next: Next ) {
+	context.primary = <Patterns />;
+
+	next();
+}

--- a/client/my-sites/patterns/index.node.js
+++ b/client/my-sites/patterns/index.node.js
@@ -1,0 +1,6 @@
+import { makeLayout } from 'calypso/controller';
+import { renderPatterns } from 'calypso/my-sites/patterns/controller';
+
+export default function ( router ) {
+	router( '/patterns', renderPatterns, makeLayout );
+}

--- a/client/my-sites/patterns/index.web.js
+++ b/client/my-sites/patterns/index.web.js
@@ -1,0 +1,6 @@
+import { makeLayout } from 'calypso/controller';
+import { renderPatterns } from 'calypso/my-sites/patterns/controller';
+
+export default function ( router ) {
+	router( '/patterns', renderPatterns, makeLayout );
+}

--- a/client/my-sites/patterns/package.json
+++ b/client/my-sites/patterns/package.json
@@ -1,0 +1,4 @@
+{
+	"main": "index.node.js",
+	"browser": "index.web.js"
+}

--- a/client/my-sites/patterns/patterns.tsx
+++ b/client/my-sites/patterns/patterns.tsx
@@ -1,0 +1,18 @@
+import Main from 'calypso/components/main';
+
+import './style.scss';
+
+export default () => {
+	return (
+		<Main fullWidthLayout isLoggedOut>
+			<div>
+				<h1>Build your perfect site with patterns</h1>
+
+				<p>
+					Hundreds of expertly designed, fully responsive patterns allow you to craft a beautiful
+					site in minutes.
+				</p>
+			</div>
+		</Main>
+	);
+};

--- a/client/my-sites/patterns/style.scss
+++ b/client/my-sites/patterns/style.scss
@@ -1,0 +1,3 @@
+.is-section-patterns .layout__content {
+	background: #e5f4ff;
+}

--- a/client/my-sites/patterns/test/__snapshots__/patterns.tsx.snap
+++ b/client/my-sites/patterns/test/__snapshots__/patterns.tsx.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Patterns renders server-side correctly 1`] = `"<main class=\\"main is-full-width-layout is-logged-out\\" role=\\"main\\"><div><h1>Build your perfect site with patterns</h1><p>Hundreds of expertly designed, fully responsive patterns allow you to craft a beautiful site in minutes.</p></div></main>"`;

--- a/client/my-sites/patterns/test/patterns.tsx
+++ b/client/my-sites/patterns/test/patterns.tsx
@@ -1,0 +1,8 @@
+import { renderToString } from 'react-dom/server';
+import Patterns from '../patterns';
+
+describe( 'Patterns', () => {
+	test( 'renders server-side correctly', () => {
+		expect( renderToString( <Patterns /> ) ).toMatchSnapshot();
+	} );
+} );

--- a/client/sections.js
+++ b/client/sections.js
@@ -247,6 +247,13 @@ const sections = [
 		module: 'calypso/my-sites/google-my-business',
 		group: 'sites',
 	},
+	{
+		name: 'patterns',
+		paths: [ '/patterns' ],
+		module: 'calypso/my-sites/patterns',
+		enableLoggedOut: true,
+		isomorphic: true,
+	},
 	// Since we're using find() and startsWith() on paths, 'themes' needs to go before 'theme',
 	// or it'll be falsely associated with the latter section.
 	{

--- a/docs/isomorphic-routing.md
+++ b/docs/isomorphic-routing.md
@@ -65,7 +65,7 @@ SSR logged-in requests.
 
 It's common for SSR layouts to include network-fetched data. For example, the themes
 SSR page includes themes fetched on the backend. If your SSR section includes
-network requsets, it is **crucial** for those requsets to be cached and optimized
+network requsets, it is **crucial** for those requests to be cached and optimized
 as much as possible. Caching cannot be a follow-up enhancement -- without caching,
 performance across the server can be negatively impacted, resulting in route timeouts
 and even outages.

--- a/packages/help-center/src/hooks/use-zendesk-messaging.ts
+++ b/packages/help-center/src/hooks/use-zendesk-messaging.ts
@@ -50,6 +50,7 @@ export default function useZendeskMessaging(
 	}, [ setMessagingScriptLoaded, enabled, zendeskKey, isMessagingScriptLoaded ] );
 
 	if (
+		document &&
 		document.getElementById( ZENDESK_SCRIPT_ID ) &&
 		enabled &&
 		typeof window.zE === 'function' &&

--- a/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
+++ b/packages/wpcom-template-parts/src/universal-header-navigation/style.scss
@@ -29,10 +29,11 @@ $studio-blue-30: #0675c4;
 	}
 }
 
-.is-section-themes,
-.is-section-theme,
+.is-section-patterns,
 .is-section-reader,
-.is-section-site-profiler {
+.is-section-site-profiler,
+.is-section-theme,
+.is-section-themes {
 	&.has-no-sidebar {
 		.masterbar-menu {
 			.masterbar {


### PR DESCRIPTION
This pull request adds a new `Patterns` page at http://calypso.localhost:3000/patterns. This is the very first step in introducing a patterns library on WordPress.com. This page is rendered client-side (as usual) but also server-side (for SEO and performance purposes). Its layout differs depending on whether the user is logged in or not, even if ultimately its content will be the same:

Logged Out | Logged In
------ | -----
<img width="623" alt="Logged Out" src="https://github.com/Automattic/wp-calypso/assets/594356/df71de28-f5a4-40be-8d2c-8268cdf56d83"> | <img width="622" alt="Logged In" src="https://github.com/Automattic/wp-calypso/assets/594356/d686542f-6460-4610-ac3d-a467de13aed9">

#### Additional notes

I went for two distinct entry points `index.node.js` and `index.web.js` as localization will be handled differently client-side and server-side through [distinct middleware](https://github.com/Automattic/wp-calypso/pull/87511/files#diff-ddc57c32c80226276fa5ec0199e3a02eb4113ddc9779252edd57d720d72ad506). Here are a few examples of pages rendered server-side, with varying degrees of support:

* http://calypso.localhost:3000/tags
* http://calypso.localhost:3000/themes/filter/business
* http://calypso.localhost:3000/themes
* http://calypso.localhost:3000/site-profiler
* http://calypso.localhost:3000/plugins

Note how different they look depending on whether the user is logged in or not. We'll have to decide how far we want to go in regard to that: should we show the masterbar when logged in? Should we show the sidebar? Right now there is a very annoying flicker effect when loading the page since the version rendered first by the server has a different layout than the one rendered by the client.

#### Testing instructions

1. Run `git checkout add/patterns-page` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/87647#issuecomment-1954059649)
2. Open the [`Patterns` page](http://calypso.localhost:3000/patterns) while logged out
3. Assert that it looks like the screenshot above
4. Open that page again while logged in
5. Assert that it looks like the screenshot above