### PR TITLE
Fix /sites top grey bar

### DIFF
--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -24,7 +24,6 @@ const FilterBar = styled.div( {
 	display: 'flex',
 	alignItems: 'center',
 	gap: '16px',
-	paddingBlock: '32px',
 	paddingInline: 0,
 
 	flexDirection: 'column',

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -72,6 +72,7 @@ const PageBodyWrapper = styled.div( {
 	maxWidth: MAX_PAGE_WIDTH,
 	marginBlock: 0,
 	marginInline: 'auto',
+	backgroundColor: '#fdfdfd',
 } );
 
 const HeaderControls = styled.div( {

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -38,7 +38,7 @@ interface SitesDashboardProps {
 	queryParams: SitesDashboardQueryParams;
 }
 
-const MAX_PAGE_WIDTH = '1280px';
+const MAX_PAGE_WIDTH = '1224px';
 
 // Two wrappers are necessary (both pagePadding _and_ wideCentered) because we
 // want there to be some padding that extends all around the page, but the header's
@@ -64,7 +64,7 @@ const PageHeader = styled.div( {
 		padding: '16px',
 	},
 
-	boxShadow: 'inset 0px -1px 0px rgba( 0, 0, 0, 0.05 )',
+	// boxShadow: 'inset 0px -1px 0px rgba( 0, 0, 0, 0.05 )',
 } );
 
 const PageBodyWrapper = styled.div( {
@@ -72,7 +72,6 @@ const PageBodyWrapper = styled.div( {
 	maxWidth: MAX_PAGE_WIDTH,
 	marginBlock: 0,
 	marginInline: 'auto',
-	backgroundColor: '#fdfdfd',
 } );
 
 const HeaderControls = styled.div( {
@@ -92,10 +91,22 @@ const DashboardHeading = styled.h1( {
 	flex: 1,
 } );
 
-const sitesMargin = css( {
-	marginBlockStart: 0,
+const sitesMarginTable = css( {
+	marginBlockStart: '14px',
 	marginInline: 0,
 	marginBlockEnd: '1.5em',
+	[ MEDIA_QUERIES.small ]: {
+		marginBlockStart: '0',
+	},
+} );
+
+const sitesMargin = css( {
+	marginBlockStart: '32px',
+	marginInline: 0,
+	marginBlockEnd: '1.5em',
+	[ MEDIA_QUERIES.small ]: {
+		marginBlockStart: '0',
+	},
 } );
 
 export const PageBodyBottomContainer = styled.div( {
@@ -281,7 +292,7 @@ export function SitesDashboard( {
 													<SitesTable
 														isLoading={ isLoading }
 														sites={ paginatedSites }
-														className={ sitesMargin }
+														className={ sitesMarginTable }
 													/>
 												) }
 												{ displayMode === 'tile' && (

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -63,8 +63,6 @@ const PageHeader = styled.div( {
 	[ MEDIA_QUERIES.mediumOrSmaller ]: {
 		padding: '16px',
 	},
-
-	// boxShadow: 'inset 0px -1px 0px rgba( 0, 0, 0, 0.05 )',
 } );
 
 const PageBodyWrapper = styled.div( {

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -29,8 +29,6 @@ const THead = styled.thead< { blockOffset: number } >( ( { blockOffset } ) => ( 
 	position: 'sticky',
 	zIndex: 3,
 	insetBlockStart: `${ blockOffset }px`,
-
-	background: '#fdfdfd',
 } ) );
 
 const headerShadow: React.CSSProperties = {

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -113,7 +113,7 @@ function hostingFlowForkingPage( context: PageJSContext, next: () => void ) {
 function sitesDashboard( context: PageJSContext, next: () => void ) {
 	let sitesDashboardGlobalStyles = css`
 		body.is-group-sites-dashboard {
-			background: #fdfdfd;
+			background: #ffffff;
 
 			.layout__content {
 				// The page header background extends all the way to the edge of the screen


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5659
Slack: p1708440470812809-slack-C06DN6QQVAQ

## Proposed Changes

Fixes the `/sites` grey top bar before the Sites title (you might need to adjust your brightness/contrast to see it)

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/375eddc1-6221-4749-9218-6cc1d26ff175) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/bdd4c898-7a27-475a-8b39-280eaf22e8db) |

## Testing Instructions

* Go to `/sites`
* Check for a grey top bar before the title.
* Go to `/sites?flags=layout/dotcom-nav-redesign`