### PR TITLE
Jp Manage: Preview Pane - Layout with 4 placeholders: header, tabs bar, content, footer

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
@@ -18,9 +18,9 @@ export default function SitePreviewPane( { selectedSite, closeSitePreviewPane }:
 				selectedSite={ selectedSite }
 				closeSitePreviewPane={ closeSitePreviewPane }
 			/>
-			<SitePreviewPaneTabs selectedSite={ selectedSite } />
-			<SitePreviewPaneContent selectedSite={ selectedSite } />
-			<SitePreviewPaneFooter selectedSite={ selectedSite } />
+			<SitePreviewPaneTabs />
+			<SitePreviewPaneContent />
+			<SitePreviewPaneFooter />
 		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
@@ -15,7 +15,9 @@ export default function SitePreviewPane( { selectedSite, closeSitePreviewPane }:
 	return (
 		<div className="site-preview__pane">
 			<SitePreviewPaneHeader
-				selectedSite={ selectedSite }
+				title={ selectedSite.blogname }
+				url={ selectedSite.url }
+				urlWithScheme={ selectedSite.url_with_scheme }
 				closeSitePreviewPane={ closeSitePreviewPane }
 			/>
 			<SitePreviewPaneTabs />

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
@@ -1,0 +1,30 @@
+import { Site } from '../types';
+import SitePreviewPaneContent from './site-preview-pane-content';
+import SitePreviewPaneFooter from './site-preview-pane-footer';
+import SitePreviewPaneHeader from './site-preview-pane-header';
+import SitePreviewPaneTabs from './site-preview-pane-tabs';
+
+import './style.scss';
+
+interface Props {
+	selectedSite?: Site | undefined;
+	closeSitePreviewPane: () => void;
+}
+
+export default function SitePreviewPane( { selectedSite, closeSitePreviewPane }: Props ) {
+	if ( ! selectedSite ) {
+		return null;
+	}
+
+	return (
+		<div className="site-preview__pane">
+			<SitePreviewPaneHeader
+				selectedSite={ selectedSite }
+				closeSitePreviewPane={ closeSitePreviewPane }
+			/>
+			<SitePreviewPaneTabs selectedSite={ selectedSite } />
+			<SitePreviewPaneContent selectedSite={ selectedSite } />
+			<SitePreviewPaneFooter selectedSite={ selectedSite } />
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
@@ -7,15 +7,11 @@ import SitePreviewPaneTabs from './site-preview-pane-tabs';
 import './style.scss';
 
 interface Props {
-	selectedSite?: Site | undefined;
+	selectedSite: Site;
 	closeSitePreviewPane: () => void;
 }
 
 export default function SitePreviewPane( { selectedSite, closeSitePreviewPane }: Props ) {
-	if ( ! selectedSite ) {
-		return null;
-	}
-
 	return (
 		<div className="site-preview__pane">
 			<SitePreviewPaneHeader

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-content/index.tsx
@@ -1,0 +1,15 @@
+import { Site } from '../../types';
+
+import './style.scss';
+
+interface Props {
+	selectedSite?: Site | undefined;
+}
+
+export default function SitePreviewPaneContent( { selectedSite }: Props ) {
+	if ( ! selectedSite ) {
+		return null;
+	}
+
+	return <div className="site-preview__content">Content goes here</div>;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-content/index.tsx
@@ -1,15 +1,5 @@
-import { Site } from '../../types';
-
 import './style.scss';
 
-interface Props {
-	selectedSite?: Site | undefined;
-}
-
-export default function SitePreviewPaneContent( { selectedSite }: Props ) {
-	if ( ! selectedSite ) {
-		return null;
-	}
-
+export default function SitePreviewPaneContent() {
 	return <div className="site-preview__content">Content goes here</div>;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-content/style.scss
@@ -1,0 +1,4 @@
+.site-preview__content {
+	flex-grow: 1;
+	background-color: #fff;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-footer/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-footer/index.tsx
@@ -1,0 +1,15 @@
+import { Site } from '../../types';
+
+import './style.scss';
+
+interface Props {
+	selectedSite?: Site | undefined;
+}
+
+export default function SitePreviewPaneFooter( { selectedSite }: Props ) {
+	if ( ! selectedSite ) {
+		return null;
+	}
+
+	return <div className="site-preview__footer">Footer goes here</div>;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-footer/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-footer/index.tsx
@@ -1,15 +1,5 @@
-import { Site } from '../../types';
-
 import './style.scss';
 
-interface Props {
-	selectedSite?: Site | undefined;
-}
-
-export default function SitePreviewPaneFooter( { selectedSite }: Props ) {
-	if ( ! selectedSite ) {
-		return null;
-	}
-
+export default function SitePreviewPaneFooter() {
 	return <div className="site-preview__footer">Footer goes here</div>;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-footer/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-footer/style.scss
@@ -1,0 +1,4 @@
+.site-preview__footer {
+	height: 48px;
+	background-color: #add8e6;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/index.tsx
@@ -1,0 +1,53 @@
+import { Gridicon } from '@automattic/components';
+import { Button } from '@wordpress/components';
+import { Icon, external } from '@wordpress/icons';
+import { translate } from 'i18n-calypso';
+import { Site } from '../../types';
+
+import './style.scss';
+
+const ICON_SIZE = 24;
+
+interface Props {
+	selectedSite?: Site | undefined;
+	closeSitePreviewPane: () => void;
+}
+
+export default function SitePreviewPaneHeader( { selectedSite, closeSitePreviewPane }: Props ) {
+	if ( ! selectedSite ) {
+		return null;
+	}
+
+	// eslint-disable-next-line no-console
+	console.log( selectedSite );
+
+	return (
+		<div className="site-preview__header">
+			<div className="site-preview__header-bg"></div>
+			<div className="sites-dataviews__site-favicon site-preview__header-favicon"></div>
+			<div className="site-preview__header-content">
+				<div className="site-preview__header-title-summary">
+					<div className="site-preview__header-title">{ selectedSite.blogname }</div>
+					<div className="site-preview__header-summary">
+						<Button
+							variant="link"
+							className="site-preview__header-summary-link"
+							href={ selectedSite.url_with_scheme }
+							target="_blank"
+						>
+							<span>{ selectedSite.url }</span>
+							<Icon className="sidebar-v2__external-icon" icon={ external } size={ ICON_SIZE } />
+						</Button>
+					</div>
+				</div>
+				<Button
+					onClick={ closeSitePreviewPane }
+					className="site-preview__close-preview"
+					aria-label={ translate( 'Close Preview' ) }
+				>
+					<Gridicon icon="cross" size={ 24 } />
+				</Button>
+			</div>
+		</div>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/index.tsx
@@ -18,9 +18,6 @@ export default function SitePreviewPaneHeader( { selectedSite, closeSitePreviewP
 		return null;
 	}
 
-	// eslint-disable-next-line no-console
-	console.log( selectedSite );
-
 	return (
 		<div className="site-preview__header">
 			<div className="site-preview__header-bg"></div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/index.tsx
@@ -2,37 +2,39 @@ import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { Icon, external } from '@wordpress/icons';
 import { translate } from 'i18n-calypso';
-import { Site } from '../../types';
 
 import './style.scss';
 
 const ICON_SIZE = 24;
 
 interface Props {
-	selectedSite?: Site | undefined;
+	title: string;
+	url: string;
+	urlWithScheme: string;
 	closeSitePreviewPane: () => void;
 }
 
-export default function SitePreviewPaneHeader( { selectedSite, closeSitePreviewPane }: Props ) {
-	if ( ! selectedSite ) {
-		return null;
-	}
-
+export default function SitePreviewPaneHeader( {
+	title,
+	url,
+	urlWithScheme,
+	closeSitePreviewPane,
+}: Props ) {
 	return (
 		<div className="site-preview__header">
 			<div className="site-preview__header-bg"></div>
 			<div className="sites-dataviews__site-favicon site-preview__header-favicon"></div>
 			<div className="site-preview__header-content">
 				<div className="site-preview__header-title-summary">
-					<div className="site-preview__header-title">{ selectedSite.blogname }</div>
+					<div className="site-preview__header-title">{ title }</div>
 					<div className="site-preview__header-summary">
 						<Button
 							variant="link"
 							className="site-preview__header-summary-link"
-							href={ selectedSite.url_with_scheme }
+							href={ urlWithScheme }
 							target="_blank"
 						>
-							<span>{ selectedSite.url }</span>
+							<span>{ url }</span>
 							<Icon className="sidebar-v2__external-icon" icon={ external } size={ ICON_SIZE } />
 						</Button>
 					</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/style.scss
@@ -1,0 +1,61 @@
+.site-preview__header {
+
+	.site-preview__header-bg {
+		background-image: url(data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI5MDAiIGhlaWdodD0iMTYwIiB2aWV3Qm94PSIwIDAgOTAwIDE2MCIgZmlsbD0ibm9uZSI+CiAgPGcgY2xpcC1wYXRoPSJ1cmwoI2NsaXAwXzExNDA1XzY2MDE5KSI+CiAgICA8ZyBmaWx0ZXI9InVybCgjZmlsdGVyMF9mXzExNDA1XzY2MDE5KSI+CiAgICAgIDxlbGxpcHNlIGN4PSI3MjQuNTQ2IiBjeT0iMzIyLjEzMiIgcng9IjIzMy41IiByeT0iMjIxIiB0cmFuc2Zvcm09InJvdGF0ZSgtODEuNDI4NyA3MjQuNTQ2IDMyMi4xMzIpIiBmaWxsPSIjMDY5RTA4IiBmaWxsLW9wYWNpdHk9IjAuMTUiPjwvZWxsaXBzZT4KICAgIDwvZz4KICAgIDxnIGZpbHRlcj0idXJsKCNmaWx0ZXIxX2ZfMTE0MDVfNjYwMTkpIj4KICAgICAgPGVsbGlwc2UgY3g9IjQ3OS40MDQiIGN5PSIzMzguMjc1IiByeD0iMjAzIiByeT0iMTkyIiB0cmFuc2Zvcm09InJvdGF0ZSgtODEuNDI4NyA0NzkuNDA0IDMzOC4yNzUpIiBmaWxsPSIjRjVFNkIzIj48L2VsbGlwc2U+CiAgICA8L2c+CiAgICA8ZyBvcGFjaXR5PSIwLjciIGZpbHRlcj0idXJsKCNmaWx0ZXIyX2ZfMTE0MDVfNjYwMTkpIj4KICAgICAgPGVsbGlwc2UgY3g9IjE2MC4wNjYiIGN5PSI0MjAuNjAyIiByeD0iMzI5IiByeT0iMzEwLjUiIHRyYW5zZm9ybT0icm90YXRlKC04MS40Mjg3IDE2MC4wNjYgNDIwLjYwMikiIGZpbGw9IiNDRUQ5RjIiPjwvZWxsaXBzZT4KICAgIDwvZz4KICA8L2c+CiAgPGRlZnM+CiAgICA8ZmlsdGVyIGlkPSJmaWx0ZXIwX2ZfMTE0MDVfNjYwMTkiIHg9IjM3OC4yMjkiIHk9Ii0zNi4xMjc5IiB3aWR0aD0iNjkyLjYzNiIgaGVpZ2h0PSI3MTYuNTE5IiBmaWx0ZXJVbml0cz0idXNlclNwYWNlT25Vc2UiIGNvbG9yLWludGVycG9sYXRpb24tZmlsdGVycz0ic1JHQiI+CiAgICAgIDxmZUZsb29kIGZsb29kLW9wYWNpdHk9IjAiIHJlc3VsdD0iQmFja2dyb3VuZEltYWdlRml4Ij48L2ZlRmxvb2Q+CiAgICAgIDxmZUJsZW5kIG1vZGU9Im5vcm1hbCIgaW49IlNvdXJjZUdyYXBoaWMiIGluMj0iQmFja2dyb3VuZEltYWdlRml4IiByZXN1bHQ9InNoYXBlIj48L2ZlQmxlbmQ+CiAgICAgIDxmZUdhdXNzaWFuQmx1ciBzdGREZXZpYXRpb249IjYyLjUiIHJlc3VsdD0iZWZmZWN0MV9mb3JlZ3JvdW5kQmx1cl8xMTQwNV82NjAxOSI+PC9mZUdhdXNzaWFuQmx1cj4KICAgIDwvZmlsdGVyPgogICAgPGZpbHRlciBpZD0iZmlsdGVyMV9mXzExNDA1XzY2MDE5IiB4PSIxMTIuMTI0IiB5PSItMzkuNTEyNyIgd2lkdGg9IjczNC41NTkiIGhlaWdodD0iNzU1LjU3NiIgZmlsdGVyVW5pdHM9InVzZXJTcGFjZU9uVXNlIiBjb2xvci1pbnRlcnBvbGF0aW9uLWZpbHRlcnM9InNSR0IiPgogICAgICA8ZmVGbG9vZCBmbG9vZC1vcGFjaXR5PSIwIiByZXN1bHQ9IkJhY2tncm91bmRJbWFnZUZpeCI+PC9mZUZsb29kPgogICAgICA8ZmVCbGVuZCBtb2RlPSJub3JtYWwiIGluPSJTb3VyY2VHcmFwaGljIiBpbjI9IkJhY2tncm91bmRJbWFnZUZpeCIgcmVzdWx0PSJzaGFwZSI+PC9mZUJsZW5kPgogICAgICA8ZmVHYXVzc2lhbkJsdXIgc3RkRGV2aWF0aW9uPSI4Ny41IiByZXN1bHQ9ImVmZmVjdDFfZm9yZWdyb3VuZEJsdXJfMTE0MDVfNjYwMTkiPjwvZmVHYXVzc2lhbkJsdXI+CiAgICA8L2ZpbHRlcj4KICAgIDxmaWx0ZXIgaWQ9ImZpbHRlcjJfZl8xMTQwNV82NjAxOSIgeD0iLTI3NS45MDMiIHk9Ii0zMy4wNCIgd2lkdGg9Ijg3MS45MzgiIGhlaWdodD0iOTA3LjI4MyIgZmlsdGVyVW5pdHM9InVzZXJTcGFjZU9uVXNlIiBjb2xvci1pbnRlcnBvbGF0aW9uLWZpbHRlcnM9InNSR0IiPgogICAgICA8ZmVGbG9vZCBmbG9vZC1vcGFjaXR5PSIwIiByZXN1bHQ9IkJhY2tncm91bmRJbWFnZUZpeCI+PC9mZUZsb29kPgogICAgICA8ZmVCbGVuZCBtb2RlPSJub3JtYWwiIGluPSJTb3VyY2VHcmFwaGljIiBpbjI9IkJhY2tncm91bmRJbWFnZUZpeCIgcmVzdWx0PSJzaGFwZSI+PC9mZUJsZW5kPgogICAgICA8ZmVHYXVzc2lhbkJsdXIgc3RkRGV2aWF0aW9uPSI2Mi41IiByZXN1bHQ9ImVmZmVjdDFfZm9yZWdyb3VuZEJsdXJfMTE0MDVfNjYwMTkiPjwvZmVHYXVzc2lhbkJsdXI+CiAgICA8L2ZpbHRlcj4KICAgIDxjbGlwUGF0aCBpZD0iY2xpcDBfMTE0MDVfNjYwMTkiPgogICAgICA8cmVjdCB3aWR0aD0iOTAwIiBoZWlnaHQ9IjE2MCI+PC9yZWN0PgogICAgPC9jbGlwUGF0aD4KICA8L2RlZnM+Cjwvc3ZnPgo=);
+		background-size: cover;
+		background-repeat: no-repeat;
+		height: 100px;
+	}
+
+	.site-preview__header-favicon {
+		position: relative;
+		top: -44px;
+		left: 48px;
+		width: 64px;
+		height: 64px;
+		margin-bottom: -64px;
+	}
+
+	.site-preview__header-content {
+		padding: 48px 48px 24px 48px;
+		display: flex;
+		align-items: center;
+
+		.site-preview__header-title-summary {
+			flex-grow: 1;
+			display: flex;
+			flex-direction: column;
+
+			.site-preview__header-title {
+				font-family: "SF Pro Text", sans-serif;
+				font-style: normal;
+				font-weight: 500;
+				font-size: 32px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				line-height: 32px;
+				color: #000;
+				margin-bottom: 4px;
+			}
+
+			.site-preview__header-summary {
+
+				.site-preview__header-summary-link {
+					display: flex;
+					align-items: center;
+					font-family: "SF Pro Text", sans-serif;
+					font-size: 18px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+					font-weight: 400;
+					color: #3c434a;
+					line-height: 26px;
+					width: fit-content;
+
+					&:focus {
+						box-shadow: none;
+					}
+				}
+
+			}
+
+		}
+
+	}
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/style.scss
@@ -30,7 +30,7 @@
 				font-family: "SF Pro Text", sans-serif;
 				font-style: normal;
 				font-weight: 500;
-				font-size: 32px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+				font-size: rem(32px);
 				line-height: 32px;
 				color: #000;
 				margin-bottom: 4px;
@@ -42,7 +42,7 @@
 					display: flex;
 					align-items: center;
 					font-family: "SF Pro Text", sans-serif;
-					font-size: 18px; /* stylelint-disable-line declaration-property-unit-allowed-list */
+					font-size: rem(18px);
 					font-weight: 400;
 					color: #3c434a;
 					line-height: 26px;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/style.scss
@@ -31,7 +31,7 @@
 				font-weight: 500;
 				font-size: rem(32px);
 				line-height: 32px;
-				color: #000;
+				color: var(--studio-black);
 				margin-bottom: 4px;
 			}
 
@@ -42,7 +42,7 @@
 					align-items: center;
 					font-size: rem(18px);
 					font-weight: 400;
-					color: #3c434a;
+					color: var(--studio-gray-70);
 					line-height: 26px;
 					width: fit-content;
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/style.scss
@@ -27,7 +27,6 @@
 			flex-direction: column;
 
 			.site-preview__header-title {
-				font-family: "SF Pro Text", sans-serif;
 				font-style: normal;
 				font-weight: 500;
 				font-size: rem(32px);
@@ -41,7 +40,6 @@
 				.site-preview__header-summary-link {
 					display: flex;
 					align-items: center;
-					font-family: "SF Pro Text", sans-serif;
 					font-size: rem(18px);
 					font-weight: 400;
 					color: #3c434a;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-tabs/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-tabs/index.tsx
@@ -1,0 +1,15 @@
+import { Site } from '../../types';
+
+import './style.scss';
+
+interface Props {
+	selectedSite?: Site | undefined;
+}
+
+export default function SitePreviewPaneTabs( { selectedSite }: Props ) {
+	if ( ! selectedSite ) {
+		return null;
+	}
+
+	return <div className="site-preview__tabs">Tabs go here</div>;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-tabs/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-tabs/index.tsx
@@ -1,15 +1,5 @@
-import { Site } from '../../types';
-
 import './style.scss';
 
-interface Props {
-	selectedSite?: Site | undefined;
-}
-
-export default function SitePreviewPaneTabs( { selectedSite }: Props ) {
-	if ( ! selectedSite ) {
-		return null;
-	}
-
+export default function SitePreviewPaneTabs() {
 	return <div className="site-preview__tabs">Tabs go here</div>;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-tabs/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-tabs/style.scss
@@ -1,0 +1,4 @@
+.site-preview__tabs {
+	height: 48px;
+	background-color: #add8e6;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/style.scss
@@ -1,0 +1,4 @@
+.site-preview__pane {
+	display: flex;
+	flex-direction: column;
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
@@ -314,10 +314,12 @@ export default function SitesDashboardV2() {
 					</div>
 				) }
 			</div>
-			<SitePreviewPane
-				selectedSite={ sitesViewState.selectedSite }
-				closeSitePreviewPane={ closeSitePreviewPane }
-			/>
+			{ sitesViewState.selectedSite && (
+				<SitePreviewPane
+					selectedSite={ sitesViewState.selectedSite }
+					closeSitePreviewPane={ closeSitePreviewPane }
+				/>
+			) }
 		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
@@ -31,6 +31,7 @@ import { DASHBOARD_PRODUCT_SLUGS_BY_TYPE } from './lib/constants';
 import SiteAddLicenseNotification from './site-add-license-notification';
 import SiteContentHeader from './site-content-header';
 import SiteNotifications from './site-notifications';
+import SitePreviewPane from './site-preview-pane';
 import SiteTopHeaderButtons from './site-top-header-buttons';
 import SitesDataViews from './sites-dataviews';
 import { SitesViewState } from './sites-dataviews/interfaces';
@@ -313,16 +314,10 @@ export default function SitesDashboardV2() {
 					</div>
 				) }
 			</div>
-			<div className="site-preview__pane">
-				<div className="site-preview__header">
-					<h2>{ sitesViewState.selectedSite?.blogname }</h2>
-					<div>{ sitesViewState.selectedSite?.url }</div>
-					<hr />
-					<Button onClick={ closeSitePreviewPane } borderless>
-						<b>Close the Preview Pane</b>
-					</Button>
-				</div>
-			</div>
+			<SitePreviewPane
+				selectedSite={ sitesViewState.selectedSite }
+				closeSitePreviewPane={ closeSitePreviewPane }
+			/>
 		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style.scss
@@ -27,15 +27,10 @@
 	.site-preview__pane {
 		flex-grow: 1;
 		width: auto;
-		padding: 48px 48px;
 		transition: flex-grow 0.2s;
 		background: var(--studio-white);
 		overflow: hidden;
 		border-radius: 8px; /* stylelint-disable-line scales/radii */
-	}
-
-	.site-preview__header {
-		text-align: center;
 	}
 
 	&.preview-hidden {


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/292 and https://github.com/Automattic/jetpack-manage/issues/294

## Proposed Changes

* This PR adds a new preview panel with 4 placeholders,  header, tabs bar, content, footer, according to  https://github.com/Automattic/jetpack-manage/issues/292

## Testing Instructions

- Open the new sites listing ( http://jetpack.cloud.localhost:3000/sites )
- Click on any site
- The new preview panel should open
- Check the header according to https://github.com/Automattic/jetpack-manage/issues/294
  - The `X` (close button) should be functional
  - Clicking over the URL in the preview pane should open the website in a new window
  - The website's favicon is not yet implemented, it is using a placeholder for the moment.

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
