### PR TITLE
Global sidebar - update elements for a11y focus styles

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -57,6 +57,10 @@ $brand-text: "SF Pro Text", $sans;
 		}
 	}
 
+	.sidebar__item {
+		border-radius: 2px;
+	}
+
 	.sidebar__header {
 		align-items: center;
 		display: flex;
@@ -86,6 +90,10 @@ $brand-text: "SF Pro Text", $sans;
 			background-repeat: no-repeat;
 			background-position: center;
 			width: 125px;
+		}
+
+		.link-logo {
+			border-radius: 2px;
 		}
 
 		.sidebar__item-search {
@@ -150,6 +158,7 @@ $brand-text: "SF Pro Text", $sans;
 		.sidebar__footer-link {
 			display: flex;
 			align-items: center;
+			border-radius: 2px;
 		}
 		.sidebar__item-help {
 			display: flex;
@@ -248,10 +257,11 @@ $brand-text: "SF Pro Text", $sans;
 		flex: unset;
 		padding: 0;
 		margin: 16px 12px;
-		border-radius: 4px;
+		border-radius: 2px;
 
 		a.site__content {
 			padding: 12px;
+			border-radius: 2px;
 		}
 		&.is-selected,
 		&:hover {

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -122,6 +122,12 @@ $brand-text: "SF Pro Text", $sans;
 			flex-direction: column;
 		}
 
+		.sidebar {
+			&:first-child {
+				margin-top: 4px;
+			}
+		}
+
 		li.sidebar__separator {
 			margin: 0 0 24px;
 		}

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -189,6 +189,7 @@ $brand-text: "SF Pro Text", $sans;
 			height: 16px;
 			padding: 8px 0;
 			font-size: $font-body-small;
+			border-radius: 2px;
 
 			svg {
 				&.wpicon {

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -363,7 +363,7 @@ $font-size: rem(14px);
 		.sidebar__menu.is-togglable .sidebar__heading {
 			padding: 12px 10px;
 			margin: 0 12px;
-			border-radius: 4px;
+			border-radius: 2px;
 		}
 
 		.sidebar__heading:not([tabindex="-1"]),


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/wp-calypso/issues/87673

## Proposed Changes

* Updates some border radii and minor positioning of various sidebar items so their a11y focus outline fits with proposed design.

before

![a11y-styles-old](https://github.com/Automattic/wp-calypso/assets/28742426/286ea303-1325-4921-a03f-346b692a304b)

after

![a11y-styles-new](https://github.com/Automattic/wp-calypso/assets/28742426/fa081496-91cd-442b-bc4f-4ee920ea167f)



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* load up this branch of calypso
* test the global sidebar through keyboard navigation. verify each item is slightly rounded by 2px radius.
* select an atomic site with classic view to get the global site sidebar, verify the same here.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
