### PR TITLE
Use wp-admin Blaze link for Classic sites

### DIFF
--- a/client/my-sites/advertising/useAdvertisingUrl.jsx
+++ b/client/my-sites/advertising/useAdvertisingUrl.jsx
@@ -6,13 +6,15 @@ import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selecto
 const useAdvertisingUrl = () => {
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
+	const siteAdminUrl = useSelector( ( state ) =>
+		getSiteAdminUrl( state, siteId, 'tools.php?page=advertising' )
+	);
 	const adminInterface = useSelector( ( state ) =>
 		getSiteOption( state, siteId, 'wpcom_admin_interface' )
 	);
 
 	return adminInterface === 'wp-admin' && isEnabled( 'layout/dotcom-nav-redesign' )
-		? `${ siteAdminUrl }tools.php?page=advertising`
+		? siteAdminUrl
 		: `/advertising/${ selectedSiteSlug }`;
 };
 

--- a/client/my-sites/advertising/useAdvertisingUrl.jsx
+++ b/client/my-sites/advertising/useAdvertisingUrl.jsx
@@ -1,0 +1,19 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { useSelector } from 'react-redux';
+import { getSiteAdminUrl, getSiteOption } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+const useAdvertisingUrl = () => {
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
+	const adminInterface = useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'wpcom_admin_interface' )
+	);
+
+	return adminInterface === 'wp-admin' && isEnabled( 'layout/dotcom-nav-redesign' )
+		? `${ siteAdminUrl }tools.php?page=advertising`
+		: `/advertising/${ selectedSiteSlug }`;
+};
+
+export default useAdvertisingUrl;

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -86,6 +86,15 @@ export const QuickLinks = ( {
 	const hasBackups = getAllFeaturesForPlan( currentSitePlanSlug ).includes( 'backups' );
 	const hasBoost = site?.options?.jetpack_connection_active_plugins?.includes( 'jetpack-boost' );
 	const [ isAILogoGeneratorOpen, setIsAILogoGeneratorOpen ] = useState( false );
+	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const adminInterface = useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'wpcom_admin_interface' )
+	);
+
+	const advertisingUrl =
+		adminInterface === 'wp-admin'
+			? `https://${ selectedSiteSlug }/wp-admin/tools.php?page=advertising`
+			: `/advertising/${ selectedSiteSlug }`;
 
 	const addNewDomain = () => {
 		trackAddDomainAction();
@@ -124,7 +133,7 @@ export const QuickLinks = ( {
 			/>
 			{ isPromotePostActive && ! isWpcomStagingSite && (
 				<ActionBox
-					href={ `/advertising/${ siteSlug }` }
+					href={ advertisingUrl }
 					hideLinkIndicator
 					onClick={ trackPromotePostAction }
 					label={ translate( 'Promote with Blaze' ) }

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -1,4 +1,4 @@
-import config, { isEnabled } from '@automattic/calypso-config';
+import config from '@automattic/calypso-config';
 import { getAllFeaturesForPlan } from '@automattic/calypso-products/';
 import { JetpackLogo, FoldableCard } from '@automattic/components';
 import { GeneratorModal } from '@automattic/jetpack-ai-calypso';
@@ -16,6 +16,7 @@ import {
 	usePromoteWidget,
 	PromoteWidgetStatus,
 } from 'calypso/lib/promote-post';
+import useAdvertisingUrl from 'calypso/my-sites/advertising/useAdvertisingUrl';
 import { bumpStat, composeAnalytics, recordTracksEvent } from 'calypso/state/analytics/actions';
 import { savePreference } from 'calypso/state/preferences/actions';
 import { getPreference } from 'calypso/state/preferences/selectors';
@@ -86,15 +87,7 @@ export const QuickLinks = ( {
 	const hasBackups = getAllFeaturesForPlan( currentSitePlanSlug ).includes( 'backups' );
 	const hasBoost = site?.options?.jetpack_connection_active_plugins?.includes( 'jetpack-boost' );
 	const [ isAILogoGeneratorOpen, setIsAILogoGeneratorOpen ] = useState( false );
-	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
-	const adminInterface = useSelector( ( state ) =>
-		getSiteOption( state, siteId, 'wpcom_admin_interface' )
-	);
-
-	const advertisingUrl =
-		adminInterface === 'wp-admin' && isEnabled( 'layout/dotcom-nav-redesign' )
-			? `https://${ selectedSiteSlug }/wp-admin/tools.php?page=advertising`
-			: `/advertising/${ selectedSiteSlug }`;
+	const advertisingUrl = useAdvertisingUrl();
 
 	const addNewDomain = () => {
 		trackAddDomainAction();

--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -1,4 +1,4 @@
-import config from '@automattic/calypso-config';
+import config, { isEnabled } from '@automattic/calypso-config';
 import { getAllFeaturesForPlan } from '@automattic/calypso-products/';
 import { JetpackLogo, FoldableCard } from '@automattic/components';
 import { GeneratorModal } from '@automattic/jetpack-ai-calypso';
@@ -92,7 +92,7 @@ export const QuickLinks = ( {
 	);
 
 	const advertisingUrl =
-		adminInterface === 'wp-admin'
+		adminInterface === 'wp-admin' && isEnabled( 'layout/dotcom-nav-redesign' )
 			? `https://${ selectedSiteSlug }/wp-admin/tools.php?page=advertising`
 			: `/advertising/${ selectedSiteSlug }`;
 

--- a/client/my-sites/customer-home/cards/tasks/promote-post/index.js
+++ b/client/my-sites/customer-home/cards/tasks/promote-post/index.js
@@ -10,13 +10,22 @@ import {
 } from 'calypso/lib/promote-post';
 import { TASK_PROMOTE_POST } from 'calypso/my-sites/customer-home/cards/constants';
 import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSiteOption } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const PromotePost = () => {
 	const translate = useTranslate();
 	const showPromotePost = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
 	const dispatch = useDispatch();
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const adminInterface = useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'wpcom_admin_interface' )
+	);
+	const advertisingUrl =
+		adminInterface === 'wp-admin'
+			? `https://${ selectedSiteSlug }/wp-admin/tools.php?page=advertising`
+			: `/advertising/${ selectedSiteSlug }`;
 	const trackDspAction = async () => {
 		dispatch( recordDSPEntryPoint( 'myhome_tasks-swipeable' ) );
 	};
@@ -36,7 +45,7 @@ const PromotePost = () => {
 						'Grow your audience by promoting your content with Blaze campaigns. Reach interested users across millions of sites on Tumblr and WordPress.com.'
 					) }
 					actionText={ translate( 'Create campaign' ) }
-					actionUrl={ `/advertising/${ selectedSiteSlug }` }
+					actionUrl={ advertisingUrl }
 					actionOnClick={ trackDspAction }
 					completeOnStart={ false }
 					illustration={ blazeIllustration }

--- a/client/my-sites/customer-home/cards/tasks/promote-post/index.js
+++ b/client/my-sites/customer-home/cards/tasks/promote-post/index.js
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
@@ -23,7 +24,7 @@ const PromotePost = () => {
 		getSiteOption( state, siteId, 'wpcom_admin_interface' )
 	);
 	const advertisingUrl =
-		adminInterface === 'wp-admin'
+		adminInterface === 'wp-admin' && isEnabled( 'layout/dotcom-nav-redesign' )
 			? `https://${ selectedSiteSlug }/wp-admin/tools.php?page=advertising`
 			: `/advertising/${ selectedSiteSlug }`;
 	const trackDspAction = async () => {

--- a/client/my-sites/customer-home/cards/tasks/promote-post/index.js
+++ b/client/my-sites/customer-home/cards/tasks/promote-post/index.js
@@ -1,7 +1,6 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect } from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import blazeIllustration from 'calypso/assets/images/customer-home/illustration--blaze.svg';
 import {
 	loadDSPWidgetJS,
@@ -9,24 +8,15 @@ import {
 	usePromoteWidget,
 	PromoteWidgetStatus,
 } from 'calypso/lib/promote-post';
+import useAdvertisingUrl from 'calypso/my-sites/advertising/useAdvertisingUrl';
 import { TASK_PROMOTE_POST } from 'calypso/my-sites/customer-home/cards/constants';
 import Task from 'calypso/my-sites/customer-home/cards/tasks/task';
-import { getSiteOption } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const PromotePost = () => {
 	const translate = useTranslate();
 	const showPromotePost = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
 	const dispatch = useDispatch();
-	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const adminInterface = useSelector( ( state ) =>
-		getSiteOption( state, siteId, 'wpcom_admin_interface' )
-	);
-	const advertisingUrl =
-		adminInterface === 'wp-admin' && isEnabled( 'layout/dotcom-nav-redesign' )
-			? `https://${ selectedSiteSlug }/wp-admin/tools.php?page=advertising`
-			: `/advertising/${ selectedSiteSlug }`;
+	const advertisingUrl = useAdvertisingUrl();
 	const trackDspAction = async () => {
 		dispatch( recordDSPEntryPoint( 'myhome_tasks-swipeable' ) );
 	};

--- a/client/my-sites/purchases/subscriptions/account-level-advertising-links.tsx
+++ b/client/my-sites/purchases/subscriptions/account-level-advertising-links.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import { CompactCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { PromoteWidgetStatus, usePromoteWidget } from 'calypso/lib/promote-post';
@@ -19,7 +20,7 @@ export default function AccountLevelAdvertisingLinks() {
 	}
 
 	const advertisingUrl =
-		adminInterface === 'wp-admin'
+		adminInterface === 'wp-admin' && isEnabled( 'layout/dotcom-nav-redesign' )
 			? `https://${ selectedSiteSlug }/wp-admin/tools.php?page=advertising`
 			: `/advertising/${ selectedSiteSlug }`;
 

--- a/client/my-sites/purchases/subscriptions/account-level-advertising-links.tsx
+++ b/client/my-sites/purchases/subscriptions/account-level-advertising-links.tsx
@@ -1,28 +1,19 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { CompactCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { PromoteWidgetStatus, usePromoteWidget } from 'calypso/lib/promote-post';
+import useAdvertisingUrl from 'calypso/my-sites/advertising/useAdvertisingUrl';
 import { useSelector } from 'calypso/state';
-import { getSiteOption } from 'calypso/state/sites/selectors';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 export default function AccountLevelAdvertisingLinks() {
 	const translate = useTranslate();
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const shouldShowAdvertisingOption = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
-	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const adminInterface = useSelector( ( state ) =>
-		getSiteOption( state, siteId, 'wpcom_admin_interface' )
-	);
+	const advertisingUrl = useAdvertisingUrl();
 
 	if ( ! shouldShowAdvertisingOption || ! selectedSiteSlug ) {
 		return null;
 	}
-
-	const advertisingUrl =
-		adminInterface === 'wp-admin' && isEnabled( 'layout/dotcom-nav-redesign' )
-			? `https://${ selectedSiteSlug }/wp-admin/tools.php?page=advertising`
-			: `/advertising/${ selectedSiteSlug }`;
 
 	return (
 		<>

--- a/client/my-sites/purchases/subscriptions/account-level-advertising-links.tsx
+++ b/client/my-sites/purchases/subscriptions/account-level-advertising-links.tsx
@@ -2,20 +2,30 @@ import { CompactCard } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { PromoteWidgetStatus, usePromoteWidget } from 'calypso/lib/promote-post';
 import { useSelector } from 'calypso/state';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSiteOption } from 'calypso/state/sites/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 export default function AccountLevelAdvertisingLinks() {
 	const translate = useTranslate();
 	const selectedSiteSlug = useSelector( getSelectedSiteSlug );
 	const shouldShowAdvertisingOption = usePromoteWidget() === PromoteWidgetStatus.ENABLED;
+	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
+	const adminInterface = useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'wpcom_admin_interface' )
+	);
 
 	if ( ! shouldShowAdvertisingOption || ! selectedSiteSlug ) {
 		return null;
 	}
 
+	const advertisingUrl =
+		adminInterface === 'wp-admin'
+			? `https://${ selectedSiteSlug }/wp-admin/tools.php?page=advertising`
+			: `/advertising/${ selectedSiteSlug }`;
+
 	return (
 		<>
-			<CompactCard href={ `/advertising/${ selectedSiteSlug }` }>
+			<CompactCard href={ advertisingUrl }>
 				{ translate( 'View advertising campaigns' ) }
 			</CompactCard>
 		</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5724

> [!WARNING]  
> https://github.com/Automattic/jetpack/pull/35724 needs to roll out before this PR is merged so the wp-admin Blaze link will work.


> [!WARNING]  
> https://github.com/Automattic/jetpack/pull/35724 puts the wp-admin/tools.php?page=advertising page behind a proxy check. This PR places the update links behind the `layout/dotcom-nav-redesign` feature flag. This means for rollout, the proxy needs to be removed first before the feature flag is enabled. Otherwise, these links will point to a broken page.

## Proposed Changes

* Dynamically set the links to Blaze so that Classic admin sites are linked to wp-admin Blaze page and "Default" admin sites are linked to the Calypso Blaze page.

There are 3 link updates in this PR

- "View advertising campaigns" in https://wpcalypso.wordpress.com/purchases/subscriptions/[site_slug]
- "Create campaign" in the promo card on https://wpcalypso.wordpress.com/home/[site_slug]
- "Promote with Blaze" in the "Quick links" on https://wpcalypso.wordpress.com/home/[site_slug]

<img width="1722" alt="Screenshot 2024-02-22 at 11 45 43 AM" src="https://github.com/Automattic/wp-calypso/assets/140841/2d4ef7b4-1141-44e3-b407-aaada427463a">
<img width="1722" alt="Screenshot 2024-02-22 at 11 44 58 AM" src="https://github.com/Automattic/wp-calypso/assets/140841/6ad35576-4f5f-41bd-815f-061f66506d3a">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* With this PR loaded
* Click the links above on a Classic admin style site. They should link to wp-admin Blaze.
* Click the links above on a Default admin style site. They should link to Calypso Blaze.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?