### PR TITLE
Expect an ISO 8601 timestamp from the api instead of a unix timestamp

### DIFF
--- a/client/my-sites/github-deployments/deployment-run-logs/deployments-run-item.tsx
+++ b/client/my-sites/github-deployments/deployment-run-logs/deployments-run-item.tsx
@@ -50,7 +50,7 @@ export const DeploymentsRunItem = ( { run }: DeploymentsListItemProps ) => {
 					<DeploymentStatus status={ run.status as DeploymentStatusValue } />
 				</td>
 				<td>
-					<span>{ formatDate( locale, new Date( deployment.updated_on * 1000 ) ) }</span>
+					<span>{ formatDate( locale, new Date( deployment.updated_on ) ) }</span>
 				</td>
 				<td>
 					<DeploymentDuration run={ run } />

--- a/client/my-sites/github-deployments/deployment-run-logs/use-code-deployment-run-query.ts
+++ b/client/my-sites/github-deployments/deployment-run-logs/use-code-deployment-run-query.ts
@@ -19,9 +19,9 @@ export type DeploymentRunStatus =
 export interface DeploymentRun {
 	id: number;
 	code_deployment_id: number;
-	created_on: number;
-	started_on: number;
-	completed_on: number;
+	created_on: string;
+	started_on: string;
+	completed_on: string;
 	status: DeploymentRunStatus;
 	failure_code: string;
 	triggered_by_user_id: number;

--- a/client/my-sites/github-deployments/deployments/deployment-duration.tsx
+++ b/client/my-sites/github-deployments/deployments/deployment-duration.tsx
@@ -6,23 +6,19 @@ import {
 } from '../deployment-run-logs/use-code-deployment-run-query';
 
 function formatDuration( run: DeploymentRun ) {
-	const completedOn = run.completed_on
-		? new Date( run.completed_on * 1000 ).valueOf()
-		: new Date().valueOf();
-
-	const milliseconds = completedOn - new Date( run.started_on * 1000 ).valueOf();
-
-	const totalSeconds = milliseconds / 1000;
-	const minutes = Math.floor( totalSeconds / 60 );
-	const seconds = Math.ceil( totalSeconds % 60 );
-
-	if ( minutes > 0 ) {
-		if ( seconds > 0 ) {
-			return `${ minutes }m ${ seconds }s`;
-		}
-		return `${ minutes }m`;
+	// If deployment has not yet started, we don't have a date to calculate the duration from.
+	if ( ! run.started_on ) {
+		return '-';
 	}
-	return `${ seconds }s`;
+	const startedOn = new Date( run.started_on ).valueOf();
+	const completedOn = run.completed_on
+		? new Date( run.completed_on ).valueOf()
+		: new Date().valueOf();
+	const totalSeconds = Math.ceil( ( completedOn - startedOn ) / 1000 );
+	const minutes = Math.floor( totalSeconds / 60 );
+	const seconds = totalSeconds % 60;
+
+	return `${ minutes > 0 ? `${ minutes }m ` : '' }${ seconds }s`;
 }
 
 interface DeploymentDurationProps {

--- a/client/my-sites/github-deployments/deployments/deployment-duration.tsx
+++ b/client/my-sites/github-deployments/deployments/deployment-duration.tsx
@@ -29,8 +29,8 @@ const IDLE_STATUSES: DeploymentRunStatus[] = [ 'dispatched', 'queued', 'building
 
 export const DeploymentDuration = ( { run }: DeploymentDurationProps ) => {
 	const [ , setState ] = useState( 0 );
-
-	useInterval( () => setState( ( i ) => i + 1 ), 1000 );
+	const isRunCompleted = run.completed_on !== null;
+	useInterval( () => setState( ( i ) => i + 1 ), isRunCompleted ? null : 1000 );
 
 	if ( IDLE_STATUSES.includes( run.status ) ) {
 		return '0s';

--- a/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
+++ b/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
@@ -89,7 +89,7 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 			<td>{ run && <DeploymentCommitDetails run={ run } deployment={ deployment } /> }</td>
 			<td>{ run && <DeploymentStatus status={ run.status as DeploymentStatusValue } /> }</td>
 			<td>
-				<span>{ formatDate( locale, new Date( run.created_on * 1000 ) ) }</span>
+				<span>{ formatDate( locale, new Date( run.created_on ) ) }</span>
 			</td>
 			<td>{ run && <DeploymentDuration run={ run } /> }</td>
 		</>

--- a/client/my-sites/github-deployments/deployments/deployments-list.tsx
+++ b/client/my-sites/github-deployments/deployments/deployments-list.tsx
@@ -25,11 +25,11 @@ function applySort( deployments: CodeDeploymentData[], key: string, direction: S
 		case 'date':
 			if ( direction === 'asc' ) {
 				return deployments.sort( ( left, right ) => {
-					return left.updated_on - right.updated_on;
+					return left.updated_on.localeCompare( right.updated_on );
 				} );
 			}
 			return deployments.sort( ( left, right ) => {
-				return right.updated_on - left.updated_on;
+				return left.updated_on.localeCompare( right.updated_on ) * -1;
 			} );
 
 		case 'status':

--- a/client/my-sites/github-deployments/deployments/use-code-deployments-query.ts
+++ b/client/my-sites/github-deployments/deployments/use-code-deployments-query.ts
@@ -9,8 +9,8 @@ export interface CodeDeploymentData {
 	id: number;
 	blog_id: number;
 	created_by_user_id: number;
-	created_on: number;
-	updated_on: number;
+	created_on: string;
+	updated_on: string;
 	external_repository_id: number;
 	repository_name: string;
 	branch_name: string;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to D139444-code

This diff changes the logic of the date handling to expect an ISO 8601 formatted date from the code deployment endpoints.

With that, there is no need to do the * 1000 multiplication when using the dates returned by the API. The related diff will ensure that the date are returned in ISO 8601.

There was also a bug with the formatDuration function that does not account for the scenario where the `started_on` field is empty. While this should not happen, if it does, it will show that my deployment was already running for tens of thousands of minutes.

Finally, I also added a condition to stop updating the duration when completed_on is set. This means the run has a completed and the duration will not change anymore, so no need to keep running an interval to rerender the component.

## Proposed Changes

* Dates are a string.
* Remove the multiplication of dates.
* Simplify and improve the formatDuration function to handle empty `started_on`.
* Stop the rerender interval for the duration component when run is completed.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the code deployments page and check that the dates are displayed correctly and that for deployment runs, the duration is calculated correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?