### PR TITLE
Plans: Fix sticky container offset in plans grid not being set properly

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -649,6 +649,7 @@ const PlansFeaturesMain = ( {
 	} );
 
 	const [ masterbarHeight, setMasterbarHeight ] = useState( 0 );
+
 	/**
 	 * Calculates the height of the masterbar if it exists, and passes it to the component as an offset
 	 * for the sticky CTA bar.
@@ -665,15 +666,12 @@ const PlansFeaturesMain = ( {
 			return;
 		}
 
-		let lastHeight = masterbarElement.offsetHeight;
-
 		const observer = new ResizeObserver(
 			( [ masterbar ]: Parameters< ResizeObserverCallback >[ 0 ] ) => {
 				const currentHeight = masterbar.contentRect.height;
 
-				if ( currentHeight !== lastHeight ) {
+				if ( currentHeight !== masterbarHeight ) {
 					setMasterbarHeight( currentHeight );
-					lastHeight = currentHeight;
 				}
 			}
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the  linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/87765

## Proposed Changes

Fixes the StickyContainer's offset not being set properly when in admin `/plans/:site`.

Not sure why this worked previously. The only way to get it working on my end is to load the page in mobile/narrow view and resize to medium/large from there. In every other case, the offset is not updated - `currentHeight` and `lastHeight` in the assertion are always the same. 

Not sure if I'm missing something - @aneeshd16 / @jeyip ?

### Before

<img width="400" alt="Screenshot 2024-02-23 at 3 38 23 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/0b6d662a-c715-4fe8-8cbc-d057362d7a75">

### After

<img width="400" alt="Screenshot 2024-02-23 at 3 37 27 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/5c87a04d-d2d9-4793-bcdf-7e30d0eb6ce4">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/plans` and `/plans/:site` in mobile/desktop and scroll down. The buttons should be stuck as in the media.
* Resize to mobile and back and confirm it works correctly / not cut off at the top.
* Try the same starting on mobile and resizing out.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?