### PR TITLE
Checkoutv2: Feedback pass two

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -1111,7 +1111,7 @@ const WPCheckoutSidebarContent = styled.div`
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 		margin-top: 0;
-		padding: 144px 24px 0 64px;
+		padding: 144px 24px 144px 64px;
 
 		.rtl & {
 			padding: 144px 64px 0 24px;

--- a/client/my-sites/checkout/src/hooks/product-variants.tsx
+++ b/client/my-sites/checkout/src/hooks/product-variants.tsx
@@ -205,7 +205,7 @@ function getTermText(
 
 		case TERM_ANNUALLY:
 			return String(
-				! shouldUseCheckoutV2 ? translate( 'One year' ) : translate( 'Billed every one year' )
+				! shouldUseCheckoutV2 ? translate( 'One year' ) : translate( 'Billed every year' )
 			);
 
 		case TERM_MONTHLY:

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -17,7 +17,6 @@ import {
 	isDIFMProduct,
 	isTieredVolumeSpaceAddon,
 	isAkismetProduct,
-	isGoogleWorkspace,
 } from '@automattic/calypso-products';
 import { Gridicon, Popover } from '@automattic/components';
 import {
@@ -1024,14 +1023,6 @@ function LineItemMetaInfo( { product }: { product: ResponseCartProduct } ) {
 		return translate( '%(quantity)s GB extra space', {
 			args: { quantity: spaceQuantity },
 		} );
-	}
-
-	if ( isGoogleWorkspace( product ) || isGSuiteOrExtraLicenseProductSlug( productSlug ) ) {
-		return translate( 'Mailboxes and Productivity Tools' );
-	}
-
-	if ( isTitanMail( product ) ) {
-		return translate( 'Mailboxes' );
 	}
 }
 


### PR DESCRIPTION
This PR contains a number of small tweaks from the CFT feedback - pbOQVh-45k-p2#comment-5540

Related to #

## Proposed Changes

* Updated `Billed every one year` to `Billed every year`
* Remove the `Mailboxes` and `Mailboxes and Productivity Tools` meta lines from Google Workspace and Professional Email product line items
* Add additional padding to 'features list'
* Remove back button 'chevron' for WordPress.com checkout


## Testing Instructions

- Go to `checkoutVersion=2` and check that the above items are displayed correctly
- You can check these by adding a plan, a domain with Professional Email, and a domain with Google Workspace to the cart
