### PR TITLE
GitHub Deployments: Fix empty deployment run empty state

### DIFF
--- a/client/my-sites/github-deployments/components/repositories/repository-list-item.tsx
+++ b/client/my-sites/github-deployments/components/repositories/repository-list-item.tsx
@@ -18,9 +18,12 @@ export const GitHubRepositoryListItem = ( {
 	return (
 		<tr>
 			<td>
-				<div className="github-deployments-repository-list__name">
-					{ repository.name } { repository.private && <Icon icon={ lock } size={ 16 } /> }
-				</div>
+				<span css={ { fontWeight: 500 } }>
+					{ repository.name }{ ' ' }
+					{ repository.private && (
+						<Icon icon={ lock } size={ 16 } css={ { verticalAlign: 'middle' } } />
+					) }
+				</span>
 			</td>
 			<td>{ formatDate( locale, new Date( repository.updated_at ) ) }</td>
 			<td>

--- a/client/my-sites/github-deployments/components/repositories/style.scss
+++ b/client/my-sites/github-deployments/components/repositories/style.scss
@@ -14,9 +14,12 @@
 
 	&__search {
 		flex-grow: 1;
+		height: 40px;
+		.gridicons-search {
+			top: 8px !important;
+		}
 		input {
 			max-width: 400px;
-			height: 43px;
 		}
 	}
 	.components-spinner {
@@ -76,12 +79,6 @@
 	tr th {
 		font-weight: 500;
 		color: var(--studio-gray-60, #50575e);
-	}
-
-	&__name {
-		display: flex;
-		align-items: center;
-		font-weight: 500 !important;
 	}
 
 	tr td:last-child {

--- a/client/my-sites/github-deployments/deployments/deployments-list-table.tsx
+++ b/client/my-sites/github-deployments/deployments/deployments-list-table.tsx
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { useMemo } from 'react';
 import { SortButton } from 'calypso/my-sites/github-deployments/components/sort-button/sort-button';
 import { SortDirection } from 'calypso/my-sites/github-deployments/components/sort-button/use-sort';
 import { CodeDeploymentData } from 'calypso/my-sites/github-deployments/deployments/use-code-deployments-query';
@@ -17,6 +18,12 @@ export const DeploymentsListTable = ( {
 	sortDirection,
 	onSortChange,
 }: DeploymentsListProps ) => {
+	const hasRuns = useMemo( () => {
+		return !! deployments.find(
+			( deployment ) => deployment.current_deployed_run || deployment.current_deployment_run
+		);
+	}, [ deployments ] );
+
 	return (
 		<table>
 			<thead>
@@ -34,36 +41,42 @@ export const DeploymentsListTable = ( {
 					<th style={ { width: '100%' } }>
 						<span>{ __( 'Last commit' ) }</span>
 					</th>
-					<th>
-						<SortButton
-							value="status"
-							activeValue={ sortKey }
-							direction={ sortDirection }
-							onChange={ onSortChange }
-						>
-							<span>{ __( 'Status' ) }</span>
-						</SortButton>
-					</th>
-					<th>
-						<SortButton
-							value="date"
-							activeValue={ sortKey }
-							direction={ sortDirection }
-							onChange={ onSortChange }
-						>
-							<span>{ __( 'Date' ) }</span>
-						</SortButton>
-					</th>
-					<th>
-						<SortButton
-							value="duration"
-							activeValue={ sortKey }
-							direction={ sortDirection }
-							onChange={ onSortChange }
-						>
-							<span>{ __( 'Duration' ) }</span>
-						</SortButton>
-					</th>
+					{ hasRuns ? (
+						<>
+							<th>
+								<SortButton
+									value="status"
+									activeValue={ sortKey }
+									direction={ sortDirection }
+									onChange={ onSortChange }
+								>
+									<span>{ __( 'Status' ) }</span>
+								</SortButton>
+							</th>
+							<th>
+								<SortButton
+									value="date"
+									activeValue={ sortKey }
+									direction={ sortDirection }
+									onChange={ onSortChange }
+								>
+									<span>{ __( 'Date' ) }</span>
+								</SortButton>
+							</th>
+							<th>
+								<SortButton
+									value="duration"
+									activeValue={ sortKey }
+									direction={ sortDirection }
+									onChange={ onSortChange }
+								>
+									<span>{ __( 'Duration' ) }</span>
+								</SortButton>
+							</th>
+						</>
+					) : (
+						<th colSpan={ 3 } />
+					) }
 					<th> </th>
 				</tr>
 			</thead>


### PR DESCRIPTION
## Proposed Changes

The table headings were getting squished if there was a deployment but no runs.

| Before | After |
| ------ | ------ |
| ![image](https://github.com/Automattic/wp-calypso/assets/26530524/48d52e55-9c08-4d7b-8c7c-63f735922d05) | ![image](https://github.com/Automattic/wp-calypso/assets/26530524/f9a513d5-0544-4cfd-8fe1-a111ff3c0a99) |