### PR TITLE
Subscribers Stats: Use EmptyListView as the Launchpad for Jetpack sites

### DIFF
--- a/client/my-sites/stats/pages/subscribers/index.tsx
+++ b/client/my-sites/stats/pages/subscribers/index.tsx
@@ -64,7 +64,12 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 		( subscribersTotals?.total === 1 && subscribersTotals?.is_owner_subscribing );
 	const showLaunchpad = ! isLoading && hasNoSubscriberOtherThanAdmin;
 
-	const EmptyComponent = isSimple || isAtomic ? SubscriberLaunchpad : EmptyListView;
+	const emptyComponent =
+		isSimple || isAtomic ? (
+			<SubscriberLaunchpad launchpadContext="subscriber-stats" />
+		) : (
+			<EmptyListView />
+		);
 
 	// Track the last viewed tab.
 	// Necessary to properly configure the fixed navigation headers.
@@ -92,7 +97,7 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 				{ isLoading && <StatsModulePlaceholder className="is-subscriber-page" isLoading /> }
 				{ ! isLoading &&
 					( showLaunchpad ? (
-						<EmptyComponent />
+						emptyComponent
 					) : (
 						<>
 							<SubscribersHighlightSection siteId={ siteId } />

--- a/client/my-sites/stats/pages/subscribers/index.tsx
+++ b/client/my-sites/stats/pages/subscribers/index.tsx
@@ -7,6 +7,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import JetpackColophon from 'calypso/components/jetpack-colophon';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
+import { EmptyListView } from 'calypso/my-sites/subscribers/components/empty-list-view';
 import { SubscriberLaunchpad } from 'calypso/my-sites/subscribers/components/subscriber-launchpad';
 import { useSelector } from 'calypso/state';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
@@ -61,7 +62,9 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 	const hasNoSubscriberOtherThanAdmin =
 		! subscribersTotals?.total ||
 		( subscribersTotals?.total === 1 && subscribersTotals?.is_owner_subscribing );
-	const showLaunchpad = ! isLoading && ( isSimple || isAtomic ) && hasNoSubscriberOtherThanAdmin;
+	const showLaunchpad = ! isLoading && hasNoSubscriberOtherThanAdmin;
+
+	const EmptyComponent = isSimple || isAtomic ? SubscriberLaunchpad : EmptyListView;
 
 	// Track the last viewed tab.
 	// Necessary to properly configure the fixed navigation headers.
@@ -89,7 +92,7 @@ const StatsSubscribersPage = ( { period }: StatsSubscribersPageProps ) => {
 				{ isLoading && <StatsModulePlaceholder className="is-subscriber-page" isLoading /> }
 				{ ! isLoading &&
 					( showLaunchpad ? (
-						<SubscriberLaunchpad launchpadContext="subscriber-stats" />
+						<EmptyComponent />
 					) : (
 						<>
 							<SubscribersHighlightSection siteId={ siteId } />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/86762#issuecomment-1945188882

## Proposed Changes

* Use `EmptyListView` as the Launchpad for Jetpack sites.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live link.
* Navigate to the Subscribers Stats page for a site without any subscribers except for the site owner.
* Ensure the page shows a prompt for growing subscribers rather than the chart with the admin as the only subscriber.

| Before | After |
|-|-|
|<img width="1318" alt="截圖 2024-02-20 下午11 24 24" src="https://github.com/Automattic/wp-calypso/assets/6869813/bc434569-4090-49f3-9e42-01b3f6990ab4">|<img width="1099" alt="截圖 2024-02-20 下午11 23 38" src="https://github.com/Automattic/wp-calypso/assets/6869813/3e6cbbb2-1b8e-4a75-9ce4-ce515c79ebae">|

* Build the change for Odyssey Stats and ensure it works as well.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?