### PR TITLE
Fix styling of upsell banner in sidebar

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -480,6 +480,8 @@ $font-size: rem(14px);
 
 		.upsell-nudge.banner.card.is-compact .dismissible-card__close-button .gridicon {
 			fill: #000;
+			width: 16px;
+			height: 16px;
 		}
 	}
 

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -470,16 +470,16 @@ $font-size: rem(14px);
 	&:not(.is-classic-bright):not(.is-contrast) {
 		.upsell-nudge.banner.card.is-compact {
 			background-color: var(--studio-white);
-			color: #000;
+			color: var(--studio-black);
 		}
 
 		.upsell-nudge.banner.card.is-compact .banner__info .banner__title {
-			color: #000;
+			color: var(--studio-black);
 			text-wrap: wrap;
 		}
 
 		.upsell-nudge.banner.card.is-compact .dismissible-card__close-button .gridicon {
-			fill: #000;
+			fill: var(--studio-black);
 			width: 16px;
 			height: 16px;
 		}

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -475,6 +475,11 @@ $font-size: rem(14px);
 
 		.upsell-nudge.banner.card.is-compact .banner__info .banner__title {
 			color: #000;
+			text-wrap: wrap;
+		}
+
+		.upsell-nudge.banner.card.is-compact .dismissible-card__close-button .gridicon {
+			fill: #000;
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/martech/issues/2745

Initial discussion in Slack: p1708512826252879-slack-C0BNMNMNG

## Proposed Changes

Styling fix for the upsell banner:

- The 'x' button is now visible
- The text now wraps onto next line without a large gap after 'sale'

| Before | After |
| -- | -- |
|![CleanShot 2024-02-23 at 12 04 30@2x](https://github.com/Automattic/wp-calypso/assets/69198925/a615f993-a893-4443-9933-db17e8a30e20)|![CleanShot 2024-02-23 at 12 05 00@2x](https://github.com/Automattic/wp-calypso/assets/69198925/97dc3824-4c29-4e49-9154-8a6ffe79939d)|



## Testing Instructions

Note: this is the first time I've used my backend sandbox for testing a Calypso change. When providing testing instructions in this scenario:

- Do we usually provide a link to the backend diff (like I've done below) for the reviewer to run on their sandbox? Or do we have a way to test against someone else's sandbox with our local Calypso?
- Is there a way to use a particular backend/sandbox with the 'Calypso Live' link that's generated for the PR?

Any suggestions/guidance, greatly appreciated 🙏 



---

In order to display this particular upsell banner in Calypso, the easiest approach I found was to hardcode a change on my sandbox to return the required banner config. Here is the backend diff I used on my sandbox: D139438-code.

Once you have your local Calypso pointing at your updated sandbox:

1. Create or use a simple site (I don't believe the sandbox works with atomic sites?)
2. Visit `/plans/:site` and check that you can see the upsell banner in the sidebar
3. Check that the 'x' button is visible and the text wraps as per the above screenshot


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?