### PR TITLE
Checkout: Rename WPCheckout to CheckoutMainContent

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -238,7 +238,7 @@ function CheckoutSidebarNudge( { responseCart }: { responseCart: ResponseCart } 
 	}
 	return null;
 }
-export default function WPCheckout( {
+export default function CheckoutMainContent( {
 	addItemToCart,
 	changeSelection,
 	countriesList,

--- a/client/my-sites/checkout/src/components/checkout-main.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main.tsx
@@ -50,10 +50,10 @@ import weChatProcessor from '../lib/we-chat-processor';
 import webPayProcessor from '../lib/web-pay-processor';
 import { CHECKOUT_STORE } from '../lib/wpcom-store';
 import { CheckoutLoadingPlaceholder } from './checkout-loading-placeholder';
+import CheckoutMainContent from './checkout-main-content';
 import { OnChangeItemVariant } from './item-variation-picker';
 import JetpackProRedirectModal from './jetpack-pro-redirect-modal';
 import PrePurchaseNotices from './prepurchase-notices';
-import WPCheckout from './wp-checkout';
 import type { PaymentProcessorOptions } from '../types/payment-processors';
 import type {
 	CheckoutPageErrorCallback,
@@ -748,7 +748,7 @@ export default function CheckoutMain( {
 				theme={ theme }
 				selectFirstAvailablePaymentMethod
 			>
-				<WPCheckout
+				<CheckoutMainContent
 					loadingHeader={
 						<CheckoutLoadingPlaceholder checkoutLoadingConditions={ checkoutLoadingConditions } />
 					}


### PR DESCRIPTION
## Proposed Changes

`WPCheckout` is the component that renders the content of the checkout page, but it's not very clear from its name.

This PR renames the `WPCheckout` component to `CheckoutMainContent`. This follows similar renaming PRs like https://github.com/Automattic/wp-calypso/pull/81300 and https://github.com/Automattic/wp-calypso/pull/66103. The goal is to clarify the purpose of these components. 

## Testing Instructions

Verify all tests pass.