### PR TITLE
Add auto-renew coupon details to purchase meta

### DIFF
--- a/client/me/purchases/manage-purchase/purchase-meta-auto-renew-coupon-detail.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-auto-renew-coupon-detail.tsx
@@ -1,0 +1,39 @@
+import { useTranslate } from 'i18n-calypso';
+import type { Purchase } from 'calypso/lib/purchases/types';
+import type { ReactNode } from 'react';
+
+function PurchaseMetaAutoRenewCouponDetail( {
+	purchase,
+}: {
+	purchase: Purchase;
+} ): JSX.Element | null {
+	const translate = useTranslate();
+
+	if ( ! purchase.autoRenewCouponDiscount || ! purchase.autoRenewCouponCode ) {
+		return null;
+	}
+
+	return (
+		<RenewalSubtext
+			text={ translate(
+				'Your renewal will automatically apply coupon code "%(code)s" for %(discount)s%% discount.',
+				{
+					args: {
+						discount: purchase.autoRenewCouponDiscount,
+						code: purchase.autoRenewCouponCode,
+					},
+				}
+			) }
+		/>
+	);
+}
+
+function RenewalSubtext( { text }: { text: ReactNode } ): JSX.Element {
+	return (
+		<>
+			<br /> <br /> <> { text } </>{ ' ' }
+		</>
+	);
+}
+
+export default PurchaseMetaAutoRenewCouponDetail;

--- a/client/me/purchases/manage-purchase/purchase-meta-auto-renew-coupon-detail.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-auto-renew-coupon-detail.tsx
@@ -16,7 +16,7 @@ function PurchaseMetaAutoRenewCouponDetail( {
 	return (
 		<RenewalSubtext
 			text={ translate(
-				'Your renewal will automatically apply coupon code "%(code)s" for %(discount)s%% discount.',
+				'Coupon code "%(code)s" has been applied for the next renewal for a %(discount)s%% discount.',
 				{
 					args: {
 						discount: purchase.autoRenewCouponDiscount,

--- a/client/me/purchases/manage-purchase/purchase-meta-auto-renew-coupon-detail.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta-auto-renew-coupon-detail.tsx
@@ -1,6 +1,10 @@
+import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import type { Purchase } from 'calypso/lib/purchases/types';
-import type { ReactNode } from 'react';
+
+const RenewalSubtext = styled.div`
+	margin-top: 1em;
+`;
 
 function PurchaseMetaAutoRenewCouponDetail( {
 	purchase,
@@ -9,30 +13,22 @@ function PurchaseMetaAutoRenewCouponDetail( {
 } ): JSX.Element | null {
 	const translate = useTranslate();
 
-	if ( ! purchase.autoRenewCouponDiscount || ! purchase.autoRenewCouponCode ) {
+	if ( ! purchase.autoRenewCouponDiscountPercentage || ! purchase.autoRenewCouponCode ) {
 		return null;
 	}
 
 	return (
-		<RenewalSubtext
-			text={ translate(
-				'Coupon code "%(code)s" has been applied for the next renewal for a %(discount)s%% discount.',
+		<RenewalSubtext>
+			{ translate(
+				'Coupon code "%(code)s" has been applied for the next renewal for a %(discount)d%% discount.',
 				{
 					args: {
-						discount: purchase.autoRenewCouponDiscount,
+						discount: purchase.autoRenewCouponDiscountPercentage,
 						code: purchase.autoRenewCouponCode,
 					},
 				}
 			) }
-		/>
-	);
-}
-
-function RenewalSubtext( { text }: { text: ReactNode } ): JSX.Element {
-	return (
-		<>
-			<br /> <br /> <> { text } </>{ ' ' }
-		</>
+		</RenewalSubtext>
 	);
 }
 

--- a/client/me/purchases/manage-purchase/purchase-meta.tsx
+++ b/client/me/purchases/manage-purchase/purchase-meta.tsx
@@ -29,6 +29,7 @@ import { getByPurchaseId } from 'calypso/state/purchases/selectors';
 import { getSite, isRequestingSites } from 'calypso/state/sites/selectors';
 import { managePurchase } from '../paths';
 import { isAkismetTemporarySitePurchase, isTemporarySitePurchase } from '../utils';
+import PurchaseMetaAutoRenewCouponDetail from './purchase-meta-auto-renew-coupon-detail';
 import PurchaseMetaExpiration from './purchase-meta-expiration';
 import PurchaseMetaIntroductoryOfferDetail from './purchase-meta-introductory-offer-detail';
 import PurchaseMetaOwner from './purchase-meta-owner';
@@ -115,6 +116,7 @@ export default function PurchaseMeta( {
 					<span>
 						<abbr title={ excludeTaxStringTitle }>{ excludeTaxStringAbbreviation }</abbr>
 					</span>
+					<PurchaseMetaAutoRenewCouponDetail purchase={ purchase } />
 				</li>
 				<PurchaseMetaExpiration
 					purchase={ purchase }

--- a/client/me/purchases/manage-purchase/test/purchase-meta.js
+++ b/client/me/purchases/manage-purchase/test/purchase-meta.js
@@ -363,4 +363,50 @@ describe( 'PurchaseMeta', () => {
 
 		expect( screen.getByText( /Never Expires/ ) ).toBeInTheDocument();
 	} );
+
+	it( 'does render auto renew coupon details in the price column when a auto renew coupon has been applied', () => {
+		const store = createReduxStore(
+			{
+				purchases: {
+					data: [
+						{
+							ID: 1,
+							product_slug: 'business-bundle-3y',
+							bill_period_days: 1095,
+							auto_renew_coupon_code: 'test',
+							auto_renew_coupon_discount_percentage: 10,
+						},
+					],
+				},
+				sites: {
+					requestingAll: false,
+				},
+				currentUser: {
+					id: 1,
+					user: {
+						primary_blog: 'example',
+					},
+				},
+			},
+			( state ) => state
+		);
+		render(
+			<QueryClientProvider client={ queryClient }>
+				<ReduxProvider store={ store }>
+					<PurchaseMeta
+						hasLoadedPurchasesFromServer={ true }
+						purchaseId={ 1 }
+						siteSlug="test"
+						isDataLoading={ false }
+					/>
+				</ReduxProvider>
+			</QueryClientProvider>
+		);
+
+		expect(
+			screen.getByText(
+				'Coupon code "test" has been applied for the next renewal for a 10% discount.'
+			)
+		).toBeInTheDocument();
+	} );
 } );

--- a/client/state/purchases/test/selectors.js
+++ b/client/state/purchases/test/selectors.js
@@ -78,6 +78,8 @@ describe( 'selectors', () => {
 				active: false,
 				amount: NaN,
 				attachedToPurchaseId: NaN,
+				autoRenewCouponCode: undefined,
+				autoRenewCouponDiscountPercentage: NaN,
 				billPeriodDays: NaN,
 				billPeriodLabel: undefined,
 				blogCreatedDate: undefined,

--- a/packages/data-stores/src/purchases/lib/assembler.ts
+++ b/packages/data-stores/src/purchases/lib/assembler.ts
@@ -8,7 +8,7 @@ export function createPurchaseObject( purchase: RawPurchase | RawPurchaseCreditC
 		amount: Number( purchase.amount ),
 		attachedToPurchaseId: Number( purchase.attached_to_purchase_id ),
 		autoRenewCouponCode: purchase.auto_renew_coupon_code,
-		autoRenewCouponDiscount: purchase.auto_renew_coupon_discount,
+		autoRenewCouponDiscountPercentage: Number( purchase.auto_renew_coupon_discount_percentage ),
 		billPeriodDays: Number( purchase.bill_period_days ),
 		billPeriodLabel: purchase.bill_period_label,
 		mostRecentRenewDate: purchase.most_recent_renew_date,

--- a/packages/data-stores/src/purchases/lib/assembler.ts
+++ b/packages/data-stores/src/purchases/lib/assembler.ts
@@ -7,6 +7,8 @@ export function createPurchaseObject( purchase: RawPurchase | RawPurchaseCreditC
 		active: Boolean( purchase.active ),
 		amount: Number( purchase.amount ),
 		attachedToPurchaseId: Number( purchase.attached_to_purchase_id ),
+		autoRenewCouponCode: purchase.auto_renew_coupon_code,
+		autoRenewCouponDiscount: purchase.auto_renew_coupon_discount,
 		billPeriodDays: Number( purchase.bill_period_days ),
 		billPeriodLabel: purchase.bill_period_label,
 		mostRecentRenewDate: purchase.most_recent_renew_date,

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -144,8 +144,8 @@ export interface Purchase {
 	taxAmount: number | string | undefined;
 	taxText: string | undefined;
 
-	autoRenewCouponCode?: string;
-	autoRenewCouponDiscount?: string;
+	autoRenewCouponCode: string | null;
+	autoRenewCouponDiscount: string | null;
 }
 
 export interface PurchasePriceTier {
@@ -167,8 +167,8 @@ export interface RawPurchase {
 	active: boolean;
 	amount: number | string;
 	attached_to_purchase_id: number | string;
-	auto_renew_coupon_code?: string;
-	auto_renew_coupon_discount?: string;
+	auto_renew_coupon_code: string | null;
+	auto_renew_coupon_discount: string | null;
 	bill_period_days: number | string;
 	bill_period_label: string;
 	most_recent_renew_date: string;

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -143,6 +143,9 @@ export interface Purchase {
 	tagLine: string;
 	taxAmount: number | string | undefined;
 	taxText: string | undefined;
+
+	autoRenewCouponCode?: string;
+	autoRenewCouponDiscount?: string;
 }
 
 export interface PurchasePriceTier {
@@ -164,6 +167,8 @@ export interface RawPurchase {
 	active: boolean;
 	amount: number | string;
 	attached_to_purchase_id: number | string;
+	auto_renew_coupon_code?: string;
+	auto_renew_coupon_discount?: string;
 	bill_period_days: number | string;
 	bill_period_label: string;
 	most_recent_renew_date: string;

--- a/packages/data-stores/src/purchases/types.ts
+++ b/packages/data-stores/src/purchases/types.ts
@@ -144,8 +144,15 @@ export interface Purchase {
 	taxAmount: number | string | undefined;
 	taxText: string | undefined;
 
+	/**
+	 * The coupon code that will automatically apply on the next renewal.
+	 */
 	autoRenewCouponCode: string | null;
-	autoRenewCouponDiscount: string | null;
+	/**
+	 * The discount percentage applied automatically by the coupon on the next renewal.
+	 * Example: If the discount is 10%, this will have the value `10`.
+	 */
+	autoRenewCouponDiscountPercentage: number | null;
 }
 
 export interface PurchasePriceTier {
@@ -168,7 +175,7 @@ export interface RawPurchase {
 	amount: number | string;
 	attached_to_purchase_id: number | string;
 	auto_renew_coupon_code: string | null;
-	auto_renew_coupon_discount: string | null;
+	auto_renew_coupon_discount_percentage: number | null;
 	bill_period_days: number | string;
 	bill_period_label: string;
 	most_recent_renew_date: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/martech/issues/2739

## Proposed Changes

* Shows auto-renew coupon details if it exists on the purchase object. Please see D139122-code for more details.
<img width="1173" alt="image" src="https://github.com/Automattic/wp-calypso/assets/5436027/89d0829a-0dab-41ec-a519-a89b83b63181">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Follow test instructions in D139122-code

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?