### PR TITLE
Replace dead link on logged-out `/plugins`

### DIFF
--- a/client/my-sites/plugins/education-footer/index.tsx
+++ b/client/my-sites/plugins/education-footer/index.tsx
@@ -173,13 +173,13 @@ const EducationFooter = () => {
 						target="_blank"
 						title={
 							<CardText color="var(--studio-gray-100)">
-								{ __( 'How to Choose WordPress Plugins for Your Website (7 Tips)' ) }
+								{ __( 'How to Use WordPress Plugins: The Complete Beginner’s Guide' ) }
 							</CardText>
 						}
 						titleMarginBottom="16px"
 						cta={ <ReadMoreLink /> }
 						url={ localizeUrl(
-							'https://wordpress.com/go/customization/how-to-choose-wordpress-plugins-for-your-website-7-tips/'
+							'https://wordpress.com/go/website-building/how-to-use-wordpress-plugins/'
 						) }
 						border="var(--studio-gray-5)"
 						onClick={ () => onClickLinkCard( 'customization' ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

The `How to Choose WordPress Plugins for Your Website (7 Tips)` link on the logged-out `/plugins` page leads to [this URL](https://wordpress.com/go/customization/how-to-choose-wordpress-plugins-for-your-website-7-tips/), which isn't a live page.

Per this discussion p1708443847385179-slack-C029GN3KD, we are replacing it with a link to [this article](https://wordpress.com/go/website-building/how-to-use-wordpress-plugins/).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Open `/plugins` in a logged-out window (incognito window)
2. Scroll down to the `Get started with plugins` section
3. Click the second link
4. Ensure that you are taken to https://wordpress.com/go/website-building/how-to-use-wordpress-plugins/

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?