### PR TITLE
Nav redesign: Use font size variables

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -1,3 +1,4 @@
+@import "@wordpress/base-styles/variables";
 @import "@automattic/typography/styles/variables";
 $brand-text: "SF Pro Text", $sans;
 .global-sidebar {
@@ -27,7 +28,7 @@ $brand-text: "SF Pro Text", $sans;
 			color: var(--studio-black);
 			content: attr(data-tooltip);
 			display: none;
-			font-size: 14px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: $font-body-small;
 			padding: 6px 10px;
 			position: absolute;
 			right: 0;
@@ -173,7 +174,7 @@ $brand-text: "SF Pro Text", $sans;
 			align-items: center;
 			height: 16px;
 			padding: 8px 0;
-			font-size: 14px;  /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: $font-body-small;
 
 			svg {
 				&.wpicon {
@@ -237,7 +238,7 @@ $brand-text: "SF Pro Text", $sans;
 		}
 
 		.sidebar__back-link-text {
-			font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: $default-font-size;
 			vertical-align: text-bottom;
 		}
 	}

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -1,3 +1,4 @@
+@import "@wordpress/base-styles/variables";
 @import "@wordpress/base-styles/breakpoints";
 // The following changes should be merged in their respective files before nav unification goes to production
 @import url( //s1.wp.com/wp-includes/css/dashicons.css?v=20150727 );
@@ -350,7 +351,7 @@ $font-size: rem(14px);
 
 		.sidebar__menu-link-text {
 			font-family: $brand-text;
-			font-size: 13px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+			font-size: $default-font-size;
 			font-style: normal;
 			font-weight: 400;
 			padding: 0;
@@ -396,7 +397,7 @@ $font-size: rem(14px);
 			}
 
 			.sidebar__menu-link-text {
-				font-size: 16px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-size: $font-body;
 				font-weight: 600;
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

This PR updates to utilize variables for font sizes. 

| before | after |
|--------|--------|
| <img width="781" alt="Screenshot 2024-02-21 at 12 34 47" src="https://github.com/Automattic/wp-calypso/assets/5287479/6c1ff3ec-a8db-499d-a8f9-ee80ad23bb80"> | Using the [core's variable](https://github.com/WordPress/gutenberg/blob/a4dd8d6d177de29fad12a7ead2f14bedeaff4fbc/packages/base-styles/_variables.scss#L16) <img width="770" alt="Screenshot 2024-02-21 at 12 31 55" src="https://github.com/Automattic/wp-calypso/assets/5287479/89599783-51d1-4e7c-b06c-6415c69e6d1c"> |
| <img width="760" alt="Screenshot 2024-02-21 at 12 35 03" src="https://github.com/Automattic/wp-calypso/assets/5287479/8cbd4b3e-5a87-49cd-b638-e875e4855495"> | Using the Calypso's variable <img width="750" alt="Screenshot 2024-02-21 at 12 32 29" src="https://github.com/Automattic/wp-calypso/assets/5287479/fc2f2955-44c4-4634-a817-3a18df6b71e7"> |
| <img width="735" alt="Screenshot 2024-02-21 at 12 35 32" src="https://github.com/Automattic/wp-calypso/assets/5287479/3d4defaf-6439-44b6-bfeb-3100d97be5e8"> | Using the Calypso's variable <img width="753" alt="Screenshot 2024-02-21 at 12 33 15" src="https://github.com/Automattic/wp-calypso/assets/5287479/75223f40-cc44-408f-8103-0495cb9d0d96"> | 

By doing so, it achieves the following:

- Partial compliance with [WCAG 2.2 Resize Text](https://www.w3.org/WAI/WCAG22/Understanding/resize-text), enhancing text scalability for better a11y. I created an issue to address the text resize in core: https://github.com/WordPress/gutenberg/issues/59225.
- Consistency in font size definitions using the same variables as those employed in the core.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Prepare a site with the classic view
- Open Calypso Live https://github.com/Automattic/wp-calypso/pull/87693#issuecomment-1955816226
- Go to /sites
- See the font size is updated
- Go to any Calypso page (e.g., /home)
- See the font size is updated

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?