### PR TITLE
Automattic for Agencies: Implement license list view for Marketplace

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -3,8 +3,8 @@ import MainSidebar from '../../components/sidebar-menu/main';
 import IssueLicense from './issue-license';
 
 export const marketplaceContext: Callback = ( context, next ) => {
-	const { site_id } = context.query;
+	const { site_id, product_slug } = context.query;
 	context.secondary = <MainSidebar path={ context.path } />;
-	context.primary = <IssueLicense siteId={ site_id } />;
+	context.primary = <IssueLicense siteId={ site_id } suggestedProduct={ product_slug } />;
 	next();
 };

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/context.ts
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/context.ts
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+import type { IssueLicenseContext as IssueLicenseContextInterface } from './types';
+
+const IssueLicenseContext = createContext< IssueLicenseContextInterface >( {
+	selectedLicenses: [],
+	setSelectedLicenses: () => {
+		return undefined;
+	},
+} );
+
+export default IssueLicenseContext;

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/index.tsx
@@ -1,8 +1,10 @@
+// FIXME: Lets decide later if we need to move the calypso/jetpack-cloud imports to a shared common folder.
 import { useBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo, useState } from 'react';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
 import LayoutHeader, {
 	LayoutHeaderSubtitle as Subtitle,
 	LayoutHeaderTitle as Title,
@@ -12,25 +14,26 @@ import LayoutNavigation, {
 } from 'calypso/a8c-for-agencies/components/layout/nav';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
-// FIX ME: Lets decide later if we need to move this hook to a shared common folder.
 import { useProductBundleSize } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/hooks/use-product-bundle-size';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getSites from 'calypso/state/selectors/get-sites';
 import AssignLicenseStepProgress from '../assign-license-step-progress';
+import IssueLicenseContext from './context';
+import LicensesForm from './licenses-form';
 import type { SelectedLicenseProp } from './types';
 import type { AssignLicenceProps } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 
 import './style.scss';
 
-export default function IssueLicense( { siteId }: AssignLicenceProps ) {
+export default function IssueLicense( { siteId, suggestedProduct }: AssignLicenceProps ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 
 	const { selectedSize, setSelectedSize, availableSizes } = useProductBundleSize( true );
 
-	const [ selectedLicenses ] = useState< SelectedLicenseProp[] >( [] );
+	const [ selectedLicenses, setSelectedLicenses ] = useState< SelectedLicenseProp[] >( [] );
 	const [ showReviewLicenses ] = useState< boolean >( false );
 
 	const [ selectedSite, setSelectedSite ] = useState< SiteDetails | null | undefined >( null );
@@ -121,6 +124,16 @@ export default function IssueLicense( { siteId }: AssignLicenceProps ) {
 					<LayoutNavigationTabs { ...selectedItemProps } items={ navItems } />
 				</LayoutNavigation>
 			</LayoutTop>
+
+			<LayoutBody>
+				<IssueLicenseContext.Provider value={ { setSelectedLicenses, selectedLicenses } }>
+					<LicensesForm
+						selectedSite={ selectedSite }
+						suggestedProduct={ suggestedProduct }
+						quantity={ selectedSize }
+					/>
+				</IssueLicenseContext.Provider>
+			</LayoutBody>
 		</Layout>
 	);
 }

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/index.tsx
@@ -1,0 +1,301 @@
+// FIXME: Lets decide later if we need to move the calypso/jetpack-cloud imports to a shared common folder.
+import { getQueryArg } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import QueryProductsList from 'calypso/components/data/query-products-list';
+import { parseQueryStringProducts } from 'calypso/jetpack-cloud/sections/partner-portal/lib/querystring-products';
+import LicenseMultiProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-multi-product-card';
+import LicenseProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-product-card';
+import { getSupportedBundleSizes } from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/hooks/use-product-bundle-size';
+import {
+	getIncompatibleProducts,
+	isIncompatibleProduct,
+} from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/incompatible-products';
+import useProductAndPlans from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/licenses-form/hooks/use-product-and-plans';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import IssueLicenseContext from '../context';
+import LicensesFormSection from './sections';
+import type { SelectedLicenseProp } from '../types';
+import type { SiteDetails } from '@automattic/data-stores';
+import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
+
+import './style.scss';
+
+interface LicensesFormProps {
+	selectedSite?: SiteDetails | null;
+	suggestedProduct?: string;
+	quantity?: number;
+}
+
+export default function LicensesForm( {
+	selectedSite,
+	suggestedProduct,
+	quantity = 1,
+}: LicensesFormProps ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const { selectedLicenses, setSelectedLicenses } = useContext( IssueLicenseContext );
+
+	const {
+		filteredProductsAndBundles,
+		isLoadingProducts,
+		plans,
+		backupAddons,
+		products,
+		wooExtensions,
+		data,
+	} = useProductAndPlans( {
+		selectedSite,
+		selectedBundleSize: quantity,
+		usePublicQuery: true, // FIXME: Fix this when we have the API endpoint for A4A
+	} );
+
+	// Create a ref for `filteredProductsAndBundles` to prevent unnecessary re-renders caused by the `useEffect` hook.
+	const filteredProductsAndBundlesRef = useRef( filteredProductsAndBundles );
+
+	// Update the ref whenever `filteredProductsAndBundles` changes.
+	useEffect( () => {
+		filteredProductsAndBundlesRef.current = filteredProductsAndBundles;
+	}, [ filteredProductsAndBundles ] );
+
+	const preSelectProducts = useCallback( () => {
+		const productsQueryArg = getQueryArg( window.location.href, 'products' )?.toString?.();
+		const parsedItems = parseQueryStringProducts( productsQueryArg );
+		const availableSizes = getSupportedBundleSizes( data );
+
+		const allProductsAndBundles = parsedItems?.length
+			? ( parsedItems
+					.map( ( item ) => {
+						// Add licenses & bundles that are supported
+						const product = filteredProductsAndBundlesRef.current.find(
+							( product ) => product.slug === item.slug
+						);
+						const quantity = availableSizes.find( ( size ) => size === item.quantity );
+						if ( product && quantity ) {
+							return {
+								...product,
+								quantity,
+							};
+						}
+						return null;
+					} )
+					.filter( Boolean ) as SelectedLicenseProp[] )
+			: null;
+
+		if ( allProductsAndBundles ) {
+			setSelectedLicenses( allProductsAndBundles );
+		}
+	}, [ setSelectedLicenses, data ] );
+
+	useEffect( () => {
+		if ( isLoadingProducts ) {
+			return;
+		}
+		preSelectProducts();
+	}, [ isLoadingProducts, preSelectProducts ] );
+
+	const incompatibleProducts = useMemo(
+		() =>
+			// Only check for incompatible products if we have a selected site.
+			selectedSite ? getIncompatibleProducts( selectedLicenses, filteredProductsAndBundles ) : [],
+		[ filteredProductsAndBundles, selectedLicenses, selectedSite ]
+	);
+
+	const handleSelectBundleLicense = useCallback(
+		( product: APIProductFamilyProduct ) => {
+			const productBundle = {
+				...product,
+				quantity,
+			};
+			const index = selectedLicenses.findIndex(
+				( item ) => item.quantity === productBundle.quantity && item.slug === productBundle.slug
+			);
+			if ( index === -1 ) {
+				// Item doesn't exist, add it
+				setSelectedLicenses( [ ...selectedLicenses, productBundle ] );
+				dispatch(
+					recordTracksEvent( 'calypso_a4a_marketplace_issue_license_select_product', {
+						product: product.slug,
+						quantity,
+					} )
+				);
+			} else {
+				// Item exists, remove it
+				setSelectedLicenses( selectedLicenses.filter( ( _, i ) => i !== index ) );
+				dispatch(
+					recordTracksEvent( 'calypso_a4a_marketplace_issue_license_unselect_product', {
+						product: product.slug,
+						quantity,
+					} )
+				);
+			}
+		},
+		[ dispatch, quantity, selectedLicenses, setSelectedLicenses ]
+	);
+
+	const onSelectProduct = useCallback(
+		( product: APIProductFamilyProduct ) => {
+			handleSelectBundleLicense( product );
+		},
+		[ handleSelectBundleLicense ]
+	);
+
+	const onSelectOrReplaceProduct = useCallback(
+		( product: APIProductFamilyProduct, replace?: APIProductFamilyProduct ) => {
+			if ( replace ) {
+				setSelectedLicenses(
+					selectedLicenses.map( ( item ) => {
+						if ( item.slug === replace.slug && item.quantity === quantity ) {
+							return { ...product, quantity };
+						}
+
+						return item;
+					} )
+				);
+
+				// Unselecting the current selected variant
+				dispatch(
+					recordTracksEvent( 'calypso_a4a_marketplace_issue_license_unselect_product', {
+						product: replace.slug,
+						quantity,
+					} )
+				);
+
+				dispatch(
+					recordTracksEvent( 'calypso_a4a_marketplace_issue_license_select_product', {
+						product: product.slug,
+						quantity,
+					} )
+				);
+			} else {
+				handleSelectBundleLicense( product );
+			}
+		},
+		[ dispatch, handleSelectBundleLicense, quantity, selectedLicenses, setSelectedLicenses ]
+	);
+
+	const isReady = true;
+
+	const isSelected = useCallback(
+		( slug: string | string[] ) =>
+			selectedLicenses.some(
+				( license ) =>
+					( Array.isArray( slug ) ? slug.includes( license.slug ) : license.slug === slug ) &&
+					license.quantity === quantity
+			),
+		[ quantity, selectedLicenses ]
+	);
+
+	const onClickVariantOption = useCallback(
+		( product: APIProductFamilyProduct ) => {
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_marketplace_issue_license_variant_option_click', {
+					product: product.slug,
+				} )
+			);
+		},
+		[ dispatch ]
+	);
+
+	const isSingleLicenseView = quantity === 1;
+
+	const getProductCards = ( products: APIProductFamilyProduct[] ) => {
+		return products.map( ( productOption ) =>
+			Array.isArray( productOption ) ? (
+				<LicenseMultiProductCard
+					key={ productOption.map( ( { slug } ) => slug ).join( ',' ) }
+					products={ productOption }
+					onSelectProduct={ onSelectOrReplaceProduct }
+					onVariantChange={ onClickVariantOption }
+					isSelected={ isSelected( productOption.map( ( { slug } ) => slug ) ) }
+					selectedOption={ productOption.find( ( option ) =>
+						selectedLicenses.find(
+							( license ) => license.slug === option.slug && license.quantity === quantity
+						)
+					) }
+					isDisabled={
+						! isReady ||
+						( isIncompatibleProduct( productOption, incompatibleProducts ) &&
+							! isSelected( productOption.map( ( { slug } ) => slug ) ) )
+					}
+					hideDiscount={ isSingleLicenseView }
+					suggestedProduct={ suggestedProduct }
+					quantity={ quantity }
+				/>
+			) : (
+				<LicenseProductCard
+					isMultiSelect
+					key={ productOption.slug }
+					product={ productOption }
+					onSelectProduct={ onSelectProduct }
+					isSelected={ isSelected( productOption.slug ) }
+					isDisabled={ ! isReady || isIncompatibleProduct( productOption, incompatibleProducts ) }
+					hideDiscount={ isSingleLicenseView }
+					suggestedProduct={ suggestedProduct }
+					quantity={ quantity }
+				/>
+			)
+		);
+	};
+
+	if ( isLoadingProducts ) {
+		return (
+			<div className="licenses-form">
+				<div className="licenses-form__placeholder" />
+			</div>
+		);
+	}
+
+	return (
+		<div className="licenses-form">
+			<QueryProductsList type="jetpack" currency="USD" />
+
+			{ plans.length > 0 && (
+				<LicensesFormSection
+					title={ translate( 'Plans' ) }
+					description={ translate(
+						'Save big with comprehensive bundles of Jetpack security, performance, and growth tools.'
+					) }
+					isTwoColumns
+				>
+					{ getProductCards( plans ) }
+				</LicensesFormSection>
+			) }
+
+			{ products.length > 0 && (
+				<LicensesFormSection
+					title={ translate( 'Products' ) }
+					description={ translate(
+						'Mix and match powerful security, performance, and growth tools for your sites.'
+					) }
+				>
+					{ getProductCards( products ) }
+				</LicensesFormSection>
+			) }
+
+			{ wooExtensions.length > 0 && (
+				<LicensesFormSection
+					title={ translate( 'WooCommerce Extensions' ) }
+					description={ translate(
+						'You must have WooCommerce installed to utilize these paid extensions.'
+					) }
+				>
+					{ getProductCards( wooExtensions ) }
+				</LicensesFormSection>
+			) }
+
+			{ backupAddons.length > 0 && (
+				<LicensesFormSection
+					title={ translate( 'VaultPress Backup Add-ons' ) }
+					description={ translate(
+						'Add additional storage to your current VaultPress Backup plans.'
+					) }
+				>
+					{ getProductCards( backupAddons ) }
+				</LicensesFormSection>
+			) }
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/index.tsx
@@ -250,7 +250,7 @@ export default function LicensesForm( {
 
 	return (
 		<div className="licenses-form">
-			<QueryProductsList type="jetpack" currency="USD" />
+			<QueryProductsList currency="USD" />
 
 			{ plans.length > 0 && (
 				<LicensesFormSection

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/sections.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/sections.tsx
@@ -1,0 +1,28 @@
+import classNames from 'classnames';
+import { ReactNode } from 'react';
+
+type Props = {
+	title: string;
+	description: string;
+	children: ReactNode;
+	isTwoColumns?: boolean;
+};
+
+export default function LicensesFormSection( {
+	title,
+	description,
+	children,
+	isTwoColumns,
+}: Props ) {
+	return (
+		<div className={ classNames( 'licenses-form__section', { 'is-two-columns': isTwoColumns } ) }>
+			<h2 className="licenses-form__section-title">
+				<span>{ title }</span>
+				<hr />
+			</h2>
+			<p className="licenses-form__section-description">{ description }</p>
+
+			<div className="licenses-form__section-content">{ children }</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/style.scss
@@ -1,0 +1,82 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+@import "../../mixins.scss";
+
+.licenses-form__placeholder {
+	@include placeholder( --color-neutral-10 );
+	height: 43px;
+}
+
+.licenses-form__section {
+	margin-block-end: 32px;
+}
+
+h2.licenses-form__section-title {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 18px;
+	margin-block-end: 10px;
+	font-size: rem(20px);
+	font-weight: 600;
+	line-height: 1.2;
+
+	hr {
+		color: var(--color-gray-5);
+		width: 1px;
+		flex-grow: 1;
+		margin: 0;
+	}
+}
+
+p.licenses-form__section-description {
+	font-size: rem(14px);
+	font-weight: 400;
+	line-height: 1.2;
+	margin-block-end: 32px;
+}
+
+.licenses-form__section-content {
+	display: grid;
+	gap: 16px;
+	grid-template-columns: 1fr;
+
+	@include break-xlarge {
+		grid-template-columns: repeat(2, 1fr);
+	}
+
+	@include break-wide {
+		grid-template-columns: repeat(3, 1fr);
+	}
+}
+
+.licenses-form__section.is-two-columns .licenses-form__section-content {
+	@include break-wide {
+		grid-template-columns: repeat(2, 1fr);
+	}
+}
+
+p.licenses-form__description {
+	flex: 1 1 auto;
+	align-self: flex-end;
+	margin: 1rem 0;
+	font-size: 0.875rem;
+	color: #333;
+
+	@include breakpoint-deprecated( ">660px" ) {
+		margin-right: 1rem;
+	}
+}
+
+.licenses-form__select-license {
+	// :active introduces a 1px border but :focus introduces a 1.5px border which causes the button to move around.
+	border-width: 1.5px !important;
+	border-color: transparent;
+}
+
+.licenses-form__actions {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 16px;
+	margin: 16px 0 32px;
+}

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/types.ts
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/types.ts
@@ -4,3 +4,8 @@ export type SelectedLicenseProp = APIProductFamilyProduct & {
 	quantity: number;
 	siteUrls?: string[];
 };
+
+export interface IssueLicenseContext {
+	selectedLicenses: SelectedLicenseProp[];
+	setSelectedLicenses: ( selectedLicenses: SelectedLicenseProp[] ) => void;
+}

--- a/client/a8c-for-agencies/sections/marketplace/mixins.scss
+++ b/client/a8c-for-agencies/sections/marketplace/mixins.scss
@@ -1,0 +1,52 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+@mixin licensing-portal-bottom-action-bar() {
+	position: fixed;
+	inset-inline: 0;
+	inset-block-end: 0;
+	padding: 0.875rem 0.875rem 1.5rem;
+	background: var(--studio-white);
+	box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.12);
+	z-index: 20;
+
+	.button {
+		width: 100%;
+		padding: 8px 24px;
+		font-size: 1rem;
+		white-space: nowrap;
+	}
+
+	@include breakpoint-deprecated( ">660px" ) {
+		position: static;
+		padding: 0;
+		background: transparent;
+		box-shadow: none;
+
+		.button {
+			width: auto;
+		}
+	}
+}
+
+@mixin licensing-portal-cursor-pagination() {
+	.pagination__list-item.is-right,
+	.pagination__list-item.is-left {
+		opacity: 0.5;
+		pointer-events: none;
+	}
+
+	&--has-prev {
+		.pagination__list-item.is-left {
+			opacity: 1;
+			pointer-events: initial;
+		}
+	}
+
+	&--has-next {
+		.pagination__list-item.is-right {
+			opacity: 1;
+			pointer-events: initial;
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/marketplace/types.ts
+++ b/client/a8c-for-agencies/sections/marketplace/types.ts
@@ -1,4 +1,5 @@
 export interface AssignLicenceProps {
 	siteId?: string;
+	suggestedProduct?: string;
 	quantity?: number;
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-product-card/style.scss
@@ -203,8 +203,8 @@
 }
 
 .license-product-card.selected .license-product-card__select-button {
-	border: 2px solid var(--studio-jetpack-green-50);
-	background: var(--studio-jetpack-green-50);
+	border: 2px solid  var(--color-link);
+	background: var(--color-link);
 }
 
 @mixin license-product-card-block__pricing {
@@ -268,7 +268,7 @@
 	}
 
 	.form-radio:checked::before {
-		background: var(--studio-green-50);
+		background: var(--color-link);
 	}
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/product-price-with-discount-info/style.scss
@@ -18,7 +18,7 @@
 		margin-inline-start: 8px;
 		font-size: 1rem;
 		font-weight: 500;
-		color: var(--studio-jetpack-green-50);
+		color: var(--color-link);
 		text-wrap: nowrap;
 	}
 


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/236

## Proposed Changes

This PR implements a license list view for A4A Marketplace.

## Testing Instructions

Note: The steps are static currently, it doesn't change as of now.

- Switch branch: `git checkout add/a4a-marketplace-products-view`.
- Start the server by running `yarn start-a8c-for-agencies`.
- Click the `Marketplace` menu item > Verify that the page shows the list of products as shown below. Please note you can only select products as of now. The Review Licenses button will be implemented on another PR.

<img width="1570" alt="Screenshot 2024-02-21 at 6 15 43 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/5e2f0c38-884c-4717-b531-00ca0e98d229">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?