### PR TITLE
Pattern Library: Initial version of pattern previews

### DIFF
--- a/client/my-sites/patterns/components/pattern-preview-placeholder.tsx
+++ b/client/my-sites/patterns/components/pattern-preview-placeholder.tsx
@@ -1,0 +1,14 @@
+import type { Pattern } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types';
+
+import './pattern-preview.scss';
+
+type Props = { pattern: Pattern };
+
+export function PatternPreviewPlaceholder( { pattern }: Props ) {
+	return (
+		<div className="pattern-preview pattern-preview_loading">
+			<div className="pattern-preview__renderer" />
+			<div className="pattern-preview__title">{ pattern.title }</div>
+		</div>
+	);
+}

--- a/client/my-sites/patterns/components/pattern-preview-placeholder.tsx
+++ b/client/my-sites/patterns/components/pattern-preview-placeholder.tsx
@@ -6,7 +6,7 @@ type Props = { pattern: Pattern };
 
 export function PatternPreviewPlaceholder( { pattern }: Props ) {
 	return (
-		<div className="pattern-preview pattern-preview_loading">
+		<div className="pattern-preview is-loading">
 			<div className="pattern-preview__renderer" />
 			<div className="pattern-preview__title">{ pattern.title }</div>
 		</div>

--- a/client/my-sites/patterns/components/pattern-preview.scss
+++ b/client/my-sites/patterns/components/pattern-preview.scss
@@ -1,0 +1,23 @@
+.pattern-preview {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	justify-content: space-between;
+
+	.pattern-preview__renderer {
+		background: var(--color-surface);
+		border-radius: 4px;
+		box-shadow: 0 0 8px hsla(0, 0%, 0%, 0.08);
+		display: grid;
+		flex: 1;
+		overflow: hidden;
+
+		.pattern-preview_loading & {
+			aspect-ratio: 7 / 3;
+		}
+	}
+
+	.pattern-preview__title {
+		min-height: 3rem;
+	}
+}

--- a/client/my-sites/patterns/components/pattern-preview.scss
+++ b/client/my-sites/patterns/components/pattern-preview.scss
@@ -3,6 +3,7 @@
 	flex-direction: column;
 	gap: 16px;
 	justify-content: space-between;
+	position: relative;
 
 	.pattern-preview__renderer {
 		background: var(--color-surface);
@@ -11,10 +12,10 @@
 		display: grid;
 		flex: 1;
 		overflow: hidden;
+	}
 
-		.pattern-preview_loading & {
-			aspect-ratio: 7 / 3;
-		}
+	&.is-loading .pattern-preview__renderer {
+		aspect-ratio: 7 / 3;
 	}
 
 	.pattern-preview__title {

--- a/client/my-sites/patterns/components/pattern-preview.tsx
+++ b/client/my-sites/patterns/components/pattern-preview.tsx
@@ -23,7 +23,7 @@ export function PatternPreview( { isGridView, pattern }: Props ) {
 	return (
 		<div
 			className={ classNames( 'pattern-preview', {
-				'pattern-preview_loading': ! renderedPattern,
+				'is-loading': ! renderedPattern,
 			} ) }
 		>
 			{ resizeObserver }

--- a/client/my-sites/patterns/components/pattern-preview.tsx
+++ b/client/my-sites/patterns/components/pattern-preview.tsx
@@ -1,0 +1,42 @@
+import { PatternRenderer } from '@automattic/block-renderer';
+import { usePatternsRendererContext } from '@automattic/block-renderer/src/components/patterns-renderer-context';
+import { useResizeObserver } from '@wordpress/compose';
+import classNames from 'classnames';
+import { encodePatternId } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils';
+import type { Pattern } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types';
+
+import './pattern-preview.scss';
+
+const DESKTOP_VIEWPORT_WIDTH = 1200;
+
+type Props = {
+	isGridView?: boolean;
+	pattern: Pattern;
+};
+
+export function PatternPreview( { isGridView, pattern }: Props ) {
+	const { renderedPatterns } = usePatternsRendererContext();
+	const patternId = encodePatternId( pattern.ID );
+	const renderedPattern = renderedPatterns[ patternId ];
+	const [ resizeObserver, nodeSize ] = useResizeObserver();
+
+	return (
+		<div
+			className={ classNames( 'pattern-preview', {
+				'pattern-preview_loading': ! renderedPattern,
+			} ) }
+		>
+			{ resizeObserver }
+
+			<div className="pattern-preview__renderer">
+				<PatternRenderer
+					minHeight={ nodeSize.width ? nodeSize.width / ( 7 / 3 ) : undefined }
+					patternId={ patternId }
+					viewportWidth={ isGridView ? DESKTOP_VIEWPORT_WIDTH : undefined }
+				/>
+			</div>
+
+			<div className="pattern-preview__title">{ pattern.title }</div>
+		</div>
+	);
+}

--- a/client/my-sites/patterns/controller.tsx
+++ b/client/my-sites/patterns/controller.tsx
@@ -1,9 +1,8 @@
 import { getPatternsQueryOptions } from 'calypso/my-sites/patterns/hooks/use-patterns';
-import Patterns from 'calypso/my-sites/patterns/patterns';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import type { Context as PageJSContext } from '@automattic/calypso-router';
 
-type Next = ( error?: Error ) => void;
+export type Next = ( error?: Error ) => void;
 
 export function fetchPatterns( context: PageJSContext, next: Next ) {
 	const { cachedMarkup, queryClient, lang, params, store } = context;
@@ -27,10 +26,4 @@ export function fetchPatterns( context: PageJSContext, next: Next ) {
 		.catch( ( error: Error ) => {
 			next( error );
 		} );
-}
-
-export function renderPatterns( context: PageJSContext, next: Next ) {
-	context.primary = <Patterns category={ context.params.category } />;
-
-	next();
 }

--- a/client/my-sites/patterns/index.node.tsx
+++ b/client/my-sites/patterns/index.node.tsx
@@ -1,8 +1,18 @@
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import { makeLayout, ssrSetupLocale } from 'calypso/controller';
 import { setHrefLangLinks, setLocalizedCanonicalUrl } from 'calypso/controller/localized-links';
-import { fetchPatterns, renderPatterns } from 'calypso/my-sites/patterns/controller';
+import { fetchPatterns, Next } from 'calypso/my-sites/patterns/controller';
+import PatternsSSR from 'calypso/my-sites/patterns/patterns-ssr';
 import { serverRouter } from 'calypso/server/isomorphic-routing';
+import type { Context as PageJSContext } from '@automattic/calypso-router';
+
+function renderPatterns( context: PageJSContext, next: Next ) {
+	context.primary = (
+		<PatternsSSR category={ context.params.category } isGridView={ !! context.query.grid } />
+	);
+
+	next();
+}
 
 export default function ( router: ReturnType< typeof serverRouter > ) {
 	const langParam = getLanguageRouteParam();

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -5,7 +5,17 @@ import {
 	redirectWithoutLocaleParamInFrontIfLoggedIn,
 	render as clientRender,
 } from 'calypso/controller/index.web';
-import { fetchPatterns, renderPatterns } from 'calypso/my-sites/patterns/controller';
+import { fetchPatterns, Next } from 'calypso/my-sites/patterns/controller';
+import Patterns from 'calypso/my-sites/patterns/patterns';
+import type { Context as PageJSContext } from '@automattic/calypso-router';
+
+function renderPatterns( context: PageJSContext, next: Next ) {
+	context.primary = (
+		<Patterns category={ context.params.category } isGridView={ !! context.query.grid } />
+	);
+
+	next();
+}
 
 export default function ( router: typeof clientRouter ) {
 	const langParam = getLanguageRouteParam();

--- a/client/my-sites/patterns/package.json
+++ b/client/my-sites/patterns/package.json
@@ -1,4 +1,4 @@
 {
-	"main": "index.node.ts",
-	"browser": "index.web.ts"
+	"main": "index.node.tsx",
+	"browser": "index.web.tsx"
 }

--- a/client/my-sites/patterns/patterns-ssr.tsx
+++ b/client/my-sites/patterns/patterns-ssr.tsx
@@ -1,0 +1,34 @@
+import { useLocale } from '@automattic/i18n-utils';
+import classNames from 'classnames';
+import DocumentHead from 'calypso/components/data/document-head';
+import Main from 'calypso/components/main';
+import { usePatterns } from 'calypso/my-sites/patterns/hooks/use-patterns';
+
+import './style.scss';
+
+type Props = {
+	category: string;
+	isGridView?: boolean;
+};
+
+export default function PatternsSSR( { category, isGridView }: Props ) {
+	const locale = useLocale();
+	const { data: patterns } = usePatterns( locale, category );
+
+	return (
+		<Main isLoggedOut fullWidthLayout>
+			<DocumentHead title="WordPress Patterns" />
+
+			<h1>Build your perfect site with patterns</h1>
+
+			<div className={ classNames( 'patterns', { patterns_grid: isGridView } ) }>
+				{ patterns?.map( ( pattern ) => (
+					<div className="patterns__item" key={ pattern.ID }>
+						<div className="patterns__preview">Loading…</div>
+						<div className="patterns__title">{ pattern.title }</div>
+					</div>
+				) ) }
+			</div>
+		</Main>
+	);
+}

--- a/client/my-sites/patterns/patterns-ssr.tsx
+++ b/client/my-sites/patterns/patterns-ssr.tsx
@@ -23,7 +23,7 @@ export default function PatternsSSR( { category, isGridView }: Props ) {
 
 			<div className={ classNames( 'patterns', { patterns_grid: isGridView } ) }>
 				{ patterns?.map( ( pattern ) => (
-					<div className="patterns__item" key={ pattern.ID }>
+					<div className="patterns__item patterns__item_loading" key={ pattern.ID }>
 						<div className="patterns__preview">Loading…</div>
 						<div className="patterns__title">{ pattern.title }</div>
 					</div>

--- a/client/my-sites/patterns/patterns-ssr.tsx
+++ b/client/my-sites/patterns/patterns-ssr.tsx
@@ -2,16 +2,17 @@ import { useLocale } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
+import { PatternPreviewPlaceholder } from 'calypso/my-sites/patterns/components/pattern-preview-placeholder';
 import { usePatterns } from 'calypso/my-sites/patterns/hooks/use-patterns';
 
 import './style.scss';
 
-type PatternsSSRProps = {
+type Props = {
 	category: string;
 	isGridView?: boolean;
 };
 
-export default function PatternsSSR( { category, isGridView }: PatternsSSRProps ) {
+export default function PatternsSSR( { category, isGridView }: Props ) {
 	const locale = useLocale();
 	const { data: patterns } = usePatterns( locale, category );
 
@@ -23,10 +24,7 @@ export default function PatternsSSR( { category, isGridView }: PatternsSSRProps 
 
 			<div className={ classNames( 'patterns', { patterns_grid: isGridView } ) }>
 				{ patterns?.map( ( pattern ) => (
-					<div className="patterns__item patterns__item_loading" key={ pattern.ID }>
-						<div className="patterns__preview" />
-						<div className="patterns__title">{ pattern.title }</div>
-					</div>
+					<PatternPreviewPlaceholder key={ pattern.ID } pattern={ pattern } />
 				) ) }
 			</div>
 		</Main>

--- a/client/my-sites/patterns/patterns-ssr.tsx
+++ b/client/my-sites/patterns/patterns-ssr.tsx
@@ -6,12 +6,12 @@ import { usePatterns } from 'calypso/my-sites/patterns/hooks/use-patterns';
 
 import './style.scss';
 
-type Props = {
+type PatternsSSRProps = {
 	category: string;
 	isGridView?: boolean;
 };
 
-export default function PatternsSSR( { category, isGridView }: Props ) {
+export default function PatternsSSR( { category, isGridView }: PatternsSSRProps ) {
 	const locale = useLocale();
 	const { data: patterns } = usePatterns( locale, category );
 
@@ -24,7 +24,7 @@ export default function PatternsSSR( { category, isGridView }: Props ) {
 			<div className={ classNames( 'patterns', { patterns_grid: isGridView } ) }>
 				{ patterns?.map( ( pattern ) => (
 					<div className="patterns__item patterns__item_loading" key={ pattern.ID }>
-						<div className="patterns__preview">Loading…</div>
+						<div className="patterns__preview" />
 						<div className="patterns__title">{ pattern.title }</div>
 					</div>
 				) ) }

--- a/client/my-sites/patterns/patterns.tsx
+++ b/client/my-sites/patterns/patterns.tsx
@@ -1,28 +1,57 @@
+import {
+	BlockRendererProvider,
+	PatternsRendererProvider,
+	PatternRenderer,
+} from '@automattic/block-renderer';
+import { getPlaceholderSiteID } from '@automattic/data-stores/src/site/constants';
 import { useLocale } from '@automattic/i18n-utils';
+import classNames from 'classnames';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
+import { encodePatternId } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils';
 import { usePatterns } from 'calypso/my-sites/patterns/hooks/use-patterns';
 
 import './style.scss';
 
-export default ( { category }: { category: string } ) => {
-	const locale = useLocale();
+type Props = {
+	category: string;
+	isGridView?: boolean;
+};
 
+export default function Patterns( { category, isGridView }: Props ) {
+	const locale = useLocale();
 	const { data: patterns } = usePatterns( locale, category );
+	const rendererSiteId = getPlaceholderSiteID();
+
+	const patternIdsByCategory = { intro: patterns?.map( ( { ID } ) => `${ ID }` ) ?? [] };
 
 	return (
 		<Main isLoggedOut fullWidthLayout>
 			<DocumentHead title="WordPress Patterns" />
-
 			<h1>Build your perfect site with patterns</h1>
 
-			<ul className="patterns">
-				{ patterns?.map( ( pattern ) => (
-					<li key={ pattern.ID }>
-						<iframe srcDoc={ pattern?.html } title={ pattern.title } />
-					</li>
-				) ) }
-			</ul>
+			<BlockRendererProvider siteId={ rendererSiteId }>
+				<PatternsRendererProvider
+					patternIdsByCategory={ patternIdsByCategory }
+					shouldShufflePosts={ false }
+					siteId={ rendererSiteId }
+				>
+					<div className={ classNames( 'patterns', { patterns_grid: isGridView } ) }>
+						{ patterns?.map( ( pattern ) => (
+							<div className="patterns__item" key={ pattern.ID }>
+								<div className="patterns__preview">
+									<PatternRenderer
+										patternId={ encodePatternId( pattern.ID ) }
+										viewportWidth={ isGridView ? 1200 : undefined }
+									/>
+								</div>
+
+								<div className="patterns__title">{ pattern.title }</div>
+							</div>
+						) ) }
+					</div>
+				</PatternsRendererProvider>
+			</BlockRendererProvider>
 		</Main>
 	);
-};
+}

--- a/client/my-sites/patterns/patterns.tsx
+++ b/client/my-sites/patterns/patterns.tsx
@@ -15,6 +15,8 @@ import type { Pattern } from 'calypso/landing/stepper/declarative-flow/internals
 
 import './style.scss';
 
+const DESKTOP_VIEWPORT_WIDTH = 1200;
+
 type PatternPreviewProps = {
 	isGridView?: boolean;
 	pattern: Pattern;
@@ -32,7 +34,10 @@ function PatternPreview( { isGridView, pattern }: PatternPreviewProps ) {
 			} ) }
 		>
 			<div className="patterns__preview">
-				<PatternRenderer patternId={ patternId } viewportWidth={ isGridView ? 1200 : undefined } />
+				<PatternRenderer
+					patternId={ patternId }
+					viewportWidth={ isGridView ? DESKTOP_VIEWPORT_WIDTH : undefined }
+				/>
 			</div>
 
 			<div className="patterns__title">{ pattern.title }</div>

--- a/client/my-sites/patterns/patterns.tsx
+++ b/client/my-sites/patterns/patterns.tsx
@@ -1,72 +1,21 @@
-import {
-	BlockRendererProvider,
-	PatternsRendererProvider,
-	PatternRenderer,
-} from '@automattic/block-renderer';
-import { usePatternsRendererContext } from '@automattic/block-renderer/src/components/patterns-renderer-context';
+import { BlockRendererProvider, PatternsRendererProvider } from '@automattic/block-renderer';
 import { getPlaceholderSiteID } from '@automattic/data-stores/src/site/constants';
 import { useLocale } from '@automattic/i18n-utils';
-import { useResizeObserver } from '@wordpress/compose';
 import classNames from 'classnames';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
-import { encodePatternId } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils';
+import { PatternPreview } from 'calypso/my-sites/patterns/components/pattern-preview';
+import { PatternPreviewPlaceholder } from 'calypso/my-sites/patterns/components/pattern-preview-placeholder';
 import { usePatterns } from 'calypso/my-sites/patterns/hooks/use-patterns';
-import type { Pattern } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types';
 
 import './style.scss';
 
-const DESKTOP_VIEWPORT_WIDTH = 1200;
-
-type PatternPreviewProps = {
-	isGridView?: boolean;
-	pattern: Pattern;
-};
-
-function PatternPreview( { isGridView, pattern }: PatternPreviewProps ) {
-	const { renderedPatterns } = usePatternsRendererContext();
-	const patternId = encodePatternId( pattern.ID );
-	const renderedPattern = renderedPatterns[ patternId ];
-	const [ resizeObserver, nodeSize ] = useResizeObserver();
-
-	return (
-		<div
-			className={ classNames( 'patterns__item', {
-				patterns__item_loading: ! renderedPattern,
-			} ) }
-		>
-			{ resizeObserver }
-
-			<div className="patterns__preview">
-				<PatternRenderer
-					minHeight={ nodeSize.width ? nodeSize.width / ( 7 / 3 ) : undefined }
-					patternId={ patternId }
-					viewportWidth={ isGridView ? DESKTOP_VIEWPORT_WIDTH : undefined }
-				/>
-			</div>
-
-			<div className="patterns__title">{ pattern.title }</div>
-		</div>
-	);
-}
-
-type PatternPreviewPlaceholderProps = { pattern: Pattern };
-
-function PatternPreviewPlaceholder( { pattern }: PatternPreviewPlaceholderProps ) {
-	return (
-		<div className="patterns__item patterns__item_loading">
-			<div className="patterns__preview" />
-			<div className="patterns__title">{ pattern.title }</div>
-		</div>
-	);
-}
-
-type PatternsProps = {
+type Props = {
 	category: string;
 	isGridView?: boolean;
 };
 
-export default function Patterns( { category, isGridView }: PatternsProps ) {
+export default function Patterns( { category, isGridView }: Props ) {
 	const locale = useLocale();
 	const { data: patterns } = usePatterns( locale, category );
 	const rendererSiteId = getPlaceholderSiteID();

--- a/client/my-sites/patterns/patterns.tsx
+++ b/client/my-sites/patterns/patterns.tsx
@@ -6,6 +6,7 @@ import {
 import { usePatternsRendererContext } from '@automattic/block-renderer/src/components/patterns-renderer-context';
 import { getPlaceholderSiteID } from '@automattic/data-stores/src/site/constants';
 import { useLocale } from '@automattic/i18n-utils';
+import { useResizeObserver } from '@wordpress/compose';
 import classNames from 'classnames';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
@@ -26,6 +27,7 @@ function PatternPreview( { isGridView, pattern }: PatternPreviewProps ) {
 	const { renderedPatterns } = usePatternsRendererContext();
 	const patternId = encodePatternId( pattern.ID );
 	const renderedPattern = renderedPatterns[ patternId ];
+	const [ resizeObserver, nodeSize ] = useResizeObserver();
 
 	return (
 		<div
@@ -33,13 +35,27 @@ function PatternPreview( { isGridView, pattern }: PatternPreviewProps ) {
 				patterns__item_loading: ! renderedPattern,
 			} ) }
 		>
+			{ resizeObserver }
+
 			<div className="patterns__preview">
 				<PatternRenderer
+					minHeight={ nodeSize.width ? nodeSize.width / ( 7 / 3 ) : undefined }
 					patternId={ patternId }
 					viewportWidth={ isGridView ? DESKTOP_VIEWPORT_WIDTH : undefined }
 				/>
 			</div>
 
+			<div className="patterns__title">{ pattern.title }</div>
+		</div>
+	);
+}
+
+type PatternPreviewPlaceholderProps = { pattern: Pattern };
+
+function PatternPreviewPlaceholder( { pattern }: PatternPreviewPlaceholderProps ) {
+	return (
+		<div className="patterns__item patterns__item_loading">
+			<div className="patterns__preview" />
 			<div className="patterns__title">{ pattern.title }</div>
 		</div>
 	);
@@ -64,7 +80,16 @@ export default function Patterns( { category, isGridView }: PatternsProps ) {
 			<DocumentHead title="WordPress Patterns" />
 			<h1>Build your perfect site with patterns</h1>
 
-			<BlockRendererProvider siteId={ rendererSiteId }>
+			<BlockRendererProvider
+				siteId={ rendererSiteId }
+				placeholder={
+					<div className="patterns">
+						{ patterns?.map( ( pattern ) => (
+							<PatternPreviewPlaceholder key={ pattern.ID } pattern={ pattern } />
+						) ) }
+					</div>
+				}
+			>
 				<PatternsRendererProvider
 					patternIdsByCategory={ patternIdsByCategory }
 					shouldShufflePosts={ false }

--- a/client/my-sites/patterns/patterns.tsx
+++ b/client/my-sites/patterns/patterns.tsx
@@ -3,6 +3,7 @@ import {
 	PatternsRendererProvider,
 	PatternRenderer,
 } from '@automattic/block-renderer';
+import { usePatternsRendererContext } from '@automattic/block-renderer/src/components/patterns-renderer-context';
 import { getPlaceholderSiteID } from '@automattic/data-stores/src/site/constants';
 import { useLocale } from '@automattic/i18n-utils';
 import classNames from 'classnames';
@@ -10,20 +11,48 @@ import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import { encodePatternId } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils';
 import { usePatterns } from 'calypso/my-sites/patterns/hooks/use-patterns';
+import type { Pattern } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types';
 
 import './style.scss';
 
-type Props = {
+type PatternPreviewProps = {
+	isGridView?: boolean;
+	pattern: Pattern;
+};
+
+function PatternPreview( { isGridView, pattern }: PatternPreviewProps ) {
+	const { renderedPatterns } = usePatternsRendererContext();
+	const patternId = encodePatternId( pattern.ID );
+	const renderedPattern = renderedPatterns[ patternId ];
+
+	return (
+		<div
+			className={ classNames( 'patterns__item', {
+				patterns__item_loading: ! renderedPattern,
+			} ) }
+		>
+			<div className="patterns__preview">
+				<PatternRenderer patternId={ patternId } viewportWidth={ isGridView ? 1200 : undefined } />
+			</div>
+
+			<div className="patterns__title">{ pattern.title }</div>
+		</div>
+	);
+}
+
+type PatternsProps = {
 	category: string;
 	isGridView?: boolean;
 };
 
-export default function Patterns( { category, isGridView }: Props ) {
+export default function Patterns( { category, isGridView }: PatternsProps ) {
 	const locale = useLocale();
 	const { data: patterns } = usePatterns( locale, category );
 	const rendererSiteId = getPlaceholderSiteID();
 
-	const patternIdsByCategory = { intro: patterns?.map( ( { ID } ) => `${ ID }` ) ?? [] };
+	const patternIdsByCategory = {
+		intro: patterns?.map( ( { ID } ) => `${ ID }` ) ?? [],
+	};
 
 	return (
 		<Main isLoggedOut fullWidthLayout>
@@ -38,16 +67,7 @@ export default function Patterns( { category, isGridView }: Props ) {
 				>
 					<div className={ classNames( 'patterns', { patterns_grid: isGridView } ) }>
 						{ patterns?.map( ( pattern ) => (
-							<div className="patterns__item" key={ pattern.ID }>
-								<div className="patterns__preview">
-									<PatternRenderer
-										patternId={ encodePatternId( pattern.ID ) }
-										viewportWidth={ isGridView ? 1200 : undefined }
-									/>
-								</div>
-
-								<div className="patterns__title">{ pattern.title }</div>
-							</div>
+							<PatternPreview isGridView={ isGridView } key={ pattern.ID } pattern={ pattern } />
 						) ) }
 					</div>
 				</PatternsRendererProvider>

--- a/client/my-sites/patterns/patterns.tsx
+++ b/client/my-sites/patterns/patterns.tsx
@@ -1,5 +1,4 @@
 import { BlockRendererProvider, PatternsRendererProvider } from '@automattic/block-renderer';
-import { getPlaceholderSiteID } from '@automattic/data-stores/src/site/constants';
 import { useLocale } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import DocumentHead from 'calypso/components/data/document-head';
@@ -10,6 +9,8 @@ import { usePatterns } from 'calypso/my-sites/patterns/hooks/use-patterns';
 
 import './style.scss';
 
+const RENDERER_SITE_ID = '226011606'; // assemblerdemo
+
 type Props = {
 	category: string;
 	isGridView?: boolean;
@@ -18,7 +19,6 @@ type Props = {
 export default function Patterns( { category, isGridView }: Props ) {
 	const locale = useLocale();
 	const { data: patterns } = usePatterns( locale, category );
-	const rendererSiteId = getPlaceholderSiteID();
 
 	const patternIdsByCategory = {
 		intro: patterns?.map( ( { ID } ) => `${ ID }` ) ?? [],
@@ -30,7 +30,7 @@ export default function Patterns( { category, isGridView }: Props ) {
 			<h1>Build your perfect site with patterns</h1>
 
 			<BlockRendererProvider
-				siteId={ rendererSiteId }
+				siteId={ RENDERER_SITE_ID }
 				placeholder={
 					<div className="patterns">
 						{ patterns?.map( ( pattern ) => (
@@ -42,7 +42,7 @@ export default function Patterns( { category, isGridView }: Props ) {
 				<PatternsRendererProvider
 					patternIdsByCategory={ patternIdsByCategory }
 					shouldShufflePosts={ false }
-					siteId={ rendererSiteId }
+					siteId={ RENDERER_SITE_ID }
 				>
 					<div className={ classNames( 'patterns', { patterns_grid: isGridView } ) }>
 						{ patterns?.map( ( pattern ) => (

--- a/client/my-sites/patterns/style.scss
+++ b/client/my-sites/patterns/style.scss
@@ -18,7 +18,7 @@
 }
 .patterns__preview {
 	background: var(--color-surface);
-	border-radius: 3px;
+	border-radius: 4px;
 	box-shadow: 0 0 8px hsla(0, 0%, 0%, 0.08);
 	display: grid;
 	flex: 1;

--- a/client/my-sites/patterns/style.scss
+++ b/client/my-sites/patterns/style.scss
@@ -4,19 +4,29 @@
 
 .patterns {
 	display: grid;
-	padding: 20px 0;
+	padding: 24px 0;
 }
 .patterns_grid {
-	gap: 20px;
+	gap: 24px;
 	grid-template-columns: repeat(4, 1fr);
 }
 .patterns__item {
 	display: flex;
 	flex-direction: column;
+	gap: 16px;
 	justify-content: space-between;
 }
 .patterns__preview {
-	aspect-ratio: 7 / 3;
+	background: var(--color-surface);
+	border-radius: 3px;
+	box-shadow: 0 0 8px hsla(0, 0%, 0%, 0.08);
+	display: grid;
+	flex: 1;
+	overflow: hidden;
+
+	.patterns__item_loading & {
+		aspect-ratio: 7 / 3;
+	}
 }
 .patterns__title {
 	min-height: 3rem;

--- a/client/my-sites/patterns/style.scss
+++ b/client/my-sites/patterns/style.scss
@@ -8,7 +8,7 @@
 }
 .patterns_grid {
 	gap: 24px;
-	grid-template-columns: repeat(4, 1fr);
+	grid-template-columns: repeat(3, 1fr);
 }
 .patterns__item {
 	display: flex;

--- a/client/my-sites/patterns/style.scss
+++ b/client/my-sites/patterns/style.scss
@@ -10,24 +10,3 @@
 	gap: 24px;
 	grid-template-columns: repeat(3, 1fr);
 }
-.patterns__item {
-	display: flex;
-	flex-direction: column;
-	gap: 16px;
-	justify-content: space-between;
-}
-.patterns__preview {
-	background: var(--color-surface);
-	border-radius: 4px;
-	box-shadow: 0 0 8px hsla(0, 0%, 0%, 0.08);
-	display: grid;
-	flex: 1;
-	overflow: hidden;
-
-	.patterns__item_loading & {
-		aspect-ratio: 7 / 3;
-	}
-}
-.patterns__title {
-	min-height: 3rem;
-}

--- a/client/my-sites/patterns/style.scss
+++ b/client/my-sites/patterns/style.scss
@@ -3,6 +3,21 @@
 }
 
 .patterns {
-	list-style-type: none;
-	padding: 20px;
+	display: grid;
+	padding: 20px 0;
+}
+.patterns_grid {
+	gap: 20px;
+	grid-template-columns: repeat(4, 1fr);
+}
+.patterns__item {
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+}
+.patterns__preview {
+	aspect-ratio: 7 / 3;
+}
+.patterns__title {
+	min-height: 3rem;
 }

--- a/packages/block-renderer/src/components/patterns-renderer-provider.tsx
+++ b/packages/block-renderer/src/components/patterns-renderer-provider.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, PropsWithChildren } from 'react';
 import useRenderedPatterns from '../hooks/use-rendered-patterns';
 import PatternsRendererContext from './patterns-renderer-context';
 import type { SiteInfo } from '../types';
@@ -7,8 +7,7 @@ interface Props {
 	siteId: number | string;
 	stylesheet?: string;
 	patternIdsByCategory: Record< string, string[] >;
-	children: JSX.Element;
-	siteInfo: SiteInfo;
+	siteInfo?: SiteInfo;
 	shouldShufflePosts: boolean;
 }
 
@@ -19,7 +18,7 @@ const PatternsRendererProvider = ( {
 	children,
 	siteInfo = {},
 	shouldShufflePosts,
-}: Props ) => {
+}: PropsWithChildren< Props > ) => {
 	const renderedPatterns = useRenderedPatterns(
 		siteId,
 		stylesheet,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5598

## Proposed Changes

This PR adds the basic pieces for rendering pattern previews in list view (full-width) and grid view. We do this by utilizing components from Assembler. A brief overview of how this works:
- `BlockRendererProvider` initializes the block rendering setup by fetching config details (most notably, CSS styles) for the pattern previews.
- `PatternsRendererProvider` sends an array of pattern IDs and receives an array of rendered HTML.
- `PatternRenderer` renders an `iframe` by looking up the rendered HTML for the given pattern from the `PatternsRenderer` context.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Load `/patterns`
2. Ensure that patterns render in full-width and look as expected
3. Load `/patterns?grid=1`
4. Ensure that patterns render in a grid

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?