### PR TITLE
Jetpack login: clarify username label for screen reader users

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -3,7 +3,7 @@ import page from '@automattic/calypso-router';
 import { Button, Card, FormInputValidation, FormLabel, Gridicon } from '@automattic/components';
 import { alert } from '@automattic/components/src/icons';
 import { localizeUrl } from '@automattic/i18n-utils';
-import { Spinner } from '@wordpress/components';
+import { Spinner, VisuallyHidden } from '@wordpress/components';
 import { Icon } from '@wordpress/icons';
 import classNames from 'classnames';
 import { localize } from 'i18n-calypso';
@@ -543,9 +543,19 @@ export class LoginForm extends Component {
 			return this.props.translate( 'Your email address or username' );
 		}
 
-		return this.isPasswordView()
-			? this.renderChangeUsername()
-			: this.props.translate( 'Email Address or Username' );
+		return this.isPasswordView() ? (
+			this.renderChangeUsername()
+		) : (
+			// Since the input receives focus on page load, screen reader users don't have any context
+			// for what credentials to use. Unlike other users, they won't have seen the informative
+			// text above the form. We therefore need to clarity the must use WordPress.com credentials.
+			<>
+				<VisuallyHidden as="span">
+					{ this.props.translate( 'WordPress.com Email Address or Username' ) }
+				</VisuallyHidden>
+				<span aria-hidden="true">{ this.props.translate( 'Email Address or Username' ) }</span>
+			</>
+		);
 	}
 
 	renderLostPasswordLink() {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/issues/35488

## Proposed Changes

Screen reader users don't get all the necessary context to fill out the login form seamlessly (see linked issue above). This PR makes the label of the username field more descriptive to screen readers. It doesn't change the visual render of the form.

<img width="454" alt="Screenshot 2024-02-21 at 10 41 07 AM" src="https://github.com/Automattic/wp-calypso/assets/1620183/e490a379-0c67-4baf-9f42-967ab99cc80e">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Spin up a test self-hosted site
- Go through the Jetpack connection flow
- When you land on the login page on WordPress.com, copy the URL (it should be something like `https://wordpress.com/log-in/jetpack?redirect_to=...`)
- Run Calypso with this branch
- Visit the URL above, replacing `https://wordpress.com` with `http://calypso.localhost:3000/`
- Inspect the email/username input
- In the Accessibility panel on Chrome (or the equivalent in another browser), notice the accessible name of the input is `WordPress.com Email Address or Username`
- Check that the screen hasn't changed visually

|Before|After|
|-|-|
|<img width="500" alt="Screenshot 2024-02-21 at 10 41 01 AM" src="https://github.com/Automattic/wp-calypso/assets/1620183/8ccdeed6-44e2-4257-913e-345bef9ef95f">|<img width="500" alt="Screenshot 2024-02-21 at 10 45 17 AM" src="https://github.com/Automattic/wp-calypso/assets/1620183/ea2aa72c-1281-4b8e-b055-fd0485321c98">|


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?