### PR TITLE
Global sidebar - Add sidebar skip to content a11y link

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -52,6 +52,7 @@ $z-layers: (
 		".following__intro-close-icon-bg": 0,
 		".form-text-input-with-affixes .form-text-input": 1,
 		".is-section-signup": 1,
+		".sidebar__skip-navigation": 1,
 		".media-library .search.is-expanded-to-container": 1,
 		".ribbon": 1,
 		".reader__featured-post-title": 1,

--- a/client/layout/global-sidebar/header.tsx
+++ b/client/layout/global-sidebar/header.tsx
@@ -1,4 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
+import SkipNavigation from '../sidebar/skip-navigation';
 import SidebarNotifications from './menu-items/notifications';
 import { SidebarSearch } from './menu-items/search';
 
@@ -6,6 +7,10 @@ export const GlobalSidebarHeader = () => {
 	const translate = useTranslate();
 	return (
 		<div className="sidebar__header">
+			<SkipNavigation
+				skipToElementId="primary"
+				displayText={ translate( 'Skip to main content' ) }
+			/>
 			<a
 				href="/sites"
 				className="link-logo tooltip tooltip-bottom-left"

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -232,6 +232,7 @@ $brand-text: "SF Pro Text", $sans;
 
 	.sidebar__back-link {
 		padding-left: 12px;
+		margin-top: 4px;
 		a {
 			color: var(--nav-link);
 			text-decoration: none;
@@ -283,7 +284,8 @@ $brand-text: "SF Pro Text", $sans;
 	}
 
 	.button,
-	.site__content {
+	.site__content,
+	.components-button {
 		&:focus {
 			box-shadow: none;
 			border-color: inherit;

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -100,7 +100,7 @@ $brand-text: "SF Pro Text", $sans;
 		.sidebar__skip-navigation {
 			position: absolute;
 			left: -10000px;
-			z-index: 1;
+			z-index: z-index("root", ".sidebar__skip-navigation");
 			border-radius: 2px;
 
 			&:focus {

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -249,6 +249,7 @@ $brand-text: "SF Pro Text", $sans;
 	.sidebar__back-link {
 		padding-left: 12px;
 		margin-top: 4px;
+
 		a {
 			color: var(--nav-link);
 			text-decoration: none;
@@ -256,6 +257,7 @@ $brand-text: "SF Pro Text", $sans;
 			display: inline-flex;
 			margin-bottom: 24px;
 			padding: 9px;
+			border-radius: 2px;
 			gap: 8px;
 		}
 

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -294,16 +294,14 @@ $brand-text: "SF Pro Text", $sans;
 	}
 }
 
-.accessible-focus .global-sidebar {
-	*,
-	.site__content {
-		&:focus {
-			outline-style: solid;
-			outline-color: var(--color-sidebar-menu-selected-background);
-			outline-width: 2px;
-			outline-offset: 2px;
-		}
+.accessible-focus div.global-sidebar {
+	*:focus {
+		outline-style: solid;
+		outline-color: var(--color-sidebar-menu-selected-background);
+		outline-width: 2px;
+		outline-offset: 2px;
 	}
+
 
 	.button,
 	.site__content,

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -96,6 +96,17 @@ $brand-text: "SF Pro Text", $sans;
 				fill: var(--studio-white);
 			}
 		}
+
+		.sidebar__skip-navigation {
+			position: absolute;
+			left: -10000px;
+			z-index: 1;
+			border-radius: 2px;
+
+			&:focus {
+				left: auto;
+			}
+		}
 	}
 
 	.sidebar__body {

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -281,6 +281,14 @@ $brand-text: "SF Pro Text", $sans;
 		outline-width: 2px;
 		outline-offset: 2px;
 	}
+
+	.button,
+	.site__content {
+		&:focus {
+			box-shadow: none;
+			border-color: inherit;
+		}
+	}
 }
 
 .masterbar {

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -295,11 +295,14 @@ $brand-text: "SF Pro Text", $sans;
 }
 
 .accessible-focus .global-sidebar {
-	*:focus {
-		outline-style: solid;
-		outline-color: var(--color-sidebar-menu-selected-background);
-		outline-width: 2px;
-		outline-offset: 2px;
+	*,
+	.site__content {
+		&:focus {
+			outline-style: solid;
+			outline-color: var(--color-sidebar-menu-selected-background);
+			outline-width: 2px;
+			outline-offset: 2px;
+		}
 	}
 
 	.button,

--- a/client/layout/sidebar/skip-navigation.jsx
+++ b/client/layout/sidebar/skip-navigation.jsx
@@ -6,6 +6,7 @@ import { Component } from 'react';
 class SkipNavigation extends Component {
 	static propTypes = {
 		skipToElementId: PropTypes.string,
+		displayText: PropTypes.string,
 	};
 
 	onClick = ( event ) => {
@@ -20,9 +21,11 @@ class SkipNavigation extends Component {
 	};
 
 	render() {
+		const displayText = this.props.displayText || this.props.translate( 'Skip navigation' );
+
 		return (
 			<Button onClick={ this.onClick } className="sidebar__skip-navigation">
-				{ this.props.translate( 'Skip navigation' ) }
+				{ displayText }
 			</Button>
 		);
 	}

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -66,7 +66,7 @@ class MeSidebar extends Component {
 			path: this.props.path,
 			requireBackLink: true,
 		};
-		return <GlobalSidebar { ...props }>{ this.renderMenu() }</GlobalSidebar>;
+		return <GlobalSidebar { ...props }>{ this.renderMenu( { isGlobal: true } ) }</GlobalSidebar>;
 	}
 
 	renderSidebar() {
@@ -80,126 +80,134 @@ class MeSidebar extends Component {
 		);
 	}
 
-	renderMenu() {
+	renderMenu( options = {} ) {
 		const { context, locale, translate } = this.props;
 		const path = context.path.replace( '/me', '' ); // Remove base path.
 
-		return (
+		const { isGlobal } = options;
+
+		const mainContent = (
 			<>
-				<SidebarRegion>
-					<ProfileGravatar inSidebar user={ this.props.currentUser } />
+				<ProfileGravatar inSidebar user={ this.props.currentUser } />
 
-					<div className="sidebar__me-signout">
-						<Button
-							compact
-							className="sidebar__me-signout-button"
-							onClick={ this.onSignOut }
-							title={ translate( 'Log out of WordPress.com' ) }
-						>
-							<span className="sidebar__me-signout-text">{ translate( 'Log out' ) }</span>
-							<Gridicon icon="popout" size={ 16 } />
-						</Button>
-					</div>
+				<div className="sidebar__me-signout">
+					<Button
+						compact
+						className="sidebar__me-signout-button"
+						onClick={ this.onSignOut }
+						title={ translate( 'Log out of WordPress.com' ) }
+					>
+						<span className="sidebar__me-signout-text">{ translate( 'Log out' ) }</span>
+						<Gridicon icon="popout" size={ 16 } />
+					</Button>
+				</div>
 
-					<SidebarMenu>
+				<SidebarMenu>
+					<SidebarItem
+						selected={ itemLinkMatches( '', path ) }
+						link="/me"
+						label={ translate( 'My Profile' ) }
+						materialIcon="person"
+						onNavigate={ this.onNavigate }
+					/>
+
+					<SidebarItem
+						selected={ itemLinkMatches( '/account', path ) }
+						link="/me/account"
+						label={ translate( 'Account Settings' ) }
+						materialIcon="settings"
+						onNavigate={ this.onNavigate }
+						preloadSectionName="account"
+					/>
+
+					<SidebarItem
+						selected={ itemLinkMatches( '/purchases', path ) }
+						link={ purchasesRoot }
+						label={ translate( 'Purchases' ) }
+						materialIcon="credit_card"
+						onNavigate={ this.onNavigate }
+						preloadSectionName="purchases"
+					/>
+
+					<SidebarItem
+						selected={ itemLinkMatches( '/security', path ) }
+						link="/me/security"
+						label={ translate( 'Security' ) }
+						materialIcon="lock"
+						onNavigate={ this.onNavigate }
+						preloadSectionName="security"
+					/>
+
+					<SidebarItem
+						selected={ itemLinkMatches( '/privacy', path ) }
+						link="/me/privacy"
+						label={ translate( 'Privacy' ) }
+						materialIcon="visibility"
+						onNavigate={ this.onNavigate }
+						preloadSectionName="privacy"
+					/>
+
+					<SidebarItem
+						selected={ itemLinkMatches( '/developer', path ) }
+						link="/me/developer"
+						label={ translate( 'Developer Features' ) }
+						icon="code"
+						onNavigate={ this.onNavigate }
+						preloadSectionName="developer"
+					/>
+
+					<SidebarItem
+						link="https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs"
+						label={ translate( 'Manage Blogs' ) }
+						materialIcon="apps"
+					/>
+
+					{ ( englishLocales.includes( locale ) ||
+						i18n.hasTranslation( 'Manage All Domains' ) ) && (
 						<SidebarItem
-							selected={ itemLinkMatches( '', path ) }
-							link="/me"
-							label={ translate( 'My Profile' ) }
-							materialIcon="person"
-							onNavigate={ this.onNavigate }
+							link="/domains/manage"
+							label={ translate( 'Manage All Domains' ) }
+							materialIcon="language"
+							forceExternalLink
 						/>
+					) }
 
-						<SidebarItem
-							selected={ itemLinkMatches( '/account', path ) }
-							link="/me/account"
-							label={ translate( 'Account Settings' ) }
-							materialIcon="settings"
-							onNavigate={ this.onNavigate }
-							preloadSectionName="account"
-						/>
+					<SidebarItem
+						selected={ itemLinkMatches( '/notifications', path ) }
+						link="/me/notifications"
+						label={ translate( 'Notification Settings' ) }
+						materialIcon="notifications"
+						onNavigate={ this.onNavigate }
+						preloadSectionName="notification-settings"
+					/>
 
-						<SidebarItem
-							selected={ itemLinkMatches( '/purchases', path ) }
-							link={ purchasesRoot }
-							label={ translate( 'Purchases' ) }
-							materialIcon="credit_card"
-							onNavigate={ this.onNavigate }
-							preloadSectionName="purchases"
-						/>
+					<SidebarItem
+						selected={ itemLinkMatches( '/site-blocks', path ) }
+						link="/me/site-blocks"
+						label={ translate( 'Blocked Sites' ) }
+						materialIcon="block"
+						onNavigate={ this.onNavigate }
+						preloadSectionName="site-blocks"
+					/>
 
-						<SidebarItem
-							selected={ itemLinkMatches( '/security', path ) }
-							link="/me/security"
-							label={ translate( 'Security' ) }
-							materialIcon="lock"
-							onNavigate={ this.onNavigate }
-							preloadSectionName="security"
-						/>
-
-						<SidebarItem
-							selected={ itemLinkMatches( '/privacy', path ) }
-							link="/me/privacy"
-							label={ translate( 'Privacy' ) }
-							materialIcon="visibility"
-							onNavigate={ this.onNavigate }
-							preloadSectionName="privacy"
-						/>
-
-						<SidebarItem
-							selected={ itemLinkMatches( '/developer', path ) }
-							link="/me/developer"
-							label={ translate( 'Developer Features' ) }
-							icon="code"
-							onNavigate={ this.onNavigate }
-							preloadSectionName="developer"
-						/>
-
-						<SidebarItem
-							link="https://dashboard.wordpress.com/wp-admin/index.php?page=my-blogs"
-							label={ translate( 'Manage Blogs' ) }
-							materialIcon="apps"
-						/>
-
-						{ ( englishLocales.includes( locale ) ||
-							i18n.hasTranslation( 'Manage All Domains' ) ) && (
-							<SidebarItem
-								link="/domains/manage"
-								label={ translate( 'Manage All Domains' ) }
-								materialIcon="language"
-								forceExternalLink
-							/>
-						) }
-
-						<SidebarItem
-							selected={ itemLinkMatches( '/notifications', path ) }
-							link="/me/notifications"
-							label={ translate( 'Notification Settings' ) }
-							materialIcon="notifications"
-							onNavigate={ this.onNavigate }
-							preloadSectionName="notification-settings"
-						/>
-
-						<SidebarItem
-							selected={ itemLinkMatches( '/site-blocks', path ) }
-							link="/me/site-blocks"
-							label={ translate( 'Blocked Sites' ) }
-							materialIcon="block"
-							onNavigate={ this.onNavigate }
-							preloadSectionName="site-blocks"
-						/>
-
-						<SidebarItem
-							selected={ itemLinkMatches( '/get-apps', path ) }
-							link="/me/get-apps"
-							label={ translate( 'Apps' ) }
-							icon="plans"
-							onNavigate={ this.onNavigate }
-						/>
-					</SidebarMenu>
-				</SidebarRegion>
+					<SidebarItem
+						selected={ itemLinkMatches( '/get-apps', path ) }
+						link="/me/get-apps"
+						label={ translate( 'Apps' ) }
+						icon="plans"
+						onNavigate={ this.onNavigate }
+					/>
+				</SidebarMenu>
 			</>
 		);
+
+		// The SkipNavigation that SidebarRegion supplies is already added within the global
+		// sidebar, only add SidebarRegion if we are not using the global sidebar.
+		if ( isGlobal ) {
+			return mainContent;
+		}
+
+		return <SidebarRegion>{ mainContent }</SidebarRegion>;
 	}
 
 	render() {

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -280,11 +280,8 @@ export class ReaderSidebar extends Component {
 		};
 		return (
 			<GlobalSidebar { ...props }>
-				<SidebarRegion>
-					<ReaderSidebarNudges />
-					{ this.renderSidebarMenu() }
-				</SidebarRegion>
-
+				<ReaderSidebarNudges />
+				{ this.renderSidebarMenu() }
 				<ReaderSidebarPromo />
 			</GlobalSidebar>
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/dotcom-forge/issues/5688

## Proposed Changes

Adds a "Skip to main content" a11y link at the top of the global nav that appears on top of the wpcom link.

notes:
* Adding new skip link - Bring `SkipNavigation` component into the global sidebar header, and updates to allow a custom string instead of always reading "Skip navigation".

![skip-nav-link](https://github.com/Automattic/wp-calypso/assets/28742426/6ec3d7ad-1627-4af3-bcec-ad9bc705beec)


* Removing old skip links - Updates the /me and /read sidebars that use the global navigation to no longer user the `SidebarRegion` component. This component was the previous sidebars way of delivering the SkipNavigation link, but becomes redundant once within the global sidebar.

![Screenshot 2024-02-21 at 1 58 38 PM](https://github.com/Automattic/wp-calypso/assets/28742426/3686bfc6-39f5-4d4a-9ff1-5be288270e46)


* Update some minor a11y focus styles and bleeds - Removes style bleed of a11y focus styles on a few items: site card, add tag button, etc. and minor margin updates in some places to ensure a11y focus styles are visible.

![Screenshot 2024-02-21 at 1 58 23 PM](https://github.com/Automattic/wp-calypso/assets/28742426/6bbfa07f-bb45-463e-8355-686e840851f3)
![Screenshot 2024-02-21 at 1 59 27 PM](https://github.com/Automattic/wp-calypso/assets/28742426/2db939ba-5100-41eb-8451-0dbd13ba6a76)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Test new:
* Run this calypso branch.
* Test the global sidebar with keyboard navigation. Verify the "skip to main content" link is surfaced as the first item when tabbing through the navigation, and that it focuses the primary page content when used.
* Verify there are no duplicate "skip navigation" links.
* Verify a11y focus styles no longer have extra red borders as seen above.
* Test the /me, /read, and global side view forms of the sidebar. 

Test old:
* apply the `?flags=-layout/dotcom-nav-redesign` in the URL to view the old sidebar.
* test the /me and /read sidebars to ensure there are no regressions and the "skip navigation" links that previously existed are still there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
