### PR TITLE
Checkout: Activate Pix payment method in all environments

### DIFF
--- a/config/jetpack-cloud-development.json
+++ b/config/jetpack-cloud-development.json
@@ -31,7 +31,7 @@
 	"features": {
 		"activity-log/v2": true,
 		"always_use_logout_url": true,
-		"checkout/ebanx-pix": false,
+		"checkout/ebanx-pix": true,
 		"checkout/google-pay": false,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": false,

--- a/config/jetpack-cloud-horizon.json
+++ b/config/jetpack-cloud-horizon.json
@@ -28,7 +28,7 @@
 	"features": {
 		"activity-log/v2": true,
 		"always_use_logout_url": false,
-		"checkout/ebanx-pix": false,
+		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": false,

--- a/config/jetpack-cloud-production.json
+++ b/config/jetpack-cloud-production.json
@@ -30,7 +30,7 @@
 		"activity-log/v2": true,
 		"ad-tracking": true,
 		"always_use_logout_url": true,
-		"checkout/ebanx-pix": false,
+		"checkout/ebanx-pix": true,
 		"checkout/google-pay": false,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": false,

--- a/config/jetpack-cloud-stage.json
+++ b/config/jetpack-cloud-stage.json
@@ -30,7 +30,7 @@
 		"activity-log/v2": true,
 		"ad-tracking": false,
 		"always_use_logout_url": true,
-		"checkout/ebanx-pix": false,
+		"checkout/ebanx-pix": true,
 		"checkout/google-pay": false,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": false,

--- a/config/production.json
+++ b/config/production.json
@@ -28,7 +28,7 @@
 		"calypsoify/plugins": true,
 		"cancellation-offers": true,
 		"catch-js-errors": true,
-		"checkout/ebanx-pix": false,
+		"checkout/ebanx-pix": true,
 		"checkout/google-pay": true,
 		"checkout/vat-form": true,
 		"checkout/checkout-version": false,


### PR DESCRIPTION
## Proposed Changes

This PR activates the Ebanx Pix payment method in all environments (notably, production). It was previously available in staging, wpcalypso, development, and horizon.

## Testing Instructions

See https://github.com/Automattic/wp-calypso/pull/87239 for some screenshots and testing instructions. The only difference in this PR is that Pix will now be available outside of staging and testing environments.