### PR TITLE
Jetpack Manage: Fix a style glitch introduced on /dashboard view

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { useMobileBreakpoint } from '@automattic/viewport-react';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
@@ -44,7 +44,6 @@ export default function SiteTopHeaderButtons() {
 				<span className="sites-overview__issue-license-button-caption">
 					{ translate( 'Issue License', { context: 'button label' } ) }
 				</span>
-				<Gridicon icon="plus-small" size={ 12 } />
 			</Button>
 
 			{ isWPCOMAtomicSiteCreationEnabled ? (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-top-header-buttons/index.tsx
@@ -41,9 +41,7 @@ export default function SiteTopHeaderButtons() {
 				disabled={ ! partnerCanIssueLicense }
 				onClick={ onIssueNewLicenseClick }
 			>
-				<span className="sites-overview__issue-license-button-caption">
-					{ translate( 'Issue License', { context: 'button label' } ) }
-				</span>
+				{ translate( 'Issue License', { context: 'button label' } ) }
 			</Button>
 
 			{ isWPCOMAtomicSiteCreationEnabled ? (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.scss
@@ -24,15 +24,6 @@
 		visibility: visible;
 	}
 
-	.sites-dashboard__layout {
-		.sites-overview__issue-license-button-caption {
-			display: block;
-		}
-		.sites-overview__issue-license-button-short-caption {
-			display: none;
-		}
-	}
-
 	.sites-dashboard__layout:not(.preview-hidden) {
 
 		.sites-overview {
@@ -44,14 +35,11 @@
 			padding: 0;
 		}
 
-		.sites-overview__issue-license-button-caption {
-			display: none;
-		}
-
 		.sites-overview__issue-license-button-short-caption {
-			display: block;
 			height: 28px;
-			width: 28px;
+			width: auto;
+			line-height: 11px;
+			font-size: rem(12px);
 		}
 
 		.sites-overview__page-subtitle {
@@ -103,18 +91,10 @@
 
 		.sites-overview__issue-license-button {
 			display: flex;
+			font-size: rem(12px);
 			justify-content: center;
 			align-items: center;
 			height: 28px;
-			width: 28px;
-
-			.gridicon {
-				flex-shrink: 0;
-				width: 20px;
-				height: 20px;
-				top: 0;
-				margin-top: 0;
-			}
 		}
 
 		ul.dataviews-view-list {


### PR DESCRIPTION
## Proposed Changes

This PR fixes a style issue introduced on the `/dashboard` section with this PR https://github.com/Automattic/wp-calypso/pull/87814:

![image](https://github.com/Automattic/wp-calypso/assets/9832440/9b05a4bc-c06a-4396-a950-6b381d633a76)

I've removed the `+` icon and touched the styles to show the `Issue License` text.

In `/sites` after this fix:

![image](https://github.com/Automattic/wp-calypso/assets/9832440/e6a825c5-52e8-4856-993e-18c5df1c6ae6)

---
Anyway, we had to remove that `+` based on the A4A designs:

![image](https://github.com/Automattic/wp-calypso/assets/9832440/efee0cb2-e0a5-41ff-a2fa-3560e7c87b69)

When we move to A4A, we will have to exchange the button colors and change `Issue License` to `Add products`


## Testing Instructions

- Check on `/dashboard` that the `+` icon doesn't appear
- Check on `/sites`, by clicking on any site on the list, that you see the button `Issue License` instead of the `+`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
