### PR TITLE
Odie clean up & React Query Cache

### DIFF
--- a/packages/odie-client/src/components/message/index.tsx
+++ b/packages/odie-client/src/components/message/index.tsx
@@ -60,6 +60,9 @@ const ChatMessage = (
 	const hasSources = message?.context?.sources && message.context?.sources.length > 0;
 	const hasFeedback = !! message?.rating_value;
 
+	const isPositiveFeedback =
+		hasFeedback && message && message.rating_value && +message.rating_value === 1;
+
 	// dedupe sources based on url
 	let sources = message?.context?.sources ?? [];
 	if ( sources.length > 0 ) {
@@ -262,6 +265,7 @@ const ChatMessage = (
 						{ ! hasFeedback && ! isUser && messageFullyTyped && (
 							<WasThisHelpfulButtons message={ message } onDislike={ onDislike } />
 						) }
+						{ hasFeedback && messageFullyTyped && ! isPositiveFeedback && extraContactOptions }
 					</>
 				) }
 				{ message.type === 'introduction' && (

--- a/packages/odie-client/src/query/index.ts
+++ b/packages/odie-client/src/query/index.ts
@@ -3,10 +3,10 @@ import apiFetch from '@wordpress/api-fetch';
 import { canAccessWpcomApis } from 'wpcom-proxy-request';
 // eslint-disable-next-line no-restricted-imports
 import wpcom from 'calypso/lib/wp';
-import { WAPUU_ERROR_MESSAGE, ODIE_THUMBS_DOWN_RATING_VALUE } from '..';
+import { WAPUU_ERROR_MESSAGE } from '..';
 import { useOdieAssistantContext } from '../context';
 import { broadcastOdieMessage, setOdieStorage } from '../data';
-import type { Chat, Message, MessageRole, MessageType, OdieAllowedBots } from '../types';
+import type { Chat, Message, OdieAllowedBots } from '../types';
 
 // Either we use wpcom or apiFetch for the request for accessing odie endpoint for atomic or wpcom sites
 const buildSendChatMessage = async (
@@ -197,34 +197,6 @@ export const useOdieGetChat = (
 		queryFn: () => buildGetChatMessage( botNameSlug, chatId, page, perPage, includeFeedback ),
 		refetchOnWindowFocus: false,
 		enabled: !! chatId && ! chat.chat_id,
-		select: ( data ) => {
-			const modifiedMessages: Message[] = [];
-
-			data.messages.forEach( ( message ) => {
-				modifiedMessages.push( message );
-
-				// Check if the message has negative feedback
-				if (
-					message.rating_value &&
-					message.rating_value === ODIE_THUMBS_DOWN_RATING_VALUE &&
-					! message.context?.flags?.forward_to_human_support
-				) {
-					// Add a new 'dislike-feedback' message right after the current message
-					const dislikeFeedbackMessage = {
-						content: '...',
-						role: 'bot' as MessageRole,
-						type: 'dislike-feedback' as MessageType,
-						simulateTyping: false,
-					};
-					modifiedMessages.push( dislikeFeedbackMessage );
-				}
-			} );
-
-			return {
-				...data,
-				messages: modifiedMessages,
-			};
-		},
 	} );
 };
 

--- a/packages/odie-client/src/query/index.ts
+++ b/packages/odie-client/src/query/index.ts
@@ -274,7 +274,7 @@ export const useOdieSendMessageFeedback = (): UseMutationResult<
 				}
 
 				return {
-					...old,
+					...currentChatCache,
 					messages: currentChatCache.messages.map( ( m ) =>
 						m.internal_message_id === message.internal_message_id ? { ...m, rating_value } : m
 					),


### PR DESCRIPTION
## Proposed Changes

Fixes and cleanup! The issue (that still exist before this patch) is that the cache needs to be updated with the user interactions, othwesei refreshing the screen takes a lot of time to see the latest interactions due to the get_chat endpoint.

I've also added caching to React Query, that means that now when retrieving the whole chat when refreshing, it's almost instantly. It's done by updating the cache that holds the `useOdieGetChat` query for both methods, `useOdieSendMessage` and `useOdieSendMessageFeedback`.

## Testing Instructions

The feedback is going to be improved in the next PR's this one just settles the base.
Test that you can keep chatting and you can add feedback.

Type any message and refresh the WordPress site (F5) for both type of messages we send back to the backend (feedback and regular messages). Assert that the chat loads instantly and entirely (up to the 30 last messages, no need to test the "up to 30 messages")

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
