### PR TITLE
A4A: Add Marketplace assign license page.

### DIFF
--- a/client/a8c-for-agencies/sections/marketplace/assign-license/constants.ts
+++ b/client/a8c-for-agencies/sections/marketplace/assign-license/constants.ts
@@ -1,0 +1,1 @@
+export const SITE_CARDS_PER_PAGE = 7;

--- a/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/assign-license/index.tsx
@@ -1,0 +1,209 @@
+import page from '@automattic/calypso-router';
+import { Button, Card } from '@automattic/components';
+import { getQueryArg } from '@wordpress/url';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderActions as Actions,
+	LayoutHeaderSubtitle as Subtitle,
+	LayoutHeaderTitle as Title,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import FormRadio from 'calypso/components/forms/form-radio';
+import Pagination from 'calypso/components/pagination';
+import SearchCard from 'calypso/components/search-card';
+import areLicenseKeysAssignableToMultisite from 'calypso/jetpack-cloud/sections/partner-portal/lib/are-license-keys-assignable-to-multisite';
+import isWooCommerceProduct from 'calypso/jetpack-cloud/sections/partner-portal/lib/is-woocommerce-product';
+import { addQueryArgs } from 'calypso/lib/url';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import AssignLicenseStepProgress from '../assign-license-step-progress';
+import { SITE_CARDS_PER_PAGE } from './constants';
+
+import './styles.scss';
+
+type Props = {
+	sites: Array< any >;
+	currentPage: number;
+	search: string;
+};
+
+function setPage( pageNumber: number ): void {
+	const queryParams = { page: pageNumber };
+	const currentPath = window.location.pathname + window.location.search;
+
+	page( addQueryArgs( queryParams, currentPath ) );
+}
+
+function setSearch( search: string ): void {
+	const queryParams = { search, page: 1 };
+	const currentPath = window.location.pathname + window.location.search;
+
+	page( addQueryArgs( queryParams, currentPath ) );
+}
+
+function paginate( arr: Array< any >, currentPage: number ): Array< any > {
+	return (
+		arr
+			// Slices sites list based on pagination settings
+			.slice( SITE_CARDS_PER_PAGE * ( currentPage - 1 ), SITE_CARDS_PER_PAGE * currentPage )
+	);
+}
+
+export default function AssignLicense( { sites, currentPage, search }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const isReady = true; // FIXME: Fix this with actual form ready state
+
+	const [ selectedSite, setSelectedSite ] = useState( { ID: 0, domain: '' } );
+
+	const licenseKeysArray = useMemo( () => {
+		const products = getQueryArg( window.location.href, 'products' );
+		if ( typeof products === 'string' ) {
+			return products.split( ',' );
+		}
+
+		const licenseKey = getQueryArg( window.location.href, 'key' );
+		if ( typeof licenseKey === 'string' ) {
+			return [ licenseKey ];
+		}
+
+		return [];
+	}, [] );
+
+	// We need to filter out multisites if the licenses are not assignable to a multisite.
+	let results = areLicenseKeysAssignableToMultisite( licenseKeysArray )
+		? sites
+		: sites.filter( ( site: any ) => ! site.is_multisite );
+
+	if ( search ) {
+		results = results.filter( ( site: any ) => site.domain.search( search ) !== -1 );
+	}
+
+	const showDownloadStep = licenseKeysArray.some( isWooCommerceProduct );
+
+	useEffect( () => {
+		const layoutClass = 'layout__content--partner-portal-assign-license';
+		const content = document.getElementById( 'content' );
+
+		if ( content ) {
+			content.classList.add( layoutClass );
+
+			return () => content.classList.remove( layoutClass );
+		}
+	}, [] );
+
+	const title = translate( 'Assign your license', 'Assign your licenses', {
+		count: licenseKeysArray.length,
+	} );
+
+	const onClickAssignLater = useCallback( () => {
+		if ( licenseKeysArray.length > 1 ) {
+			page.redirect( '/partner-portal/licenses' );
+		}
+
+		const licenseKey = licenseKeysArray[ 0 ];
+		page.redirect( addQueryArgs( { highlight: licenseKey }, '/purchases/licenses' ) );
+	}, [ licenseKeysArray ] );
+
+	const onClickAssignLicenses = useCallback( () => {
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_assign_multiple_licenses_submit', {
+				products: licenseKeysArray.join( ',' ),
+				selected_site: selectedSite?.ID,
+			} )
+		);
+
+		// TODO: Need to implement actual assign Licenses operation once we have a working API
+	}, [ dispatch, licenseKeysArray, selectedSite?.ID ] );
+
+	return (
+		<Layout
+			className={ classNames( 'assign-license' ) }
+			title={ title }
+			wide
+			sidebarNavigation={ <MobileSidebarNavigation /> }
+		>
+			<LayoutTop>
+				<AssignLicenseStepProgress
+					currentStep="assignLicense"
+					showDownloadStep={ showDownloadStep }
+				/>
+
+				<LayoutHeader>
+					<Title>{ title } </Title>
+					<Subtitle>
+						{ translate( 'Select the website you would like to assign the license to.' ) }
+					</Subtitle>
+
+					<Actions>
+						<div className="assign-license__controls">
+							<Button
+								borderless
+								onClick={ onClickAssignLater }
+								disabled={ ! isReady }
+								className="assign-license-form__assign-later"
+							>
+								{ translate( 'Assign later' ) }
+							</Button>
+
+							<Button
+								primary
+								className="assign-license__assign-now"
+								disabled={ selectedSite?.ID === 0 }
+								busy={ ! isReady }
+								onClick={ onClickAssignLicenses }
+							>
+								{ translate( 'Assign %(numLicenses)d License', 'Assign %(numLicenses)d Licenses', {
+									count: licenseKeysArray.length,
+									args: {
+										numLicenses: licenseKeysArray.length,
+									},
+								} ) }
+							</Button>
+						</div>
+					</Actions>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody>
+				<SearchCard
+					className="assign-license__search-field"
+					placeHolder={ translate( 'Search for website URL right here' ) }
+					onSearch={ ( query: any ) => setSearch( query ) }
+				/>
+
+				<div className="assign-license__sites-list">
+					{ paginate( results, currentPage ).map( ( site: any ) => {
+						if ( -1 !== site.domain.search( search ) || null === search ) {
+							return (
+								<Card key={ site.ID } onClick={ () => setSelectedSite( site ) }>
+									<FormRadio
+										className="assign-license-form__site-card-radio"
+										label={ site.domain }
+										name="site_select"
+										disabled={ ! isReady }
+										checked={ selectedSite?.ID === site.ID }
+									/>
+								</Card>
+							);
+						}
+					} ) }
+				</div>
+
+				<Pagination
+					className="assign-license__pagination"
+					page={ currentPage }
+					perPage={ SITE_CARDS_PER_PAGE }
+					total={ results.length }
+					pageClick={ ( page: number ) => setPage( page ) }
+				/>
+			</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/a8c-for-agencies/sections/marketplace/assign-license/styles.scss
+++ b/client/a8c-for-agencies/sections/marketplace/assign-license/styles.scss
@@ -1,0 +1,36 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.assign-license .a4a-layout__body {
+	padding-block-start: 16px;
+}
+
+.assign-license__controls {
+	display: flex;
+	gap: 16px;
+	align-items: center;
+
+	.assign-license-form__assign-later.button {
+		margin-inline-end: 0;
+		font-weight: 700;
+		text-decoration: underline;
+		white-space: nowrap;
+	}
+
+}
+
+.assign-license__search-field {
+	margin-block-end: 1px;
+}
+
+.assign-license__sites-list {
+	margin-block-end: 64px;
+
+	.card {
+		margin: 0;
+	}
+}
+
+.assign-license__site-card-radio.form-radio {
+	margin-inline-end: 1rem;
+}

--- a/client/a8c-for-agencies/sections/marketplace/controller.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/controller.tsx
@@ -1,10 +1,25 @@
 import { type Callback } from '@automattic/calypso-router';
+import getSites from 'calypso/state/selectors/get-sites';
 import MainSidebar from '../../components/sidebar-menu/main';
+import AssignLicense from './assign-license';
 import IssueLicense from './issue-license';
 
 export const marketplaceContext: Callback = ( context, next ) => {
 	const { site_id, product_slug } = context.query;
 	context.secondary = <MainSidebar path={ context.path } />;
 	context.primary = <IssueLicense siteId={ site_id } suggestedProduct={ product_slug } />;
+	next();
+};
+
+export const assignLicenseContext: Callback = ( context, next ) => {
+	const { page, search } = context.query;
+	const state = context.store.getState();
+	const sites = getSites( state );
+	const currentPage = parseInt( page ) || 1;
+
+	context.secondary = <MainSidebar path={ context.path } />;
+	context.primary = (
+		<AssignLicense sites={ sites } currentPage={ currentPage } search={ search || '' } />
+	);
 	next();
 };

--- a/client/a8c-for-agencies/sections/marketplace/index.tsx
+++ b/client/a8c-for-agencies/sections/marketplace/index.tsx
@@ -1,7 +1,8 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { marketplaceContext } from './controller';
+import { assignLicenseContext, marketplaceContext } from './controller';
 
 export default function () {
 	page( '/marketplace', marketplaceContext, makeLayout, clientRender );
+	page( '/marketplace/assign-license', assignLicenseContext, makeLayout, clientRender );
 }

--- a/client/sections.js
+++ b/client/sections.js
@@ -723,7 +723,7 @@ const sections = [
 	},
 	{
 		name: 'a8c-for-agencies-marketplace',
-		paths: [ '/marketplace' ],
+		paths: [ '/marketplace', '/marketplace/assign-license' ],
 		module: 'calypso/a8c-for-agencies/sections/marketplace',
 		group: 'a8c-for-agencies',
 		enableLoggedOut: true,


### PR DESCRIPTION
This PR adds the Assign license page. The design is based on Jetpack Manage.

<img width="866" alt="Screenshot 2024-02-22 at 5 26 18 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/a320d6dd-4deb-4361-9b8c-f9d442df5e2a">


Closes https://github.com/Automattic/jetpack-genesis/issues/238

## Proposed Changes

* Add new Marketplace section path `/marketplace/assign-license`
* Implement the Assign license page based on the Jetpack Manage `/partner-portal/assign-license`.

## Testing Instructions

* Switch branch: `git checkout add/a4a-marketplace-assign-license-page`
* Start the server by running `yarn start-a8c-for-agencies.`
* Go to http://agencies.localhost:3000/marketplace/assign-license?key=test
* Confirm that you see the Assign License page similar to the Jetpack Manage version.

_**Note: The buttons do not work at the moment as we do not have all the pages to redirect (e.g. licenses) and a working API to assign a license.**_

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?