### PR TITLE
Enable masterbar top menu on mobile version of global nav

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -431,11 +431,8 @@ export default withCurrentRoute(
 				'comments',
 			].includes( sectionName );
 			const sidebarIsHidden = ! secondary || isWcMobileApp() || isDomainAndPlanPackageFlow;
-
 			const userAllowedToHelpCenter = config.isEnabled( 'calypso/help-center' );
-
 			const isCommandPaletteOpen = getIsCommandPaletteOpen( state );
-
 			return {
 				masterbarIsHidden,
 				sidebarIsHidden,

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -170,12 +170,12 @@ class Layout extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			isDesktop: isWithinBreakpoint( '>782px' ),
+			isDesktop: isWithinBreakpoint( '>781px' ),
 		};
 	}
 
 	componentDidMount() {
-		this.unsubscribe = subscribeIsWithinBreakpoint( '>782px', ( isDesktop ) => {
+		this.unsubscribe = subscribeIsWithinBreakpoint( '>781px', ( isDesktop ) => {
 			this.setState( { isDesktop } );
 		} );
 

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -403,14 +403,14 @@ export default withCurrentRoute(
 				// hide the masterBar until the section is loaded. To flicker the masterBar in, is better than to flicker it out.
 				! sectionName ||
 				( ! isWooCoreProfilerFlow && [ 'signup', 'jetpack-connect' ].includes( sectionName ) );
+			const isDesktop = isWithinBreakpoint( '>782px' );
 			const masterbarIsHidden =
 				! masterbarIsVisible( state ) ||
 				noMasterbarForSection ||
 				noMasterbarForRoute ||
 				isWpMobileApp() ||
 				isWcMobileApp() ||
-				shouldShowGlobalSidebar ||
-				shouldShowGlobalSiteSidebar ||
+				( ( shouldShowGlobalSidebar || shouldShowGlobalSiteSidebar ) && isDesktop ) ||
 				isJetpackCloud() ||
 				config.isEnabled( 'a8c-for-agencies' );
 			const isJetpackMobileFlow = 'jetpack-connect' === sectionName && !! retrieveMobileRedirect();

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -170,12 +170,12 @@ class Layout extends Component {
 	constructor( props ) {
 		super( props );
 		this.state = {
-			isDesktop: isWithinBreakpoint( '>781px' ),
+			isDesktop: isWithinBreakpoint( '>=782px' ),
 		};
 	}
 
 	componentDidMount() {
-		this.unsubscribe = subscribeIsWithinBreakpoint( '>781px', ( isDesktop ) => {
+		this.unsubscribe = subscribeIsWithinBreakpoint( '>=782px', ( isDesktop ) => {
 			this.setState( { isDesktop } );
 		} );
 

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -141,7 +141,7 @@ class MasterbarLoggedIn extends Component {
 	clickMySites = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_my_sites_clicked' );
 
-		if ( this.props.shouldShowMobileGlobalNav ) {
+		if ( this.props.isMobileGlobalNavVisible ) {
 			// Fall through to navigate to /sites
 			return;
 		}
@@ -599,7 +599,7 @@ class MasterbarLoggedIn extends Component {
 			return this.renderCheckout();
 		}
 
-		if ( this.props.shouldShowMobileGlobalNav ) {
+		if ( this.props.isMobileGlobalNavVisible ) {
 			return (
 				<>
 					<Masterbar>
@@ -700,6 +700,7 @@ export default connect(
 			currentSelectedSiteId,
 			sectionGroup
 		);
+		const isDesktop = isWithinBreakpoint( '>782px' );
 		return {
 			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
 			isNotificationsShowing: isNotificationsOpen( state ),
@@ -730,7 +731,8 @@ export default connect(
 				new Date( getCurrentUserDate( state ) ).getTime() > NEW_MASTERBAR_SHIPPING_DATE,
 			currentRoute: getCurrentRoute( state ),
 			isSiteTrialExpired: isTrialExpired( state, siteId ),
-			shouldShowMobileGlobalNav: shouldShowGlobalSidebar || shouldShowGlobalSiteSidebar,
+			isMobileGlobalNavVisible:
+				( shouldShowGlobalSidebar || shouldShowGlobalSiteSidebar ) && ! isDesktop,
 		};
 	},
 	{

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -20,7 +20,10 @@ import {
 	getCurrentUserDate,
 	getCurrentUserSiteCount,
 } from 'calypso/state/current-user/selectors';
-import { getShouldShowGlobalSidebar } from 'calypso/state/global-sidebar/selectors';
+import {
+	getShouldShowGlobalSidebar,
+	getShouldShowGlobalSiteSidebar,
+} from 'calypso/state/global-sidebar/selectors';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference, isFetchingPreferences } from 'calypso/state/preferences/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -77,6 +80,7 @@ class MasterbarLoggedIn extends Component {
 		hasDismissedThePopover: PropTypes.bool,
 		isUserNewerThanNewNavigation: PropTypes.bool,
 		loadHelpCenterIcon: PropTypes.bool,
+		shouldShowGlobalSiteSidebar: PropTypes.bool,
 	};
 
 	subscribeToViewPortChanges() {
@@ -123,8 +127,25 @@ class MasterbarLoggedIn extends Component {
 		this.unsubscribeResponsiveMenuViewPortChanges?.();
 	}
 
+	handleToggleMobileMenu = () => {
+		this.props.recordTracksEvent( 'calypso_masterbar_menu_clicked' );
+		// this.handleLayoutFocus( 'sites' );
+		if ( 'sidebar' === this.props.currentLayoutFocus ) {
+			this.props.setNextLayoutFocus( 'content' );
+		} else {
+			this.props.setNextLayoutFocus( 'sidebar' );
+		}
+		this.props.activateNextLayoutFocus();
+	};
+
 	clickMySites = () => {
 		this.props.recordTracksEvent( 'calypso_masterbar_my_sites_clicked' );
+
+		if ( this.props.shouldShowMobileGlobalNav ) {
+			// Fall through to navigate to /sites
+			return;
+		}
+
 		this.handleLayoutFocus( 'sites' );
 		this.props.activateNextLayoutFocus();
 
@@ -202,6 +223,10 @@ class MasterbarLoggedIn extends Component {
 		return section === this.props.section && ! this.props.isNotificationsShowing;
 	};
 
+	isSidebarOpen = () => {
+		return 'sidebar' === this.props.currentLayoutFocus;
+	};
+
 	wordpressIcon = () => {
 		// WP icon replacement for "horizon" environment
 		if ( config( 'hostname' ) === 'horizon.wordpress.com' ) {
@@ -211,21 +236,40 @@ class MasterbarLoggedIn extends Component {
 		return 'my-sites';
 	};
 
+	/**
+	 * Hamburger menu used by the global nav.
+	 * In nav unification, the menu is openned with the Sites button
+	 */
+	renderSidebarMobileMenu() {
+		const { isResponsiveMenu } = this.state;
+		const { translate } = this.props;
+
+		if ( isResponsiveMenu ) {
+			return (
+				<Item
+					tipTarget="Menu"
+					icon="menu"
+					onClick={ this.handleToggleMobileMenu }
+					isActive={ this.isSidebarOpen() }
+					className="masterbar__item-menu"
+					tooltip={ translate( 'Menu' ) }
+				/>
+			);
+		}
+		return null;
+	}
+
 	renderGlobalMySites() {
-		const { siteSlug, translate, section } = this.props;
-		const { isMenuOpen, isResponsiveMenu } = this.state;
+		const { translate, section } = this.props;
+		const { isResponsiveMenu } = this.state;
 
 		let mySitesUrl = '/sites';
 
 		const icon =
 			this.state.isMobile && this.props.isInEditor ? 'chevron-left' : this.wordpressIcon();
 
-		if ( 'sites' === section && isResponsiveMenu ) {
+		if ( 'sites-dashboard' === section && isResponsiveMenu ) {
 			mySitesUrl = '';
-		}
-		if ( ! siteSlug && section === 'sites-dashboard' ) {
-			// we are the /sites page but there is no site. Disable the home link
-			return <Item icon={ icon } disabled />;
 		}
 
 		return (
@@ -234,7 +278,7 @@ class MasterbarLoggedIn extends Component {
 				tipTarget="my-sites"
 				icon={ icon }
 				onClick={ this.clickMySites }
-				isActive={ this.isActive( 'sites' ) && ! isMenuOpen }
+				isActive={ this.isActive( 'sites-dashboard' ) && ! this.isSidebarOpen() }
 				tooltip={ translate( 'Manage your sites' ) }
 			/>
 		);
@@ -445,7 +489,7 @@ class MasterbarLoggedIn extends Component {
 		const { translate } = this.props;
 		return (
 			<Notifications
-				isShowing={ this.props.isNotificationsShowing }
+				isShowing={ true }
 				isActive={ this.isActive( 'notifications' ) }
 				className="masterbar__item-notifications"
 				tooltip={ translate( 'Manage your notifications' ) }
@@ -555,12 +599,18 @@ class MasterbarLoggedIn extends Component {
 			return this.renderCheckout();
 		}
 
-		if ( this.props.shouldShowGlobalSidebar ) {
+		if ( this.props.shouldShowMobileGlobalNav ) {
 			return (
 				<>
 					<Masterbar>
 						<div className="masterbar__section masterbar__section--left">
+							{ this.renderSidebarMobileMenu() }
 							{ this.renderGlobalMySites() }
+						</div>
+						<div className="masterbar__section masterbar__section--right">
+							{ this.renderSearch() }
+							{ this.renderCart() }
+							{ this.renderNotifications() }
 						</div>
 					</Masterbar>
 				</>
@@ -575,7 +625,8 @@ class MasterbarLoggedIn extends Component {
 							{ this.renderMySites() }
 						</div>
 						<div className="masterbar__section masterbar__section--right">
-							{ this.renderHelpCenter() }
+							{ this.renderCart() }
+							{ this.renderNotifications() }
 						</div>
 					</Masterbar>
 				);
@@ -639,8 +690,16 @@ export default connect(
 			isSiteMigrationActiveRoute( state );
 
 		const siteCount = getCurrentUserSiteCount( state ) ?? 0;
-		const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, siteId, sectionGroup );
-
+		const shouldShowGlobalSidebar = getShouldShowGlobalSidebar(
+			state,
+			currentSelectedSiteId,
+			sectionGroup
+		);
+		const shouldShowGlobalSiteSidebar = getShouldShowGlobalSiteSidebar(
+			state,
+			currentSelectedSiteId,
+			sectionGroup
+		);
 		return {
 			isCustomerHomeEnabled: canCurrentUserUseCustomerHome( state, siteId ),
 			isNotificationsShowing: isNotificationsOpen( state ),
@@ -671,7 +730,7 @@ export default connect(
 				new Date( getCurrentUserDate( state ) ).getTime() > NEW_MASTERBAR_SHIPPING_DATE,
 			currentRoute: getCurrentRoute( state ),
 			isSiteTrialExpired: isTrialExpired( state, siteId ),
-			shouldShowGlobalSidebar,
+			shouldShowMobileGlobalNav: shouldShowGlobalSidebar || shouldShowGlobalSiteSidebar,
 		};
 	},
 	{

--- a/packages/viewport/src/index.ts
+++ b/packages/viewport/src/index.ts
@@ -103,6 +103,7 @@ const mediaQueryOptions: Record< string, QueryOption > = {
 	'<1400px': { max: 1400 },
 	'>480px': { min: 480 },
 	'>660px': { min: 660 },
+	'>=782px': { min: 781 },
 	'>782px': { min: 782 },
 	'>800px': { min: 800 },
 	'>=960px': { min: 959 },


### PR DESCRIPTION
see 5658-gh-Automattic/dotcom-forge#issuecomment-1954702269, see also slack thread p1708465376696259-slack-C06DN6QQVAQ

This re-enables a mobile version of the masterbar menu on pages where global nav is enabled. It should show a hamburger menu on mobile only as described in 5658-gh-Automattic/dotcom-forge

When `?flags=-layout/dotcom-nav-redesign`, it should have no effect.

In nav unification, the "Sites" menu works to open the hamburger menu.

<img width="547" alt="Screenshot 2024-02-21 at 6 55 40 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/213f9d9a-e0b7-4ce2-87c2-e7f00690796a">

I'm still waiting on a few questions:
p1708474757813929/1708465376.696259-slack-C06DN6QQVAQ

I'm aware of two issues:
* Global slide out mobile menu is a little broken visually.
* This seems to have effected the behaviour of clicking the MySites button on nav unification pages, it is taking you back to /sites instead of /home/$slug, I need to investigate this further

### Testing instructions
with `?flags=+layout/dotcom-nav-redesign`:
Should appear on pages:
* /sites
* /domains/manage
* /me
* /home/$site_slug, where site_slug is the slug of an atomic site with `wpcom_admin_interface === wp-admin`
  * And any other calypso pages for such sites.