### PR TITLE
Site Migration: Add test helper to render steps

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/test/index.tsx
@@ -6,11 +6,11 @@ import nock from 'nock';
 import React from 'react';
 import SiteMigrationPluginInstall from '../';
 import { StepProps } from '../../../types';
-import { renderStep, mockStepProps } from '../../test/helpers';
+import { renderStep, mockStepProps, RenderStepOptions } from '../../test/helpers';
 
 const mockApi = () => nock( 'https://public-api.wordpress.com:443' );
 
-const render = ( props?: Partial< StepProps >, renderOptions: RenderStepOptions ) => {
+const render = ( props?: Partial< StepProps >, renderOptions?: RenderStepOptions ) => {
 	const combinedProps = { ...mockStepProps( props ) };
 	return renderStep( <SiteMigrationPluginInstall { ...combinedProps } />, renderOptions );
 };

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/test/index.tsx
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen, waitFor } from '@testing-library/react';
+import nock from 'nock';
+import React from 'react';
+import SiteMigrationPluginInstall from '../';
+import { StepProps } from '../../../types';
+import { renderStep, mockStepProps } from '../../test/helpers';
+
+const mockApi = () => nock( 'https://public-api.wordpress.com:443' );
+
+const render = ( props?: Partial< StepProps >, renderOptions: RenderStepOptions ) => {
+	const combinedProps = { ...mockStepProps( props ) };
+	return renderStep( <SiteMigrationPluginInstall { ...combinedProps } />, renderOptions );
+};
+
+describe( 'Site Migration Plugin Step Install', () => {
+	beforeAll( () => {
+		nock.disableNetConnect();
+	} );
+
+	it( 'shows the loading state', async () => {
+		render();
+
+		expect( screen.getByText( 'Installing plugins' ) ).toBeVisible();
+	} );
+
+	it( 'triggers the next step when the plugin is installed', async () => {
+		const submit = jest.fn();
+
+		mockApi().post( '/rest/v1.2/sites/123/plugins/install', { slug: 'migrate-guru' } ).reply( 200 );
+
+		mockApi()
+			.post( '/rest/v1.2/sites/123/plugins/migrate-guru%2fmigrateguru', { active: true } )
+			.reply( 200 );
+
+		render( { navigation: { submit } } );
+
+		await waitFor( () => expect( submit ).toHaveBeenCalledWith() );
+	} );
+
+	it( 'redirects to the error page when there is any error', async () => {
+		const submit = jest.fn();
+
+		mockApi()
+			.post( '/rest/v1.2/sites/123/plugins/install' )
+			.reply( 500, new Error( 'Internal Server Error' ) );
+
+		render( { navigation: { submit } } );
+
+		//TODO: Update it when we add error handling with message.
+		await waitFor( () => expect( submit ).toHaveBeenCalledWith( { error: expect.any( Error ) } ) );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/test/helpers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/test/helpers/index.tsx
@@ -8,13 +8,13 @@ import { renderWithProvider } from 'calypso/test-helpers/testing-library';
 import { Step, StepProps } from '../../../types';
 import type { Reducer } from 'redux';
 
-interface RenderStepOptions {
+export interface RenderStepOptions {
 	initialEntry?: string;
 	reducers: Record< string, Reducer >;
 }
 
 /** Utility to render a step for testing purposes */
-export const renderStep = ( step: ReactElement< Step >, options: RenderStepOptions ) => {
+export const renderStep = ( step: ReactElement< Step >, options?: RenderStepOptions ) => {
 	const { initialEntry = '/some-path?siteId=123', reducers = [] } = options ?? {};
 
 	return renderWithProvider(

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/test/helpers/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/test/helpers/index.tsx
@@ -1,0 +1,54 @@
+import { SiteIntent } from '@automattic/data-stores/src/onboard';
+import { merge } from 'lodash';
+import React, { ReactElement } from 'react';
+import { MemoryRouter } from 'react-router';
+import documentHeadReducer from 'calypso/state/document-head/reducer';
+import uiReducer from 'calypso/state/ui/reducer';
+import { renderWithProvider } from 'calypso/test-helpers/testing-library';
+import { Step, StepProps } from '../../../types';
+import type { Reducer } from 'redux';
+
+interface RenderStepOptions {
+	initialEntry?: string;
+	reducers: Record< string, Reducer >;
+}
+
+/** Utility to render a step for testing purposes */
+export const renderStep = ( step: ReactElement< Step >, options: RenderStepOptions ) => {
+	const { initialEntry = '/some-path?siteId=123', reducers = [] } = options ?? {};
+
+	return renderWithProvider(
+		<MemoryRouter initialEntries={ [ initialEntry ] }>{ step }</MemoryRouter>,
+		{
+			initialState: {},
+			reducers: {
+				ui: uiReducer,
+				documentHead: documentHeadReducer,
+				...reducers,
+			},
+		}
+	);
+};
+
+const navigation = {
+	submit: jest.fn(),
+	goNext: jest.fn(),
+	goToStep: jest.fn(),
+};
+
+const defaultProps = {
+	navigation,
+	stepName: 'site-migration-plugin-install',
+	flow: 'site-migration',
+	data: {
+		siteId: 123,
+		siteSlug: 'example.wordpress.com',
+		path: '/site-migration-plugin-install',
+		intent: SiteIntent.Build,
+		previousStep: 'site-migration-source',
+	},
+};
+
+export const mockStepProps = ( props: Partial< StepProps > = {} ) => {
+	return merge( defaultProps, props ) satisfies StepProps;
+};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, to avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87643 

## Proposed Changes

* Add initial tests to the site migration plugin install step
* Add a utility to test to simplify the rendering of the test
## How it works?

The goal is to have a reliable, fast, and flexible test suite where we can quickly introduce new changes based on the project evolution without running manual tests on every PR.

To reach this goal, we need to follow some principles:

- Render the component in a way that most closely resembles browser rendering.
- Intercept the API requests at the lowest level possible to ensure we pass the required parameters and handle the endpoint answer.  Nock is the tool we have now to do it.
- Simulate the user behavior as closely as possible when the user finishes interacting with the component. In this case, I am using navigation. submit` to identify if the user can finish the step.

## Testing instructions

**Scenario 1:** 
We accidentally introduced a change that breaks our API calls

- Go to the file https://github.com/Automattic/wp-calypso/blob/30c79fb8a40784b88fc7c81084f6ea9fa91cd14e/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/index.tsx?plain=1#L39 and remove the line we are using to call the endpoint ``/sites/${ siteId }/plugins/migrate-guru%2fmigrateguru`,`
- Run the test suite and check if the test suite provides feedback about it.

**Scenario 2:**
Update the code without affecting the tests

- Reset the Scenario 1 changes.
- Wrap the component `h1` https://github.com/Automattic/wp-calypso/blob/30c79fb8a40784b88fc7c81084f6ea9fa91cd14e/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/index.tsx?plain=1#L68C7-L68C58 with a div `<div><h1....></h1><div>
- Run the tests and check if they are green.

