### PR TITLE
JP Manage: Add the Sites Dashboard layout to support the Site Preview Pane

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/controller.tsx
@@ -49,6 +49,12 @@ export const agencyDashboardContext: Callback = ( context, next ) => {
 		enable( 'jetpack/manage-sites-v2-menu' );
 	}
 
+	// TODO: This insert dynamically into the body the class sites-dashboard-v2 to be able to modify some styles outside
+	//  of the SitesDashboardV2 context. This way it won't affect the current styles in any context (dev, staging, production).
+	if ( showSitesDashboardV2 && ! document.body.classList.contains( 'sites-dashboard-v2' ) ) {
+		document.body.classList.add( 'sites-dashboard-v2' );
+	}
+
 	const currentPage = parseInt( contextPage ) || 1;
 
 	context.header = <Header />;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.scss
@@ -1,0 +1,26 @@
+.sites-dashboard-v2 {
+	.sidebar-v2,
+	.sidebar-v2__navigator .components-surface.components-card {
+		background: var(--studio-gray-0) !important;
+	}
+
+	.sites-overview__large-screen {
+		.site-search-filter-container__search .search.is-open .search__open-icon {
+			width: 60px;
+		}
+	}
+
+	.layout__content {
+		padding: 0 16px 16px calc(var(--sidebar-width-max) + 16px);
+	}
+
+	@media (min-width: 661px) {
+		.theme-jetpack-cloud .layout.has-no-masterbar {
+			padding-top: 16px !important;
+		}
+	}
+
+	.sites-dataviews__favorite-btn-wrapper .site-set-favorite__favorite-icon {
+		visibility: visible;
+	}
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
@@ -36,6 +36,7 @@ import SitesDataViews from './sites-dataviews';
 import { SitesViewState } from './sites-dataviews/interfaces';
 
 import './style.scss';
+import './sites-dashboard-v2.scss';
 
 const QUERY_PARAM_PROVISIONING = 'provisioning';
 
@@ -237,120 +238,91 @@ export default function SitesDashboardV2() {
 
 	// TODO: the style element is injected temporary here only to not interfere with the styles in production.
 	return (
-		<>
-			<style>
-				{ `
-					.sidebar-v2,
-					.sidebar-v2__navigator .components-surface.components-card {
-						background: var(--studio-gray-0) !important;
-					}
-					.sites-overview__large-screen {
-						.site-search-filter-container__search .search.is-open .search__open-icon {
-							width: 60px;
-						}
-					}
+		<div
+			className={ classNames(
+				'sites-dashboard__layout',
+				! sitesViewState.selectedSite && 'preview-hidden'
+			) }
+		>
+			<div className="sites-overview">
+				<DocumentHead title={ pageTitle } />
+				<SidebarNavigation sectionTitle={ pageTitle } />
+				<SiteNotifications />
+				<div className="sites-overview__container">
+					<div className="sites-overview__tabs">
+						<div className="sites-overview__content-wrapper">
+							<DashboardBanners />
 
-					.layout__content {
-						padding: 0 16px 16px calc(var(--sidebar-width-max) + 16px);
-					}
-					
-					@media (min-width: 661px) {
-						.theme-jetpack-cloud .layout.has-no-masterbar {
-							padding-top: 16px !important;
-						}
-					}
-					
-					.sites-dataviews__favorite-btn-wrapper .site-set-favorite__favorite-icon {
-						visibility: visible;
-					}
-				` }
-			</style>
-			<div
-				className={ classNames(
-					'sites-dashboard__layout',
-					! sitesViewState.selectedSite && 'preview-hidden'
-				) }
-			>
-				<div className="sites-overview">
-					<DocumentHead title={ pageTitle } />
-					<SidebarNavigation sectionTitle={ pageTitle } />
-					<SiteNotifications />
-					<div className="sites-overview__container">
-						<div className="sites-overview__tabs">
-							<div className="sites-overview__content-wrapper">
-								<DashboardBanners />
-
-								{ isProvisioningSite && ! hasDismissedProvisioningNotice && (
-									<Notice status="is-info" onDismissClick={ onDismissProvisioningNotice }>
-										{ translate(
-											"We're setting up your new WordPress.com site and will notify you once it's ready, which should only take a few minutes."
-										) }
-									</Notice>
-								) }
-								{ data?.sites && <SiteAddLicenseNotification /> }
-								<SiteContentHeader
-									content={
-										// render content only on large screens, The buttons for small screen have their own section
-										isLargeScreen &&
-										( selectedLicensesCount > 0 ? (
-											renderIssueLicenseButton()
-										) : (
-											<SiteTopHeaderButtons />
-										) )
-									}
-									pageTitle={ pageTitle }
-									// Only renderIssueLicenseButton should be sticky.
-									showStickyContent={ !! ( selectedLicensesCount > 0 && isLargeScreen ) }
-								/>
-								{
-									// Render the add site and issue license buttons on mobile as a different component.
-									! isLargeScreen && <SiteTopHeaderButtons />
+							{ isProvisioningSite && ! hasDismissedProvisioningNotice && (
+								<Notice status="is-info" onDismissClick={ onDismissProvisioningNotice }>
+									{ translate(
+										"We're setting up your new WordPress.com site and will notify you once it's ready, which should only take a few minutes."
+									) }
+								</Notice>
+							) }
+							{ data?.sites && <SiteAddLicenseNotification /> }
+							<SiteContentHeader
+								content={
+									// render content only on large screens, The buttons for small screen have their own section
+									isLargeScreen &&
+									( selectedLicensesCount > 0 ? (
+										renderIssueLicenseButton()
+									) : (
+										<SiteTopHeaderButtons />
+									) )
 								}
-							</div>
+								pageTitle={ pageTitle }
+								// Only renderIssueLicenseButton should be sticky.
+								showStickyContent={ !! ( selectedLicensesCount > 0 && isLargeScreen ) }
+							/>
+							{
+								// Render the add site and issue license buttons on mobile as a different component.
+								! isLargeScreen && <SiteTopHeaderButtons />
+							}
 						</div>
-						<div className="sites-overview__content">
-							<DashboardDataContext.Provider
-								value={ {
-									verifiedContacts: {
-										emails: verifiedContacts?.emails ?? [],
-										phoneNumbers: verifiedContacts?.phoneNumbers ?? [],
-										refetchIfFailed: () => {
-											if ( fetchContactFailed ) {
-												refetchContacts();
-											}
-											return;
-										},
+					</div>
+					<div className="sites-overview__content">
+						<DashboardDataContext.Provider
+							value={ {
+								verifiedContacts: {
+									emails: verifiedContacts?.emails ?? [],
+									phoneNumbers: verifiedContacts?.phoneNumbers ?? [],
+									refetchIfFailed: () => {
+										if ( fetchContactFailed ) {
+											refetchContacts();
+										}
+										return;
 									},
-									products: products ?? [],
-									isLargeScreen: isLargeScreen || false,
-								} }
-							>
-								<SitesDataViews
-									data={ data }
-									isLoading={ isLoading }
-									onSitesViewChange={ onSitesViewChange }
-									sitesViewState={ sitesViewState }
-								/>
-							</DashboardDataContext.Provider>
-						</div>
+								},
+								products: products ?? [],
+								isLargeScreen: isLargeScreen || false,
+							} }
+						>
+							<SitesDataViews
+								data={ data }
+								isLoading={ isLoading }
+								onSitesViewChange={ onSitesViewChange }
+								sitesViewState={ sitesViewState }
+							/>
+						</DashboardDataContext.Provider>
 					</div>
-					{ ! isLargeScreen && selectedLicensesCount > 0 && (
-						<div className="sites-overview__issue-licenses-button-small-screen">
-							{ renderIssueLicenseButton() }
-						</div>
-					) }
 				</div>
-				<div className="site-preview__pane">
-					<div className="site-preview__header">
-						<h2>{ sitesViewState.selectedSite?.blogname }</h2>
-						<div>{ sitesViewState.selectedSite?.url }</div>
-						<hr />
-						<Button onClick={ closeSitePreviewPane } borderless>
-							<b>Close the Preview Pane</b>
-						</Button>
+				{ ! isLargeScreen && selectedLicensesCount > 0 && (
+					<div className="sites-overview__issue-licenses-button-small-screen">
+						{ renderIssueLicenseButton() }
 					</div>
+				) }
+			</div>
+			<div className="site-preview__pane">
+				<div className="site-preview__header">
+					<h2>{ sitesViewState.selectedSite?.blogname }</h2>
+					<div>{ sitesViewState.selectedSite?.url }</div>
+					<hr />
+					<Button onClick={ closeSitePreviewPane } borderless>
+						<b>Close the Preview Pane</b>
+					</Button>
 				</div>
 			</div>
-		</>
+		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -1,13 +1,14 @@
+import { Button, Gridicon } from '@automattic/components';
 import { DataViews } from '@wordpress/dataviews';
-import { Icon, starFilled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback } from 'react';
+import { useCallback, useMemo } from 'react';
 import SiteActions from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions';
 import useFormattedSites from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-content/hooks/use-formatted-sites';
 import SiteStatusContent from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-status-content';
+import SiteDataField from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/site-data-field';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
 import SiteSetFavorite from '../site-set-favorite';
-import { AllowedTypes, SiteData } from '../types';
+import { AllowedTypes, Site, SiteData } from '../types';
 import { SitesDataViewsProps } from './interfaces';
 
 import './style.scss';
@@ -21,6 +22,17 @@ const SitesDataViews = ( {
 	const translate = useTranslate();
 
 	const sites = useFormattedSites( data?.sites ?? [] );
+
+	const openSitePreviewPane = useCallback(
+		( site: Site ) => {
+			onSitesViewChange( {
+				...sitesViewState,
+				selectedSite: site,
+				type: 'list',
+			} );
+		},
+		[ onSitesViewChange, sitesViewState ]
+	);
 
 	const renderField = useCallback(
 		( column: AllowedTypes, item: SiteData ) => {
@@ -43,137 +55,146 @@ const SitesDataViews = ( {
 		[ isLoading ]
 	);
 
-	const fields = [
-		{
-			id: 'status',
-			header: '',
-			getValue: ( { item }: { item: SiteData } ) =>
-				item.site.error || item.scan.status === 'critical',
-			render: () => {},
-			type: 'enumeration',
-			elements: [
-				{ value: 1, label: 'Needs attention' },
-				{ value: 2, label: 'Favorite' },
-			],
-			enableHiding: true,
-			enableSorting: true,
-		},
-		{
-			id: 'site',
-			header: (
-				<span className="sites-dataview__site-header">{ translate( 'Site' ).toUpperCase() }</span>
-			),
-			getValue: ( { item }: { item: SiteData } ) => item.site.value.url,
-			render: ( { item }: { item: SiteData } ) => {
-				if ( isLoading ) {
-					return <TextPlaceholder />;
-				}
-				const site = item.site.value;
-				return (
-					<div className="sites-dataviews__site">
-						<div className="sites-dataviews__site-favicon"></div>
-						<div className="sites-dataviews__site-name">
-							<div>{ site.blogname }</div>
-							<div className="sites-dataviews__site-url">{ site.url }</div>
-						</div>
-					</div>
-				);
+	const fields = useMemo(
+		() => [
+			{
+				id: 'status',
+				header: '',
+				getValue: ( { item }: { item: SiteData } ) =>
+					item.site.error || item.scan.status === 'critical',
+				render: () => {},
+				type: 'enumeration',
+				elements: [
+					{ value: 1, label: 'Needs attention' },
+					{ value: 2, label: 'Favorite' },
+				],
+				enableHiding: true,
+				enableSorting: true,
 			},
-			enableHiding: false,
-			enableSorting: true,
-		},
-		{
-			id: 'stats',
-			header: <span className="sites-dataview__stats-header">STATS</span>,
-			getValue: () => 'Stats status',
-			render: ( { item }: { item: SiteData } ) => renderField( 'stats', item ),
-			enableHiding: false,
-			enableSorting: false,
-		},
-		{
-			id: 'boost',
-			header: <span className="sites-dataview__boost-header">BOOST</span>,
-			getValue: ( { item }: { item: SiteData } ) => item.boost.status,
-			render: ( { item }: { item: SiteData } ) => renderField( 'boost', item ),
-			enableHiding: false,
-			enableSorting: false,
-		},
-		{
-			id: 'backup',
-			header: <span className="sites-dataview__backup-header">BACKUP</span>,
-			getValue: () => 'Backup status',
-			render: ( { item }: { item: SiteData } ) => renderField( 'backup', item ),
-			enableHiding: false,
-			enableSorting: false,
-		},
-		{
-			id: 'monitor',
-			header: <span className="sites-dataview__monitor-header">MONITOR</span>,
-			getValue: () => 'Monitor status',
-			render: ( { item }: { item: SiteData } ) => renderField( 'monitor', item ),
-			enableHiding: false,
-			enableSorting: false,
-		},
-		{
-			id: 'scan',
-			header: <span className="sites-dataview__scan-header">SCAN</span>,
-			getValue: () => 'Scan status',
-			render: ( { item }: { item: SiteData } ) => renderField( 'scan', item ),
-			enableHiding: false,
-			enableSorting: false,
-		},
-		{
-			id: 'plugins',
-			header: <span className="sites-dataview__plugins-header">PLUGINS</span>,
-			getValue: () => 'Plugins status',
-			render: ( { item }: { item: SiteData } ) => renderField( 'plugin', item ),
-			enableHiding: false,
-			enableSorting: false,
-		},
-		{
-			id: 'favorite',
-			header: (
-				<Icon
-					className="site-table__favorite-icon sites-dataview__favorites-header"
-					size={ 24 }
-					icon={ starFilled }
-				/>
-			),
-			getValue: ( { item }: { item: SiteData } ) => item.isFavorite,
-			render: ( { item }: { item: SiteData } ) => {
-				if ( isLoading ) {
-					return <TextPlaceholder />;
-				}
-				return (
-					<span className="sites-dataviews__favorite-btn-wrapper">
-						<SiteSetFavorite
-							isFavorite={ item.isFavorite || false }
-							siteId={ item.site.value.blog_id }
-							siteUrl={ item.site.value.url }
+			{
+				id: 'site',
+				header: (
+					<span className="sites-dataview__site-header">{ translate( 'Site' ).toUpperCase() }</span>
+				),
+				getValue: ( { item }: { item: SiteData } ) => item.site.value.url,
+				render: ( { item }: { item: SiteData } ) => {
+					if ( isLoading ) {
+						return <TextPlaceholder />;
+					}
+					const site = item.site.value;
+					return (
+						<SiteDataField
+							site={ site }
+							isLoading={ isLoading }
+							onSiteTitleClick={ openSitePreviewPane }
 						/>
-					</span>
-				);
+					);
+				},
+				enableHiding: false,
+				enableSorting: true,
 			},
-			enableHiding: false,
-			enableSorting: false,
-		},
-		{
-			id: 'actions',
-			header: <span className="sites-dataview__actions-header">{ translate( 'ACTIONS' ) }</span>,
-			getValue: ( { item }: { item: SiteData } ) => item.isFavorite,
-			render: ( { item }: { item: SiteData } ) => {
-				if ( isLoading ) {
-					return <TextPlaceholder />;
-				}
-				return <SiteActions isLargeScreen site={ item.site } siteError={ item.site.error } />;
+			{
+				id: 'stats',
+				header: <span className="sites-dataview__stats-header">STATS</span>,
+				getValue: () => 'Stats status',
+				render: ( { item }: { item: SiteData } ) => renderField( 'stats', item ),
+				enableHiding: false,
+				enableSorting: false,
 			},
-			enableHiding: false,
-			enableSorting: false,
-		},
-	];
-
-	// TODO: remove this hardcoded style. If we set background in the CSS it will be loaded with and without the feature flag:
-	document.body.style.backgroundColor = 'white';
+			{
+				id: 'boost',
+				header: <span className="sites-dataview__boost-header">BOOST</span>,
+				getValue: ( { item }: { item: SiteData } ) => item.boost.status,
+				render: ( { item }: { item: SiteData } ) => renderField( 'boost', item ),
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'backup',
+				header: <span className="sites-dataview__backup-header">BACKUP</span>,
+				getValue: () => 'Backup status',
+				render: ( { item }: { item: SiteData } ) => renderField( 'backup', item ),
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'monitor',
+				header: <span className="sites-dataview__monitor-header">MONITOR</span>,
+				getValue: () => 'Monitor status',
+				render: ( { item }: { item: SiteData } ) => renderField( 'monitor', item ),
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'scan',
+				header: <span className="sites-dataview__scan-header">SCAN</span>,
+				getValue: () => 'Scan status',
+				render: ( { item }: { item: SiteData } ) => renderField( 'scan', item ),
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'plugins',
+				header: <span className="sites-dataview__plugins-header">PLUGINS</span>,
+				getValue: () => 'Plugins status',
+				render: ( { item }: { item: SiteData } ) => renderField( 'plugin', item ),
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'favorite',
+				header: (
+					<Icon
+						className="site-table__favorite-icon sites-dataview__favorites-header"
+						size={ 24 }
+						icon={ starFilled }
+					/>
+				),
+				getValue: ( { item }: { item: SiteData } ) => item.isFavorite,
+				render: ( { item }: { item: SiteData } ) => {
+					if ( isLoading ) {
+						return <TextPlaceholder />;
+					}
+					return (
+						<span className="sites-dataviews__favorite-btn-wrapper">
+							<SiteSetFavorite
+								isFavorite={ item.isFavorite || false }
+								siteId={ item.site.value.blog_id }
+								siteUrl={ item.site.value.url }
+							/>
+						</span>
+					);
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+			{
+				id: 'actions',
+				header: <span className="sites-dataview__actions-header">{ translate( 'ACTIONS' ) }</span>,
+				getValue: ( { item }: { item: SiteData } ) => item.isFavorite,
+				render: ( { item }: { item: SiteData } ) => {
+					if ( isLoading ) {
+						return <TextPlaceholder />;
+					}
+					return (
+						<div className="sites-dataviews__actions">
+							<SiteActions isLargeScreen site={ item.site } siteError={ item.site.error } />
+							<Button
+								onClick={ () => openSitePreviewPane( item.site.value ) }
+								className="site-preview__open"
+								borderless
+							>
+								<Gridicon icon="chevron-right" />
+							</Button>
+						</div>
+					);
+				},
+				enableHiding: false,
+				enableSorting: false,
+			},
+		],
+		[ isLoading, openSitePreviewPane, renderField, translate ]
+	);
 
 	return (
 		<>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/index.tsx
@@ -1,5 +1,6 @@
 import { Button, Gridicon } from '@automattic/components';
 import { DataViews } from '@wordpress/dataviews';
+import { Icon, starFilled } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useMemo } from 'react';
 import SiteActions from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-actions';

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/site-data-field.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/site-data-field.tsx
@@ -1,0 +1,33 @@
+import { Button } from '@automattic/components';
+import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
+import { Site } from '../types';
+
+interface SiteDataFieldProps {
+	isLoading: boolean;
+	site: Site;
+	onSiteTitleClick: ( site: Site ) => void;
+}
+
+const SiteDataField = ( { isLoading, site, onSiteTitleClick }: SiteDataFieldProps ) => {
+	if ( isLoading ) {
+		return <TextPlaceholder />;
+	}
+
+	return (
+		<div className="sites-dataviews__site">
+			<Button onClick={ () => onSiteTitleClick( site ) } borderless>
+				<div className="sites-dataviews__site-favicon"></div>
+			</Button>
+			<div className="sites-dataviews__site-name">
+				<Button onClick={ () => onSiteTitleClick( site ) } borderless>
+					{ site.blogname }
+				</Button>
+				<Button href={ site.url_with_scheme } borderless target="_blank">
+					<div className="sites-dataviews__site-url">{ site.url }</div>
+				</Button>
+			</div>
+		</div>
+	);
+};
+
+export default SiteDataField;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
@@ -47,6 +47,10 @@
 .sites-dataviews__site {
 	display: flex;
 	flex-direction: row;
+
+	.button {
+		padding: 0;
+	}
 }
 
 .sites-dataviews__site-name {
@@ -55,18 +59,42 @@
 	align-items: flex-start;
 	justify-content: flex-start;
 	white-space: nowrap;
-	font-weight: 600;
+	font-weight: 500;
+	font-size: rem(14px);
 }
 
 .sites-dataviews__site-url {
-	font-size: 0.75rem;
+	font-size: rem(12px);
 	color: var(--studio-gray-60);
 	font-weight: 400;
 }
 
 .sites-dataviews__site-favicon {
-	width: 50px;
-	height: 50px;
+	width: 40px;
+	height: 40px;
 	background: linear-gradient(45deg, #ff0056, #ff8a78, #57b7ff, #9c00d4);
 	margin-right: 16px;
+	border-radius: 10px; /* stylelint-disable-line scales/radii */
+}
+
+.sites-dataviews__actions {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	justify-content: center;
+	flex-wrap: nowrap;
+
+	@media (min-width: 1080px) {
+		.site-actions__actions-large-screen {
+			float: none;
+			margin-inline-end: 20px;
+		}
+	}
+
+	.site-preview__open {
+		.gridicon.gridicons-chevron-right {
+			width: 18px;
+			height: 18px;
+		}
+	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -1,9 +1,55 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.sites-overview__large-screen {
-	.site-search-filter-container__search .search.is-open .search__open-icon {
-		width: 60px;
+.sites-dashboard__layout {
+	display: flex;
+	flex-wrap: nowrap;
+	gap: 16px;
+
+	.sites-overview {
+		width: 400px;
+		flex-shrink: 0;
+		overflow-y: auto;
+		transition: all 0.2s;
+		background: var(--studio-white);
+		padding: 24px 18px;
+		border-radius: 8px; /* stylelint-disable-line scales/radii */
+	}
+
+	.sites-overview__container {
+		min-height: calc(100vh - 90px);
+	}
+
+	.sites-overview__page-title {
+		font-size: rem(24px);
+	}
+
+	.site-preview__pane {
+		flex-grow: 1;
+		width: auto;
+		padding: 48px 48px;
+		transition: flex-grow 0.2s;
+		background: var(--studio-white);
+		overflow: hidden;
+		border-radius: 8px; /* stylelint-disable-line scales/radii */
+	}
+
+	.site-preview__header {
+		text-align: center;
+	}
+
+	&.preview-hidden {
+		.sites-overview {
+			flex-grow: 1;
+			padding: 48px 64px 0;
+			margin-right: -14px;
+			transition: flex-grow 0.2s;
+		}
+
+		.site-preview__pane {
+			max-width: 0;
+			padding: 0;
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes: https://github.com/Automattic/jetpack-manage/issues/291

## Proposed Changes

![image](https://github.com/Automattic/wp-calypso/assets/9832440/ffba0e55-0ae9-4d4f-b798-08c77a07873c)

![image](https://github.com/Automattic/wp-calypso/assets/9832440/eaf44914-ebc4-44bb-86dc-47ec721e7470)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
