### PR TITLE
GitHub deployments: Update workflow dropdown component

### DIFF
--- a/client/my-sites/github-deployments/components/repositories/deployment-style/deployment-style.tsx
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/deployment-style.tsx
@@ -320,18 +320,26 @@ export const DeploymentStyle = ( {
 		} );
 
 		if ( hasAnyError ) {
-			return translate( 'Please edit {{filename/}} and fix the problems we found:', {
-				components: {
-					filename: <ExternalLink href={ workflowFileUrl }>{ workflowFileName }</ExternalLink>,
-				},
-			} );
+			return (
+				<p>
+					{ translate( 'Please edit {{filename/}} and fix the problems we found:', {
+						components: {
+							filename: <ExternalLink href={ workflowFileUrl }>{ workflowFileName }</ExternalLink>,
+						},
+					} ) }
+				</p>
+			);
 		}
 
-		return translate( 'Your workflow {{filename/}} is good to go!', {
-			components: {
-				filename: <ExternalLink href={ workflowFileUrl }>{ workflowFileName }</ExternalLink>,
-			},
-		} );
+		return (
+			<p>
+				{ translate( 'Your workflow {{filename/}} is good to go!', {
+					components: {
+						filename: <ExternalLink href={ workflowFileUrl }>{ workflowFileName }</ExternalLink>,
+					},
+				} ) }
+			</p>
+		);
 	};
 
 	return (
@@ -396,12 +404,9 @@ export const DeploymentStyle = ( {
 						! isCreatingNewWorkflow && (
 							<>
 								<FormLabel>{ __( 'Workflow check' ) }</FormLabel>
-								<p>
-									<ExternalWorkflowLink />
-								</p>
-
+								<ExternalWorkflowLink />
 								{ workflowsValidations.map( ( validation ) => (
-									<>
+									<div key={ validation.key }>
 										<FoldableCard
 											disabled={ validation.key !== 'valid_yaml_file' && ! isYamlValid }
 											key={ validation.key }
@@ -420,7 +425,7 @@ export const DeploymentStyle = ( {
 										{ validation.status === 'error' && (
 											<FormInputValidation isError text={ translate( 'Please fix this error' ) } />
 										) }
-									</>
+									</div>
 								) ) }
 							</>
 						) }

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/style.scss
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/style.scss
@@ -81,12 +81,18 @@
 		margin-bottom: 0;
 	}
 
-	.form-fieldset .form-label {
-		display: inline-flex;
-		margin-top: 16px;
-		font-weight: 500;
-		margin-bottom: 0;
-		color: var(--studio-black);
+	.form-fieldset {
+		>.spinner {
+			margin-bottom: 1.5em;
+		}
+
+		.form-label {
+			display: inline-flex;
+			margin-top: 16px;
+			font-weight: 500;
+			margin-bottom: 0;
+			color: var(--studio-black);
+		}
 	}
 
 	.support-info {

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/style.scss
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/style.scss
@@ -121,4 +121,8 @@
 			margin-bottom: 16px;
 		}
 	}
+
+	&__workflow-selection {
+		margin-top: 8px;
+	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5334

## Proposed Changes

* Improved Workflow dropdown component:

<img width="691" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/4e031611-4109-4334-a670-43c7d78c53ee">

* Improved external workflow file link check

<img width="684" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/706b4c2a-5cb7-475c-94a0-9a4ae08ec6c3">

<img width="692" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/79e152d5-b2d2-4236-b800-b1e68bfecc78">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?