### PR TITLE
Add-Ons: Pass siteId as a prop to the various hooks and fetch Site details via `useSite` hook

### DIFF
--- a/client/my-sites/add-ons/components/add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/add-ons-card.tsx
@@ -2,8 +2,10 @@ import { PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
 import { Badge, Button, Gridicon, Spinner } from '@automattic/components';
 import styled from '@emotion/styled';
 import { Card, CardBody, CardFooter, CardHeader } from '@wordpress/components';
+import { useSelector } from '@wordpress/element';
 import { Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { AddOnMeta } from '@automattic/data-stores';
 
 export interface Props {
@@ -15,7 +17,13 @@ export interface Props {
 		text: string;
 		handler: ( productSlug: string ) => void;
 	};
-	useAddOnAvailabilityStatus?: ( addOnMeta: AddOnMeta ) => {
+	useAddOnAvailabilityStatus?: ( {
+		selectedSiteId,
+		addOnMeta,
+	}: {
+		selectedSiteId?: number | null | undefined;
+		addOnMeta: AddOnMeta;
+	} ) => {
 		available: boolean;
 		text?: string;
 	};
@@ -96,7 +104,8 @@ const AddOnCard = ( {
 	highlightFeatured,
 }: Props ) => {
 	const translate = useTranslate();
-	const availabilityStatus = useAddOnAvailabilityStatus?.( addOnMeta );
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const availabilityStatus = useAddOnAvailabilityStatus?.( { selectedSiteId, addOnMeta } );
 
 	const onActionPrimary = () => {
 		actionPrimary?.handler( addOnMeta.productSlug, addOnMeta.quantity );

--- a/client/my-sites/add-ons/components/add-ons-card.tsx
+++ b/client/my-sites/add-ons/components/add-ons-card.tsx
@@ -2,9 +2,9 @@ import { PRODUCT_1GB_SPACE } from '@automattic/calypso-products';
 import { Badge, Button, Gridicon, Spinner } from '@automattic/components';
 import styled from '@emotion/styled';
 import { Card, CardBody, CardFooter, CardHeader } from '@wordpress/components';
-import { useSelector } from '@wordpress/element';
 import { Icon } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
+import { useSelector } from 'react-redux';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import type { AddOnMeta } from '@automattic/data-stores';
 

--- a/client/my-sites/add-ons/hooks/use-add-on-purchase-status.ts
+++ b/client/my-sites/add-ons/hooks/use-add-on-purchase-status.ts
@@ -2,21 +2,26 @@ import { useTranslate } from 'i18n-calypso';
 import { useSelector } from 'calypso/state';
 import { getSitePurchases } from 'calypso/state/purchases/selectors/get-site-purchases';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
 import type { AddOnMeta } from '@automattic/data-stores';
+
+interface Props {
+	addOnMeta: AddOnMeta;
+	selectedSiteId?: number | null | undefined;
+}
 
 /**
  * Returns whether add-on product has been purchased or included in site plan.
  */
-const useAddOnPurchaseStatus = ( { productSlug, featureSlugs }: AddOnMeta ) => {
+const useAddOnPurchaseStatus = ( { addOnMeta, selectedSiteId }: Props ) => {
 	const translate = useTranslate();
-	const selectedSite = useSelector( getSelectedSite );
-	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, selectedSite?.ID ) );
-	const purchased = sitePurchases.find( ( product ) => product.productSlug === productSlug );
+	const sitePurchases = useSelector( ( state ) => getSitePurchases( state, selectedSiteId ) );
+	const purchased = sitePurchases.find(
+		( product ) => product.productSlug === addOnMeta.productSlug
+	);
 	const isSiteFeature = useSelector(
 		( state ) =>
-			selectedSite &&
-			featureSlugs?.find( ( slug ) => siteHasFeature( state, selectedSite?.ID, slug ) )
+			selectedSiteId &&
+			addOnMeta.featureSlugs?.find( ( slug ) => siteHasFeature( state, selectedSiteId, slug ) )
 	);
 
 	/*

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -5,7 +5,12 @@ import {
 	PRODUCT_1GB_SPACE,
 	WPCOM_FEATURES_AI_ASSISTANT,
 } from '@automattic/calypso-products';
-import { useAddOnCheckoutLink, useAddOnFeatureSlugs, ProductsList } from '@automattic/data-stores';
+import {
+	useAddOnCheckoutLink,
+	useAddOnFeatureSlugs,
+	ProductsList,
+	Site,
+} from '@automattic/data-stores';
 import { useMemo } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
 import useMediaStorageQuery from 'calypso/data/media-storage/use-media-storage-query';
@@ -14,7 +19,6 @@ import { useSelector } from 'calypso/state';
 import getBillingTransactionFilters from 'calypso/state/selectors/get-billing-transaction-filters';
 import getFeaturesBySiteId from 'calypso/state/selectors/get-site-features';
 import { usePastBillingTransactions } from 'calypso/state/sites/hooks/use-billing-history';
-import { getSelectedSite } from 'calypso/state/ui/selectors';
 import { STORAGE_LIMIT } from '../constants';
 import customDesignIcon from '../icons/custom-design';
 import jetpackAIIcon from '../icons/jetpack-ai';
@@ -23,7 +27,7 @@ import unlimitedThemesIcon from '../icons/unlimited-themes';
 import isStorageAddonEnabled from '../is-storage-addon-enabled';
 import useAddOnDisplayCost from './use-add-on-display-cost';
 import useAddOnPrices from './use-add-on-prices';
-import type { AddOnMeta, SiteDetails } from '@automattic/data-stores';
+import type { AddOnMeta } from '@automattic/data-stores';
 
 const useSpaceUpgradesPurchased = ( {
 	isInSignup,
@@ -56,9 +60,11 @@ const useSpaceUpgradesPurchased = ( {
 	}, [ billingTransactions, filter, isInSignup, siteId, isLoading ] );
 };
 
-const useActiveAddOnsDefs = ( selectedSite: SiteDetails | null ) => {
+const useActiveAddOnsDefs = ( selectedSiteId: Props[ 'selectedSiteId' ] ) => {
 	const translate = useTranslate();
 	const checkoutLink = useAddOnCheckoutLink();
+	const selectedSite = Site.useSite( { siteId: selectedSiteId } );
+	const selectedSiteSlug = selectedSite.data?.slug;
 
 	/*
 	 * TODO: `useAddOnFeatureSlugs` be refactored instead to return an index of `{ [ slug ]: featureSlug[] }`
@@ -132,7 +138,7 @@ const useActiveAddOnsDefs = ( selectedSite: SiteDetails | null ) => {
 					),
 					featured: false,
 					purchased: false,
-					checkoutLink: checkoutLink( selectedSite?.slug ?? null, PRODUCT_1GB_SPACE, 50 ),
+					checkoutLink: checkoutLink( selectedSiteSlug ?? null, PRODUCT_1GB_SPACE, 50 ),
 				},
 				{
 					productSlug: PRODUCT_1GB_SPACE,
@@ -147,7 +153,7 @@ const useActiveAddOnsDefs = ( selectedSite: SiteDetails | null ) => {
 					),
 					featured: false,
 					purchased: false,
-					checkoutLink: checkoutLink( selectedSite?.slug ?? null, PRODUCT_1GB_SPACE, 100 ),
+					checkoutLink: checkoutLink( selectedSiteSlug ?? null, PRODUCT_1GB_SPACE, 100 ),
 				},
 			] as const,
 		[
@@ -164,21 +170,31 @@ const useActiveAddOnsDefs = ( selectedSite: SiteDetails | null ) => {
 			featureSlugsCustomDesign,
 			featureSlugsJetpackAIMonthly,
 			featureSlugsUnlimitedThemes,
-			selectedSite?.slug,
+			selectedSiteSlug,
 			translate,
 		]
 	);
 };
 
-const useAddOns = ( siteId?: number, isInSignup = false ): ( AddOnMeta | null )[] => {
+interface Props {
+	selectedSiteId?: number | null | undefined;
+	isInSignup?: boolean;
+}
+
+const useAddOns = ( {
+	selectedSiteId,
+	isInSignup = false,
+}: Props = {} ): ( AddOnMeta | null )[] => {
 	// if upgrade is bought - show as manage
 	// if upgrade is not bought - only show it if available storage and if it's larger than previously bought upgrade
-	const { data: mediaStorage } = useMediaStorageQuery( siteId );
-	const { isLoading, spaceUpgradesPurchased } = useSpaceUpgradesPurchased( { isInSignup, siteId } );
-	const selectedSite = useSelector( getSelectedSite ) ?? null;
-	const activeAddOns = useActiveAddOnsDefs( selectedSite );
+	const { data: mediaStorage } = useMediaStorageQuery( selectedSiteId );
+	const { isLoading, spaceUpgradesPurchased } = useSpaceUpgradesPurchased( {
+		isInSignup,
+		siteId: selectedSiteId ?? undefined,
+	} );
+	const activeAddOns = useActiveAddOnsDefs( selectedSiteId );
 	const productsList = ProductsList.useProducts();
-	const siteFeatures = useSelector( ( state ) => getFeaturesBySiteId( state, siteId ) );
+	const siteFeatures = useSelector( ( state ) => getFeaturesBySiteId( state, selectedSiteId ) );
 
 	return useMemo(
 		() =>

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -63,7 +63,7 @@ const useSpaceUpgradesPurchased = ( {
 const useActiveAddOnsDefs = ( selectedSiteId: Props[ 'selectedSiteId' ] ) => {
 	const translate = useTranslate();
 	const checkoutLink = useAddOnCheckoutLink();
-	const selectedSite = Site.useSite( { siteId: selectedSiteId } );
+	const selectedSite = Site.useSite( { siteIdOrSlug: selectedSiteId } );
 	const selectedSiteSlug = selectedSite.data?.slug;
 
 	/*

--- a/client/my-sites/add-ons/hooks/use-storage-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-storage-add-ons.ts
@@ -8,7 +8,7 @@ interface Props {
 }
 
 const useStorageAddOns = ( { siteId, isInSignup }: Props ) => {
-	const addOns = useAddOns( siteId ?? undefined, isInSignup );
+	const addOns = useAddOns( { selectedSiteId: siteId, isInSignup } );
 
 	return useMemo(
 		() => addOns.filter( ( addOn ) => addOn?.productSlug === PRODUCT_1GB_SPACE ),

--- a/client/my-sites/add-ons/main.tsx
+++ b/client/my-sites/add-ons/main.tsx
@@ -93,7 +93,7 @@ const NoAccess = () => {
 const AddOnsMain = () => {
 	const translate = useTranslate();
 	const selectedSite = useSelector( getSelectedSite ) ?? null;
-	const addOns = useAddOns( selectedSite?.ID );
+	const addOns = useAddOns( { selectedSiteId: selectedSite?.ID } );
 	const filteredAddOns = addOns.filter( ( addOn ) => ! addOn?.exceedsSiteStorageLimits );
 
 	const checkoutLink = useAddOnCheckoutLink();

--- a/client/signup/steps/add-ons/index.tsx
+++ b/client/signup/steps/add-ons/index.tsx
@@ -53,8 +53,10 @@ const AddOns = ( {
 	const translate = useTranslate();
 
 	const getAddOnSelectedStatus = useCallback(
-		( { productSlug }: AddOnMeta ) => {
-			const available = ! selectedAddOns.find( ( product: string ) => product === productSlug );
+		( { addOnMeta }: { addOnMeta: AddOnMeta } ) => {
+			const available = ! selectedAddOns.find(
+				( product: string ) => product === addOnMeta.productSlug
+			);
 			return {
 				available,
 				text: translate( 'Added to your plan' ),

--- a/packages/data-stores/src/site/index.ts
+++ b/packages/data-stores/src/site/index.ts
@@ -29,3 +29,8 @@ export function register( clientCreds: WpcomClientCredentials ): typeof STORE_KE
 	}
 	return STORE_KEY;
 }
+
+/**
+ * Queries
+ */
+export { default as useSite } from './queries/use-site';

--- a/packages/data-stores/src/site/queries/lib/use-query-keys-factory.ts
+++ b/packages/data-stores/src/site/queries/lib/use-query-keys-factory.ts
@@ -1,0 +1,5 @@
+const useQueryKeysFactory = () => ( {
+	site: ( siteId?: string | number | null ) => [ 'site', siteId ],
+} );
+
+export default useQueryKeysFactory;

--- a/packages/data-stores/src/site/queries/use-site.ts
+++ b/packages/data-stores/src/site/queries/use-site.ts
@@ -4,24 +4,24 @@ import useQueryKeysFactory from './lib/use-query-keys-factory';
 import type { SiteDetails } from '../types';
 
 interface Props {
-	siteId: string | number | null | undefined;
+	siteIdOrSlug: string | number | null | undefined;
 }
 
 /**
  * Site details from `/sites/[ siteId ]` endpoint
  */
-function useSite( { siteId }: Props ): UseQueryResult< SiteDetails | undefined > {
+function useSite( { siteIdOrSlug }: Props ): UseQueryResult< SiteDetails | undefined > {
 	const queryKeys = useQueryKeysFactory();
 
 	return useQuery( {
-		queryKey: queryKeys.site( siteId ),
+		queryKey: queryKeys.site( siteIdOrSlug ),
 		queryFn: async (): Promise< SiteDetails | undefined > => {
 			return await wpcomRequest( {
-				path: `/sites/${ encodeURIComponent( siteId as string ) }`,
+				path: `/sites/${ encodeURIComponent( siteIdOrSlug as string ) }`,
 				apiVersion: '1.1',
 			} );
 		},
-		enabled: !! siteId,
+		enabled: !! siteIdOrSlug,
 	} );
 }
 

--- a/packages/data-stores/src/site/queries/use-site.ts
+++ b/packages/data-stores/src/site/queries/use-site.ts
@@ -1,0 +1,28 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import useQueryKeysFactory from './lib/use-query-keys-factory';
+import type { SiteDetails } from '../types';
+
+interface Props {
+	siteId: string | number | null | undefined;
+}
+
+/**
+ * Site details from `/sites/[ siteId ]` endpoint
+ */
+function useSite( { siteId }: Props ): UseQueryResult< SiteDetails | undefined > {
+	const queryKeys = useQueryKeysFactory();
+
+	return useQuery( {
+		queryKey: queryKeys.site( siteId ),
+		queryFn: async (): Promise< SiteDetails | undefined > => {
+			return await wpcomRequest( {
+				path: `/sites/${ encodeURIComponent( siteId as string ) }`,
+				apiVersion: '1.1',
+			} );
+		},
+		enabled: !! siteId,
+	} );
+}
+
+export default useSite;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/87494

## Proposed Changes

Part of a series of work to uncouple the Add-Ons metadata hooks from Calypso dependencies and prepare them for migration to data-stores package. This PR:

- Updates `useAddOns` hook to accept a selectedSiteID prop to propagate throughout for use
- Updates `useAddOnPurchaseStatus` to work similarly (this is used in add-ons page separately)
- Introduces a `queries` slice under `/packages/data-stores/site` and implements a light `useSite` hook for fetching the raw (API) site details. It's a fairly complex structure to attempt to refactor into a cleaner camelCased structure for the frontend right now. 
    - There are also more than one similar React Query hooks in the codebase, which can gradually be refactored to use this more centrally defined one. Hopefully the existence of it under `/data-stores/site` will make it more visible.
    - We did not opt to use the wp-data store primarily for consistency with everything else (Plans, Purchases, Products) and to surface a hook to inspire reuse (and not reimplementing whenever a Query hook is preferred).

(^ follow-up issue will be created for the above once merged)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Ensure Add-Ons render correctly under `/add-ons`
- Ensure storage Add-Ons in `/pans/[ site ]` and `/start/plans` render correctly
- Ensure a Stepper flow renders storage Add-Ons correctly where applicable e.g. `/setup/newsletter/plans`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?