### PR TITLE
GitHub deployments: Creating a default workflow file

### DIFF
--- a/client/my-sites/github-deployments/components/repositories/deployment-style/deployment-style.tsx
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/deployment-style.tsx
@@ -27,7 +27,11 @@ import {
 	useCheckWorkflowQuery,
 	useDeploymentWorkflowsQuery,
 } from './use-deployment-workflows-query';
-
+import {
+	CodePushExample,
+	NewWorkflowExample,
+	UploadArtifactExample,
+} from './workflow-yaml-examples';
 import './style.scss';
 
 interface DeploymentStyleProps {
@@ -80,8 +84,7 @@ export const DeploymentStyle = ( {
 			} ) ) || []
 		);
 
-		return mappedValues;
-		// return mappedValues.concat( { value: 'create-new', label: __( 'Create new workflow' ) } );
+		return mappedValues.concat( { value: 'create-new', label: __( 'Create new workflow' ) } );
 	}, [ workflows ] );
 
 	const {
@@ -134,12 +137,7 @@ export const DeploymentStyle = ( {
 					<p>{ __( 'Ensure that your workflow triggers on code push.' ) }</p>
 					<pre>
 						<code ref={ yamlCodeRef } className="language-yaml">
-							{ `
-on:
-  push:
-    branches:
-      - ${ repository.default_branch }
-        ` }
+							{ CodePushExample( repository.default_branch ) }
 						</code>
 					</pre>
 				</div>
@@ -154,13 +152,7 @@ on:
 					<p>{ __( "Ensure that your workflow generates an artifact named 'wpcom'." ) }</p>
 					<pre>
 						<code ref={ yamlCodeRef } className="language-yaml">
-							{ `
-
-    - name: Upload the artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: wpcom
-        ` }
+							{ UploadArtifactExample() }
 						</code>
 					</pre>
 				</div>
@@ -188,9 +180,10 @@ on:
 	const installWorkflow = async () => {
 		createDeployment( {
 			repositoryId: repository.id,
-			branchName: 'main',
+			branchName: branchName,
 			installationId,
 			fileName: '.github/workflows/wpcom.yml',
+			fileContent: NewWorkflowExample( repository.default_branch ),
 		} );
 	};
 
@@ -358,32 +351,7 @@ on:
 								<div>
 									<pre>
 										<code ref={ yamlCodeRef } className="language-yaml">
-											{
-												// eslint-disable-next-line inclusive-language/use-inclusive-words
-												`
-name: Publish Website
-
-on:
-  push:
-    branches:
-      - trunk
-  workflow_dispatch:
-
-  jobs:
-    name: Build-Artifact-Action
-    runs-on: ubuntu-latest
-    steps:
-
-	- uses: actions/checkout@master
-
-    - name: Upload the artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: wpcom
-        path: .
-
-`
-											}
+											{ NewWorkflowExample( repository.default_branch ) }
 										</code>
 									</pre>
 								</div>
@@ -395,14 +363,16 @@ on:
 					) }
 					{ deploymentStyle === 'custom' && selectedWorkflow !== 'none' && (
 						<div className="github-deployments-deployment-style__actions">
-							<Button
-								type="button"
-								busy={ isCheckingWorkflowFile || isRefreshingWorkflowValidation }
-								className="button form-button"
-								onClick={ handleVerifyWorkflow }
-							>
-								{ __( 'Verify workflow' ) }
-							</Button>
+							{ ! isCreatingNewWorkflow && (
+								<Button
+									type="button"
+									busy={ isCheckingWorkflowFile || isRefreshingWorkflowValidation }
+									className="button form-button"
+									onClick={ handleVerifyWorkflow }
+								>
+									{ __( 'Verify workflow' ) }
+								</Button>
+							) }
 							{ /* { workflowCheckResult?.conclusion === 'error' && (
 							<Button type="button" className="button form-button" onClick={ fixWorfklow }>
 								{ __( 'Fix workflow for me' ) }

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/use-create-workflow.tsx
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/use-create-workflow.tsx
@@ -3,11 +3,12 @@ import { useCallback } from 'react';
 import wp from 'calypso/lib/wp';
 import { GITHUB_DEPLOYMENTS_QUERY_KEY } from 'calypso/my-sites/github-deployments/constants';
 import { CODE_DEPLOYMENTS_QUERY_KEY } from 'calypso/my-sites/github-deployments/deployments/use-code-deployments-query';
+import { GitHubRepositoryData } from 'calypso/my-sites/github-deployments/use-github-repositories-query';
 
 interface MutationVariables {
 	repositoryId: number;
 	branchName: string;
-	installationId: number;
+	repository: GitHubRepositoryData;
 	fileName: string;
 	fileContent: string;
 }
@@ -30,7 +31,7 @@ export const useCreateWorkflow = (
 		mutationFn: async ( {
 			repositoryId,
 			branchName,
-			installationId,
+			repository,
 			fileName,
 			fileContent,
 		}: MutationVariables ) =>
@@ -42,7 +43,8 @@ export const useCreateWorkflow = (
 				{
 					repository_id: repositoryId,
 					branch_name: branchName,
-					installation_id: installationId,
+					repository_name: repository.name,
+					repository_owner: repository.owner,
 					file_name: fileName,
 					file_content: fileContent,
 				}

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/use-create-workflow.tsx
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/use-create-workflow.tsx
@@ -9,6 +9,7 @@ interface MutationVariables {
 	branchName: string;
 	installationId: number;
 	fileName: string;
+	fileContent: string;
 }
 
 interface MutationResponse {
@@ -31,6 +32,7 @@ export const useCreateWorkflow = (
 			branchName,
 			installationId,
 			fileName,
+			fileContent,
 		}: MutationVariables ) =>
 			wp.req.post(
 				{
@@ -42,6 +44,7 @@ export const useCreateWorkflow = (
 					branch_name: branchName,
 					installation_id: installationId,
 					file_name: fileName,
+					file_content: fileContent,
 				}
 			),
 		...options,

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/workflow-yaml-examples.tsx
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/workflow-yaml-examples.tsx
@@ -1,0 +1,50 @@
+export const NewWorkflowExample = ( default_branch: string ) => {
+	return `
+name: Publish Website
+
+on:
+  push:
+    branches:
+      - ${
+				default_branch
+				// eslint-disable-next-line inclusive-language/use-inclusive-words
+			}
+  workflow_dispatch:
+jobs:
+  Build-Artifact-Action:
+    name: Build-Artifact-Action
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+
+    - name: Upload the artifact
+        uses: actions/upload-artifact@v4
+        with:
+            name: wpcom
+            path: .
+
+`;
+};
+
+export const CodePushExample = ( default_branch: string ) => {
+	return `
+on:
+  push:
+    branches:
+      - ${ default_branch }
+
+`;
+};
+
+export const UploadArtifactExample = () => {
+	// It's important to keep the indentation the same way we expect to see it in the final file
+	return `
+
+    - name: Upload the artifact
+        uses: actions/upload-artifact@v4
+        with:
+            name: wpcom
+            path: .
+
+`;
+};

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/workflow-yaml-examples.tsx
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/workflow-yaml-examples.tsx
@@ -5,11 +5,9 @@ name: Publish Website
 on:
   push:
     branches:
-      - ${
-				default_branch
-				// eslint-disable-next-line inclusive-language/use-inclusive-words
-			}
+      - ${ default_branch }
   workflow_dispatch:
+
 jobs:
   Build-Artifact-Action:
     name: Build-Artifact-Action
@@ -18,10 +16,10 @@ jobs:
     - uses: actions/checkout@master
 
     - name: Upload the artifact
-        uses: actions/upload-artifact@v4
-        with:
-            name: wpcom
-            path: .
+      uses: actions/upload-artifact@v4
+      with:
+        name: wpcom
+        path: .
 
 `;
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5334

## Proposed Changes

* Allow users to create a default workflow file
* Added a new YAML structure validation check


Full workflow validations:

https://github.com/Automattic/wp-calypso/assets/1044309/a03fd360-f5bf-4f27-9cab-941a4f47482d


Creating a default and functional workflow file:

https://github.com/Automattic/wp-calypso/assets/1044309/b95923d1-b31d-4b32-8589-d5e6bb62f0d3




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?