### PR TITLE
Checkout v2: Show discounts for each line item and introductory offer detail

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -200,7 +200,7 @@ function LineItemCostOverrideIntroOfferDueDate( { product }: { product: Response
 				} ) }
 			</div>
 			<div>
-				{ translate( 'Due %(dueDate)s: %(price)s', {
+				{ translate( 'Billed %(dueDate)s: %(price)s', {
 					args: {
 						dueDate: new Date( dueDate ).toLocaleDateString( undefined, {
 							dateStyle: 'long',

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -73,11 +73,13 @@ export function CostOverridesList( {
 	currency,
 	removeCoupon,
 	couponCode,
+	showOnlyCoupons,
 }: {
 	costOverridesList: Array< CostOverrideForDisplay >;
 	currency: string;
 	removeCoupon?: RemoveCouponFromCart;
 	couponCode: ResponseCart[ 'coupon' ];
+	showOnlyCoupons?: boolean;
 } ) {
 	const translate = useTranslate();
 	// Let's put the coupon code last because it will have its own "Remove" button.
@@ -91,18 +93,21 @@ export function CostOverridesList( {
 	const isDisabled = formStatus !== FormStatus.READY;
 	return (
 		<CostOverridesListStyle>
-			{ nonCouponOverrides.map( ( costOverride ) => {
-				return (
-					<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
-						<span className="cost-overrides-list-item__reason">
-							{ costOverride.humanReadableReason }
-						</span>
-						<span className="cost-overrides-list-item__discount">
-							{ formatCurrency( -costOverride.discountAmount, currency, { isSmallestUnit: true } ) }
-						</span>
-					</div>
-				);
-			} ) }
+			{ ! showOnlyCoupons &&
+				nonCouponOverrides.map( ( costOverride ) => {
+					return (
+						<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
+							<span className="cost-overrides-list-item__reason">
+								{ costOverride.humanReadableReason }
+							</span>
+							<span className="cost-overrides-list-item__discount">
+								{ formatCurrency( -costOverride.discountAmount, currency, {
+									isSmallestUnit: true,
+								} ) }
+							</span>
+						</div>
+					);
+				} ) }
 			{ ! removeCoupon &&
 				couponOverrides.map( ( costOverride ) => {
 					return (

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -5,16 +5,18 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import type { Theme } from '@automattic/composite-checkout';
 import type { ResponseCart, RemoveCouponFromCart } from '@automattic/shopping-cart';
-import type { CostOverrideForDisplay } from '@automattic/wpcom-checkout';
+import type {
+	CostOverrideForDisplay,
+	LineItemCostOverrideForDisplay,
+} from '@automattic/wpcom-checkout';
 
 const CostOverridesListStyle = styled.div`
+	grid-area: discounts;
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
 	font-size: 12px;
 	font-weight: 400;
-	margin-top: 10px;
-	margin-bottom: 20px;
 
 	& .cost-overrides-list-item {
 		display: grid;
@@ -140,6 +142,32 @@ export function CostOverridesList( {
 						</div>
 					);
 				} ) }
+		</CostOverridesListStyle>
+	);
+}
+
+export function LineItemCostOverrides( {
+	costOverridesList,
+	currency,
+}: {
+	costOverridesList: LineItemCostOverrideForDisplay[];
+	currency: string;
+} ) {
+	return (
+		<CostOverridesListStyle>
+			{ costOverridesList.map( ( costOverride ) => {
+				return (
+					<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
+						<span className="cost-overrides-list-item__reason">
+							{ costOverride.humanReadableReason }
+						</span>
+						<span className="cost-overrides-list-item__discount">
+							{ costOverride.discountAmount &&
+								formatCurrency( -costOverride.discountAmount, currency, { isSmallestUnit: true } ) }
+						</span>
+					</div>
+				);
+			} ) }
 		</CostOverridesListStyle>
 	);
 }

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -189,17 +189,29 @@ function LineItemCostOverrideIntroOfferDueDate( { product }: { product: Response
 
 	return (
 		<div>
-			{ translate( 'Due %(dueDate)s: %(price)s', {
-				args: {
-					dueDate: new Date( dueDate ).toLocaleDateString( undefined, {
-						dateStyle: 'long',
-					} ),
-					price: formatCurrency( dueAmount, product.currency, {
-						isSmallestUnit: true,
-						stripZeros: true,
-					} ),
-				},
-			} ) }
+			<div>
+				{ translate( 'Due today: %(price)s', {
+					args: {
+						price: formatCurrency( product.item_subtotal_integer, product.currency, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ),
+					},
+				} ) }
+			</div>
+			<div>
+				{ translate( 'Due %(dueDate)s: %(price)s', {
+					args: {
+						dueDate: new Date( dueDate ).toLocaleDateString( undefined, {
+							dateStyle: 'long',
+						} ),
+						price: formatCurrency( dueAmount, product.currency, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ),
+					},
+				} ) }
+			</div>
 			<div>
 				<LineItemBillingInterval product={ product } />{ ' ' }
 				<span>
@@ -223,7 +235,12 @@ function LineItemCostOverride( {
 	return (
 		<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
 			<span className="cost-overrides-list-item__reason">{ costOverride.humanReadableReason }</span>
-			<span className="cost-overrides-list-item__discount">{ costOverride.formattedPrice }</span>
+			<span className="cost-overrides-list-item__discount">
+				{ costOverride.discountAmount &&
+					formatCurrency( -costOverride.discountAmount, product.currency, {
+						isSmallestUnit: true,
+					} ) }
+			</span>
 			<LineItemCostOverrideIntroOfferDueDate product={ product } />
 		</div>
 	);

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -7,6 +7,7 @@ import {
 	useShoppingCart,
 } from '@automattic/shopping-cart';
 import {
+	LineItemBillingInterval,
 	doesIntroductoryOfferHaveDifferentTermLengthThanProduct,
 	hasCheckoutVersion,
 } from '@automattic/wpcom-checkout';
@@ -181,7 +182,8 @@ function LineItemCostOverrideIntroOfferDueDate( { product }: { product: Response
 	} )?.args;
 	const dueDate = tosData?.subscription_auto_renew_date;
 	const dueAmount = tosData?.renewal_price_integer;
-	if ( ! dueDate || ! dueAmount ) {
+	const renewAmount = tosData?.regular_renewal_price_integer;
+	if ( ! dueDate || ! dueAmount || ! renewAmount ) {
 		return null;
 	}
 
@@ -198,6 +200,15 @@ function LineItemCostOverrideIntroOfferDueDate( { product }: { product: Response
 					} ),
 				},
 			} ) }
+			<div>
+				<LineItemBillingInterval product={ product } />{ ' ' }
+				<span>
+					{ formatCurrency( renewAmount, product.currency, {
+						isSmallestUnit: true,
+						stripZeros: true,
+					} ) }
+				</span>
+			</div>
 		</div>
 	);
 }
@@ -212,12 +223,7 @@ function LineItemCostOverride( {
 	return (
 		<div className="cost-overrides-list-item" key={ costOverride.humanReadableReason }>
 			<span className="cost-overrides-list-item__reason">{ costOverride.humanReadableReason }</span>
-			<span className="cost-overrides-list-item__discount">
-				{ costOverride.discountAmount &&
-					formatCurrency( -costOverride.discountAmount, product.currency, {
-						isSmallestUnit: true,
-					} ) }
-			</span>
+			<span className="cost-overrides-list-item__discount">{ costOverride.formattedPrice }</span>
 			<LineItemCostOverrideIntroOfferDueDate product={ product } />
 		</div>
 	);

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -165,7 +165,7 @@ function LineItemCostOverrideIntroOfferDueDate( { product }: { product: Response
 	if ( ! doesIntroductoryOfferHaveDifferentTermLengthThanProduct( product ) ) {
 		return null;
 	}
-	const dueDate = responseCart.terms_of_service?.find( ( tos ) => {
+	const tosData = responseCart.terms_of_service?.find( ( tos ) => {
 		if ( ! new RegExp( `product_id:${ product.product_id }` ).test( tos.key ) ) {
 			return false;
 		}
@@ -173,8 +173,10 @@ function LineItemCostOverrideIntroOfferDueDate( { product }: { product: Response
 			return false;
 		}
 		return true;
-	} )?.args?.subscription_auto_renew_date;
-	if ( ! dueDate ) {
+	} )?.args;
+	const dueDate = tosData?.subscription_auto_renew_date;
+	const dueAmount = tosData?.renewal_price_integer;
+	if ( ! dueDate || ! dueAmount ) {
 		return null;
 	}
 
@@ -185,7 +187,10 @@ function LineItemCostOverrideIntroOfferDueDate( { product }: { product: Response
 					dueDate: new Date( dueDate ).toLocaleDateString( undefined, {
 						dateStyle: 'long',
 					} ),
-					price: '$26.25', // FIXME
+					price: formatCurrency( dueAmount, product.currency, {
+						isSmallestUnit: true,
+						stripZeros: true,
+					} ),
 				},
 			} ) }
 		</div>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -50,7 +50,7 @@ const CouponLinkWrapper = styled.div`
 `;
 
 const CouponAreaWrapper = styled.div`
-	padding-bottom: ${ hasCheckoutVersion( '2' ) ? '24px' : 'inherit' };
+	padding-bottom: ${ hasCheckoutVersion( '2' ) ? '12px' : 'inherit' };
 `;
 
 const CouponField = styled( Coupon )``;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -935,6 +935,7 @@ const CheckoutSubtotalSection = styled.div`
 const CheckoutSummaryAmountWrapper = styled.div`
 	border-top: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
 	padding: 20px 0;
+	margin-top: 20px;
 `;
 
 const CheckoutFirstSubtotalLineItem = styled.div`

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -34,7 +34,6 @@ import { CostOverridesList, LineItemCostOverrides } from './cost-overrides-list'
 import { ItemVariationPicker } from './item-variation-picker';
 import type { OnChangeAkProQuantity } from './akismet-pro-quantity-dropdown';
 import type { OnChangeItemVariant } from './item-variation-picker';
-import type { Theme } from '@automattic/composite-checkout';
 import type {
 	ResponseCart,
 	RemoveProductFromCart,
@@ -44,9 +43,9 @@ import type {
 } from '@automattic/shopping-cart';
 import type { PropsWithChildren } from 'react';
 
-const WPOrderReviewList = styled.ul< { theme?: Theme } >`
+const WPOrderReviewList = styled.ul< { hasCheckoutVersion2: boolean } >`
 	box-sizing: border-box;
-	margin: 24px 0;
+	${ ( props ) => ( props.hasCheckoutVersion2 ? 'margin: 24px 0 0 0;' : 'margin: 24px 0;' ) }
 	padding: 0;
 `;
 
@@ -172,7 +171,10 @@ export function WPOrderReviewLineItems( {
 	);
 
 	return (
-		<WPOrderReviewList className={ joinClasses( [ className, 'order-review-line-items' ] ) }>
+		<WPOrderReviewList
+			className={ joinClasses( [ className, 'order-review-line-items' ] ) }
+			hasCheckoutVersion2={ hasCheckoutVersion( '2' ) }
+		>
 			{ responseCart.products.map( ( product ) => (
 				<LineItemWrapper
 					key={ product.uuid }

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -231,6 +231,7 @@ export function WPOrderReviewLineItems( {
 					currency={ responseCart.currency }
 					removeCoupon={ removeCoupon }
 					couponCode={ responseCart.coupon }
+					showOnlyCoupons
 				/>
 			) }
 		</WPOrderReviewList>

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -388,10 +388,7 @@ function LineItemWrapper( {
 					) }
 				</DropdownWrapper>
 				{ hasCheckoutVersion( '2' ) && (
-					<LineItemCostOverrides
-						costOverridesList={ costOverridesList }
-						currency={ product.currency }
-					/>
+					<LineItemCostOverrides product={ product } costOverridesList={ costOverridesList } />
 				) }
 			</LineItem>
 		</WPOrderReviewListItem>

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -238,7 +238,7 @@ export function WPOrderReviewLineItems( {
 }
 
 const DropdownWrapper = styled.span< { hasCheckoutVersion2: boolean } >`
-	${ ( props ) => ( props.hasCheckoutVersion2 ? `width: 100%; max-width: 200px` : null ) }
+	${ ( props ) => ( props.hasCheckoutVersion2 ? `width: 100%; max-width: 200px` : `width: 100%;` ) }
 `;
 
 function LineItemWrapper( {

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1330,19 +1330,6 @@ function CheckoutLineItem( {
 
 	const isIntroductoryOfferWithDifferentLength =
 		doesIntroductoryOfferHaveDifferentTermLengthThanProduct( product );
-	const amountWithIntroductoryOfferOnly = product.cost_overrides?.reduce(
-		( total, costOverride ) =>
-			costOverride.override_code === 'introductory-offer'
-				? total + costOverride.new_subtotal_integer
-				: total,
-		0
-	);
-	const formattedAmountWithIntroductoryOfferOnly = amountWithIntroductoryOfferOnly
-		? formatCurrency( amountWithIntroductoryOfferOnly, product.currency, {
-				isSmallestUnit: true,
-				stripZeros: true,
-		  } )
-		: undefined;
 
 	return (
 		<div
@@ -1367,7 +1354,7 @@ function CheckoutLineItem( {
 				<LineItemPrice
 					actualAmount={
 						isIntroductoryOfferWithDifferentLength
-							? formattedAmountWithIntroductoryOfferOnly
+							? undefined
 							: formatCurrency( costBeforeDiscounts, product.currency, {
 									isSmallestUnit: true,
 									stripZeros: true,

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -41,7 +41,10 @@ import { isWpComProductRenewal } from './is-wpcom-product-renewal';
 import { joinClasses } from './join-classes';
 import { getPartnerCoupon } from './partner-coupon';
 import IonosLogo from './partner-logo-ionos';
-import { getSubtotalWithoutDiscountsForProduct } from './transformations';
+import {
+	doesIntroductoryOfferHaveDifferentTermLengthThanProduct,
+	getSubtotalWithoutDiscountsForProduct,
+} from './transformations';
 import type { LineItemType } from './types';
 import type {
 	GSuiteProductUser,
@@ -198,7 +201,10 @@ const LineItemTitle = styled.div< { theme?: Theme; isSummary?: boolean } >`
 		   font-size: inherit;` }
 `;
 
-const LineItemPriceWrapper = styled.span< { theme?: Theme; isSummary?: boolean } >`
+const LineItemPriceWrapper = styled.span`
+	display: flex;
+	gap: 4px;
+
 	${ hasCheckoutVersion2
 		? `margin-left: 0px;
 		   font-size: 14px;
@@ -247,25 +253,16 @@ const DeleteButton = styled( Button )< { theme?: Theme } >`
 `;
 
 function LineItemPrice( {
-	isDiscounted,
 	actualAmount,
-	originalAmount,
-	isSummary,
+	crossedOutAmount,
 }: {
-	isDiscounted?: boolean;
-	actualAmount: string;
-	originalAmount?: string;
-	isSummary?: boolean;
+	actualAmount?: string;
+	crossedOutAmount?: string;
 } ) {
 	return (
-		<LineItemPriceWrapper isSummary={ isSummary }>
-			{ isDiscounted && originalAmount ? (
-				<>
-					<s>{ originalAmount }</s> { actualAmount }
-				</>
-			) : (
-				actualAmount
-			) }
+		<LineItemPriceWrapper>
+			{ crossedOutAmount && <s>{ crossedOutAmount }</s> }
+			<span>{ actualAmount }</span>
 		</LineItemPriceWrapper>
 	);
 }
@@ -313,14 +310,10 @@ function WPNonProductLineItem( {
 				{ label }
 			</LineItemTitle>
 			{ hasCheckoutVersion2 ? (
-				<LineItemPrice
-					aria-labelledby={ itemSpanId }
-					actualAmount={ actualAmountDisplay }
-					isSummary={ isSummary }
-				/>
+				<LineItemPrice aria-labelledby={ itemSpanId } actualAmount={ actualAmountDisplay } />
 			) : (
 				<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
-					<LineItemPrice actualAmount={ actualAmountDisplay } isSummary={ isSummary } />
+					<LineItemPrice actualAmount={ actualAmountDisplay } />
 				</span>
 			) }
 			{ hasDeleteButton && removeProductFromCart && (
@@ -1335,7 +1328,22 @@ function CheckoutLineItem( {
 		coupon: responseCart.coupon,
 	} );
 
-	/* eslint-disable wpcalypso/jsx-classname-namespace */
+	const isIntroductoryOfferWithDifferentLength =
+		doesIntroductoryOfferHaveDifferentTermLengthThanProduct( product );
+	const amountWithIntroductoryOfferOnly = product.cost_overrides?.reduce(
+		( total, costOverride ) =>
+			costOverride.override_code === 'introductory-offer'
+				? total + costOverride.new_subtotal_integer
+				: total,
+		0
+	);
+	const formattedAmountWithIntroductoryOfferOnly = amountWithIntroductoryOfferOnly
+		? formatCurrency( amountWithIntroductoryOfferOnly, product.currency, {
+				isSmallestUnit: true,
+				stripZeros: true,
+		  } )
+		: undefined;
+
 	return (
 		<div
 			className={ joinClasses( [ className, 'checkout-line-item' ] ) }
@@ -1357,19 +1365,28 @@ function CheckoutLineItem( {
 			</LineItemTitle>
 			{ hasCheckoutVersion2 ? (
 				<LineItemPrice
-					actualAmount={ formatCurrency( costBeforeDiscounts, product.currency, {
-						isSmallestUnit: true,
-						stripZeros: true,
-					} ) }
-					isSummary={ isSummary }
+					actualAmount={
+						isIntroductoryOfferWithDifferentLength
+							? formattedAmountWithIntroductoryOfferOnly
+							: formatCurrency( costBeforeDiscounts, product.currency, {
+									isSmallestUnit: true,
+									stripZeros: true,
+							  } )
+					}
+					crossedOutAmount={
+						isIntroductoryOfferWithDifferentLength
+							? formatCurrency( costBeforeDiscounts, product.currency, {
+									isSmallestUnit: true,
+									stripZeros: true,
+							  } )
+							: undefined
+					}
 				/>
 			) : (
 				<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
 					<LineItemPrice
-						isDiscounted={ isDiscounted }
 						actualAmount={ actualAmountDisplay }
-						originalAmount={ originalAmountDisplay }
-						isSummary={ isSummary }
+						crossedOutAmount={ isDiscounted ? originalAmountDisplay : undefined }
 					/>
 				</span>
 			) }
@@ -1485,5 +1502,4 @@ function CheckoutLineItem( {
 			) }
 		</div>
 	);
-	/* eslint-enable wpcalypso/jsx-classname-namespace */
 }

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -92,7 +92,8 @@ export const LineItem = styled( CheckoutLineItem )< {
 	grid-template-areas:
 		'label price'
 		'term remove'
-		'meta   meta';
+		'meta meta'
+		'discounts discounts';
 	gap: 6px 4px;
 	margin-bottom: 8px;
 	padding: 10px 0;`
@@ -223,9 +224,6 @@ const BillingInterval = styled.div< { theme?: Theme } >`
 	overflow-wrap: anywhere;
 	flex-direction: column;
 	align-content: flex-start;
-`;
-const DropdownWrapper = styled.span`
-	${ hasCheckoutVersion2 ? `width: 100%; max-width: 200px` : null }
 `;
 
 const DeleteButtonWrapper = styled.div`
@@ -1259,8 +1257,7 @@ function CheckoutLineItem( {
 	onRemoveProductClick,
 	onRemoveProductCancel,
 	isAkPro500Cart,
-	areThereVariants,
-	shouldShowVariantSelector,
+	shouldShowBillingInterval,
 }: PropsWithChildren< {
 	product: ResponseCartProduct;
 	className?: string;
@@ -1274,8 +1271,7 @@ function CheckoutLineItem( {
 	onRemoveProductClick?: ( label: string ) => void;
 	onRemoveProductCancel?: ( label: string ) => void;
 	isAkPro500Cart?: boolean;
-	areThereVariants?: boolean;
-	shouldShowVariantSelector?: boolean;
+	shouldShowBillingInterval?: boolean;
 } > ) {
 	const id = product.uuid;
 	const translate = useTranslate();
@@ -1378,17 +1374,15 @@ function CheckoutLineItem( {
 				</span>
 			) }
 
-			{ product && ! containsPartnerCoupon && (
+			{ ! containsPartnerCoupon && (
 				<>
 					{ hasCheckoutVersion2 ? (
 						<>
-							<BillingInterval>
-								{ areThereVariants && shouldShowVariantSelector ? (
-									<DropdownWrapper>{ children }</DropdownWrapper>
-								) : (
+							{ shouldShowBillingInterval && (
+								<BillingInterval>
 									<LineItemBillingIntervalWrapper product={ product } />
-								) }
-							</BillingInterval>
+								</BillingInterval>
+							) }
 							<LineItemMeta>
 								<LineItemMetaInfoWrapper product={ product } />
 								{ isJetpackSearch( product ) && <JetpackSearchMeta product={ product } /> }
@@ -1411,7 +1405,7 @@ function CheckoutLineItem( {
 				</>
 			) }
 
-			{ product && containsPartnerCoupon && (
+			{ containsPartnerCoupon && (
 				<LineItemMeta>
 					{ hasCheckoutVersion2 ? (
 						<LineItemBillingInterval product={ product } />
@@ -1429,7 +1423,8 @@ function CheckoutLineItem( {
 				<EmailMeta product={ product } isRenewal={ isRenewal } />
 			) }
 
-			{ ! hasCheckoutVersion2 && ! isEmail && <>{ children }</> }
+			{ children }
+
 			{ hasDeleteButton && removeProductFromCart && (
 				<>
 					<DeleteButtonWrapper>

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1330,6 +1330,19 @@ function CheckoutLineItem( {
 
 	const isIntroductoryOfferWithDifferentLength =
 		doesIntroductoryOfferHaveDifferentTermLengthThanProduct( product );
+	const amountWithIntroductoryOfferOnly = product.cost_overrides?.reduce(
+		( total, costOverride ) =>
+			costOverride.override_code === 'introductory-offer'
+				? total + costOverride.new_subtotal_integer
+				: total,
+		0
+	);
+	const formattedAmountWithIntroductoryOfferOnly = amountWithIntroductoryOfferOnly
+		? formatCurrency( amountWithIntroductoryOfferOnly, product.currency, {
+				isSmallestUnit: true,
+				stripZeros: true,
+		  } )
+		: undefined;
 
 	return (
 		<div
@@ -1354,7 +1367,7 @@ function CheckoutLineItem( {
 				<LineItemPrice
 					actualAmount={
 						isIntroductoryOfferWithDifferentLength
-							? undefined
+							? formattedAmountWithIntroductoryOfferOnly
 							: formatCurrency( costBeforeDiscounts, product.currency, {
 									isSmallestUnit: true,
 									stripZeros: true,

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -169,11 +169,13 @@ export interface LineItemCostOverrideForDisplay {
 	overrideCode: string;
 
 	/**
-	 * Typically this is the amount saved by this cost override.
+	 * The amount saved by this cost override in the currency's smallest unit.
 	 *
-	 * However, sometimes this is something else like an adjusted total.
+	 * If not set, a number will not be displayed. This can be useful for some
+	 * types of discounts where the amount will be communicated in some other
+	 * manner.
 	 */
-	formattedPrice: string;
+	discountAmount?: number;
 }
 
 function isUserVisibleCostOverride(
@@ -307,21 +309,13 @@ export function filterCostOverridesForLineItem(
 					return {
 						humanReadableReason: costOverride.human_readable_reason,
 						overrideCode: costOverride.override_code,
-						formattedPrice: formatCurrency( product.item_subtotal_integer, product.currency, {
-							isSmallestUnit: true,
-							stripZeros: true,
-						} ),
 					};
 				}
 
 				return {
 					humanReadableReason: costOverride.human_readable_reason,
 					overrideCode: costOverride.override_code,
-					formattedPrice: formatCurrency(
-						-getDiscountForCostOverrideForDisplay( costOverride ),
-						product.currency,
-						{ isSmallestUnit: true, stripZeros: true }
-					),
+					discountAmount: getDiscountForCostOverrideForDisplay( costOverride ),
 				};
 			} )
 	);

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -253,11 +253,22 @@ function getBillPeriodMonthsForIntroductoryOfferInterval(
 	}
 }
 
-function doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
-	costOverride: ResponseCartCostOverride,
+/**
+ * Returns true if the product has an introductory offer which is for a
+ * different term length than the term length of the product (eg: a 3 month
+ * discount for an annual plan).
+ */
+export function doesIntroductoryOfferHaveDifferentTermLengthThanProduct(
 	product: ResponseCartProduct
 ): boolean {
-	if ( costOverride.override_code !== 'introductory-offer' || ! product.introductory_offer_terms ) {
+	if (
+		product.cost_overrides?.some( ( costOverride ) => {
+			costOverride.override_code !== 'introductory-offer';
+		} )
+	) {
+		return false;
+	}
+	if ( ! product.introductory_offer_terms?.enabled ) {
 		return false;
 	}
 	if (
@@ -288,7 +299,7 @@ export function filterCostOverridesForLineItem(
 			// annual plan) need to be displayed differently because the
 			// discount is only temporary and the user will still be charged
 			// the remainder before the next renewal.
-			if ( doesIntroductoryOfferHaveDifferentTermLengthThanProduct( costOverride, product ) ) {
+			if ( doesIntroductoryOfferHaveDifferentTermLengthThanProduct( product ) ) {
 				return {
 					humanReadableReason: costOverride.human_readable_reason,
 					overrideCode: costOverride.override_code,

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -141,13 +141,14 @@ export function getCreditsLineItemFromCart( responseCart: ResponseCart ): LineIt
 function getDiscountReasonForIntroductoryOffer(
 	product: ResponseCartProduct,
 	terms: IntroductoryOfferTerms,
-	translate: ReturnType< typeof useTranslate >
+	translate: ReturnType< typeof useTranslate >,
+	allowFreeText: boolean
 ): string {
 	return getIntroductoryOfferIntervalDisplay(
 		translate,
 		terms.interval_unit,
 		terms.interval_count,
-		product.item_subtotal_integer === 0,
+		product.item_subtotal_integer === 0 && allowFreeText,
 		'checkout',
 		terms.transition_after_renewal_count
 	);
@@ -219,7 +220,8 @@ function makeSaleCostOverrideUnique(
 function makeIntroductoryOfferCostOverrideUnique(
 	costOverride: ResponseCartCostOverride,
 	product: ResponseCartProduct,
-	translate: ReturnType< typeof useTranslate >
+	translate: ReturnType< typeof useTranslate >,
+	allowFreeText: boolean
 ): ResponseCartCostOverride {
 	// Replace introductory offer cost override text with wording specific to
 	// that offer.
@@ -229,7 +231,8 @@ function makeIntroductoryOfferCostOverrideUnique(
 			human_readable_reason: getDiscountReasonForIntroductoryOffer(
 				product,
 				product.introductory_offer_terms,
-				translate
+				translate,
+				allowFreeText
 			),
 		};
 	}
@@ -291,7 +294,7 @@ export function filterCostOverridesForLineItem(
 		.filter( ( costOverride ) => isUserVisibleCostOverride( costOverride, product ) )
 		.map( ( costOverride ) => makeSaleCostOverrideUnique( costOverride, product, translate ) )
 		.map( ( costOverride ) =>
-			makeIntroductoryOfferCostOverrideUnique( costOverride, product, translate )
+			makeIntroductoryOfferCostOverrideUnique( costOverride, product, translate, true )
 		)
 		.map( ( costOverride ) => {
 			// Introductory offer discounts with term lengths that differ from
@@ -359,7 +362,7 @@ export function filterAndGroupCostOverridesForDisplay(
 			.filter( ( costOverride ) => isUserVisibleCostOverride( costOverride, product ) )
 			.map( ( costOverride ) => makeSaleCostOverrideUnique( costOverride, product, translate ) )
 			.map( ( costOverride ) =>
-				makeIntroductoryOfferCostOverrideUnique( costOverride, product, translate )
+				makeIntroductoryOfferCostOverrideUnique( costOverride, product, translate, false )
 			)
 			.forEach( ( costOverride ) => {
 				// Group discounts by human_readable_reason.

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -139,6 +139,7 @@ export function getCreditsLineItemFromCart( responseCart: ResponseCart ): LineIt
 }
 
 function getDiscountReasonForIntroductoryOffer(
+	product: ResponseCartProduct,
 	terms: IntroductoryOfferTerms,
 	translate: ReturnType< typeof useTranslate >
 ): string {
@@ -146,7 +147,7 @@ function getDiscountReasonForIntroductoryOffer(
 		translate,
 		terms.interval_unit,
 		terms.interval_count,
-		false,
+		product.item_subtotal_integer === 0,
 		'checkout',
 		terms.transition_after_renewal_count
 	);
@@ -226,6 +227,7 @@ function makeIntroductoryOfferCostOverrideUnique(
 		return {
 			...costOverride,
 			human_readable_reason: getDiscountReasonForIntroductoryOffer(
+				product,
 				product.introductory_offer_terms,
 				translate
 			),

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -169,13 +169,11 @@ export interface LineItemCostOverrideForDisplay {
 	overrideCode: string;
 
 	/**
-	 * The amount saved by this cost override in the currency's smallest unit.
+	 * Typically this is the amount saved by this cost override.
 	 *
-	 * If not set, a number will not be displayed. This can be useful for some
-	 * types of discounts where the amount will be communicated in some other
-	 * manner.
+	 * However, sometimes this is something else like an adjusted total.
 	 */
-	discountAmount?: number;
+	formattedPrice: string;
 }
 
 function isUserVisibleCostOverride(
@@ -309,13 +307,21 @@ export function filterCostOverridesForLineItem(
 					return {
 						humanReadableReason: costOverride.human_readable_reason,
 						overrideCode: costOverride.override_code,
+						formattedPrice: formatCurrency( product.item_subtotal_integer, product.currency, {
+							isSmallestUnit: true,
+							stripZeros: true,
+						} ),
 					};
 				}
 
 				return {
 					humanReadableReason: costOverride.human_readable_reason,
 					overrideCode: costOverride.override_code,
-					discountAmount: getDiscountForCostOverrideForDisplay( costOverride ),
+					formattedPrice: formatCurrency(
+						-getDiscountForCostOverrideForDisplay( costOverride ),
+						product.currency,
+						{ isSmallestUnit: true, stripZeros: true }
+					),
 				};
 			} )
 	);


### PR DESCRIPTION
The discount list in v2 checkout can sometimes create confusion because the discounts are displayed summarized far away from the line items they apply to. This is fine for simpler discounts but for complex discounts this can be impossible to understand.

## Proposed Changes

In this PR we refactor the discount list in checkout v2 to show each discount next to the line item to which it applies, with a few exceptions like coupon discounts which will still be shown below the line item list.

In addition, this PR adds additional detail to introductory offer discounts where the billing term length of the discount is different from the term length of the product. For example, a 3 month discount for an annual product. This discount is misleading because while the user may indeed be "saving" $X today, they will owe ($X / 12) * 3 in 3 months. This PR hides those discount amounts, instead showing the line item price crossed-out with today's price adjacent to it (or just the crossed-out price if the discount is 100%). It also adds text like `Due XXXX-MM-YY: $X` below the line item to clarify when and how much the user will next be charged.

Before             |  After
:-------------------------:|:-------------------------:
<img width="259" alt="before-another" src="https://github.com/Automattic/wp-calypso/assets/2036909/801e474a-df26-41f7-ab43-c618a59750b5"> | <img width="257" alt="after-another" src="https://github.com/Automattic/wp-calypso/assets/2036909/134f1e37-983a-4630-9d8a-ad73bd74d68b">

Fixes https://github.com/Automattic/payments-shilling/issues/2410
Fixes https://github.com/Automattic/payments-shilling/issues/2437

## Testing Instructions

- Add a plan, a domain, and a Professional email product to your cart and visit checkout.
- Add a coupon to the cart.
- Compare checkout (v1) on this branch to production and verify that there are no changes.
- Add `?checkoutVersion=2` to the checkout URL on this branch and verify that the changes described above look correct, particularly the "Due" date and price.