### PR TITLE
Stats: Update the subscriber total query parameters on the Insights page

### DIFF
--- a/client/my-sites/stats/annual-highlights-section/index.tsx
+++ b/client/my-sites/stats/annual-highlights-section/index.tsx
@@ -29,9 +29,10 @@ type Followers = {
 	subscribers: Array< object >;
 	total_email: number;
 	total_wpcom: number;
+	total: number;
 };
 
-const FOLLOWERS_QUERY = { type: 'wpcom', max: 0 };
+const FOLLOWERS_QUERY = { type: 'all', max: 0 };
 
 // Meant to replace annual-site-stats section
 export default function AnnualHighlightsSection( { siteId }: { siteId: number } ) {
@@ -56,7 +57,7 @@ export default function AnnualHighlightsSection( { siteId }: { siteId: number } 
 			likes: currentYearData?.total_likes ?? ( hasYearsData ? 0 : null ),
 			posts: currentYearData?.total_posts ?? ( hasYearsData ? 0 : null ),
 			words: currentYearData?.total_words ?? ( hasYearsData ? 0 : null ),
-			followers: year === currentYear ? followers?.total_wpcom ?? null : null,
+			followers: year === currentYear ? followers?.total ?? null : null,
 		};
 	}, [ year, followers, insights, currentYear ] );
 

--- a/client/state/stats/lists/test/utils.js
+++ b/client/state/stats/lists/test/utils.js
@@ -383,7 +383,7 @@ describe( 'utils', () => {
 					normalizers.statsFollowers( {
 						page: 1,
 						pages: 1,
-						total: 1,
+						total: 125,
 						total_email: 5,
 						total_wpcom: 120,
 						subscribers: [
@@ -400,6 +400,7 @@ describe( 'utils', () => {
 				).toEqual( {
 					total_email: 5,
 					total_wpcom: 120,
+					total: 125,
 					subscribers: [
 						{
 							label: 'wapuu@wordpress.org',

--- a/client/state/stats/lists/utils.js
+++ b/client/state/stats/lists/utils.js
@@ -489,7 +489,7 @@ export const normalizers = {
 		if ( ! data ) {
 			return null;
 		}
-		const { total_wpcom, total_email } = data;
+		const { total_wpcom, total_email, total } = data;
 		const subscriberData = get( data, [ 'subscribers' ], [] );
 
 		const subscribers = subscriberData.map( ( item ) => {
@@ -511,7 +511,7 @@ export const normalizers = {
 			};
 		} );
 
-		return { total_wpcom, total_email, subscribers };
+		return { total_wpcom, total_email, total, subscribers };
 	},
 
 	statsCommentFollowers( data ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/86762#issuecomment-1945188882

## Proposed Changes

* Align the query parameters `type` for the endpoint `stats/followers` on the Stats Insights page with [querySubscribersTotals](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/stats/hooks/use-subscribers-totals-query.tsx#L8-L11) on the Subscriber Stats page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the Calypso Live link.
* Navigate to the Stats > `Insights` page.
* Ensure the number of the `Subscribers` card on the annual highlights section is the same as the `Total subscribers` card on the Subscriber Stats page.
#### Insights page
<img width="1299" alt="截圖 2024-02-21 下午10 59 54" src="https://github.com/Automattic/wp-calypso/assets/6869813/0f7ba0a5-c676-442e-8fe6-b0a6ad0345c2">

#### Subscribers page
<img width="1285" alt="截圖 2024-02-21 下午10 59 59" src="https://github.com/Automattic/wp-calypso/assets/6869813/a41faf0b-339e-44a7-b075-b12385346287">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
