### PR TITLE
Global Sidebar - update search tooltip to use ellipsis character

### DIFF
--- a/client/layout/global-sidebar/header.jsx
+++ b/client/layout/global-sidebar/header.jsx
@@ -14,7 +14,7 @@ export const GlobalSidebarHeader = () => {
 				<span className="dotcom"></span>
 			</a>
 			<span className="gap"></span>
-			<SidebarSearch tooltip={ translate( 'Jump to...' ) } />
+			<SidebarSearch tooltip={ translate( 'Jump to…' ) } />
 			<SidebarNotifications
 				isShowing={ false }
 				isActive={ true }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* I noticed this via a linter error when I was trying to commit in a separate PR in this area. This updates the "Jump to..." tooltip to use the ellipsis character (…) instead of 3 periods.

![Screenshot 2024-02-20 at 11 26 06 AM](https://github.com/Automattic/wp-calypso/assets/28742426/ddf57334-c25f-452f-9e6f-a5915b2fcdd2)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Test the tooltip still works as expected.
* No unhappy linters.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
