### PR TITLE
GitHub Deployments: Hide feature from non-admins

### DIFF
--- a/client/my-sites/github-deployments/controller.tsx
+++ b/client/my-sites/github-deployments/controller.tsx
@@ -1,8 +1,11 @@
+import { __ } from '@wordpress/i18n';
 import { PageViewTracker } from 'calypso/lib/analytics/page-view-tracker';
 import { CreateRepository } from 'calypso/my-sites/github-deployments/components/repositories/create-repository/index';
 import { DeploymentRunsLogs } from 'calypso/my-sites/github-deployments/deployment-run-logs/index';
+import { errorNotice } from 'calypso/state/notices/actions';
 import { isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { canCurrentUser } from '../../state/selectors/can-current-user';
 import { GitHubDeploymentCreation } from './deployment-creation';
 import { GitHubDeploymentManagement } from './deployment-management';
 import { GitHubDeployments } from './deployments';
@@ -110,6 +113,18 @@ export const redirectHomeIfIneligible: Callback = ( context, next ) => {
 
 	if ( isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } ) ) {
 		context.page.replace( `/stats/day/${ siteSlug }` );
+		return;
+	}
+
+	const canManageOptions = canCurrentUser( state, siteId, 'manage_options' );
+
+	if ( ! canManageOptions ) {
+		context.store.dispatch(
+			errorNotice( __( 'You are not authorized to manage GitHub Deployments for this site.' ), {
+				displayOnNextPage: true,
+			} )
+		);
+		context.page.replace( `/home/${ siteSlug }` );
 		return;
 	}
 


### PR DESCRIPTION
## Proposed Changes

Redirects to `/home/%s` if a non-admin tries to enter `/github-deployments/%s`.

## Testing Instructions

Check that you can enter the page and invite a user that's not an admin. Try entering the page as this user and verify that it's not possible and you get redirected to the blog home.