### PR TITLE
Stats: Add UTM module to post details page

### DIFF
--- a/client/my-sites/stats/stats-module-utm/index.jsx
+++ b/client/my-sites/stats/stats-module-utm/index.jsx
@@ -2,11 +2,14 @@ import StatsModuleDataQuery from '../stats-module/stats-module-data-query';
 import statsStrings from '../stats-strings';
 import { useMockData } from './useMockData';
 
-const StatsModuleUTM = ( { period, query } ) => {
+const StatsModuleUTM = ( { period, postId, query } ) => {
 	const moduleStrings = statsStrings();
 
 	// TODO: Use TanStack for API requests.
 	const { isRequestingData, data } = useMockData();
+
+	// TODO: Hide summary link on summary page too.
+	const hideSummaryLink = postId !== undefined;
 
 	return (
 		<StatsModuleDataQuery
@@ -17,8 +20,8 @@ const StatsModuleUTM = ( { period, query } ) => {
 			moduleStrings={ moduleStrings.utm }
 			period={ period }
 			query={ query }
-			summary={ false }
 			isLoading={ isRequestingData }
+			hideSummaryLink={ hideSummaryLink }
 		/>
 	);
 };

--- a/client/my-sites/stats/stats-module-utm/index.jsx
+++ b/client/my-sites/stats/stats-module-utm/index.jsx
@@ -2,14 +2,13 @@ import StatsModuleDataQuery from '../stats-module/stats-module-data-query';
 import statsStrings from '../stats-strings';
 import { useMockData } from './useMockData';
 
-const StatsModuleUTM = ( { period, postId, query } ) => {
+const StatsModuleUTM = ( { period, postId, query, summary } ) => {
 	const moduleStrings = statsStrings();
 
 	// TODO: Use TanStack for API requests.
 	const { isRequestingData, data } = useMockData( postId );
 
-	// TODO: Hide summary link on summary page too.
-	const hideSummaryLink = postId !== undefined;
+	const hideSummaryLink = postId !== undefined || summary === true;
 
 	return (
 		<StatsModuleDataQuery

--- a/client/my-sites/stats/stats-module-utm/index.jsx
+++ b/client/my-sites/stats/stats-module-utm/index.jsx
@@ -6,7 +6,7 @@ const StatsModuleUTM = ( { period, postId, query } ) => {
 	const moduleStrings = statsStrings();
 
 	// TODO: Use TanStack for API requests.
-	const { isRequestingData, data } = useMockData();
+	const { isRequestingData, data } = useMockData( postId );
 
 	// TODO: Hide summary link on summary page too.
 	const hideSummaryLink = postId !== undefined;

--- a/client/my-sites/stats/stats-module-utm/useMockData.js
+++ b/client/my-sites/stats/stats-module-utm/useMockData.js
@@ -40,26 +40,50 @@ const mockUTMData = [
 	},
 ];
 
-async function fetchMockDataAsync() {
-	const fetchDelay = 4000;
+const mockUTMDataSinglePost = [
+	{
+		source: 'google',
+		medium: 'cpc',
+		label: 'google / cpc',
+		value: 100,
+	},
+	{
+		source: 'bing',
+		medium: 'organic',
+		label: 'bing / organic',
+		value: 50,
+	},
+	{
+		source: 'yahoo',
+		medium: 'organic',
+		label: 'yahoo / organic',
+		value: 25,
+	},
+];
+
+async function fetchMockDataAsync( postId = undefined ) {
+	const fetchDelay = 3000;
 	// Simulate an API request so we can see the loading state.
 	await new Promise( ( r ) => setTimeout( r, fetchDelay ) );
+	if ( postId !== undefined ) {
+		return mockUTMDataSinglePost;
+	}
 	return mockUTMData;
 }
 
-export function useMockData() {
+export function useMockData( postId ) {
 	const [ data, setData ] = useState( null );
 	const [ isRequestingData, setIsRequestingData ] = useState( false );
 
 	useEffect( () => {
 		async function fetchMockData() {
-			const fetchedData = await fetchMockDataAsync();
+			const fetchedData = await fetchMockDataAsync( postId );
 			setIsRequestingData( false );
 			setData( fetchedData );
 		}
 		setIsRequestingData( true );
 		fetchMockData();
-	}, [] );
+	}, [ postId ] );
 
 	return { isRequestingData, data };
 }

--- a/client/my-sites/stats/stats-post-detail/index.jsx
+++ b/client/my-sites/stats/stats-post-detail/index.jsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
@@ -22,6 +23,7 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import PostDetailHighlightsSection from '../post-detail-highlights-section';
 import PostDetailTableSection from '../post-detail-table-section';
 import StatsPlaceholder from '../stats-module/placeholder';
+import StatsModuleUTM from '../stats-module-utm';
 import PageViewTracker from '../stats-page-view-tracker';
 import PostSummary from '../stats-post-summary';
 
@@ -210,6 +212,12 @@ class StatsPostDetail extends Component {
 							<PostSummary siteId={ siteId } postId={ postId } />
 							<PostDetailTableSection siteId={ siteId } postId={ postId } />
 						</>
+					) }
+
+					{ config.isEnabled( 'stats/utm-module' ) && (
+						<div className="stats-module-utm__post-detail">
+							<StatsModuleUTM postId={ postId } />
+						</div>
 					) }
 
 					<JetpackColophon />


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87565.

## Proposed Changes

Adds the UTM module to the Post Detail page like so:

<img width="464" alt="SCR-20240221-oyih" src="https://github.com/Automattic/wp-calypso/assets/40267301/7189a44d-96ac-4428-9ca7-8b9594d8c285">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live site.
* Visit Traffic page and select a post from the "Posts & pages" list.
* Confirm the UTM module loads properly on the detail page.
* Confirm the "View details" link is not present.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?