### PR TITLE
GitHub Deployments: Display current deployment run instead of last deployment

### DIFF
--- a/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
+++ b/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
@@ -1,7 +1,7 @@
 import page from '@automattic/calypso-router';
 import { Gridicon } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
-import { DropdownMenu, ExternalLink, MenuGroup, MenuItem, Spinner } from '@wordpress/components';
+import { DropdownMenu, MenuGroup, MenuItem, Spinner } from '@wordpress/components';
 import { Fragment, useState } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
 import { Icon, linkOff } from '@wordpress/icons';
@@ -69,7 +69,7 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 	const [ isDisconnectRepositoryDialogVisible, setDisconnectRepositoryDialogVisibility ] =
 		useState( false );
 
-	const run = deployment.current_deployed_run;
+	const run = deployment.current_deployment_run;
 	const [ installation, repo ] = deployment.repository_name.split( '/' );
 
 	return (
@@ -110,13 +110,6 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 											} }
 										>
 											{ __( 'Open deployment list' ) }
-										</MenuItem>
-										<MenuItem onClick={ onClose }>
-											<ExternalLink
-												href={ `https://github.com/${ deployment.repository_name }/commits/${ deployment.branch_name }` }
-											>
-												{ __( 'Read logs on GitHub' ) }
-											</ExternalLink>
 										</MenuItem>
 										<MenuItem
 											onClick={ () => {

--- a/client/my-sites/github-deployments/deployments/deployments-list.tsx
+++ b/client/my-sites/github-deployments/deployments/deployments-list.tsx
@@ -35,8 +35,8 @@ function applySort( deployments: CodeDeploymentData[], key: string, direction: S
 		case 'status':
 			if ( direction === 'asc' ) {
 				return deployments.sort( ( left, right ) => {
-					const leftRun = left.current_deployed_run;
-					const rightRun = right.current_deployed_run;
+					const leftRun = left.current_deployment_run;
+					const rightRun = right.current_deployment_run;
 					if ( leftRun && rightRun ) {
 						return leftRun?.status.localeCompare( rightRun.status );
 					} else if ( leftRun ) {
@@ -46,8 +46,8 @@ function applySort( deployments: CodeDeploymentData[], key: string, direction: S
 				} );
 			}
 			return deployments.sort( ( left, right ) => {
-				const leftRun = left.current_deployed_run;
-				const rightRun = right.current_deployed_run;
+				const leftRun = left.current_deployment_run;
+				const rightRun = right.current_deployment_run;
 				if ( leftRun && rightRun ) {
 					return leftRun?.status.localeCompare( rightRun.status );
 				} else if ( leftRun ) {


### PR DESCRIPTION
Related to p1708617976780179-slack-C06D9M3CHMK.

## Proposed Changes

Displays the current deployment run in the list view for a deployment instead of what's deployed. This is to give the user more feedback about what's happening to their connection.