### PR TITLE
Continue with GitHub: E2E test for login flow

### DIFF
--- a/packages/calypso-e2e/src/lib/pages/external/github-login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/external/github-login-page.ts
@@ -1,0 +1,106 @@
+import { Page } from 'playwright';
+
+const selectors = {
+	// General
+	buttonContainingText: ( text: string ) => `button:has-text("${ text }")`,
+	buttonWithExactText: ( text: string ) => `button:text-is("${ text }")`,
+
+	// Inputs
+	emailInput: 'input[id="login_field"]',
+	passwordInput: 'input[id="password"]',
+	otpInput: 'input[id="app_totp"]',
+
+	// Button
+	submitFormButton: 'input[type="submit"][name="commit"]',
+	authorizeFormButton:
+		'button#js-oauth-authorize-btn[type="submit"][name="authorize"]:not(:disabled)',
+};
+
+/**
+ * Represents the login screens shown by GitHub.
+ */
+export class GitHubLoginPage {
+	/**
+	 * Construct and instance of the GitHubLoginPage.
+	 *
+	 * @param {Page} page Handler for instance of the Google login page.
+	 */
+	constructor( private page: Page ) {}
+
+	/**
+	 * Press enter to proceed to the next login step.
+	 */
+	async pressEnter(): Promise< void > {
+		await this.page.keyboard.press( 'Enter' );
+	}
+
+	/**
+	 * Clicks on a button containing a string of text.
+	 *
+	 * @param {string} text Text on the button.
+	 */
+	async clickButtonContainingText( text: string ): Promise< void > {
+		const locator = this.page.locator( selectors.buttonContainingText( text ) );
+		await locator.click();
+	}
+
+	/**
+	 * Clicks on a button with the **exact** text.
+	 *
+	 * @param {string} text Text on the button.
+	 */
+	async clickButtonWithExactText( text: string ): Promise< void > {
+		const locator = this.page.locator( selectors.buttonWithExactText( text ) );
+		await locator.click();
+	}
+
+	/**
+	 * Fills the Apple ID username/email field.
+	 *
+	 * @param {string} email Username (Apple ID) of the user.
+	 */
+	async enterEmail( email: string ): Promise< void > {
+		const locator = this.page.locator( selectors.emailInput );
+		await locator.fill( email );
+	}
+
+	/**
+	 * Fills the password field.
+	 *
+	 * @param {string} password Password of the user.
+	 */
+	async enterPassword( password: string ): Promise< void > {
+		const locator = this.page.locator( selectors.passwordInput );
+		await locator.type( password );
+	}
+
+	/**
+	 * Clicks the submit button, e.g. for the login form.
+	 */
+	async clickSubmit(): Promise< void > {
+		const buttonLocator = this.page.locator( selectors.submitFormButton );
+		await buttonLocator.waitFor();
+		await buttonLocator.click();
+	}
+
+	/**
+	 * Clicks the authorize button, e.g. for the permissions form.
+	 */
+	async tryToClickAuthorize(): Promise< void > {
+		const buttonLocator = this.page.locator( selectors.authorizeFormButton );
+		await buttonLocator.waitFor( { timeout: 2000 } );
+		await buttonLocator.click();
+	}
+
+	/* 2FA */
+
+	/**
+	 * Fills the 2FA code.
+	 *
+	 * @param {string} code 2FA code for the user.
+	 */
+	async enter2FACode( code: string ): Promise< void > {
+		const locator = this.page.locator( selectors.otpInput ).first();
+		await locator.type( code, { delay: 150 } );
+	}
+}

--- a/packages/calypso-e2e/src/lib/pages/external/github-login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/external/github-login-page.ts
@@ -23,7 +23,7 @@ export class GitHubLoginPage {
 	/**
 	 * Construct and instance of the GitHubLoginPage.
 	 *
-	 * @param {Page} page Handler for instance of the Google login page.
+	 * @param {Page} page Handler for instance of the GitHub login page.
 	 */
 	constructor( private page: Page ) {}
 
@@ -55,9 +55,9 @@ export class GitHubLoginPage {
 	}
 
 	/**
-	 * Fills the Apple ID username/email field.
+	 * Fills the GitHub username/email field.
 	 *
-	 * @param {string} email Username (Apple ID) of the user.
+	 * @param {string} email Username of the user.
 	 */
 	async enterEmail( email: string ): Promise< void > {
 		const locator = this.page.locator( selectors.emailInput );
@@ -90,17 +90,5 @@ export class GitHubLoginPage {
 		const buttonLocator = this.page.locator( selectors.authorizeFormButton );
 		await buttonLocator.waitFor( { timeout: 2000 } );
 		await buttonLocator.click();
-	}
-
-	/* 2FA */
-
-	/**
-	 * Fills the 2FA code.
-	 *
-	 * @param {string} code 2FA code for the user.
-	 */
-	async enter2FACode( code: string ): Promise< void > {
-		const locator = this.page.locator( selectors.otpInput ).first();
-		await locator.type( code, { delay: 150 } );
 	}
 }

--- a/packages/calypso-e2e/src/lib/pages/external/index.ts
+++ b/packages/calypso-e2e/src/lib/pages/external/index.ts
@@ -1,2 +1,3 @@
 export * from './apple-login-page';
+export * from './github-login-page';
 export * from './google-login-page';

--- a/packages/calypso-e2e/src/lib/pages/login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/login-page.ts
@@ -31,7 +31,7 @@ export class LoginPage {
 				status: 200,
 			} );
 		} );
-		return await this.page.goto( getCalypsoURL( targetUrl ), { timeout: 90000 } );
+		return await this.page.goto( getCalypsoURL( targetUrl ) );
 	}
 
 	/**

--- a/packages/calypso-e2e/src/lib/pages/login-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/login-page.ts
@@ -31,7 +31,7 @@ export class LoginPage {
 				status: 200,
 			} );
 		} );
-		return await this.page.goto( getCalypsoURL( targetUrl ) );
+		return await this.page.goto( getCalypsoURL( targetUrl ), { timeout: 90000 } );
 	}
 
 	/**
@@ -122,6 +122,16 @@ export class LoginPage {
 		const locator = await this.page.locator( ':text-is("Continue with Apple")' );
 		await locator.click();
 
+		return locator;
+	}
+
+	/**
+	 * Clicks the "Continue with GitHub" link.
+	 */
+	async clickLoginWithGitHub(): Promise< Locator > {
+		const locator = await this.page.locator( ':text-is("Continue with GitHub")' );
+		await locator.waitFor();
+		await locator.click();
 		return locator;
 	}
 

--- a/packages/calypso-e2e/src/secrets/secrets-manager.ts
+++ b/packages/calypso-e2e/src/secrets/secrets-manager.ts
@@ -37,6 +37,7 @@ export const TEST_ACCOUNT_NAMES = [
 	'notificationsUser',
 	'googleLoginUser',
 	'appleLoginUser',
+	'gitHubLoginUser',
 	'jetpackAtomicDefaultUser',
 	'jetpackAtomicPhpOldUser',
 	'jetpackAtomicPhpNewUser',
@@ -237,6 +238,9 @@ export class SecretsManager {
 					totpKey: 'FAKE_VALUE',
 				},
 				appleLoginUser: {
+					...fakeAccount,
+				},
+				gitHubLoginUser: {
 					...fakeAccount,
 				},
 				jetpackAtomicDefaultUser: {

--- a/test/e2e/specs/authentication/authentication__github.ts
+++ b/test/e2e/specs/authentication/authentication__github.ts
@@ -24,7 +24,7 @@ describe( DataHelper.createSuiteTitle( 'Authentication: GitHub' ), function () {
 		} );
 
 		it( 'Click on Login with GitHub button', async function () {
-			// Without a short delay, the click might not work.
+			// Without a short delay, the click does not work.
 			await new Promise( ( resolve ) => setTimeout( resolve, 500 ) );
 
 			await Promise.all( [
@@ -74,7 +74,7 @@ describe( DataHelper.createSuiteTitle( 'Authentication: GitHub' ), function () {
 		} );
 
 		it( 'Click on Login with GitHub button', async function () {
-			// Without a short delay, the click might not work.
+			// Without a short delay, the click does not work.
 			await new Promise( ( resolve ) => setTimeout( resolve, 500 ) );
 
 			await Promise.all( [

--- a/test/e2e/specs/authentication/authentication__github.ts
+++ b/test/e2e/specs/authentication/authentication__github.ts
@@ -1,0 +1,113 @@
+/**
+ * @group authentication
+ */
+
+import { DataHelper, LoginPage, SecretsManager, GitHubLoginPage } from '@automattic/calypso-e2e';
+import { Page, Browser } from 'playwright';
+
+declare const browser: Browser;
+
+describe( DataHelper.createSuiteTitle( 'Authentication: GitHub' ), function () {
+	const credentials = SecretsManager.secrets.testAccounts.gitHubLoginUser;
+	let page: Page;
+	let loginPage: LoginPage;
+	let gitHubLoginPage: GitHubLoginPage;
+
+	describe( 'WordPress.com', function () {
+		beforeAll( async () => {
+			page = await browser.newPage();
+		} );
+
+		it( 'Navigate to Login page', async function () {
+			loginPage = new LoginPage( page );
+			await loginPage.visit();
+		} );
+
+		it( 'Click on Login with GitHub button', async function () {
+			// Without a short delay, the click might not work.
+			await new Promise( ( resolve ) => setTimeout( resolve, 500 ) );
+
+			await Promise.all( [
+				page.waitForNavigation( { url: /.github.com.*/ } ),
+				loginPage.clickLoginWithGitHub(),
+			] );
+		} );
+
+		it( 'Enter email', async function () {
+			gitHubLoginPage = new GitHubLoginPage( page );
+			await gitHubLoginPage.enterEmail( credentials.email as string );
+		} );
+
+		it( 'Enter password', async function () {
+			await gitHubLoginPage.enterPassword( credentials.password );
+		} );
+
+		it( 'Click submit', async function () {
+			await gitHubLoginPage.clickSubmit();
+		} );
+
+		it( 'Authorize permissions', async function () {
+			try {
+				await gitHubLoginPage.tryToClickAuthorize();
+			} catch ( error ) {}
+		} );
+
+		it( 'Confirm login with GitHub', async function () {
+			await Promise.all( [ page.waitForNavigation( { url: /.*\/sites/ } ) ] );
+		} );
+
+		afterAll( async () => {
+			await page.close();
+		} );
+	} );
+
+	describe( 'WooCommerce', function () {
+		beforeAll( async () => {
+			page = await browser.newPage();
+		} );
+
+		it( 'Navigate to Login page', async function () {
+			loginPage = new LoginPage( page );
+			await loginPage.visit( {
+				path: SecretsManager.secrets.wooLoginPath,
+			} );
+		} );
+
+		it( 'Click on Login with GitHub button', async function () {
+			// Without a short delay, the click might not work.
+			await new Promise( ( resolve ) => setTimeout( resolve, 500 ) );
+
+			await Promise.all( [
+				page.waitForNavigation( { url: /.github.com.*/ } ),
+				loginPage.clickLoginWithGitHub(),
+			] );
+		} );
+
+		it( 'Enter email', async function () {
+			gitHubLoginPage = new GitHubLoginPage( page );
+			await gitHubLoginPage.enterEmail( credentials.email as string );
+		} );
+
+		it( 'Enter password', async function () {
+			await gitHubLoginPage.enterPassword( credentials.password );
+		} );
+
+		it( 'Click submit', async function () {
+			await gitHubLoginPage.clickSubmit();
+		} );
+
+		it( 'Authorize permissions', async function () {
+			try {
+				await gitHubLoginPage.tryToClickAuthorize();
+			} catch ( error ) {}
+		} );
+
+		it( 'Confirm login with GitHub', async function () {
+			await Promise.all( [ page.waitForNavigation( { url: /.*\/sites/ } ) ] );
+		} );
+
+		afterAll( async () => {
+			await page.close();
+		} );
+	} );
+} );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/87211

## Proposed Changes

Adds E2E tests to test the login flow.


## Testing Instructions

1. Apply PR
2. Decrypt the secrets: PCYsg-vnR-p2 
3. Build the tests ` yarn workspace wp-e2e-tests build --watch`
4. Run the GitHub test: ` CALYPSO_BASE_URL=http://calypso.localhost:3000 yarn workspace wp-e2e-tests test -- specs/authentication/authentication__github.ts`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?