### PR TITLE
A4A: Add Marketplace product search and filtering functionality.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/constants.ts
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/constants.ts
@@ -1,0 +1,5 @@
+export const PRODUCT_FILTER_ALL = '';
+export const PRODUCT_FILTER_PLANS = 'plans';
+export const PRODUCT_FILTER_PRODUCTS = 'products';
+export const PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS = 'woocommerce-extensions';
+export const PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS = 'vaultpress-backup-addons';

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/index.tsx
@@ -14,8 +14,8 @@ import {
 import useProductAndPlans from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/licenses-form/hooks/use-product-and-plans';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
-import { PRODUCT_FILTER_ALL } from '../constants';
 import IssueLicenseContext from '../context';
+import { PRODUCT_FILTER_ALL } from './constants';
 import ProductFilterSearch from './product-filter-search';
 import ProductFilterSelect from './product-filter-select';
 import LicensesFormSection from './sections';

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/index.tsx
@@ -1,7 +1,7 @@
 // FIXME: Lets decide later if we need to move the calypso/jetpack-cloud imports to a shared common folder.
 import { getQueryArg } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
-import { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import QueryProductsList from 'calypso/components/data/query-products-list';
 import { parseQueryStringProducts } from 'calypso/jetpack-cloud/sections/partner-portal/lib/querystring-products';
 import LicenseMultiProductCard from 'calypso/jetpack-cloud/sections/partner-portal/license-multi-product-card';
@@ -14,14 +14,16 @@ import {
 import useProductAndPlans from 'calypso/jetpack-cloud/sections/partner-portal/primary/issue-license/licenses-form/hooks/use-product-and-plans';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { PRODUCT_FILTER_ALL } from '../constants';
 import IssueLicenseContext from '../context';
+import ProductFilterSearch from './product-filter-search';
+import ProductFilterSelect from './product-filter-select';
 import LicensesFormSection from './sections';
 import type { SelectedLicenseProp } from '../types';
 import type { SiteDetails } from '@automattic/data-stores';
 import type { APIProductFamilyProduct } from 'calypso/state/partner-portal/types';
 
 import './style.scss';
-
 interface LicensesFormProps {
 	selectedSite?: SiteDetails | null;
 	suggestedProduct?: string;
@@ -38,6 +40,12 @@ export default function LicensesForm( {
 
 	const { selectedLicenses, setSelectedLicenses } = useContext( IssueLicenseContext );
 
+	const [ productSearchQuery, setProductSearchQuery ] = useState< string >( '' );
+
+	const [ selectedProductFilter, setSelectedProductFilter ] = useState< string | null >(
+		PRODUCT_FILTER_ALL
+	);
+
 	const {
 		filteredProductsAndBundles,
 		isLoadingProducts,
@@ -48,7 +56,9 @@ export default function LicensesForm( {
 		data,
 	} = useProductAndPlans( {
 		selectedSite,
+		selectedProductFilter,
 		selectedBundleSize: quantity,
+		productSearchQuery,
 		usePublicQuery: true, // FIXME: Fix this when we have the API endpoint for A4A
 	} );
 
@@ -188,6 +198,26 @@ export default function LicensesForm( {
 		[ quantity, selectedLicenses ]
 	);
 
+	const onProductFilterSelect = useCallback(
+		( value: string | null ) => {
+			setSelectedProductFilter( value );
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_marketplace_issue_license_filter_submit', { value } )
+			);
+		},
+		[ dispatch ]
+	);
+
+	const onProductSearch = useCallback(
+		( value: string ) => {
+			setProductSearchQuery( value );
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_marketplace_issue_license_search_submit', { value } )
+			);
+		},
+		[ dispatch ]
+	);
+
 	const onClickVariantOption = useCallback(
 		( product: APIProductFamilyProduct ) => {
 			dispatch(
@@ -196,6 +226,12 @@ export default function LicensesForm( {
 				} )
 			);
 		},
+		[ dispatch ]
+	);
+
+	const trackClickCallback = useCallback(
+		( component: string ) => () =>
+			dispatch( recordTracksEvent( `calypso_a4a_marketplace_issue_license_${ component }_click` ) ),
 		[ dispatch ]
 	);
 
@@ -251,6 +287,19 @@ export default function LicensesForm( {
 	return (
 		<div className="licenses-form">
 			<QueryProductsList currency="USD" />
+
+			<div className="licenses-form__actions">
+				<ProductFilterSearch
+					onProductSearch={ onProductSearch }
+					onClick={ trackClickCallback( 'search' ) }
+				/>
+				<ProductFilterSelect
+					selectedProductFilter={ selectedProductFilter }
+					onProductFilterSelect={ onProductFilterSelect }
+					onClick={ trackClickCallback( 'filter' ) }
+					isSingleLicense={ isSingleLicenseView }
+				/>
+			</div>
 
 			{ plans.length > 0 && (
 				<LicensesFormSection

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/product-filter-search.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/product-filter-search.tsx
@@ -1,0 +1,23 @@
+import { useTranslate } from 'i18n-calypso';
+import Search from 'calypso/components/search';
+
+type Props = {
+	onProductSearch: ( value: string ) => void;
+	onClick?: () => void;
+};
+
+export default function ProductFilterSearch( { onProductSearch, onClick }: Props ) {
+	const translate = useTranslate();
+
+	return (
+		<div className="licenses-form__product-filter-search">
+			<Search
+				onClick={ onClick }
+				onSearch={ onProductSearch }
+				placeholder={ translate( 'Search plans, products, add-ons, and extensions' ) }
+				compact
+				hideFocus
+			/>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/product-filter-select.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/product-filter-select.tsx
@@ -7,7 +7,7 @@ import {
 	PRODUCT_FILTER_PRODUCTS,
 	PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
 	PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
-} from '../constants';
+} from './constants';
 
 type Props = {
 	selectedProductFilter: string | null;

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/product-filter-select.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/product-filter-select.tsx
@@ -1,0 +1,109 @@
+import { SelectDropdown } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect, useMemo } from 'react';
+import {
+	PRODUCT_FILTER_ALL,
+	PRODUCT_FILTER_PLANS,
+	PRODUCT_FILTER_PRODUCTS,
+	PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
+	PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
+} from '../constants';
+
+type Props = {
+	selectedProductFilter: string | null;
+	onClick?: () => void;
+	onProductFilterSelect: ( value: string | null ) => void;
+	isSingleLicense?: boolean;
+};
+
+type Option = {
+	value?: string | null;
+	label: string;
+};
+
+const getOptionByValue = ( options: Option[], value: string | null ): Option => {
+	return options.find( ( option ) => option.value === value ) ?? options[ 0 ];
+};
+
+export default function ProductFilterSelect( {
+	selectedProductFilter,
+	onClick,
+	onProductFilterSelect,
+	isSingleLicense,
+}: Props ) {
+	const translate = useTranslate();
+
+	const productFilterOptions = useMemo< Option[] >( () => {
+		const options = [
+			{
+				value: PRODUCT_FILTER_ALL,
+				label: translate( 'All' ),
+			},
+			{
+				value: PRODUCT_FILTER_PLANS,
+				label: translate( 'Plans' ),
+			},
+			{
+				value: PRODUCT_FILTER_PRODUCTS,
+				label: translate( 'Products' ),
+			},
+		];
+
+		if ( isSingleLicense ) {
+			options.push(
+				{
+					value: PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS,
+					label: translate( 'WooCommerce Extensions' ),
+				},
+				{
+					value: PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS,
+					label: translate( 'VaultPress Backup Add-ons' ),
+				}
+			);
+		}
+
+		return options;
+	}, [ isSingleLicense, translate ] );
+
+	const currentSelectedOption = getOptionByValue( productFilterOptions, selectedProductFilter );
+
+	const selectedText = translate( '{{b}}Products{{/b}}: %(productFilter)s', {
+		args: {
+			productFilter: currentSelectedOption.label as string,
+		},
+		components: {
+			b: <b />,
+		},
+		comment: 'productFilter is the selected filter type.',
+	} );
+
+	const onToggle = useCallback(
+		( { open }: { open: boolean } ) => {
+			if ( open ) {
+				onClick?.();
+			}
+		},
+		[ onClick ]
+	);
+
+	useEffect( () => {
+		if (
+			! isSingleLicense &&
+			( selectedProductFilter === PRODUCT_FILTER_WOOCOMMERCE_EXTENSIONS ||
+				selectedProductFilter === PRODUCT_FILTER_VAULTPRESS_BACKUP_ADDONS )
+		) {
+			onProductFilterSelect( PRODUCT_FILTER_ALL );
+		}
+	}, [ isSingleLicense, onProductFilterSelect, selectedProductFilter ] );
+
+	return (
+		<SelectDropdown
+			className="licenses-form__product-filter-select"
+			selectedText={ selectedText }
+			options={ productFilterOptions }
+			onToggle={ onToggle }
+			onSelect={ ( option: { value: string | null } ) => onProductFilterSelect( option.value ) }
+			compact
+		/>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/style.scss
@@ -146,7 +146,7 @@ p.licenses-form__description {
 				height: 33px;
 			}
 		}
-		margin-bottom: 0;
+		margin-block-end: 0;
 		border: 1px solid var(--color-neutral-10);
 	}
 

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/style.scss
@@ -80,3 +80,79 @@ p.licenses-form__description {
 	gap: 16px;
 	margin: 16px 0 32px;
 }
+
+.select-dropdown.is-compact.licenses-form__product-filter-select {
+	flex-basis: 100%;
+	height: 46px;
+
+	@include break-xlarge {
+		flex-basis: auto;
+	}
+
+	.select-dropdown__header {
+		height: 46px;
+	}
+
+	@include breakpoint-deprecated( ">660px" ) {
+		height: 35px;
+
+		.select-dropdown__header {
+			height: 35px;
+		}
+	}
+
+	.select-dropdown__header-text {
+		font-size: rem(13px);
+		font-weight: 400;
+		color: var(--color-text);
+		padding-inline-end: 8px;
+	}
+
+	.select-dropdown__header-text b {
+		color: var(--color-text);
+	}
+
+	.select-dropdown__container {
+		width: 100%;
+
+		@include break-xlarge {
+			width: auto;
+		}
+	}
+
+	.select-dropdown__item.is-selected {
+		background: var(--color-link-5);
+		color: var(--color-link-dark);
+	}
+
+	.select-dropdown__item:hover {
+		background: var(--color-link-5);
+		color: var(--color-neutral-90);
+	}
+}
+
+.licenses-form__product-filter-search {
+	flex-basis: 100%;
+
+	@include break-xlarge {
+		flex-basis: 360px;
+	}
+
+	.search {
+		&.is-open {
+			height: 46px;
+
+			@include breakpoint-deprecated( ">660px" ) {
+				height: 33px;
+			}
+		}
+		margin-bottom: 0;
+		border: 1px solid var(--color-neutral-10);
+	}
+
+	.search__input.form-text-input[type="search"] {
+		font-size: rem(13px);
+		font-weight: 400;
+		color: var(--color-text);
+	}
+}


### PR DESCRIPTION
This pull request brings the product search and filtering functionality from the Jetpack Manage pricing page to the A4A Marketplace.

<img width="823" alt="Screenshot 2024-02-21 at 5 36 45 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/86b9b215-7284-46c5-97ed-7af7a90e7ada">


Closes https://github.com/Automattic/jetpack-genesis/issues/235
Depends on https://github.com/Automattic/wp-calypso/pull/87703

## Proposed Changes

* Copy search and filter component implementation from the Jetpack Manage pricing page.

## Testing Instructions

* Switch branch: `git checkout add/a4a-marketplace-product-filtering`
* Start the server by running `yarn start-a8c-for-agencies`.
* Click the Marketplace menu item > Verify that the page shows the marketplace.
* Confirm that the product search and filtering functionality works.

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?