### PR TITLE
Github Deployments: Allow user to activate hosting on deployments page when on creator plan

### DIFF
--- a/client/my-sites/github-deployments/components/page-shell/index.tsx
+++ b/client/my-sites/github-deployments/components/page-shell/index.tsx
@@ -46,7 +46,7 @@ export function PageShell( { topRightButton, pageTitle, children }: GitHubDeploy
 				className="hosting__activating-notice"
 				status="is-info"
 				showDismiss={ false }
-				text={ translate( 'Please activate the hosting access to begin using these features.' ) }
+				text={ translate( 'Please activate hosting access to begin using this feature.' ) }
 				icon="globe"
 			>
 				<NoticeAction onClick={ clickActivate }>{ translate( 'Activate' ) }</NoticeAction>

--- a/client/my-sites/github-deployments/components/page-shell/index.tsx
+++ b/client/my-sites/github-deployments/components/page-shell/index.tsx
@@ -1,10 +1,19 @@
 import { translate } from 'i18n-calypso';
-import { ReactNode } from 'react';
+import { Fragment, ReactNode, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
+import FeatureExample from 'calypso/components/feature-example';
 import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
-
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
+import HostingActivateStatus from 'calypso/my-sites/hosting/hosting-activate-status';
+import { useDispatch, useSelector } from 'calypso/state';
+import { transferInProgress } from 'calypso/state/automated-transfer/constants';
+import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import { initiateThemeTransfer } from 'calypso/state/themes/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './style.scss';
 
 interface GitHubDeploymentsProps {
@@ -14,6 +23,44 @@ interface GitHubDeploymentsProps {
 }
 
 export function PageShell( { topRightButton, pageTitle, children }: GitHubDeploymentsProps ) {
+	const siteId = useSelector( getSelectedSiteId );
+	const isSiteAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId as number ) );
+	const dispatch = useDispatch();
+	const transferState = useSelector( ( state ) => getAutomatedTransferStatus( state, siteId ) );
+	const [ hasTransfer, setHasTransferring ] = useState(
+		!! (
+			transferState &&
+			transferInProgress.includes( transferState as ( typeof transferInProgress )[ number ] )
+		)
+	);
+	const showHostingActivationBanner = ! isSiteAtomic && ! hasTransfer;
+
+	const clickActivate = () => {
+		dispatch( initiateThemeTransfer( siteId ?? 0, null, '', '', 'hosting' ) );
+		setHasTransferring( true );
+	};
+
+	const getAtomicActivationNotice = () => {
+		return (
+			<Notice
+				className="hosting__activating-notice"
+				status="is-info"
+				showDismiss={ false }
+				text={ translate( 'Please activate the hosting access to begin using these features.' ) }
+				icon="globe"
+			>
+				<NoticeAction onClick={ clickActivate }>{ translate( 'Activate' ) }</NoticeAction>
+			</Notice>
+		);
+	};
+
+	const onTick = ( isTransferring?: boolean ) => {
+		if ( isTransferring && ! hasTransfer ) {
+			setHasTransferring( true );
+		}
+	};
+
+	const WrapperComponent = ! isSiteAtomic ? FeatureExample : Fragment;
 	return (
 		<Main className="github-deployments" fullWidthLayout>
 			<DocumentHead title={ pageTitle } />
@@ -34,7 +81,15 @@ export function PageShell( { topRightButton, pageTitle, children }: GitHubDeploy
 			>
 				{ topRightButton }
 			</NavigationHeader>
-			{ children }
+			{ showHostingActivationBanner && getAtomicActivationNotice() }
+			{ ! showHostingActivationBanner && (
+				<HostingActivateStatus
+					context="hosting"
+					onTick={ onTick }
+					keepAlive={ ! isSiteAtomic && hasTransfer }
+				/>
+			) }
+			<WrapperComponent>{ children }</WrapperComponent>
 		</Main>
 	);
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Add overlay if site is not atomic but on creator plan
* Allow user to transfer to atomic on the deployments page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* have a site on creator plan that's not atomic
* go to `/github-deployments/site`
* Verify overlay is present
* Verify you can activate from the page.

![image](https://github.com/Automattic/wp-calypso/assets/47489215/7130936a-9086-4ebb-af50-1f2eb176e657)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?