### PR TITLE
Jetpack login: hide password from screen readers on username view

### DIFF
--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -834,6 +834,7 @@ export class LoginForm extends Component {
 							className={ classNames( 'login__form-password', {
 								'is-hidden': isPasswordHidden,
 							} ) }
+							aria-hidden={ isPasswordHidden }
 						>
 							<FormLabel htmlFor="password">
 								{ this.props.isWoo && ! this.props.isPartnerSignup


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/issues/35489

## Proposed Changes

In the Jetpack login screen, the password section is hidden visually in the username view but not from screen readers. This PR fixes it.


https://github.com/Automattic/wp-calypso/assets/1620183/b6ccd390-3a2b-476b-b282-8c24499d58bc



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

If you can use a screen reader:
- Spin up a test self-hosted site
- Go through the Jetpack connection flow
- When you land on the login page on WordPress.com, copy the URL (it should be something like `https://wordpress.com/log-in/jetpack?redirect_to=...`)
- Run Calypso with this branch
- Visit the URL above, replacing `https://wordpress.com` with `http://calypso.localhost:3000/`
- Parse the form with the screen reader and notice the password input is not announced in the username view anymore



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?