### PR TITLE
GitHub Deployments: Add connection change notice

### DIFF
--- a/client/my-sites/github-deployments/deployment-management/deployment-management-form.tsx
+++ b/client/my-sites/github-deployments/deployment-management/deployment-management-form.tsx
@@ -77,7 +77,7 @@ export const GitHubDeploymentManagementForm = ( {
 	return (
 		<>
 			<div css={ { marginBottom: '16px' } }>
-				<Notice isCompact status="is-transparent-info">
+				<Notice isCompact>
 					{ __( 'Changes to an existing connection will be applied in the next deployment run.' ) }
 				</Notice>
 			</div>

--- a/client/my-sites/github-deployments/deployment-management/deployment-management-form.tsx
+++ b/client/my-sites/github-deployments/deployment-management/deployment-management-form.tsx
@@ -4,6 +4,7 @@ import { GitHubConnectionForm } from 'calypso/my-sites/github-deployments/compon
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import Notice from '../../../components/notice';
 import { useDispatch, useSelector } from '../../../state';
 import { GitHubLoadingPlaceholder } from '../components/loading-placeholder';
 import { CodeDeploymentData } from '../deployments/use-code-deployments-query';
@@ -74,28 +75,36 @@ export const GitHubDeploymentManagementForm = ( {
 	}
 
 	return (
-		<GitHubConnectionForm
-			installation={ installation }
-			ctaLabel={ __( 'Update connection' ) }
-			repository={ repository }
-			initialValues={ initialValues }
-			onSubmit={ ( {
-				externalRepositoryId,
-				branchName,
-				targetDir,
-				installationId,
-				isAutomated,
-				workflowPath,
-			} ) =>
-				updateDeployment( {
+		<>
+			<div css={ { marginBottom: '16px' } }>
+				<Notice isCompact status="is-transparent-info">
+					{ __( 'Changes to an existing connection will be applied in the next deployment run.' ) }
+				</Notice>
+			</div>
+
+			<GitHubConnectionForm
+				installation={ installation }
+				ctaLabel={ __( 'Update connection' ) }
+				repository={ repository }
+				initialValues={ initialValues }
+				onSubmit={ ( {
 					externalRepositoryId,
 					branchName,
 					targetDir,
 					installationId,
 					isAutomated,
 					workflowPath,
-				} )
-			}
-		/>
+				} ) =>
+					updateDeployment( {
+						externalRepositoryId,
+						branchName,
+						targetDir,
+						installationId,
+						isAutomated,
+						workflowPath,
+					} )
+				}
+			/>
+		</>
 	);
 };


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/5693.

## Proposed Changes

Let's the user know that changes to a connection will only take effect in their next deployment run:

![image](https://github.com/Automattic/wp-calypso/assets/26530524/4fac3c2d-b62d-4b53-a7a2-e00530dda788)
