### PR TITLE
Github Deploy: Match design for deployment style on when creating a repository

### DIFF
--- a/client/my-sites/github-deployments/components/repositories/create-repository/create-repository-form.tsx
+++ b/client/my-sites/github-deployments/components/repositories/create-repository/create-repository-form.tsx
@@ -179,7 +179,9 @@ export const CreateRepositoryForm = ( {
 					{ __( 'Create repository' ) }
 				</Button>
 			</form>
-			<DeploymentStyle />
+			<div className="github-deployments-create-repository__deployment-style">
+				<DeploymentStyle />
+			</div>
 		</div>
 	);
 };

--- a/client/my-sites/github-deployments/components/repositories/create-repository/style.scss
+++ b/client/my-sites/github-deployments/components/repositories/create-repository/style.scss
@@ -2,8 +2,8 @@
 
 .github-deployments-create-repository {
 	display: flex;
-	gap: 24px;
-	color: var(--color-primary);
+	gap: 34px;
+	color: var(--studio-gray-90);
 
 	.form-label {
 		font-weight: 500;
@@ -81,13 +81,13 @@
 		margin-top: 1px;
 	}
 
-	.deployment-style {
+	&__deployment-style {
 		flex: 1;
 		border: 1px solid var(--studio-gray-5);
 		box-sizing: border-box;
 		padding: 24px;
 		border-radius: 2px;
-		max-height: 136px;
 		background-color: var(--studio-gray-0);
+		height: fit-content;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Style create repository sections to match designs

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*
![image](https://github.com/Automattic/wp-calypso/assets/47489215/c593b7c3-40ab-44d0-9311-e79495858ba5)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?