### PR TITLE
Stepper: Add Flow.isSignupFlow

### DIFF
--- a/client/landing/stepper/README.md
+++ b/client/landing/stepper/README.md
@@ -38,7 +38,7 @@ To create a flow, you only have to implement `useSteps` and `useStepNavigation`.
 
 There is also an optional `useSideEffect` hook. You can implement this hook to run any side-effects to the flow. You can prefetch information, send track events when something changes, etc...
 
-There is a required `isSignupFlow` flag that _MUST be `true` for signup flows_ (generally where a new site may be created), and should be `false` for other flows. There is also an optional `useSignupStartEventProps()` hook. The `isSignupFlow` flag controls whether we'll trigger a `calypso_signup_start` Tracks event when the flow starts, while the `useSignupStartEventProps()` hook makes it possible to add custom fields to the event that will get logged.
+There is a required `isSignupFlow` flag that _MUST be `true` for signup flows_ (generally where a new site may be created), and should be `false` for other flows. The `isSignupFlow` flag controls whether we'll trigger a `calypso_signup_start` Tracks event when the flow starts.
 
 ```tsx
 // prettier-ignore

--- a/client/landing/stepper/README.md
+++ b/client/landing/stepper/README.md
@@ -38,7 +38,7 @@ To create a flow, you only have to implement `useSteps` and `useStepNavigation`.
 
 There is also an optional `useSideEffect` hook. You can implement this hook to run any side-effects to the flow. You can prefetch information, send track events when something changes, etc...
 
-There is an optional `isSignupFlow` flag that _MUST be implemented for signup flows_ (generally where a new site may be created), as well as an optional `useSignupStartEventProps()` hook. The `isSignupFlow` flag controls whether we'll trigger a `calypso_signup_start` Tracks event when the flow starts, while the `useSignupStartEventProps()` hook makes it possible to add custom field to the event that will get logged.
+There is a required `isSignupFlow` flag that _MUST be `true` for signup flows_ (generally where a new site may be created), and should be `false` for other flows. There is also an optional `useSignupStartEventProps()` hook. The `isSignupFlow` flag controls whether we'll trigger a `calypso_signup_start` Tracks event when the flow starts, while the `useSignupStartEventProps()` hook makes it possible to add custom fields to the event that will get logged.
 
 ```tsx
 // prettier-ignore

--- a/client/landing/stepper/README.md
+++ b/client/landing/stepper/README.md
@@ -38,6 +38,8 @@ To create a flow, you only have to implement `useSteps` and `useStepNavigation`.
 
 There is also an optional `useSideEffect` hook. You can implement this hook to run any side-effects to the flow. You can prefetch information, send track events when something changes, etc...
 
+There is an optional `isSignupFlow` flag that _MUST be implemented for signup flows_ (generally where a new site may be created), as well as an optional `useSignupStartEventProps()` hook. The `isSignupFlow` flag controls whether we'll trigger a `calypso_signup_start` Tracks event when the flow starts, while the `useSignupStartEventProps()` hook makes it possible to add custom field to the event that will get logged.
+
 ```tsx
 // prettier-ignore
 /**

--- a/client/landing/stepper/declarative-flow/ai-assembler.ts
+++ b/client/landing/stepper/declarative-flow/ai-assembler.ts
@@ -29,6 +29,7 @@ const SiteIntent = Onboard.SiteIntent;
 
 const withAIAssemblerFlow: Flow = {
 	name: AI_ASSEMBLER_FLOW,
+	isSignupFlow: true,
 	useSideEffect() {
 		const selectedDesign = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),

--- a/client/landing/stepper/declarative-flow/assembler-first-flow.ts
+++ b/client/landing/stepper/declarative-flow/assembler-first-flow.ts
@@ -28,6 +28,7 @@ const SiteIntent = Onboard.SiteIntent;
 
 const assemblerFirstFlow: Flow = {
 	name: ASSEMBLER_FIRST_FLOW,
+	isSignupFlow: true,
 	useSideEffect() {
 		const selectedDesign = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),

--- a/client/landing/stepper/declarative-flow/blog.ts
+++ b/client/landing/stepper/declarative-flow/blog.ts
@@ -17,6 +17,7 @@ const Blog: Flow = {
 	get title() {
 		return translate( 'Blog' );
 	},
+	isSignupFlow: false,
 	useSteps() {
 		return [
 			{

--- a/client/landing/stepper/declarative-flow/build.ts
+++ b/client/landing/stepper/declarative-flow/build.ts
@@ -14,6 +14,7 @@ const build: Flow = {
 	get title() {
 		return 'WordPress';
 	},
+	isSignupFlow: false,
 	useSteps() {
 		return [
 			{ slug: 'launchpad', component: LaunchPad },

--- a/client/landing/stepper/declarative-flow/connect-domain.ts
+++ b/client/landing/stepper/declarative-flow/connect-domain.ts
@@ -30,6 +30,7 @@ const connectDomain: Flow = {
 	get title() {
 		return translate( 'Connect your domain' );
 	},
+	isSignupFlow: false,
 	useAssertConditions: () => {
 		const { domain, provider } = useDomainParams();
 		const flowName = CONNECT_DOMAIN_FLOW;

--- a/client/landing/stepper/declarative-flow/copy-site.tsx
+++ b/client/landing/stepper/declarative-flow/copy-site.tsx
@@ -75,6 +75,7 @@ const copySite: Flow = {
 	get title() {
 		return '';
 	},
+	isSignupFlow: false,
 
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/design-first.ts
+++ b/client/landing/stepper/declarative-flow/design-first.ts
@@ -26,6 +26,7 @@ const designFirst: Flow = {
 	get title() {
 		return translate( 'Blog' );
 	},
+	isSignupFlow: true,
 	useSteps() {
 		return [
 			{

--- a/client/landing/stepper/declarative-flow/domain-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-transfer.ts
@@ -25,6 +25,7 @@ const domainTransfer: Flow = {
 	get title() {
 		return translate( 'Bulk domain transfer' );
 	},
+	isSignupFlow: false,
 	useSteps() {
 		return [
 			{

--- a/client/landing/stepper/declarative-flow/domain-upsell.ts
+++ b/client/landing/stepper/declarative-flow/domain-upsell.ts
@@ -16,6 +16,7 @@ const domainUpsell: Flow = {
 	get title() {
 		return translate( 'Domain Upsell' );
 	},
+	isSignupFlow: false,
 
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/domain-user-transfer.ts
+++ b/client/landing/stepper/declarative-flow/domain-user-transfer.ts
@@ -18,6 +18,7 @@ import DomainContactInfo from './internals/steps-repository/domain-contact-info'
 
 const domainUserTransfer: Flow = {
 	name: 'domain-user-transfer',
+	isSignupFlow: false,
 	useSteps() {
 		return [ { slug: 'domain-contact-info', component: DomainContactInfo } ];
 	},

--- a/client/landing/stepper/declarative-flow/free-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/free-post-setup.ts
@@ -11,6 +11,7 @@ const freePostSetup: Flow = {
 	get title() {
 		return translate( 'Free' );
 	},
+	isSignupFlow: false,
 	useSteps() {
 		return [ STEPS.FREE_POST_SETUP ];
 	},

--- a/client/landing/stepper/declarative-flow/free.ts
+++ b/client/landing/stepper/declarative-flow/free.ts
@@ -33,6 +33,7 @@ const free: Flow = {
 	get title() {
 		return translate( 'Free' );
 	},
+	isSignupFlow: true,
 	useSteps() {
 		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );
 

--- a/client/landing/stepper/declarative-flow/hundred-year-plan.ts
+++ b/client/landing/stepper/declarative-flow/hundred-year-plan.ts
@@ -20,6 +20,7 @@ const HundredYearPlanFlow: Flow = {
 	get title() {
 		return translate( '100-year Plan' );
 	},
+	isSignupFlow: true,
 	useSteps() {
 		const currentUser = useSelect(
 			( select ) => ( select( USER_STORE ) as UserSelect ).getCurrentUser(),

--- a/client/landing/stepper/declarative-flow/import-flow.ts
+++ b/client/landing/stepper/declarative-flow/import-flow.ts
@@ -34,6 +34,7 @@ import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
 
 const importFlow: Flow = {
 	name: IMPORT_FOCUSED_FLOW,
+	isSignupFlow: true,
 
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/import-hosted-site.ts
+++ b/client/landing/stepper/declarative-flow/import-hosted-site.ts
@@ -24,6 +24,7 @@ import type { UserSelect } from '@automattic/data-stores';
 
 const importHostedSiteFlow: Flow = {
 	name: IMPORT_HOSTED_SITE_FLOW,
+	isSignupFlow: true,
 
 	useSteps() {
 		const { resetOnboardStore } = useDispatch( ONBOARD_STORE );

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -159,8 +159,8 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 	}, [ location ] );
 
 	useEffect( () => {
-		if ( isFlowStart() ) {
-			recordSignupStart( flow.name, ref );
+		if ( flow.isSignupFlow && isFlowStart() ) {
+			recordSignupStart( flow.name, ref, flow.useSignupStartEventProps?.() ?? {} );
 		}
 	}, [ flow, ref, isFlowStart ] );
 

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -160,7 +160,7 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 
 	useEffect( () => {
 		if ( flow.isSignupFlow && isFlowStart() ) {
-			recordSignupStart( flow.name, ref, flow.useSignupStartEventProps?.() ?? {} );
+			recordSignupStart( flow.name, ref );
 		}
 	}, [ flow, ref, isFlowStart ] );
 

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -106,7 +106,6 @@ export type Flow = {
 	 * Required flag to indicate if the flow is a signup flow.
 	 */
 	isSignupFlow: boolean;
-	useSignupStartEventProps?: () => Record< string, string | number >;
 	useSteps: UseStepsHook;
 	useStepNavigation: UseStepNavigationHook< ReturnType< Flow[ 'useSteps' ] > >;
 	useAssertConditions?: UseAssertConditionsHook< ReturnType< Flow[ 'useSteps' ] > >;

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -103,8 +103,7 @@ export type Flow = {
 	title?: string;
 	classnames?: string | [ string ];
 	/**
-	 * Optional flag to indicate if the flow is a signup flow.
-	 * Thus MUST be implemented for signup flows.
+	 * Required flag to indicate if the flow is a signup flow.
 	 */
 	isSignupFlow: boolean;
 	useSignupStartEventProps?: () => Record< string, string | number >;

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -102,6 +102,12 @@ export type Flow = {
 	variantSlug?: string;
 	title?: string;
 	classnames?: string | [ string ];
+	/**
+	 * Optional flag to indicate if the flow is a signup flow.
+	 * Thus MUST be implemented for signup flows.
+	 */
+	isSignupFlow?: boolean;
+	useSignupStartEventProps?: () => Record< string, string | number >;
 	useSteps: UseStepsHook;
 	useStepNavigation: UseStepNavigationHook< ReturnType< Flow[ 'useSteps' ] > >;
 	useAssertConditions?: UseAssertConditionsHook< ReturnType< Flow[ 'useSteps' ] > >;

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -106,7 +106,7 @@ export type Flow = {
 	 * Optional flag to indicate if the flow is a signup flow.
 	 * Thus MUST be implemented for signup flows.
 	 */
-	isSignupFlow?: boolean;
+	isSignupFlow: boolean;
 	useSignupStartEventProps?: () => Record< string, string | number >;
 	useSteps: UseStepsHook;
 	useStepNavigation: UseStepNavigationHook< ReturnType< Flow[ 'useSteps' ] > >;

--- a/client/landing/stepper/declarative-flow/link-in-bio-domain.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-domain.ts
@@ -28,6 +28,7 @@ const linkInBioDomain: Flow = {
 	get title() {
 		return translate( 'Link in Bio' );
 	},
+	isSignupFlow: true,
 	variantSlug: LINK_IN_BIO_DOMAIN_FLOW,
 	useAssertConditions: () => {
 		const { domain } = useDomainParams();

--- a/client/landing/stepper/declarative-flow/link-in-bio-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-post-setup.ts
@@ -11,6 +11,7 @@ const linkInBioPostSetup: Flow = {
 	get title() {
 		return translate( 'Link in Bio' );
 	},
+	isSignupFlow: false,
 	useSteps() {
 		return [ { slug: 'linkInBioPostSetup', component: LinkInBioPostSetup } ];
 	},

--- a/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio-tld.ts
@@ -30,6 +30,7 @@ const linkInBio: Flow = {
 	get title() {
 		return translate( 'Link in Bio' );
 	},
+	isSignupFlow: true,
 	useSteps() {
 		return [
 			{ slug: 'domains', component: DomainsStep },

--- a/client/landing/stepper/declarative-flow/link-in-bio.ts
+++ b/client/landing/stepper/declarative-flow/link-in-bio.ts
@@ -24,6 +24,7 @@ const linkInBio: Flow = {
 	get title() {
 		return translate( 'Link in Bio' );
 	},
+	isSignupFlow: true,
 	useSteps() {
 		return [
 			{ slug: 'intro', asyncComponent: () => import( './internals/steps-repository/intro' ) },

--- a/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/new-hosted-site-flow.ts
@@ -20,6 +20,7 @@ import './internals/new-hosted-site-flow.scss';
 
 const hosting: Flow = {
 	name: NEW_HOSTED_SITE_FLOW,
+	isSignupFlow: true,
 	useSteps() {
 		return [
 			{ slug: 'plans', asyncComponent: () => import( './internals/steps-repository/plans' ) },

--- a/client/landing/stepper/declarative-flow/newsletter-post-setup.ts
+++ b/client/landing/stepper/declarative-flow/newsletter-post-setup.ts
@@ -11,6 +11,7 @@ const newsletterPostSetup: Flow = {
 	get title() {
 		return translate( 'Newsletter' );
 	},
+	isSignupFlow: false,
 	useSteps() {
 		return [ { slug: 'newsletterPostSetup', component: NewsletterPostSetup } ];
 	},

--- a/client/landing/stepper/declarative-flow/newsletter.ts
+++ b/client/landing/stepper/declarative-flow/newsletter.ts
@@ -26,6 +26,7 @@ const newsletter: Flow = {
 	get title() {
 		return translate( 'Newsletter' );
 	},
+	isSignupFlow: true,
 	useSteps() {
 		const query = useQuery();
 		const isComingFromMarketingPage = query.get( 'ref' ) === 'newsletter-lp';

--- a/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
+++ b/client/landing/stepper/declarative-flow/plugin-bundle-flow.ts
@@ -39,6 +39,7 @@ const SiteIntent = Onboard.SiteIntent;
 
 const pluginBundleFlow: Flow = {
 	name: 'plugin-bundle',
+	isSignupFlow: false,
 
 	useSteps() {
 		const pluginSlug = useSitePluginSlug();

--- a/client/landing/stepper/declarative-flow/podcasts.ts
+++ b/client/landing/stepper/declarative-flow/podcasts.ts
@@ -10,6 +10,7 @@ const podcasts: Flow = {
 	get title() {
 		return translate( 'Podcasting' );
 	},
+	isSignupFlow: false,
 	useSteps() {
 		return [
 			{ slug: 'letsGetStarted', component: LetsGetStarted },

--- a/client/landing/stepper/declarative-flow/reblogging.ts
+++ b/client/landing/stepper/declarative-flow/reblogging.ts
@@ -20,6 +20,7 @@ const reblogging: Flow = {
 	get title() {
 		return translate( 'Reblogging' );
 	},
+	isSignupFlow: true,
 	useSteps() {
 		return [
 			{ slug: 'domains', asyncComponent: () => import( './internals/steps-repository/domains' ) },

--- a/client/landing/stepper/declarative-flow/sensei.ts
+++ b/client/landing/stepper/declarative-flow/sensei.ts
@@ -26,6 +26,7 @@ const sensei: Flow = {
 	get title() {
 		return translate( 'Course Creator' );
 	},
+	isSignupFlow: false,
 	useSteps() {
 		return [
 			{ slug: 'intro', component: Intro },

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -13,6 +13,7 @@ import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-sto
 
 const siteMigration: Flow = {
 	name: 'site-migration',
+	isSignupFlow: false,
 
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -44,6 +44,7 @@ function isLaunchpadIntent( intent: string ) {
 
 const siteSetupFlow: Flow = {
 	name: 'site-setup',
+	isSignupFlow: false,
 
 	useSideEffect( currentStep, navigate ) {
 		const selectedDesign = useSelect(

--- a/client/landing/stepper/declarative-flow/start-writing.ts
+++ b/client/landing/stepper/declarative-flow/start-writing.ts
@@ -25,6 +25,7 @@ const startWriting: Flow = {
 	get title() {
 		return translate( 'Blog' );
 	},
+	isSignupFlow: false,
 	useSteps() {
 		return [
 			{

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -48,7 +48,10 @@ function getPlanFromRecurType( recurType: string ) {
 
 const ecommerceFlow: Flow = {
 	name: ECOMMERCE_FLOW,
-	isSignupFlow: true,
+	/* This is technically a signup flow, but we're manually triggering an event in useSteps()
+	 * for now, so we're disabling the centralised tracking for calypso_signup_start events.
+	 */
+	isSignupFlow: false,
 	useSteps() {
 		const recurType = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getEcommerceFlowRecurType(),

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -49,15 +49,16 @@ function getPlanFromRecurType( recurType: string ) {
 const ecommerceFlow: Flow = {
 	name: ECOMMERCE_FLOW,
 	isSignupFlow: true,
-	useSignupStartEventProps() {
-		const recur = useSelect(
+	useSteps() {
+		const recurType = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getEcommerceFlowRecurType(),
 			[]
 		);
 
-		return { recur };
-	},
-	useSteps() {
+		useEffect( () => {
+			recordTracksEvent( 'calypso_signup_start', { flow: this.name, recur: recurType } );
+		}, [] );
+
 		return [
 			{
 				slug: 'storeProfiler',

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -48,16 +48,16 @@ function getPlanFromRecurType( recurType: string ) {
 
 const ecommerceFlow: Flow = {
 	name: ECOMMERCE_FLOW,
-	useSteps() {
-		const recurType = useSelect(
+	isSignupFlow: true,
+	useSignupStartEventProps() {
+		const recur = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getEcommerceFlowRecurType(),
 			[]
 		);
 
-		useEffect( () => {
-			recordTracksEvent( 'calypso_signup_start', { flow: this.name, recur: recurType } );
-		}, [] );
-
+		return { recur };
+	},
+	useSteps() {
 		return [
 			{
 				slug: 'storeProfiler',

--- a/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
+++ b/client/landing/stepper/declarative-flow/transferring-hosted-site-flow.ts
@@ -13,6 +13,7 @@ import type { Flow, ProvidedDependencies } from './internals/types';
 
 const transferringHostedSite: Flow = {
 	name: TRANSFERRING_HOSTED_SITE_FLOW,
+	isSignupFlow: false,
 
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
+++ b/client/landing/stepper/declarative-flow/trial-wooexpress-flow.ts
@@ -19,6 +19,7 @@ import type { OnboardSelect, SiteSelect, UserSelect } from '@automattic/data-sto
 
 const wooexpress: Flow = {
 	name: 'wooexpress',
+	isSignupFlow: true,
 
 	useSteps() {
 		return [

--- a/client/landing/stepper/declarative-flow/update-design.ts
+++ b/client/landing/stepper/declarative-flow/update-design.ts
@@ -22,6 +22,7 @@ const updateDesign: Flow = {
 	get title() {
 		return translate( 'Choose Design' );
 	},
+	isSignupFlow: false,
 	useSteps() {
 		return [ STEPS.DESIGN_SETUP, STEPS.PATTERN_ASSEMBLER, STEPS.PROCESSING, STEPS.ERROR ];
 	},

--- a/client/landing/stepper/declarative-flow/update-options.ts
+++ b/client/landing/stepper/declarative-flow/update-options.ts
@@ -8,6 +8,7 @@ import type { Flow } from './internals/types';
 
 const updateOptions: Flow = {
 	name: 'update-options',
+	isSignupFlow: false,
 	useSteps() {
 		return [ STEPS.OPTIONS, STEPS.PROCESSING, STEPS.ERROR ];
 	},

--- a/client/landing/stepper/declarative-flow/videopress-tv-purchase.ts
+++ b/client/landing/stepper/declarative-flow/videopress-tv-purchase.ts
@@ -25,6 +25,7 @@ const videopressTvPurchase: Flow = {
 	get title() {
 		return translate( 'VideoPress TV' );
 	},
+	isSignupFlow: false,
 	useSteps() {
 		return [
 			{ slug: 'processing', component: ProcessingStep },

--- a/client/landing/stepper/declarative-flow/videopress-tv.ts
+++ b/client/landing/stepper/declarative-flow/videopress-tv.ts
@@ -18,6 +18,7 @@ const videopressTv: Flow = {
 	get title() {
 		return translate( 'VideoPress TV' );
 	},
+	isSignupFlow: false,
 	useSteps() {
 		return [
 			{

--- a/client/landing/stepper/declarative-flow/videopress.ts
+++ b/client/landing/stepper/declarative-flow/videopress.ts
@@ -31,6 +31,7 @@ const videopress: Flow = {
 	get title() {
 		return translate( 'Video' );
 	},
+	isSignupFlow: true,
 	useSteps() {
 		return [
 			{

--- a/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
+++ b/client/landing/stepper/declarative-flow/with-theme-assembler-flow.ts
@@ -18,6 +18,7 @@ const SiteIntent = Onboard.SiteIntent;
 
 const withThemeAssemblerFlow: Flow = {
 	name: WITH_THEME_ASSEMBLER_FLOW,
+	isSignupFlow: false,
 	useSideEffect() {
 		const selectedDesign = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getSelectedDesign(),

--- a/client/landing/stepper/declarative-flow/write.ts
+++ b/client/landing/stepper/declarative-flow/write.ts
@@ -27,6 +27,7 @@ const write: Flow = {
 	get title() {
 		return translate( 'Write' );
 	},
+	isSignupFlow: false,
 	useSteps() {
 		return [
 			{ slug: 'launchpad', component: LaunchPad },


### PR DESCRIPTION
Related to:
* https://github.com/Automattic/automattic-analytics/issues/406
* https://github.com/Automattic/wp-calypso/pull/85769

## Proposed Changes

* This PR explores requiring an explicit declaration for Stepper flows to be considered a signup flow via a new `Flow.isSignupFlow` flag. In turn, this explicit declaration controls whether we trigger a `calypso_signup_start` event for the flow.
  - The driver for this particular change is that after https://github.com/Automattic/wp-calypso/pull/85769 was merged, we're now logging `calypso_signup_start` events for a number of onboarding flows, not only signup flows
* ~The PR also explores a new `useSignupStartEventProps()` hook on the `Flow` type to make it possible for flows to augment the event props for the `calypso_signup_start` event.~ This part of the PR will be tackled in a follow-up. This means we will continue to fire two `calypso_signup_start` events for the `/setup/ecommerce` flow.
* Finally, the PR sets the `isSignupFlow` flag to `true` for a subset of flows that I _think_ should be considered signup flows, primarily for cases where they may create a site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch locally or via Calypso.live (as per the link in [this comment](https://github.com/Automattic/wp-calypso/pull/87758#issuecomment-1959015650))
* Ensure you can view Tracks events easily, e.g. via Tracks Vigilante
* Run through various `/setup/*` flows, and verify that a `calypso_signup_start` Tracks event is only fired when the `isSignupFlow` flag is true in the code. Verify that we do not trigger a `calypso_signup_start` event for flows where `isSignupFlow` is false.
  - Note that this is distinct from the `calypso_signup_step_start` event -- we do expect that to be triggered
  - Also note that we expect two `calypso_signup_start` events to be triggered for the `/setup/ecommerce` flow. We will fix that in a follow-up PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
