### PR TITLE
Add jetpack_boost_yearly icon support

### DIFF
--- a/packages/components/src/product-icon/config.ts
+++ b/packages/components/src/product-icon/config.ts
@@ -99,6 +99,7 @@ export type SupportedSlugs =
 	| 'jetpack_backup_t2_monthly'
 	| 'jetpack_boost'
 	| 'jetpack_boost_monthly'
+	| 'jetpack_boost_yearly'
 	| 'jetpack_scan'
 	| 'jetpack_scan_monthly'
 	| 'jetpack_scan_v2'
@@ -208,7 +209,7 @@ export const iconToProductSlugMap: Record< keyof typeof paths, readonly Supporte
 		'jetpack_backup_addon_storage_3tb_yearly',
 		'jetpack_backup_addon_storage_5tb_yearly',
 	],
-	'jetpack-boost': [ 'jetpack_boost', 'jetpack_boost_monthly' ],
+	'jetpack-boost': [ 'jetpack_boost', 'jetpack_boost_monthly', 'jetpack_boost_yearly' ],
 	'jetpack-scan': [
 		'jetpack_scan',
 		'jetpack_scan_monthly',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5731

## Proposed Changes

* Add `jetpack_boost_yearly` slug for icon support.

Before | After
--|--
<img width="1721" alt="Screenshot 2024-02-22 at 10 10 02 AM" src="https://github.com/Automattic/wp-calypso/assets/140841/5ccfa257-b56f-4053-b11f-5c638b8e39b0">  | <img width="1720" alt="Screenshot 2024-02-22 at 10 10 36 AM" src="https://github.com/Automattic/wp-calypso/assets/140841/dfbfb60d-fbfc-4e0b-a945-2005bba310f7">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use Store Admin to add Jetpack Boost Yearly to a site
* Visit https://wordpress.com/plans/my-plan/[site_slug] to see the icon is missing
* Visit http://calypso.localhost:3000/plans/my-plan/[site_slug] and view the icon

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?