### PR TITLE
Add contact fields to the Razorpay payment method

### DIFF
--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -18,7 +18,6 @@ import {
 	createAlipayMethod,
 	createAlipayPaymentMethodStore,
 	createRazorpayMethod,
-	createRazorpayPaymentMethodStore,
 	isValueTruthy,
 } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
@@ -39,6 +38,7 @@ import {
 import { createPayPalMethod, createPayPalStore } from '../../payment-methods/paypal';
 import { createPixPaymentMethod } from '../../payment-methods/pix';
 import { createWeChatMethod, createWeChatPaymentMethodStore } from '../../payment-methods/wechat';
+import { useCachedContactDetails } from '../use-cached-contact-details';
 import useCreateExistingCards from './use-create-existing-cards';
 import type { RazorpayConfiguration, RazorpayLoadingError } from '@automattic/calypso-razorpay';
 import type { StripeConfiguration, StripeLoadingError } from '@automattic/calypso-stripe';
@@ -383,7 +383,9 @@ function useCreateRazorpay( {
 		debug( 'Razorpay disabled by configuration' );
 	}
 
-	const paymentMethodStore = useMemo( () => createRazorpayPaymentMethodStore(), [] );
+	const { responseCart } = useShoppingCart( cartKey );
+	const isLoggedOut = responseCart.cart_key === 'no-user';
+	const contactDetails = useCachedContactDetails( { isLoggedOut } );
 
 	const isRazorpayReady =
 		! isRazorpayLoading &&
@@ -396,11 +398,11 @@ function useCreateRazorpay( {
 			? createRazorpayMethod( {
 					razorpayConfiguration,
 					cartKey,
-					store: paymentMethodStore,
 					submitButtonContent: <CheckoutSubmitButtonContent />,
+					contactDetails: contactDetails,
 			  } )
 			: null;
-	}, [ razorpayConfiguration, isRazorpayReady, cartKey, paymentMethodStore ] );
+	}, [ razorpayConfiguration, isRazorpayReady, cartKey, contactDetails ] );
 }
 
 export default function useCreatePaymentMethods( {

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -18,6 +18,7 @@ import {
 	createAlipayMethod,
 	createAlipayPaymentMethodStore,
 	createRazorpayMethod,
+	createRazorpayPaymentMethodStore,
 	isValueTruthy,
 } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
@@ -382,6 +383,8 @@ function useCreateRazorpay( {
 		debug( 'Razorpay disabled by configuration' );
 	}
 
+	const paymentMethodStore = useMemo( () => createRazorpayPaymentMethodStore(), [] );
+
 	const isRazorpayReady =
 		! isRazorpayLoading &&
 		! razorpayLoadingError &&
@@ -393,10 +396,11 @@ function useCreateRazorpay( {
 			? createRazorpayMethod( {
 					razorpayConfiguration,
 					cartKey,
+					store: paymentMethodStore,
 					submitButtonContent: <CheckoutSubmitButtonContent />,
 			  } )
 			: null;
-	}, [ razorpayConfiguration, isRazorpayReady, cartKey ] );
+	}, [ razorpayConfiguration, isRazorpayReady, cartKey, paymentMethodStore ] );
 }
 
 export default function useCreatePaymentMethods( {

--- a/client/my-sites/checkout/src/lib/razorpay-processor.ts
+++ b/client/my-sites/checkout/src/lib/razorpay-processor.ts
@@ -35,7 +35,9 @@ const debug = debugFactory( 'calypso:razorpay-processor' );
 type RazorpayTransactionRequest = {
 	razorpay: Razorpay;
 	razorpayConfiguration: RazorpayConfiguration;
-	name: string | undefined;
+	name?: string;
+	phoneNumber?: string;
+	email?: string;
 };
 
 export default async function razorpayProcessor(

--- a/client/my-sites/checkout/src/lib/razorpay-processor.ts
+++ b/client/my-sites/checkout/src/lib/razorpay-processor.ts
@@ -184,8 +184,8 @@ function combineRazorpayOptions(
 
 	debug( 'Constructing Razorpay prefill object using contact details', contactDetails );
 	const prefill = options.prefill ?? {};
-	prefill.contact = prefill.contact ?? contactDetails?.phoneNumber?.replace( '.', '' ) ?? '';
-	prefill.email = prefill.email ?? contactDetails?.email ?? '';
+	prefill.contact = contactDetails?.phoneNumber?.replace( '.', '' ) ?? prefill.contact ?? '';
+	prefill.email = contactDetails?.email ?? prefill.email ?? '';
 	options.prefill = prefill;
 
 	return options;

--- a/client/my-sites/checkout/src/lib/razorpay-processor.ts
+++ b/client/my-sites/checkout/src/lib/razorpay-processor.ts
@@ -48,7 +48,7 @@ export default async function razorpayProcessor(
 	if ( submitData == null || typeof submitData !== 'object' ) {
 		throw new Error( 'submitData must be an object' );
 	}
-	const validationResult = validateRazorpaySubmitData( submitData );
+	const validationResult = validateRazorpaySubmitData( submitData, translate );
 	debug( { validationResult: validationResult } );
 	if ( 'error' in validationResult ) {
 		debug( 'Submit data failed validation:' + validationResult.error );
@@ -161,19 +161,22 @@ type RazorpaySubmitData = {
 	email: string;
 };
 
-function validateRazorpaySubmitData( submitData: object ): RazorpaySubmitData | { error: string } {
+function validateRazorpaySubmitData(
+	submitData: object,
+	translate: LocalizeProps[ 'translate' ]
+): RazorpaySubmitData | { error: string } {
 	if ( ! ( 'phoneNumber' in submitData ) ) {
-		return { error: 'Please enter a phone number.' };
+		return { error: translate( 'Please enter a phone number.' ) };
 	}
 	if ( ! ( 'email' in submitData ) ) {
-		return { error: 'Please enter an email address.' };
+		return { error: translate( 'Please enter an email address.' ) };
 	}
 	const { phoneNumber, email } = submitData;
 	if ( typeof phoneNumber !== 'string' || ! phoneNumber.length ) {
-		return { error: 'Please enter a phone number.' };
+		return { error: translate( 'Please enter a phone number.' ) };
 	}
 	if ( typeof email !== 'string' || ! email.length || ! email.includes( '@' ) ) {
-		return { error: 'Please enter a valid email address.' };
+		return { error: translate( 'Please enter a valid email address.' ) };
 	}
 	return { phoneNumber, email };
 }

--- a/packages/wpcom-checkout/src/payment-methods/razorpay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/razorpay.tsx
@@ -61,25 +61,25 @@ function useSubscribeToEventEmitter( state: RazorpayPaymentMethodState ) {
 function usePrefillState( {
 	state,
 	contactDetails,
+	razorpayConfiguration,
 }: {
 	state: RazorpayPaymentMethodState;
 	contactDetails: PossiblyCompleteDomainContactDetails | null;
+	razorpayConfiguration: RazorpayConfiguration;
 } ): void {
 	// Don't try to pre-fill if the form has been edited. (Also prevents
 	// infinite loops.)
 	if ( state.isTouched ) {
 		return;
 	}
-
-	if ( ! contactDetails ) {
-		return;
-	}
-	if ( contactDetails.phone ) {
-		state.change( 'phoneNumber', contactDetails.phone );
-	}
-	if ( contactDetails.email ) {
-		state.change( 'email', contactDetails.email );
-	}
+	state.change(
+		'phoneNumber',
+		razorpayConfiguration.options.prefill?.contact ?? contactDetails?.phone ?? ''
+	);
+	state.change(
+		'email',
+		razorpayConfiguration.options.prefill?.email ?? contactDetails?.email ?? ''
+	);
 }
 
 export function createRazorpayMethod( {
@@ -107,7 +107,13 @@ export function createRazorpayMethod( {
 				state={ state }
 			/>
 		),
-		activeContent: <RazorpayFields state={ state } contactDetails={ contactDetails } />,
+		activeContent: (
+			<RazorpayFields
+				state={ state }
+				contactDetails={ contactDetails }
+				razorpayConfiguration={ razorpayConfiguration }
+			/>
+		),
 		inactiveContent: <RazorpaySummary />,
 		getAriaLabel: ( __ ) => __( 'Razorpay' ),
 	};
@@ -163,13 +169,15 @@ const RazorpayField = styled( Field )`
 function RazorpayFields( {
 	state,
 	contactDetails,
+	razorpayConfiguration,
 }: {
 	state: RazorpayPaymentMethodState;
 	contactDetails: PossiblyCompleteDomainContactDetails | null;
+	razorpayConfiguration: RazorpayConfiguration;
 } ) {
 	const { __ } = useI18n();
 	useSubscribeToEventEmitter( state );
-	usePrefillState( { state, contactDetails } );
+	usePrefillState( { state, contactDetails, razorpayConfiguration } );
 
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;

--- a/packages/wpcom-checkout/src/payment-methods/razorpay.tsx
+++ b/packages/wpcom-checkout/src/payment-methods/razorpay.tsx
@@ -182,6 +182,10 @@ function RazorpayFields( {
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 
+	const isPhoneNumberError = state.isTouched && state.data.phoneNumber.length === 0;
+	const isEmailError =
+		state.isTouched && ( state.data.email.length === 0 || ! state.data.email.includes( '@' ) );
+
 	return (
 		<RazorpayFormWrapper>
 			<RazorpayField
@@ -193,8 +197,8 @@ function RazorpayFields( {
 				onChange={ ( value: string ) => {
 					state.change( 'phoneNumber', value );
 				} }
-				isError={ state.isTouched && state.data.phoneNumber.length === 0 }
-				errorMessage={ __( 'This field is required' ) }
+				isError={ isPhoneNumberError }
+				errorMessage={ __( 'Please enter a valid phone number.' ) }
 				disabled={ isDisabled }
 			/>
 			<RazorpayField
@@ -206,29 +210,12 @@ function RazorpayFields( {
 				onChange={ ( value: string ) => {
 					state.change( 'email', value );
 				} }
-				isError={ state.isTouched && state.data.email.length === 0 }
-				errorMessage={ __( 'This field is required' ) }
+				isError={ isEmailError }
+				errorMessage={ __( 'Please enter a valid email address.' ) }
 				disabled={ isDisabled }
 			/>
 		</RazorpayFormWrapper>
 	);
-}
-
-function isFormValid( state: RazorpayPaymentMethodState ): boolean {
-	const customerPhone = state.data.phoneNumber;
-	const customerEmail = state.data.email;
-
-	if ( ! customerPhone.length ) {
-		// Touch the field so it displays a validation error
-		state.change( 'phoneNumber', '' );
-	}
-	if ( ! customerEmail.length ) {
-		state.change( 'email', '' );
-	}
-	if ( ! customerPhone.length || ! customerEmail.length ) {
-		return false;
-	}
-	return true;
 }
 
 export function RazorpaySubmitButton( {
@@ -261,16 +248,14 @@ export function RazorpaySubmitButton( {
 		<Button
 			disabled={ disabled }
 			onClick={ ( ev ) => {
-				if ( isFormValid( state ) ) {
-					ev.preventDefault();
-					debug( 'Initiate razorpay payment' );
-					onClick( {
-						razorpayConfiguration,
-						cartKey,
-						phoneNumber: state.data.phoneNumber,
-						email: state.data.email,
-					} );
-				}
+				ev.preventDefault();
+				debug( 'Initiate razorpay payment' );
+				onClick( {
+					razorpayConfiguration,
+					cartKey,
+					phoneNumber: state.data.phoneNumber,
+					email: state.data.email,
+				} );
 			} }
 			buttonType="primary"
 			isBusy={ FormStatus.SUBMITTING === formStatus }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Off-session payments with Razorpay require that the user have a phone number and email address. This patch adds fields to the Razorpay payment method to collect these in checkout and pass them to the transactions endpoint. Also supports prefilling the data, preferring details returned in the Razorpay configuration endpoint and then in the domain contact details if present.

When creating a token for recharging off-session, it is required to have a phone number and email address for the customer.

## Proposed Changes

- Add phone and email contact fields to the Razorpay processor, and pass them to the transactions endpoint and the Razorpay modal via the options object.
- Prefill the fields using data from the Razorpay configuration if it is present; if not, then prefill from the domain contact details if present. The idea here is to prefer prefilling with existing Razorpay contact data if we have it. What gets passed to the modal is the live form data, so the user can control it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Enter checkout as a user without stored domain details. Verify that you see contact fields in the Razorpay payment method like so (they should be empty in this scenario):
<img width="593" alt="Screenshot 2024-03-18 at 5 17 28 PM" src="https://github.com/Automattic/wp-calypso/assets/9310939/e7b0d280-fa58-452e-b30d-60c91f9b5550">

- Leave the fields blank and click to submit. Verify that you see a calypso error notification and that the empty contact fields are highlighted.
- Fill out the fields and click to submit again. Verify that the details you entered are included in the payment property of the payload submitted to the transactions endpoint. Verify that the Razorpay modal is prefilled with the form data.
- Enter checkout again as a user with stored contact details for a domain. Verify that the Razorpay fields are prefilled with your domain contact data. Click to submit. Verify that the details you entered are included with the transaction endpoint payload and that the Razorpay modal is prefilled with the form data. Cancel the payment.
- Edit the prefilled details. Click to submit again, and verify that the Razorpay modal opens with the edited data.
- (a12s): Manually edit the razorpay configuration to return `contact` and `email` data in the `prefill` property. Load checkout and verify that the contact fields are prefilled with this data. Click to submit and verify that the Razorpay modal is prefilled with this data. Cancel the payment.
- (a12s): Edit the prefilled data. Click to submit and verify that the Razorpay modal opens with the edited data.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
