### PR TITLE
Display "the settings saved notice" at the correct timing

### DIFF
--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -103,6 +103,7 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 					this.props.errorNotice( text, noticeSettings );
 				}
 			} else if (
+				! this.props.isSavingSettings &&
 				this.props.siteIsJetpack &&
 				this.props.saveInstantSearchRequest?.status === 'success' &&
 				( typeof prevProps.saveInstantSearchRequest?.lastUpdated === 'undefined' ||

--- a/client/my-sites/site-settings/wrap-settings-form.jsx
+++ b/client/my-sites/site-settings/wrap-settings-form.jsx
@@ -232,7 +232,7 @@ const wrapSettingsForm = ( getFormSettings ) => ( SettingsForm ) => {
 			this.props.removeNotice( 'site-settings-save' );
 			debug( 'submitForm', { fields, settingsFields } );
 
-			if ( siteIsJetpack ) {
+			if ( siteIsJetpack && Object.keys( jetpackFieldsToUpdate ).length > 0 ) {
 				this.props.saveJetpackSettings( siteId, jetpackFieldsToUpdate );
 			}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Close https://github.com/Automattic/dotcom-forge/issues/5631

## Proposed Changes

This PR makes "the settings saved notice" display at the correct timing. 

before

https://github.com/Automattic/wp-calypso/assets/5287479/4129aa65-da35-4543-acc2-b0811c23b528

after

https://github.com/Automattic/wp-calypso/assets/5287479/1ea91077-ec10-4758-915d-86ee8b9fbeba


### How

- Condtiion `! this.props.isSavingSettings`
	- Since we don't wanna show the notice while saving.
	- This condition itself addresses (or hide) the problem.
- Condition `Object.keys( jetpackFieldsToUpdate ).length > 0` 
	- An incorrect condition evaluation in `wrap-settings-form.jsx` caused improper handling of settings save operations. The code can be found at https://github.com/Automattic/wp-calypso/blob/3d36563a7bb60f7d374a70bfd9a8584cc805c043/client/my-sites/site-settings/wrap-settings-form.jsx#L107-L110, where the condition was mistakenly evaluated as true.
	- **Root Cause 1:** The request logging mechanism inaccurately treated different requests as identical, stemming from how `JSON.stringify` omits `undefined` properties. This resulted in objects like `{a: {b: undefined}}` being reduced to `"{a: {}}"` at https://github.com/Automattic/wp-calypso/blob/0377f8715cf420bc2050a1616d4dfbc80c267632/client/my-sites/site-settings/wrap-settings-form.jsx#L388-L393, https://github.com/Automattic/wp-calypso/blob/0377f8715cf420bc2050a1616d4dfbc80c267632/client/state/data-layer/wpcom-http/utils.js#L63-L68. Identical object representation caused the misidentification of distinct requests, leading to the inappropriate evaluation of the condition mentioned above. 
	- **Root Cause 2:** Pressing the `Save Settings` button triggered unnecessary requests, even without any modifications to the Jetpack settings.
	- The combination of Root Causes 1 & 2 triggered save operations when the `Save settings` button was clicked, incorrectly identified as `saveInstantSearchRequest`, leading to the initial problem. 
	- I addressed it by adding the condition `Object.keys( jetpackFieldsToUpdate ).length > 0` (which fixes **Root Cause 2**) so that it only requests when needed.



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Go to `/settings/site-tools/<your-site>`.
	- You can test `/marketing/traffic/<your-site>` and `/settings/general/<your-site>`, as it's using the same mechanism.
- Change settings and save it.
- Ensure the notice gets shown at the right timing.
- Ensure it's saved.

Regression testing

- Go to https://<your-site>/wp-admin/admin.php?page=jetpack-search.
- Enable instant search experience.
- Go to `/settings/performance/<your-site>`.
- Enable/Disable Jetpack Search and ensure it's saved.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?