### PR TITLE
Checkoutv2: Implement checkout redesign ab test

### DIFF
--- a/client/my-sites/checkout/src/components/akismet-pro-quantity-dropdown/index.tsx
+++ b/client/my-sites/checkout/src/components/akismet-pro-quantity-dropdown/index.tsx
@@ -12,6 +12,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useCallback, useState, useMemo } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
+import { useCheckoutV2 } from '../../hooks/use-checkout-v2';
 import type { AkismetProQuantityDropDownProps } from './types';
 import type { FunctionComponent } from 'react';
 
@@ -108,7 +109,7 @@ const OptionList = styled.ul`
 	}
 `;
 
-const CurrentOptionContainer = styled.div`
+const CurrentOptionContainer = styled.div< { shouldUseCheckoutV2: boolean } >`
 	align-items: center;
 	display: flex;
 	font-size: ${ ( props ) => props.theme.fontSize.small };
@@ -119,7 +120,10 @@ const CurrentOptionContainer = styled.div`
 	column-gap: 20px;
 	text-align: left;
 
-	${ hasCheckoutVersion( '2' ) ? `flex-direction: column; align-items: flex-start;` : null }
+	${ ( shouldUseCheckoutV2 ) =>
+		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2
+			? `flex-direction: column; align-items: flex-start;`
+			: null }
 `;
 
 const Price = styled.span`
@@ -130,7 +134,10 @@ const Price = styled.span`
 		font-size: calc( ${ ( props ) => props.theme.fontSize.small } - 1px );
 	}
 
-	${ hasCheckoutVersion( '2' ) ? `text-align: initial;` : `text-align: right;` }
+	${ ( shouldUseCheckoutV2 ) =>
+		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2
+			? `text-align: initial;`
+			: `text-align: right;` }
 `;
 
 export const AkismetProQuantityDropDown: FunctionComponent< AkismetProQuantityDropDownProps > = ( {
@@ -142,7 +149,7 @@ export const AkismetProQuantityDropDown: FunctionComponent< AkismetProQuantityDr
 	isOpen,
 } ) => {
 	const translate = useTranslate();
-
+	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 	const { dropdownOptions, AkBusinessDropdownPosition } = useMemo( () => {
 		const dropdownOptions = [
 			preventWidows( translate( '1 Site' ) ),
@@ -405,7 +412,7 @@ export const AkismetProQuantityDropDown: FunctionComponent< AkismetProQuantityDr
 					open={ isOpen }
 					role="button"
 				>
-					<CurrentOptionContainer>
+					<CurrentOptionContainer shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 						<span>{ dropdownOptions[ selectedQuantity - 1 ] }</span>
 						<Price>{ getCurrentOptionPriceDisplay() }</Price>
 					</CurrentOptionContainer>

--- a/client/my-sites/checkout/src/components/akismet-pro-quantity-dropdown/index.tsx
+++ b/client/my-sites/checkout/src/components/akismet-pro-quantity-dropdown/index.tsx
@@ -6,7 +6,6 @@ import {
 import { Gridicon } from '@automattic/components';
 import formatCurrency from '@automattic/format-currency';
 import { isMobile } from '@automattic/viewport';
-import { hasCheckoutVersion } from '@automattic/wpcom-checkout';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -120,13 +119,11 @@ const CurrentOptionContainer = styled.div< { shouldUseCheckoutV2: boolean } >`
 	column-gap: 20px;
 	text-align: left;
 
-	${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2
-			? `flex-direction: column; align-items: flex-start;`
-			: null }
+	${ ( props ) =>
+		props.shouldUseCheckoutV2 ? `flex-direction: column; align-items: flex-start;` : null }
 `;
 
-const Price = styled.span`
+const Price = styled.span< { shouldUseCheckoutV2: boolean } >`
 	flex: 1 0 auto;
 	text-align: right;
 	color: #646970;
@@ -134,10 +131,7 @@ const Price = styled.span`
 		font-size: calc( ${ ( props ) => props.theme.fontSize.small } - 1px );
 	}
 
-	${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2
-			? `text-align: initial;`
-			: `text-align: right;` }
+	${ ( props ) => ( props.shouldUseCheckoutV2 ? `text-align: initial;` : `text-align: right;` ) }
 `;
 
 export const AkismetProQuantityDropDown: FunctionComponent< AkismetProQuantityDropDownProps > = ( {
@@ -414,7 +408,9 @@ export const AkismetProQuantityDropDown: FunctionComponent< AkismetProQuantityDr
 				>
 					<CurrentOptionContainer shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 						<span>{ dropdownOptions[ selectedQuantity - 1 ] }</span>
-						<Price>{ getCurrentOptionPriceDisplay() }</Price>
+						<Price shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
+							{ getCurrentOptionPriceDisplay() }
+						</Price>
 					</CurrentOptionContainer>
 					<Gridicon icon={ isOpen ? 'chevron-up' : 'chevron-down' } />
 				</CurrentOption>

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -25,7 +25,7 @@ import {
 import { formatCurrency } from '@automattic/format-currency';
 import { useLocale } from '@automattic/i18n-utils';
 import { useShoppingCart } from '@automattic/shopping-cart';
-import { styled, joinClasses, hasCheckoutVersion } from '@automattic/wpcom-checkout';
+import { styled, joinClasses } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
 import { useSelect, useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
@@ -228,10 +228,11 @@ function CheckoutSidebarNudge( { responseCart }: { responseCart: ResponseCart } 
 	const isWcMobile = isWcMobileApp();
 	const isDIFMInCart = hasDIFMProduct( responseCart );
 	const hasMonthlyProduct = responseCart?.products?.some( isMonthlyProduct );
+	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 
 	if ( ! isWcMobile && ! isDIFMInCart && ! hasMonthlyProduct ) {
 		return (
-			<CheckoutSidebarNudgeWrapper>
+			<CheckoutSidebarNudgeWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 				<CheckoutSidebarPlanUpsell />
 				<JetpackAkismetCheckoutSidebarPlanUpsell />
 			</CheckoutSidebarNudgeWrapper>
@@ -469,7 +470,7 @@ export default function CheckoutMainContent( {
 								className="checkout__summary-body"
 								shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 							>
-								{ ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) && (
+								{ shouldUseCheckoutV2 && (
 									<WPCheckoutOrderReview
 										removeProductFromCart={ removeProductFromCart }
 										couponFieldStateProps={ couponFieldStateProps }
@@ -481,7 +482,7 @@ export default function CheckoutMainContent( {
 
 								<WPCheckoutOrderSummary siteId={ siteId } onChangeSelection={ changeSelection } />
 								<CheckoutSidebarNudge responseCart={ responseCart } />
-								{ ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) && (
+								{ shouldUseCheckoutV2 && (
 									<CheckoutSummaryFeaturedList
 										responseCart={ responseCart }
 										siteId={ siteId }
@@ -507,7 +508,7 @@ export default function CheckoutMainContent( {
 				<CheckoutStepGroup loadingHeader={ loadingHeader } onStepChanged={ onStepChanged }>
 					<PerformanceTrackerStop />
 					{ infoMessage }
-					{ ! ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) && (
+					{ ! shouldUseCheckoutV2 && (
 						<CheckoutStepBody
 							onError={ onReviewError }
 							className="wp-checkout__review-order-step"
@@ -779,14 +780,12 @@ const CheckoutSummaryBody = styled.div< { shouldUseCheckoutV2: boolean } >`
 	width: 100%;
 	display: none;
 
-	${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2
-			? `padding: 32px 24px 24px 24px;`
-			: 'padding: 24px;' }
+	${ ( props ) =>
+		props.shouldUseCheckoutV2 ? `padding: 32px 24px 24px 24px;` : 'padding: 24px;' }
 
 	.is-visible & {
-		${ ( shouldUseCheckoutV2 ) =>
-			hasCheckoutVersion( '2' ) || shouldUseCheckoutV2
+		${ ( props ) =>
+			props.shouldUseCheckoutV2
 				? ` display: grid;
 			grid-template-areas:
 			"preview"
@@ -807,14 +806,12 @@ const CheckoutSummaryBody = styled.div< { shouldUseCheckoutV2: boolean } >`
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		${ ( shouldUseCheckoutV2 ) =>
-			hasCheckoutVersion( '2' ) || shouldUseCheckoutV2
-				? `padding: 50px 24px 24px 24px;`
-				: 'padding: 24px;' }
+		${ ( props ) =>
+			props.shouldUseCheckoutV2 ? `padding: 50px 24px 24px 24px;` : 'padding: 24px;' }
 
 		.is-visible & {
-			${ ( shouldUseCheckoutV2 ) =>
-				( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) &&
+			${ ( props ) =>
+				props.shouldUseCheckoutV2 &&
 				`grid-template-areas:
 			"preview preview"
 			"review review"
@@ -830,8 +827,8 @@ const CheckoutSummaryBody = styled.div< { shouldUseCheckoutV2: boolean } >`
 
 		.is-visible &,
 		& {
-			${ ( shouldUseCheckoutV2 ) =>
-				hasCheckoutVersion( '2' ) || shouldUseCheckoutV2
+			${ ( props ) =>
+				props.shouldUseCheckoutV2
 					? `grid-template-areas:
 					"preview"
 					"review"
@@ -853,11 +850,10 @@ const CheckoutSummaryBody = styled.div< { shouldUseCheckoutV2: boolean } >`
 	}
 `;
 
-const CheckoutSidebarNudgeWrapper = styled.div`
+const CheckoutSidebarNudgeWrapper = styled.div< { shouldUseCheckoutV2: boolean } >`
 	display: flex;
 	flex-direction: column;
-	${ ( shouldUseCheckoutV2 ) =>
-		( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) && `grid-area: nudge` };
+	${ ( props ) => props.shouldUseCheckoutV2 && `grid-area: nudge` };
 
 	& > * {
 		max-width: 288px;

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -25,6 +25,7 @@ import { isJetpackSite } from 'calypso/state/sites/selectors';
 import useActOnceOnStrings from '../hooks/use-act-once-on-strings';
 import useAddProductsFromUrl from '../hooks/use-add-products-from-url';
 import useCheckoutFlowTrackKey from '../hooks/use-checkout-flow-track-key';
+import { useCheckoutV2 } from '../hooks/use-checkout-v2';
 import useCountryList from '../hooks/use-country-list';
 import useCreatePaymentCompleteCallback from '../hooks/use-create-payment-complete-callback';
 import useCreatePaymentMethods from '../hooks/use-create-payment-methods';
@@ -538,6 +539,8 @@ export default function CheckoutMain( {
 		: {};
 	const theme = { ...checkoutTheme, colors: { ...checkoutTheme.colors, ...jetpackColors } };
 
+	const isCheckoutV2ExperimentLoading = useCheckoutV2() === 'loading';
+
 	// This variable determines if we see the loading page or if checkout can
 	// render its steps.
 	//
@@ -561,6 +564,7 @@ export default function CheckoutMain( {
 			isLoading: responseCart.products.length < 1,
 		},
 		{ name: translate( 'Loading countries list' ), isLoading: countriesList.length < 1 },
+		{ name: translate( 'Loading Site' ), isLoading: isCheckoutV2ExperimentLoading },
 	];
 	const isCheckoutPageLoading: boolean = checkoutLoadingConditions.some(
 		( condition ) => condition.isLoading

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -15,6 +15,7 @@ import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { useGetProductVariants } from '../../hooks/product-variants';
+import { useCheckoutV2 } from '../../hooks/use-checkout-v2';
 import {
 	getItemVariantCompareToPrice,
 	getItemVariantDiscountPercentage,
@@ -36,6 +37,7 @@ export function CheckoutSidebarPlanUpsell() {
 	);
 	const variants = useGetProductVariants( plan );
 	const translate = useTranslate();
+	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 
 	const PromoCardV2 = styled.div`
 		position: relative;
@@ -160,10 +162,9 @@ export function CheckoutSidebarPlanUpsell() {
 		),
 		{ strong: createElement( 'strong' ) }
 	);
-
 	return (
 		<>
-			{ plan && hasCheckoutVersion( '2' ) ? (
+			{ plan && ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) ? (
 				<PromoCardV2>
 					<div className="checkout-sidebar-plan-upsell__v2-wrapper">
 						<p>

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -2,7 +2,6 @@ import { isPlan, isJetpackPlan } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import formatCurrency from '@automattic/format-currency';
 import { useShoppingCart } from '@automattic/shopping-cart';
-import { hasCheckoutVersion } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { createElement, createInterpolateElement, useState } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
@@ -164,7 +163,7 @@ export function CheckoutSidebarPlanUpsell() {
 	);
 	return (
 		<>
-			{ plan && ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) ? (
+			{ plan && shouldUseCheckoutV2 ? (
 				<PromoCardV2>
 					<div className="checkout-sidebar-plan-upsell__v2-wrapper">
 						<p>

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -14,6 +14,7 @@ import {
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import useCartKey from '../../use-cart-key';
+import { useCheckoutV2 } from '../hooks/use-checkout-v2';
 import type { Theme } from '@automattic/composite-checkout';
 import type {
 	CostOverrideForDisplay,
@@ -63,9 +64,10 @@ const CostOverridesListStyle = styled.div`
 	}
 `;
 
-const DeleteButton = styled( Button )< { theme?: Theme } >`
+const DeleteButton = styled( Button )< { theme?: Theme; shouldUseCheckoutV2: boolean } >`
 	width: auto;
-	font-size: ${ hasCheckoutVersion( '2' ) ? '12px' : 'inherit' };
+	font-size: ${ ( shouldUseCheckoutV2 ) =>
+		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ? '12px' : 'inherit' };
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 `;
 
@@ -82,6 +84,8 @@ export function CostOverridesList( {
 	couponCode: ResponseCart[ 'coupon' ];
 	showOnlyCoupons?: boolean;
 } ) {
+	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
+
 	const translate = useTranslate();
 	// Let's put the coupon code last because it will have its own "Remove" button.
 	const nonCouponOverrides = costOverridesList.filter(
@@ -150,6 +154,7 @@ export function CostOverridesList( {
 									className="cost-overrides-list-item__actions-remove"
 									onClick={ removeCoupon }
 									aria-label={ translate( 'Remove coupon' ) }
+									shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 								>
 									{ translate( 'Remove' ) }
 								</DeleteButton>

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -9,7 +9,6 @@ import {
 import {
 	LineItemBillingInterval,
 	doesIntroductoryOfferHaveDifferentTermLengthThanProduct,
-	hasCheckoutVersion,
 } from '@automattic/wpcom-checkout';
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
@@ -66,8 +65,7 @@ const CostOverridesListStyle = styled.div`
 
 const DeleteButton = styled( Button )< { theme?: Theme; shouldUseCheckoutV2: boolean } >`
 	width: auto;
-	font-size: ${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ? '12px' : 'inherit' };
+	font-size: ${ ( props ) => ( props.shouldUseCheckoutV2 ? '12px' : 'inherit' ) };
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 `;
 

--- a/client/my-sites/checkout/src/components/coupon.tsx
+++ b/client/my-sites/checkout/src/components/coupon.tsx
@@ -3,6 +3,7 @@ import { Field, styled, joinClasses, hasCheckoutVersion } from '@automattic/wpco
 import { keyframes } from '@emotion/react';
 import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import { useCheckoutV2 } from '../hooks/use-checkout-v2';
 import type { CouponFieldStateProps } from '../hooks/use-coupon-field-state';
 import type { CouponStatus } from '@automattic/shopping-cart';
 
@@ -36,6 +37,8 @@ export default function Coupon( {
 
 	const errorMessage = getCouponErrorMessageFromStatus( translate, couponStatus, isFreshOrEdited );
 
+	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
+
 	return (
 		<CouponWrapper
 			className={ joinClasses( [ className, 'coupon' ] ) }
@@ -44,8 +47,9 @@ export default function Coupon( {
 				setIsFreshOrEdited( false );
 				handleCouponSubmit();
 			} }
+			shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 		>
-			{ hasCheckoutVersion( '2' ) ? (
+			{ hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ? (
 				<>
 					<CouponLabel>{ translate( 'Coupon code' ) }</CouponLabel>
 					<CouponField
@@ -79,7 +83,11 @@ export default function Coupon( {
 			) }
 
 			{ isApplyButtonActive && (
-				<ApplyButton disabled={ isPending } buttonType="secondary">
+				<ApplyButton
+					disabled={ isPending }
+					buttonType="secondary"
+					shouldUseCheckoutV2={ shouldUseCheckoutV2 }
+				>
 					{ isPending ? translate( 'Processing…' ) : translate( 'Apply' ) }
 				</ApplyButton>
 			) }
@@ -117,13 +125,14 @@ const animateInRTL = keyframes`
   }
 `;
 
-const CouponWrapper = styled.form`
+const CouponWrapper = styled.form< { shouldUseCheckoutV2: boolean } >`
 	margin: 0;
 	padding-top: 0;
 	position: relative;
 
-	${ hasCheckoutVersion( '2' )
-		? `display: grid; 
+	${ ( shouldUseCheckoutV2 ) =>
+		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2
+			? `display: grid;
 		align-items: center; 
 		justify-content: space-between; 
 		grid-template-columns: 1fr max-content; 
@@ -131,7 +140,7 @@ const CouponWrapper = styled.form`
 		'label     .  '
 		'field  button';
 		gap: .5em;`
-		: null }
+			: null }
 `;
 
 const CouponLabel = styled.label`
@@ -144,14 +153,15 @@ const CouponField = styled( Field )`
 	grid-area: field;
 `;
 
-const ApplyButton = styled( Button )`
+const ApplyButton = styled( Button )< { shouldUseCheckoutV2: boolean } >`
 	animation: ${ animateIn } 0.2s ease-out;
 	animation-fill-mode: backwards;
 	margin: 0;
 
-	${ hasCheckoutVersion( '2' )
-		? `position: relative; font-size: 14px; min-width: 70px; height: 37px; padding: 0 8px; grid-area: button; align-self: flex-start;`
-		: `position: absolute; padding: 8px;
+	${ ( shouldUseCheckoutV2 ) =>
+		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2
+			? `position: relative; font-size: 14px; min-width: 70px; height: 37px; padding: 0 8px; grid-area: button; align-self: flex-start;`
+			: `position: absolute; padding: 8px;
 	top: 3px;
 	right: 3px;` }
 

--- a/client/my-sites/checkout/src/components/coupon.tsx
+++ b/client/my-sites/checkout/src/components/coupon.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@automattic/composite-checkout';
-import { Field, styled, joinClasses, hasCheckoutVersion } from '@automattic/wpcom-checkout';
+import { Field, styled, joinClasses } from '@automattic/wpcom-checkout';
 import { keyframes } from '@emotion/react';
 import i18n, { getLocaleSlug, useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -49,7 +49,7 @@ export default function Coupon( {
 			} }
 			shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 		>
-			{ hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ? (
+			{ shouldUseCheckoutV2 ? (
 				<>
 					<CouponLabel>{ translate( 'Coupon code' ) }</CouponLabel>
 					<CouponField
@@ -64,6 +64,7 @@ export default function Coupon( {
 							setIsFreshOrEdited( true );
 							setCouponFieldValue( input );
 						} }
+						shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 					/>
 				</>
 			) : (
@@ -130,8 +131,8 @@ const CouponWrapper = styled.form< { shouldUseCheckoutV2: boolean } >`
 	padding-top: 0;
 	position: relative;
 
-	${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2
+	${ ( props ) =>
+		props.shouldUseCheckoutV2
 			? `display: grid;
 		align-items: center; 
 		justify-content: space-between; 
@@ -158,8 +159,8 @@ const ApplyButton = styled( Button )< { shouldUseCheckoutV2: boolean } >`
 	animation-fill-mode: backwards;
 	margin: 0;
 
-	${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2
+	${ ( props ) =>
+		props.shouldUseCheckoutV2
 			? `position: relative; font-size: 14px; min-width: 70px; height: 37px; padding: 0 8px; grid-area: button; align-self: flex-start;`
 			: `position: absolute; padding: 8px;
 	top: 3px;

--- a/client/my-sites/checkout/src/components/item-variation-picker/item-variation-dropdown.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/item-variation-dropdown.tsx
@@ -7,6 +7,7 @@ import { Gridicon } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent, useCallback, useEffect, useState } from 'react';
 import isJetpackCheckout from 'calypso/lib/jetpack/is-jetpack-checkout';
+import { useCheckoutV2 } from '../../hooks/use-checkout-v2';
 import { JetpackItemVariantDropDownPrice } from './jetpack-variant-dropdown-price';
 import { CurrentOption, Dropdown, OptionList, Option } from './styles';
 import { ItemVariantDropDownPrice } from './variant-dropdown-price';
@@ -26,7 +27,7 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 	isOpen,
 } ) => {
 	const translate = useTranslate();
-
+	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 	const [ highlightedVariantIndex, setHighlightedVariantIndex ] = useState< number | null >( null );
 
 	// Multi-year domain products must be compared by volume because they have the same product id.
@@ -137,6 +138,7 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 			aria-expanded={ isOpen }
 			aria-haspopup="listbox"
 			onKeyDown={ handleKeyDown }
+			shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 		>
 			<CurrentOption
 				aria-label={ translate( 'Pick a product term' ) }
@@ -144,6 +146,7 @@ export const ItemVariationDropDown: FunctionComponent< ItemVariationPickerProps 
 				onClick={ () => toggle( id ) }
 				open={ isOpen }
 				role="button"
+				shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 			>
 				{ selectedVariantIndex !== null ? (
 					<ItemVariantDropDownPriceWrapper variant={ variants[ selectedVariantIndex ] } />
@@ -213,6 +216,7 @@ function ItemVariantOption( {
 	allVariants: WPCOMProductVariant[];
 } ) {
 	const { variantLabel, productId, productSlug } = variant;
+	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 	return (
 		<Option
 			id={ productId.toString() }
@@ -222,6 +226,7 @@ function ItemVariantOption( {
 			role="option"
 			onClick={ onSelect }
 			selected={ isSelected }
+			shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 		>
 			{ isJetpack( variant ) ? (
 				<JetpackItemVariantDropDownPrice variant={ variant } allVariants={ allVariants } />

--- a/client/my-sites/checkout/src/components/item-variation-picker/jetpack-variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/jetpack-variant-dropdown-price.tsx
@@ -1,6 +1,5 @@
 import formatCurrency from '@automattic/format-currency';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
-import { hasCheckoutVersion } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useCheckoutV2 } from '../../hooks/use-checkout-v2';
 import { Discount, Label, Price, PriceTextContainer, Variant } from './styles';
@@ -87,7 +86,7 @@ export const JetpackItemVariantDropDownPrice: FunctionComponent< {
 						isFirstMonthTrial={ isFirstMonthTrial( variant ) }
 					/>
 				) }
-				{ ! ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) && (
+				{ ! shouldUseCheckoutV2 && (
 					<Price aria-hidden={ variant.introductoryInterval > 0 }>
 						{ formatCurrency( variant.priceInteger, variant.currency, {
 							stripZeros: true,

--- a/client/my-sites/checkout/src/components/item-variation-picker/jetpack-variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/jetpack-variant-dropdown-price.tsx
@@ -19,17 +19,12 @@ const JetpackDiscountDisplay: FunctionComponent< {
 	currency: string;
 } > = ( { finalPriceInteger, isFirstMonthTrial, showIntroOffer, discountInteger, currency } ) => {
 	const translate = useTranslate();
-	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 	if ( isFirstMonthTrial && 0 === finalPriceInteger ) {
-		return (
-			<Discount shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
-				{ translate( 'One month free trial' ) }
-			</Discount>
-		);
+		return <Discount>{ translate( 'One month free trial' ) }</Discount>;
 	}
 
 	return (
-		<Discount shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
+		<Discount>
 			{ showIntroOffer && translate( 'Introductory offer: ' ) }
 			{ translate( 'Save %(price)s', {
 				args: {

--- a/client/my-sites/checkout/src/components/item-variation-picker/jetpack-variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/jetpack-variant-dropdown-price.tsx
@@ -2,6 +2,7 @@ import formatCurrency from '@automattic/format-currency';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import { hasCheckoutVersion } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
+import { useCheckoutV2 } from '../../hooks/use-checkout-v2';
 import { Discount, Label, Price, PriceTextContainer, Variant } from './styles';
 import type { WPCOMProductVariant } from './types';
 import type { FunctionComponent } from 'react';
@@ -19,13 +20,17 @@ const JetpackDiscountDisplay: FunctionComponent< {
 	currency: string;
 } > = ( { finalPriceInteger, isFirstMonthTrial, showIntroOffer, discountInteger, currency } ) => {
 	const translate = useTranslate();
-
+	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 	if ( isFirstMonthTrial && 0 === finalPriceInteger ) {
-		return <Discount>{ translate( 'One month free trial' ) }</Discount>;
+		return (
+			<Discount shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
+				{ translate( 'One month free trial' ) }
+			</Discount>
+		);
 	}
 
 	return (
-		<Discount>
+		<Discount shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 			{ showIntroOffer && translate( 'Introductory offer: ' ) }
 			{ translate( 'Save %(price)s', {
 				args: {
@@ -44,6 +49,7 @@ export const JetpackItemVariantDropDownPrice: FunctionComponent< {
 	allVariants: WPCOMProductVariant[];
 } > = ( { variant, allVariants } ) => {
 	const isMobile = useMobileBreakpoint();
+	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 
 	// We offer a free month trial for selected yearly plans (for now, only Social Advanced)
 
@@ -60,8 +66,8 @@ export const JetpackItemVariantDropDownPrice: FunctionComponent< {
 	const showIntroOffer = variant.introductoryInterval > 0 && variant.termIntervalInMonths === 12;
 
 	return (
-		<Variant>
-			<Label>
+		<Variant shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
+			<Label shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 				{ variant.variantLabel }
 				{ isMobile && discountInteger > 0 && (
 					<JetpackDiscountDisplay
@@ -71,7 +77,7 @@ export const JetpackItemVariantDropDownPrice: FunctionComponent< {
 					/>
 				) }
 			</Label>
-			<PriceTextContainer>
+			<PriceTextContainer shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 				{ ! isMobile && discountInteger > 0 && (
 					<JetpackDiscountDisplay
 						finalPriceInteger={ variant.priceInteger }
@@ -81,7 +87,7 @@ export const JetpackItemVariantDropDownPrice: FunctionComponent< {
 						isFirstMonthTrial={ isFirstMonthTrial( variant ) }
 					/>
 				) }
-				{ ! hasCheckoutVersion( '2' ) && (
+				{ ! ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) && (
 					<Price aria-hidden={ variant.introductoryInterval > 0 }>
 						{ formatCurrency( variant.priceInteger, variant.currency, {
 							stripZeros: true,

--- a/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
@@ -11,7 +11,10 @@ export const CurrentOption = styled.button< CurrentOptionProps >`
 	display: flex;
 	flex-direction: row;
 	justify-content: space-between;
-	${ hasCheckoutVersion( '2' ) ? `padding: 10px; min-height: 40px` : `padding:14px 16px` };
+	${ ( props ) =>
+		hasCheckoutVersion( '2' ) || props.shouldUseCheckoutV2
+			? `padding: 10px; min-height: 40px`
+			: `padding:14px 16px` };
 	width: 100%;
 	cursor: pointer;
 
@@ -36,16 +39,15 @@ export const Option = styled.li< OptionProps >`
 	font-weight: ${ ( props ) => props.theme.weights.normal };
 	cursor: pointer;
 
-	${
-		hasCheckoutVersion( '2' )
+	${ ( props ) =>
+		hasCheckoutVersion( '2' ) || props.shouldUseCheckoutV2
 			? `flex-direction: column; justify-content: center;
 		align-items: flex-start;
 		padding: 10px; min-height: 40px;`
 			: `flex-direction: row;
 		justify-content: space-between; align-items: center;
 		/* the calc aligns the price with the price in CurrentOption */
-		padding: 10px calc( 14px + 24px + 16px ) 10px 16px;`
-	}
+		padding: 10px calc( 14px + 24px + 16px ) 10px 16px;` }
 
 
 	&:hover {
@@ -58,10 +60,11 @@ export const Option = styled.li< OptionProps >`
 	}
 `;
 
-export const Dropdown = styled.div`
+export const Dropdown = styled.div< { shouldUseCheckoutV2: boolean } >`
 	position: relative;
 	width: 100%;
-	margin: ${ hasCheckoutVersion( '2' ) ? null : '16px 0' };
+	margin: ${ ( shouldUseCheckoutV2 ) =>
+		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ? null : '16px 0' };
 	> ${ Option } {
 		border-radius: 3px;
 	}
@@ -83,12 +86,13 @@ export const OptionList = styled.ul`
 	}
 `;
 
-export const Discount = styled.span`
+export const Discount = styled.span< { shouldUseCheckoutV2: boolean } >`
 	color: ${ ( props ) => props.theme.colors.discount };
 	margin-right: 8px;
-	${ hasCheckoutVersion( '2' )
-		? `align-items: left; font-size: 12px;`
-		: `align-items: center; font-size: 100%;` }
+	${ ( shouldUseCheckoutV2 ) =>
+		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2
+			? `align-items: left; font-size: 14px;`
+			: `align-items: center; font-size: 100%;` }
 
 	.rtl & {
 		margin-right: 0;
@@ -132,7 +136,7 @@ export const Price = styled.span`
 	}
 `;
 
-export const Variant = styled.div`
+export const Variant = styled.div< { shouldUseCheckoutV2: boolean } >`
 	display: flex;
 	font-size: 14px;
 	font-weight: 400;
@@ -141,20 +145,22 @@ export const Variant = styled.div`
 	width: 100%;
 	column-gap: 20px;
 
-	${ hasCheckoutVersion( '2' )
-		? `flex-direction: column; align-items: left`
-		: `flex-direciton: row; align-items: center` }
+	${ ( shouldUseCheckoutV2 ) =>
+		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2
+			? `flex-direction: column; align-items: left`
+			: `flex-direciton: row; align-items: center` }
 
 	.item-variant-option--selected & {
 		color: var( --studio-white );
 	}
 `;
 
-export const Label = styled.span`
+export const Label = styled.span< { shouldUseCheckoutV2: boolean } >`
 	display: flex;
 	white-space: nowrap;
 
-	${ hasCheckoutVersion( '2' ) ? 'font-size: 14px' : 'font-size: inherit' };
+	${ ( shouldUseCheckoutV2 ) =>
+		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ? 'font-size: 14px' : 'font-size: inherit' };
 
 	// MOBILE_BREAKPOINT is <480px, used in useMobileBreakpoint
 	@media ( max-width: 480px ) {
@@ -175,8 +181,9 @@ export const IntroPricingText = styled.span`
 	margin-bottom: 0rem;
 `;
 
-export const PriceTextContainer = styled.span`
-	${ hasCheckoutVersion( '2' )
-		? 'font-size: 12px; text-align: initial;'
-		: 'font-size: inherit;	text-align: right;' };
+export const PriceTextContainer = styled.span< { shouldUseCheckoutV2: boolean } >`
+	${ ( shouldUseCheckoutV2 ) =>
+		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2
+			? 'font-size: 12px; text-align: initial;'
+			: 'font-size: inherit;	text-align: right;' };
 `;

--- a/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
@@ -1,4 +1,3 @@
-import { hasCheckoutVersion } from '@automattic/wpcom-checkout';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import { CurrentOptionProps, OptionProps } from './types';
@@ -12,9 +11,7 @@ export const CurrentOption = styled.button< CurrentOptionProps >`
 	flex-direction: row;
 	justify-content: space-between;
 	${ ( props ) =>
-		hasCheckoutVersion( '2' ) || props.shouldUseCheckoutV2
-			? `padding: 10px; min-height: 40px`
-			: `padding:14px 16px` };
+		props.shouldUseCheckoutV2 ? `padding: 10px; min-height: 40px` : `padding:14px 16px` };
 	width: 100%;
 	cursor: pointer;
 
@@ -40,7 +37,7 @@ export const Option = styled.li< OptionProps >`
 	cursor: pointer;
 
 	${ ( props ) =>
-		hasCheckoutVersion( '2' ) || props.shouldUseCheckoutV2
+		props.shouldUseCheckoutV2
 			? `flex-direction: column; justify-content: center;
 		align-items: flex-start;
 		padding: 10px; min-height: 40px;`
@@ -63,8 +60,7 @@ export const Option = styled.li< OptionProps >`
 export const Dropdown = styled.div< { shouldUseCheckoutV2: boolean } >`
 	position: relative;
 	width: 100%;
-	margin: ${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ? null : '16px 0' };
+	margin: ${ ( props ) => ( props.shouldUseCheckoutV2 ? null : '16px 0' ) };
 	> ${ Option } {
 		border-radius: 3px;
 	}
@@ -89,8 +85,8 @@ export const OptionList = styled.ul`
 export const Discount = styled.span< { shouldUseCheckoutV2: boolean } >`
 	color: ${ ( props ) => props.theme.colors.discount };
 	margin-right: 8px;
-	${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2
+	${ ( props ) =>
+		props.shouldUseCheckoutV2
 			? `align-items: left; font-size: 14px;`
 			: `align-items: center; font-size: 100%;` }
 
@@ -145,8 +141,8 @@ export const Variant = styled.div< { shouldUseCheckoutV2: boolean } >`
 	width: 100%;
 	column-gap: 20px;
 
-	${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2
+	${ ( props ) =>
+		props.shouldUseCheckoutV2
 			? `flex-direction: column; align-items: left`
 			: `flex-direciton: row; align-items: center` }
 
@@ -159,8 +155,7 @@ export const Label = styled.span< { shouldUseCheckoutV2: boolean } >`
 	display: flex;
 	white-space: nowrap;
 
-	${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ? 'font-size: 14px' : 'font-size: inherit' };
+	${ ( props ) => ( props.shouldUseCheckoutV2 ? 'font-size: 14px' : 'font-size: inherit' ) };
 
 	// MOBILE_BREAKPOINT is <480px, used in useMobileBreakpoint
 	@media ( max-width: 480px ) {
@@ -182,8 +177,8 @@ export const IntroPricingText = styled.span`
 `;
 
 export const PriceTextContainer = styled.span< { shouldUseCheckoutV2: boolean } >`
-	${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2
+	${ ( props ) =>
+		props.shouldUseCheckoutV2
 			? 'font-size: 12px; text-align: initial;'
 			: 'font-size: inherit;	text-align: right;' };
 `;

--- a/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/styles.tsx
@@ -82,13 +82,10 @@ export const OptionList = styled.ul`
 	}
 `;
 
-export const Discount = styled.span< { shouldUseCheckoutV2: boolean } >`
+export const Discount = styled.span`
 	color: ${ ( props ) => props.theme.colors.discount };
 	margin-right: 8px;
-	${ ( props ) =>
-		props.shouldUseCheckoutV2
-			? `align-items: left; font-size: 14px;`
-			: `align-items: center; font-size: 100%;` }
+	font-size: 100%;
 
 	.rtl & {
 		margin-right: 0;

--- a/client/my-sites/checkout/src/components/item-variation-picker/types.ts
+++ b/client/my-sites/checkout/src/components/item-variation-picker/types.ts
@@ -37,8 +37,10 @@ export type OnChangeItemVariant = (
 
 export type CurrentOptionProps = {
 	open: boolean;
+	shouldUseCheckoutV2: boolean;
 };
 
 export type OptionProps = {
 	selected: boolean;
+	shouldUseCheckoutV2: boolean;
 };

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
@@ -1,6 +1,5 @@
 import formatCurrency from '@automattic/format-currency';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
-import { hasCheckoutVersion } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
@@ -178,12 +177,10 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 				{ hasDiscount && ! isMobile && canDisplayDiscountPercentage && (
 					<DiscountPercentage percent={ discountPercentage } />
 				) }
-				{ ! ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) &&
-					hasDiscount &&
-					! isIntroductoryOffer && (
-						<DoNotPayThis>{ formattedCompareToPriceForVariantTerm }</DoNotPayThis>
-					) }
-				{ ! ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) && (
+				{ ! shouldUseCheckoutV2 && hasDiscount && ! isIntroductoryOffer && (
+					<DoNotPayThis>{ formattedCompareToPriceForVariantTerm }</DoNotPayThis>
+				) }
+				{ ! shouldUseCheckoutV2 && (
 					<Price aria-hidden={ isIntroductoryOffer }>{ formattedCurrentPrice }</Price>
 				) }
 				<IntroPricing>

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
@@ -4,6 +4,7 @@ import { hasCheckoutVersion } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { FunctionComponent } from 'react';
 import { preventWidows } from 'calypso/lib/formatting';
+import { useCheckoutV2 } from '../../hooks/use-checkout-v2';
 import {
 	Discount,
 	DoNotPayThis,
@@ -19,8 +20,9 @@ import type { WPCOMProductVariant } from './types';
 
 const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent } ) => {
 	const translate = useTranslate();
+	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 	return (
-		<Discount>
+		<Discount shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 			{ translate( 'Save %(percent)s%%', {
 				args: {
 					percent,
@@ -61,6 +63,7 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 	const productBillingTermInMonths = variant.productBillingTermInMonths;
 	const isIntroductoryOffer = introCount > 0;
 	const translate = useTranslate();
+	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 
 	const translatedIntroOfferDetails = () => {
 		const args = {
@@ -166,19 +169,21 @@ export const ItemVariantDropDownPrice: FunctionComponent< {
 	const canDisplayDiscountPercentage = ! isIntroductoryOffer;
 
 	return (
-		<Variant>
-			<Label>
+		<Variant shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
+			<Label shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 				{ variant.variantLabel }
 				{ hasDiscount && isMobile && <DiscountPercentage percent={ discountPercentage } /> }
 			</Label>
-			<PriceTextContainer>
+			<PriceTextContainer shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 				{ hasDiscount && ! isMobile && canDisplayDiscountPercentage && (
 					<DiscountPercentage percent={ discountPercentage } />
 				) }
-				{ ! hasCheckoutVersion( '2' ) && hasDiscount && ! isIntroductoryOffer && (
-					<DoNotPayThis>{ formattedCompareToPriceForVariantTerm }</DoNotPayThis>
-				) }
-				{ ! hasCheckoutVersion( '2' ) && (
+				{ ! ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) &&
+					hasDiscount &&
+					! isIntroductoryOffer && (
+						<DoNotPayThis>{ formattedCompareToPriceForVariantTerm }</DoNotPayThis>
+					) }
+				{ ! ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) && (
 					<Price aria-hidden={ isIntroductoryOffer }>{ formattedCurrentPrice }</Price>
 				) }
 				<IntroPricing>

--- a/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
+++ b/client/my-sites/checkout/src/components/item-variation-picker/variant-dropdown-price.tsx
@@ -19,9 +19,8 @@ import type { WPCOMProductVariant } from './types';
 
 const DiscountPercentage: FunctionComponent< { percent: number } > = ( { percent } ) => {
 	const translate = useTranslate();
-	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 	return (
-		<Discount shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
+		<Discount>
 			{ translate( 'Save %(percent)s%%', {
 				args: {
 					percent,

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -15,6 +15,7 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import CheckoutTerms from '../components/checkout-terms';
+import { useCheckoutV2 } from '../hooks/use-checkout-v2';
 import { WPOrderReviewSection } from './wp-order-review-line-items';
 
 const CheckoutTermsWrapper = styled.div`
@@ -112,13 +113,15 @@ export default function BeforeSubmitCheckoutHeader() {
 		} ),
 	};
 
+	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
+
 	return (
 		<>
 			<CheckoutTermsWrapper>
 				<CheckoutTerms cart={ responseCart } />
 			</CheckoutTermsWrapper>
 
-			{ ! hasCheckoutVersion( '2' ) && (
+			{ ! ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) && (
 				<WPOrderReviewSection>
 					<NonTotalPrices>
 						<NonProductLineItem subtotal lineItem={ subTotalLineItemWithoutCoupon } />

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -5,7 +5,6 @@ import {
 	getTaxBreakdownLineItemsFromCart,
 	getCreditsLineItemFromCart,
 	NonProductLineItem,
-	hasCheckoutVersion,
 	LineItemType,
 	getSubtotalWithoutDiscounts,
 	getTotalDiscountsWithoutCredits,
@@ -121,7 +120,7 @@ export default function BeforeSubmitCheckoutHeader() {
 				<CheckoutTerms cart={ responseCart } />
 			</CheckoutTermsWrapper>
 
-			{ ! ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) && (
+			{ ! shouldUseCheckoutV2 && (
 				<WPOrderReviewSection>
 					<NonTotalPrices>
 						<NonProductLineItem subtotal lineItem={ subTotalLineItemWithoutCoupon } />

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -53,7 +53,7 @@ const CouponLinkWrapper = styled.div< { shouldUseCheckoutV2: boolean } >`
 
 const CouponAreaWrapper = styled.div< { shouldUseCheckoutV2: boolean } >`
 	padding-bottom: ${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ? '24px' : 'inherit' };
+		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ? '12px' : 'inherit' };
 `;
 
 const CouponField = styled( Coupon )``;

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -18,6 +18,7 @@ import { NON_PRIMARY_DOMAINS_TO_FREE_USERS } from 'calypso/state/current-user/co
 import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/selectors';
 import { getWpComDomainBySiteId } from 'calypso/state/sites/domains/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
+import { useCheckoutV2 } from '../hooks/use-checkout-v2';
 import Coupon from './coupon';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
 import type { OnChangeItemVariant } from './item-variation-picker';
@@ -45,23 +46,26 @@ const SiteSummary = styled.div`
 	}
 `;
 
-const CouponLinkWrapper = styled.div`
-	${ hasCheckoutVersion( '2' ) ? `font-size: 12px;` : `font-size: 14px;` }
+const CouponLinkWrapper = styled.div< { shouldUseCheckoutV2: boolean } >`
+	${ ( shouldUseCheckoutV2 ) =>
+		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ? `font-size: 12px;` : `font-size: 14px;` }
 `;
 
-const CouponAreaWrapper = styled.div`
-	padding-bottom: ${ hasCheckoutVersion( '2' ) ? '12px' : 'inherit' };
+const CouponAreaWrapper = styled.div< { shouldUseCheckoutV2: boolean } >`
+	padding-bottom: ${ ( shouldUseCheckoutV2 ) =>
+		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ? '24px' : 'inherit' };
 `;
 
 const CouponField = styled( Coupon )``;
 
-const CouponEnableButton = styled.button`
+const CouponEnableButton = styled.button< { shouldUseCheckoutV2: boolean } >`
 	cursor: pointer;
 	text-decoration: underline;
 	color: ${ ( props ) => props.theme.colors.highlight };
 
 	&.wp-checkout-order-review__show-coupon-field-button {
-		${ hasCheckoutVersion( '2' ) ? `font-size: 12px` : `font-size: 14px;` }
+		${ ( shouldUseCheckoutV2 ) =>
+			hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ? `font-size: 12px` : `font-size: 14px;` }
 	}
 	:hover {
 		text-decoration: none;
@@ -123,6 +127,7 @@ export default function WPCheckoutOrderReview( {
 	const { responseCart, removeCoupon, couponStatus } = useShoppingCart( cartKey );
 	const isPurchaseFree = responseCart.total_cost_integer === 0;
 	const reduxDispatch = useDispatch();
+	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 
 	const onRemoveProductCancel = useCallback( () => {
 		reduxDispatch( recordTracksEvent( 'calypso_checkout_composite_cancel_delete_product' ) );
@@ -173,14 +178,19 @@ export default function WPCheckoutOrderReview( {
 
 	return (
 		<>
-			{ /** Only show the site preview for WPCOM domains that have a site connected to the site id **/ }
-			{ hasCheckoutVersion( '2' ) && selectedSiteData && wpcomDomain && ! isSignupCheckout && (
-				<div className="checkout-site-preview">
-					<SitePreviewWrapper>
-						<SitePreview showEditSite={ false } showSiteDetails={ false } />
-					</SitePreviewWrapper>
-				</div>
-			) }
+			{ /*
+			 * Only show the site preview for WPCOM domains that have a site connected to the site id
+			 * */ }
+			{ ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) &&
+				selectedSiteData &&
+				wpcomDomain &&
+				! isSignupCheckout && (
+					<div className="checkout-site-preview">
+						<SitePreviewWrapper>
+							<SitePreview showEditSite={ false } showSiteDetails={ false } />
+						</SitePreviewWrapper>
+					</div>
+				) }
 			<div
 				className={ joinClasses( [
 					className,
@@ -246,6 +256,7 @@ function CouponFieldArea( {
 	const { formStatus } = useFormStatus();
 	const translate = useTranslate();
 	const { setCouponFieldValue } = couponFieldStateProps;
+	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 
 	useEffect( () => {
 		if ( couponStatus === 'applied' ) {
@@ -260,7 +271,7 @@ function CouponFieldArea( {
 
 	if ( isCouponFieldVisible ) {
 		return (
-			<CouponAreaWrapper>
+			<CouponAreaWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 				<CouponField
 					id="order-review-coupon"
 					disabled={ formStatus !== FormStatus.READY }
@@ -272,12 +283,13 @@ function CouponFieldArea( {
 	}
 
 	return (
-		<CouponAreaWrapper>
-			<CouponLinkWrapper>
+		<CouponAreaWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
+			<CouponLinkWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 				{ translate( 'Have a coupon? ' ) }{ ' ' }
 				<CouponEnableButton
 					className="wp-checkout-order-review__show-coupon-field-button"
 					onClick={ () => setCouponFieldVisible( true ) }
+					shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 				>
 					{ translate( 'Add a coupon code' ) }
 				</CouponEnableButton>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -5,7 +5,7 @@ import {
 } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
-import { styled, joinClasses, hasCheckoutVersion } from '@automattic/wpcom-checkout';
+import { styled, joinClasses } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
 import { useState, useEffect, useCallback } from 'react';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
@@ -47,13 +47,11 @@ const SiteSummary = styled.div`
 `;
 
 const CouponLinkWrapper = styled.div< { shouldUseCheckoutV2: boolean } >`
-	${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ? `font-size: 12px;` : `font-size: 14px;` }
+	${ ( props ) => ( props.shouldUseCheckoutV2 ? `font-size: 12px;` : `font-size: 14px;` ) }
 `;
 
 const CouponAreaWrapper = styled.div< { shouldUseCheckoutV2: boolean } >`
-	padding-bottom: ${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ? '12px' : 'inherit' };
+	padding-bottom: ${ ( props ) => ( props.shouldUseCheckoutV2 ? '12px' : 'inherit' ) };
 `;
 
 const CouponField = styled( Coupon )``;
@@ -64,8 +62,7 @@ const CouponEnableButton = styled.button< { shouldUseCheckoutV2: boolean } >`
 	color: ${ ( props ) => props.theme.colors.highlight };
 
 	&.wp-checkout-order-review__show-coupon-field-button {
-		${ ( shouldUseCheckoutV2 ) =>
-			hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ? `font-size: 12px` : `font-size: 14px;` }
+		${ ( props ) => ( props.shouldUseCheckoutV2 ? `font-size: 12px` : `font-size: 14px;` ) }
 	}
 	:hover {
 		text-decoration: none;
@@ -181,16 +178,13 @@ export default function WPCheckoutOrderReview( {
 			{ /*
 			 * Only show the site preview for WPCOM domains that have a site connected to the site id
 			 * */ }
-			{ ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) &&
-				selectedSiteData &&
-				wpcomDomain &&
-				! isSignupCheckout && (
-					<div className="checkout-site-preview">
-						<SitePreviewWrapper>
-							<SitePreview showEditSite={ false } showSiteDetails={ false } />
-						</SitePreviewWrapper>
-					</div>
-				) }
+			{ shouldUseCheckoutV2 && selectedSiteData && wpcomDomain && ! isSignupCheckout && (
+				<div className="checkout-site-preview">
+					<SitePreviewWrapper>
+						<SitePreview showEditSite={ false } showSiteDetails={ false } />
+					</SitePreviewWrapper>
+				</div>
+			) }
 			<div
 				className={ joinClasses( [
 					className,

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -35,7 +35,6 @@ import { useShoppingCart } from '@automattic/shopping-cart';
 import {
 	getTaxBreakdownLineItemsFromCart,
 	getTotalLineItemFromCart,
-	hasCheckoutVersion,
 	getSubtotalWithoutDiscounts,
 	filterAndGroupCostOverridesForDisplay,
 	getCreditsLineItemFromCart,
@@ -97,8 +96,9 @@ export function WPCheckoutOrderSummary( {
 		<CheckoutSummaryCard
 			className={ isCartUpdating ? 'is-loading' : '' }
 			data-e2e-cart-is-loading={ isCartUpdating }
+			shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 		>
-			{ ! ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) && (
+			{ ! shouldUseCheckoutV2 && (
 				<CheckoutSummaryFeaturedList
 					responseCart={ responseCart }
 					siteId={ siteId }
@@ -181,7 +181,7 @@ function CheckoutSummaryPriceList() {
 
 	return (
 		<>
-			{ ! ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) && costOverridesList.length > 0 && (
+			{ ! shouldUseCheckoutV2 && costOverridesList.length > 0 && (
 				<CheckoutFirstSubtotalLineItem key="checkout-summary-line-item-subtotal-one">
 					<span>{ translate( 'Subtotal before discounts' ) }</span>
 					<span>
@@ -192,7 +192,7 @@ function CheckoutSummaryPriceList() {
 					</span>
 				</CheckoutFirstSubtotalLineItem>
 			) }
-			{ ! ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) && costOverridesList.length > 0 && (
+			{ ! shouldUseCheckoutV2 && costOverridesList.length > 0 && (
 				<CostOverridesList
 					costOverridesList={ costOverridesList }
 					currency={ responseCart.currency }
@@ -837,19 +837,15 @@ const pulse = keyframes`
 
 const CheckoutSummaryCard = styled.div< { shouldUseCheckoutV2?: boolean } >`
 	border-bottom: none 0;
-	${ ( shouldUseCheckoutV2 ) =>
-		( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) && `grid-area: summary` }
+	${ ( props ) => props.shouldUseCheckoutV2 && `grid-area: summary` }
 `;
 
 const CheckoutSummaryFeatures = styled.div< { shouldUseCheckoutV2: boolean } >`
 	padding: 24px 0;
-	${ ( shouldUseCheckoutV2 ) =>
-		( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) &&
-		`grid-area: features; justify-self: flex-start;` }
+	${ ( props ) => props.shouldUseCheckoutV2 && `grid-area: features; justify-self: flex-start;` }
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
-		${ ( shouldUseCheckoutV2 ) =>
-			hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ? ` padding: 0 0 24px` : `padding: 24px 0;` }
+		${ ( props ) => ( props.shouldUseCheckoutV2 ? ` padding: 0 0 24px` : `padding: 24px 0;` ) }
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
@@ -979,29 +975,19 @@ const CheckoutSummaryTotal = styled( CheckoutSummaryLineItem )< { shouldUseCheck
 	color: ${ ( props ) => props.theme.colors.textColorDark };
 	font-weight: ${ ( props ) => props.theme.weights.bold };
 	line-height: 26px;
-	${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2
-			? `margin-bottom: 0px;`
-			: `margin-bottom: 16px;` }
+	${ ( props ) => ( props.shouldUseCheckoutV2 ? `margin-bottom: 0px;` : `margin-bottom: 16px;` ) }
 	font-size: 20px;
 
 	& span {
-		${ ( shouldUseCheckoutV2 ) =>
-			hasCheckoutVersion( '2' ) || shouldUseCheckoutV2
-				? `font-family: 'Recoleta', sans-serif;`
-				: null }
+		${ ( props ) => ( props.shouldUseCheckoutV2 ? `font-family: 'Recoleta', sans-serif;` : null ) }
 	}
 
 	& .wp-checkout-order-summary__label {
-		${ ( shouldUseCheckoutV2 ) =>
-			( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) &&
-			'font-size: 28px; line-height: 40px; ' }
+		${ ( props ) => props.shouldUseCheckoutV2 && 'font-size: 28px; line-height: 40px; ' }
 	}
 
 	& .wp-checkout-order-summary__total-price {
-		${ ( shouldUseCheckoutV2 ) =>
-			( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) &&
-			'font-size: 40px; line-height: 44px;' }
+		${ ( props ) => props.shouldUseCheckoutV2 && 'font-size: 40px; line-height: 44px;' }
 	}
 `;
 

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -227,6 +227,7 @@ export function WPOrderReviewLineItems( {
 					lineItem={ creditsLineItem }
 					isSummary={ isSummary }
 					isPwpoUser={ isPwpoUser }
+					shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 				/>
 			) }
 			{ shouldUseCheckoutV2 && costOverridesList.length > 0 && (

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -370,8 +370,6 @@ function LineItemWrapper( {
 				onRemoveProductCancel={ onRemoveProductCancel }
 				isAkPro500Cart={ isAkPro500Cart }
 				shouldShowBillingInterval={ ! finalShouldShowVariantSelector }
-				areThereVariants={ areThereVariants }
-				shouldShowVariantSelector={ shouldShowVariantSelector }
 				shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 			>
 				<DropdownWrapper hasCheckoutVersion2={ hasCheckoutVersion( '2' ) }>

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -29,6 +29,7 @@ import { useGetProductVariants } from 'calypso/my-sites/checkout/src/hooks/produ
 import { getSignupCompleteFlowName } from 'calypso/signup/storageUtils';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { useCheckoutV2 } from '../hooks/use-checkout-v2';
 import { AkismetProQuantityDropDown } from './akismet-pro-quantity-dropdown';
 import { CostOverridesList, LineItemCostOverrides } from './cost-overrides-list';
 import { ItemVariationPicker } from './item-variation-picker';
@@ -101,7 +102,7 @@ export function WPOrderReviewLineItems( {
 	const hasPartnerCoupon = getPartnerCoupon( {
 		coupon: responseCart.coupon,
 	} );
-
+	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 	const [ initialProducts ] = useState( () => responseCart.products );
 	const [ forceShowAkQuantityDropdown, setForceShowAkQuantityDropdown ] = useState( false );
 
@@ -206,7 +207,7 @@ export function WPOrderReviewLineItems( {
 					akQuantityOpenId={ akQuantityOpenId }
 				/>
 			) ) }
-			{ ! hasCheckoutVersion( '2' ) && couponLineItem && (
+			{ ! ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) && couponLineItem && (
 				<WPOrderReviewListItem key={ couponLineItem.id }>
 					<CouponLineItem
 						lineItem={ couponLineItem }
@@ -219,15 +220,17 @@ export function WPOrderReviewLineItems( {
 					/>
 				</WPOrderReviewListItem>
 			) }
-			{ ! hasCheckoutVersion( '2' ) && creditsLineItem && responseCart.sub_total_integer > 0 && (
-				<NonProductLineItem
-					subtotal
-					lineItem={ creditsLineItem }
-					isSummary={ isSummary }
-					isPwpoUser={ isPwpoUser }
-				/>
-			) }
-			{ hasCheckoutVersion( '2' ) && costOverridesList.length > 0 && (
+			{ ! ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) &&
+				creditsLineItem &&
+				responseCart.sub_total_integer > 0 && (
+					<NonProductLineItem
+						subtotal
+						lineItem={ creditsLineItem }
+						isSummary={ isSummary }
+						isPwpoUser={ isPwpoUser }
+					/>
+				) }
+			{ ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) && costOverridesList.length > 0 && (
 				<CostOverridesList
 					costOverridesList={ costOverridesList }
 					currency={ responseCart.currency }
@@ -291,6 +294,7 @@ function LineItemWrapper( {
 	const isWooMobile = isWcMobileApp();
 	let isDeletable = canItemBeRemovedFromCart( product, responseCart ) && ! isWooMobile;
 	const has100YearPlanProduct = has100YearPlan( responseCart );
+	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 
 	const signupFlowName = getSignupCompleteFlowName();
 	if ( isCopySiteFlow( signupFlowName ) && ! product.is_domain_registration ) {
@@ -366,6 +370,9 @@ function LineItemWrapper( {
 				onRemoveProductCancel={ onRemoveProductCancel }
 				isAkPro500Cart={ isAkPro500Cart }
 				shouldShowBillingInterval={ ! finalShouldShowVariantSelector }
+				areThereVariants={ areThereVariants }
+				shouldShowVariantSelector={ shouldShowVariantSelector }
+				shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 			>
 				<DropdownWrapper hasCheckoutVersion2={ hasCheckoutVersion( '2' ) }>
 					{ finalShouldShowVariantSelector && (

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -16,7 +16,6 @@ import {
 	NonProductLineItem,
 	LineItem,
 	getPartnerCoupon,
-	hasCheckoutVersion,
 	filterAndGroupCostOverridesForDisplay,
 	filterCostOverridesForLineItem,
 } from '@automattic/wpcom-checkout';
@@ -45,14 +44,10 @@ import type {
 import type { PropsWithChildren } from 'react';
 
 const WPOrderReviewList = styled.ul< {
-	hasCheckoutVersion2: boolean;
 	shouldUseCheckoutV2?: boolean;
 } >`
 	box-sizing: border-box;
-	${ ( props ) =>
-		props.hasCheckoutVersion2 || props.shouldUseCheckoutV2
-			? 'margin: 24px 0 0 0;'
-			: 'margin: 24px 0;' }
+	${ ( props ) => ( props.shouldUseCheckoutV2 ? 'margin: 24px 0 0 0;' : 'margin: 24px 0;' ) }
 	padding: 0;
 `;
 
@@ -180,7 +175,6 @@ export function WPOrderReviewLineItems( {
 	return (
 		<WPOrderReviewList
 			className={ joinClasses( [ className, 'order-review-line-items' ] ) }
-			hasCheckoutVersion2={ hasCheckoutVersion( '2' ) }
 			shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 		>
 			{ responseCart.products.map( ( product ) => (
@@ -214,7 +208,7 @@ export function WPOrderReviewLineItems( {
 					akQuantityOpenId={ akQuantityOpenId }
 				/>
 			) ) }
-			{ ! ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) && couponLineItem && (
+			{ ! shouldUseCheckoutV2 && couponLineItem && (
 				<WPOrderReviewListItem key={ couponLineItem.id }>
 					<CouponLineItem
 						lineItem={ couponLineItem }
@@ -227,17 +221,15 @@ export function WPOrderReviewLineItems( {
 					/>
 				</WPOrderReviewListItem>
 			) }
-			{ ! ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) &&
-				creditsLineItem &&
-				responseCart.sub_total_integer > 0 && (
-					<NonProductLineItem
-						subtotal
-						lineItem={ creditsLineItem }
-						isSummary={ isSummary }
-						isPwpoUser={ isPwpoUser }
-					/>
-				) }
-			{ ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) && costOverridesList.length > 0 && (
+			{ ! shouldUseCheckoutV2 && creditsLineItem && responseCart.sub_total_integer > 0 && (
+				<NonProductLineItem
+					subtotal
+					lineItem={ creditsLineItem }
+					isSummary={ isSummary }
+					isPwpoUser={ isPwpoUser }
+				/>
+			) }
+			{ shouldUseCheckoutV2 && costOverridesList.length > 0 && (
 				<CostOverridesList
 					costOverridesList={ costOverridesList }
 					currency={ responseCart.currency }
@@ -251,13 +243,9 @@ export function WPOrderReviewLineItems( {
 }
 
 const DropdownWrapper = styled.span< {
-	hasCheckoutVersion2: boolean;
 	shouldUseCheckoutV2?: boolean;
 } >`
-	${ ( props ) =>
-		props.hasCheckoutVersion2 || props.shouldUseCheckoutV2
-			? `width: 100%; max-width: 200px`
-			: `width: 100%;` }
+	${ ( props ) => ( props.shouldUseCheckoutV2 ? `width: 100%; max-width: 200px` : `width: 100%;` ) }
 `;
 
 function LineItemWrapper( {
@@ -385,10 +373,7 @@ function LineItemWrapper( {
 				shouldShowBillingInterval={ ! finalShouldShowVariantSelector }
 				shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 			>
-				<DropdownWrapper
-					hasCheckoutVersion2={ hasCheckoutVersion( '2' ) }
-					shouldUseCheckoutV2={ shouldUseCheckoutV2 }
-				>
+				<DropdownWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 					{ finalShouldShowVariantSelector && (
 						<ItemVariationPicker
 							id={ product.uuid }
@@ -411,7 +396,7 @@ function LineItemWrapper( {
 						/>
 					) }
 				</DropdownWrapper>
-				{ ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) && (
+				{ shouldUseCheckoutV2 && (
 					<LineItemCostOverrides product={ product } costOverridesList={ costOverridesList } />
 				) }
 			</LineItem>

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -44,9 +44,15 @@ import type {
 } from '@automattic/shopping-cart';
 import type { PropsWithChildren } from 'react';
 
-const WPOrderReviewList = styled.ul< { hasCheckoutVersion2: boolean } >`
+const WPOrderReviewList = styled.ul< {
+	hasCheckoutVersion2: boolean;
+	shouldUseCheckoutV2?: boolean;
+} >`
 	box-sizing: border-box;
-	${ ( props ) => ( props.hasCheckoutVersion2 ? 'margin: 24px 0 0 0;' : 'margin: 24px 0;' ) }
+	${ ( props ) =>
+		props.hasCheckoutVersion2 || props.shouldUseCheckoutV2
+			? 'margin: 24px 0 0 0;'
+			: 'margin: 24px 0;' }
 	padding: 0;
 `;
 
@@ -175,6 +181,7 @@ export function WPOrderReviewLineItems( {
 		<WPOrderReviewList
 			className={ joinClasses( [ className, 'order-review-line-items' ] ) }
 			hasCheckoutVersion2={ hasCheckoutVersion( '2' ) }
+			shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 		>
 			{ responseCart.products.map( ( product ) => (
 				<LineItemWrapper
@@ -243,8 +250,14 @@ export function WPOrderReviewLineItems( {
 	);
 }
 
-const DropdownWrapper = styled.span< { hasCheckoutVersion2: boolean } >`
-	${ ( props ) => ( props.hasCheckoutVersion2 ? `width: 100%; max-width: 200px` : `width: 100%;` ) }
+const DropdownWrapper = styled.span< {
+	hasCheckoutVersion2: boolean;
+	shouldUseCheckoutV2?: boolean;
+} >`
+	${ ( props ) =>
+		props.hasCheckoutVersion2 || props.shouldUseCheckoutV2
+			? `width: 100%; max-width: 200px`
+			: `width: 100%;` }
 `;
 
 function LineItemWrapper( {
@@ -372,7 +385,10 @@ function LineItemWrapper( {
 				shouldShowBillingInterval={ ! finalShouldShowVariantSelector }
 				shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 			>
-				<DropdownWrapper hasCheckoutVersion2={ hasCheckoutVersion( '2' ) }>
+				<DropdownWrapper
+					hasCheckoutVersion2={ hasCheckoutVersion( '2' ) }
+					shouldUseCheckoutV2={ shouldUseCheckoutV2 }
+				>
 					{ finalShouldShowVariantSelector && (
 						<ItemVariationPicker
 							id={ product.uuid }
@@ -395,7 +411,7 @@ function LineItemWrapper( {
 						/>
 					) }
 				</DropdownWrapper>
-				{ hasCheckoutVersion( '2' ) && (
+				{ ( hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ) && (
 					<LineItemCostOverrides product={ product } costOverridesList={ costOverridesList } />
 				) }
 			</LineItem>

--- a/client/my-sites/checkout/src/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/src/hooks/product-variants.tsx
@@ -15,7 +15,7 @@ import {
 	TERM_NOVENNIALLY,
 	TERM_DECENNIALLY,
 } from '@automattic/calypso-products';
-import { isValueTruthy, hasCheckoutVersion } from '@automattic/wpcom-checkout';
+import { isValueTruthy } from '@automattic/wpcom-checkout';
 import debugFactory from 'debug';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
@@ -160,79 +160,57 @@ function getTermText(
 	switch ( term ) {
 		case TERM_DECENNIALLY:
 			return String(
-				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
-					? translate( 'Ten years' )
-					: translate( 'Billed every ten years' )
+				shouldUseCheckoutV2 ? translate( 'Ten years' ) : translate( 'Billed every ten years' )
 			);
 
 		case TERM_NOVENNIALLY:
 			return String(
-				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
-					? translate( 'Nine years' )
-					: translate( 'Billed every nine years' )
+				shouldUseCheckoutV2 ? translate( 'Nine years' ) : translate( 'Billed every nine years' )
 			);
 
 		case TERM_OCTENNIALLY:
 			return String(
-				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
-					? translate( 'Eight years' )
-					: translate( 'Billed every eight years' )
+				shouldUseCheckoutV2 ? translate( 'Eight years' ) : translate( 'Billed every eight years' )
 			);
 
 		case TERM_SEPTENNIALLY:
 			return String(
-				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
-					? translate( 'Seven years' )
-					: translate( 'Billed every seven years' )
+				shouldUseCheckoutV2 ? translate( 'Seven years' ) : translate( 'Billed every seven years' )
 			);
 
 		case TERM_SEXENNIALLY:
 			return String(
-				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
-					? translate( 'Six years' )
-					: translate( 'Billed every six years' )
+				shouldUseCheckoutV2 ? translate( 'Six years' ) : translate( 'Billed every six years' )
 			);
 
 		case TERM_QUINQUENNIALLY:
 			return String(
-				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
-					? translate( 'Five years' )
-					: translate( 'Billed every five years' )
+				shouldUseCheckoutV2 ? translate( 'Five years' ) : translate( 'Billed every five years' )
 			);
 
 		case TERM_QUADRENNIALLY:
 			return String(
-				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
-					? translate( 'Four years' )
-					: translate( 'Billed every four years' )
+				shouldUseCheckoutV2 ? translate( 'Four years' ) : translate( 'Billed every four years' )
 			);
 
 		case TERM_TRIENNIALLY:
 			return String(
-				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
-					? translate( 'Three years' )
-					: translate( 'Billed every three years' )
+				shouldUseCheckoutV2 ? translate( 'Three years' ) : translate( 'Billed every three years' )
 			);
 
 		case TERM_BIENNIALLY:
 			return String(
-				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
-					? translate( 'Two years' )
-					: translate( 'Billed every two years' )
+				shouldUseCheckoutV2 ? translate( 'Two years' ) : translate( 'Billed every two years' )
 			);
 
 		case TERM_ANNUALLY:
 			return String(
-				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
-					? translate( 'One year' )
-					: translate( 'Billed every one year' )
+				shouldUseCheckoutV2 ? translate( 'One year' ) : translate( 'Billed every one year' )
 			);
 
 		case TERM_MONTHLY:
 			return String(
-				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
-					? translate( 'One month' )
-					: translate( 'Billed every month' )
+				shouldUseCheckoutV2 ? translate( 'One month' ) : translate( 'Billed every month' )
 			);
 
 		default:

--- a/client/my-sites/checkout/src/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/src/hooks/product-variants.tsx
@@ -160,57 +160,57 @@ function getTermText(
 	switch ( term ) {
 		case TERM_DECENNIALLY:
 			return String(
-				shouldUseCheckoutV2 ? translate( 'Ten years' ) : translate( 'Billed every ten years' )
+				! shouldUseCheckoutV2 ? translate( 'Ten years' ) : translate( 'Billed every ten years' )
 			);
 
 		case TERM_NOVENNIALLY:
 			return String(
-				shouldUseCheckoutV2 ? translate( 'Nine years' ) : translate( 'Billed every nine years' )
+				! shouldUseCheckoutV2 ? translate( 'Nine years' ) : translate( 'Billed every nine years' )
 			);
 
 		case TERM_OCTENNIALLY:
 			return String(
-				shouldUseCheckoutV2 ? translate( 'Eight years' ) : translate( 'Billed every eight years' )
+				! shouldUseCheckoutV2 ? translate( 'Eight years' ) : translate( 'Billed every eight years' )
 			);
 
 		case TERM_SEPTENNIALLY:
 			return String(
-				shouldUseCheckoutV2 ? translate( 'Seven years' ) : translate( 'Billed every seven years' )
+				! shouldUseCheckoutV2 ? translate( 'Seven years' ) : translate( 'Billed every seven years' )
 			);
 
 		case TERM_SEXENNIALLY:
 			return String(
-				shouldUseCheckoutV2 ? translate( 'Six years' ) : translate( 'Billed every six years' )
+				! shouldUseCheckoutV2 ? translate( 'Six years' ) : translate( 'Billed every six years' )
 			);
 
 		case TERM_QUINQUENNIALLY:
 			return String(
-				shouldUseCheckoutV2 ? translate( 'Five years' ) : translate( 'Billed every five years' )
+				! shouldUseCheckoutV2 ? translate( 'Five years' ) : translate( 'Billed every five years' )
 			);
 
 		case TERM_QUADRENNIALLY:
 			return String(
-				shouldUseCheckoutV2 ? translate( 'Four years' ) : translate( 'Billed every four years' )
+				! shouldUseCheckoutV2 ? translate( 'Four years' ) : translate( 'Billed every four years' )
 			);
 
 		case TERM_TRIENNIALLY:
 			return String(
-				shouldUseCheckoutV2 ? translate( 'Three years' ) : translate( 'Billed every three years' )
+				! shouldUseCheckoutV2 ? translate( 'Three years' ) : translate( 'Billed every three years' )
 			);
 
 		case TERM_BIENNIALLY:
 			return String(
-				shouldUseCheckoutV2 ? translate( 'Two years' ) : translate( 'Billed every two years' )
+				! shouldUseCheckoutV2 ? translate( 'Two years' ) : translate( 'Billed every two years' )
 			);
 
 		case TERM_ANNUALLY:
 			return String(
-				shouldUseCheckoutV2 ? translate( 'One year' ) : translate( 'Billed every one year' )
+				! shouldUseCheckoutV2 ? translate( 'One year' ) : translate( 'Billed every one year' )
 			);
 
 		case TERM_MONTHLY:
 			return String(
-				shouldUseCheckoutV2 ? translate( 'One month' ) : translate( 'Billed every month' )
+				! shouldUseCheckoutV2 ? translate( 'One month' ) : translate( 'Billed every month' )
 			);
 
 		default:

--- a/client/my-sites/checkout/src/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/src/hooks/product-variants.tsx
@@ -22,6 +22,7 @@ import { useMemo } from 'react';
 import { logToLogstash } from 'calypso/lib/logstash';
 import { useStableCallback } from 'calypso/lib/use-stable-callback';
 import { convertErrorToString } from '../lib/analytics';
+import { useCheckoutV2 } from './use-checkout-v2';
 import type { WPCOMProductVariant } from '../components/item-variation-picker';
 import type { ResponseCartProduct, ResponseCartProductVariant } from '@automattic/shopping-cart';
 
@@ -89,7 +90,7 @@ export function useGetProductVariants(
 ): WPCOMProductVariant[] {
 	const translate = useTranslate();
 	const filterCallbackMemoized = useStableCallback( filterCallback ?? fallbackFilter );
-
+	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 	const variants = product?.product_variants ?? fallbackVariants;
 	const variantProductSlugs = variants.map( ( variant ) => variant.product_slug );
 	debug( 'variantProductSlugs', variantProductSlugs );
@@ -102,7 +103,7 @@ export function useGetProductVariants(
 					const term = getBillingTermForMonths( variant.bill_period_in_months );
 					const introductoryTerms = variant.introductory_offer_terms;
 					return {
-						variantLabel: getTermText( term, translate ),
+						variantLabel: getTermText( term, translate, shouldUseCheckoutV2 ),
 						productSlug: variant.product_slug,
 						productId: variant.product_id,
 						priceInteger: variant.price_integer,
@@ -136,7 +137,7 @@ export function useGetProductVariants(
 			.filter( isValueTruthy );
 
 		return convertedVariants.filter( ( product ) => filterCallbackMemoized( product ) );
-	}, [ translate, variants, filterCallbackMemoized ] );
+	}, [ variants, translate, shouldUseCheckoutV2, filterCallbackMemoized ] );
 
 	return filteredVariants;
 }
@@ -151,79 +152,87 @@ function sortVariant( a: ResponseCartProductVariant, b: ResponseCartProductVaria
 	return 0;
 }
 
-function getTermText( term: string, translate: ReturnType< typeof useTranslate > ): string {
+function getTermText(
+	term: string,
+	translate: ReturnType< typeof useTranslate >,
+	shouldUseCheckoutV2: boolean
+): string {
 	switch ( term ) {
 		case TERM_DECENNIALLY:
 			return String(
-				! hasCheckoutVersion( '2' )
+				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
 					? translate( 'Ten years' )
 					: translate( 'Billed every ten years' )
 			);
 
 		case TERM_NOVENNIALLY:
 			return String(
-				! hasCheckoutVersion( '2' )
+				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
 					? translate( 'Nine years' )
 					: translate( 'Billed every nine years' )
 			);
 
 		case TERM_OCTENNIALLY:
 			return String(
-				! hasCheckoutVersion( '2' )
+				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
 					? translate( 'Eight years' )
 					: translate( 'Billed every eight years' )
 			);
 
 		case TERM_SEPTENNIALLY:
 			return String(
-				! hasCheckoutVersion( '2' )
+				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
 					? translate( 'Seven years' )
 					: translate( 'Billed every seven years' )
 			);
 
 		case TERM_SEXENNIALLY:
 			return String(
-				! hasCheckoutVersion( '2' )
+				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
 					? translate( 'Six years' )
 					: translate( 'Billed every six years' )
 			);
 
 		case TERM_QUINQUENNIALLY:
 			return String(
-				! hasCheckoutVersion( '2' )
+				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
 					? translate( 'Five years' )
 					: translate( 'Billed every five years' )
 			);
 
 		case TERM_QUADRENNIALLY:
 			return String(
-				! hasCheckoutVersion( '2' )
+				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
 					? translate( 'Four years' )
 					: translate( 'Billed every four years' )
 			);
 
 		case TERM_TRIENNIALLY:
 			return String(
-				! hasCheckoutVersion( '2' )
+				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
 					? translate( 'Three years' )
 					: translate( 'Billed every three years' )
 			);
 
 		case TERM_BIENNIALLY:
 			return String(
-				! hasCheckoutVersion( '2' )
+				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
 					? translate( 'Two years' )
 					: translate( 'Billed every two years' )
 			);
 
 		case TERM_ANNUALLY:
 			return String(
-				! hasCheckoutVersion( '2' ) ? translate( 'One year' ) : translate( 'Billed every one year' )
+				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
+					? translate( 'One year' )
+					: translate( 'Billed every one year' )
 			);
 
 		case TERM_MONTHLY:
 			return String(
-				! hasCheckoutVersion( '2' ) ? translate( 'One month' ) : translate( 'Billed every month' )
+				! hasCheckoutVersion( '2' ) || ! shouldUseCheckoutV2
+					? translate( 'One month' )
+					: translate( 'Billed every month' )
 			);
 
 		default:

--- a/client/my-sites/checkout/src/hooks/use-checkout-v2.ts
+++ b/client/my-sites/checkout/src/hooks/use-checkout-v2.ts
@@ -8,7 +8,7 @@ export function useCheckoutV2(): 'loading' | 'treatment' | 'control' {
 
 	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
 		'calypso_launch_checkout_v2',
-		{ isEligible: isCheckoutSection }
+		{ isEligible: isCheckoutSection && ! hasCheckoutVersion( '2' ) }
 	);
 
 	// Is loading experiment assignment

--- a/client/my-sites/checkout/src/hooks/use-checkout-v2.ts
+++ b/client/my-sites/checkout/src/hooks/use-checkout-v2.ts
@@ -1,0 +1,23 @@
+import { useExperiment } from 'calypso/lib/explat';
+import { useSelector } from 'calypso/state';
+import { getSectionName } from 'calypso/state/ui/selectors';
+
+export function useCheckoutV2(): 'loading' | 'treatment' | 'control' {
+	const isCheckoutSection = useSelector( getSectionName ) === 'checkout';
+
+	const [ isLoadingExperimentAssignment, experimentAssignment ] = useExperiment(
+		'calypso_launch_checkout_v2',
+		{ isEligible: isCheckoutSection }
+	);
+
+	// Is loading experiment assignment
+	if ( isLoadingExperimentAssignment ) {
+		return 'loading';
+	}
+	// Done loading experiment assignment, and treatment assignment found
+	if ( experimentAssignment?.variationName === 'treatment' ) {
+		return 'treatment';
+	}
+	// Done loading experiment assignment, and control or null assignment found
+	return 'control';
+}

--- a/client/my-sites/checkout/src/hooks/use-checkout-v2.ts
+++ b/client/my-sites/checkout/src/hooks/use-checkout-v2.ts
@@ -1,3 +1,4 @@
+import { hasCheckoutVersion } from '@automattic/wpcom-checkout';
 import { useExperiment } from 'calypso/lib/explat';
 import { useSelector } from 'calypso/state';
 import { getSectionName } from 'calypso/state/ui/selectors';
@@ -15,7 +16,7 @@ export function useCheckoutV2(): 'loading' | 'treatment' | 'control' {
 		return 'loading';
 	}
 	// Done loading experiment assignment, and treatment assignment found
-	if ( experimentAssignment?.variationName === 'treatment' ) {
+	if ( experimentAssignment?.variationName === 'treatment' || hasCheckoutVersion( '2' ) ) {
 		return 'treatment';
 	}
 	// Done loading experiment assignment, and control or null assignment found

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -210,10 +210,11 @@ const LineItemTitle = styled.div< {
 `;
 
 const LineItemPriceWrapper = styled.span< {
-	theme?: Theme;
-	isSummary?: boolean;
 	shouldUseCheckoutV2?: boolean;
 } >`
+	display: flex;
+	gap: 4px;
+
 	${ ( shouldUseCheckoutV2 ) =>
 		hasCheckoutVersion2 || shouldUseCheckoutV2
 			? `margin-left: 0px;
@@ -1284,6 +1285,7 @@ const DesktopGiftWrapper = styled.div`
 `;
 
 function CheckoutLineItem( {
+	children,
 	product,
 	className,
 	hasDeleteButton,
@@ -1312,8 +1314,6 @@ function CheckoutLineItem( {
 	onRemoveProductCancel?: ( label: string ) => void;
 	isAkPro500Cart?: boolean;
 	shouldShowBillingInterval?: boolean;
-	areThereVariants?: boolean;
-	shouldShowVariantSelector?: boolean;
 	shouldUseCheckoutV2?: boolean;
 } > ) {
 	const id = product.uuid;
@@ -1495,6 +1495,8 @@ function CheckoutLineItem( {
 			{ ! ( hasCheckoutVersion2 || shouldUseCheckoutV2 ) && isEmail && (
 				<EmailMeta product={ product } isRenewal={ isRenewal } />
 			) }
+
+			{ children }
 
 			{ hasDeleteButton && removeProductFromCart && (
 				<>

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -59,6 +59,7 @@ export const NonProductLineItem = styled( WPNonProductLineItem )< {
 	tax?: boolean;
 	coupon?: boolean;
 	subtotal?: boolean;
+	shouldUseCheckoutV2?: boolean;
 } >`
 	display: flex;
 	flex-wrap: wrap;
@@ -328,7 +329,11 @@ function WPNonProductLineItem( {
 			</LineItemTitle>
 
 			{ shouldUseCheckoutV2 ? (
-				<LineItemPrice aria-labelledby={ itemSpanId } actualAmount={ actualAmountDisplay } />
+				<LineItemPrice
+					aria-labelledby={ itemSpanId }
+					actualAmount={ actualAmountDisplay }
+					shouldUseCheckoutV2={ shouldUseCheckoutV2 }
+				/>
 			) : (
 				<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
 					<LineItemPrice actualAmount={ actualAmountDisplay } />
@@ -1429,6 +1434,7 @@ function CheckoutLineItem( {
 							  } )
 							: undefined
 					}
+					shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 				/>
 			) : (
 				<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -32,7 +32,6 @@ import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import { useState, PropsWithChildren, useRef } from 'react';
 import { getLabel, DefaultLineItemSublabel } from './checkout-labels';
-import { hasCheckoutVersion } from './checkout-version-checker';
 import {
 	getIntroductoryOfferIntervalDisplay,
 	getItemIntroductoryOfferDisplay,
@@ -53,8 +52,6 @@ import type {
 	ResponseCartProduct,
 	TitanProductUser,
 } from '@automattic/shopping-cart';
-
-const hasCheckoutVersion2 = hasCheckoutVersion( '2' );
 
 export const NonProductLineItem = styled( WPNonProductLineItem )< {
 	theme?: Theme;
@@ -89,8 +86,8 @@ export const LineItem = styled( CheckoutLineItem )< {
 	theme?: Theme;
 	shouldUseCheckoutV2?: boolean;
 } >`
-	${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion2 || shouldUseCheckoutV2
+	${ ( props ) =>
+		props.shouldUseCheckoutV2
 			? `display: grid;
 	grid-template-columns: 1fr min-content;
 	grid-template-rows: auto;
@@ -151,8 +148,8 @@ const LineItemMeta = styled.div< { theme?: Theme; shouldUseCheckoutV2?: boolean 
 	flex-wrap: wrap;
 	overflow-wrap: anywhere;
 
-	${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion2 || shouldUseCheckoutV2
+	${ ( props ) =>
+		props.shouldUseCheckoutV2
 			? `grid-area: meta; flex-direction: column; align-content: flex-start; `
 			: 'flex-direction: row; align-content: center; gap: 2px 10px;' }
 `;
@@ -198,8 +195,8 @@ const LineItemTitle = styled.div< {
 	word-break: break-word;
 	font-weight: ${ ( { theme } ) => theme.weights.bold };
 
-	${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion2 || shouldUseCheckoutV2
+	${ ( props ) =>
+		props.shouldUseCheckoutV2
 			? `grid-area: label;
 		   font-size: 14px;
 		   align-self: center;`
@@ -215,8 +212,8 @@ const LineItemPriceWrapper = styled.span< {
 	display: flex;
 	gap: 4px;
 
-	${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion2 || shouldUseCheckoutV2
+	${ ( props ) =>
+		props.shouldUseCheckoutV2
 			? `margin-left: 0px;
 		   font-size: 14px;
 		   grid-area: price;
@@ -246,8 +243,8 @@ const BillingInterval = styled.div< { theme?: Theme } >`
 const DeleteButtonWrapper = styled.div< { shouldUseCheckoutV2?: boolean } >`
 	width: 100%;
 
-	${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion2 || shouldUseCheckoutV2
+	${ ( props ) =>
+		props.shouldUseCheckoutV2
 			? `
 	grid-area: remove;
 	display: grid;
@@ -260,8 +257,7 @@ const DeleteButtonWrapper = styled.div< { shouldUseCheckoutV2?: boolean } >`
 
 const DeleteButton = styled( Button )< { theme?: Theme; shouldUseCheckoutV2?: boolean } >`
 	width: auto;
-	${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion2 || shouldUseCheckoutV2 ? `font-size:  12px;` : `font-size: 0.75rem` };
+	${ ( props ) => ( props.shouldUseCheckoutV2 ? `font-size:  12px;` : `font-size: 0.75rem` ) };
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 `;
 
@@ -331,7 +327,7 @@ function WPNonProductLineItem( {
 				{ label }
 			</LineItemTitle>
 
-			{ hasCheckoutVersion2 || shouldUseCheckoutV2 ? (
+			{ shouldUseCheckoutV2 ? (
 				<LineItemPrice aria-labelledby={ itemSpanId } actualAmount={ actualAmountDisplay } />
 			) : (
 				<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
@@ -355,9 +351,7 @@ function WPNonProductLineItem( {
 							} }
 							shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 						>
-							{ hasCheckoutVersion2 || shouldUseCheckoutV2
-								? translate( 'Remove' )
-								: translate( 'Remove from cart' ) }
+							{ shouldUseCheckoutV2 ? translate( 'Remove' ) : translate( 'Remove from cart' ) }
 						</DeleteButton>
 					</DeleteButtonWrapper>
 
@@ -1410,16 +1404,14 @@ function CheckoutLineItem( {
 				isSummary={ isSummary }
 				shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 			>
-				{ ( hasCheckoutVersion2 || shouldUseCheckoutV2 ) && isRenewal
-					? `${ label } Renewal`
-					: label }
+				{ shouldUseCheckoutV2 && isRenewal ? `${ label } Renewal` : label }
 				{ responseCart.is_gift_purchase && (
 					<DesktopGiftWrapper>
 						<GiftBadgeWithText />
 					</DesktopGiftWrapper>
 				) }
 			</LineItemTitle>
-			{ hasCheckoutVersion2 || shouldUseCheckoutV2 ? (
+			{ shouldUseCheckoutV2 ? (
 				<LineItemPrice
 					actualAmount={
 						isIntroductoryOfferWithDifferentLength
@@ -1449,7 +1441,7 @@ function CheckoutLineItem( {
 
 			{ ! containsPartnerCoupon && (
 				<>
-					{ hasCheckoutVersion2 || shouldUseCheckoutV2 ? (
+					{ shouldUseCheckoutV2 ? (
 						<>
 							{ shouldShowBillingInterval && (
 								<BillingInterval>
@@ -1480,7 +1472,7 @@ function CheckoutLineItem( {
 
 			{ containsPartnerCoupon && (
 				<LineItemMeta shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
-					{ hasCheckoutVersion2 || shouldUseCheckoutV2 ? (
+					{ shouldUseCheckoutV2 ? (
 						<LineItemBillingInterval product={ product } />
 					) : (
 						<LineItemSublabelAndPrice product={ product } />
@@ -1488,11 +1480,11 @@ function CheckoutLineItem( {
 				</LineItemMeta>
 			) }
 
-			{ ! ( hasCheckoutVersion2 || shouldUseCheckoutV2 ) && isJetpackSearch( product ) && (
+			{ ! shouldUseCheckoutV2 && isJetpackSearch( product ) && (
 				<JetpackSearchMeta product={ product } />
 			) }
 
-			{ ! ( hasCheckoutVersion2 || shouldUseCheckoutV2 ) && isEmail && (
+			{ ! shouldUseCheckoutV2 && isEmail && (
 				<EmailMeta product={ product } isRenewal={ isRenewal } />
 			) }
 
@@ -1516,9 +1508,7 @@ function CheckoutLineItem( {
 							} }
 							shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 						>
-							{ hasCheckoutVersion2 || shouldUseCheckoutV2
-								? translate( 'Remove' )
-								: translate( 'Remove from cart' ) }
+							{ shouldUseCheckoutV2 ? translate( 'Remove' ) : translate( 'Remove from cart' ) }
 						</DeleteButton>
 					</DeleteButtonWrapper>
 

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -87,9 +87,11 @@ export const NonProductLineItem = styled( WPNonProductLineItem )< {
 
 export const LineItem = styled( CheckoutLineItem )< {
 	theme?: Theme;
+	shouldUseCheckoutV2?: boolean;
 } >`
-	${ hasCheckoutVersion2
-		? `display: grid;
+	${ ( shouldUseCheckoutV2 ) =>
+		hasCheckoutVersion2 || shouldUseCheckoutV2
+			? `display: grid;
 	grid-template-columns: 1fr min-content;
 	grid-template-rows: auto;
 	grid-template-areas:
@@ -100,7 +102,7 @@ export const LineItem = styled( CheckoutLineItem )< {
 	gap: 6px 4px;
 	margin-bottom: 8px;
 	padding: 10px 0;`
-		: `display: flex;
+			: `display: flex;
 			flex-wrap: wrap;
 			justify-content: space-between;
 			padding: 20px 0;` }
@@ -140,7 +142,7 @@ const GiftBadge = styled.span`
 	font-size: small;
 `;
 
-const LineItemMeta = styled.div< { theme?: Theme } >`
+const LineItemMeta = styled.div< { theme?: Theme; shouldUseCheckoutV2?: boolean } >`
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 	font-size: 14px;
 	width: 100%;
@@ -149,9 +151,10 @@ const LineItemMeta = styled.div< { theme?: Theme } >`
 	flex-wrap: wrap;
 	overflow-wrap: anywhere;
 
-	${ hasCheckoutVersion2
-		? `grid-area: meta; flex-direction: column; align-content: flex-start; `
-		: 'flex-direction: row; align-content: center; gap: 2px 10px;' }
+	${ ( shouldUseCheckoutV2 ) =>
+		hasCheckoutVersion2 || shouldUseCheckoutV2
+			? `grid-area: meta; flex-direction: column; align-content: flex-start; `
+			: 'flex-direction: row; align-content: center; gap: 2px 10px;' }
 `;
 
 const UpgradeCreditInformationLineItem = styled( LineItemMeta )< { theme?: Theme } >`
@@ -187,30 +190,37 @@ const NotApplicableCallout = styled.div< { theme?: Theme } >`
 	display: block;
 `;
 
-const LineItemTitle = styled.div< { theme?: Theme; isSummary?: boolean } >`
+const LineItemTitle = styled.div< {
+	theme?: Theme;
+	isSummary?: boolean;
+	shouldUseCheckoutV2?: boolean;
+} >`
 	word-break: break-word;
 	font-weight: ${ ( { theme } ) => theme.weights.bold };
 
-	${ hasCheckoutVersion2
-		? `grid-area: label;
+	${ ( shouldUseCheckoutV2 ) =>
+		hasCheckoutVersion2 || shouldUseCheckoutV2
+			? `grid-area: label;
 		   font-size: 14px;
 		   align-self: center;`
-		: `flex: 1;
+			: `flex: 1;
 		   display: flex;
 		   gap: 0.5em;
 		   font-size: inherit;` }
 `;
 
-const LineItemPriceWrapper = styled.span`
-	display: flex;
-	gap: 4px;
-
-	${ hasCheckoutVersion2
-		? `margin-left: 0px;
+const LineItemPriceWrapper = styled.span< {
+	theme?: Theme;
+	isSummary?: boolean;
+	shouldUseCheckoutV2?: boolean;
+} >`
+	${ ( shouldUseCheckoutV2 ) =>
+		hasCheckoutVersion2 || shouldUseCheckoutV2
+			? `margin-left: 0px;
 		   font-size: 14px;
 		   grid-area: price;
 		   justify-self: flex-end;`
-		: `
+			: `
 		margin-left: 12px;
 		font-size: inherit;` }
 	.rtl & {
@@ -232,35 +242,39 @@ const BillingInterval = styled.div< { theme?: Theme } >`
 	align-content: flex-start;
 `;
 
-const DeleteButtonWrapper = styled.div`
+const DeleteButtonWrapper = styled.div< { shouldUseCheckoutV2?: boolean } >`
 	width: 100%;
 
-	${ hasCheckoutVersion2
-		? `
+	${ ( shouldUseCheckoutV2 ) =>
+		hasCheckoutVersion2 || shouldUseCheckoutV2
+			? `
 	grid-area: remove;
 	display: grid;
 	align-items: center;
 	justify-content: end;
 	`
-		: `display: inherit };
+			: `display: inherit };
 	justify-content: 'inherit' }` };
 `;
 
-const DeleteButton = styled( Button )< { theme?: Theme } >`
+const DeleteButton = styled( Button )< { theme?: Theme; shouldUseCheckoutV2?: boolean } >`
 	width: auto;
-	${ hasCheckoutVersion2 ? `font-size:  12px;` : `font-size: 0.75rem` };
+	${ ( shouldUseCheckoutV2 ) =>
+		hasCheckoutVersion2 || shouldUseCheckoutV2 ? `font-size:  12px;` : `font-size: 0.75rem` };
 	color: ${ ( props ) => props.theme.colors.textColorLight };
 `;
 
 function LineItemPrice( {
 	actualAmount,
 	crossedOutAmount,
+	shouldUseCheckoutV2,
 }: {
 	actualAmount?: string;
 	crossedOutAmount?: string;
+	shouldUseCheckoutV2?: boolean;
 } ) {
 	return (
-		<LineItemPriceWrapper>
+		<LineItemPriceWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 			{ crossedOutAmount && <s>{ crossedOutAmount }</s> }
 			<span>{ actualAmount }</span>
 		</LineItemPriceWrapper>
@@ -275,6 +289,7 @@ function WPNonProductLineItem( {
 	removeProductFromCart,
 	createUserAndSiteBeforeTransaction,
 	isPwpoUser,
+	shouldUseCheckoutV2,
 }: {
 	lineItem: LineItemType;
 	className?: string | null;
@@ -283,6 +298,7 @@ function WPNonProductLineItem( {
 	removeProductFromCart?: () => void;
 	createUserAndSiteBeforeTransaction?: boolean;
 	isPwpoUser?: boolean;
+	shouldUseCheckoutV2?: boolean;
 } ) {
 	const id = lineItem.id;
 	const itemSpanId = `checkout-line-item-${ id }`;
@@ -306,10 +322,15 @@ function WPNonProductLineItem( {
 			data-e2e-product-slug={ lineItem.id }
 			data-product-type={ lineItem.type }
 		>
-			<LineItemTitle id={ itemSpanId } isSummary={ isSummary }>
+			<LineItemTitle
+				id={ itemSpanId }
+				isSummary={ isSummary }
+				shouldUseCheckoutV2={ shouldUseCheckoutV2 }
+			>
 				{ label }
 			</LineItemTitle>
-			{ hasCheckoutVersion2 ? (
+
+			{ hasCheckoutVersion2 || shouldUseCheckoutV2 ? (
 				<LineItemPrice aria-labelledby={ itemSpanId } actualAmount={ actualAmountDisplay } />
 			) : (
 				<span aria-labelledby={ itemSpanId } className="checkout-line-item__price">
@@ -318,7 +339,7 @@ function WPNonProductLineItem( {
 			) }
 			{ hasDeleteButton && removeProductFromCart && (
 				<>
-					<DeleteButtonWrapper>
+					<DeleteButtonWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 						<DeleteButton
 							className="checkout-line-item__remove-product"
 							buttonType="text-button"
@@ -331,8 +352,11 @@ function WPNonProductLineItem( {
 							onClick={ () => {
 								setIsModalVisible( true );
 							} }
+							shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 						>
-							{ hasCheckoutVersion2 ? translate( 'Remove' ) : translate( 'Remove from cart' ) }
+							{ hasCheckoutVersion2 || shouldUseCheckoutV2
+								? translate( 'Remove' )
+								: translate( 'Remove from cart' ) }
 						</DeleteButton>
 					</DeleteButtonWrapper>
 
@@ -395,7 +419,15 @@ function WPCouponLineItem( {
 	);
 }
 
-function EmailMeta( { product, isRenewal }: { product: ResponseCartProduct; isRenewal: boolean } ) {
+function EmailMeta( {
+	product,
+	isRenewal,
+	shouldUseCheckoutV2,
+}: {
+	product: ResponseCartProduct;
+	isRenewal: boolean;
+	shouldUseCheckoutV2?: boolean;
+} ) {
 	const translate = useTranslate();
 
 	if ( isRenewal ) {
@@ -414,7 +446,7 @@ function EmailMeta( { product, isRenewal }: { product: ResponseCartProduct; isRe
 		}
 
 		return (
-			<LineItemMeta>
+			<LineItemMeta shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 				{ translate(
 					'%(numberOfMailboxes)d mailbox for %(domainName)s',
 					'%(numberOfMailboxes)d mailboxes for %(domainName)s',
@@ -447,7 +479,7 @@ function EmailMeta( { product, isRenewal }: { product: ResponseCartProduct; isRe
 		<>
 			{ mailboxes.map( ( mailbox, index ) => {
 				return (
-					<LineItemMeta key={ mailbox.email }>
+					<LineItemMeta key={ mailbox.email } shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 						<div key={ mailbox.email }>{ mailbox.email }</div>
 
 						{ index === 0 && <GSuiteDiscountCallout product={ product } /> }
@@ -666,7 +698,13 @@ function JetpackSearchMeta( { product }: { product: ResponseCartProduct } ) {
 	return <ProductTier product={ product } />;
 }
 
-function ProductTier( { product }: { product: ResponseCartProduct } ) {
+function ProductTier( {
+	product,
+	shouldUseCheckoutV2,
+}: {
+	product: ResponseCartProduct;
+	shouldUseCheckoutV2?: boolean;
+} ) {
 	const translate = useTranslate();
 	if ( isJetpackSearch( product ) && product.price_tier_transform_quantity_divide_by ) {
 		const currentQuantity = product.current_quantity || 1;
@@ -679,7 +717,7 @@ function ProductTier( { product }: { product: ResponseCartProduct } ) {
 		const purchaseQuantityDividedByThousand =
 			( units_used * product.price_tier_transform_quantity_divide_by ) / 1000;
 		return (
-			<LineItemMeta>
+			<LineItemMeta shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 				{ translate(
 					'Up to %(purchaseQuantityDividedByThousand)sk records and/or requests per month',
 					{ args: { purchaseQuantityDividedByThousand } }
@@ -1168,12 +1206,21 @@ function JetpackAkismetSaleCouponCallout( { product }: { product: ResponseCartPr
 	return <DiscountCallout>{ discountText }</DiscountCallout>;
 }
 
-function PartnerLogo( { className }: { className?: string } ) {
+function PartnerLogo( {
+	className,
+	shouldUseCheckoutV2,
+}: {
+	className?: string;
+	shouldUseCheckoutV2?: boolean;
+} ) {
 	const translate = useTranslate();
 
 	/* eslint-disable wpcalypso/jsx-classname-namespace */
 	return (
-		<LineItemMeta className={ joinClasses( [ className, 'jetpack-partner-logo' ] ) }>
+		<LineItemMeta
+			className={ joinClasses( [ className, 'jetpack-partner-logo' ] ) }
+			shouldUseCheckoutV2={ shouldUseCheckoutV2 }
+		>
 			<div>{ translate( 'Included in your IONOS plan' ) }</div>
 			<div className="checkout-line-item__partner-logo-image">
 				<IonosLogo />
@@ -1237,7 +1284,6 @@ const DesktopGiftWrapper = styled.div`
 `;
 
 function CheckoutLineItem( {
-	children,
 	product,
 	className,
 	hasDeleteButton,
@@ -1251,6 +1297,7 @@ function CheckoutLineItem( {
 	onRemoveProductCancel,
 	isAkPro500Cart,
 	shouldShowBillingInterval,
+	shouldUseCheckoutV2,
 }: PropsWithChildren< {
 	product: ResponseCartProduct;
 	className?: string;
@@ -1265,6 +1312,9 @@ function CheckoutLineItem( {
 	onRemoveProductCancel?: ( label: string ) => void;
 	isAkPro500Cart?: boolean;
 	shouldShowBillingInterval?: boolean;
+	areThereVariants?: boolean;
+	shouldShowVariantSelector?: boolean;
+	shouldUseCheckoutV2?: boolean;
 } > ) {
 	const id = product.uuid;
 	const translate = useTranslate();
@@ -1355,15 +1405,21 @@ function CheckoutLineItem( {
 					<GiftBadgeWithText />
 				</MobileGiftWrapper>
 			) }
-			<LineItemTitle id={ itemSpanId } isSummary={ isSummary }>
-				{ hasCheckoutVersion2 && isRenewal ? `${ label } Renewal` : label }
+			<LineItemTitle
+				id={ itemSpanId }
+				isSummary={ isSummary }
+				shouldUseCheckoutV2={ shouldUseCheckoutV2 }
+			>
+				{ ( hasCheckoutVersion2 || shouldUseCheckoutV2 ) && isRenewal
+					? `${ label } Renewal`
+					: label }
 				{ responseCart.is_gift_purchase && (
 					<DesktopGiftWrapper>
 						<GiftBadgeWithText />
 					</DesktopGiftWrapper>
 				) }
 			</LineItemTitle>
-			{ hasCheckoutVersion2 ? (
+			{ hasCheckoutVersion2 || shouldUseCheckoutV2 ? (
 				<LineItemPrice
 					actualAmount={
 						isIntroductoryOfferWithDifferentLength
@@ -1393,14 +1449,14 @@ function CheckoutLineItem( {
 
 			{ ! containsPartnerCoupon && (
 				<>
-					{ hasCheckoutVersion2 ? (
+					{ hasCheckoutVersion2 || shouldUseCheckoutV2 ? (
 						<>
 							{ shouldShowBillingInterval && (
 								<BillingInterval>
 									<LineItemBillingIntervalWrapper product={ product } />
 								</BillingInterval>
 							) }
-							<LineItemMeta>
+							<LineItemMeta shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 								<LineItemMetaInfoWrapper product={ product } />
 								{ isJetpackSearch( product ) && <JetpackSearchMeta product={ product } /> }
 								{ isEmail && <EmailMeta product={ product } isRenewal={ isRenewal } /> }
@@ -1408,10 +1464,10 @@ function CheckoutLineItem( {
 						</>
 					) : (
 						<>
-							<UpgradeCreditInformationLineItem>
+							<UpgradeCreditInformationLineItem shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 								<UpgradeCreditInformation product={ product } />
 							</UpgradeCreditInformationLineItem>
-							<LineItemMeta>
+							<LineItemMeta shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 								<LineItemSublabelAndPrice product={ product } />
 								<DomainDiscountCallout product={ product } />
 								<IntroductoryOfferCallout product={ product } />
@@ -1423,8 +1479,8 @@ function CheckoutLineItem( {
 			) }
 
 			{ containsPartnerCoupon && (
-				<LineItemMeta>
-					{ hasCheckoutVersion2 ? (
+				<LineItemMeta shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
+					{ hasCheckoutVersion2 || shouldUseCheckoutV2 ? (
 						<LineItemBillingInterval product={ product } />
 					) : (
 						<LineItemSublabelAndPrice product={ product } />
@@ -1432,19 +1488,17 @@ function CheckoutLineItem( {
 				</LineItemMeta>
 			) }
 
-			{ ! hasCheckoutVersion2 && isJetpackSearch( product ) && (
+			{ ! ( hasCheckoutVersion2 || shouldUseCheckoutV2 ) && isJetpackSearch( product ) && (
 				<JetpackSearchMeta product={ product } />
 			) }
 
-			{ ! hasCheckoutVersion2 && isEmail && (
+			{ ! ( hasCheckoutVersion2 || shouldUseCheckoutV2 ) && isEmail && (
 				<EmailMeta product={ product } isRenewal={ isRenewal } />
 			) }
 
-			{ children }
-
 			{ hasDeleteButton && removeProductFromCart && (
 				<>
-					<DeleteButtonWrapper>
+					<DeleteButtonWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 						<DeleteButton
 							className="checkout-line-item__remove-product"
 							buttonType="text-button"
@@ -1458,8 +1512,11 @@ function CheckoutLineItem( {
 								setIsModalVisible( true );
 								onRemoveProductClick?.( label );
 							} }
+							shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 						>
-							{ hasCheckoutVersion2 ? translate( 'Remove' ) : translate( 'Remove from cart' ) }
+							{ hasCheckoutVersion2 || shouldUseCheckoutV2
+								? translate( 'Remove' )
+								: translate( 'Remove from cart' ) }
 						</DeleteButton>
 					</DeleteButtonWrapper>
 

--- a/packages/wpcom-checkout/src/field.tsx
+++ b/packages/wpcom-checkout/src/field.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@automattic/composite-checkout';
 import styled from '@emotion/styled';
-import { hasCheckoutVersion } from './checkout-version-checker';
 import type { ReactNode } from 'react';
 
 // Disabling this to make migrating files easier
@@ -116,8 +115,7 @@ const Input = styled.input< {
 	padding: 7px ${ ( props ) => ( props.icon ? '60px' : '10px' ) } 7px 10px;
 	line-height: 1.5;
 
-	${ ( shouldUseCheckoutV2 ) =>
-		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ? `font-size: 14px;` : `font-size: 16px;` }
+	${ ( props ) => ( props.shouldUseCheckoutV2 ? `font-size: 14px;` : `font-size: 16px;` ) }
 
 	.rtl & {
 		padding: 7px 10px 7px ${ ( props ) => ( props.icon ? '60px' : '10px' ) };

--- a/packages/wpcom-checkout/src/field.tsx
+++ b/packages/wpcom-checkout/src/field.tsx
@@ -23,6 +23,7 @@ export default function Field( {
 	errorMessage,
 	autoComplete,
 	disabled,
+	shouldUseCheckoutV2,
 }: {
 	type?: string;
 	id: string;
@@ -41,6 +42,7 @@ export default function Field( {
 	errorMessage?: ReactNode;
 	autoComplete?: string;
 	disabled?: boolean;
+	shouldUseCheckoutV2?: boolean;
 } ) {
 	const fieldOnChange = ( event: { target: { value: string } } ) => {
 		if ( onChange ) {
@@ -76,6 +78,7 @@ export default function Field( {
 					isError={ isError }
 					autoComplete={ autoComplete }
 					disabled={ disabled }
+					shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 				/>
 				<RenderedIcon icon={ icon } iconAction={ iconAction } isIconVisible={ isIconVisible } />
 			</InputWrapper>
@@ -100,7 +103,11 @@ const Label = styled.label< { disabled?: boolean } >`
 	}
 `;
 
-const Input = styled.input< { isError?: boolean; icon?: ReactNode } >`
+const Input = styled.input< {
+	isError?: boolean;
+	icon?: ReactNode;
+	shouldUseCheckoutV2?: boolean;
+} >`
 	display: block;
 	width: 100%;
 	box-sizing: border-box;
@@ -109,7 +116,8 @@ const Input = styled.input< { isError?: boolean; icon?: ReactNode } >`
 	padding: 7px ${ ( props ) => ( props.icon ? '60px' : '10px' ) } 7px 10px;
 	line-height: 1.5;
 
-	${ hasCheckoutVersion( '2' ) ? `font-size: 14px;` : `font-size: 16px;` }
+	${ ( shouldUseCheckoutV2 ) =>
+		hasCheckoutVersion( '2' ) || shouldUseCheckoutV2 ? `font-size: 14px;` : `font-size: 16px;` }
 
 	.rtl & {
 		padding: 7px 10px 7px ${ ( props ) => ( props.icon ? '60px' : '10px' ) };


### PR DESCRIPTION
This PR adds the `useCheckoutV2()` hook to return a string based on the state the checkout experiment is in - either 'loading', 'treatment', or 'control'.

Additionally, this code allows you to see the checkout v2 treatment without the feature flag. You can assign yourself to the treatment by following these steps: PCYsg-SwK-p2 (scroll down to 'Manually assign with Abacus assignment bookmarklet').

Related to pbOQVh-45k-p2 

## Testing Instructions

* Go to Checkout and ensure the v1 version looks correct - look for any style or functionality bleed
* Assign yourself to the treatment group according to the instructions in the link above
* Go to Checkout again and make sure the v2 styles and functionality match those found under the checkout v2 feature flag
* Test a number of products and use cases to ensure that styling remains the same between the feature flagged v2 and the non-flagged 'treatment' v2