### PR TITLE
GitHub deployments: Add/prismjs formatter to yml config files

### DIFF
--- a/client/my-sites/github-deployments/components/repositories/deployment-style/deployment-style.tsx
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/deployment-style.tsx
@@ -10,7 +10,10 @@ import { sprintf, __ } from '@wordpress/i18n';
 import { check, closeSmall } from '@wordpress/icons';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
-import { useEffect, useMemo, useState } from 'react';
+import Prism from 'prismjs';
+import 'prismjs/themes/prism.css';
+import 'prismjs/components/prism-yaml';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormRadiosBar from 'calypso/components/forms/form-radios-bar';
 import SupportInfo from 'calypso/components/support-info';
@@ -62,7 +65,7 @@ export const DeploymentStyle = ( {
 	const validationTriggered = false;
 	const [ errorMesseage, setErrorMesseage ] = useState( '' );
 	const isTemplateRepository = repository.owner === 'Automattic';
-
+	const yamlCodeRef = useRef( null );
 	const {
 		data: workflows,
 		isLoading: isFetchingWorkflows,
@@ -128,11 +131,17 @@ export const DeploymentStyle = ( {
 			key: 'triggered_on_push',
 			item: (
 				<div>
-					<p>{ __( "Ensure that your workflow generates an artifact named 'wpcom'." ) }</p>
-					<p>
-						- name: Upload the artifact <br></br>uses: actions/upload-artifact@v4 <br></br>
-						with: name: wpcom
-					</p>
+					<p>{ __( 'Ensure that your workflow triggers on code push.' ) }</p>
+					<pre>
+						<code ref={ yamlCodeRef } className="language-yaml">
+							{ `
+on:
+  push:
+    branches:
+      - trunk
+        ` }
+						</code>
+					</pre>
 				</div>
 			),
 			status: 'loading',
@@ -143,10 +152,17 @@ export const DeploymentStyle = ( {
 			item: (
 				<div>
 					<p>{ __( "Ensure that your workflow generates an artifact named 'wpcom'." ) }</p>
-					<p>
-						- name: Upload the artifact <br></br>uses: actions/upload-artifact@v4 <br></br>
-						with: name: wpcom
-					</p>
+					<pre>
+						<code ref={ yamlCodeRef } className="language-yaml">
+							{ `
+
+    - name: Upload the artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: wpcom
+        ` }
+						</code>
+					</pre>
 				</div>
 			),
 			status: 'loading',
@@ -235,6 +251,12 @@ export const DeploymentStyle = ( {
 			onChooseWorkflow?.( selectedWorkflow );
 		}
 	}, [ onChooseWorkflow, deploymentStyle, selectedWorkflow ] );
+
+	useEffect( () => {
+		if ( yamlCodeRef.current ) {
+			Prism.highlightElement( yamlCodeRef.current );
+		}
+	}, [ workflowsValidations ] );
 
 	return (
 		<div className="github-deployments-deployment-style">
@@ -334,10 +356,36 @@ export const DeploymentStyle = ( {
 								screenReaderText="More"
 							>
 								<div>
-									<p>
-										- name: Upload the artifact <br></br>uses: actions/upload-artifact@v4 <br></br>
-										with: name: wpcom
-									</p>
+									<pre>
+										<code ref={ yamlCodeRef } className="language-yaml">
+											{
+												// eslint-disable-next-line inclusive-language/use-inclusive-words
+												`
+name: Publish Website
+
+on:
+  push:
+    branches:
+      - trunk
+  workflow_dispatch:
+
+  jobs:
+    name: Build-Artifact-Action
+    runs-on: ubuntu-latest
+    steps:
+
+	- uses: actions/checkout@master
+
+    - name: Upload the artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: wpcom
+        path: .
+
+`
+											}
+										</code>
+									</pre>
 								</div>
 							</FoldableCard>
 						</>

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/deployment-style.tsx
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/deployment-style.tsx
@@ -138,7 +138,7 @@ export const DeploymentStyle = ( {
 on:
   push:
     branches:
-      - trunk
+      - ${ repository.default_branch }
         ` }
 						</code>
 					</pre>

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/style.scss
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/style.scss
@@ -20,6 +20,21 @@
 		}
 		&__content {
 			background-color: var(--studio-gray-0);
+
+			p {
+				margin: 0;
+			}
+			pre {
+				margin: 0;
+				padding: 0;
+				background: transparent;
+			}
+			.language-yaml {
+				color: var(--studio-wordpress-blue-60) !important;
+			}
+			.token.key.atrule {
+				color: var(--studio-green) !important;
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5334

## Proposed Changes

* Added syntax highlighter to YAML file configurations
* We can just copy and paste them since they have the correct format/spacing
* We use the default's branch name for the workflow trigger example

<img width="642" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/72a3a58c-df2f-4c2f-9cc1-7c9a20f4fee3">

<img width="631" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/1860feda-4125-4fa2-8965-2efe52aaf425">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?