### PR TITLE
Theme Showcase: Prompt user to choose site when clicking on the "Design your own" theme button

### DIFF
--- a/client/components/theme-design-your-own-modal/index.tsx
+++ b/client/components/theme-design-your-own-modal/index.tsx
@@ -1,0 +1,46 @@
+import { Button, Modal } from '@wordpress/components';
+import { translate } from 'i18n-calypso';
+import { FC } from 'react';
+
+const ThemeDesignYourOwnModal: FC< {
+	handleOpenSiteSelector: () => void;
+	isOpen: boolean;
+	onClose: () => void;
+} > = ( { handleOpenSiteSelector, isOpen, onClose } ) => {
+	// const handleCreateSite = () => {
+	// 	// Logic for creating a new site
+	// };
+
+	// const handleCloseModal = () => {
+	// 	setShowModal( false );
+	// };
+
+	if ( ! isOpen ) {
+		return null;
+	}
+
+	return (
+		<Modal
+			className="theme-design-your-own-modal"
+			onRequestClose={ onClose }
+			size="medium"
+			title={ translate( 'Design your own theme', {
+				comment: 'TODO',
+				textOnly: true,
+			} ) }
+		>
+			<p>Choose the site you want to design a theme for.</p>
+
+			<div>
+				<Button variant="primary" onClick={ () => {} }>
+					Create a new site
+				</Button>
+				<Button variant="secondary" onClick={ handleOpenSiteSelector }>
+					Select one of my sites
+				</Button>
+			</div>
+		</Modal>
+	);
+};
+
+export default ThemeDesignYourOwnModal;

--- a/client/components/theme-design-your-own-modal/index.tsx
+++ b/client/components/theme-design-your-own-modal/index.tsx
@@ -19,25 +19,27 @@ const ThemeDesignYourOwnModal: FC< {
 			onRequestClose={ onClose }
 			size="medium"
 			title={ translate( 'Design your own theme', {
-				comment: 'TODO',
+				comment:
+					'Title for a modal dialog that allows the user to choose a site to design a theme for.',
 				textOnly: true,
 			} ) }
 		>
 			<p>
 				{ translate( 'Choose the site you want to design a theme for.', {
-					comment: 'TODO',
+					comment:
+						'Text for a modal dialog that allows the user to choose a site to design a theme for.',
 				} ) }
 			</p>
 
 			<div className="theme-design-your-own-modal__footer">
 				<Button variant="primary" onClick={ onCreateNewSite }>
 					{ translate( 'Create a new site', {
-						comment: 'TODO',
+						comment: 'Button label for creating a new site.',
 					} ) }
 				</Button>
 				<Button variant="secondary" onClick={ onSelectSite }>
 					{ translate( 'Select one of my sites', {
-						comment: 'TODO',
+						comment: "Button label for selecting one of the user's existing sites.",
 					} ) }
 				</Button>
 			</div>

--- a/client/components/theme-design-your-own-modal/index.tsx
+++ b/client/components/theme-design-your-own-modal/index.tsx
@@ -4,11 +4,11 @@ import { translate } from 'i18n-calypso';
 import { FC } from 'react';
 
 const ThemeDesignYourOwnModal: FC< {
-	handleCreateNewSite: () => void;
-	handleOpenSiteSelector: () => void;
 	isOpen: boolean;
 	onClose: () => void;
-} > = ( { handleCreateNewSite, handleOpenSiteSelector, isOpen, onClose } ) => {
+	onCreateNewSite: () => void;
+	onSelectSite: () => void;
+} > = ( { isOpen, onClose, onCreateNewSite, onSelectSite } ) => {
 	if ( ! isOpen ) {
 		return null;
 	}
@@ -30,12 +30,12 @@ const ThemeDesignYourOwnModal: FC< {
 			</p>
 
 			<div className="theme-design-your-own-modal__footer">
-				<Button variant="primary" onClick={ handleCreateNewSite }>
+				<Button variant="primary" onClick={ onCreateNewSite }>
 					{ translate( 'Create a new site', {
 						comment: 'TODO',
 					} ) }
 				</Button>
-				<Button variant="secondary" onClick={ handleOpenSiteSelector }>
+				<Button variant="secondary" onClick={ onSelectSite }>
 					{ translate( 'Select one of my sites', {
 						comment: 'TODO',
 					} ) }

--- a/client/components/theme-design-your-own-modal/index.tsx
+++ b/client/components/theme-design-your-own-modal/index.tsx
@@ -1,20 +1,14 @@
+import './style.scss';
 import { Button, Modal } from '@wordpress/components';
 import { translate } from 'i18n-calypso';
 import { FC } from 'react';
 
 const ThemeDesignYourOwnModal: FC< {
+	handleCreateNewSite: () => void;
 	handleOpenSiteSelector: () => void;
 	isOpen: boolean;
 	onClose: () => void;
-} > = ( { handleOpenSiteSelector, isOpen, onClose } ) => {
-	// const handleCreateSite = () => {
-	// 	// Logic for creating a new site
-	// };
-
-	// const handleCloseModal = () => {
-	// 	setShowModal( false );
-	// };
-
+} > = ( { handleCreateNewSite, handleOpenSiteSelector, isOpen, onClose } ) => {
 	if ( ! isOpen ) {
 		return null;
 	}
@@ -29,14 +23,22 @@ const ThemeDesignYourOwnModal: FC< {
 				textOnly: true,
 			} ) }
 		>
-			<p>Choose the site you want to design a theme for.</p>
+			<p>
+				{ translate( 'Choose the site you want to design a theme for.', {
+					comment: 'TODO',
+				} ) }
+			</p>
 
-			<div>
-				<Button variant="primary" onClick={ () => {} }>
-					Create a new site
+			<div className="theme-design-your-own-modal__footer">
+				<Button variant="primary" onClick={ handleCreateNewSite }>
+					{ translate( 'Create a new site', {
+						comment: 'TODO',
+					} ) }
 				</Button>
 				<Button variant="secondary" onClick={ handleOpenSiteSelector }>
-					Select one of my sites
+					{ translate( 'Select one of my sites', {
+						comment: 'TODO',
+					} ) }
 				</Button>
 			</div>
 		</Modal>

--- a/client/components/theme-design-your-own-modal/style.scss
+++ b/client/components/theme-design-your-own-modal/style.scss
@@ -1,0 +1,4 @@
+.theme-design-your-own-modal__footer {
+	display: flex;
+	gap: 12px;
+}

--- a/client/components/theme-site-selector-modal/index.jsx
+++ b/client/components/theme-site-selector-modal/index.jsx
@@ -10,7 +10,7 @@ import getSitesItems from 'calypso/state/selectors/get-sites-items';
 import getVisibleSites from 'calypso/state/selectors/get-visible-sites';
 import { getSiteSlug, getSiteTitle } from 'calypso/state/sites/selectors';
 
-export default function ThemeSiteSelectorModal( { isOpen, onClose } ) {
+export default function ThemeSiteSelectorModal( { isOpen, navigateOnClose = true, onClose } ) {
 	const store = useStore();
 	const translate = useTranslate();
 
@@ -26,8 +26,8 @@ export default function ThemeSiteSelectorModal( { isOpen, onClose } ) {
 		const siteTitle = getSiteTitle( state, siteId );
 
 		const pathWithSite = addSiteFragment( currentRoute, siteSlug );
-		navigate( pathWithSite );
-		onClose( { siteTitle } );
+		navigateOnClose && navigate( pathWithSite );
+		onClose( { siteSlug, siteTitle } );
 	};
 
 	if ( ! isOpen ) {

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -94,6 +94,7 @@ const defaultStaticFilter = Object.values( staticFilters ).find(
 class ThemeShowcase extends Component {
 	state = {
 		isDesignThemeModalVisible: false,
+		isDesignThemeFlow: false,
 		isSiteSelectorModalVisible: false,
 	};
 
@@ -378,14 +379,14 @@ class ThemeShowcase extends Component {
 		} );
 
 		if ( shouldSelectSite( { isLoggedIn, siteCount, siteId } ) ) {
-			this.setState( { isDesignThemeModalVisible: true } );
+			this.setState( { isDesignThemeFlow: true, isDesignThemeModalVisible: true } );
 		} else {
-			this.redirectToSiteAssembler();
+			this.redirectToSiteAssembler( this.props.site );
 		}
 	};
 
-	redirectToSiteAssembler = () => {
-		const { isLoggedIn, site: selectedSite, siteEditorUrl } = this.props;
+	redirectToSiteAssembler = ( selectedSite ) => {
+		const { isLoggedIn, siteEditorUrl } = this.props;
 		const shouldGoToAssemblerStep = isAssemblerSupported();
 
 		const destinationUrl = getSiteAssemblerUrl( {
@@ -624,10 +625,11 @@ class ThemeShowcase extends Component {
 				/>
 				<ThemeSiteSelectorModal
 					isOpen={ this.state.isSiteSelectorModalVisible }
-					onClose={ ( { siteTitle } ) => {
-						this.setState( { isSiteSelectorModalVisible: false } );
-
-						if ( siteTitle ) {
+					navigateOnClose={ ! this.state.isDesignThemeFlow }
+					onClose={ ( { siteSlug, siteTitle } ) => {
+						if ( siteSlug && this.state.isDesignThemeFlow ) {
+							this.redirectToSiteAssembler( { slug: siteSlug } );
+						} else if ( siteTitle ) {
 							showSuccessNotice(
 								translate( 'You have selected the site {{strong}}%(siteTitle)s{{/strong}}.', {
 									args: { siteTitle },
@@ -644,16 +646,20 @@ class ThemeShowcase extends Component {
 								}
 							);
 						}
+
+						this.setState( { isDesignThemeFlow: false, isSiteSelectorModalVisible: false } );
 					} }
 				/>
 				<ThemeDesignYourOwnModal
-					handleCreateNewSite={ this.redirectToSiteAssembler }
+					handleCreateNewSite={ () => {
+						this.redirectToSiteAssembler( this.props.site );
+					} }
 					handleOpenSiteSelector={ () => {
 						this.setState( { isDesignThemeModalVisible: false, isSiteSelectorModalVisible: true } );
 					} }
 					isOpen={ this.state.isDesignThemeModalVisible }
 					onClose={ () => {
-						this.setState( { isDesignThemeModalVisible: false } );
+						this.setState( { isDesignThemeFlow: false, isDesignThemeModalVisible: false } );
 					} }
 				/>
 				{ isLoggedIn && (

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -647,6 +647,7 @@ class ThemeShowcase extends Component {
 					} }
 				/>
 				<ThemeDesignYourOwnModal
+					handleCreateNewSite={ this.redirectToSiteAssembler }
 					handleOpenSiteSelector={ () => {
 						this.setState( { isDesignThemeModalVisible: false, isSiteSelectorModalVisible: true } );
 					} }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -564,6 +564,7 @@ class ThemeShowcase extends Component {
 			isCollectionView,
 			lastNonEditorRoute,
 		} = this.props;
+		const { isDesignThemeModalVisible, isSiteSelectorModalVisible } = this.state;
 		const tier = this.props.tier || 'all';
 		const canonicalUrl = 'https://wordpress.com' + pathName;
 
@@ -621,7 +622,7 @@ class ThemeShowcase extends Component {
 					isSiteECommerceFreeTrial={ isSiteECommerceFreeTrial }
 				/>
 				<ThemeSiteSelectorModal
-					isOpen={ this.state.isSiteSelectorModalVisible }
+					isOpen={ isSiteSelectorModalVisible }
 					navigateOnClose={ false }
 					onClose={ ( args ) => {
 						if ( args?.siteSlug ) {
@@ -632,7 +633,7 @@ class ThemeShowcase extends Component {
 					} }
 				/>
 				<ThemeDesignYourOwnModal
-					isOpen={ this.state.isDesignThemeModalVisible }
+					isOpen={ isDesignThemeModalVisible }
 					onClose={ () => {
 						this.setState( { isDesignThemeModalVisible: false } );
 					} }

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -626,13 +626,13 @@ class ThemeShowcase extends Component {
 				<ThemeSiteSelectorModal
 					isOpen={ this.state.isSiteSelectorModalVisible }
 					navigateOnClose={ ! this.state.isDesignThemeFlow }
-					onClose={ ( { siteSlug, siteTitle } ) => {
-						if ( siteSlug && this.state.isDesignThemeFlow ) {
-							this.redirectToSiteAssembler( { slug: siteSlug } );
-						} else if ( siteTitle ) {
+					onClose={ ( args ) => {
+						if ( args?.siteSlug && this.state.isDesignThemeFlow ) {
+							this.redirectToSiteAssembler( { slug: args.siteSlug } );
+						} else if ( args?.siteTitle ) {
 							showSuccessNotice(
 								translate( 'You have selected the site {{strong}}%(siteTitle)s{{/strong}}.', {
-									args: { siteTitle },
+									args: { siteTitle: args.siteTitle },
 									components: { strong: <strong /> },
 									comment:
 										'On the themes page, notification shown to the user after they choose one of their sites to browse the themes',

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -28,6 +28,7 @@ import ThemeCollectionViewHeader from 'calypso/my-sites/themes/collections/theme
 import ThemeShowcaseSurvey, { SurveyType } from 'calypso/my-sites/themes/survey';
 import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { successNotice } from 'calypso/state/notices/actions';
 import getLastNonEditorRoute from 'calypso/state/selectors/get-last-non-editor-route';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import getSiteFeaturesById from 'calypso/state/selectors/get-site-features';
@@ -555,6 +556,7 @@ class ThemeShowcase extends Component {
 			isSiteWooExpress,
 			isCollectionView,
 			lastNonEditorRoute,
+			successNotice: showSuccessNotice,
 		} = this.props;
 		const tier = this.props.tier || 'all';
 		const canonicalUrl = 'https://wordpress.com' + pathName;
@@ -614,8 +616,26 @@ class ThemeShowcase extends Component {
 				/>
 				<ThemeSiteSelectorModal
 					isOpen={ this.state.isSiteSelectorModalVisible }
-					onClose={ () => {
+					onClose={ ( { siteTitle } ) => {
 						this.setState( { isSiteSelectorModalVisible: false } );
+
+						if ( siteTitle ) {
+							showSuccessNotice(
+								translate( 'You have selected the site {{strong}}%(siteTitle)s{{/strong}}.', {
+									args: { siteTitle },
+									components: { strong: <strong /> },
+									comment:
+										'On the themes page, notification shown to the user after they choose one of their sites to browse the themes',
+								} ),
+								{
+									button: translate( 'Choose a different site', {
+										comment:
+											'On the themes page, notification shown to the user offering them the option to choose a different site for browsing themes',
+									} ),
+									onClick: () => this.setState( { isSiteSelectorModalVisible: true } ),
+								}
+							);
+						}
 					} }
 				/>
 				{ isLoggedIn && (
@@ -741,4 +761,6 @@ const mapStateToProps = ( state, { siteId, filter } ) => {
 	};
 };
 
-export default connect( mapStateToProps, { setBackPath } )( localize( ThemeShowcase ) );
+export default connect( mapStateToProps, { setBackPath, successNotice } )(
+	localize( ThemeShowcase )
+);

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -651,15 +651,15 @@ class ThemeShowcase extends Component {
 					} }
 				/>
 				<ThemeDesignYourOwnModal
-					handleCreateNewSite={ () => {
-						this.redirectToSiteAssembler( this.props.site );
-					} }
-					handleOpenSiteSelector={ () => {
-						this.setState( { isDesignThemeModalVisible: false, isSiteSelectorModalVisible: true } );
-					} }
 					isOpen={ this.state.isDesignThemeModalVisible }
 					onClose={ () => {
 						this.setState( { isDesignThemeFlow: false, isDesignThemeModalVisible: false } );
+					} }
+					onCreateNewSite={ () => {
+						this.redirectToSiteAssembler( this.props.site );
+					} }
+					onSelectSite={ () => {
+						this.setState( { isDesignThemeModalVisible: false, isSiteSelectorModalVisible: true } );
 					} }
 				/>
 				{ isLoggedIn && (

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -29,7 +29,6 @@ import ThemeCollectionViewHeader from 'calypso/my-sites/themes/collections/theme
 import ThemeShowcaseSurvey, { SurveyType } from 'calypso/my-sites/themes/survey';
 import ThanksModal from 'calypso/my-sites/themes/thanks-modal';
 import { getCurrentUserSiteCount, isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { successNotice } from 'calypso/state/notices/actions';
 import getLastNonEditorRoute from 'calypso/state/selectors/get-last-non-editor-route';
 import getSiteEditorUrl from 'calypso/state/selectors/get-site-editor-url';
 import getSiteFeaturesById from 'calypso/state/selectors/get-site-features';
@@ -565,7 +564,6 @@ class ThemeShowcase extends Component {
 			isSiteWooExpress,
 			isCollectionView,
 			lastNonEditorRoute,
-			successNotice: showSuccessNotice,
 		} = this.props;
 		const tier = this.props.tier || 'all';
 		const canonicalUrl = 'https://wordpress.com' + pathName;
@@ -629,22 +627,6 @@ class ThemeShowcase extends Component {
 					onClose={ ( args ) => {
 						if ( args?.siteSlug && this.state.isDesignThemeFlow ) {
 							this.redirectToSiteAssembler( { slug: args.siteSlug } );
-						} else if ( args?.siteTitle ) {
-							showSuccessNotice(
-								translate( 'You have selected the site {{strong}}%(siteTitle)s{{/strong}}.', {
-									args: { siteTitle: args.siteTitle },
-									components: { strong: <strong /> },
-									comment:
-										'On the themes page, notification shown to the user after they choose one of their sites to browse the themes',
-								} ),
-								{
-									button: translate( 'Choose a different site', {
-										comment:
-											'On the themes page, notification shown to the user offering them the option to choose a different site for browsing themes',
-									} ),
-									onClick: () => this.setState( { isSiteSelectorModalVisible: true } ),
-								}
-							);
 						}
 
 						this.setState( { isDesignThemeFlow: false, isSiteSelectorModalVisible: false } );
@@ -785,6 +767,4 @@ const mapStateToProps = ( state, { siteId, filter } ) => {
 	};
 };
 
-export default connect( mapStateToProps, { setBackPath, successNotice } )(
-	localize( ThemeShowcase )
-);
+export default connect( mapStateToProps, { setBackPath } )( localize( ThemeShowcase ) );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -93,7 +93,6 @@ const defaultStaticFilter = Object.values( staticFilters ).find(
 class ThemeShowcase extends Component {
 	state = {
 		isDesignThemeModalVisible: false,
-		isDesignThemeFlow: false,
 		isSiteSelectorModalVisible: false,
 	};
 
@@ -378,7 +377,7 @@ class ThemeShowcase extends Component {
 		} );
 
 		if ( shouldSelectSite( { isLoggedIn, siteCount, siteId } ) ) {
-			this.setState( { isDesignThemeFlow: true, isDesignThemeModalVisible: true } );
+			this.setState( { isDesignThemeModalVisible: true } );
 		} else {
 			this.redirectToSiteAssembler( this.props.site );
 		}
@@ -623,19 +622,19 @@ class ThemeShowcase extends Component {
 				/>
 				<ThemeSiteSelectorModal
 					isOpen={ this.state.isSiteSelectorModalVisible }
-					navigateOnClose={ ! this.state.isDesignThemeFlow }
+					navigateOnClose={ false }
 					onClose={ ( args ) => {
-						if ( args?.siteSlug && this.state.isDesignThemeFlow ) {
+						if ( args?.siteSlug ) {
 							this.redirectToSiteAssembler( { slug: args.siteSlug } );
 						}
 
-						this.setState( { isDesignThemeFlow: false, isSiteSelectorModalVisible: false } );
+						this.setState( { isSiteSelectorModalVisible: false } );
 					} }
 				/>
 				<ThemeDesignYourOwnModal
 					isOpen={ this.state.isDesignThemeModalVisible }
 					onClose={ () => {
-						this.setState( { isDesignThemeFlow: false, isDesignThemeModalVisible: false } );
+						this.setState( { isDesignThemeModalVisible: false } );
 					} }
 					onCreateNewSite={ () => {
 						this.redirectToSiteAssembler( this.props.site );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -379,11 +379,11 @@ class ThemeShowcase extends Component {
 		if ( shouldSelectSite( { isLoggedIn, siteCount, siteId } ) ) {
 			this.setState( { isDesignThemeModalVisible: true } );
 		} else {
-			this.redirectToSiteAssembler( this.props.site );
+			this.redirectToSiteAssembler();
 		}
 	};
 
-	redirectToSiteAssembler = ( selectedSite ) => {
+	redirectToSiteAssembler = ( selectedSite = this.props.site ) => {
 		const { isLoggedIn, siteEditorUrl } = this.props;
 		const shouldGoToAssemblerStep = isAssemblerSupported();
 
@@ -637,7 +637,7 @@ class ThemeShowcase extends Component {
 						this.setState( { isDesignThemeModalVisible: false } );
 					} }
 					onCreateNewSite={ () => {
-						this.redirectToSiteAssembler( this.props.site );
+						this.redirectToSiteAssembler();
 					} }
 					onSelectSite={ () => {
 						this.setState( { isDesignThemeModalVisible: false, isSiteSelectorModalVisible: true } );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -16,6 +16,7 @@ import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import QuerySitePurchases from 'calypso/components/data/query-site-purchases';
 import QueryThemeFilters from 'calypso/components/data/query-theme-filters';
 import { SearchThemes, SearchThemesV2 } from 'calypso/components/search-themes';
+import ThemeDesignYourOwnModal from 'calypso/components/theme-design-your-own-modal';
 import ThemeSiteSelectorModal from 'calypso/components/theme-site-selector-modal';
 import { THEME_TIERS } from 'calypso/components/theme-tier/constants';
 import getSiteAssemblerUrl from 'calypso/components/themes-list/get-site-assembler-url';
@@ -92,6 +93,7 @@ const defaultStaticFilter = Object.values( staticFilters ).find(
 
 class ThemeShowcase extends Component {
 	state = {
+		isDesignThemeModalVisible: false,
 		isSiteSelectorModalVisible: false,
 	};
 
@@ -376,7 +378,7 @@ class ThemeShowcase extends Component {
 		} );
 
 		if ( shouldSelectSite( { isLoggedIn, siteCount, siteId } ) ) {
-			this.setState( { isSiteSelectorModalVisible: true } );
+			this.setState( { isDesignThemeModalVisible: true } );
 		} else {
 			this.redirectToSiteAssembler();
 		}
@@ -642,6 +644,15 @@ class ThemeShowcase extends Component {
 								}
 							);
 						}
+					} }
+				/>
+				<ThemeDesignYourOwnModal
+					handleOpenSiteSelector={ () => {
+						this.setState( { isDesignThemeModalVisible: false, isSiteSelectorModalVisible: true } );
+					} }
+					isOpen={ this.state.isDesignThemeModalVisible }
+					onClose={ () => {
+						this.setState( { isDesignThemeModalVisible: false } );
 					} }
 				/>
 				{ isLoggedIn && (

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -369,16 +369,22 @@ class ThemeShowcase extends Component {
 	};
 
 	onDesignYourOwnClick = () => {
-		const { isLoggedIn, site: selectedSite, siteCount, siteEditorUrl, siteId } = this.props;
-		const shouldGoToAssemblerStep = isAssemblerSupported();
+		const { isLoggedIn, siteCount, siteId } = this.props;
+
 		recordTracksEvent( 'calypso_themeshowcase_pattern_assembler_top_button_click', {
 			is_logged_in: isLoggedIn,
 		} );
 
 		if ( shouldSelectSite( { isLoggedIn, siteCount, siteId } ) ) {
 			this.setState( { isSiteSelectorModalVisible: true } );
-			return;
+		} else {
+			this.redirectToSiteAssembler();
 		}
+	};
+
+	redirectToSiteAssembler = () => {
+		const { isLoggedIn, site: selectedSite, siteEditorUrl } = this.props;
+		const shouldGoToAssemblerStep = isAssemblerSupported();
 
 		const destinationUrl = getSiteAssemblerUrl( {
 			isLoggedIn,

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -501,6 +501,38 @@ class ThemeShowcase extends Component {
 		return upsellBanner;
 	};
 
+	renderSiteAssemblerSelectorModal = () => {
+		const { isDesignThemeModalVisible, isSiteSelectorModalVisible } = this.state;
+
+		return (
+			<>
+				<ThemeSiteSelectorModal
+					isOpen={ isSiteSelectorModalVisible }
+					navigateOnClose={ false }
+					onClose={ ( args ) => {
+						if ( args?.siteSlug ) {
+							this.redirectToSiteAssembler( { slug: args.siteSlug } );
+						}
+
+						this.setState( { isSiteSelectorModalVisible: false } );
+					} }
+				/>
+				<ThemeDesignYourOwnModal
+					isOpen={ isDesignThemeModalVisible }
+					onClose={ () => {
+						this.setState( { isDesignThemeModalVisible: false } );
+					} }
+					onCreateNewSite={ () => {
+						this.redirectToSiteAssembler();
+					} }
+					onSelectSite={ () => {
+						this.setState( { isDesignThemeModalVisible: false, isSiteSelectorModalVisible: true } );
+					} }
+				/>
+			</>
+		);
+	};
+
 	renderThemes = ( themeProps ) => {
 		const tabKey = this.getSelectedTabFilter().key;
 
@@ -564,7 +596,6 @@ class ThemeShowcase extends Component {
 			isCollectionView,
 			lastNonEditorRoute,
 		} = this.props;
-		const { isDesignThemeModalVisible, isSiteSelectorModalVisible } = this.state;
 		const tier = this.props.tier || 'all';
 		const canonicalUrl = 'https://wordpress.com' + pathName;
 
@@ -621,29 +652,7 @@ class ThemeShowcase extends Component {
 					isSiteWooExpressOrEcomFreeTrial={ isSiteWooExpressOrEcomFreeTrial }
 					isSiteECommerceFreeTrial={ isSiteECommerceFreeTrial }
 				/>
-				<ThemeSiteSelectorModal
-					isOpen={ isSiteSelectorModalVisible }
-					navigateOnClose={ false }
-					onClose={ ( args ) => {
-						if ( args?.siteSlug ) {
-							this.redirectToSiteAssembler( { slug: args.siteSlug } );
-						}
-
-						this.setState( { isSiteSelectorModalVisible: false } );
-					} }
-				/>
-				<ThemeDesignYourOwnModal
-					isOpen={ isDesignThemeModalVisible }
-					onClose={ () => {
-						this.setState( { isDesignThemeModalVisible: false } );
-					} }
-					onCreateNewSite={ () => {
-						this.redirectToSiteAssembler();
-					} }
-					onSelectSite={ () => {
-						this.setState( { isDesignThemeModalVisible: false, isSiteSelectorModalVisible: true } );
-					} }
-				/>
+				{ this.renderSiteAssemblerSelectorModal() }
 				{ isLoggedIn && (
 					<ThemeShowcaseSurvey
 						survey={ SurveyType.FEBRUARY_2024 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5386

## Proposed Changes

When the user clicks on the "Design your own" button on the Theme Showcase, if they haven't selected any site, let them choose between creating a new site or proceeding with one of their current ones.

![image](https://github.com/Automattic/wp-calypso/assets/8511199/36ac5ee3-eae2-4436-84fe-28a6ffa01f65)

## Testing Instructions

* Open the PR preview with a user that has multiple sites.
* Enter the Theme Showcase page without site fragment (`/themes`).
* Click on the "Design your own" button (top right corner).
* Check that a modal lets you choose between creating a new site or selecting one of yours
* Click on "Create a new site", check that you go to the "Choose a domain" page, as it happened before this change
* Repeat the previous steps and now click on "Select one of my sites", check that the site selector modal is opened
* Check that you go to the theme assembler page with the selected site after choosing one

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?