### PR TITLE
Add recurring flag to Razorpay options

### DIFF
--- a/client/my-sites/checkout/src/lib/razorpay-processor.ts
+++ b/client/my-sites/checkout/src/lib/razorpay-processor.ts
@@ -172,8 +172,11 @@ function combineRazorpayOptions(
 	const options = razorpayConfiguration.options;
 	options.order_id = txnResponse.razorpay_order_id;
 	options.customer_id = txnResponse.razorpay_customer_id;
-	options.handler = handler;
+	if ( txnResponse.razorpay_option_recurring ) {
+		options.recurring = '1';
+	}
 
+	options.handler = handler;
 	const modal = options.modal ?? {};
 	modal.ondismiss = handler;
 	options.modal = modal;

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -40,6 +40,7 @@ export type WPCOMTransactionEndpointResponseRedirect = {
 	qr_code?: string;
 	razorpay_order_id?: string;
 	razorpay_customer_id?: string;
+	razorpay_option_recurring?: boolean;
 };
 
 export type WPCOMTransactionEndpointResponse =


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/payments-florin/issues/427

## Proposed Changes

* This PR adds a new configuration option to the Razorpay widget, enabling recurring payments.

## Testing Instructions

* (a12s) Enable store sandbox and billing sandbox and tail the logs.
* (a12s) Apply this patch D136447-code 
* Change your user's currency to INR
* In checkout, set your tax location to India. Use any 6 digit numeric postal code.
* Go through a normal new purchase for a subscription product, like a plan. Pick Razorpay as the payment method and submit
* You should now see the Razorpay widget displaying the widget to set a recurring payment

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?