### PR TITLE
Help Center: Add developer badge on search result

### DIFF
--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import page from '@automattic/calypso-router';
-import { Gridicon } from '@automattic/components';
+import { Gridicon, Badge } from '@automattic/components';
 import {
 	getContextResults,
 	LinksForSection,
@@ -233,9 +233,10 @@ function HelpSearchResults( {
 			return (
 				<div className="help-center-search-results__content">
 					{ isResultFromDeveloperWordpress( result.link ) && (
-						<span className="help-center-search-results__badge">
-							{ __( 'DEV', __i18n_text_domain__ ) }
-						</span>
+						<Badge type="info" className="help-center-search-results__badge">
+							{ /* translators: Dev is an acronym of Developers */ }
+							{ __( 'Dev', __i18n_text_domain__ ) }
+						</Badge>
 					) }
 					<span>{ preventWidows( decodeEntities( title ) ) }</span>
 				</div>

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -46,6 +46,11 @@ const noop = () => {
 	return;
 };
 
+const isResultFromDeveloperWordpress = ( url: string ) => {
+	const developerSiteRegex: RegExp = /developer\.wordpress\.com/;
+	return developerSiteRegex.test( url );
+};
+
 function debounceSpeak( { message = '', priority = 'polite', timeout = 800 } ) {
 	return debounce( () => {
 		speak( message, priority );
@@ -224,6 +229,19 @@ function HelpSearchResults( {
 			return <Icon icon={ pageIcon } />;
 		};
 
+		const DeveloperBadge = () => {
+			return (
+				<div className="help-center-search-results__content">
+					{ isResultFromDeveloperWordpress( result.link ) && (
+						<span className="help-center-search-results__badge">
+							{ __( 'DEV', __i18n_text_domain__ ) }
+						</span>
+					) }
+					<span>{ preventWidows( decodeEntities( title ) ) }</span>
+				</div>
+			);
+		};
+
 		return (
 			<Fragment key={ `${ result.post_id ?? link ?? title }-${ index }` }>
 				<li className="help-center-search-results__item">
@@ -242,7 +260,7 @@ function HelpSearchResults( {
 							} ) }
 						>
 							<LinkIcon />
-							<span>{ preventWidows( decodeEntities( title ) ) }</span>
+							<DeveloperBadge />
 							<Icon
 								width={ 20 }
 								height={ 20 }

--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -152,8 +152,8 @@
 						width: 100%;
 						.help-center-search-results__badge {
 							font-size: $font-body-extra-small;
-							font-style: italic;
-							background: var(--studio-gray-5);
+							color: #fff;
+							background: var(--studio-gray-10);
 							width: 35px;
 							border-radius: 4px;
 							text-align: center;

--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -152,10 +152,7 @@
 						width: 100%;
 						.help-center-search-results__badge {
 							font-size: $font-body-extra-small;
-							color: #fff;
-							background: var(--studio-gray-10);
-							width: 35px;
-							border-radius: 4px;
+							text-transform: uppercase;
 							text-align: center;
 						}
 					}

--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -151,9 +151,10 @@
 					.help-center-search-results__content {
 						width: 100%;
 						.help-center-search-results__badge {
+							height: auto;
 							font-size: $font-body-extra-small;
+							padding: 0 8px;
 							text-transform: uppercase;
-							text-align: center;
 						}
 					}
 				}

--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -148,6 +148,17 @@
 						display: block;
 						align-self: center;
 					}
+					.help-center-search-results__content {
+						width: 100%;
+						.help-center-search-results__badge {
+							font-size: $font-body-extra-small;
+							font-style: italic;
+							background: var(--studio-gray-5);
+							width: 35px;
+							border-radius: 4px;
+							text-align: center;
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87824

## Proposed Changes

* When a search result is from `developer.wordpress.com` in Help center, we display a badge to indicate to users that the resource is from `developer.wordpress.com`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull this branch and run calypso or use live link
* Open the help center and check if results from developers have the badge “DEV”.
* Search for “OAuth”, “PHP” play with it :)

![image](https://github.com/Automattic/wp-calypso/assets/52076348/fffca52f-19c0-421f-8def-65bb1d457154)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?