### PR TITLE
Global Sidebar: Fix styles on expandable sidebar menus

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -418,6 +418,18 @@ $font-size: rem(14px);
 			}
 		}
 
+		.sidebar__menu {
+			// Is toggled open and selected
+			&.sidebar__menu--selected .sidebar__heading {
+				background: var(--color-sidebar-menu-selected-background);
+				color: var(--color-sidebar-menu-selected-text);
+
+				&:hover {
+					background-color: var(--color-sidebar-menu-selected-background);
+				}
+			}
+		}
+
 		.sidebar__expandable-content {
 			border-radius: 4px;
 			margin: 0 12px;
@@ -426,6 +438,13 @@ $font-size: rem(14px);
 		.sidebar__expandable-title {
 			padding: 0;
 			margin: 0;
+		}
+
+		.sidebar__heading,
+		.sidebar__menu-link {
+			&::after {
+				border: none;
+			}
 		}
 
 		.selected .sidebar__menu-link {

--- a/client/reader/sidebar/index.jsx
+++ b/client/reader/sidebar/index.jsx
@@ -60,7 +60,6 @@ export class ReaderSidebar extends Component {
 	handleClick = ( event ) => {
 		if ( ! event.isDefaultPrevented() && closest( event.target, 'a,span' ) ) {
 			this.props.setNextLayoutFocus( 'content' );
-			window.scrollTo( 0, 0 );
 		}
 	};
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5730

Updates
* Removes the hover to the expandable menu if that menu is already expanded
* Removes the border arrow when the expandable menu is selected
* Removes a `scrollTo` that causes the sidebar to reset to top when clicked

### Before

https://github.com/Automattic/wp-calypso/assets/5560595/fc627ed7-a6c6-4a52-95c8-acc9ef616a25

### After

https://github.com/Automattic/wp-calypso/assets/5560595/7157945a-c8b7-42f2-9e08-6331faa12a71



