### PR TITLE
Global Sidebar - add a11y focus styles.

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -263,6 +263,15 @@ $brand-text: "SF Pro Text", $sans;
 	}
 }
 
+.accessible-focus .global-sidebar {
+	*:focus {
+		outline-style: solid;
+		outline-color: var(--color-sidebar-menu-selected-background);
+		outline-width: 2px;
+		outline-offset: 2px;
+	}
+}
+
 .masterbar {
 	border: none;
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/dotcom-forge/issues/5687

## Proposed Changes

* adds a11y focus styles to global sidebar items.
* Note - shapes of the outline, some places it is cutoff, etc. are issues with the shapes and layout properties of the individual elements. These need to be handled separately and individually, I am branching off this PR to start resolving those but am leaving them out of this for the time being as they can be separate concerns and we can merge this progress regardless of those items.

![a11y-focus](https://github.com/Automattic/wp-calypso/assets/28742426/eafc2259-2f05-40b4-bec8-42d260847829)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch of calypso
* visit the /sites page and try navigating via a11y commands. Notice the focus outline appears.
* 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
