### PR TITLE
Jetpack Manage: Bundle price calculation fix

### DIFF
--- a/client/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/pricing.ts
+++ b/client/jetpack-cloud/sections/partner-portal/primary/issue-license/lib/pricing.ts
@@ -9,13 +9,11 @@ export const getProductPricingInfo = (
 	quantity: number
 ) => {
 	const bundle = product?.supported_bundles?.find( ( bundle ) => bundle.quantity === quantity );
-	const bundleAmount =
-		bundle && bundle.price_per_unit_float && bundle.quantity
-			? bundle.price_per_unit_float * bundle.quantity
-			: 0;
+	const bundleAmount = bundle && bundle.amount ? bundle.amount.replace( ',', '' ) : '';
 
-	const productBundleCost = bundle ? bundleAmount : parseFloat( product?.amount ) || 0;
-
+	const productBundleCost = bundle
+		? parseFloat( bundleAmount )
+		: parseFloat( product?.amount ) || 0;
 	const isDailyPricing = product.price_interval === 'day';
 
 	const discountInfo: {

--- a/client/state/partner-portal/types.ts
+++ b/client/state/partner-portal/types.ts
@@ -98,7 +98,6 @@ export interface APILicense {
 export interface APIProductFamilyProductBundlePrice {
 	quantity: number;
 	amount: string;
-	price_per_unit_float: number;
 }
 
 export interface APIProductFamilyProduct {


### PR DESCRIPTION
This is a follow-on to https://github.com/Automattic/wp-calypso/pull/87781

## Proposed Changes

* As a follow-on to the above PR, this PR changes the logic in terms of how the bundle prices are calculated to prevent incorrect price calculations.


## Testing Instructions

* To test the new issue, visit the Partner Portal Issue Licenses page in trunk, selecting a bundle size of 50 or 100 (eg. http://jetpack.cloud.localhost:3000/partner-portal/issue-license?bundle_size=100). You will see a  much increased price for the Jetpack VaultPress Backup Add-on of 5TB and 3TB in particular, but all products are affected.
Then after applying this PR, visit the same page and bundle sizes, and the prices showing should be correct.


Correct extension and add-on prices for a bundle of 100:
<img width="1261" alt="Screenshot 2024-02-22 at 20 16 11" src="https://github.com/Automattic/wp-calypso/assets/16754605/56ea0a74-a35d-48da-a5fc-70f3ac7f2c83">


Correct product prices for a bundle of 100:

<img width="1224" alt="Screenshot 2024-02-22 at 20 16 49" src="https://github.com/Automattic/wp-calypso/assets/16754605/3385ce21-9cb4-4327-be1a-f8f3b10d027e">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?