### PR TITLE
GitHub Deployments: Display feature depending on availability query

### DIFF
--- a/client/my-sites/github-deployments/controller.tsx
+++ b/client/my-sites/github-deployments/controller.tsx
@@ -1,13 +1,15 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { PageViewTracker } from 'calypso/lib/analytics/page-view-tracker';
 import { CreateRepository } from 'calypso/my-sites/github-deployments/components/repositories/create-repository/index';
-import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { GitHubDeploymentCreation } from './deployment-creation';
 import { GitHubDeploymentManagement } from './deployment-management';
 import { GitHubDeployments } from './deployments';
 import { indexPage } from './routes';
+import {
+	GitHubDeploymentsAvailableResponse,
+	gitHubDeploymentsAvailableQueryOptions,
+} from './use-is-feature-available';
 import type { Callback } from '@automattic/calypso-router';
 
 export const deploymentsList: Callback = ( context, next ) => {
@@ -78,7 +80,7 @@ export const redirectHomeIfIneligible: Callback = ( context, next ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSelectedSiteSlug( state );
 
-	if ( ! isEnabled( 'github-deployments' ) || ! isAtomicSite( state, siteId ) ) {
+	if ( ! siteId ) {
 		context.page.replace( `/home/${ siteSlug }` );
 		return;
 	}
@@ -88,5 +90,16 @@ export const redirectHomeIfIneligible: Callback = ( context, next ) => {
 		return;
 	}
 
-	next();
+	context.queryClient
+		.fetchQuery( gitHubDeploymentsAvailableQueryOptions( { siteId } ) )
+		.then( ( result: GitHubDeploymentsAvailableResponse ) => {
+			if ( result.available ) {
+				next();
+			} else {
+				context.page.replace( `/home/${ siteSlug }` );
+			}
+		} )
+		.catch( () => {
+			context.page.replace( `/home/${ siteSlug }` );
+		} );
 };

--- a/client/my-sites/github-deployments/use-is-feature-available.ts
+++ b/client/my-sites/github-deployments/use-is-feature-available.ts
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query';
+import wp from 'calypso/lib/wp';
+import { GITHUB_DEPLOYMENTS_QUERY_KEY } from './constants';
+
+interface GitHubDeploymentsAvailableRequestParams {
+	siteId: number;
+}
+
+export interface GitHubDeploymentsAvailableResponse {
+	available: boolean;
+}
+
+const fetchFeatureAvailability = ( {
+	siteId,
+}: GitHubDeploymentsAvailableRequestParams ): GitHubDeploymentsAvailableResponse =>
+	wp.req.get( {
+		path: `/sites/${ siteId }/hosting/github/available`,
+		apiNamespace: 'wpcom/v2',
+	} );
+
+export const gitHubDeploymentsAvailableQueryOptions = ( {
+	siteId,
+}: GitHubDeploymentsAvailableRequestParams ) => ( {
+	queryKey: [ GITHUB_DEPLOYMENTS_QUERY_KEY, 'github-deployments-available', siteId ],
+	queryFn: () => fetchFeatureAvailability( { siteId } ),
+	retry: false,
+	retryOnMount: false,
+	refetchOnMount: false,
+	meta: {
+		persist: ( data: GitHubDeploymentsAvailableResponse | undefined ) => data?.available,
+	},
+} );
+
+export const useIsGitHubDeploymentsAvailableQuery = ( {
+	siteId,
+}: GitHubDeploymentsAvailableRequestParams ) => {
+	return useQuery( gitHubDeploymentsAvailableQueryOptions( { siteId } ) );
+};

--- a/config/development.json
+++ b/config/development.json
@@ -68,7 +68,6 @@
 		"external-media/google-photos": true,
 		"external-media/openverse": true,
 		"cookie-banner": false,
-		"github-deployments": true,
 		"google-drive": true,
 		"google-my-business": true,
 		"help": true,


### PR DESCRIPTION
## Proposed Changes

This PR uses the `/available` query to determine whether or not to display the GitHub Deployments submenu. It will allow us to easily test the feature without needing to deploy feature flag code.

## Testing Instructions

- As an A11n, visit `/github-deployments/%s` from a Jetpack site and verify you're redirected to `/home/%s`;
- As an A11n, visit `/github-deployments/%s` from a simple site and verify you're redirected to `/home/%s`;
- As an A11n, visit `/github-deployments/%s` from an Atomic site and verify you're allowed to enter the page.

Retry the same tests with a regular account, and for the last case, add the sticker to your site and verify you can enter the page.