### PR TITLE
Automattic for Agencies: Add 'Purchases' > 'Licenses' menu item

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -4,3 +4,5 @@ export const A4A_SITES_LINK_NEEDS_ATTENTION = '/sites?issue_types=all_issues';
 export const A4A_SITES_LINK_FAVORITE = '/sites/favorite';
 export const A4A_PLUGINS_LINK = '/plugins';
 export const A4A_MARKETPLACE_LINK = '/marketplace';
+export const A4A_PURCHASES_LINK = '/purchases';
+export const A4A_LICENSES_LINK = `${ A4A_PURCHASES_LINK }/licenses`;

--- a/client/a8c-for-agencies/components/sidebar-menu/main.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/main.tsx
@@ -1,4 +1,4 @@
-import { category, home, plugins, tag } from '@wordpress/icons';
+import { category, home, plugins, tag, currencyDollar } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import Sidebar from '../sidebar';
@@ -7,6 +7,8 @@ import {
 	A4A_PLUGINS_LINK,
 	A4A_SITES_LINK,
 	A4A_MARKETPLACE_LINK,
+	A4A_PURCHASES_LINK,
+	A4A_LICENSES_LINK,
 } from './lib/constants';
 import { createItem } from './lib/utils';
 
@@ -54,6 +56,16 @@ export default function ( { path }: Props ) {
 				trackEventProps: {
 					menu_item: 'Automattic for Agencies / Marketplace',
 				},
+			},
+			{
+				icon: currencyDollar,
+				path: A4A_PURCHASES_LINK,
+				link: A4A_LICENSES_LINK,
+				title: translate( 'Purchases' ),
+				trackEventProps: {
+					menu_item: 'Automattic for Agencies / Purchases',
+				},
+				withChevron: true,
 			},
 		].map( ( item ) => createItem( item, path ) );
 	}, [ path, translate ] );

--- a/client/a8c-for-agencies/components/sidebar-menu/purchases.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/purchases.tsx
@@ -1,0 +1,50 @@
+import page from '@automattic/calypso-router';
+import { chevronLeft, key } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import Sidebar from '../sidebar';
+import { A4A_OVERVIEW_LINK, A4A_PURCHASES_LINK, A4A_LICENSES_LINK } from './lib/constants';
+import { createItem } from './lib/utils';
+
+type Props = {
+	path: string;
+};
+
+export default function ( { path }: Props ) {
+	const translate = useTranslate();
+
+	const menuItems = useMemo( () => {
+		return [
+			createItem(
+				{
+					icon: key,
+					path: A4A_PURCHASES_LINK,
+					link: A4A_LICENSES_LINK,
+					title: translate( 'Licenses' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Purchases / Licenses',
+					},
+				},
+				path
+			),
+		].map( ( item ) => createItem( item, path ) );
+	}, [ path, translate ] );
+
+	return (
+		<Sidebar
+			path={ A4A_PURCHASES_LINK }
+			title={ translate( 'Purchases' ) }
+			description={ translate( 'Manage all your billing related settings from one place.' ) }
+			backButtonProps={ {
+				label: translate( 'Back to overview' ),
+				icon: chevronLeft,
+				onClick: () => {
+					page( A4A_OVERVIEW_LINK );
+				},
+			} }
+			menuItems={ menuItems }
+			withSiteSelector
+			withGetHelpLink
+		/>
+	);
+}

--- a/client/a8c-for-agencies/sections/purchases/controller.tsx
+++ b/client/a8c-for-agencies/sections/purchases/controller.tsx
@@ -1,0 +1,14 @@
+import page, { type Callback } from '@automattic/calypso-router';
+import PurchasesSidebar from '../../components/sidebar-menu/purchases';
+
+export const purchasesContext: Callback = () => {
+	page.redirect( '/purchases/licenses' );
+};
+
+export const licensesContext: Callback = ( context, next ) => {
+	context.header = <div>Header</div>;
+	context.secondary = <PurchasesSidebar path={ context.path } />;
+	context.primary = <div>Licenses</div>;
+
+	next();
+};

--- a/client/a8c-for-agencies/sections/purchases/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/index.tsx
@@ -1,0 +1,8 @@
+import page from '@automattic/calypso-router';
+import { makeLayout, render as clientRender } from 'calypso/controller';
+import { purchasesContext, licensesContext } from './controller';
+
+export default function () {
+	page( '/purchases', purchasesContext, makeLayout, clientRender );
+	page( '/purchases/licenses', licensesContext, makeLayout, clientRender );
+}

--- a/client/sections.js
+++ b/client/sections.js
@@ -728,6 +728,13 @@ const sections = [
 		group: 'a8c-for-agencies',
 		enableLoggedOut: true,
 	},
+	{
+		name: 'a8c-for-agencies-purchases',
+		paths: [ '/purchases', 'purchases/licenses' ],
+		module: 'calypso/a8c-for-agencies/sections/purchases',
+		group: 'a8c-for-agencies',
+		enableLoggedOut: true,
+	},
 ];
 
 module.exports = sections;

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -162,6 +162,7 @@
 		"a8c-for-agencies-plugins": false,
 		"a8c-for-agencies-sites": false,
 		"a8c-for-agencies-marketplace": false,
+		"a8c-for-agencies-purchases": false,
 		"jetpack-cloud": false,
 		"jetpack-cloud-overview": false,
 		"jetpack-cloud-agency-dashboard": false,

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -23,7 +23,8 @@
 		"a8c-for-agencies-overview": true,
 		"a8c-for-agencies-plugins": true,
 		"a8c-for-agencies-sites": true,
-		"a8c-for-agencies-marketplace": true
+		"a8c-for-agencies-marketplace": true,
+		"a8c-for-agencies-purchases": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -17,7 +17,8 @@
 		"a8c-for-agencies-overview": true,
 		"a8c-for-agencies-plugins": true,
 		"a8c-for-agencies-sites": true,
-		"a8c-for-agencies-marketplace": true
+		"a8c-for-agencies-marketplace": true,
+		"a8c-for-agencies-purchases": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -19,7 +19,8 @@
 		"a8c-for-agencies-overview": true,
 		"a8c-for-agencies-plugins": true,
 		"a8c-for-agencies-sites": true,
-		"a8c-for-agencies-marketplace": true
+		"a8c-for-agencies-marketplace": true,
+		"a8c-for-agencies-purchases": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/239

## Proposed Changes

This PR adds:

- New "Purchases > Licenses" menu item
- Section for Licenses

## Testing Instructions

- Open the Calypso live link > Verify the /licenses URL is not accessible. 
- Switch to the branch `git checkout add/a4a-licenses-menu-item`.
- Start the server by running `yarn start-a8c-for-agencies`.
- Verify that you can now see a new menu item for Purchases:

<img width="281" alt="Screenshot 2024-02-26 at 2 55 31 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/e51474c4-9026-467b-a46b-0f730ff4692f">

- Click the menu item and verify that you can see the below page:

<img width="293" alt="Screenshot 2024-02-26 at 2 55 48 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/3a885430-85c5-47dd-b7dd-209f6270817a">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?