### PR TITLE
Automattic for Agencies: Implement marketplace review license screen

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/licenses-form/index.tsx
@@ -176,7 +176,7 @@ export default function LicensesForm( {
 		[ dispatch, handleSelectBundleLicense, quantity, selectedLicenses, setSelectedLicenses ]
 	);
 
-	const isReady = true;
+	const isReady = true; // FIXME: Fix this with actual form ready state
 
 	const isSelected = useCallback(
 		( slug: string | string[] ) =>
@@ -257,7 +257,7 @@ export default function LicensesForm( {
 					title={ translate( 'Plans' ) }
 					description={ translate(
 						'Save big with comprehensive bundles of Jetpack security, performance, and growth tools.'
-					) }
+					) } // FIXME: Add proper description for A4A
 					isTwoColumns
 				>
 					{ getProductCards( plans ) }

--- a/client/a8c-for-agencies/sections/marketplace/issue-license/style.scss
+++ b/client/a8c-for-agencies/sections/marketplace/issue-license/style.scss
@@ -1,5 +1,18 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
+@import "../mixins.scss";
+
+.issue-license__select-license {
+	// :active introduces a 1px border but :focus introduces a 1.5px border which causes the button to move around.
+	border-width: 1.5px !important;
+	border-color: transparent;
+	text-wrap: nowrap;
+
+	@include breakpoint-deprecated("<660px") {
+		width: auto;
+		flex-grow: 1;
+	}
+}
 
 .issue-license .assign-license-step-progress {
 	margin-block-start: 16px;
@@ -16,4 +29,15 @@
 	.a4a-layout__header-subtitle {
 		padding-block-end: 16px;
 	}
+}
+
+.issue-license__actions {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.issue-license__controls {
+	@include licensing-portal-bottom-action-bar;
+	padding: 14px;
 }

--- a/client/jetpack-cloud/sections/partner-portal/license-lightbox/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-lightbox/style.scss
@@ -1,7 +1,7 @@
 .license-lightbox__pricing {
 	background-color: var(--studio-white);
 	border-radius: 8px; /* stylelint-disable-line scales/radii */
-	border: 1px solid var(--studio-jetpack-green-50);
+	border: 1px solid var(--color-link);
 	padding: 1rem;
 }
 

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/index.tsx
@@ -43,8 +43,6 @@ export default function IssueLicense( { selectedSite, suggestedProduct }: Assign
 		?.toString()
 		.split( ',' );
 
-	const { isReady } = useSubmitForm( selectedSite, suggestedProductSlugs );
-
 	const [ selectedLicenses, setSelectedLicenses ] = useState< SelectedLicenseProp[] >( [] );
 	const [ showReviewLicenses, setShowReviewLicenses ] = useState< boolean >( false );
 
@@ -165,6 +163,8 @@ export default function IssueLicense( { selectedSite, suggestedProduct }: Assign
 			: translate( 'Select the Jetpack products you would like to issue a new license for:' );
 	}, [ selectedSite?.domain, showBundle, translate ] );
 
+	const { isReady, submitForm } = useSubmitForm( selectedSite, suggestedProductSlugs );
+
 	return (
 		<>
 			<Layout
@@ -235,6 +235,8 @@ export default function IssueLicense( { selectedSite, suggestedProduct }: Assign
 					onClose={ onDismissReviewLicensesModal }
 					selectedLicenses={ getGroupedLicenses() }
 					selectedSite={ selectedSite }
+					isFormReady={ isReady }
+					submitForm={ submitForm }
 				/>
 			) }
 		</>

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/review-licenses/index.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/review-licenses/index.tsx
@@ -15,9 +15,17 @@ interface Props {
 	onClose: () => void;
 	selectedLicenses: SelectedLicenseProp[];
 	selectedSite?: SiteDetails | null;
+	isFormReady: boolean;
+	submitForm: ( selectedLicenses: SelectedLicenseProp[] ) => void;
 }
 
-export default function ReviewLicenses( { onClose, selectedLicenses, selectedSite }: Props ) {
+export default function ReviewLicenses( {
+	onClose,
+	selectedLicenses,
+	selectedSite,
+	isFormReady,
+	submitForm,
+}: Props ) {
 	const translate = useTranslate();
 
 	const { sidebarRef, mainRef, initMobileSidebar } = useMobileSidebar();
@@ -48,7 +56,12 @@ export default function ReviewLicenses( { onClose, selectedLicenses, selectedSit
 			</JetpackLightboxMain>
 
 			<JetpackLightboxAside ref={ sidebarRef }>
-				<PricingSummary selectedLicenses={ selectedLicenses } selectedSite={ selectedSite } />
+				<PricingSummary
+					selectedLicenses={ selectedLicenses }
+					selectedSite={ selectedSite }
+					isFormReady={ isFormReady }
+					submitForm={ submitForm }
+				/>
 			</JetpackLightboxAside>
 		</JetpackLightbox>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/review-licenses/pricing-summary.tsx
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/review-licenses/pricing-summary.tsx
@@ -1,3 +1,4 @@
+import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { useTranslate } from 'i18n-calypso';
@@ -6,7 +7,6 @@ import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getProductsList } from 'calypso/state/products-list/selectors';
-import useSubmitForm from '../hooks/use-submit-form';
 import { getTotalInvoiceValue } from '../lib/pricing';
 import PricingBreakdown from './pricing-breakdown';
 import type { SelectedLicenseProp } from '../types';
@@ -15,9 +15,13 @@ import type { SiteDetails } from '@automattic/data-stores';
 export default function PricingSummary( {
 	selectedLicenses,
 	selectedSite,
+	isFormReady,
+	submitForm,
 }: {
 	selectedLicenses: SelectedLicenseProp[];
 	selectedSite?: SiteDetails | null;
+	isFormReady: boolean;
+	submitForm: ( selectedLicenses: SelectedLicenseProp[] ) => void;
 } ) {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
@@ -29,7 +33,8 @@ export default function PricingSummary( {
 		.map( ( license ) => license.quantity )
 		.reduce( ( a, b ) => a + b, 0 );
 
-	const { isReady: isFormReady, submitForm } = useSubmitForm( selectedSite );
+	const isA4A = config.isEnabled( 'a8c-for-agencies' );
+
 	const handleCTAClick = useCallback( () => {
 		if ( ! isFormReady ) {
 			return;
@@ -38,23 +43,33 @@ export default function PricingSummary( {
 		submitForm( selectedLicenses );
 
 		dispatch(
-			recordTracksEvent( 'calypso_jetpack_agency_issue_license_review_licenses_submit', {
-				total_licenses: selectedLicenseCount,
-				items: selectedLicenses
-					?.map( ( license ) => `${ license.slug } x ${ license.quantity }` )
-					.join( ',' ),
-			} )
+			recordTracksEvent(
+				isA4A
+					? 'calypso_a4a_issue_license_review_licenses_submit'
+					: 'calypso_jetpack_agency_issue_license_review_licenses_submit',
+				{
+					total_licenses: selectedLicenseCount,
+					items: selectedLicenses
+						?.map( ( license ) => `${ license.slug } x ${ license.quantity }` )
+						.join( ',' ),
+				}
+			)
 		);
-	}, [ dispatch, isFormReady, selectedLicenseCount, selectedLicenses, submitForm ] );
+	}, [ dispatch, isA4A, isFormReady, selectedLicenseCount, selectedLicenses, submitForm ] );
 
-	const learnMoreLink =
-		'https://jetpack.com/support/jetpack-manage-instructions/jetpack-manage-billing-payment-faqs';
+	const learnMoreLink = isA4A
+		? '' //FIXME: Add link for A4A
+		: 'https://jetpack.com/support/jetpack-manage-instructions/jetpack-manage-billing-payment-faqs';
 
 	const onClickLearnMore = useCallback( () => {
 		dispatch(
-			recordTracksEvent( 'calypso_jetpack_agency_issue_license_review_licenses_learn_more_click' )
+			recordTracksEvent(
+				isA4A
+					? 'calypso_a4a_issue_license_review_licenses_learn_more_click'
+					: 'calypso_jetpack_agency_issue_license_review_licenses_learn_more_click'
+			)
 		);
-	}, [ dispatch ] );
+	}, [ dispatch, isA4A ] );
 
 	// Make sure we have a/any selected licenses available to prevent fatal errors in the console.
 	if ( selectedLicenses.length === 0 ) {

--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/review-licenses/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/review-licenses/style.scss
@@ -98,7 +98,7 @@
 .review-licenses__pricing {
 	background-color: var(--studio-white);
 	border-radius: 8px; /* stylelint-disable-line scales/radii */
-	border: 1px solid var(--studio-jetpack-green-50);
+	border: 1px solid var(--color-link);
 	padding: 1rem;
 
 	@media only screen and ( min-width: 782px ) {


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/237

## Proposed Changes

This PR implements a marketplace review license screen.

## Testing Instructions

Note: Clicking on the `Issue c licenses` button does nothing as of now. Also, the `Learn More` link will be updated later

- Open the Jetpack Cloud link > Verify the issue license flow works as expected. Also, verify the colors on the review screen is not changed.
- Switch branch: `git checkout a4a-marketplace-review-license-screen`.
- Start the server by running `yarn start-a8c-for-agencies`.
- Click the `Marketplace` menu item > Select a few licenses from different bundle sizes > Verify that you can see the Total & the `Review x licenses` button 

<img width="1642" alt="Screenshot 2024-02-22 at 9 53 35 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/973d0417-134c-480f-b3cc-835bde625c7d">

-  Click the `Review x licenses` button > Verify that the breakdown is displayed as shown below. 

<img width="1187" alt="Screenshot 2024-02-22 at 9 55 20 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/53894490-1dc3-4e9e-a271-14ce3efd4838">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?