### PR TITLE
Jetpack login: link verification code label and input

### DIFF
--- a/client/blocks/login/two-factor-authentication/verification-code-form.jsx
+++ b/client/blocks/login/two-factor-authentication/verification-code-form.jsx
@@ -141,6 +141,7 @@ class VerificationCodeForm extends Component {
 							value={ this.state.twoStepCode }
 							onChange={ this.onChangeField }
 							isError={ requestError && requestError.field === 'twoStepCode' }
+							id="twoStepCode"
 							name="twoStepCode"
 							method={ twoFactorAuthType }
 							ref={ this.saveRef }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->

Related to https://github.com/Automattic/jetpack/issues/35490

## Proposed Changes

In the Jetpack login flow, in the authenticator app screen, the label and input of the verification code field are not associated programmatically. This causes the input to have no accessible name, and screen readers can't announce what it is. This PR fixes it by adding an `id` to the `input`.

<img width="458" alt="Screenshot 2024-02-22 at 4 37 39 PM" src="https://github.com/Automattic/wp-calypso/assets/1620183/0792acb9-8c2c-404b-a964-86b5383a15e9">


|Before|After|
|-|-|
|<img width="623" alt="Screenshot 2024-02-22 at 4 40 35 PM" src="https://github.com/Automattic/wp-calypso/assets/1620183/7de43e8a-f269-4f46-a2e1-952ed7e5457c">|<img width="629" alt="Screenshot 2024-02-22 at 4 41 16 PM" src="https://github.com/Automattic/wp-calypso/assets/1620183/8a5496a5-19f6-4aca-9431-5029cb204313">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Spin up Calypso with this branch
- Visit `http://calypso.localhost:3000/log-in/jetpack`
- Enter your username and password
- Then click _Continue with your authenticator app_
- Using the Accessibility panel in Chrome (or the equivalent in another browser), check that the input accessible name matches the label

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?