### PR TITLE
Untangle: Add the action buttons to the site grid

### DIFF
--- a/client/sites-dashboard/components/sites-grid-actions.tsx
+++ b/client/sites-dashboard/components/sites-grid-actions.tsx
@@ -1,0 +1,48 @@
+import { Button } from '@automattic/components';
+import styled from '@emotion/styled';
+import { useI18n } from '@wordpress/react-i18n';
+import { getDashboardUrl, getSiteWpAdminUrl } from '../utils';
+import type { SiteExcerptData } from 'calypso/data/sites/site-excerpt-types';
+
+interface Props {
+	site: SiteExcerptData;
+}
+
+const SitesGridActionsWrapper = styled.div( {
+	position: 'absolute',
+	top: 0,
+	bottom: 0,
+	left: 0,
+	right: 0,
+	display: 'flex',
+	justifyContent: 'center',
+	backgroundColor: 'rgba( 255, 255, 255, 0.1 )',
+	boxShadow: '0 7px 30px -10px rgba( 0, 0, 0, 0.2 )',
+	opacity: 0,
+	'&:hover': {
+		opacity: 1,
+	},
+} );
+
+const SitesGridActionsButtons = styled.div( {
+	display: 'flex',
+	flexDirection: 'column',
+	justifyContent: 'center',
+	alignContent: 'center',
+	gap: '10px',
+} );
+
+export const SitesGridActions = ( { site }: Props ) => {
+	const { __ } = useI18n();
+
+	return (
+		<SitesGridActionsWrapper>
+			<SitesGridActionsButtons>
+				<Button primary href={ getSiteWpAdminUrl( site ) }>
+					{ __( 'WP Admin' ) }
+				</Button>
+				<Button href={ getDashboardUrl( site.slug ) }>{ __( 'Settings' ) }</Button>
+			</SitesGridActionsButtons>
+		</SitesGridActionsWrapper>
+	);
+};

--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -20,6 +20,7 @@ import {
 } from '../utils';
 import { SitesEllipsisMenu } from './sites-ellipsis-menu';
 import { SitesGridActionRenew } from './sites-grid-action-renew';
+import { SitesGridActions } from './sites-grid-actions';
 import { SitesGridTile } from './sites-grid-tile';
 import SitesLaunchStatusBadge from './sites-launch-status-badge';
 import SitesP2Badge from './sites-p2-badge';
@@ -68,6 +69,10 @@ const selectAction = css( {
 	},
 } );
 
+const ThumbnailDiv = styled.div( {
+	position: 'relative',
+} );
+
 export const siteThumbnail = css( {
 	aspectRatio: '16 / 11',
 	width: '100%',
@@ -113,7 +118,7 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 		site,
 		showLaunchNag = true,
 		showBadgeSection = true,
-		showThumbnailLink = ! isEnabled( 'layout/dotcom-nav-redesign' ),
+		showThumbnailLink = true,
 		showSiteRenewLink = true,
 		onSiteSelectBtnClick,
 	} = props;
@@ -125,20 +130,24 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 	const isAtomicSite = useSelector( ( state ) => isSiteAutomatedTransfer( state, site.ID ) );
 	const wpAdminUrl = getSiteWpAdminUrl( site );
 	const { ref, inView } = useInView( { triggerOnce: true } );
+	const showSiteActions =
+		isAtomicSite &&
+		siteDefaultInterface( site ) === 'wp-admin' &&
+		isEnabled( 'layout/dotcom-nav-redesign' );
+	const ThumbnailWrapper = showThumbnailLink && ! showSiteActions ? ThumbnailLink : ThumbnailDiv;
 
-	const ThumbnailWrapper = showThumbnailLink ? ThumbnailLink : 'div';
-
-	const siteDashboardUrlProps = showThumbnailLink
-		? {
-				href:
-					isAtomicSite &&
-					siteDefaultInterface( site ) === 'wp-admin' &&
-					! isEnabled( 'layout/dotcom-nav-redesign' )
-						? wpAdminUrl || getDashboardUrl( site.slug )
-						: getDashboardUrl( site.slug ),
-				title: __( 'Visit Dashboard' ),
-		  }
-		: {};
+	const siteDashboardUrlProps =
+		showThumbnailLink && ! showSiteActions
+			? {
+					href:
+						isAtomicSite &&
+						siteDefaultInterface( site ) === 'wp-admin' &&
+						! isEnabled( 'layout/dotcom-nav-redesign' )
+							? wpAdminUrl || getDashboardUrl( site.slug )
+							: getDashboardUrl( site.slug ),
+					title: __( 'Visit Dashboard' ),
+			  }
+			: {};
 
 	let siteUrl = site.URL;
 	if ( site.options?.is_redirect && site.options?.unmapped_url ) {
@@ -159,6 +168,7 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 							height={ THUMBNAIL_DIMENSION.height }
 							sizesAttr={ SIZES_ATTR }
 						/>
+						{ showSiteActions && <SitesGridActions site={ site } /> }
 					</ThumbnailWrapper>
 					{ showSiteRenewLink && site.plan?.expired && (
 						<SitesGridActionRenew site={ site } isUpgradeable={ isTrialSitePlan } />

--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -210,7 +210,7 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 								return <TransferNoticeWrapper { ...result } />;
 							} else if ( showLaunchNag && 'unlaunched' === site.launch_status ) {
 								return <SiteLaunchNag site={ site } />;
-							} else if ( site.is_wpcom_atomic ) {
+							} else if ( site.is_wpcom_atomic && ! isEnabled( 'layout/dotcom-nav-redesign' ) ) {
 								return (
 									<a
 										href={ wpAdminUrl }

--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -113,7 +113,7 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 		site,
 		showLaunchNag = true,
 		showBadgeSection = true,
-		showThumbnailLink = true,
+		showThumbnailLink = ! isEnabled( 'layout/dotcom-nav-redesign' ),
 		showSiteRenewLink = true,
 		onSiteSelectBtnClick,
 	} = props;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5708

## Proposed Changes

* Remove the link of the screenshot when we want to display the action buttons
* Remove the WP Admin link next to the site address

![image](https://github.com/Automattic/wp-calypso/assets/13596067/d7706b1c-4c2e-4e0b-9d2e-2fa06c4040a0)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Hover on the site with the admin interface
* Make sure you can see the action buttons
* Make sure the `WP Admin` links to the `/wp-admin` page
* Make sure the `Settings` links to the `/home/:site` page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?