### PR TITLE
Deploy the updated version of domain step escape hatch to the onboarding flow and the paid media flow

### DIFF
--- a/client/components/domains/choose-domain-later/index.tsx
+++ b/client/components/domains/choose-domain-later/index.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-import { useExperiment } from 'calypso/lib/explat';
 import ReskinSideExplainer from '../reskin-side-explainer';
 
 type Props = {
@@ -11,22 +9,15 @@ type Props = {
 	};
 	handleDomainExplainerClick: () => void;
 	flowName: string;
+	showEscapeHatchAfterQuery: boolean;
 };
 
-export default function ChooseDomainLater( props: Props ) {
-	const [ isEscapeHatchShownOnce, setisEscapeHatchShownOnce ] = useState( false );
-	const [ isLoading, experimentAssignment ] = useExperiment(
-		'calypso_gf_signup_onboarding_escape_hatch',
-		{
-			isEligible: props.flowName === 'onboarding',
-		}
-	);
-
-	if ( isLoading ) {
-		return null;
-	}
-	const escapeHatchVariant = experimentAssignment?.variationName;
-	const { step, handleDomainExplainerClick, flowName } = props;
+export default function ChooseDomainLater( {
+	step,
+	handleDomainExplainerClick,
+	flowName,
+	showEscapeHatchAfterQuery,
+}: Props ) {
 	const domainForm = step?.domainForm ?? {};
 
 	const isDomainResultsLoaded =
@@ -34,58 +25,19 @@ export default function ChooseDomainLater( props: Props ) {
 		Array.isArray( domainForm?.searchResults ) &&
 		domainForm?.searchResults?.length > 0;
 
-	if (
-		escapeHatchVariant === 'treatment_search' &&
-		( isEscapeHatchShownOnce || isDomainResultsLoaded )
-	) {
-		if ( ! isEscapeHatchShownOnce ) {
-			setisEscapeHatchShownOnce( true );
-		}
-		return (
-			<div className="domains__domain-side-content domains__free-domain">
-				<ReskinSideExplainer
-					onClick={ handleDomainExplainerClick }
-					type="free-domain-explainer-treatment-search"
-					flowName={ flowName }
-				/>
-			</div>
-		);
-	} else if (
-		escapeHatchVariant === 'treatment_type' &&
-		( isEscapeHatchShownOnce || isDomainResultsLoaded )
-	) {
-		if ( ! isEscapeHatchShownOnce ) {
-			setisEscapeHatchShownOnce( true );
-		}
-		return (
-			<div className="domains__domain-side-content domains__free-domain">
-				<ReskinSideExplainer
-					onClick={ handleDomainExplainerClick }
-					type="free-domain-explainer-treatment-type"
-					flowName={ flowName }
-				/>
-			</div>
-		);
-	}
-
-	if (
-		[ 'treatment_search', 'treatment_type' ].includes( escapeHatchVariant ?? '' ) &&
-		( domainForm.loadingResults ||
-			! Array.isArray( domainForm?.searchResults ) ||
-			domainForm?.searchResults?.length === 0 )
-	) {
-		/**
-		 * We do not show the free domain explainer until there is at least one search query
-		 */
+	if ( showEscapeHatchAfterQuery && ! isDomainResultsLoaded ) {
 		return null;
 	}
 
-	// The default behavior is the control variant
 	return (
 		<div className="domains__domain-side-content domains__free-domain">
 			<ReskinSideExplainer
 				onClick={ handleDomainExplainerClick }
-				type="free-domain-explainer"
+				type={
+					showEscapeHatchAfterQuery
+						? 'free-domain-explainer-treatment-type'
+						: 'free-domain-explainer'
+				}
 				flowName={ flowName }
 			/>
 		</div>

--- a/client/components/domains/choose-domain-later/index.tsx
+++ b/client/components/domains/choose-domain-later/index.tsx
@@ -1,31 +1,19 @@
 import ReskinSideExplainer from '../reskin-side-explainer';
 
 type Props = {
-	step: {
-		domainForm: {
-			loadingResults: boolean;
-			searchResults?: Array< any > | null;
-		};
-	};
+	hasSearchedDomains: boolean;
 	handleDomainExplainerClick: () => void;
 	flowName: string;
 	showEscapeHatchAfterQuery: boolean;
 };
 
 export default function ChooseDomainLater( {
-	step,
+	hasSearchedDomains,
 	handleDomainExplainerClick,
 	flowName,
 	showEscapeHatchAfterQuery,
 }: Props ) {
-	const domainForm = step?.domainForm ?? {};
-
-	const isDomainResultsLoaded =
-		! domainForm.loadingResults &&
-		Array.isArray( domainForm?.searchResults ) &&
-		domainForm?.searchResults?.length > 0;
-
-	if ( showEscapeHatchAfterQuery && ! isDomainResultsLoaded ) {
+	if ( showEscapeHatchAfterQuery && ! hasSearchedDomains ) {
 		return null;
 	}
 

--- a/client/components/domains/choose-domain-later/index.tsx
+++ b/client/components/domains/choose-domain-later/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useExperiment } from 'calypso/lib/explat';
 import ReskinSideExplainer from '../reskin-side-explainer';
 

--- a/client/components/domains/choose-domain-later/index.tsx
+++ b/client/components/domains/choose-domain-later/index.tsx
@@ -4,16 +4,16 @@ type Props = {
 	hasSearchedDomains: boolean;
 	handleDomainExplainerClick: () => void;
 	flowName: string;
-	showEscapeHatchAfterQuery: boolean;
+	showEscapeHatchAfterSearch: boolean;
 };
 
 export default function ChooseDomainLater( {
 	hasSearchedDomains,
 	handleDomainExplainerClick,
 	flowName,
-	showEscapeHatchAfterQuery,
+	showEscapeHatchAfterSearch,
 }: Props ) {
-	if ( showEscapeHatchAfterQuery && ! hasSearchedDomains ) {
+	if ( showEscapeHatchAfterSearch && ! hasSearchedDomains ) {
 		return null;
 	}
 
@@ -22,7 +22,7 @@ export default function ChooseDomainLater( {
 			<ReskinSideExplainer
 				onClick={ handleDomainExplainerClick }
 				type={
-					showEscapeHatchAfterQuery
+					showEscapeHatchAfterSearch
 						? 'free-domain-explainer-treatment-type'
 						: 'free-domain-explainer'
 				}

--- a/client/components/domains/choose-domain-later/test/choose-domain-later.test.tsx
+++ b/client/components/domains/choose-domain-later/test/choose-domain-later.test.tsx
@@ -14,18 +14,14 @@ jest.mock( 'calypso/lib/explat', () => ( {
 } ) );
 
 describe( 'ChooseDomainLater', () => {
-	test( 'Renders treatment_type when that treatment is active', () => {
+	test( 'Renders treatment_type when showEscapeHatchAfterSearch and hasSearchedDomains are true', () => {
 		useExperimentMock.mockImplementation( () => [ false, { variationName: 'treatment_type' } ] );
 
 		const { getByText } = render(
 			<ChooseDomainLater
 				flowName="onboarding"
-				step={ {
-					domainForm: {
-						loadingResults: false,
-						searchResults: Array( 5 ).fill( {} ),
-					},
-				} }
+				showEscapeHatchAfterSearch={ true }
+				hasSearchedDomains={ true }
 				handleDomainExplainerClick={ () => {} }
 			/>
 		);
@@ -33,37 +29,14 @@ describe( 'ChooseDomainLater', () => {
 		expect( getByText( 'Not ready to choose a domain just yet?' ) ).toBeTruthy();
 	} );
 
-	test( 'Renders treatment_search when that treatment is active', () => {
-		useExperimentMock.mockImplementation( () => [ false, { variationName: 'treatment_search' } ] );
-
-		const { getByText } = render(
-			<ChooseDomainLater
-				flowName="onboarding"
-				step={ {
-					domainForm: {
-						loadingResults: false,
-						searchResults: Array( 5 ).fill( {} ),
-					},
-				} }
-				handleDomainExplainerClick={ () => {} }
-			/>
-		);
-
-		expect( getByText( 'Get a free domain with select paid plans' ) ).toBeTruthy();
-	} );
-
-	test( 'Renders control when that control is active', () => {
+	test( 'Renders the standard domain explainer control', () => {
 		useExperimentMock.mockImplementation( () => [ false, { variationName: 'control' } ] );
 
 		const { container } = render(
 			<ChooseDomainLater
 				flowName="onboarding"
-				step={ {
-					domainForm: {
-						loadingResults: false,
-						searchResults: Array( 5 ).fill( {} ),
-					},
-				} }
+				showEscapeHatchAfterSearch={ false }
+				hasSearchedDomains={ false }
 				handleDomainExplainerClick={ () => {} }
 			/>
 		);
@@ -73,55 +46,13 @@ describe( 'ChooseDomainLater', () => {
 		);
 	} );
 
-	test( 'Does not render if treatment_search and domain results not loaded', () => {
-		useExperimentMock.mockImplementation( () => [ false, { variationName: 'treatment_search' } ] );
-
-		const { queryByText } = render(
-			<ChooseDomainLater
-				flowName="onboarding"
-				step={ {
-					domainForm: {
-						loadingResults: true,
-						searchResults: [],
-					},
-				} }
-				handleDomainExplainerClick={ () => {} }
-			/>
-		);
-
-		expect( queryByText( 'Get a free domain with select paid plans' ) ).toBeFalsy();
-	} );
-
-	test( 'Does not render if treatment_type and domain results not loaded', () => {
-		useExperimentMock.mockImplementation( () => [ false, { variationName: 'treatment_type' } ] );
-
-		const { queryByText } = render(
-			<ChooseDomainLater
-				flowName="onboarding"
-				step={ {
-					domainForm: {
-						loadingResults: true,
-						searchResults: [],
-					},
-				} }
-				handleDomainExplainerClick={ () => {} }
-			/>
-		);
-
-		expect( queryByText( 'Not ready to choose a domain just yet?' ) ).toBeFalsy();
-	} );
-
-	test( 'Does not render anything if experiment is still loading', () => {
+	test( 'Does not render anything if domains have not been searched while the escape hatch should be rendered after', () => {
 		useExperimentMock.mockImplementation( () => [ true, null ] );
 		const { container } = render(
 			<ChooseDomainLater
 				flowName="onboarding"
-				step={ {
-					domainForm: {
-						loadingResults: false,
-						searchResults: [],
-					},
-				} }
+				hasSearchedDomains={ false }
+				showEscapeHatchAfterSearch={ true }
 				handleDomainExplainerClick={ () => {} }
 			/>
 		);

--- a/client/signup/flow-actions.ts
+++ b/client/signup/flow-actions.ts
@@ -1,8 +1,3 @@
-import { loadExperimentAssignment } from 'calypso/lib/explat';
-
-export const onEnterOnboarding = ( flowName: string ) => {
-	// just to be extra safe since `loadExperimentAssignment` doesn't have the same eligibility check like `useExperiment` does
-	if ( flowName === 'onboarding' ) {
-		loadExperimentAssignment( 'calypso_gf_signup_onboarding_escape_hatch' );
-	}
-};
+// Remove this eslint disabling line once there are things to be preloaded
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const onEnterOnboarding = ( flowName: string ) => {};

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -932,7 +932,7 @@ export class RenderDomainsStep extends Component {
 					! this.shouldHideDomainExplainer() &&
 					this.props.isPlanSelectionAvailableLaterInFlow && (
 						<ChooseDomainLater
-							step={ this.props.step }
+							hasSearchedDomains={ Array.isArray( this.props.step?.domainForm?.searchResults ) }
 							flowName={ flowName }
 							handleDomainExplainerClick={ this.handleDomainExplainerClick }
 							showEscapeHatchAfterQuery={

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -36,7 +36,6 @@ import {
 	getFixedDomainSearch,
 } from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
-import { useExperiment } from 'calypso/lib/explat';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import { getSitePropertyDefaults } from 'calypso/lib/signup/site-properties';
 import { maybeExcludeEmailsStep } from 'calypso/lib/signup/step-actions';
@@ -1466,12 +1465,10 @@ const RenderDomainsStepConnect = connect(
 )( withCartKey( withShoppingCart( localize( RenderDomainsStep ) ) ) );
 
 export default function DomainsStep( props ) {
-	const [ isSideContentExperimentLoading ] = useExperiment(
-		'calypso_gf_signup_onboarding_escape_hatch',
-		{
-			isEligible: props.flowName === 'onboarding',
-		}
-	);
+	// this is kept since there will likely be more experiments to come.
+	// See peP6yB-1Np-p2
+	const isSideContentExperimentLoading = false;
+
 	return (
 		<CalypsoShoppingCartProvider>
 			<RenderDomainsStepConnect

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -920,7 +920,7 @@ export class RenderDomainsStep extends Component {
 						temporaryCart={ this.state.temporaryCart }
 						domainRemovalQueue={ this.state.domainRemovalQueue }
 						cartIsLoading={ cartIsLoading }
-						flowName={ this.props.flowName }
+						flowName={ flowName }
 						removeDomainClickHandler={ this.removeDomainClickHandler }
 						isMiniCartContinueButtonBusy={ this.state.isMiniCartContinueButtonBusy }
 						goToNext={ this.goToNext }
@@ -933,8 +933,11 @@ export class RenderDomainsStep extends Component {
 					this.props.isPlanSelectionAvailableLaterInFlow && (
 						<ChooseDomainLater
 							step={ this.props.step }
-							flowName={ this.props.flowName }
+							flowName={ flowName }
 							handleDomainExplainerClick={ this.handleDomainExplainerClick }
+							showEscapeHatchAfterQuery={
+								flowName === 'onboarding' || flowName === 'onboarding-pm'
+							}
 						/>
 					)
 				) }

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -935,7 +935,7 @@ export class RenderDomainsStep extends Component {
 							hasSearchedDomains={ Array.isArray( this.props.step?.domainForm?.searchResults ) }
 							flowName={ flowName }
 							handleDomainExplainerClick={ this.handleDomainExplainerClick }
-							showEscapeHatchAfterQuery={
+							showEscapeHatchAfterSearch={
 								flowName === 'onboarding' || flowName === 'onboarding-pm'
 							}
 						/>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/growth-foundations#217

## Proposed Changes

Now that This PR deploys the `treatment-type` variation of the escape hatch experiment to both the onboarding flow and the paid media flow. The original implementation can be found in https://github.com/Automattic/wp-calypso/pull/84398. There is a bug that the escape hatch will need another mouse/key click to be shown. This PR also fixes it(see p1702476889332839-slack-C059R8S4ALT). 

Note that we will also roll this out to all the other flows per decision in p1708466639469999-slack-C059R8S4ALT?thread_ts=1706700309.500389&cid=C059R8S4ALT . It will be handled as series of follow-up PRs.

Screencast:

https://github.com/Automattic/wp-calypso/assets/1842898/9aadeb43-eb90-469b-8d9e-bb5b745e05ad

## Testing Instructions

* In `/start/domain`, the escape hatch that allows users to choose their domain later will only show after they have searched for domains.
* The above should also apply to `/start/onboarding-pm/domain`
* All the other flows shouldn't be affected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
