### PR TITLE
Add docs about override feature flag state vai session storage

### DIFF
--- a/packages/calypso-config/README.md
+++ b/packages/calypso-config/README.md
@@ -69,7 +69,7 @@ Session Storage:
 - `window.sessionStorage.setItem( 'flags', 'flag1,-flag2' );`: Enable feature `flag1` and disable feature `flag2`.
 - `window.sessionStorage.removeItem( 'flags' );`: Reset flags session item to config values.
 
-Note: the `flags` query argument, cookie and sessionStorage won't work for feature flags used by the Node.js
+Note: the `flags` query argument, cookie, and sessionStorage won't work for feature flags used by Node.js
 server. For this case, you can use the
 [`ENABLE_FEATURES` and/or `DISABLE_FEATURES`](../../config/README.md#feature-flags)
 environment variables instead.

--- a/packages/calypso-config/README.md
+++ b/packages/calypso-config/README.md
@@ -59,12 +59,17 @@ Query argument examples:
 - `?flags=-flag2`: Disable feature `flag2`.
 - `?flags=+flag1,-flag2`: Enable feature `flag1` and disable feature `flag2`.
 
-You can use the same syntax in a cookie:
+You can use the same syntax in a cookie or via session storage
 
+Cookies:
 - `document.cookie = 'flags=+flag1,-flag2;max-age=1209600;path=/';`: Enable feature `flag1` and disable feature `flag2`.
 - `document.cookie = 'flags= ; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/;';`: Reset flags cookie to config values.
 
-Note: the `flags` query argument and cookie won't work for feature flags used by the Node.js
+Session Storage: 
+- `window.sessionStorage.setItem( 'flags', 'flag1,-flag2' );`: Enable feature `flag1` and disable feature `flag2`.
+- `window.sessionStorage.removeItem( 'flags' );`: Reset flags session item to config values.
+
+Note: the `flags` query argument, cookie and sessionStorage won't work for feature flags used by the Node.js
 server. For this case, you can use the
 [`ENABLE_FEATURES` and/or `DISABLE_FEATURES`](../../config/README.md#feature-flags)
 environment variables instead.


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

* Add docs explaining how to enable/disable feature flags via session storage

## Testing Instructions
* Check if your env has the flag 'onboarding/new-migration-flow' set as false. You can verify on the developer bottom bar on the 'features' tab as screenshot 1 demonstrates. When the feature flag is off the feature list will not show the feature flag name.

* Follow the instructions added by this PR to enable the feature flag on your env
* Reload the page
* Check the list of features again without restarting your env. (Screenshot 2)


### Screenshots
**1. Feature Disabled**:

<img width="774" alt="image" src="https://github.com/Automattic/wp-calypso/assets/38718/bdcc2339-11b3-45f6-9b61-98357514036d">

**2. Feature Enabled:**
<img width="913" alt="image" src="https://github.com/Automattic/wp-calypso/assets/38718/bc06a11b-795a-4bb9-a5af-761c503f83d8">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?