### PR TITLE
JP Manage: 257 and 297 - site favorites fixes

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/index.tsx
@@ -203,7 +203,7 @@ export default function SitesOverview() {
 
 	const selectedTab = navItems.find( ( i ) => i.selected ) || navItems[ 0 ];
 	const hasAppliedFilter = !! search || filter?.issueTypes?.length > 0;
-	const showEmptyState = ! isLoading && ! isError && ! data?.total;
+	const showEmptyState = ! isLoading && ! isError && data?.sites?.length === 0;
 
 	let emptyState;
 	if ( showEmptyState ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Resolves Automattic/jetpack-manage#257 and Automattic/jetpack-manage#297

## Proposed Changes
There were a couple of bugs.

In the API endpoint, `get_agency_sites()` treats an empty filter of site IDs (e.g. favorites) the same as no filter. In D138814-code:

* We don't run the ES query at all if there are no favorites stored against the partner config.
* In all other cases, we always run the ES query and use the returned count to determine the proper count. This prevents a ghost count where it'd previously return 1 favorite as the count, but have no sites listed (since ES is the source of truth and sites may disappear from there). More on the complexities of that issue can be found at https://github.com/Automattic/jetpack-manage/issues/257#issuecomment-1953179234.
* The default return array was defined earlier.
* The `parse_es_query_results()` function was simplified.

And in this PR, we account for the empty state of favorites.

## Testing Instructions
Check out this PR and D138814-code:
* Verify that if there is one or more favorite site, the sites show up in the favorites section of the sites dashboard (with the correct counts).
* Verify that if there are no favorite sites, it shows the correct messaging (and counts).
* Set your favorites to the following bad site and verify the favorite count still shows as 0: `array(228864565)`

The easiest way to set the favorite would be to modify line 331 of `wp-content/rest-api-plugins/centralized/jetpack-agency/agency-dashboard-endpoints.php`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?