### PR TITLE
Global Sidebar: Set colors to prevent dashboard color scheme bleeding

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -38,7 +38,12 @@ $brand-text: "SF Pro Text", $sans;
 		--sidebar-width-min: 295px;
 
 		--color-sidebar-background: var(--studio-black);
+		--color-sidebar-text-alternative: var(--studio-white);
+		// Resetting these colors to prevent bleeding from dashboard color schemes
+		--color-sidebar-submenu-background: #2d2d2d;
 		--color-sidebar-menu-selected-background: #3858e9;
+		--color-sidebar-submenu-hover-text: #3858e9;
+		--color-sidebar-menu-hover-background: #1a1e23;
 	}
 }
 
@@ -361,7 +366,7 @@ $font-size: rem(14px);
 
 		.sidebar__heading:not([tabindex="-1"]),
 		.sidebar__menu-link {
-			color: var(--studio-gray-5);
+			color: var(--studio-white);
 
 			.sidebar__menu-icon {
 				color: inherit;

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -40,10 +40,11 @@ $brand-text: "SF Pro Text", $sans;
 		--color-sidebar-background: var(--studio-black);
 		--color-sidebar-text-alternative: var(--studio-white);
 		// Resetting these colors to prevent bleeding from dashboard color schemes
+		--color-sidebar-text: var(--studio-white);
 		--color-sidebar-submenu-background: #2d2d2d;
 		--color-sidebar-menu-selected-background: #3858e9;
 		--color-sidebar-submenu-hover-text: #3858e9;
-		--color-sidebar-menu-hover-background: #1a1e23;
+		--color-sidebar-menu-hover-background: var(--studio-gray-90);
 	}
 }
 


### PR DESCRIPTION
When you select a dashboard color scheme, its possible that the global sidebar picks up these colors for font colors, and hover and select states.

This PR updates the styling to try to prevent this bleeding of colors.

### Before
<img width="339" alt="Screenshot 2024-02-20 at 16 37 29" src="https://github.com/Automattic/wp-calypso/assets/5560595/a291d22d-7ace-4ecd-87d7-c3d06e64735e">

### After
<img width="311" alt="Screenshot 2024-02-20 at 16 39 26" src="https://github.com/Automattic/wp-calypso/assets/5560595/b553eaf2-d844-4a8d-b535-ebf5f9898be3">

### Testing
* Apply patch 
* Go through various menus on my sites, domains, reader, profile and site home pages to confirm no color bleeding