### PR TITLE
Gihub Deployments: Match deployment mode component to Figma design

### DIFF
--- a/client/my-sites/github-deployments/components/repositories/create-repository/create-repository-form.tsx
+++ b/client/my-sites/github-deployments/components/repositories/create-repository/create-repository-form.tsx
@@ -51,6 +51,7 @@ export const CreateRepositoryForm = ( {
 	const [ repository, setRepository ] = useState< GitHubRepositoryData >(
 		{} as GitHubRepositoryData
 	);
+	const [ workflowPath, setWorkflowPath ] = useState< string | undefined >();
 
 	const [ isSubmitted, setSubmitted ] = useState( false );
 
@@ -71,6 +72,7 @@ export const CreateRepositoryForm = ( {
 			targetDir,
 			isPrivate,
 			isAutomated,
+			workflowPath,
 		} );
 	};
 
@@ -216,7 +218,13 @@ export const CreateRepositoryForm = ( {
 						{ __( 'Deploy changes on push' ) }
 					</div>
 				</FormFieldset>
-				<Button primary type="submit" busy={ isPending } disabled={ isPending }>
+				<Button
+					primary
+					type="submit"
+					busy={ isPending }
+					disabled={ isPending }
+					onClick={ handleCreateRepository }
+				>
 					{ __( 'Create repository' ) }
 				</Button>
 			</form>
@@ -226,6 +234,14 @@ export const CreateRepositoryForm = ( {
 						branchName="main"
 						installationId={ installation.external_id }
 						repository={ repository }
+						onChooseWorkflow={ ( filePath ) => setWorkflowPath( filePath ) }
+						onValidationChange={ ( status ) => {
+							// if ( status === 'success' ) {
+							// 	setSubmitDisabled( false );
+							// } else {
+							// 	setSubmitDisabled( true );
+							// }
+						} }
 					/>
 				</div>
 			) }

--- a/client/my-sites/github-deployments/components/repositories/create-repository/create-repository-form.tsx
+++ b/client/my-sites/github-deployments/components/repositories/create-repository/create-repository-form.tsx
@@ -52,6 +52,7 @@ export const CreateRepositoryForm = ( {
 		{} as GitHubRepositoryData
 	);
 	const [ workflowPath, setWorkflowPath ] = useState< string | undefined >();
+	const [ deploymentModeStatus, setDeploymentModeStatus ] = useState( 'loading' );
 
 	const [ isSubmitted, setSubmitted ] = useState( false );
 
@@ -60,7 +61,7 @@ export const CreateRepositoryForm = ( {
 
 		setSubmitted( true );
 
-		if ( ! installation || ! repositoryName ) {
+		if ( ! installation || ! repositoryName || deploymentModeStatus !== 'success' ) {
 			return;
 		}
 
@@ -235,13 +236,7 @@ export const CreateRepositoryForm = ( {
 						installationId={ installation.external_id }
 						repository={ repository }
 						onChooseWorkflow={ ( filePath ) => setWorkflowPath( filePath ) }
-						onValidationChange={ ( status ) => {
-							// if ( status === 'success' ) {
-							// 	setSubmitDisabled( false );
-							// } else {
-							// 	setSubmitDisabled( true );
-							// }
-						} }
+						onValidationChange={ ( status ) => setDeploymentModeStatus( status ) }
 					/>
 				</div>
 			) }

--- a/client/my-sites/github-deployments/components/repositories/create-repository/index.tsx
+++ b/client/my-sites/github-deployments/components/repositories/create-repository/index.tsx
@@ -70,6 +70,7 @@ export const CreateRepository = () => {
 				branchName: response.default_branch,
 				targetDir: args.targetDir,
 				isAutomated: args.isAutomated,
+				workflowPath: args.workflowPath,
 			} );
 		} );
 	};

--- a/client/my-sites/github-deployments/components/repositories/create-repository/style.scss
+++ b/client/my-sites/github-deployments/components/repositories/create-repository/style.scss
@@ -44,7 +44,12 @@
 		gap: 8px;
 
 		.components-form-toggle {
-			line-height: 1;
+			margin-left: 5px;
+			margin-top: 1px;
 		}
+	}
+
+	&__deployment-style {
+		flex: 1;
 	}
 }

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/deployment-style.tsx
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/deployment-style.tsx
@@ -309,6 +309,17 @@ export const DeploymentStyle = ( {
 
 	useEffect( () => {
 		setAdvancedOptionsDisabled( workflows?.length === 0 && isTemplateRepository );
+
+		if ( isTemplateRepository && workflows?.length && workflows?.length > 0 ) {
+			const dotcomBuildArtefact = workflows.find( ( workflow ) => {
+				return workflow.file_name === 'dotcom-build-artifact.yml';
+			} );
+
+			if ( dotcomBuildArtefact ) {
+				setDeploymentStyle( 'custom' );
+				setSelectedWorkflow( dotcomBuildArtefact );
+			}
+		}
 	}, [ workflows, isTemplateRepository ] );
 
 	const RenderValidationIcon = ( { validationStatus }: { validationStatus: WorkFlowStates } ) => {

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/deployment-style.tsx
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/deployment-style.tsx
@@ -14,7 +14,7 @@ import { translate } from 'i18n-calypso';
 import Prism from 'prismjs';
 import 'prismjs/themes/prism.css';
 import 'prismjs/components/prism-yaml';
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormRadiosBar from 'calypso/components/forms/form-radios-bar';
 import SupportInfo from 'calypso/components/support-info';
@@ -75,7 +75,7 @@ export const DeploymentStyle = ( {
 	);
 
 	const [ selectedWorkflow, setSelectedWorkflow ] = useState< Workflows >( {
-		file_name: workflowPath ? getWorkflowNameFromFilepath( workflowPath ) : 'none',
+		file_name: workflowPath ? getWorkflowNameFromFilepath( workflowPath ) : __( 'Select workflow' ),
 		workflow_path: workflowPath || 'none',
 	} );
 	const [ isCreatingNewWorkflow, setIsCreatingNewWorkflow ] = useState( false );
@@ -91,9 +91,7 @@ export const DeploymentStyle = ( {
 	} = useDeploymentWorkflowsQuery( installationId, repository, branchName, deploymentStyle );
 
 	const workflowsForRendering = useMemo( () => {
-		const mappedValues = [
-			{ workflow_path: 'none', file_name: __( 'Deployment workflows' ) },
-		].concat(
+		const mappedValues = [ { workflow_path: 'none', file_name: __( 'Select workflow' ) } ].concat(
 			workflows?.map( ( workflow ) => ( {
 				workflow_path: workflow.workflow_path,
 				file_name: workflow.file_name,
@@ -120,7 +118,7 @@ export const DeploymentStyle = ( {
 	);
 
 	const isWorkflowInvalid =
-		! ( isFetchingWorkflows || isRefreshingWorkflows ) && selectedWorkflow.file_name === 'none';
+		! ( isFetchingWorkflows || isRefreshingWorkflows ) && selectedWorkflow.workflow_path === 'none';
 	const workflowFileName = workflowPath
 		? workflowPath.substring( workflowPath.lastIndexOf( '/' ) + 1 )
 		: '';
@@ -284,6 +282,9 @@ export const DeploymentStyle = ( {
 		} else {
 			onChooseWorkflow?.( selectedWorkflow.workflow_path );
 		}
+		if ( yamlCodeRef.current ) {
+			Prism.highlightElement( yamlCodeRef.current );
+		}
 	}, [ onChooseWorkflow, deploymentStyle, selectedWorkflow ] );
 
 	useEffect( () => {
@@ -344,9 +345,9 @@ export const DeploymentStyle = ( {
 
 	return (
 		<div className="github-deployments-deployment-style">
-			<strong css={ { display: 'block', fontSize: '16px', marginBottom: '16px' } }>
-				{ __( 'Pick a deployment mode' ) }
-			</strong>
+			<h3 className="github-deployments-deployment-style__header">
+				{ __( 'Pick your deployment mode' ) }
+			</h3>
 			<FormRadiosBar
 				items={ [
 					{ label: __( 'Simple' ), value: 'simple' },
@@ -358,7 +359,7 @@ export const DeploymentStyle = ( {
 			/>
 
 			{ deploymentStyle === 'custom' && (
-				<FormFieldset>
+				<FormFieldset style={ { marginBottom: '0px' } }>
 					<FormLabel>
 						{ __( 'Select deployment workflow' ) }
 
@@ -396,7 +397,7 @@ export const DeploymentStyle = ( {
 				</FormFieldset>
 			) }
 
-			{ ! isTemplateRepository && (
+			{ ! isTemplateRepository && deploymentStyle === 'custom' && ! isWorkflowInvalid && (
 				<FormFieldset className="github-deployments-deployment-style__workflow-checks">
 					{ deploymentStyle === 'custom' &&
 						selectedWorkflow.workflow_path !== 'none' &&
@@ -429,8 +430,8 @@ export const DeploymentStyle = ( {
 								) ) }
 							</>
 						) }
-					{ deploymentStyle === 'custom' && isCreatingNewWorkflow && (
-						<>
+					{ deploymentStyle === 'custom' && (
+						<div className={ isCreatingNewWorkflow ? '' : 'hide-new-workflow' }>
 							<FormLabel>{ __( 'Custom workflow' ) }</FormLabel>
 							<p>
 								{ __(
@@ -452,7 +453,7 @@ export const DeploymentStyle = ( {
 									</pre>
 								</div>
 							</FoldableCard>
-						</>
+						</div>
 					) }
 					{ deploymentStyle === 'custom' && selectedWorkflow.workflow_path !== 'none' && (
 						<div className="github-deployments-deployment-style__actions">

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/deployment-style.tsx
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/deployment-style.tsx
@@ -98,6 +98,10 @@ export const DeploymentStyle = ( {
 			} ) ) || []
 		);
 
+		if ( isTemplateRepository ) {
+			return mappedValues;
+		}
+
 		return mappedValues.concat( {
 			workflow_path: 'create-new',
 			file_name: __( 'Create new workflow' ),
@@ -259,7 +263,10 @@ export const DeploymentStyle = ( {
 	}, [ workflowCheckResult ] );
 
 	useEffect( () => {
-		if ( deploymentStyle === 'simple' || isTemplateRepository ) {
+		if (
+			deploymentStyle === 'simple' ||
+			( isTemplateRepository && selectedWorkflow.workflow_path !== 'none' )
+		) {
 			onValidationChange?.( 'success' );
 		} else {
 			onValidationChange?.( workflowCheckResult?.conclusion || 'loading' );

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/style.scss
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/style.scss
@@ -1,4 +1,7 @@
 .github-deployments-deployment-style {
+	/** Temporary **/
+	display: none !important;
+	/** End Temporary **/
 	border: 1px solid var(--studio-gray-5);
 	box-sizing: border-box;
 	padding: 24px;

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/style.scss
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/style.scss
@@ -4,7 +4,15 @@
 	padding: 24px;
 	border-radius: 2px;
 	background-color: var(--studio-gray-0);
+	width: 100%;
 	height: fit-content;
+
+	&__header {
+		font-weight: 500;
+		font-size: 1rem;
+		margin-bottom: 16px;
+		line-height: 24px;
+	}
 
 	&__repository {
 		label {
@@ -27,7 +35,6 @@
 		}
 		&__content {
 			background-color: var(--studio-gray-0);
-
 			p {
 				margin: 0;
 			}
@@ -47,7 +54,6 @@
 
 	.card,
 	.foldable-card {
-
 		border-radius: 4px;
 
 		.foldable-card__main svg {
@@ -88,8 +94,13 @@
 		margin-bottom: 0;
 	}
 
+	.form-radios-bar .form-label {
+		font-size: 0.875rem;
+		font-weight: 400;
+	}
+
 	.form-fieldset {
-		>.spinner {
+		> .spinner {
 			margin-bottom: 1.5em;
 		}
 
@@ -128,10 +139,22 @@
 		}
 	}
 
+	.hide-new-workflow {
+		display: none;
+	}
+
 	&__workflow-checks {
 		.form-input-validation.is-error {
 			margin-top: -8px;
 			margin-bottom: 16px;
+		}
+
+		&.form-fieldset {
+			margin-top: 24px;
+		}
+
+		&.form-fieldset .form-label {
+			margin-top: 0;
 		}
 	}
 

--- a/client/my-sites/github-deployments/components/repositories/deployment-style/use-deployment-workflows-query.ts
+++ b/client/my-sites/github-deployments/components/repositories/deployment-style/use-deployment-workflows-query.ts
@@ -27,6 +27,7 @@ export const useDeploymentWorkflowsQuery = (
 	repository: GitHubRepositoryData,
 	branchName: string,
 	deploymentStyle: string,
+	isTemplateRepository: boolean,
 	options?: Partial< UseQueryOptions< Workflows[] > >
 ) => {
 	const path = addQueryArgs( '/hosting/github/workflows', {
@@ -38,7 +39,7 @@ export const useDeploymentWorkflowsQuery = (
 
 	return useQuery< Workflows[] >( {
 		queryKey: [ GITHUB_DEPLOYMENTS_QUERY_KEY, CODE_DEPLOYMENTS_QUERY_KEY, path ],
-		enabled: !! installationId && deploymentStyle !== 'simple',
+		enabled: !! installationId && ( deploymentStyle !== 'simple' || isTemplateRepository ),
 		queryFn: (): Workflows[] =>
 			wp.req.get( {
 				path,

--- a/client/my-sites/github-deployments/deployment-management/style.scss
+++ b/client/my-sites/github-deployments/deployment-management/style.scss
@@ -34,9 +34,18 @@
 		display: flex;
 		align-items: center;
 		gap: 8px;
+	}
 
-		.components-form-toggle {
-			line-height: 1;
-		}
+	.components-form-toggle {
+		line-height: 1;
+	}
+
+	&__configs {
+		width: 45%;
+		margin-right: 5%;
+	}
+
+	&__deployment-style {
+		width: 50%;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes
This PR adjust styling of the `DeploymentStyle` to closely match the figma design

* Fix syntax highlighting for creating new workflows
* Add necessary borders and spacing 
* Added Template repository checks:

<img width="624" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/5e832309-c713-47dd-8b70-5928eb4d7d96">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

![image](https://github.com/Automattic/wp-calypso/assets/47489215/55c6662d-c6e2-4559-9dfe-a5e2111ce0ca)




## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?