### PR TITLE
Hosting signup flow: Fix refund period notice

### DIFF
--- a/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
+++ b/packages/plans-grid-next/src/components/shared/billing-timeframe/index.tsx
@@ -280,7 +280,7 @@ const RefundNotice = ( { planSlug, showRefundPeriod, billingPeriod }: RefundNoti
 			<br />
 			{ translate( 'Refundable within %(dayCount)s days. No questions asked.', {
 				args: {
-					dayCount: billingPeriod === 365 ? 14 : 7,
+					dayCount: billingPeriod === 31 ? 7 : 14,
 				},
 			} ) }
 		</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* In the hosting flow plans page, the refund period for 2Y and 3Y plans is mentioned as 7 days, when in fact it should be 14 days.

### BEFORE

<img width="819" alt="Screenshot 2024-02-22 at 11 31 00 AM" src="https://github.com/Automattic/wp-calypso/assets/1269602/4415e56e-72ad-4f33-93e6-dd1039135622">


### AFTER

<img width="900" alt="Screenshot 2024-02-22 at 11 33 08 AM" src="https://github.com/Automattic/wp-calypso/assets/1269602/0b9763cd-e65b-43d5-bf78-f6389bd44530">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/setup/new-hosted-site/plans` and check the refund period in the comparison grid. Verify that when the monthly option is selected in the dropdown, the refund period is 7 days, and when yearly / 2Y / 3Y period is selected in the dropdown, the refund period is 14 days.

