### PR TITLE
Deploy the updated version of domain step escape hatch to the onboarding flow and the paid media flow - the 2nd attempt

### DIFF
--- a/client/components/domains/choose-domain-later/index.tsx
+++ b/client/components/domains/choose-domain-later/index.tsx
@@ -1,91 +1,31 @@
-import React, { useState } from 'react';
-import { useExperiment } from 'calypso/lib/explat';
 import ReskinSideExplainer from '../reskin-side-explainer';
 
 type Props = {
-	step: {
-		domainForm: {
-			loadingResults: boolean;
-			searchResults?: Array< any > | null;
-		};
-	};
+	hasSearchedDomains: boolean;
 	handleDomainExplainerClick: () => void;
 	flowName: string;
+	showEscapeHatchAfterSearch: boolean;
 };
 
-export default function ChooseDomainLater( props: Props ) {
-	const [ isEscapeHatchShownOnce, setisEscapeHatchShownOnce ] = useState( false );
-	const [ isLoading, experimentAssignment ] = useExperiment(
-		'calypso_gf_signup_onboarding_escape_hatch',
-		{
-			isEligible: props.flowName === 'onboarding',
-		}
-	);
-
-	if ( isLoading ) {
-		return null;
-	}
-	const escapeHatchVariant = experimentAssignment?.variationName;
-	const { step, handleDomainExplainerClick, flowName } = props;
-	const domainForm = step?.domainForm ?? {};
-
-	const isDomainResultsLoaded =
-		! domainForm.loadingResults &&
-		Array.isArray( domainForm?.searchResults ) &&
-		domainForm?.searchResults?.length > 0;
-
-	if (
-		escapeHatchVariant === 'treatment_search' &&
-		( isEscapeHatchShownOnce || isDomainResultsLoaded )
-	) {
-		if ( ! isEscapeHatchShownOnce ) {
-			setisEscapeHatchShownOnce( true );
-		}
-		return (
-			<div className="domains__domain-side-content domains__free-domain">
-				<ReskinSideExplainer
-					onClick={ handleDomainExplainerClick }
-					type="free-domain-explainer-treatment-search"
-					flowName={ flowName }
-				/>
-			</div>
-		);
-	} else if (
-		escapeHatchVariant === 'treatment_type' &&
-		( isEscapeHatchShownOnce || isDomainResultsLoaded )
-	) {
-		if ( ! isEscapeHatchShownOnce ) {
-			setisEscapeHatchShownOnce( true );
-		}
-		return (
-			<div className="domains__domain-side-content domains__free-domain">
-				<ReskinSideExplainer
-					onClick={ handleDomainExplainerClick }
-					type="free-domain-explainer-treatment-type"
-					flowName={ flowName }
-				/>
-			</div>
-		);
-	}
-
-	if (
-		[ 'treatment_search', 'treatment_type' ].includes( escapeHatchVariant ?? '' ) &&
-		( domainForm.loadingResults ||
-			! Array.isArray( domainForm?.searchResults ) ||
-			domainForm?.searchResults?.length === 0 )
-	) {
-		/**
-		 * We do not show the free domain explainer until there is at least one search query
-		 */
+export default function ChooseDomainLater( {
+	hasSearchedDomains,
+	handleDomainExplainerClick,
+	flowName,
+	showEscapeHatchAfterSearch,
+}: Props ) {
+	if ( showEscapeHatchAfterSearch && ! hasSearchedDomains ) {
 		return null;
 	}
 
-	// The default behavior is the control variant
 	return (
 		<div className="domains__domain-side-content domains__free-domain">
 			<ReskinSideExplainer
 				onClick={ handleDomainExplainerClick }
-				type="free-domain-explainer"
+				type={
+					showEscapeHatchAfterSearch
+						? 'free-domain-explainer-treatment-type'
+						: 'free-domain-explainer'
+				}
 				flowName={ flowName }
 			/>
 		</div>

--- a/client/components/domains/choose-domain-later/test/choose-domain-later.test.tsx
+++ b/client/components/domains/choose-domain-later/test/choose-domain-later.test.tsx
@@ -14,18 +14,14 @@ jest.mock( 'calypso/lib/explat', () => ( {
 } ) );
 
 describe( 'ChooseDomainLater', () => {
-	test( 'Renders treatment_type when that treatment is active', () => {
+	test( 'Renders treatment_type when showEscapeHatchAfterSearch and hasSearchedDomains are true', () => {
 		useExperimentMock.mockImplementation( () => [ false, { variationName: 'treatment_type' } ] );
 
 		const { getByText } = render(
 			<ChooseDomainLater
 				flowName="onboarding"
-				step={ {
-					domainForm: {
-						loadingResults: false,
-						searchResults: Array( 5 ).fill( {} ),
-					},
-				} }
+				showEscapeHatchAfterSearch={ true }
+				hasSearchedDomains={ true }
 				handleDomainExplainerClick={ () => {} }
 			/>
 		);
@@ -33,37 +29,14 @@ describe( 'ChooseDomainLater', () => {
 		expect( getByText( 'Not ready to choose a domain just yet?' ) ).toBeTruthy();
 	} );
 
-	test( 'Renders treatment_search when that treatment is active', () => {
-		useExperimentMock.mockImplementation( () => [ false, { variationName: 'treatment_search' } ] );
-
-		const { getByText } = render(
-			<ChooseDomainLater
-				flowName="onboarding"
-				step={ {
-					domainForm: {
-						loadingResults: false,
-						searchResults: Array( 5 ).fill( {} ),
-					},
-				} }
-				handleDomainExplainerClick={ () => {} }
-			/>
-		);
-
-		expect( getByText( 'Get a free domain with select paid plans' ) ).toBeTruthy();
-	} );
-
-	test( 'Renders control when that control is active', () => {
+	test( 'Renders the standard domain explainer control', () => {
 		useExperimentMock.mockImplementation( () => [ false, { variationName: 'control' } ] );
 
 		const { container } = render(
 			<ChooseDomainLater
 				flowName="onboarding"
-				step={ {
-					domainForm: {
-						loadingResults: false,
-						searchResults: Array( 5 ).fill( {} ),
-					},
-				} }
+				showEscapeHatchAfterSearch={ false }
+				hasSearchedDomains={ false }
 				handleDomainExplainerClick={ () => {} }
 			/>
 		);
@@ -73,55 +46,13 @@ describe( 'ChooseDomainLater', () => {
 		);
 	} );
 
-	test( 'Does not render if treatment_search and domain results not loaded', () => {
-		useExperimentMock.mockImplementation( () => [ false, { variationName: 'treatment_search' } ] );
-
-		const { queryByText } = render(
-			<ChooseDomainLater
-				flowName="onboarding"
-				step={ {
-					domainForm: {
-						loadingResults: true,
-						searchResults: [],
-					},
-				} }
-				handleDomainExplainerClick={ () => {} }
-			/>
-		);
-
-		expect( queryByText( 'Get a free domain with select paid plans' ) ).toBeFalsy();
-	} );
-
-	test( 'Does not render if treatment_type and domain results not loaded', () => {
-		useExperimentMock.mockImplementation( () => [ false, { variationName: 'treatment_type' } ] );
-
-		const { queryByText } = render(
-			<ChooseDomainLater
-				flowName="onboarding"
-				step={ {
-					domainForm: {
-						loadingResults: true,
-						searchResults: [],
-					},
-				} }
-				handleDomainExplainerClick={ () => {} }
-			/>
-		);
-
-		expect( queryByText( 'Not ready to choose a domain just yet?' ) ).toBeFalsy();
-	} );
-
-	test( 'Does not render anything if experiment is still loading', () => {
+	test( 'Does not render anything if domains have not been searched while the escape hatch should be rendered after', () => {
 		useExperimentMock.mockImplementation( () => [ true, null ] );
 		const { container } = render(
 			<ChooseDomainLater
 				flowName="onboarding"
-				step={ {
-					domainForm: {
-						loadingResults: false,
-						searchResults: [],
-					},
-				} }
+				hasSearchedDomains={ false }
+				showEscapeHatchAfterSearch={ true }
 				handleDomainExplainerClick={ () => {} }
 			/>
 		);

--- a/client/signup/flow-actions.ts
+++ b/client/signup/flow-actions.ts
@@ -1,8 +1,3 @@
-import { loadExperimentAssignment } from 'calypso/lib/explat';
-
-export const onEnterOnboarding = ( flowName: string ) => {
-	// just to be extra safe since `loadExperimentAssignment` doesn't have the same eligibility check like `useExperiment` does
-	if ( flowName === 'onboarding' ) {
-		loadExperimentAssignment( 'calypso_gf_signup_onboarding_escape_hatch' );
-	}
-};
+// Remove this eslint disabling line once there are things to be preloaded
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const onEnterOnboarding = ( flowName: string ) => {};

--- a/client/signup/steps/domains/index.jsx
+++ b/client/signup/steps/domains/index.jsx
@@ -36,7 +36,6 @@ import {
 	getFixedDomainSearch,
 } from 'calypso/lib/domains';
 import { getSuggestionsVendor } from 'calypso/lib/domains/suggestions';
-import { useExperiment } from 'calypso/lib/explat';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import { getSitePropertyDefaults } from 'calypso/lib/signup/site-properties';
 import { maybeExcludeEmailsStep } from 'calypso/lib/signup/step-actions';
@@ -921,7 +920,7 @@ export class RenderDomainsStep extends Component {
 						temporaryCart={ this.state.temporaryCart }
 						domainRemovalQueue={ this.state.domainRemovalQueue }
 						cartIsLoading={ cartIsLoading }
-						flowName={ this.props.flowName }
+						flowName={ flowName }
 						removeDomainClickHandler={ this.removeDomainClickHandler }
 						isMiniCartContinueButtonBusy={ this.state.isMiniCartContinueButtonBusy }
 						goToNext={ this.goToNext }
@@ -933,9 +932,12 @@ export class RenderDomainsStep extends Component {
 					! this.shouldHideDomainExplainer() &&
 					this.props.isPlanSelectionAvailableLaterInFlow && (
 						<ChooseDomainLater
-							step={ this.props.step }
-							flowName={ this.props.flowName }
+							hasSearchedDomains={ Array.isArray( this.props.step?.domainForm?.searchResults ) }
+							flowName={ flowName }
 							handleDomainExplainerClick={ this.handleDomainExplainerClick }
+							showEscapeHatchAfterSearch={
+								flowName === 'onboarding' || flowName === 'onboarding-pm'
+							}
 						/>
 					)
 				) }
@@ -1466,12 +1468,10 @@ const RenderDomainsStepConnect = connect(
 )( withCartKey( withShoppingCart( localize( RenderDomainsStep ) ) ) );
 
 export default function DomainsStep( props ) {
-	const [ isSideContentExperimentLoading ] = useExperiment(
-		'calypso_gf_signup_onboarding_escape_hatch',
-		{
-			isEligible: props.flowName === 'onboarding',
-		}
-	);
+	// this is kept since there will likely be more experiments to come.
+	// See peP6yB-1Np-p2
+	const isSideContentExperimentLoading = false;
+
 	return (
 		<CalypsoShoppingCartProvider>
 			<RenderDomainsStepConnect

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-domain-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-domain-page.ts
@@ -25,4 +25,11 @@ export class SignupDomainPage {
 			this.page.getByRole( 'button', { name: 'Choose my domain later', exact: true } ).click(),
 		] );
 	}
+
+	/**
+	 * Search for domains with the query string "foo".
+	 */
+	async searchForFooDomains(): Promise< void > {
+		await this.domainSearchComponent.search( 'foo' );
+	}
 }

--- a/packages/calypso-e2e/src/lib/pages/signup/signup-domain-page.ts
+++ b/packages/calypso-e2e/src/lib/pages/signup/signup-domain-page.ts
@@ -23,6 +23,7 @@ export class SignupDomainPage {
 		await Promise.race( [
 			this.page.getByRole( 'button', { name: 'Skip Purchase', exact: true } ).click(),
 			this.page.getByRole( 'button', { name: 'Choose my domain later', exact: true } ).click(),
+			this.page.getByRole( 'button', { name: 'Check paid plans »', exact: true } ).click(),
 		] );
 	}
 

--- a/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
+++ b/test/e2e/specs/onboarding/lifecycle__signup-onboarding-launch-cancel.ts
@@ -73,6 +73,7 @@ describe( 'Lifecyle: Signup, onboard, launch and cancel subscription', function 
 
 		it( 'Skip domain selection', async function () {
 			const signupDomainPage = new SignupDomainPage( page );
+			await signupDomainPage.searchForFooDomains();
 			await signupDomainPage.skipDomainSelection();
 		} );
 

--- a/test/e2e/specs/plans/plans__signup-business.ts
+++ b/test/e2e/specs/plans/plans__signup-business.ts
@@ -52,6 +52,7 @@ describe(
 
 			it( 'Skip domain selection', async function () {
 				const signupDomainPage = new SignupDomainPage( page );
+				await signupDomainPage.searchForFooDomains();
 				await signupDomainPage.skipDomainSelection();
 			} );
 


### PR DESCRIPTION
## Summary 
This PR reverts Automattic/wp-calypso#87747 that reverted https://github.com/Automattic/wp-calypso/pull/87697, with addition of fixing the broken E2E tests.

The E2E tests were broken since the skip domain selection option will be revealed after searching for some domains. This PR adds a step of searching for domains before clicking on the skip button.