### PR TITLE
Global sidebar: Update scroll behavior

### DIFF
--- a/client/layout/global-sidebar/index.jsx
+++ b/client/layout/global-sidebar/index.jsx
@@ -35,13 +35,9 @@ const GlobalSidebar = ( { children, onClick = undefined, className = '', ...prop
 	}, [] );
 
 	useEffect( () => {
-		if ( ! wrapperRef.current ) {
-			return;
-		}
-
-		wrapperRef.current.addEventListener( 'wheel', handleWheel, { passive: false } );
+		wrapperRef.current?.addEventListener( 'wheel', handleWheel, { passive: false } );
 		return () => {
-			wrapperRef.current.removeEventListener( 'wheel', handleWheel );
+			wrapperRef.current?.removeEventListener( 'wheel', handleWheel );
 		};
 	}, [ handleWheel ] );
 

--- a/client/layout/global-sidebar/index.jsx
+++ b/client/layout/global-sidebar/index.jsx
@@ -28,9 +28,10 @@ const GlobalSidebar = ( { children, onClick = undefined, className = '', ...prop
 	} );
 
 	const handleWheel = useCallback( ( event ) => {
-		if ( bodyRef.current?.contains( event.target ) ) {
+		const bodyEl = bodyRef.current;
+		if ( bodyEl && bodyEl.contains( event.target ) && bodyEl.scrollHeight > bodyEl.clientHeight ) {
 			event.preventDefault();
-			bodyRef.current.scrollTop += event.deltaY;
+			bodyEl.scrollTop += event.deltaY;
 		}
 	}, [] );
 

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -4,13 +4,10 @@
 $brand-text: "SF Pro Text", $sans;
 .global-sidebar {
 	bottom: 0;
-	contain: content;
 	display: flex;
 	flex-direction: column;
 	left: 0;
 	height: 100%;
-	overflow-y: auto;
-	overscroll-behavior: contain;
 	position: relative;
 	top: 0;
 	transition: all 220ms ease-out;
@@ -106,6 +103,7 @@ $brand-text: "SF Pro Text", $sans;
 		@include custom-scrollbars-on-hover(transparent, $gray-600);
 		flex: 1;
 		overflow-y: auto;
+
 
 		.sidebar,
 		.sidebar__menu:not(.is-togglable) {

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -1,12 +1,16 @@
+@import "@wordpress/base-styles/mixins";
 @import "@wordpress/base-styles/variables";
 @import "@automattic/typography/styles/variables";
 $brand-text: "SF Pro Text", $sans;
 .global-sidebar {
 	bottom: 0;
+	contain: content;
 	display: flex;
 	flex-direction: column;
 	left: 0;
 	height: 100%;
+	overflow-y: auto;
+	overscroll-behavior: contain;
 	position: relative;
 	top: 0;
 	transition: all 220ms ease-out;
@@ -99,13 +103,9 @@ $brand-text: "SF Pro Text", $sans;
 	}
 
 	.sidebar__body {
+		@include custom-scrollbars-on-hover(transparent, $gray-600);
 		flex: 1;
 		overflow-y: auto;
-
-		scrollbar-width: none;
-		&::-webkit-scrollbar {
-			display: none;
-		}
 
 		.sidebar,
 		.sidebar__menu:not(.is-togglable) {

--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -52,7 +52,7 @@ import {
 } from 'calypso/state/ui/selectors';
 import BodySectionCssClass from './body-section-css-class';
 import LayoutLoader from './loader';
-import { handleScroll, handleScrollGlobalSidebar } from './utils';
+import { handleScroll } from './utils';
 
 // goofy import for environment badge, which is SSR'd
 import 'calypso/components/environment-badge/style.scss';
@@ -68,35 +68,27 @@ import './style.scss';
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
-function SidebarScrollSynchronizer( { isGlobalSidebarOrGlobalSiteSidebar } ) {
+function SidebarScrollSynchronizer() {
 	const isNarrow = useBreakpoint( '<660px' );
 	const active = ! isNarrow && ! config.isEnabled( 'jetpack-cloud' ); // Jetpack cloud hasn't yet aligned with WPCOM.
 
 	useEffect( () => {
 		if ( active ) {
-			if ( isGlobalSidebarOrGlobalSiteSidebar ) {
-				window.addEventListener( 'scroll', handleScrollGlobalSidebar );
-			} else {
-				window.addEventListener( 'scroll', handleScroll );
-				window.addEventListener( 'resize', handleScroll );
-			}
+			window.addEventListener( 'scroll', handleScroll );
+			window.addEventListener( 'resize', handleScroll );
 		}
 
 		return () => {
 			if ( active ) {
-				if ( isGlobalSidebarOrGlobalSiteSidebar ) {
-					window.removeEventListener( 'scroll', handleScrollGlobalSidebar );
-				} else {
-					window.removeEventListener( 'scroll', handleScroll );
-					window.removeEventListener( 'resize', handleScroll );
-				}
+				window.removeEventListener( 'scroll', handleScroll );
+				window.removeEventListener( 'resize', handleScroll );
 
 				// remove style attributes added by `handleScroll`
 				document.getElementById( 'content' )?.removeAttribute( 'style' );
 				document.getElementById( 'secondary' )?.removeAttribute( 'style' );
 			}
 		};
-	}, [ active, isGlobalSidebarOrGlobalSiteSidebar ] );
+	}, [ active ] );
 
 	return null;
 }
@@ -279,6 +271,9 @@ class Layout extends Component {
 				shouldLoadInlineHelp( this.props.sectionName, this.props.currentRoute ) ) &&
 			this.props.userAllowedToHelpCenter;
 
+		const shouldDisableSidebarScrollSynchronizer =
+			this.props.isGlobalSidebarVisible || this.props.isGlobalSiteSidebarVisible;
+
 		return (
 			<div className={ sectionClass }>
 				<HelpCenterLoader
@@ -286,12 +281,9 @@ class Layout extends Component {
 					loadHelpCenter={ loadHelpCenter }
 					currentRoute={ this.props.currentRoute }
 				/>
-				<SidebarScrollSynchronizer
-					layoutFocus={ this.props.currentLayoutFocus }
-					isGlobalSidebarOrGlobalSiteSidebar={
-						this.props.isGlobalSidebarVisible || this.props.isGlobalSiteSidebarVisible
-					}
-				/>
+				{ ! shouldDisableSidebarScrollSynchronizer && (
+					<SidebarScrollSynchronizer layoutFocus={ this.props.currentLayoutFocus } />
+				) }
 				<SidebarOverflowDelay layoutFocus={ this.props.currentLayoutFocus } />
 				<BodySectionCssClass
 					layoutFocus={ this.props.currentLayoutFocus }

--- a/client/layout/utils.ts
+++ b/client/layout/utils.ts
@@ -140,21 +140,3 @@ export const handleScroll = ( event: React.UIEvent< HTMLElement > ): void => {
 		ticking = true;
 	}
 };
-
-export const handleScrollGlobalSidebar = ( event: Event ): void => {
-	const globalSidebarBodyEl = document.querySelector( '.global-sidebar .sidebar__body' );
-	if ( ! globalSidebarBodyEl ) {
-		return;
-	}
-
-	if ( ! globalSidebarBodyEl.hasAttribute( 'data-scroll-initialized' ) ) {
-		globalSidebarBodyEl.setAttribute( 'data-scroll-initialized', 'true' );
-		globalSidebarBodyEl.addEventListener( 'scroll', handleScrollGlobalSidebar );
-	}
-
-	if ( event.currentTarget === globalSidebarBodyEl ) {
-		document.documentElement.scrollTop = globalSidebarBodyEl.scrollTop;
-	} else {
-		globalSidebarBodyEl.scrollTop = scrollY;
-	}
-};


### PR DESCRIPTION
## Proposed Changes

This PR updates the global sidebar scrolling behavior so that it's independent of the scrolling of the right-side content.
See recording for reference:

https://github.com/Automattic/wp-calypso/assets/797888/e6d553be-5cb9-47d7-9d25-bf3da33dd263

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that the global sidebar scrolling is independent of the one in the right-side content.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?