### PR TITLE
A4A: Update layout styling to match the Atelier design.

### DIFF
--- a/client/a8c-for-agencies/components/a4a-logo/index.tsx
+++ b/client/a8c-for-agencies/components/a4a-logo/index.tsx
@@ -1,7 +1,8 @@
 import classNames from 'classnames';
 
-const LOGO_COLOR_PRIMARY = '#029CD7';
-const LOGO_COLOR_SECONDARY = '#021A23';
+export const LOGO_COLOR_PRIMARY = '#029CD7';
+export const LOGO_COLOR_SECONDARY = '#021A23';
+export const LOGO_COLOR_SECONDARY_ALT = '#fff';
 
 interface A4ALogoProps {
 	full?: boolean;

--- a/client/a8c-for-agencies/components/layout/nav.tsx
+++ b/client/a8c-for-agencies/components/layout/nav.tsx
@@ -57,18 +57,20 @@ export default function LayoutNavigation( {
 	children,
 }: LayoutNavigationProps ) {
 	return (
-		<SectionNav
-			className={ classNames( 'a4a-layout__navigation', className ) }
-			applyUpdatedStyles
-			selectedText={
-				<span>
-					{ selectedText }
-					{ Number.isInteger( selectedCount ) && <Count count={ selectedCount } compact /> }
-				</span>
-			}
-			selectedCount={ selectedCount }
-		>
-			{ children }
-		</SectionNav>
+		<div className="a4a-layout__navigation-wrapper">
+			<SectionNav
+				className={ classNames( 'a4a-layout__navigation', className ) }
+				applyUpdatedStyles
+				selectedText={
+					<span>
+						{ selectedText }
+						{ Number.isInteger( selectedCount ) && <Count count={ selectedCount } compact /> }
+					</span>
+				}
+				selectedCount={ selectedCount }
+			>
+				{ children }
+			</SectionNav>
+		</div>
 	);
 }

--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -196,8 +196,9 @@
 		z-index: 23;
 	}
 
-	@include breakpoint-deprecated( ">960px" ) {
+	@include breakpoint-deprecated( ">1040px" ) {
 		margin-block-start: 32px;
+		margin-inline: -16px;
 	}
 }
 

--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -2,6 +2,11 @@
 @import "@wordpress/base-styles/mixins";
 
 .main.a4a-layout {
+	background: var(--color-surface);
+	margin: 0;
+	padding-block-start: 48px;
+	border-radius: 8px; /* stylelint-disable-line scales/radii */
+
 	header.current-section {
 		button {
 			padding: 20px 8px;
@@ -20,15 +25,7 @@
 
 .a4a-layout__body {
 	width: 100%;
-	margin-block-end: -32px;
 	flex: 1 1 100%;
-
-	@include breakpoint-deprecated( ">660px" ) {
-		// We need these negative margin values because we want to make the container full-width,
-		// but our element is inside a limited-width parent.
-		margin-inline-start: -73px;
-		padding-inline: 73px;
-	}
 }
 
 .a4a-layout__top-wrapper,
@@ -38,18 +35,17 @@
 	> * {
 		max-width: 1500px;
 		margin-inline: auto !important;
+		padding-inline: 64px;
 	}
 }
-
 .main.a4a-layout.is-with-border {
 	@include breakpoint-deprecated( ">660px" ) {
-		.a4a-layout__top {
-			border-block-end: 1px solid var(--color-primary-5);
+		.a4a-layout__top-wrapper {
+			border-block-end: 1px solid var(--color-neutral-5);
 		}
 
 		.a4a-layout__body {
-			background: rgba(255, 255, 255, 0.5);
-			padding-block: 16px;
+			padding-block-start: 16px;
 		}
 	}
 }

--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -26,10 +26,11 @@
 .a4a-layout__body {
 	width: 100%;
 	flex: 1 1 100%;
+	padding-block-start: 16px;
 }
 
 .a4a-layout__top-wrapper,
-.a4a-layout__body-wrapper {
+.a4a-layout__body {
 	margin-inline: 0;
 
 	> * {
@@ -38,14 +39,11 @@
 		padding-inline: 64px;
 	}
 }
+
 .main.a4a-layout.is-with-border {
 	@include breakpoint-deprecated( ">660px" ) {
 		.a4a-layout__top-wrapper {
 			border-block-end: 1px solid var(--color-neutral-5);
-		}
-
-		.a4a-layout__body {
-			padding-block-start: 16px;
 		}
 	}
 }

--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -16,7 +16,7 @@
 
 .a4a-layout__container {
 	max-width: 100%;
-	min-height: calc(100vh - 123px);
+	min-height: calc(100vh - 80px);
 	display: flex;
 	flex-direction: column;
 	margin: auto;
@@ -34,9 +34,13 @@
 	margin-inline: 0;
 
 	> * {
-		max-width: 1500px;
-		margin-inline: auto !important;
-		padding-inline: 64px;
+		padding-inline: 16px;
+
+		@include breakpoint-deprecated( ">660px" ) {
+			max-width: 1500px;
+			margin-inline: auto !important;
+			padding-inline: 64px;
+		}
 	}
 }
 

--- a/client/a8c-for-agencies/components/sidebar/header/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/index.tsx
@@ -9,7 +9,7 @@ import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import { AppState } from 'calypso/types';
-import A4ALogo from '../../a4a-logo';
+import A4ALogo, { LOGO_COLOR_PRIMARY, LOGO_COLOR_SECONDARY_ALT } from '../../a4a-logo';
 import ProfileDropdown from './profile-dropdown';
 
 type Props = {
@@ -17,7 +17,13 @@ type Props = {
 	simple?: boolean;
 };
 
-const AllSitesIcon = () => <A4ALogo className="a4a-sidebar__all-sites-icon" size={ 32 } />;
+const AllSitesIcon = () => (
+	<A4ALogo
+		className="a4a-sidebar__all-sites-icon"
+		colors={ { primary: LOGO_COLOR_PRIMARY, secondary: LOGO_COLOR_SECONDARY_ALT } }
+		size={ 32 }
+	/>
+);
 
 // NOTE: This hook is a little hacky, to get around the "outside click"
 // close behavior that happens inside `<SiteSelector />`. Instead of

--- a/client/a8c-for-agencies/components/sidebar/header/index.tsx
+++ b/client/a8c-for-agencies/components/sidebar/header/index.tsx
@@ -9,7 +9,7 @@ import { setLayoutFocus } from 'calypso/state/ui/layout-focus/actions';
 import { getCurrentLayoutFocus } from 'calypso/state/ui/layout-focus/selectors';
 import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import { AppState } from 'calypso/types';
-import A4ALogo, { LOGO_COLOR_PRIMARY, LOGO_COLOR_SECONDARY_ALT } from '../../a4a-logo';
+import A4ALogo, { LOGO_COLOR_SECONDARY_ALT } from '../../a4a-logo';
 import ProfileDropdown from './profile-dropdown';
 
 type Props = {
@@ -20,7 +20,7 @@ type Props = {
 const AllSitesIcon = () => (
 	<A4ALogo
 		className="a4a-sidebar__all-sites-icon"
-		colors={ { primary: LOGO_COLOR_PRIMARY, secondary: LOGO_COLOR_SECONDARY_ALT } }
+		colors={ { secondary: LOGO_COLOR_SECONDARY_ALT } }
 		size={ 32 }
 	/>
 );

--- a/client/a8c-for-agencies/components/sidebar/header/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/header/style.scss
@@ -25,6 +25,7 @@
 	justify-content: center;
 	align-items: flex-start;
 	gap: 4px;
+	color: var(--color-sidebar-text);
 
 }
 
@@ -78,7 +79,7 @@ html.accessible-focus .a4a-sidebar__profile-dropdown-button:focus {
 
 	&:hover,
 	&:focus {
-		background: var(--color-sidebar-menu-hover-background);
+		background: var(--color-sidebar-text-alternative);
 	}
 
 	a,
@@ -89,7 +90,7 @@ html.accessible-focus .a4a-sidebar__profile-dropdown-button:focus {
 		width: 100%;
 		height: 100%;
 
-		color: var(--color-text);
+		color: var(--color-sidebar-text);
 	}
 
 	.button {
@@ -119,4 +120,8 @@ a.a4a-sidebar__external-link {
 		position: absolute;
 		inset-inline-end: 16px;
 	}
+}
+
+.a4a-sidebar svg.all-sites__title-chevron-icon {
+	fill: var(--color-sidebar-text);
 }

--- a/client/a8c-for-agencies/components/sidebar/style.scss
+++ b/client/a8c-for-agencies/components/sidebar/style.scss
@@ -4,24 +4,8 @@
 // This file is meant to house style rules that all implementations of the base
 // sidebar will implement by default.
 .a4a-sidebar {
-	background-color: var(--color-sidebar-background);
-
 	.a4a-sidebar__site-selector {
 		background-color: var(--color-sidebar-background);
-	}
-
-	.sidebar-v2__menu-item {
-		svg {
-			color: var(--color-sidebar-text);
-		}
-		&.is-active {
-			background: var(--color-sidebar-menu-selected-background);
-			color: var(--color-sidebar-menu-selected-text);
-
-			svg {
-				color: var(--color-sidebar-menu-selected-text);
-			}
-		}
 	}
 
 	.sidebar__menu-icon {

--- a/client/a8c-for-agencies/sections/overview/controller.tsx
+++ b/client/a8c-for-agencies/sections/overview/controller.tsx
@@ -1,10 +1,29 @@
 import { type Callback } from '@automattic/calypso-router';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderSubtitle as Subtitle,
+	LayoutHeaderTitle as Title,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import MainSidebar from '../../components/sidebar-menu/main';
 
 export const overviewContext: Callback = ( context, next ) => {
-	context.header = <div>Header</div>;
 	context.secondary = <MainSidebar path={ context.path } />;
-	context.primary = <div>Overview</div>;
+	context.primary = (
+		<Layout title="Overview" wide sidebarNavigation={ <MobileSidebarNavigation /> }>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>Overview</Title>
+					<Subtitle>Overview of your agency</Subtitle>
+				</LayoutHeader>
+			</LayoutTop>
+			<LayoutBody>
+				<div>test</div>
+			</LayoutBody>
+		</Layout>
+	);
 
 	next();
 };

--- a/client/a8c-for-agencies/sections/plugins/controller.tsx
+++ b/client/a8c-for-agencies/sections/plugins/controller.tsx
@@ -1,10 +1,29 @@
 import { type Callback } from '@automattic/calypso-router';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderSubtitle as Subtitle,
+	LayoutHeaderTitle as Title,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import MainSidebar from '../../components/sidebar-menu/main';
 
 export const pluginsContext: Callback = ( context, next ) => {
-	context.header = <div>Header</div>;
 	context.secondary = <MainSidebar path={ context.path } />;
-	context.primary = <div>plugins</div>;
+	context.primary = (
+		<Layout title="Overview" wide sidebarNavigation={ <MobileSidebarNavigation /> }>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>plugins</Title>
+					<Subtitle>plugins of your agency</Subtitle>
+				</LayoutHeader>
+			</LayoutTop>
+			<LayoutBody>
+				<div>test</div>
+			</LayoutBody>
+		</Layout>
+	);
 
 	next();
 };

--- a/client/a8c-for-agencies/sections/plugins/controller.tsx
+++ b/client/a8c-for-agencies/sections/plugins/controller.tsx
@@ -12,10 +12,10 @@ import MainSidebar from '../../components/sidebar-menu/main';
 export const pluginsContext: Callback = ( context, next ) => {
 	context.secondary = <MainSidebar path={ context.path } />;
 	context.primary = (
-		<Layout title="Overview" wide sidebarNavigation={ <MobileSidebarNavigation /> }>
+		<Layout title="Plugins" wide sidebarNavigation={ <MobileSidebarNavigation /> }>
 			<LayoutTop>
 				<LayoutHeader>
-					<Title>plugins</Title>
+					<Title>Plugins</Title>
 					<Subtitle>plugins of your agency</Subtitle>
 				</LayoutHeader>
 			</LayoutTop>

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -1,18 +1,45 @@
 import { type Callback } from '@automattic/calypso-router';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import SitesSidebar from '../../components/sidebar-menu/sites';
 
 export const sitesContext: Callback = ( context, next ) => {
-	context.header = <div>Header</div>;
 	context.secondary = <SitesSidebar path={ context.path } />;
-	context.primary = <div>sites</div>;
+	context.primary = (
+		<Layout title="Overview" wide sidebarNavigation={ <MobileSidebarNavigation /> }>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>sites</Title>
+				</LayoutHeader>
+			</LayoutTop>
+			<LayoutBody>
+				<div>test</div>
+			</LayoutBody>
+		</Layout>
+	);
 
 	next();
 };
 
 export const sitesFavoriteContext: Callback = ( context, next ) => {
-	context.header = <div>Header</div>;
 	context.secondary = <SitesSidebar path={ context.path } />;
-	context.primary = <div>sites favorite</div>;
+	context.primary = (
+		<Layout title="Overview" wide sidebarNavigation={ <MobileSidebarNavigation /> }>
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>sites favorite</Title>
+				</LayoutHeader>
+			</LayoutTop>
+			<LayoutBody>
+				<div>test</div>
+			</LayoutBody>
+		</Layout>
+	);
 
 	next();
 };

--- a/client/a8c-for-agencies/sections/sites/controller.tsx
+++ b/client/a8c-for-agencies/sections/sites/controller.tsx
@@ -11,10 +11,10 @@ import SitesSidebar from '../../components/sidebar-menu/sites';
 export const sitesContext: Callback = ( context, next ) => {
 	context.secondary = <SitesSidebar path={ context.path } />;
 	context.primary = (
-		<Layout title="Overview" wide sidebarNavigation={ <MobileSidebarNavigation /> }>
+		<Layout title="Sites" wide sidebarNavigation={ <MobileSidebarNavigation /> }>
 			<LayoutTop>
 				<LayoutHeader>
-					<Title>sites</Title>
+					<Title>Sites</Title>
 				</LayoutHeader>
 			</LayoutTop>
 			<LayoutBody>
@@ -29,10 +29,10 @@ export const sitesContext: Callback = ( context, next ) => {
 export const sitesFavoriteContext: Callback = ( context, next ) => {
 	context.secondary = <SitesSidebar path={ context.path } />;
 	context.primary = (
-		<Layout title="Overview" wide sidebarNavigation={ <MobileSidebarNavigation /> }>
+		<Layout title="Sites favorites" wide sidebarNavigation={ <MobileSidebarNavigation /> }>
 			<LayoutTop>
 				<LayoutHeader>
-					<Title>sites favorite</Title>
+					<Title>Sites favorites</Title>
 				</LayoutHeader>
 			</LayoutTop>
 			<LayoutBody>

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -5,6 +5,8 @@
 	--a4a-corners-soft: 4px;
 
 	// FIXME: Remove this when we have a proper color scheme
+	--color-surface-backdrop: #021a23;
+
 	--color-sidebar-background: #021a23;
 	--color-sidebar-menu-hover-background: #02395c;
 	--color-sidebar-menu-hover-text: #fff;
@@ -21,27 +23,22 @@
 	@media only screen and ( min-width: 782px ) {
 		--masterbar-height: 46px;
 	}
-
-	.main {
-		box-sizing: border-box;
-		padding-inline-start: 16px;
-		padding-inline-end: 16px;
-	}
 }
 
 // New navigation will not include a masterbar
 .theme-a8c-for-agencies .layout.has-no-masterbar {
 	--masterbar-height: 0;
 
-	// By default, there's 32px of top padding on the layout component.
-	// On mobile views this accommodates the masterbar, but we don't have one;
-	// so, we can remove it by default and re-add it when our width is >660px.
 	.layout__content {
-		padding-block-start: initial;
+		padding: 16px;
 	}
 
 	@include breakpoint-deprecated( ">660px" ) {
-		padding-block-start: 32px;
+		padding-block-start: 0;
+
+		.layout__content {
+			padding: 16px 16px 16px calc(var(--sidebar-width-max));
+		}
 	}
 }
 
@@ -82,6 +79,10 @@
 			}
 		}
 	}
+}
+
+.theme-a8c-for-agencies .current-section {
+	margin: -32px 0 0;
 }
 
 // Universal Text Styles

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -3,6 +3,17 @@
 	// border-radius
 	--a4a-corners-sharp: 0;
 	--a4a-corners-soft: 4px;
+
+	// FIXME: Remove this when we have a proper color scheme
+	--color-sidebar-background: #021a23;
+	--color-sidebar-menu-hover-background: #02395c;
+	--color-sidebar-menu-hover-text: #fff;
+	--color-sidebar-menu-selected-background: #02395c;
+	--color-sidebar-menu-selected-text: #fff;
+	--color-sidebar-text: #fff;
+	--color-sidebar-text-alternative: #bbe0fa;
+	--color-sidebar-gridicon-fill: #bbe0fa;
+
 }
 
 .theme-a8c-for-agencies {

--- a/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
@@ -48,7 +48,14 @@ export const SidebarNavigatorMenuItem = ( {
 				target={ isExternalLink ? '_blank' : undefined }
 			>
 				<HStack justify="flex-start">
-					{ icon && <Icon style={ { fill: 'currentcolor' } } icon={ icon } size={ ICON_SIZE } /> }
+					{ icon && (
+						<Icon
+							className="sidebar__menu-icon"
+							style={ { fill: 'currentcolor' } }
+							icon={ icon }
+							size={ ICON_SIZE }
+						/>
+					) }
 					<FlexBlock>{ children }</FlexBlock>
 					{ withChevron && <Icon icon={ chevronRightSmall } size={ ICON_SIZE } /> }
 					{ isExternalLink && (

--- a/client/layout/sidebar-v2/navigator/style.scss
+++ b/client/layout/sidebar-v2/navigator/style.scss
@@ -10,7 +10,7 @@
 }
 
 .sidebar-v2__navigator-group-description {
-	color: var(--studio-gray-50);
+	color: var(--color-sidebar-text-alternative);
 	font-size: rem(12px);
 	margin-block-end: 16px;
 	padding: 0 12px;
@@ -25,7 +25,7 @@
 	display: flex;
 	align-items: center;
 	gap: 8px;
-	color: var(--studio-gray-90);
+	color: var(--color-sidebar-text);
 	font-size: rem(16px);
 	font-weight: 600;
 	justify-content: start;
@@ -33,8 +33,7 @@
 }
 
 .sidebar-v2__menu-item.components-item {
-	color: inherit;
-
+	color: var(--color-sidebar-text);
 	font-size: rem(13px);
 }
 
@@ -42,9 +41,14 @@
 .sidebar-v2__menu-item.components-item {
 	border-radius: 4px;
 
-	&:hover:not(.is-active) {
-		background: var(--studio-gray-0);
-		color: initial;
+	&.is-active {
+		background: var(--color-sidebar-menu-selected-background);
+		color: var(--color-sidebar-menu-selected-text);
+	}
+
+	&:hover {
+		background: var(--color-sidebar-menu-hover-background);
+		color: var(--color-sidebar-menu-hover-text);
 	}
 
 	&:focus {
@@ -52,10 +56,21 @@
 	}
 
 	&:focus-visible {
-		box-shadow: 0 0 0 1px var(--studio-gray-10);
+		box-shadow: 0 0 0 1px var(--color-sidebar-text-alternative);
+	}
+}
+
+.sidebar-v2__navigator-sub-menu .components-navigator-back-button svg {
+	color: var(--color-sidebar-text);
+}
+
+.sidebar-v2__menu-item,
+.sidebar-v2__menu-item.is-active, {
+	.sidebar__menu-icon {
+		color: var(--color-sidebar-gridicon-fill);
 	}
 }
 
 .sidebar-v2__external-icon {
-	color: var(--studio-gray-30);
+	color: var(--color-sidebar-text);
 }

--- a/client/layout/sidebar-v2/navigator/style.scss
+++ b/client/layout/sidebar-v2/navigator/style.scss
@@ -21,6 +21,10 @@
 	margin: 0;
 }
 
+.sidebar-v2__navigator-sub-menu ul li:not(:last-child) {
+	margin-block-end: 2px;
+}
+
 .sidebar-v2__navigator-sub-menu-header {
 	display: flex;
 	align-items: center;

--- a/client/layout/sidebar-v2/navigator/style.scss
+++ b/client/layout/sidebar-v2/navigator/style.scss
@@ -21,7 +21,7 @@
 	margin: 0;
 }
 
-.sidebar-v2__navigator-sub-menu ul li:not(:last-child) {
+.sidebar-v2__navigator-sub-menu li:not(:last-child) .sidebar-v2__menu-item {
 	margin-block-end: 2px;
 }
 

--- a/client/layout/sidebar-v2/style.scss
+++ b/client/layout/sidebar-v2/style.scss
@@ -1,15 +1,11 @@
 .sidebar-v2 {
-	// TODO: Existing variables, overridden with values directly from designs;
-	// confirm these colors are correct and refactor as necessary
-	--color-sidebar-menu-hover-background: var(--studio-gray-0);
-	--color-sidebar-background: #fcfcfc;
-
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
 
 	height: 100vh;
 	background-color: var(--color-sidebar-background);
+	color: var(--color-sidebar-text);
 
 	margin: 0;
 	padding: 16px;


### PR DESCRIPTION
This PR updates the current A4A layout component styling to match the Atelier design.

https://github.com/Automattic/wp-calypso/assets/56598660/f77d2504-e854-4fb6-85bb-2a9fc22435b3



## Proposed Changes

* Update the Sidebar V2 component to use color theme properties to allow swappable colors using color scheme-defined colors.
* Update the A4A Layout component to have the correct background color, spacing, and borders that match the Atelier design.
* Update the placeholder page to use the new layout.

## Testing Instructions

* Switch branch: `git checkout update/a4a-layout-colors`
* Start the server by running `yarn start-a8c-for-agencies`.
* Go to http://agencies.localhost:3000/
* Confirm that the layout page matches the design.
* **Please also test if Jetpack cloud's sidebar is not broken with this PR.**

## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?