### PR TITLE
Jetpack Manage: Preview Pane - Left Sidebar

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Button } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -41,7 +41,10 @@ export default function SiteTopHeaderButtons() {
 				disabled={ ! partnerCanIssueLicense }
 				onClick={ onIssueNewLicenseClick }
 			>
-				{ translate( 'Issue License', { context: 'button label' } ) }
+				<span className="sites-overview__issue-license-button-caption">
+					{ translate( 'Issue License', { context: 'button label' } ) }
+				</span>
+				<Gridicon icon="plus-small" size={ 12 } />
 			</Button>
 
 			{ isWPCOMAtomicSiteCreationEnabled ? (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.scss
@@ -23,4 +23,128 @@
 	.sites-dataviews__favorite-btn-wrapper .site-set-favorite__favorite-icon {
 		visibility: visible;
 	}
+
+	.sites-dashboard__layout {
+		.sites-overview__issue-license-button-caption {
+			display: block;
+		}
+		.sites-overview__issue-license-button-short-caption {
+			display: none;
+		}
+	}
+
+	.sites-dashboard__layout:not(.preview-hidden) {
+
+		.sites-overview {
+			padding: 16px 24px;
+			overflow: hidden;
+		}
+
+		.sites-overview__content {
+			padding: 0;
+		}
+
+		.sites-overview__issue-license-button-caption {
+			display: none;
+		}
+
+		.sites-overview__issue-license-button-short-caption {
+			display: block;
+			height: 28px;
+			width: 28px;
+		}
+
+		.sites-overview__page-subtitle {
+			display: none;
+		}
+
+		.sites-overview__tabs,
+		.dataviews-filters__view-actions {
+			border-bottom: 1px solid var(--studio-gray-5);
+		}
+
+		.dataviews-filters__view-actions {
+			padding: 16px 24px;
+			margin: 0;
+			display: flex;
+
+			.components-h-stack {
+				width: unset;
+			}
+
+			.components-h-stack,
+			.components-button {
+				flex-grow: 1;
+			}
+
+		}
+
+		.sites-overview__tabs {
+			padding: 0 24px;
+		}
+
+		.split-button__main,
+		.split-button__toggle {
+			height: 28px;
+			line-height: 11px;
+			font-size: rem(12px);
+		}
+
+		.split-button .button .gridicon {
+			top: 0;
+			width: 16px;
+			height: 16px;
+		}
+
+		.sites-overview__page-title {
+			font-size: rem(20px);
+			font-weight: 500;
+		}
+
+		.sites-overview__issue-license-button {
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			height: 28px;
+			width: 28px;
+
+			.gridicon {
+				flex-shrink: 0;
+				width: 20px;
+				height: 20px;
+				top: 0;
+				margin-top: 0;
+			}
+		}
+
+		ul.dataviews-view-list {
+			list-style: none;
+			margin: 0;
+			padding: 0;
+
+			li {
+				padding: 16px 24px;
+				border-bottom: 1px solid var(--studio-gray-5);
+			}
+
+			.dataviews-view-list__fields {
+				display: flex;
+				justify-content: space-between;
+			}
+
+			.components-h-stack,
+			.dataviews-view-list__item {
+				width: 100%;
+			}
+
+			.sites-overview__stats-trend,
+			.sites-overview__column-action-button,
+			.sites-overview__row-status,
+			.toggle-activate-monitoring__toggle-button,
+			.sites-dataviews__favorite-btn-wrapper {
+				display: none;
+			}
+
+		}
+	}
 }


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/290

## Proposed Changes

* This PR makes the left side bar look as intended by the design team when the site is in preview mode of the new Site dashboard (SitesV2).

## Testing Instructions

NOTES:
- Mobile version will be addressed in a later PR, since the whole page is not mobile friendly. Trying to make the sidebar alone look mobile friendly would require changes in all components.
- The number of items that need attention was not added because we do not have that information available yet.
- Instead of a vertical ellipsis for the site actions this PR uses a normal ellipsis icon.
- We do not have pagination yet.

* Go to the new sites dashboard ( `http://jetpack.cloud.localhost:3000/sites` )
* Click over a site to open its preview
* Check if the sidebar's design is looking as intended


![image](https://github.com/Automattic/wp-calypso/assets/37049295/562e4ac1-fc70-4ba4-b212-0386d35bb468)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?