### PR TITLE
Site Migration: Update error step copy

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
@@ -28,7 +28,7 @@ const ErrorStep: Step = function ErrorStep( { navigation } ) {
 		domain = siteDomains[ 0 ].domain;
 	}
 
-	const errorCopy = () => {
+	const messageCopy = () => {
 		// New copy waiting on translation.
 		if (
 			englishLocales.includes( translate?.localeSlug || '' ) ||
@@ -48,7 +48,7 @@ const ErrorStep: Step = function ErrorStep( { navigation } ) {
 	};
 
 	const headerText = siteSetupError?.error || __( "We've hit a snag" );
-	const bodyText = siteSetupError?.message || errorCopy();
+	const bodyText = siteSetupError?.message || messageCopy();
 
 	const getContent = () => {
 		return (

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/error-step/index.tsx
@@ -1,6 +1,8 @@
+import { englishLocales } from '@automattic/i18n-utils';
 import { StepContainer } from '@automattic/onboarding';
 import styled from '@emotion/styled';
 import { useI18n } from '@wordpress/react-i18n';
+import { useTranslate } from 'i18n-calypso';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSiteDomains } from '../../../../hooks/use-site-domains';
@@ -15,7 +17,8 @@ const WarningsOrHoldsSection = styled.div`
 
 const ErrorStep: Step = function ErrorStep( { navigation } ) {
 	const { goBack, goNext } = navigation;
-	const { __ } = useI18n();
+	const translate = useTranslate();
+	const { __, hasTranslation } = useI18n();
 	const siteDomains = useSiteDomains();
 	const siteSetupError = useSiteSetupError();
 
@@ -25,12 +28,27 @@ const ErrorStep: Step = function ErrorStep( { navigation } ) {
 		domain = siteDomains[ 0 ].domain;
 	}
 
-	const defaultBodyText = __(
-		'It looks like something went wrong while setting up your store. Please contact support so that we can help you out.'
-	);
+	const errorCopy = () => {
+		// New copy waiting on translation.
+		if (
+			englishLocales.includes( translate?.localeSlug || '' ) ||
+			hasTranslation(
+				'It looks like something went wrong while setting up your site. Please contact support so that we can help you out.'
+			)
+		) {
+			return __(
+				'It looks like something went wrong while setting up your site. Please contact support so that we can help you out.'
+			);
+		}
+
+		// Original copy
+		return __(
+			'It looks like something went wrong while setting up your store. Please contact support so that we can help you out.'
+		);
+	};
 
 	const headerText = siteSetupError?.error || __( "We've hit a snag" );
-	const bodyText = siteSetupError?.message || defaultBodyText;
+	const bodyText = siteSetupError?.message || errorCopy();
 
 	const getContent = () => {
 		return (

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -1,6 +1,7 @@
 import config from '@automattic/calypso-config';
 import { useLocale } from '@automattic/i18n-utils';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
 import recordGTMDatalayerEvent from 'calypso/lib/analytics/ad-tracking/woo/record-gtm-datalayer-event';
@@ -31,6 +32,8 @@ const wooexpress: Flow = {
 	},
 	useAssertConditions(): AssertConditionResult {
 		const { setProfilerData } = useDispatch( ONBOARD_STORE );
+		const { setSiteSetupError } = useDispatch( SITE_STORE );
+		const translate = useTranslate();
 		const userIsLoggedIn = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).isCurrentUserLoggedIn(),
 			[]
@@ -48,6 +51,13 @@ const wooexpress: Flow = {
 		const queryLocaleSlug = getLocaleFromQueryParam();
 		const pathLocaleSlug = getLocaleFromPathname();
 		const locale = queryLocaleSlug || pathLocaleSlug || useLocaleSlug;
+
+		setSiteSetupError(
+			undefined,
+			translate(
+				'It looks like something went wrong while setting up your store. Please contact support so that we can help you out.'
+			)
+		);
 
 		const queryParams = new URLSearchParams( window.location.search );
 		const profilerData = queryParams.get( 'profilerdata' );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87651

## Proposed Changes

* Update fallback copy for the error step to be more generic from `It looks like something went wrong while setting up your store. Please contact support so that we can help you out.` to `It looks like something went wrong while setting up your site. Please contact support so that we can help you out.` -- `store` becomes `site`.
* Wrap the new copy in a function so we can check to see if it's translated for non-English locales before showing it.
* Update WooExpress step to use the `store` variation via the `setSiteSetupError` hook

<img width="1398" alt="Screenshot 2024-02-21 at 12 18 56 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/faae26fe-a8a9-42f9-aabd-25aa999f766c">

<img width="1402" alt="Screenshot 2024-02-21 at 12 18 47 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/daee1bba-b52b-4ff0-b49e-a7c91df81404">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Do the following while browsing with an English locale:
* Navigate to `/setup/wooexpress/error` -- you should see the old copy
* Navigate to `/setup/site-migration/error?flags=onboarding/new-migration-flow` -- you should see the new copy
* Switch your locale to a non-English one from `/me/account`, and navigate to `/setup/site-migration/error?flags=onboarding/new-migration-flow`
* Confirm you still see the old translation for now

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?