### PR TITLE
Upgrade plan Happy block: Add affiliate link setting

### DIFF
--- a/apps/happy-blocks/block-library/pricing-plans/components/block-settings.tsx
+++ b/apps/happy-blocks/block-library/pricing-plans/components/block-settings.tsx
@@ -23,6 +23,7 @@ interface Props {
 const NORMALIZE_DOMAIN_REGEX = /(?:^http(?:s)?:)?(?:[/]*)(?:www\.)?([^/?]*)(?:.*)$/gi;
 const VALIDATE_DOMAIN_REGEX =
 	/^(([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)\.)+([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?)$/;
+const VALIDATE_AFFILIATE_REGEX = /^https:\/\/automattic\.pxf\.io\/.+/;
 
 const BlockSettings: FunctionComponent<
 	Pick< BlockEditProps< BlockAttributes >, 'attributes' | 'setAttributes' > & Props
@@ -79,14 +80,12 @@ const BlockSettings: FunctionComponent<
 	const onAffiliateChange = ( value: string ) => {
 		setNewAffiliateLinkInputValue( value );
 
-		if ( ! value ) {
+		if ( ! value || ! VALIDATE_AFFILIATE_REGEX.test( value ) ) {
 			setAttributes( { affiliateLink: false } );
 			return;
 		}
 
-		if ( VALIDATE_DOMAIN_REGEX.test( value ) ) {
-			setAttributes( { affiliateLink: value } );
-		}
+		setAttributes( { affiliateLink: value } );
 	};
 
 	return (

--- a/apps/happy-blocks/block-library/pricing-plans/components/block-settings.tsx
+++ b/apps/happy-blocks/block-library/pricing-plans/components/block-settings.tsx
@@ -27,10 +27,11 @@ const VALIDATE_DOMAIN_REGEX =
 const BlockSettings: FunctionComponent<
 	Pick< BlockEditProps< BlockAttributes >, 'attributes' | 'setAttributes' > & Props
 > = ( { attributes, setAttributes, plans } ) => {
-	const { productSlug, planTypeOptions, domain } = attributes;
+	const { productSlug, planTypeOptions, domain, affiliateLink } = attributes;
 	const planOptions = usePlanOptions( plans );
 	const currentPlan = plans?.find( ( plan ) => plan.productSlug === productSlug );
 	const [ newDomainInputValue, setNewDomainInputValue ] = useState( domain );
+	const [ newAffiliateLinkInputValue, setNewAffiliateLinkInputValue ] = useState( affiliateLink );
 
 	const setPlan = ( type: string, term: string ) => {
 		const plan = plans?.find( ( plan ) => plan.type === type && plan.term === term );
@@ -75,6 +76,20 @@ const BlockSettings: FunctionComponent<
 		}
 	};
 
+	const onAffiliateChange = ( value: string ) => {
+		setNewAffiliateLinkInputValue( value );
+
+		if ( ! value ) {
+			setAttributes( { affiliateLink: false } );
+			return;
+		}
+
+		const normalizedDomain = value.replace( NORMALIZE_DOMAIN_REGEX, '$1' );
+		if ( VALIDATE_DOMAIN_REGEX.test( normalizedDomain ) ) {
+			setAttributes( { affiliateLink: normalizedDomain } );
+		}
+	};
+
 	return (
 		<InspectorControls>
 			<PanelBody
@@ -104,6 +119,13 @@ const BlockSettings: FunctionComponent<
 							'happy-blocks'
 						) }
 						onChange={ onDomainChange }
+					/>
+					<TextControl
+						className="hb-pricing-plans-embed__settings-domain"
+						label={ __( 'Affiliate Link', 'happy-blocks' ) }
+						value={ newAffiliateLinkInputValue || '' }
+						help={ __( 'Enter the affiliate link for the Upgrade CTA', 'happy-blocks' ) }
+						onChange={ onAffiliateChange }
 					/>
 					<RadioControl
 						label={ __( 'Price', 'happy-blocks' ) }

--- a/apps/happy-blocks/block-library/pricing-plans/components/block-settings.tsx
+++ b/apps/happy-blocks/block-library/pricing-plans/components/block-settings.tsx
@@ -84,9 +84,8 @@ const BlockSettings: FunctionComponent<
 			return;
 		}
 
-		const normalizedDomain = value.replace( NORMALIZE_DOMAIN_REGEX, '$1' );
-		if ( VALIDATE_DOMAIN_REGEX.test( normalizedDomain ) ) {
-			setAttributes( { affiliateLink: normalizedDomain } );
+		if ( VALIDATE_DOMAIN_REGEX.test( value ) ) {
+			setAttributes( { affiliateLink: value } );
 		}
 	};
 

--- a/apps/happy-blocks/block-library/pricing-plans/components/pricing-plan-detail.tsx
+++ b/apps/happy-blocks/block-library/pricing-plans/components/pricing-plan-detail.tsx
@@ -44,7 +44,7 @@ const PricingPlanDetail: FunctionComponent< BlockSaveProps< BlockAttributes > & 
 	}
 
 	if ( attributes.affiliateLink ) {
-		CtaLink = attributes.affiliateLink;
+		CtaLink = `${ PLANS_URL }/?aff=${ attributes.affiliateLink }`;
 	}
 
 	return (

--- a/apps/happy-blocks/block-library/pricing-plans/components/pricing-plan-detail.tsx
+++ b/apps/happy-blocks/block-library/pricing-plans/components/pricing-plan-detail.tsx
@@ -34,6 +34,8 @@ const PricingPlanDetail: FunctionComponent< BlockSaveProps< BlockAttributes > & 
 		recordTracksEvent( 'calypso_happyblocks_upgrade_plan_click', {
 			plan: currentPlan.productSlug,
 			domain: attributes.domain,
+			isAffiliateLink: attributes.affiliateLink !== false,
+			affiliateLink: attributes.affiliateLink,
 		} );
 	};
 
@@ -44,7 +46,7 @@ const PricingPlanDetail: FunctionComponent< BlockSaveProps< BlockAttributes > & 
 	}
 
 	if ( attributes.affiliateLink ) {
-		CtaLink = `${ PLANS_URL }/?aff=${ attributes.affiliateLink }`;
+		CtaLink = attributes.affiliateLink;
 	}
 
 	return (

--- a/apps/happy-blocks/block-library/pricing-plans/components/pricing-plan-detail.tsx
+++ b/apps/happy-blocks/block-library/pricing-plans/components/pricing-plan-detail.tsx
@@ -37,9 +37,15 @@ const PricingPlanDetail: FunctionComponent< BlockSaveProps< BlockAttributes > & 
 		} );
 	};
 
-	const CtaLink = attributes.domain
-		? `${ CHECKOUT_URL }/${ attributes.domain }/${ currentPlan.pathSlug }`
-		: PLANS_URL;
+	let CtaLink = PLANS_URL;
+
+	if ( attributes.domain ) {
+		CtaLink = `${ CHECKOUT_URL }/${ attributes.domain }/${ currentPlan.pathSlug }`;
+	}
+
+	if ( attributes.affiliateLink ) {
+		CtaLink = attributes.affiliateLink;
+	}
 
 	return (
 		<section className="hb-pricing-plans-embed__detail">

--- a/apps/happy-blocks/block-library/pricing-plans/components/pricing-plan-detail.tsx
+++ b/apps/happy-blocks/block-library/pricing-plans/components/pricing-plan-detail.tsx
@@ -34,7 +34,6 @@ const PricingPlanDetail: FunctionComponent< BlockSaveProps< BlockAttributes > & 
 		recordTracksEvent( 'calypso_happyblocks_upgrade_plan_click', {
 			plan: currentPlan.productSlug,
 			domain: attributes.domain,
-			isAffiliateLink: attributes.affiliateLink !== false,
 			affiliateLink: attributes.affiliateLink,
 		} );
 	};

--- a/apps/happy-blocks/block-library/pricing-plans/components/pricing-plans-header.tsx
+++ b/apps/happy-blocks/block-library/pricing-plans/components/pricing-plans-header.tsx
@@ -10,9 +10,15 @@ interface Props {
 }
 
 const PricingPlansHeader: FunctionComponent< Props > = ( { currentPlan, attributes } ) => {
-	const learnMoreLink = attributes.domain
-		? `https://wordpress.com/plans/${ attributes.domain }`
-		: `https://wordpress.com/pricing/`;
+	let learnMoreLink = 'https://wordpress.com/pricing/';
+
+	if ( attributes.domain ) {
+		learnMoreLink = `https://wordpress.com/plans/${ attributes.domain }`;
+	}
+
+	if ( attributes.affiliateLink ) {
+		learnMoreLink = attributes.affiliateLink;
+	}
 
 	return (
 		<section className="hb-pricing-plans-embed__header">

--- a/apps/happy-blocks/block-library/pricing-plans/edit.tsx
+++ b/apps/happy-blocks/block-library/pricing-plans/edit.tsx
@@ -21,8 +21,15 @@ export const Edit: FunctionComponent< BlockEditProps< BlockAttributes > > = ( {
 		setAttributes( {
 			productSlug: attributes.productSlug ?? attributes.defaultProductSlug,
 			domain: attributes.domain,
+			affiliateLink: attributes.affiliateLink,
 		} );
-	}, [ attributes.defaultProductSlug, attributes.domain, attributes.productSlug, setAttributes ] );
+	}, [
+		attributes.defaultProductSlug,
+		attributes.domain,
+		attributes.productSlug,
+		attributes.affiliateLink,
+		setAttributes,
+	] );
 
 	useEffect( () => {
 		if ( ! plans.length ) {

--- a/apps/happy-blocks/block-library/pricing-plans/index.jsx
+++ b/apps/happy-blocks/block-library/pricing-plans/index.jsx
@@ -20,6 +20,9 @@ const blockAttributes = {
 	domain: {
 		type: 'string',
 	},
+	affiliateLink: {
+		type: 'string',
+	},
 	planTypeOptions: {
 		type: 'array',
 		default: [],

--- a/apps/happy-blocks/block-library/pricing-plans/types.d.ts
+++ b/apps/happy-blocks/block-library/pricing-plans/types.d.ts
@@ -2,6 +2,7 @@ export interface BlockAttributes {
 	defaultProductSlug: string;
 	productSlug: string;
 	domain: string | false;
+	affiliateLink: string | false;
 	planTypeOptions: string[];
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* Refer to the request made in pfjeM4-kJ-p2, this PR adds the capability for the Upgrade Happy Block to use an affiliate link.
* Add a new "Affiliate link" setting
<img width="274" alt="Screenshot 2024-02-20 at 9 26 29 PM" src="https://github.com/Automattic/wp-calypso/assets/1269602/64ba0126-56a5-4216-93e0-9a880322d7ba">

* On the frontend, the block CTA URL will be the affiliate link if it exists. 

<img width="584" alt="Screenshot 2024-02-21 at 9 29 03 AM" src="https://github.com/Automattic/wp-calypso/assets/1269602/5dbd5b78-169e-48b0-a06d-abdca92bbe82">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run yarn dev --sync in apps/happy-blocks to sync code to your sandbox (might need to follow the[ instructions](https://github.com/Automattic/wp-calypso/blob/trunk/apps/happy-blocks/README.md#development-environment) and/or the Calypso Apps field guide to get it to work). Note that you have to add `wpcom-sandbox` to ssh config to point to your sandbox - I added the entry in 3394d-pb to `~/.ssh/config`.

* Sandbox wordpress.com and en.forums.wordpress.com
* Handle any certificate errors that appear for the assets
* Go to en.forums.wordpress.com and click on "Add new topic". In the new topic editor, add the "Upgrade Starter" block.
* In the block settings, add an affiliate link of the form https://automattic.pxf.io/XXX and verify that the CTA URL changes to this affiliate link. URL of any other format, or an empty field, will default the CTA URL to `/plans` if the domain field is empty, or `/checkout` if the domain field is not empty.
* If the affiliate link field has a valid URL, then both "Learn more" and "Upgrade to PLAN_NAME" CTA links should be the affiliate link.
* If both domain and affiliate link fields have values, then the affiliate link field should take the higher precedence.
* In the Settings, select the option to include other plans, and verify that the CTAs on all plan tabs point to the affiliate link.
<img width="503" alt="Screenshot 2024-02-21 at 9 24 49 AM" src="https://github.com/Automattic/wp-calypso/assets/1269602/baefcc62-2969-4923-a07d-47572a49f673">




