### PR TITLE
Jetpack Connect: make screen reader users aware of authorization

### DIFF
--- a/client/jetpack-connect/authorize.js
+++ b/client/jetpack-connect/authorize.js
@@ -1155,6 +1155,14 @@ export class JetpackAuthorize extends Component {
 		);
 	}
 
+	renderLiveRegion() {
+		return (
+			<div className="screen-reader-text" aria-live="assertive">
+				{ this.isAuthorizing() ? this.getButtonText() : '' }
+			</div>
+		);
+	}
+
 	render() {
 		const { translate } = this.props;
 		const wooDna = this.getWooDnaConfig();
@@ -1207,6 +1215,7 @@ export class JetpackAuthorize extends Component {
 						{ this.renderFooterLinks() }
 					</div>
 				</div>
+				{ this.renderLiveRegion() }
 			</MainWrapper>
 		);
 	}

--- a/client/jetpack-connect/screen-reader-indicator.js
+++ b/client/jetpack-connect/screen-reader-indicator.js
@@ -1,0 +1,17 @@
+import { speak } from '@wordpress/a11y';
+import { useEffect, useState } from 'react';
+
+const AuthorizationScreenReaderIndicator = ( { message } ) => {
+	const [ prevMessage, setPrevMessage ] = useState( message );
+
+	useEffect( () => {
+		if ( prevMessage !== message && message ) {
+			speak( message, 'polite' );
+			setPrevMessage( message );
+		}
+	}, [ message, prevMessage, setPrevMessage ] );
+
+	return null;
+};
+
+export default AuthorizationScreenReaderIndicator;

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -210,10 +210,6 @@ exports[`JetpackAuthorize renders as expected 1`] = `
         </div>
       </div>
     </div>
-    <div
-      aria-live="assertive"
-      class="screen-reader-text"
-    />
   </main>
 </div>
 `;

--- a/client/jetpack-connect/test/__snapshots__/authorize.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/authorize.js.snap
@@ -210,6 +210,10 @@ exports[`JetpackAuthorize renders as expected 1`] = `
         </div>
       </div>
     </div>
+    <div
+      aria-live="assertive"
+      class="screen-reader-text"
+    />
   </main>
 </div>
 `;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/issues/35491

## Proposed Changes

In the Jetpack connection flow, the authorization step can take several seconds. After activating the _Approve_ button in the screen below, screen reader users have no indication of what's happening. This is a confusing experience.

<img width="400" alt="Screenshot 2024-02-22 at 5 53 13 PM" src="https://github.com/Automattic/wp-calypso/assets/1620183/fe6b0221-6794-415e-ae01-285550d13816">

This PR adds a live region so that screen readers announce the same status text that's rendered visually.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

_Note: this is best tested with a live branch rather than locally._

If you can use a screen reader:
- Spin up a self-hosted test site
- Connect Jetpack
- When approving the authorization, notice the screen reader announces the status (see video below)


https://github.com/Automattic/wp-calypso/assets/1620183/885aa3da-2ab2-414c-8158-73ca38f38aff



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?