### PR TITLE
Vertically align site card text with site icon 

### DIFF
--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -122,6 +122,7 @@
 	width: 0; // Firefox needs explicit width (even 0)
 	flex: 1 0 auto;
 	text-align: initial;
+	margin-top: -3px;
 }
 
 .site__title {

--- a/client/blocks/site/style.scss
+++ b/client/blocks/site/style.scss
@@ -122,7 +122,7 @@
 	width: 0; // Firefox needs explicit width (even 0)
 	flex: 1 0 auto;
 	text-align: initial;
-	margin-top: -3px;
+	margin-top: -2px;
 }
 
 .site__title {
@@ -139,7 +139,7 @@
 	max-width: 95%;
 	font-size: $font-body-extra-small;
 	line-height: 1.4;
-	margin-top: 2px;
+	margin-top: -1px;
 }
 
 .site__title-with-chevron-icon {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5699

## Proposed Changes

* Move the site-info text up 3px for better vertical alignment with the site-icon.

With flag ?flags=layout/dotcom-nav-redesign
Before | After
--|--
<img width="342" alt="Screenshot 2024-02-20 at 1 36 45 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/0be24878-3674-417f-a4fb-402809ed5ad5"> |  <img width="317" alt="Screenshot 2024-02-20 at 4 29 43 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/cc950e2b-a859-45bd-b4fe-dadd792c22c6">


Without flag ?flags=-layout/dotcom-nav-redesign
Before | After
--|--
<img width="303" alt="Screenshot 2024-02-20 at 2 08 01 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/fc60f271-5e19-4b5e-a169-0c1313f26998"> | <img width="287" alt="Screenshot 2024-02-20 at 4 30 01 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/7ba15136-3bc0-4cac-99fd-dc07aac474d3">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/home/[site_slug]?flags=layout/dotcom-nav-redesign
* View the site-info text compared to production http://wordpress.com/home/[site_slug]?flags=layout/dotcom-nav-redesign
* Check the site info with the flag disabled ?flags=-layout/dotcom-nav-redesign
* Check the site info on mobile with the flag disabled ?flags=-layout/dotcom-nav-redesign
* Check in Firefox, Chrome, and Safari

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?