### PR TITLE
Untangle: Hide menus that are not available on staging sites

### DIFF
--- a/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
+++ b/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
@@ -8,11 +8,13 @@ export default function globalSiteSidebarMenu( {
 	showSiteMonitoring,
 	siteDomain,
 	selectedSiteSlug,
+	isStagingSite,
 }: {
 	shouldShowAddOns: boolean;
 	showSiteMonitoring: boolean;
 	siteDomain: string;
 	selectedSiteSlug: string;
+	isStagingSite: boolean;
 } ) {
 	return [
 		{
@@ -43,35 +45,36 @@ export default function globalSiteSidebarMenu( {
 			title: translate( 'Plans' ),
 			type: 'menu-item',
 			url: `/plans/${ siteDomain }`,
+			shouldHide: isStagingSite,
 		},
-		...( shouldShowAddOns
-			? [
-					{
-						slug: 'Add-Ons',
-						title: translate( 'Add-Ons' ),
-						type: 'menu-item',
-						url: `/add-ons/${ siteDomain }`,
-					},
-			  ]
-			: [] ),
+		{
+			slug: 'Add-Ons',
+			title: translate( 'Add-Ons' ),
+			type: 'menu-item',
+			url: `/add-ons/${ siteDomain }`,
+			shouldHide: ! shouldShowAddOns,
+		},
 		{
 			slug: 'domains',
 			title: translate( 'Domains' ),
 			navigationLabel: translate( 'Manage all domains' ),
 			type: 'menu-item',
 			url: `/domains/manage/${ siteDomain }`,
+			shouldHide: isStagingSite,
 		},
 		{
 			slug: 'Emails',
 			title: translate( 'Emails' ),
 			type: 'menu-item',
 			url: `/email/${ siteDomain }`,
+			shouldHide: isStagingSite,
 		},
 		{
 			slug: 'Purchases',
 			title: translate( 'Purchases' ),
 			type: 'menu-item',
 			url: `/purchases/subscriptions/${ siteDomain }`,
+			shouldHide: isStagingSite,
 		},
 		{
 			slug: 'options-hosting-configuration-php',
@@ -79,16 +82,13 @@ export default function globalSiteSidebarMenu( {
 			type: 'menu-item',
 			url: `/hosting-config/${ siteDomain }`,
 		},
-		...( showSiteMonitoring
-			? [
-					{
-						slug: 'tools-site-monitoring',
-						title: translate( 'Monitoring' ),
-						type: 'menu-item',
-						url: `/site-monitoring/${ siteDomain }`,
-					},
-			  ]
-			: [] ),
+		{
+			slug: 'tools-site-monitoring',
+			title: translate( 'Monitoring' ),
+			type: 'menu-item',
+			url: `/site-monitoring/${ siteDomain }`,
+			shouldHide: ! showSiteMonitoring,
+		},
 		{
 			slug: 'tools-earn',
 			title: translate( 'Monetize' ),
@@ -113,5 +113,5 @@ export default function globalSiteSidebarMenu( {
 			type: 'menu-item',
 			url: `/settings/general/${ siteDomain }`,
 		},
-	];
+	].filter( ( { shouldHide } ) => ! shouldHide );
 }

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -16,6 +16,7 @@ import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isAtomicSite from 'calypso/state/selectors/is-site-automated-transfer';
+import isSiteWpcomStaging from 'calypso/state/selectors/is-site-wpcom-staging';
 import isSiteWPForTeams from 'calypso/state/selectors/is-site-wpforteams';
 import { getSiteDomain, isJetpackSite } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
@@ -36,6 +37,7 @@ const useSiteMenuItems = () => {
 	const menuItems = useSelector( ( state ) => getAdminMenu( state, selectedSiteId ) );
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, selectedSiteId ) );
 	const isAtomic = useSelector( ( state ) => isAtomicSite( state, selectedSiteId ) );
+	const isStagingSite = useSelector( ( state ) => isSiteWpcomStaging( state, selectedSiteId ) );
 	const locale = useLocale();
 	const isAllDomainsView = '/domains/manage' === currentRoute;
 	const { currentSection } = useCurrentRoute();
@@ -122,6 +124,7 @@ const useSiteMenuItems = () => {
 			shouldShowAddOns: shouldShowAddOnsInFallbackMenu,
 			showSiteMonitoring: isAtomic,
 			selectedSiteSlug,
+			isStagingSite,
 		} );
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5722

## Proposed Changes

* Hide the following menus on staging sites
  * Plans
  * Domains
  * Emails
  * Purchases

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/32fbaa89-e5c1-4d4c-836f-fb776d9301b8) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/0aaa1ea9-9050-4261-9dd1-58b7b92faabf) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to your staging site that is using wp-admin interface
* Make sure you won't see the following items on the global site sidebar
  * Plans
  * Domains
  * Emails
  * Purchases

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?