### PR TITLE
Global Sidebar - fix react error with missing key attribute

### DIFF
--- a/client/my-sites/sidebar/body.jsx
+++ b/client/my-sites/sidebar/body.jsx
@@ -34,7 +34,9 @@ export const MySitesSidebarUnifiedBody = ( { path, children } ) => {
 				const isSelected = item?.url && itemLinkMatches( item.url, path );
 
 				if ( 'current-site' === item?.type ) {
-					return <Site site={ site } href={ item?.url } isSelected={ isSelected } />;
+					return (
+						<Site key={ item.type } site={ site } href={ item?.url } isSelected={ isSelected } />
+					);
 				}
 				if ( 'separator' === item?.type ) {
 					return <SidebarSeparator key={ i } />;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5707.

Need to set the key attribute to fix error below

![Image](https://github.com/Automattic/dotcom-forge/assets/811776/5d224d30-2f01-44d4-994a-a4cb05bbb847)

