### PR TITLE
Do not show loading indicator on hosting-config page for reverted sites

### DIFF
--- a/client/my-sites/hosting/main.js
+++ b/client/my-sites/hosting/main.js
@@ -201,6 +201,7 @@ const Hosting = ( props ) => {
 				transferStates.ERROR,
 				transferStates.COMPLETED,
 				transferStates.COMPLETE,
+				transferStates.REVERTED,
 			].includes( transferState )
 	);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes
Currently trial sites that are reverted to simple sites when expired shows the loading indicator when browsing /hosting-config instead of the upsell nudge.


* Add `reverted` to the list of states that shows a transfer is not in progress.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* use a site that has been recently reverted go to /hosting-config
* Verify the upsell nudge and not the loading indicator

**Before**
![image](https://github.com/Automattic/wp-calypso/assets/47489215/6f4571ba-795e-4587-925b-f9096ec71902)


**After**
![image](https://github.com/Automattic/wp-calypso/assets/47489215/33d0889b-c824-4819-8f6b-e43d41041649)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?