### PR TITLE
Workflow: Update to check that issue has expected labels

### DIFF
--- a/.github/workflows/notify-high-priority-triaged-issues.yml
+++ b/.github/workflows/notify-high-priority-triaged-issues.yml
@@ -2,32 +2,29 @@ name: 'Notify on High Priority Triaged Items'
 on:
   issues:
     types: [labeled]
-  # This commented out section is useful for testing the workflow in the context of a pull request before merging.
-  # pull_request:
-  #   types: [labeled]
 
 jobs:
   notify-on-label:
     runs-on: ubuntu-latest
     if: >
-      ( github.event.label.name == '[Pri] High' ||
-      github.event.label.name == '[Pri] Blocker' ||
-      github.event.label.name == 'Triaged' )
+      (
+        github.event.label.name == '[Pri] High' ||
+        github.event.label.name == '[Pri] Blocker' ||
+        github.event.label.name == 'Triaged'
+      ) &&
+      contains(github.event.issue.labels.*.name, 'Triaged') &&
+      (
+        contains(github.event.issue.labels.*.name, '[Pri] High') ||
+        contains(github.event.issue.labels.*.name, '[Pri] Blocker')
+      )
     steps:
       - name: Set variables based on event type
         id: set-vars
         run: |
-          if [ "${{ github.event_name }}" = "issues" ]; then
-            echo "::set-output name=item_type::Issue"
-            echo "::set-output name=item_url::https://github.com/${{ github.repository }}/issues/${{ github.event.issue.number }}"
-            echo "::set-output name=item_title::${{ github.event.issue.title }}"
-            echo "::set-output name=item_number::${{ github.event.issue.number }}"
-          else
-            echo "::set-output name=item_type::PR"
-            echo "::set-output name=item_url::https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}"
-            echo "::set-output name=item_title::${{ github.event.pull_request.title }}"
-            echo "::set-output name=item_number::${{ github.event.pull_request.number }}"
-          fi
+          echo "::set-output name=item_type::Issue"
+          echo "::set-output name=item_url::https://github.com/${{ github.repository }}/issues/${{ github.event.issue.number }}"
+          echo "::set-output name=item_title::${{ github.event.issue.title }}"
+          echo "::set-output name=item_number::${{ github.event.issue.number }}"
       - name: Notify Slack
         uses: slackapi/slack-github-action@v1.24.0
         with:
@@ -39,7 +36,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "A high priority ${{ steps.set-vars.outputs.item_type }} labeled '${{ github.event.label.name }}' has been triaged and needs attention:\n*<${{ steps.set-vars.outputs.item_url }}|${{ steps.set-vars.outputs.item_type }} #${{ steps.set-vars.outputs.item_number }}: ${{ steps.set-vars.outputs.item_title }}>*"
+                    "text": "A high priority ${{ steps.set-vars.outputs.item_type }} has been triaged and needs attention:\n*<${{ steps.set-vars.outputs.item_url }}|${{ steps.set-vars.outputs.item_type }} #${{ steps.set-vars.outputs.item_number }}: ${{ steps.set-vars.outputs.item_title }}>*"
                   }
                 }
               ],


### PR DESCRIPTION
## Proposed Changes

* Following https://github.com/Automattic/wp-calypso/pull/87795, this PR attempts to add logic that will ensure that all expected labels are present. Otherwise, the notification fires if any of the labels are present which is not the correct behavior.

## Testing Instructions

Deploy and test. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?