### PR TITLE
Site Migration: Update the import goal

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -69,7 +69,7 @@ export const useGoals = (): Goal[] => {
 		},
 		{
 			key: SiteGoal.Import,
-			title: translate( 'Import my existing website content' ),
+			title: translate( 'Import or migrate my existing website' ),
 		},
 		{
 			key: SiteGoal.Other,

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -320,6 +320,12 @@ const siteSetupFlow: Flow = {
 
 					switch ( intent ) {
 						case SiteIntent.Import:
+							if ( config.isEnabled( 'onboarding/new-migration-flow' ) ) {
+								return exitFlow(
+									`/setup/site-migration?siteSlug=${ siteSlug }&flags=onboarding/new-migration-flow`
+								);
+							}
+
 							return navigate( 'import' );
 						case SiteIntent.DIFM:
 							return navigate( 'difmStartingPoint' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #87655

## Proposed Changes

This tweaks the copy of the "Import" goal to include migrations. Users who select this goal will be redirected to the `site-migration` flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Either applying this branch locally or using the calypso.live url, go to `/start`.
* On the Domains step, select "Choose my domain later".
* On the Plans step, pick the free plan.
* On the Goals step, add `?flags=onboarding/new-migration-flow` to the end of the url and refresh the page. The url should look like `http://calypso.localhost:3000/setup/site-setup/goals?siteSlug=:siteSlug&siteId=:siteId&flags=onboarding/new-migration-flow`.
* Select the "Import or migrate my existing website" goal and click "Continue".
* You should be redirected to the `/setup/site-migration` flow. At this point, it doesn't matter which step you end up on as long as you've changed flows.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
