### PR TITLE
A4A: Add marketplace bundle size navigation

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/issue-license/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/index.tsx
@@ -7,9 +7,14 @@ import LayoutHeader, {
 	LayoutHeaderSubtitle as Subtitle,
 	LayoutHeaderTitle as Title,
 } from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutNavigation, {
+	LayoutNavigationTabs,
+} from 'calypso/a8c-for-agencies/components/layout/nav';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
-import { useSelector } from 'calypso/state';
+import { useProductBundleSize } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/hooks/use-product-bundle-size';
+import { useDispatch, useSelector } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSites from 'calypso/state/selectors/get-sites';
 import AssignLicenseStepProgress from '../assign-license-step-progress';
 import type { SelectedLicenseProp } from './types';
@@ -20,6 +25,9 @@ import './style.scss';
 
 export default function IssueLicense( { siteId }: AssignLicenceProps ) {
 	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const { selectedSize, setSelectedSize, availableSizes } = useProductBundleSize( true );
 
 	const [ selectedLicenses ] = useState< SelectedLicenseProp[] >( [] );
 	const [ showReviewLicenses ] = useState< boolean >( false );
@@ -53,6 +61,41 @@ export default function IssueLicense( { siteId }: AssignLicenceProps ) {
 		return translate( 'Select the products you would like to issue a new license for:' );
 	}, [ selectedSite?.domain, translate ] );
 
+	const selectedText =
+		selectedSize === 1
+			? translate( 'Single license' )
+			: ( translate( '%(size)d licenses', { args: { size: selectedSize } } ) as string );
+
+	const selectedCount = selectedLicenses.filter( ( license ) => license.quantity === selectedSize )
+		?.length;
+
+	const navItems = availableSizes.map( ( size ) => {
+		const count = selectedLicenses.filter( ( license ) => license.quantity === size ).length;
+		return {
+			label:
+				size === 1
+					? translate( 'Single license' )
+					: ( translate( '%(size)d licenses', {
+							args: { size },
+					  } ) as string ),
+			selected: selectedSize === size,
+			onClick: () => {
+				setSelectedSize( size );
+				dispatch(
+					recordTracksEvent( 'calypso_a4a_marketplace_bundle_tab_click', {
+						bundle_size: size,
+					} )
+				);
+			},
+			...( count && { count } ),
+		};
+	} );
+
+	const selectedItemProps = {
+		selectedText,
+		...( selectedCount && { selectedCount } ),
+	};
+
 	return (
 		<Layout
 			className={ classNames( 'issue-license' ) }
@@ -72,6 +115,10 @@ export default function IssueLicense( { siteId }: AssignLicenceProps ) {
 					<Title>{ translate( 'Issue product licenses' ) } </Title>
 					<Subtitle>{ subtitle }</Subtitle>
 				</LayoutHeader>
+
+				<LayoutNavigation { ...selectedItemProps }>
+					<LayoutNavigationTabs { ...selectedItemProps } items={ navItems } />
+				</LayoutNavigation>
 			</LayoutTop>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/index.tsx
@@ -12,6 +12,7 @@ import LayoutNavigation, {
 } from 'calypso/a8c-for-agencies/components/layout/nav';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+// FIX ME: Lets decide later if we need to move this hook to a shared common folder.
 import { useProductBundleSize } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/hooks/use-product-bundle-size';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/hooks/use-product-bundle-size.ts
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/hooks/use-product-bundle-size.ts
@@ -24,8 +24,8 @@ export const getSupportedBundleSizes = ( products?: APIProductFamilyProduct[] ) 
 	return [ ...supported ];
 };
 
-export function useProductBundleSize() {
-	const { data: products } = useProductsQuery();
+export function useProductBundleSize( isPublicFacing = false ) {
+	const { data: products } = useProductsQuery( isPublicFacing );
 
 	const supportedBundleSizes = getSupportedBundleSizes( products );
 


### PR DESCRIPTION
This pull request introduces the Bundle Size navigation bar to the A4A Marketplace.

<img width="1415" alt="Screenshot 2024-02-21 at 3 16 25 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/ba910b0a-1aa9-46ce-a946-ffd92d7d7baa">


Closes  https://github.com/Automattic/jetpack-genesis/issues/234
Depends on https://github.com/Automattic/wp-calypso/pull/87694

## Proposed Changes

* Copy Bundle nav implementation from the Jetpack Manage pricing page.
* Update the `useProductBundleSize` hook from Jetpack Manage to support public-facing API and reuse it for A4A.

## Testing Instructions

* Switch branch: `git checkout add/a4a-marketplace-bundle-nav`
* Start the server by running `yarn start-a8c-for-agencies`.
* Click the Marketplace menu item > Verify that the page shows the bundle size nav.
* Confirm that clicking the nav updates the URL with the `bundle_size` query string parameter.

**_Note: Please ignore the discrepancies on the nav background color. This should be fix once we have the correct layout color._**

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?