### PR TITLE
Global Sidebar: fix layout for viewport width 782px

### DIFF
--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -130,7 +130,7 @@ function sitesDashboard( context: PageJSContext, next: () => void ) {
 	if ( isEnabled( 'layout/dotcom-nav-redesign' ) ) {
 		sitesDashboardGlobalStyles = css`
 			${ sitesDashboardGlobalStyles }
-			@media only screen and ( min-width: 782px ) {
+			@media only screen and ( min-width: 783px ) {
 				div.layout.is-global-sidebar-visible {
 					.layout__primary {
 						margin-left: var( --sidebar-width-max );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/dotcom-forge/issues/5704

## Proposed Changes

* Fix layout for viewport width 782px by updating the query to show the global sidebar for a min-width of 783px

|BEFORE|AFTER|
|-|-|
|<img width="782" alt="Screenshot 2567-02-21 at 14 18 23" src="https://github.com/Automattic/wp-calypso/assets/1881481/f829a587-5ee4-4fce-8a2a-8dbdf0d3ff26">|<img width="781" alt="Screenshot 2567-02-21 at 14 18 06" src="https://github.com/Automattic/wp-calypso/assets/1881481/f3c80e2b-f581-40ab-88d1-5e6d1cea0fb8">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access `/sites?flags=layout/dotcom-nav-redesign`
* Adjust the window to 782 pixels, and move between 781-783, to verify the sidebar shows as expected

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?