### PR TITLE
Revert "Temporarily don't install course theme (#87807)"

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/create-sensei-site.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/create-sensei-site.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { useLocale } from '@automattic/i18n-utils';
 import { SENSEI_FLOW, setThemeOnSite } from '@automattic/onboarding';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -99,22 +98,22 @@ export const useCreateSenseiSite = () => {
 		} );
 
 		if ( siteId ) {
-			// await setThemeOnSite( siteId.toString(), COURSE_THEME );
-			// wait( 1200 );
-			// const selectedStyleVariationTitle = getSelectedStyleVariation()?.title;
-			// const [ styleVariations, theme ]: [ StyleVariation[], Theme ] = await Promise.all( [
-			// 	getStyleVariations( siteId, COURSE_THEME ),
-			// 	getSiteTheme( siteId, COURSE_THEME ),
-			// ] );
-			// const userGlobalStylesLink: string =
-			// 	theme?._links?.[ 'wp:user-global-styles' ]?.[ 0 ]?.href || '';
-			// const userGlobalStylesId = parseInt( userGlobalStylesLink.split( '/' ).pop() || '', 10 );
-			// const styleVariation = styleVariations.find(
-			// 	( variation ) => variation.title === selectedStyleVariationTitle
-			// );
-			// if ( styleVariation && userGlobalStylesId ) {
-			// 	await updateGlobalStyles( siteId, userGlobalStylesId, styleVariation );
-			// }
+			await setThemeOnSite( siteId.toString(), COURSE_THEME );
+			wait( 1200 );
+			const selectedStyleVariationTitle = getSelectedStyleVariation()?.title;
+			const [ styleVariations, theme ]: [ StyleVariation[], Theme ] = await Promise.all( [
+				getStyleVariations( siteId, COURSE_THEME ),
+				getSiteTheme( siteId, COURSE_THEME ),
+			] );
+			const userGlobalStylesLink: string =
+				theme?._links?.[ 'wp:user-global-styles' ]?.[ 0 ]?.href || '';
+			const userGlobalStylesId = parseInt( userGlobalStylesLink.split( '/' ).pop() || '', 10 );
+			const styleVariation = styleVariations.find(
+				( variation ) => variation.title === selectedStyleVariationTitle
+			);
+			if ( styleVariation && userGlobalStylesId ) {
+				await updateGlobalStyles( siteId, userGlobalStylesId, styleVariation );
+			}
 		}
 		setProgress( {
 			percentage: 100,
@@ -139,4 +138,3 @@ export const useCreateSenseiSite = () => {
 
 	return { createAndConfigureSite, progress };
 };
-/* eslint-enable */


### PR DESCRIPTION
This reverts commit be422fcd71ad3de783fb293b483e3ba804fef80e.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* See here for more context p1708675442467019/1708633653.183779-slack-C02P7FHLVR9 . Mainly the change that was causing the issue was reverted. So now we can go back to the way we were installing it.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to http://calypso.localhost:3000/setup/sensei
* Complete the flow and make sure you don't face any issues

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?