### PR TITLE
My Sites: Remove WP Admin link from Atomic sites

### DIFF
--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -47,10 +47,6 @@ const THUMBNAIL_DIMENSION = {
 	height: 401 / ASPECT_RATIO,
 };
 
-const wpAdminCss = css( {
-	whiteSpace: 'nowrap',
-} );
-
 const badges = css( {
 	display: 'flex',
 	gap: '8px',
@@ -210,18 +206,6 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 								return <TransferNoticeWrapper { ...result } />;
 							} else if ( showLaunchNag && 'unlaunched' === site.launch_status ) {
 								return <SiteLaunchNag site={ site } />;
-							} else if ( site.is_wpcom_atomic ) {
-								return (
-									<a
-										href={ wpAdminUrl }
-										title={ __( 'Visit Wordpress Admin Dashboard' ) }
-										target="_blank"
-										rel="noreferrer"
-										className={ wpAdminCss }
-									>
-										{ __( 'WP Admin' ) }
-									</a>
-								);
 							}
 							return <></>;
 						} }


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5745

### Before

<img width="1045" alt="Screenshot 2024-02-22 at 17 37 18" src="https://github.com/Automattic/wp-calypso/assets/5560595/7ed194fa-ea10-44fe-8ac0-cadccd416c9e">

### After

<img width="1043" alt="Screenshot 2024-02-22 at 17 35 36" src="https://github.com/Automattic/wp-calypso/assets/5560595/efc9b6e8-0a32-43bb-a451-4a0fda8601c5">


