### PR TITLE
Added DeploymentStyle to the repository creation screen

### DIFF
--- a/client/my-sites/github-deployments/components/github-connection-form.tsx
+++ b/client/my-sites/github-deployments/components/github-connection-form.tsx
@@ -134,7 +134,7 @@ export const GitHubConnectionForm = ( {
 						installationId={ installation.external_id }
 						repository={ repository }
 						workflowPath={ workflowPath }
-						onChooseWorkflow={ ( item ) => setWorkflowPath( item ) }
+						onChooseWorkflow={ ( filePath ) => setWorkflowPath( filePath ) }
 						onValidationChange={ ( status ) => {
 							if ( status === 'success' ) {
 								setSubmitDisabled( false );

--- a/client/my-sites/github-deployments/components/repositories/create-repository/create-repository-form.tsx
+++ b/client/my-sites/github-deployments/components/repositories/create-repository/create-repository-form.tsx
@@ -6,6 +6,8 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { GitHubInstallationsDropdown } from 'calypso/my-sites/github-deployments/components/installations-dropdown';
 import { useLiveInstallations } from 'calypso/my-sites/github-deployments/components/installations-dropdown/use-live-installations';
+import { GitHubRepositoryData } from 'calypso/my-sites/github-deployments/use-github-repositories-query';
+import { DeploymentStyle } from '../deployment-style/deployment-style';
 import {
 	FormRadioWithTemplateSelect,
 	ProjectType,
@@ -41,6 +43,10 @@ export const CreateRepositoryForm = ( {
 	const [ template, setTemplate ] = useState< RepositoryTemplate >(
 		repositoryTemplates.plugin[ 0 ]
 	);
+	const [ workflowPath, setWorkflowPath ] = useState< string | undefined >( undefined );
+	const [ repository, setRepository ] = useState< GitHubRepositoryData >(
+		{} as GitHubRepositoryData
+	);
 
 	const isFormValid = repositoryName.trim() && ! isLoadingInstallations;
 
@@ -73,6 +79,17 @@ export const CreateRepositoryForm = ( {
 				break;
 		}
 	}, [ projectType, repositoryName ] );
+
+	useEffect( () => {
+		setRepository( {
+			id: 0,
+			private: false,
+			updated_at: '',
+			name: template.value,
+			owner: 'Automattic',
+			default_branch: 'trunk',
+		} );
+	}, [ template ] );
 
 	return (
 		<div className="github-deployments-create-repository">
@@ -178,7 +195,17 @@ export const CreateRepositoryForm = ( {
 					{ __( 'Create repository' ) }
 				</Button>
 			</form>
-			<div className="github-deployments-create-repository__deployment-style"></div>
+			{ installation && (
+				<div className="github-deployments-create-repository__deployment-style">
+					<DeploymentStyle
+						branchName="main"
+						installationId={ installation.external_id }
+						repository={ repository }
+						onChooseWorkflow={ ( filePath ) => setWorkflowPath( filePath ) }
+						onValidationChange={ ( status ) => {} }
+					/>
+				</div>
+			) }
 		</div>
 	);
 };

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/use-deployment-workflows-query.ts
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/use-deployment-workflows-query.ts
@@ -2,6 +2,7 @@ import { UseQueryOptions, useQuery } from '@tanstack/react-query';
 import { addQueryArgs } from '@wordpress/url';
 import wp from 'calypso/lib/wp';
 import { GITHUB_DEPLOYMENTS_QUERY_KEY } from 'calypso/my-sites/github-deployments/constants';
+import { GitHubRepositoryData } from 'calypso/my-sites/github-deployments/use-github-repositories-query';
 
 export const CODE_DEPLOYMENTS_QUERY_KEY = 'code-deployments';
 
@@ -23,16 +24,15 @@ export interface WorkflowsValidation {
 
 export const useDeploymentWorkflowsQuery = (
 	installationId: number,
-	repositoryName: string,
-	repositoryOwner: string,
+	repository: GitHubRepositoryData,
 	branchName: string,
 	deploymentStyle: string,
 	options?: Partial< UseQueryOptions< Workflows[] > >
 ) => {
 	const path = addQueryArgs( '/hosting/github/workflows', {
 		installation_id: installationId,
-		repository_name: repositoryName,
-		repository_owner: repositoryOwner,
+		repository_name: repository.name,
+		repository_owner: repository.owner,
 		branch_name: branchName,
 	} );
 
@@ -53,23 +53,23 @@ export const useDeploymentWorkflowsQuery = (
 
 export const useCheckWorkflowQuery = (
 	installationId: number,
-	repositoryName: string,
-	repositoryOwner: string,
+	repository: GitHubRepositoryData,
 	branchName: string,
-	workflowFilename: string
+	workflowFilename: string,
+	isTemplateRepository: boolean
 ) => {
 	const invalidFilenames = [ 'none', 'create-new' ];
 	const path = addQueryArgs( '/hosting/github/workflows/checks', {
 		installation_id: installationId,
-		repository_name: repositoryName,
-		repository_owner: repositoryOwner,
+		repository_name: repository.name,
+		repository_owner: repository.owner,
 		branch_name: branchName,
 		workflow_filename: workflowFilename,
 	} );
 
 	return useQuery< WorkflowsValidation >( {
 		queryKey: [ GITHUB_DEPLOYMENTS_QUERY_KEY, CODE_DEPLOYMENTS_QUERY_KEY, path ],
-		enabled: ! invalidFilenames.includes( workflowFilename ),
+		enabled: ! invalidFilenames.includes( workflowFilename ) && ! isTemplateRepository,
 		queryFn: (): WorkflowsValidation =>
 			wp.req.get( {
 				path,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5334

## Proposed Changes

* When creating a repository, we can now choose a Deployment style:

<img width="1383" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/e5adbd3d-bbc4-4535-9f6c-b45a15f9b907">

TODO:

- Connect it to the interface (depends on other task)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this backend diff: D139209-code
* Head to Repository creation and select the `WordPress Plugin Boilerplate Powered` plugin, the only one which will work for now (we need to publish other to work)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?