### PR TITLE
Dynamically set Site Monitoring title

### DIFF
--- a/client/my-sites/site-monitoring/main.tsx
+++ b/client/my-sites/site-monitoring/main.tsx
@@ -1,14 +1,13 @@
 import { isEnabled } from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
-import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { useSelector } from 'calypso/state';
 import { getSiteOption } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { AppState } from 'calypso/types';
 import { SiteMonitoringTabPanel } from './components/site-monitoring-tab-panel';
 import { LogsTab } from './logs-tab';
 import { MetricsTab } from './metrics-tab';
@@ -18,18 +17,18 @@ import './style.scss';
 
 interface SiteMetricsProps {
 	tab: SiteMonitoringTab;
-	isClassicView: boolean;
 }
 
-const getTitle = ( isClassicView: boolean ) => {
-	if ( isEnabled( 'layout/dotcom-nav-redesign' ) && isClassicView ) {
-		return translate( 'Monitoring' );
-	}
-	return translate( 'Site Monitoring' );
-};
+export function SiteMetrics( { tab = 'metrics' }: SiteMetricsProps ) {
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const adminInterface = useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'wpcom_admin_interface' )
+	);
 
-const Metrics = ( { tab = 'metrics', isClassicView }: SiteMetricsProps ) => {
-	const titleHeader = getTitle( isClassicView );
+	const titleHeader =
+		isEnabled( 'layout/dotcom-nav-redesign' ) && adminInterface === 'wp-admin'
+			? translate( 'Monitoring' )
+			: translate( 'Site Monitoring' );
 
 	return (
 		<Main className="site-monitoring" fullWidthLayout>
@@ -61,14 +60,4 @@ const Metrics = ( { tab = 'metrics', isClassicView }: SiteMetricsProps ) => {
 			</div>
 		</Main>
 	);
-};
-
-const mapStateToProps = ( state: AppState ) => {
-	const siteId = getSelectedSiteId( state );
-	return {
-		siteId,
-		isClassicView: getSiteOption( state, siteId, 'wpcom_admin_interface' ) === 'wp-admin',
-	};
-};
-
-export const SiteMetrics = connect( mapStateToProps )( Metrics );
+}

--- a/client/my-sites/site-monitoring/main.tsx
+++ b/client/my-sites/site-monitoring/main.tsx
@@ -1,10 +1,14 @@
-import { useI18n } from '@wordpress/react-i18n';
+import { isEnabled } from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
+import { connect } from 'react-redux';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import { getSiteOption } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { AppState } from 'calypso/types';
 import { SiteMonitoringTabPanel } from './components/site-monitoring-tab-panel';
 import { LogsTab } from './logs-tab';
 import { MetricsTab } from './metrics-tab';
@@ -12,9 +16,20 @@ import { SiteMonitoringTab } from './site-monitoring-filter-params';
 
 import './style.scss';
 
-export function SiteMetrics( { tab = 'metrics' }: { tab: SiteMonitoringTab } ) {
-	const { __ } = useI18n();
-	const titleHeader = __( 'Site Monitoring' );
+interface SiteMetricsProps {
+	tab: SiteMonitoringTab;
+	isClassicView: boolean;
+}
+
+const getTitle = ( isClassicView: boolean ) => {
+	if ( isEnabled( 'layout/dotcom-nav-redesign' ) && isClassicView ) {
+		return translate( 'Monitoring' );
+	}
+	return translate( 'Site Monitoring' );
+};
+
+const Metrics = ( { tab = 'metrics', isClassicView }: SiteMetricsProps ) => {
+	const titleHeader = getTitle( isClassicView );
 
 	return (
 		<Main className="site-monitoring" fullWidthLayout>
@@ -46,4 +61,14 @@ export function SiteMetrics( { tab = 'metrics' }: { tab: SiteMonitoringTab } ) {
 			</div>
 		</Main>
 	);
-}
+};
+
+const mapStateToProps = ( state: AppState ) => {
+	const siteId = getSelectedSiteId( state );
+	return {
+		siteId,
+		isClassicView: getSiteOption( state, siteId, 'wpcom_admin_interface' ) === 'wp-admin',
+	};
+};
+
+export const SiteMetrics = connect( mapStateToProps )( Metrics );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5623

## Proposed Changes

- The "Site Monitoring" title is renamed "Monitoring" for classic sites with the nav-redesign flag to match the sidebar menu item. Otherwise, it remains "Site Monitoring".

Without Flag or Classic | With Flag and Classic
--|--
<img width="1720" alt="Screenshot 2024-02-21 at 4 28 42 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/bea461b3-414a-4c17-9ea2-50fbdd165772">  | <img width="1722" alt="Screenshot 2024-02-21 at 4 29 06 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/450d805d-f9b4-4f8c-885c-b96a4fbad796">





## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load http://calypso.localhost:3000/site-monitoring/[site_slug]?flags=layout/dotcom-nav-redesign and view the title change. Nothing else should have changed.
* Remove the flag http://calypso.localhost:3000/site-monitoring/[site_slug]?flags=-layout/dotcom-nav-redesign and view the title is the original "Site Monitoring". Nothing else should have changed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?