### PR TITLE
Global sidebar - add tooltip-bottom-left style.

### DIFF
--- a/client/layout/global-sidebar/header.jsx
+++ b/client/layout/global-sidebar/header.jsx
@@ -8,7 +8,7 @@ export const GlobalSidebarHeader = () => {
 		<div className="sidebar__header">
 			<a
 				href="/sites"
-				className="link-logo tooltip tooltip-bottom"
+				className="link-logo tooltip tooltip-bottom-left"
 				data-tooltip={ translate( 'View all sites' ) }
 			>
 				<span className="dotcom"></span>

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -40,12 +40,6 @@ $brand-text: "SF Pro Text", $sans;
 		}
 	}
 
-	.tooltip-bottom {
-		&::after {
-			left: 0;
-			right: unset;
-		}
-	}
 	.tooltip-top {
 		&::after {
 			right: unset;

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -40,6 +40,13 @@ $brand-text: "SF Pro Text", $sans;
 		}
 	}
 
+	.tooltip-bottom-left {
+		&::after {
+			left: 0;
+			right: unset;
+		}
+	}
+
 	.tooltip-top {
 		&::after {
 			right: unset;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/dotcom-forge/issues/5690 

## Proposed Changes

* The global style sidebar specific style rules for `.tooltip-bottom` cause the tooltips for search and notifs to render outside of the sidebar area. This updates this style definition in the global sidebar from .tooltip-bottom to .tooltip-bottom-left to signify left alignment, and is used with the WordPress.com menu item. Search and notif tooltips still default to .tooltip-bottom, but no longer get the left alignment overrides.
* This does not remove the `.tooltip-bottom` class as suggested in the original issue, as the component for notifications here is set up well to handle adding these classes based on prop values. The class name is still semantic and accurate for the tooltip here, and I think we should continue to add it - the main problem was the specific styles we set for it in the global sidebar.

BEFORE
![tooltips-old](https://github.com/Automattic/wp-calypso/assets/28742426/bf7e1eab-a5af-466d-b1b1-948b4c6d0e38)


AFTER
![tooltips-good-2](https://github.com/Automattic/wp-calypso/assets/28742426/7687ba9a-6aa8-421d-9d5b-11fc4b4225ee)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Build this calypso branch.
* Go to the /sites page and test the tooltip placements in the sidebar.
* Select an atomic site with classic view and test the tooltip placement in global site view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
