### PR TITLE
Delay redirect for logged in users

### DIFF
--- a/client/login/controller.js
+++ b/client/login/controller.js
@@ -122,12 +122,11 @@ export async function login( context, next ) {
 }
 
 export function magicLogin( context, next ) {
-	const { path } = context;
-
 	if ( isUserLoggedIn( context.store.getState() ) ) {
 		return login( context, next );
 	}
 
+	const { path } = context;
 	context.primary = <MagicLogin path={ path } />;
 
 	next();
@@ -148,6 +147,10 @@ function getHandleEmailedLinkFormComponent( flow ) {
 }
 
 export function magicLoginUse( context, next ) {
+	if ( isUserLoggedIn( context.store.getState() ) ) {
+		return login( context, next );
+	}
+
 	/**
 	 * Pull the query arguments out of the URL & into the state.
 	 * It unclutters the address bar & will keep tokens out of tracking pixels.

--- a/client/login/index.node.js
+++ b/client/login/index.node.js
@@ -2,7 +2,6 @@ import config from '@automattic/calypso-config';
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import { makeLayout, setLocaleMiddleware } from 'calypso/controller';
 import webRouter from './index.web';
-// import redirectLoggedIn from './redirect-logged-in';
 
 /**
  * Re-exports
@@ -17,7 +16,6 @@ export default ( router ) => {
 		router(
 			[ `/log-in/link/use/${ lang }`, `/log-in/link/jetpack/use/${ lang }` ],
 			setLocaleMiddleware(),
-			// redirectLoggedIn,
 			makeLayout
 		);
 	}

--- a/client/login/index.node.js
+++ b/client/login/index.node.js
@@ -2,7 +2,7 @@ import config from '@automattic/calypso-config';
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import { makeLayout, setLocaleMiddleware } from 'calypso/controller';
 import webRouter from './index.web';
-import redirectLoggedIn from './redirect-logged-in';
+// import redirectLoggedIn from './redirect-logged-in';
 
 /**
  * Re-exports
@@ -17,7 +17,7 @@ export default ( router ) => {
 		router(
 			[ `/log-in/link/use/${ lang }`, `/log-in/link/jetpack/use/${ lang }` ],
 			setLocaleMiddleware(),
-			redirectLoggedIn,
+			// redirectLoggedIn,
 			makeLayout
 		);
 	}

--- a/client/login/index.web.js
+++ b/client/login/index.web.js
@@ -64,7 +64,6 @@ export default ( router ) => {
 	if ( config.isEnabled( 'login/magic-login' ) ) {
 		router(
 			[ `/log-in/link/use/${ lang }`, `/log-in/jetpack/link/use/${ lang }` ],
-			redirectLoggedIn,
 			setLocaleMiddleware(),
 			setSectionMiddleware( LOGIN_SECTION_DEFINITION ),
 			magicLoginUse,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

We have `/log-in/link` and `/log-in/link/use` routes for magic link — the former we changed to delay redirect when user is logged in already in https://github.com/Automattic/wp-calypso/pull/82366

If you're not logged in, everything works as expected.

## Proposed Changes

* Delay redirect for logged in users

## Testing Instructions

- Be logged in to .com in calypso localhost
- Open a site where you aren't subscriber, and not logged in. Subscribe.
- You'll receive magic login link; you need to use PHP urldecode to ungarble the redirect and replace with Calypso localhost version, .e.g: `http://calypso.localhost:3000/log-in/link/use?token=`
- Open the link — you should get redirected to the site/blog post where you subscribed from. Previously you were left inside calypso.


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?