### PR TITLE
Site Migration: Add optional title and subtitle

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -19,6 +19,7 @@ interface Props {
 	isBusy: boolean;
 	ctaText: string;
 	subTitleText?: string;
+	showTitleAndSubTitle?: boolean;
 	navigateToVerifyEmailStep: () => void;
 	onCtaClick: () => void;
 	onContentOnlyClick?: () => void;
@@ -35,6 +36,7 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 		onContentOnlyClick,
 		ctaText,
 		subTitleText,
+		showTitleAndSubTitle = true,
 		onCtaClick,
 		isBusy,
 		trackingEventsProps,
@@ -68,28 +70,33 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 
 	return (
 		<div className="import__upgrade-plan">
-			<div className="import__heading import__heading-center">
-				<Title>{ translate( 'Upgrade your plan' ) }</Title>
-				<SubTitle>
-					{ subTitleText ||
-						translate( 'Migrating themes, plugins, users, and settings requires a %(plan)s plan.', {
-							args: {
-								plan: plan?.getTitle() ?? '',
-							},
-						} ) }
-					<br />
-					{ ! isEligibleForTrialPlan &&
-						onContentOnlyClick &&
-						translate(
-							'To just migrate the content, use the {{link}}free content-only import option{{/link}}.',
-							{
-								components: {
-									link: <Button borderless={ true } onClick={ onContentOnlyClick } />,
-								},
-							}
-						) }
-				</SubTitle>
-			</div>
+			{ showTitleAndSubTitle && (
+				<div className="import__heading import__heading-center">
+					<Title>{ translate( 'Upgrade your plan' ) }</Title>
+					<SubTitle>
+						{ subTitleText ||
+							translate(
+								'Migrating themes, plugins, users, and settings requires a %(plan)s plan.',
+								{
+									args: {
+										plan: plan?.getTitle() ?? '',
+									},
+								}
+							) }
+						<br />
+						{ ! isEligibleForTrialPlan &&
+							onContentOnlyClick &&
+							translate(
+								'To just migrate the content, use the {{link}}free content-only import option{{/link}}.',
+								{
+									components: {
+										link: <Button borderless={ true } onClick={ onContentOnlyClick } />,
+									},
+								}
+							) }
+					</SubTitle>
+				</div>
+			) }
 
 			<UpgradePlanDetails>
 				<NextButton isBusy={ isBusy } disabled={ isAddingTrial } onClick={ onCtaClick }>

--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -19,7 +19,7 @@ interface Props {
 	isBusy: boolean;
 	ctaText: string;
 	subTitleText?: string;
-	showTitleAndSubTitle?: boolean;
+	hideTitleAndSubTitle?: boolean;
 	navigateToVerifyEmailStep: () => void;
 	onCtaClick: () => void;
 	onContentOnlyClick?: () => void;
@@ -36,7 +36,7 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 		onContentOnlyClick,
 		ctaText,
 		subTitleText,
-		showTitleAndSubTitle = true,
+		hideTitleAndSubTitle = false,
 		onCtaClick,
 		isBusy,
 		trackingEventsProps,
@@ -70,7 +70,7 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 
 	return (
 		<div className="import__upgrade-plan">
-			{ showTitleAndSubTitle && (
+			{ ! hideTitleAndSubTitle && (
 				<div className="import__heading import__heading-center">
 					<Title>{ translate( 'Upgrade your plan' ) }</Title>
 					<SubTitle>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/87605

## Proposed Changes

Provides a prop to optionally hide title/subtitle from the upgrade-plan component. This way, when it's included in stepper we can add those using the FormattedHeader component and reuse styling.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this PR or use the calypso.live link below
* Go to `/start`
* Select a free plan
* Select the `Import my existing website content` goal
* Add a valid URL for a WordPress site in the prompt (I've used jurassic ninja)
* Verify you see the upgrade plan screen as always
<img width="583" alt="image" src="https://github.com/Automattic/wp-calypso/assets/375980/240c7ead-cc4e-47eb-abed-2f4adef16590">
* Optionally, turn the default value to `false` and verify that the component hides the title

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?