### PR TITLE
Add notification suppression array to notices

### DIFF
--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -100,7 +100,8 @@ export function userSettingsSaveFailure( { settingsOverride }, error ) {
 
 	// If every property in settingsOverride is to be suppressed, don't show a notification
 	if (
-		Object.keys( settingsOverride ).every( ( key ) =>
+		settingsOverride &&
+		Object.keys( settingsOverride || {} ).every( ( key ) =>
 			PROPERTIES_TO_SUPRESS_NOTIFICATIONS.has( key )
 		)
 	) {
@@ -137,6 +138,7 @@ export const userSettingsSaveSuccess =
 
 		// If every property in settingsOverride is to be suppressed, don't show a notification
 		if (
+			settingsOverride &&
 			Object.keys( settingsOverride ).every( ( key ) =>
 				PROPERTIES_TO_SUPRESS_NOTIFICATIONS.has( key )
 			)

--- a/client/state/data-layer/wpcom/me/settings/index.js
+++ b/client/state/data-layer/wpcom/me/settings/index.js
@@ -21,6 +21,14 @@ import {
  * that the REST API returns already HTML-encoded
  */
 const PROPERTIES_TO_DECODE = new Set( [ 'display_name', 'description', 'user_URL' ] );
+
+/*
+ * Properties that should not trigger a notification when changed
+ * ex. advertising_targeting_opt_out should fail quietly in the event they have an expired 2fa token
+ * and a success notification is not standard when accepting or denying cookies
+ */
+const PROPERTIES_TO_SUPRESS_NOTIFICATIONS = new Set( [ 'advertising_targeting_opt_out' ] );
+
 export const fromApi = ( apiResponse ) =>
 	mapValues( apiResponse, ( value, name ) =>
 		PROPERTIES_TO_DECODE.has( name ) ? decodeEntities( value ) : value
@@ -90,6 +98,15 @@ export function userSettingsSaveFailure( { settingsOverride }, error ) {
 		];
 	}
 
+	// If every property in settingsOverride is to be suppressed, don't show a notification
+	if (
+		Object.keys( settingsOverride ).every( ( key ) =>
+			PROPERTIES_TO_SUPRESS_NOTIFICATIONS.has( key )
+		)
+	) {
+		return;
+	}
+
 	return [
 		errorNotice( error.message || translate( 'There was a problem saving your changes.' ), {
 			id: 'save-user-settings',
@@ -115,6 +132,15 @@ export const userSettingsSaveSuccess =
 
 		if ( settingsOverride?.user_email_change_pending !== undefined ) {
 			dispatch( successNotice( translate( 'The email change has been successfully canceled.' ) ) );
+			return;
+		}
+
+		// If every property in settingsOverride is to be suppressed, don't show a notification
+		if (
+			Object.keys( settingsOverride ).every( ( key ) =>
+				PROPERTIES_TO_SUPRESS_NOTIFICATIONS.has( key )
+			)
+		) {
 			return;
 		}
 


### PR DESCRIPTION
## Proposed Changes

* Suppress notifications when saving the cookie banner settings

In the case of the cookie banner, we don't want to show the user that something went wrong if we were unable to save their opt-out settings for cookies. This usually happens when a 2fa code is expired. We also don't really want to show them when it is successful because they might not know what "Setting" was just set

## Testing Instructions

1. Checkout this branch locally or use the Calypso live link
2. Go to `/checkout/jetpack/jetpack_social_advanced_yearly?flags=cookie-banner`
3. Make sure you don't have any `sensitive_pixel_options` saved in your browser cookies
4. If you are not in a region that shows the cookie banner, you can change your `country_code` cookie to `FR` and you should be able to see it
5. Make sure you see the cookie banner 
![image](https://github.com/Automattic/wp-calypso/assets/65001528/fc5872de-02a3-40fb-a081-380322dabec9)
6. Accept or deny cookies and make sure you do not see a notification in checkout when that is complete
7. In the Network tab, search for Settings and make sure the request was still successful
![image](https://github.com/Automattic/wp-calypso/assets/65001528/ecb127d2-80ce-407f-b69b-7408f8657fe3)
![image](https://github.com/Automattic/wp-calypso/assets/65001528/8326dbd4-3541-428f-a19f-765e8201c5cb)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?