### PR TITLE
JP Manage: 307 - add favicons to new sites dash

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-favicon/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-favicon/index.tsx
@@ -1,0 +1,28 @@
+import { WordPressLogo } from '@automattic/components';
+import classNames from 'classnames';
+import SiteIcon from 'calypso/blocks/site-icon';
+import { Site } from '../types';
+
+import './style.scss';
+
+interface SiteFaviconProps {
+	site: Site;
+	size?: number;
+	className?: string;
+}
+
+const SiteFavicon = ( { site, size = 40, className = '' }: SiteFaviconProps ) => {
+	const defaultFavicon = site.is_atomic ? (
+		<WordPressLogo className="wpcom-favicon" size={ size * 0.8 } />
+	) : (
+		<div className="no-favicon" />
+	);
+
+	return (
+		<div className={ classNames( 'site-favicon', className ) }>
+			<SiteIcon siteId={ site.blog_id } size={ size } defaultIcon={ defaultFavicon } />
+		</div>
+	);
+};
+
+export default SiteFavicon;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-favicon/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-favicon/index.tsx
@@ -12,10 +12,12 @@ interface SiteFaviconProps {
 }
 
 const SiteFavicon = ( { site, size = 40, className = '' }: SiteFaviconProps ) => {
+	const siteColor = site.site_color ?? 'linear-gradient(45deg, #ff0056, #ff8a78, #57b7ff, #9c00d4)';
+
 	const defaultFavicon = site.is_atomic ? (
 		<WordPressLogo className="wpcom-favicon" size={ size * 0.8 } />
 	) : (
-		<div className="no-favicon" />
+		<div className="no-favicon" style={ { background: siteColor } } />
 	);
 
 	return (

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-favicon/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-favicon/style.scss
@@ -8,9 +8,12 @@
 			.wpcom-favicon {
 				fill: var(--studio-blue-50);
 			}
-		}
-		&:has(.no-favicon) {
-			background: linear-gradient(45deg, #ff0056, #ff8a78, #57b7ff, #9c00d4);
+
+			.no-favicon {
+				width: 100%;
+				height: 100%;
+				background: linear-gradient(45deg, #ff0056, #ff8a78, #57b7ff, #9c00d4);
+			}
 		}
 	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-favicon/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-favicon/style.scss
@@ -1,0 +1,16 @@
+.site-favicon {
+	margin-right: 16px;
+
+	.site-icon {
+		border-radius: 10px; /* stylelint-disable-line scales/radii */
+		&.is-blank {
+			background: transparent;
+			.wpcom-favicon {
+				fill: var(--studio-blue-50);
+			}
+		}
+		&:has(.no-favicon) {
+			background: linear-gradient(45deg, #ff0056, #ff8a78, #57b7ff, #9c00d4);
+		}
+	}
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
@@ -51,12 +51,7 @@ export default function SitePreviewPane( {
 
 	return (
 		<div className={ classNames( 'site-preview__pane', className ) }>
-			<SitePreviewPaneHeader
-				title={ site.blogname }
-				url={ site.url }
-				urlWithScheme={ site.url_with_scheme }
-				closeSitePreviewPane={ closeSitePreviewPane }
-			/>
+			<SitePreviewPaneHeader site={ site } closeSitePreviewPane={ closeSitePreviewPane } />
 			<SitePreviewPaneTabs featureTabs={ featureTabs } />
 			{ selectedFeature.preview }
 		</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/index.tsx
@@ -3,41 +3,35 @@ import { Button } from '@wordpress/components';
 import { Icon, external } from '@wordpress/icons';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
+import SiteFavicon from '../../site-favicon';
+import { Site } from '../../types';
 
 import './style.scss';
 
 const ICON_SIZE = 24;
 
 interface Props {
-	title: string;
-	url: string;
-	urlWithScheme: string;
+	site: Site;
 	closeSitePreviewPane?: () => void;
 	className?: string;
 }
 
-export default function SitePreviewPaneHeader( {
-	title,
-	url,
-	urlWithScheme,
-	closeSitePreviewPane,
-	className,
-}: Props ) {
+export default function SitePreviewPaneHeader( { site, closeSitePreviewPane, className }: Props ) {
 	return (
 		<div className={ classNames( 'site-preview__header', className ) }>
 			<div className="site-preview__header-bg"></div>
-			<div className="sites-dataviews__site-favicon site-preview__header-favicon"></div>
+			<SiteFavicon site={ site } className="site-preview__header-favicon" size={ 64 } />
 			<div className="site-preview__header-content">
 				<div className="site-preview__header-title-summary">
-					<div className="site-preview__header-title">{ title }</div>
+					<div className="site-preview__header-title">{ site.blogname }</div>
 					<div className="site-preview__header-summary">
 						<Button
 							variant="link"
 							className="site-preview__header-summary-link"
-							href={ urlWithScheme }
+							href={ site.url_with_scheme }
 							target="_blank"
 						>
-							<span>{ url }</span>
+							<span>{ site.url }</span>
 							<Icon className="sidebar-v2__external-icon" icon={ external } size={ ICON_SIZE } />
 						</Button>
 					</div>
@@ -47,7 +41,7 @@ export default function SitePreviewPaneHeader( {
 					className="site-preview__close-preview"
 					aria-label={ translate( 'Close Preview' ) }
 				>
-					<Gridicon icon="cross" size={ 24 } />
+					<Gridicon icon="cross" size={ ICON_SIZE } />
 				</Button>
 			</div>
 		</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/site-data-field.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/site-data-field.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@automattic/components';
 import TextPlaceholder from 'calypso/jetpack-cloud/sections/partner-portal/text-placeholder';
+import SiteFavicon from '../site-favicon';
 import { Site } from '../types';
 
 interface SiteDataFieldProps {
@@ -16,7 +17,7 @@ const SiteDataField = ( { isLoading, site, onSiteTitleClick }: SiteDataFieldProp
 	return (
 		<div className="sites-dataviews__site">
 			<Button onClick={ () => onSiteTitleClick( site ) } borderless>
-				<div className="sites-dataviews__site-favicon"></div>
+				<SiteFavicon site={ site } />
 			</Button>
 			<div className="sites-dataviews__site-name">
 				<Button onClick={ () => onSiteTitleClick( site ) } borderless>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
@@ -82,14 +82,6 @@
 	font-weight: 400;
 }
 
-.sites-dataviews__site-favicon {
-	width: 40px;
-	height: 40px;
-	background: linear-gradient(45deg, #ff0056, #ff8a78, #57b7ff, #9c00d4);
-	margin-right: 16px;
-	border-radius: 10px; /* stylelint-disable-line scales/radii */
-}
-
 .sites-dataviews__actions {
 	display: flex;
 	flex-direction: row;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/types.ts
@@ -103,6 +103,7 @@ export interface Site {
 	has_vulnerable_plugins: boolean;
 	latest_scan_has_threats_found: boolean;
 	active_paid_subscription_slugs: Array< string >;
+	site_color?: string;
 }
 export interface SiteNode {
 	value: Site;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolves Automattic/jetpack-manage#307 - add favicons to new sites dash

## Proposed Changes
This PR introduces a `SiteFavicon` component that wraps the `SiteIcon` component used by WordPress.com, which shows the site's favicon.

It's used in the new Sites DataViews table as well as in the preview pane. If no favicon is available and it's hosted by WordPress.com, it shows the WP.com icon. Otherwise it shows a fallback gradient.

Note that I experimented with generating a color (gradient) per site to provide some variation. This PR will use a site color as the fallback if provided. To see that in action, try D139607-code.

## Testing Instructions
Go to `/sites`.

In `trunk` the sites all have a gradient.

In the `fix/jp-manage/307-add_favicons` branch:

* sites with favicons show the favicon
* otherwise, sites hosted on WP.com show the WP.com favicon
* otherwise, they'll show a gradient

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?