### PR TITLE
Remove isExternalLink on Jetpack Cloud "WP Admin" link

### DIFF
--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -115,7 +115,6 @@ const JetpackCloudSidebar = ( {
 				<ul>
 					{ ! isJetpackManage && jetpackAdminUrl && (
 						<SidebarNavigatorMenuItem
-							isExternalLink
 							title={ translate( 'WP Admin' ) }
 							link={ jetpackAdminUrl }
 							path={ jetpackAdminUrl }

--- a/client/jetpack-cloud/components/sidebar/index.tsx
+++ b/client/jetpack-cloud/components/sidebar/index.tsx
@@ -115,6 +115,8 @@ const JetpackCloudSidebar = ( {
 				<ul>
 					{ ! isJetpackManage && jetpackAdminUrl && (
 						<SidebarNavigatorMenuItem
+							isExternalLink
+							openInSameTab
 							title={ translate( 'WP Admin' ) }
 							link={ jetpackAdminUrl }
 							path={ jetpackAdminUrl }

--- a/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
+++ b/client/layout/sidebar-v2/navigator/navigator-menu-item.tsx
@@ -22,6 +22,7 @@ interface Props {
 	withChevron?: boolean;
 	isExternalLink?: boolean;
 	isSelected?: boolean;
+	openInSameTab?: boolean;
 }
 
 export const SidebarNavigatorMenuItem = ( {
@@ -34,6 +35,7 @@ export const SidebarNavigatorMenuItem = ( {
 	withChevron = false,
 	isExternalLink = false,
 	isSelected = false,
+	openInSameTab = false,
 }: Props ) => {
 	const SidebarItem = ( { children }: { children?: JSX.Element } ) => {
 		return (
@@ -45,7 +47,7 @@ export const SidebarNavigatorMenuItem = ( {
 				href={ link }
 				id={ id }
 				as="a"
-				target={ isExternalLink ? '_blank' : undefined }
+				target={ isExternalLink && ! openInSameTab ? '_blank' : undefined }
 			>
 				<HStack justify="flex-start">
 					{ icon && <Icon style={ { fill: 'currentcolor' } } icon={ icon } size={ ICON_SIZE } /> }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/87884

## Proposed Changes

* Try removing `isExternalLink` so the "WP Admin" link on the bottom of cloud.jetpack.com does NOT open in a new tab.

<img width="1173" alt="Screenshot 2024-02-23 at 5 23 29 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/35e1efe3-233b-4b8a-b3a0-a718c6c656c9">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use the Jetpack Cloud live link in the comments below to test opening the "WP Admin" link.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?