### PR TITLE
Stepper: Fix the import goal so we don't show untranslated content

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/goals/goals.tsx
@@ -1,5 +1,6 @@
 import { Onboard } from '@automattic/data-stores';
 import { useLocale, englishLocales } from '@automattic/i18n-utils';
+import { useI18n } from '@wordpress/react-i18n';
 import { useTranslate } from 'i18n-calypso';
 import type { Goal } from './types';
 
@@ -46,8 +47,22 @@ const useBBEGoal = () => {
 
 export const useGoals = (): Goal[] => {
 	const translate = useTranslate();
+	const { hasTranslation } = useI18n();
 	const locale = useLocale();
 	const builtByExpressGoalDisplayText = useBBEGoal();
+
+	const importDisplayText = () => {
+		// New copy waiting on translation.
+		if (
+			englishLocales.includes( translate?.localeSlug || '' ) ||
+			hasTranslation( 'Import existing content or website' )
+		) {
+			return translate( 'Import existing content or website' );
+		}
+
+		// Original copy
+		return translate( 'Import my existing website content' );
+	};
 
 	const goals = [
 		{
@@ -69,7 +84,7 @@ export const useGoals = (): Goal[] => {
 		},
 		{
 			key: SiteGoal.Import,
-			title: translate( 'Import or migrate my existing website' ),
+			title: importDisplayText(),
 		},
 		{
 			key: SiteGoal.Other,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #87655

## Proposed Changes

We were accidentally displaying new untranslated copy in all locales. This updates so that we fall back to the original copy in the event that we don't have a translation and the `onboarding/new-migration-flow` isn't enabled.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch locally or use the calypso.live link.
* Go to `/start` and proceed to the "Goals" step.
* Using the `en` locale, add the `&flags=onboarding/new-migration-flow` to the url.
* The import goal copy should read "Import existing content or website".
* Switch your WordPress.com account to a different locale (I tested `es`).
* Refresh the goals page and the copy should read "Import my existing website content". (you may or may not see the translated copy).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
