### PR TITLE
Site Migration: Initial import vs. migration step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -8,7 +8,7 @@ import './style.scss';
 
 type SubmitDestination = 'import' | 'migrate' | 'upgrade';
 
-const SiteMigrationSource: Step = function ( { navigation } ) {
+const SiteMigrationImportOrMigrate: Step = function ( { navigation } ) {
 	const translate = useTranslate();
 	const site = useSite();
 	const canInstallPlugins = site?.plan?.features?.active.find(
@@ -58,4 +58,4 @@ const SiteMigrationSource: Step = function ( { navigation } ) {
 	);
 };
 
-export default SiteMigrationSource;
+export default SiteMigrationImportOrMigrate;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
@@ -2,7 +2,7 @@
 @import "calypso/assets/stylesheets/shared/_loading";
 @import "@automattic/onboarding/styles/mixins";
 
-.site-migration-import-from {
+.site-migration-import-or-migrate {
 	.migration-info {
 		display: flex;
 		flex-direction: row;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-site/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-site/index.tsx
@@ -1,44 +1,56 @@
 import { Button } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
-import DocumentHead from 'calypso/components/data/document-head';
-import FormattedHeader from 'calypso/components/formatted-header';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
+import './style.scss';
+
+type SubmitDestination = 'import' | 'migrate' | 'upgrade';
 
 const SiteMigrationSource: Step = function ( { navigation } ) {
 	const translate = useTranslate();
+	const site = useSite();
+	const canInstallPlugins = site?.plan?.features?.active.find(
+		( feature ) => feature === 'install-plugins'
+	)
+		? true
+		: false;
 
-	const handleSubmit = () => {
-		navigation.submit?.();
+	const handleSubmit = ( destination: SubmitDestination ) => {
+		navigation.submit?.( { destination } );
 	};
 
 	const stepContent = (
-		<div>
-			<p>Enter the url of the site you're migrating.</p>
-			<Button primary onClick={ handleSubmit }>
-				{ translate( 'Continue' ) }
-			</Button>
+		<div className="migration-info">
+			<div className="migration-info-column">
+				<h2>{ translate( 'Import' ) }</h2>
+				<Button primary onClick={ () => handleSubmit( 'import' ) }>
+					{ translate( 'Import my website content' ) }
+				</Button>
+			</div>
+			<div className="migration-info-column">
+				<h2>{ translate( 'Migrate' ) }</h2>
+				<Button
+					primary
+					onClick={ () => {
+						handleSubmit( canInstallPlugins ? 'migrate' : 'upgrade' );
+					} }
+				>
+					{ canInstallPlugins ? translate( 'Migrate my site' ) : translate( 'Upgrade to migrate' ) }
+				</Button>
+			</div>
 		</div>
 	);
 
 	return (
 		<>
-			<DocumentHead title="Which site are you migrating?" />
 			<StepContainer
-				stepName="site-migration-instructions"
+				stepName="site-migration-source"
 				shouldHideNavButtons={ false }
-				className="is-step-site-migration-instructions"
+				className="is-step-site-migration-source"
 				hideSkip={ true }
 				hideBack={ true }
-				isHorizontalLayout
-				formattedHeader={
-					<FormattedHeader
-						id="site-migration-instructions-header"
-						headerText="Which site are you migrating?"
-						align="left"
-					/>
-				}
 				stepContent={ stepContent }
 				recordTracksEvent={ recordTracksEvent }
 			/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-site/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-source-site/style.scss
@@ -1,0 +1,15 @@
+/* stylelint-disable-next-line scss/at-import-no-partial-leading-underscore */
+@import "calypso/assets/stylesheets/shared/_loading";
+@import "@automattic/onboarding/styles/mixins";
+
+.site-migration-import-from {
+	.migration-info {
+		display: flex;
+		flex-direction: row;
+
+		.migration-info-column {
+			width: 45%;
+			margin-right: 1rem;
+		}
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -211,9 +211,9 @@ export const STEPS = {
 		asyncComponent: () => import( './steps-repository/site-migration-instructions' ),
 	},
 
-	SITE_MIGRATION_SOURCE: {
-		slug: 'site-migration-import-from',
-		asyncComponent: () => import( './steps-repository/site-migration-source-site' ),
+	SITE_MIGRATION_IMPORT_OR_MIGRATE: {
+		slug: 'site-migration-import-or-migrate',
+		asyncComponent: () => import( './steps-repository/site-migration-import-or-migrate' ),
 	},
 
 	SITE_MIGRATION_PLUGIN_INSTALL: {

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -16,7 +16,7 @@ const siteMigration: Flow = {
 
 	useSteps() {
 		return [
-			STEPS.SITE_MIGRATION_SOURCE,
+			STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE,
 			STEPS.SITE_MIGRATION_PLUGIN_INSTALL,
 			STEPS.PROCESSING,
 			STEPS.WAIT_FOR_ATOMIC,
@@ -134,7 +134,7 @@ const siteMigration: Flow = {
 			const siteId = getSiteIdBySlug( siteSlug );
 
 			switch ( currentStep ) {
-				case STEPS.SITE_MIGRATION_SOURCE.slug: {
+				case STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug: {
 					// Switch to the normal Import flow.
 					if ( providedDependencies?.destination === 'import' ) {
 						return exitFlow(

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -135,6 +135,23 @@ const siteMigration: Flow = {
 
 			switch ( currentStep ) {
 				case STEPS.SITE_MIGRATION_SOURCE.slug: {
+					// Switch to the normal Import flow.
+					if ( providedDependencies?.destination === 'import' ) {
+						return exitFlow(
+							`/setup/site-setup/importList?siteSlug=${ siteSlug }&siteId=${ siteId }`
+						);
+					}
+
+					// Take the user to the upgrade plan step.
+					if ( providedDependencies?.destination === 'upgrade' ) {
+						// TODO - Once the upgrade plan step is available, we'll want to change this to use the slug constant.
+						return navigate( 'site-migration-upgrade-plan', {
+							siteId,
+							siteSlug,
+						} );
+					}
+
+					// Continue with the migration flow.
 					return navigate( STEPS.SITE_MIGRATION_PLUGIN_INSTALL.slug, {
 						siteId,
 						siteSlug,

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -11,7 +11,7 @@ describe( 'Site Migration Flow', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 
 			runUseStepNavigationSubmit( {
-				currentStep: STEPS.SITE_MIGRATION_SOURCE.slug,
+				currentStep: STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug,
 				dependencies: {
 					destination: 'migrate',
 				},
@@ -27,7 +27,7 @@ describe( 'Site Migration Flow', () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 
 			runUseStepNavigationSubmit( {
-				currentStep: STEPS.SITE_MIGRATION_SOURCE.slug,
+				currentStep: STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug,
 				dependencies: {
 					destination: 'upgrade',
 				},

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -7,13 +7,34 @@ import { getFlowLocation, renderFlow } from './helpers';
 
 describe( 'Site Migration Flow', () => {
 	describe( 'navigation', () => {
-		it( 'redirects from the import page to waitForAtomic page', async () => {
+		it( 'migrate redirects from the import-from page to site-migration-plugin-install page', async () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 
-			runUseStepNavigationSubmit( { currentStep: STEPS.SITE_MIGRATION_SOURCE.slug } );
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.SITE_MIGRATION_SOURCE.slug,
+				dependencies: {
+					destination: 'migrate',
+				},
+			} );
 
 			expect( getFlowLocation() ).toEqual( {
 				path: '/site-migration-plugin-install',
+				state: { siteSlug: 'example.wordpress.com' },
+			} );
+		} );
+
+		it( 'upgrade redirects from the import-from page to site-migration-upgrade-plan page', async () => {
+			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.SITE_MIGRATION_SOURCE.slug,
+				dependencies: {
+					destination: 'upgrade',
+				},
+			} );
+
+			expect( getFlowLocation() ).toEqual( {
+				path: '/site-migration-upgrade-plan',
 				state: { siteSlug: 'example.wordpress.com' },
 			} );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87656

## Proposed Changes

This adds the scaffolding for a new step which helps describe the differences between importing site content and migrating a site. We've also renamed the step to `SiteMigrationImportOrMigrate` because we're planning to add a step before this to check the source of the migration.

Design/copy TBD.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
### Free Plan
* Use this branch locally or use the calypso.live url.
* Visit http://calypso.localhost:3000/start.
* On the Goals step, add `&flags=onboarding/new-migration-flow` to the url and refresh.
* Select the "Import existing content or website" goal and click "Continue".
* You should end up on `/setup/site-migration/site-migration-import-from` and the migrate button should read "Upgrade to migrate".
![CleanShot 2024-02-21 at 13 51 06](https://github.com/Automattic/wp-calypso/assets/917632/878b270b-a932-4ef7-9211-26c17e7e26a8)
* Clicking the "Upgrade to migrate" button won't do anything at this point.
* Clicking the "Import my website content" should take you to the beginning of the "Import" flow.

### Creator Plan
* Use this branch locally or use the calypso.live url.
* Visit http://calypso.localhost:3000/start.
* On the plans page, pick the Creator plan.
* On the Goals step, add `&flags=onboarding/new-migration-flow` to the url and refresh.
* Select the "Import existing content or website" goal and click "Continue".
* You should end up on `/setup/site-migration/site-migration-import-from` and the migrate button should read "Migrate my site".
![CleanShot 2024-02-21 at 13 54 35](https://github.com/Automattic/wp-calypso/assets/917632/2c56c29d-4527-46c8-909c-6381fb5d639b)
* Clicking "Migrate my site" should briefly take you to the `site-migration-plugin-install` step but will end on the Error step. This is acceptable at this point.
* Clicking the "Import my website content" should take you to the beginning of the "Import" flow.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
