### PR TITLE
GitHub deployments: Poll deployments, deployment runs, and deployment run logs

### DIFF
--- a/client/my-sites/github-deployments/deployment-run-logs/deployments-run-item.tsx
+++ b/client/my-sites/github-deployments/deployment-run-logs/deployments-run-item.tsx
@@ -11,29 +11,31 @@ import {
 	DeploymentStatus,
 	DeploymentStatusValue,
 } from 'calypso/my-sites/github-deployments/deployments/deployment-status';
-import {
-	CodeDeploymentData,
-	DeploymentRun,
-} from 'calypso/my-sites/github-deployments/deployments/use-code-deployments-query';
 import { formatDate } from 'calypso/my-sites/github-deployments/utils/dates';
 import { useSelector } from 'calypso/state/index';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors/index';
+import { DeploymentRun, DeploymentRunStatus } from './use-code-deployment-run-query';
 
 interface DeploymentsListItemProps {
 	run: DeploymentRun;
 }
 
+const RUN_ENDED_STATUSES: DeploymentRunStatus[] = [ 'success', 'failed', 'warnings' ];
+
 export const DeploymentsRunItem = ( { run }: DeploymentsListItemProps ) => {
 	const locale = useLocale();
 	const siteId = useSelector( getSelectedSiteId );
-	const deployment = run.code_deployment as CodeDeploymentData;
+	const deployment = run.code_deployment!;
 	const [ expanded, setExpanded ] = useState( false );
 	const icon = expanded ? chevronUp : chevronDown;
 	const { data: logEntries = [], isLoading: isFetchingLogs } = useCodeDeploymentsRunLogQuery(
 		siteId,
 		deployment.id,
 		run.id,
-		{ enabled: expanded }
+		{
+			enabled: expanded,
+			refetchInterval: ! RUN_ENDED_STATUSES.includes( run.status ) ? 1000 : undefined,
+		}
 	);
 
 	const handleToggleExpanded = () => setExpanded( ! expanded );

--- a/client/my-sites/github-deployments/deployment-run-logs/deployments-run-table.tsx
+++ b/client/my-sites/github-deployments/deployment-run-logs/deployments-run-table.tsx
@@ -1,8 +1,8 @@
 import { __ } from '@wordpress/i18n';
 import { SortButton } from 'calypso/my-sites/github-deployments/components/sort-button/sort-button';
 import { SortDirection } from 'calypso/my-sites/github-deployments/components/sort-button/use-sort';
-import { DeploymentRun } from 'calypso/my-sites/github-deployments/deployments/use-code-deployments-query';
 import { DeploymentsRunItem } from './deployments-run-item';
+import { DeploymentRun } from './use-code-deployment-run-query';
 
 interface DeploymentsRunsTableProps {
 	deploymentsRuns: DeploymentRun[];

--- a/client/my-sites/github-deployments/deployment-run-logs/use-code-deployment-run-query.ts
+++ b/client/my-sites/github-deployments/deployment-run-logs/use-code-deployment-run-query.ts
@@ -26,6 +26,7 @@ export const useCodeDeploymentsRunsQuery = (
 		meta: {
 			persist: false,
 		},
+		refetchInterval: 5000,
 		...options,
 	} );
 };

--- a/client/my-sites/github-deployments/deployment-run-logs/use-code-deployment-run-query.ts
+++ b/client/my-sites/github-deployments/deployment-run-logs/use-code-deployment-run-query.ts
@@ -1,9 +1,39 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
-import { DeploymentRun } from 'calypso/my-sites/github-deployments/deployments/use-code-deployments-query';
 import { GITHUB_DEPLOYMENTS_QUERY_KEY } from '../constants';
+import { CodeDeploymentData } from '../deployments/use-code-deployments-query';
 
 export const CODE_DEPLOYMENTS_RUNS_QUERY_KEY = 'code-deployments-runs';
+
+export type DeploymentRunStatus =
+	| 'pending'
+	| 'queued'
+	| 'running'
+	| 'success'
+	| 'failed'
+	| 'warnings'
+	| 'building'
+	| 'dispatched'
+	| 'unknown';
+
+export interface DeploymentRun {
+	id: number;
+	code_deployment_id: number;
+	created_on: string;
+	started_on: string;
+	completed_on: string;
+	status: DeploymentRunStatus;
+	failure_code: string;
+	triggered_by_user_id: number;
+	metadata: Metadata;
+	code_deployment?: CodeDeploymentData;
+}
+
+export interface Metadata {
+	commit_message: string;
+	commit_sha: string;
+	job_id: number;
+}
 
 export const useCodeDeploymentsRunsQuery = (
 	siteId: number | null,

--- a/client/my-sites/github-deployments/deployments/deployment-commit-details.tsx
+++ b/client/my-sites/github-deployments/deployments/deployment-commit-details.tsx
@@ -1,7 +1,5 @@
-import {
-	CodeDeploymentData,
-	DeploymentRun,
-} from 'calypso/my-sites/github-deployments/deployments/use-code-deployments-query';
+import { CodeDeploymentData } from 'calypso/my-sites/github-deployments/deployments/use-code-deployments-query';
+import { DeploymentRun } from '../deployment-run-logs/use-code-deployment-run-query';
 
 interface DeploymentCommitDetailsProps {
 	run: DeploymentRun;

--- a/client/my-sites/github-deployments/deployments/deployment-duration.tsx
+++ b/client/my-sites/github-deployments/deployments/deployment-duration.tsx
@@ -1,4 +1,4 @@
-import { DeploymentRun } from 'calypso/my-sites/github-deployments/deployments/use-code-deployments-query';
+import { DeploymentRun } from '../deployment-run-logs/use-code-deployment-run-query';
 
 function formatDuration( run: DeploymentRun ) {
 	if ( ! run.completed_on ) {

--- a/client/my-sites/github-deployments/deployments/use-code-deployments-query.ts
+++ b/client/my-sites/github-deployments/deployments/use-code-deployments-query.ts
@@ -1,6 +1,7 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import wp from 'calypso/lib/wp';
 import { GITHUB_DEPLOYMENTS_QUERY_KEY } from '../constants';
+import type { DeploymentRun } from '../deployment-run-logs/use-code-deployment-run-query';
 
 export const CODE_DEPLOYMENTS_QUERY_KEY = 'code-deployments';
 
@@ -25,25 +26,6 @@ export interface CodeDeploymentData {
 export interface CreatedBy {
 	id: number;
 	name: string;
-}
-
-export interface DeploymentRun {
-	id: number;
-	code_deployment_id: number;
-	created_on: string;
-	started_on: string;
-	completed_on: string;
-	status: string;
-	failure_code: string;
-	triggered_by_user_id: number;
-	metadata: Metadata;
-	code_deployment?: CodeDeploymentData;
-}
-
-export interface Metadata {
-	commit_message: string;
-	commit_sha: string;
-	job_id: number;
 }
 
 export const useCodeDeploymentsQuery = (

--- a/client/my-sites/github-deployments/deployments/use-code-deployments-query.ts
+++ b/client/my-sites/github-deployments/deployments/use-code-deployments-query.ts
@@ -61,6 +61,7 @@ export const useCodeDeploymentsQuery = (
 		meta: {
 			persist: false,
 		},
+		refetchInterval: 5000,
 		...options,
 	} );
 };

--- a/client/my-sites/github-deployments/use-github-repositories-query.ts
+++ b/client/my-sites/github-deployments/use-github-repositories-query.ts
@@ -18,17 +18,18 @@ export const useGithubRepositoriesQuery = (
 	installationId: number,
 	options?: UseQueryOptions< GitHubRepositoryData[] >
 ) => {
-	const path = addQueryArgs( '/hosting/github/repositories', {
-		installation_id: installationId,
-	} );
-
 	return useQuery< GitHubRepositoryData[] >( {
 		queryKey: [ GITHUB_DEPLOYMENTS_QUERY_KEY, GITHUB_REPOSITORIES_QUERY_KEY, installationId ],
-		queryFn: (): GitHubRepositoryData[] =>
-			wp.req.get( {
+		queryFn: (): GitHubRepositoryData[] => {
+			const path = addQueryArgs( '/hosting/github/repositories', {
+				installation_id: installationId,
+			} );
+
+			return wp.req.get( {
 				path,
 				apiNamespace: 'wpcom/v2',
-			} ),
+			} );
+		},
 		meta: {
 			persist: false,
 		},


### PR DESCRIPTION
## Proposed Changes

Title. We're only polling the run logs if the accordion is expanded, and if the deployment run didn't reach terminal states, such as `success`, `warnings`, or `failed`.