### PR TITLE
Jetpack Manage: Update the Preview Pane with the feature tabs bar and content with the Jetpack feature components

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-backup.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-backup.tsx
@@ -5,13 +5,15 @@ import { Site } from '../types';
 
 type Props = {
 	site: Site;
+	trackEvent: ( eventName: string ) => void;
+	hasError?: boolean;
 };
 
-export function JetpackBackupPreview( { site }: Props ) {
+export function JetpackBackupPreview( { site, trackEvent, hasError = false }: Props ) {
 	return (
 		<>
 			<SitePreviewPaneContent>
-				<BackupStorage site={ site } trackEvent={ () => {} } hasError={ false } />
+				<BackupStorage site={ site } trackEvent={ trackEvent } hasError={ hasError } />
 			</SitePreviewPaneContent>
 			<SitePreviewPaneFooter />
 		</>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-backup.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-backup.tsx
@@ -1,3 +1,4 @@
+import BackupStorage from '../site-expanded-content/backup-storage';
 import SitePreviewPaneContent from '../site-preview-pane/site-preview-pane-content';
 import SitePreviewPaneFooter from '../site-preview-pane/site-preview-pane-footer';
 import { Site } from '../types';
@@ -10,11 +11,7 @@ export function JetpackBackupPreview( { site }: Props ) {
 	return (
 		<>
 			<SitePreviewPaneContent>
-				<div>
-					<b>Backup Pane</b>
-					<br />
-					{ site.url }
-				</div>
+				<BackupStorage site={ site } trackEvent={ () => {} } hasError={ false } />
 			</SitePreviewPaneContent>
 			<SitePreviewPaneFooter />
 		</>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-backup.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-backup.tsx
@@ -1,0 +1,22 @@
+import SitePreviewPaneContent from '../site-preview-pane/site-preview-pane-content';
+import SitePreviewPaneFooter from '../site-preview-pane/site-preview-pane-footer';
+import { Site } from '../types';
+
+type Props = {
+	site: Site;
+};
+
+export function JetpackBackupPreview( { site }: Props ) {
+	return (
+		<>
+			<SitePreviewPaneContent>
+				<div>
+					<b>Backup Pane</b>
+					<br />
+					{ site.url }
+				</div>
+			</SitePreviewPaneContent>
+			<SitePreviewPaneFooter />
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-boost.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-boost.tsx
@@ -5,13 +5,15 @@ import { Site } from '../types';
 
 type Props = {
 	site: Site;
+	trackEvent: ( eventName: string ) => void;
+	hasError?: boolean;
 };
 
-export function JetpackBoostPreview( { site }: Props ) {
+export function JetpackBoostPreview( { site, trackEvent, hasError = false }: Props ) {
 	return (
 		<>
 			<SitePreviewPaneContent>
-				<BoostSitePerformance site={ site } trackEvent={ () => {} } hasError={ false } />
+				<BoostSitePerformance site={ site } trackEvent={ trackEvent } hasError={ hasError } />
 			</SitePreviewPaneContent>
 			<SitePreviewPaneFooter />
 		</>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-boost.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-boost.tsx
@@ -1,0 +1,22 @@
+import SitePreviewPaneContent from '../site-preview-pane/site-preview-pane-content';
+import SitePreviewPaneFooter from '../site-preview-pane/site-preview-pane-footer';
+import { Site } from '../types';
+
+type Props = {
+	site: Site;
+};
+
+export function JetpackBoostPreview( { site }: Props ) {
+	return (
+		<>
+			<SitePreviewPaneContent>
+				<div>
+					<b>Boost Pane</b>
+					<br />
+					{ site.url }
+				</div>
+			</SitePreviewPaneContent>
+			<SitePreviewPaneFooter />
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-boost.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-boost.tsx
@@ -1,3 +1,4 @@
+import BoostSitePerformance from '../site-expanded-content/boost-site-performance';
 import SitePreviewPaneContent from '../site-preview-pane/site-preview-pane-content';
 import SitePreviewPaneFooter from '../site-preview-pane/site-preview-pane-footer';
 import { Site } from '../types';
@@ -10,11 +11,7 @@ export function JetpackBoostPreview( { site }: Props ) {
 	return (
 		<>
 			<SitePreviewPaneContent>
-				<div>
-					<b>Boost Pane</b>
-					<br />
-					{ site.url }
-				</div>
+				<BoostSitePerformance site={ site } trackEvent={ () => {} } hasError={ false } />
 			</SitePreviewPaneContent>
 			<SitePreviewPaneFooter />
 		</>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-monitor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-monitor.tsx
@@ -1,0 +1,22 @@
+import SitePreviewPaneContent from '../site-preview-pane/site-preview-pane-content';
+import SitePreviewPaneFooter from '../site-preview-pane/site-preview-pane-footer';
+import { Site } from '../types';
+
+type Props = {
+	site: Site;
+};
+
+export function JetpackMonitorPreview( { site }: Props ) {
+	return (
+		<>
+			<SitePreviewPaneContent>
+				<div>
+					<b>Monitor Pane</b>
+					<br />
+					{ site.url }
+				</div>
+			</SitePreviewPaneContent>
+			<SitePreviewPaneFooter />
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-monitor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-monitor.tsx
@@ -1,3 +1,4 @@
+import MonitorActivity from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/monitor-activity';
 import SitePreviewPaneContent from '../site-preview-pane/site-preview-pane-content';
 import SitePreviewPaneFooter from '../site-preview-pane/site-preview-pane-footer';
 import { Site } from '../types';
@@ -10,11 +11,12 @@ export function JetpackMonitorPreview( { site }: Props ) {
 	return (
 		<>
 			<SitePreviewPaneContent>
-				<div>
-					<b>Monitor Pane</b>
-					<br />
-					{ site.url }
-				</div>
+				<MonitorActivity
+					hasMonitor={ site.monitor_settings.monitor_active }
+					site={ site }
+					trackEvent={ () => {} }
+					hasError={ false }
+				/>
 			</SitePreviewPaneContent>
 			<SitePreviewPaneFooter />
 		</>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-monitor.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-monitor.tsx
@@ -5,17 +5,19 @@ import { Site } from '../types';
 
 type Props = {
 	site: Site;
+	trackEvent: ( eventName: string ) => void;
+	hasError?: boolean;
 };
 
-export function JetpackMonitorPreview( { site }: Props ) {
+export function JetpackMonitorPreview( { site, trackEvent, hasError = false }: Props ) {
 	return (
 		<>
 			<SitePreviewPaneContent>
 				<MonitorActivity
 					hasMonitor={ site.monitor_settings.monitor_active }
 					site={ site }
-					trackEvent={ () => {} }
-					hasError={ false }
+					trackEvent={ trackEvent }
+					hasError={ hasError }
 				/>
 			</SitePreviewPaneContent>
 			<SitePreviewPaneFooter />

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
@@ -1,0 +1,63 @@
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import SitePreviewPane from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane';
+import { SitePreviewPaneProps } from '../site-preview-pane/types';
+import { JetpackBackupPreview } from './jetpack-backup';
+import { JetpackBoostPreview } from './jetpack-boost';
+import { JetpackMonitorPreview } from './jetpack-monitor';
+import { JetpackStatsPreview } from './jetpack-stats';
+
+export function JetpackPreviewPane( { site, closeSitePreviewPane }: SitePreviewPaneProps ) {
+	const translate = useTranslate();
+
+	const [ selectedFeatureId, setSelectedFeatureId ] = useState( 'jetpack_boost' );
+
+	// Jetpack features: Boost, Backup, Monitor, Stats
+	const features = [
+		{
+			id: 'jetpack_boost',
+			tab: {
+				label: translate( 'Boost' ),
+				selected: selectedFeatureId === 'jetpack_boost',
+				onTabClick: () => setSelectedFeatureId( 'jetpack_boost' ),
+			},
+			preview: <JetpackBoostPreview site={ site } />,
+		},
+		{
+			id: 'jetpack_backup',
+			tab: {
+				label: translate( 'Backup' ),
+				selected: selectedFeatureId === 'jetpack_backup',
+				onTabClick: () => setSelectedFeatureId( 'jetpack_backup' ),
+			},
+			preview: <JetpackBackupPreview site={ site } />,
+		},
+		{
+			id: 'jetpack_monitor',
+			tab: {
+				label: translate( 'Monitor' ),
+				selected: selectedFeatureId === 'jetpack_monitor',
+				onTabClick: () => setSelectedFeatureId( 'jetpack_monitor' ),
+			},
+			preview: <JetpackMonitorPreview site={ site } />,
+		},
+		{
+			id: 'jetpack_stats',
+			tab: {
+				label: translate( 'Stats' ),
+				selected: selectedFeatureId === 'jetpack_stats',
+				onTabClick: () => setSelectedFeatureId( 'jetpack_stats' ),
+			},
+			preview: <JetpackStatsPreview site={ site } />,
+		},
+	];
+
+	return (
+		<SitePreviewPane
+			site={ site }
+			closeSitePreviewPane={ closeSitePreviewPane }
+			features={ features }
+			selectedFeatureId={ selectedFeatureId }
+		/>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
@@ -22,6 +22,7 @@ export function JetpackPreviewPane( { site, closeSitePreviewPane }: SitePreviewP
 					selected: selectedFeatureId === 'jetpack_boost',
 					onTabClick: () => setSelectedFeatureId( 'jetpack_boost' ),
 				},
+				enabled: true,
 				preview: <JetpackBoostPreview site={ site } />,
 			},
 			{
@@ -31,6 +32,7 @@ export function JetpackPreviewPane( { site, closeSitePreviewPane }: SitePreviewP
 					selected: selectedFeatureId === 'jetpack_backup',
 					onTabClick: () => setSelectedFeatureId( 'jetpack_backup' ),
 				},
+				enabled: true,
 				preview: <JetpackBackupPreview site={ site } />,
 			},
 			{
@@ -40,6 +42,7 @@ export function JetpackPreviewPane( { site, closeSitePreviewPane }: SitePreviewP
 					selected: selectedFeatureId === 'jetpack_monitor',
 					onTabClick: () => setSelectedFeatureId( 'jetpack_monitor' ),
 				},
+				enabled: true,
 				preview: <JetpackMonitorPreview site={ site } />,
 			},
 			{
@@ -49,6 +52,7 @@ export function JetpackPreviewPane( { site, closeSitePreviewPane }: SitePreviewP
 					selected: selectedFeatureId === 'jetpack_stats',
 					onTabClick: () => setSelectedFeatureId( 'jetpack_stats' ),
 				},
+				enabled: true,
 				preview: <JetpackStatsPreview site={ site } />,
 			},
 		],

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
@@ -1,5 +1,5 @@
 import { useTranslate } from 'i18n-calypso';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import SitePreviewPane from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane';
 import { SitePreviewPaneProps } from '../site-preview-pane/types';
 import { JetpackBackupPreview } from './jetpack-backup';
@@ -13,51 +13,53 @@ export function JetpackPreviewPane( { site, closeSitePreviewPane }: SitePreviewP
 	const [ selectedFeatureId, setSelectedFeatureId ] = useState( 'jetpack_boost' );
 
 	// Jetpack features: Boost, Backup, Monitor, Stats
-	const features = [
-		{
-			id: 'jetpack_boost',
-			tab: {
-				label: translate( 'Boost' ),
-				selected: selectedFeatureId === 'jetpack_boost',
-				onTabClick: () => setSelectedFeatureId( 'jetpack_boost' ),
+	const features = useMemo(
+		() => [
+			{
+				id: 'jetpack_boost',
+				tab: {
+					label: translate( 'Boost' ),
+					selected: selectedFeatureId === 'jetpack_boost',
+					onTabClick: () => setSelectedFeatureId( 'jetpack_boost' ),
+				},
+				preview: <JetpackBoostPreview site={ site } />,
 			},
-			preview: <JetpackBoostPreview site={ site } />,
-		},
-		{
-			id: 'jetpack_backup',
-			tab: {
-				label: translate( 'Backup' ),
-				selected: selectedFeatureId === 'jetpack_backup',
-				onTabClick: () => setSelectedFeatureId( 'jetpack_backup' ),
+			{
+				id: 'jetpack_backup',
+				tab: {
+					label: translate( 'Backup' ),
+					selected: selectedFeatureId === 'jetpack_backup',
+					onTabClick: () => setSelectedFeatureId( 'jetpack_backup' ),
+				},
+				preview: <JetpackBackupPreview site={ site } />,
 			},
-			preview: <JetpackBackupPreview site={ site } />,
-		},
-		{
-			id: 'jetpack_monitor',
-			tab: {
-				label: translate( 'Monitor' ),
-				selected: selectedFeatureId === 'jetpack_monitor',
-				onTabClick: () => setSelectedFeatureId( 'jetpack_monitor' ),
+			{
+				id: 'jetpack_monitor',
+				tab: {
+					label: translate( 'Monitor' ),
+					selected: selectedFeatureId === 'jetpack_monitor',
+					onTabClick: () => setSelectedFeatureId( 'jetpack_monitor' ),
+				},
+				preview: <JetpackMonitorPreview site={ site } />,
 			},
-			preview: <JetpackMonitorPreview site={ site } />,
-		},
-		{
-			id: 'jetpack_stats',
-			tab: {
-				label: translate( 'Stats' ),
-				selected: selectedFeatureId === 'jetpack_stats',
-				onTabClick: () => setSelectedFeatureId( 'jetpack_stats' ),
+			{
+				id: 'jetpack_stats',
+				tab: {
+					label: translate( 'Stats' ),
+					selected: selectedFeatureId === 'jetpack_stats',
+					onTabClick: () => setSelectedFeatureId( 'jetpack_stats' ),
+				},
+				preview: <JetpackStatsPreview site={ site } />,
 			},
-			preview: <JetpackStatsPreview site={ site } />,
-		},
-	];
+		],
+		[ site, selectedFeatureId, translate ]
+	);
 
 	return (
 		<SitePreviewPane
 			site={ site }
 			closeSitePreviewPane={ closeSitePreviewPane }
 			features={ features }
-			selectedFeatureId={ selectedFeatureId }
 		/>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
@@ -18,7 +18,7 @@ export function JetpackPreviewPane( { site, closeSitePreviewPane }: SitePreviewP
 			{
 				id: 'jetpack_boost',
 				tab: {
-					label: translate( 'Boost' ),
+					label: 'Boost',
 					selected: selectedFeatureId === 'jetpack_boost',
 					onTabClick: () => setSelectedFeatureId( 'jetpack_boost' ),
 				},
@@ -27,7 +27,7 @@ export function JetpackPreviewPane( { site, closeSitePreviewPane }: SitePreviewP
 			{
 				id: 'jetpack_backup',
 				tab: {
-					label: translate( 'Backup' ),
+					label: 'Backup',
 					selected: selectedFeatureId === 'jetpack_backup',
 					onTabClick: () => setSelectedFeatureId( 'jetpack_backup' ),
 				},
@@ -36,7 +36,7 @@ export function JetpackPreviewPane( { site, closeSitePreviewPane }: SitePreviewP
 			{
 				id: 'jetpack_monitor',
 				tab: {
-					label: translate( 'Monitor' ),
+					label: 'Monitor',
 					selected: selectedFeatureId === 'jetpack_monitor',
 					onTabClick: () => setSelectedFeatureId( 'jetpack_monitor' ),
 				},
@@ -45,7 +45,7 @@ export function JetpackPreviewPane( { site, closeSitePreviewPane }: SitePreviewP
 			{
 				id: 'jetpack_stats',
 				tab: {
-					label: translate( 'Stats' ),
+					label: 'Stats',
 					selected: selectedFeatureId === 'jetpack_stats',
 					onTabClick: () => setSelectedFeatureId( 'jetpack_stats' ),
 				},

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
@@ -1,13 +1,18 @@
+import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
-import { useMemo, useState } from 'react';
-import SitePreviewPane from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane';
+import React, { useMemo, useState } from 'react';
+import SitePreviewPane, { createFeaturePreview } from '../site-preview-pane';
 import { SitePreviewPaneProps } from '../site-preview-pane/types';
 import { JetpackBackupPreview } from './jetpack-backup';
 import { JetpackBoostPreview } from './jetpack-boost';
 import { JetpackMonitorPreview } from './jetpack-monitor';
 import { JetpackStatsPreview } from './jetpack-stats';
 
-export function JetpackPreviewPane( { site, closeSitePreviewPane }: SitePreviewPaneProps ) {
+export function JetpackPreviewPane( {
+	site,
+	closeSitePreviewPane,
+	className,
+}: SitePreviewPaneProps ) {
 	const translate = useTranslate();
 
 	const [ selectedFeatureId, setSelectedFeatureId ] = useState( 'jetpack_boost' );
@@ -15,46 +20,54 @@ export function JetpackPreviewPane( { site, closeSitePreviewPane }: SitePreviewP
 	// Jetpack features: Boost, Backup, Monitor, Stats
 	const features = useMemo(
 		() => [
-			{
-				id: 'jetpack_boost',
-				tab: {
-					label: 'Boost',
-					selected: selectedFeatureId === 'jetpack_boost',
-					onTabClick: () => setSelectedFeatureId( 'jetpack_boost' ),
-				},
-				enabled: true,
-				preview: <JetpackBoostPreview site={ site } />,
-			},
-			{
-				id: 'jetpack_backup',
-				tab: {
-					label: 'Backup',
-					selected: selectedFeatureId === 'jetpack_backup',
-					onTabClick: () => setSelectedFeatureId( 'jetpack_backup' ),
-				},
-				enabled: true,
-				preview: <JetpackBackupPreview site={ site } />,
-			},
-			{
-				id: 'jetpack_monitor',
-				tab: {
-					label: 'Monitor',
-					selected: selectedFeatureId === 'jetpack_monitor',
-					onTabClick: () => setSelectedFeatureId( 'jetpack_monitor' ),
-				},
-				enabled: true,
-				preview: <JetpackMonitorPreview site={ site } />,
-			},
-			{
-				id: 'jetpack_stats',
-				tab: {
-					label: 'Stats',
-					selected: selectedFeatureId === 'jetpack_stats',
-					onTabClick: () => setSelectedFeatureId( 'jetpack_stats' ),
-				},
-				enabled: true,
-				preview: <JetpackStatsPreview site={ site } />,
-			},
+			createFeaturePreview(
+				'jetpack_boost',
+				'Boost',
+				true,
+				selectedFeatureId,
+				setSelectedFeatureId,
+				<JetpackBoostPreview site={ site } />
+			),
+			createFeaturePreview(
+				'jetpack_backup',
+				'Backup',
+				true,
+				selectedFeatureId,
+				setSelectedFeatureId,
+				<JetpackBackupPreview site={ site } />
+			),
+			createFeaturePreview(
+				'jetpack_monitor',
+				'Monitor',
+				true,
+				selectedFeatureId,
+				setSelectedFeatureId,
+				<JetpackMonitorPreview site={ site } />
+			),
+			createFeaturePreview(
+				'jetpack_stats',
+				'Stats',
+				true,
+				selectedFeatureId,
+				setSelectedFeatureId,
+				<JetpackStatsPreview site={ site } />
+			),
+			createFeaturePreview(
+				'jetpack_scan',
+				'Scan',
+				true,
+				selectedFeatureId,
+				() => page( '/scan/' + site.url ),
+				null
+			),
+			createFeaturePreview(
+				'jetpack_plugins',
+				'Plugins',
+				true,
+				selectedFeatureId,
+				() => page( '/plugins/manage/' + site.url ),
+				null
+			),
 		],
 		[ site, selectedFeatureId, translate ]
 	);
@@ -64,6 +77,7 @@ export function JetpackPreviewPane( { site, closeSitePreviewPane }: SitePreviewP
 			site={ site }
 			closeSitePreviewPane={ closeSitePreviewPane }
 			features={ features }
+			className={ className }
 		/>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
@@ -1,6 +1,7 @@
 import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
 import React, { useMemo, useState } from 'react';
+import { useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
 import SitePreviewPane, { createFeaturePreview } from '../site-preview-pane';
 import { SitePreviewPaneProps } from '../site-preview-pane/types';
 import { JetpackBackupPreview } from './jetpack-backup';
@@ -12,8 +13,15 @@ export function JetpackPreviewPane( {
 	site,
 	closeSitePreviewPane,
 	className,
+	isSmallScreen = false,
+	hasError = false,
 }: SitePreviewPaneProps ) {
 	const translate = useTranslate();
+	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( [ site ], ! isSmallScreen );
+
+	const trackEvent = ( eventName: string ) => {
+		recordEvent( eventName );
+	};
 
 	const [ selectedFeatureId, setSelectedFeatureId ] = useState( 'jetpack_boost' );
 
@@ -26,7 +34,7 @@ export function JetpackPreviewPane( {
 				true,
 				selectedFeatureId,
 				setSelectedFeatureId,
-				<JetpackBoostPreview site={ site } />
+				<JetpackBoostPreview site={ site } trackEvent={ trackEvent } hasError={ hasError } />
 			),
 			createFeaturePreview(
 				'jetpack_backup',
@@ -34,7 +42,7 @@ export function JetpackPreviewPane( {
 				true,
 				selectedFeatureId,
 				setSelectedFeatureId,
-				<JetpackBackupPreview site={ site } />
+				<JetpackBackupPreview site={ site } trackEvent={ trackEvent } hasError={ hasError } />
 			),
 			createFeaturePreview(
 				'jetpack_monitor',
@@ -42,7 +50,7 @@ export function JetpackPreviewPane( {
 				true,
 				selectedFeatureId,
 				setSelectedFeatureId,
-				<JetpackMonitorPreview site={ site } />
+				<JetpackMonitorPreview site={ site } trackEvent={ trackEvent } hasError={ hasError } />
 			),
 			createFeaturePreview(
 				'jetpack_stats',
@@ -50,7 +58,7 @@ export function JetpackPreviewPane( {
 				true,
 				selectedFeatureId,
 				setSelectedFeatureId,
-				<JetpackStatsPreview site={ site } />
+				<JetpackStatsPreview site={ site } trackEvent={ trackEvent } />
 			),
 			createFeaturePreview(
 				'jetpack_scan',

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-stats.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-stats.tsx
@@ -1,3 +1,4 @@
+import InsightsStats from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/site-expanded-content/insights-stats';
 import SitePreviewPaneContent from '../site-preview-pane/site-preview-pane-content';
 import SitePreviewPaneFooter from '../site-preview-pane/site-preview-pane-footer';
 import { Site } from '../types';
@@ -10,11 +11,11 @@ export function JetpackStatsPreview( { site }: Props ) {
 	return (
 		<>
 			<SitePreviewPaneContent>
-				<div>
-					<b>Stats Pane</b>
-					<br />
-					{ site.url }
-				</div>
+				<InsightsStats
+					stats={ site.site_stats }
+					siteUrlWithScheme={ site.url_with_scheme }
+					trackEvent={ () => {} }
+				/>
 			</SitePreviewPaneContent>
 			<SitePreviewPaneFooter />
 		</>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-stats.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-stats.tsx
@@ -1,0 +1,22 @@
+import SitePreviewPaneContent from '../site-preview-pane/site-preview-pane-content';
+import SitePreviewPaneFooter from '../site-preview-pane/site-preview-pane-footer';
+import { Site } from '../types';
+
+type Props = {
+	site: Site;
+};
+
+export function JetpackStatsPreview( { site }: Props ) {
+	return (
+		<>
+			<SitePreviewPaneContent>
+				<div>
+					<b>Stats Pane</b>
+					<br />
+					{ site.url }
+				</div>
+			</SitePreviewPaneContent>
+			<SitePreviewPaneFooter />
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-stats.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-stats.tsx
@@ -5,16 +5,17 @@ import { Site } from '../types';
 
 type Props = {
 	site: Site;
+	trackEvent: ( eventName: string ) => void;
 };
 
-export function JetpackStatsPreview( { site }: Props ) {
+export function JetpackStatsPreview( { site, trackEvent }: Props ) {
 	return (
 		<>
 			<SitePreviewPaneContent>
 				<InsightsStats
 					stats={ site.site_stats }
 					siteUrlWithScheme={ site.url_with_scheme }
-					trackEvent={ () => {} }
+					trackEvent={ trackEvent }
 				/>
 			</SitePreviewPaneContent>
 			<SitePreviewPaneFooter />

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
@@ -1,28 +1,43 @@
-import { Site } from '../types';
-import SitePreviewPaneContent from './site-preview-pane-content';
-import SitePreviewPaneFooter from './site-preview-pane-footer';
 import SitePreviewPaneHeader from './site-preview-pane-header';
 import SitePreviewPaneTabs from './site-preview-pane-tabs';
+import { SitePreviewPaneProps } from './types';
 
 import './style.scss';
 
-interface Props {
-	selectedSite: Site;
-	closeSitePreviewPane: () => void;
-}
+export default function SitePreviewPane( {
+	site,
+	selectedFeatureId,
+	features,
+	closeSitePreviewPane,
+}: SitePreviewPaneProps ) {
+	// Ensure we have features
+	if ( ! features || ! features.length ) {
+		return null;
+	}
 
-export default function SitePreviewPane( { selectedSite, closeSitePreviewPane }: Props ) {
+	// Find the selected feature or default to the first feature
+	const selectedFeature = selectedFeatureId
+		? features.find( ( feature ) => feature.id === selectedFeatureId )
+		: features[ 0 ];
+
+	// Ensure we have a valid feature
+	if ( ! selectedFeature ) {
+		return null;
+	}
+
+	// Extract the tabs from the features
+	const featureTabs = features.map( ( feature ) => feature.tab );
+
 	return (
 		<div className="site-preview__pane">
 			<SitePreviewPaneHeader
-				title={ selectedSite.blogname }
-				url={ selectedSite.url }
-				urlWithScheme={ selectedSite.url_with_scheme }
+				title={ site.blogname }
+				url={ site.url }
+				urlWithScheme={ site.url_with_scheme }
 				closeSitePreviewPane={ closeSitePreviewPane }
 			/>
-			<SitePreviewPaneTabs />
-			<SitePreviewPaneContent />
-			<SitePreviewPaneFooter />
+			<SitePreviewPaneTabs featureTabs={ featureTabs } />
+			{ selectedFeature.preview }
 		</div>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
@@ -1,13 +1,37 @@
+import classNames from 'classnames';
+import React from 'react';
 import SitePreviewPaneHeader from './site-preview-pane-header';
 import SitePreviewPaneTabs from './site-preview-pane-tabs';
-import { SitePreviewPaneProps } from './types';
+import { FeaturePreviewInterface, SitePreviewPaneProps } from './types';
 
 import './style.scss';
+
+export const createFeaturePreview = (
+	id: string,
+	label: string,
+	enabled: boolean,
+	selectedFeatureId: string,
+	setSelectedFeatureId: ( id: string ) => void,
+	preview: React.ReactNode
+): FeaturePreviewInterface => {
+	return {
+		id,
+		tab: {
+			label,
+			visible: enabled,
+			selected: enabled && selectedFeatureId === id,
+			onTabClick: () => enabled && setSelectedFeatureId( id ),
+		},
+		enabled,
+		preview: enabled ? preview : null,
+	};
+};
 
 export default function SitePreviewPane( {
 	site,
 	features,
 	closeSitePreviewPane,
+	className,
 }: SitePreviewPaneProps ) {
 	// Ensure we have features
 	if ( ! features || ! features.length ) {
@@ -26,7 +50,7 @@ export default function SitePreviewPane( {
 	const featureTabs = features.map( ( feature ) => feature.tab );
 
 	return (
-		<div className="site-preview__pane">
+		<div className={ classNames( 'site-preview__pane', className ) }>
 			<SitePreviewPaneHeader
 				title={ site.blogname }
 				url={ site.url }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/index.tsx
@@ -6,7 +6,6 @@ import './style.scss';
 
 export default function SitePreviewPane( {
 	site,
-	selectedFeatureId,
 	features,
 	closeSitePreviewPane,
 }: SitePreviewPaneProps ) {
@@ -16,9 +15,7 @@ export default function SitePreviewPane( {
 	}
 
 	// Find the selected feature or default to the first feature
-	const selectedFeature = selectedFeatureId
-		? features.find( ( feature ) => feature.id === selectedFeatureId )
-		: features[ 0 ];
+	const selectedFeature = features.find( ( feature ) => feature.tab.selected ) || features[ 0 ];
 
 	// Ensure we have a valid feature
 	if ( ! selectedFeature ) {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-content/index.tsx
@@ -1,5 +1,11 @@
+import { ReactNode } from 'react';
+
 import './style.scss';
 
-export default function SitePreviewPaneContent() {
-	return <div className="site-preview__content">Content goes here</div>;
+type Props = {
+	children?: ReactNode;
+};
+
+export default function SitePreviewPaneContent( { children }: Props ) {
+	return <div className="site-preview__content">{ children }</div>;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-content/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-content/index.tsx
@@ -1,11 +1,13 @@
+import classNames from 'classnames';
 import { ReactNode } from 'react';
 
 import './style.scss';
 
 type Props = {
 	children?: ReactNode;
+	className?: string;
 };
 
-export default function SitePreviewPaneContent( { children }: Props ) {
-	return <div className="site-preview__content">{ children }</div>;
+export default function SitePreviewPaneContent( { children, className }: Props ) {
+	return <div className={ classNames( 'site-preview__content', className ) }>{ children }</div>;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-content/style.scss
@@ -1,4 +1,6 @@
 .site-preview__content {
 	flex-grow: 1;
-	background-color: #fff;
+	background-color: var(--studio-white);
+	padding: 48px;
+	text-align: center;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-content/style.scss
@@ -3,4 +3,13 @@
 	background-color: var(--studio-white);
 	padding: 48px;
 	text-align: center;
+
+	.expanded-card {
+		max-width: 320px;
+		width: auto;
+
+		.site-expanded-content__card-footer {
+			justify-content: center;
+		}
+	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-footer/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-footer/index.tsx
@@ -1,5 +1,13 @@
 import './style.scss';
 
-export default function SitePreviewPaneFooter() {
-	return <div className="site-preview__footer">Footer goes here</div>;
+type Props = {
+	children?: React.ReactNode;
+};
+
+export default function SitePreviewPaneFooter( { children }: Props ) {
+	return (
+		<>
+			<div className="site-preview__footer">{ children }</div>
+		</>
+	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-footer/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-footer/index.tsx
@@ -1,13 +1,15 @@
+import classNames from 'classnames';
 import './style.scss';
 
 type Props = {
 	children?: React.ReactNode;
+	className?: string;
 };
 
-export default function SitePreviewPaneFooter( { children }: Props ) {
+export default function SitePreviewPaneFooter( { children, className }: Props ) {
 	return (
 		<>
-			<div className="site-preview__footer">{ children }</div>
+			<div className={ classNames( 'site-preview__footer', className ) }>{ children }</div>
 		</>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-footer/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-footer/style.scss
@@ -1,4 +1,6 @@
 .site-preview__footer {
 	height: 48px;
-	background-color: #add8e6;
+	background-color: var(--studio-white);
+	padding: 32px 48px 32px 48px;
+	border-top: 1px solid var(--studio-gray-0);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-footer/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-footer/style.scss
@@ -1,6 +1,6 @@
 .site-preview__footer {
 	height: 48px;
 	background-color: var(--studio-white);
-	padding: 32px 48px 32px 48px;
+	padding: 32px 48px;
 	border-top: 1px solid var(--studio-gray-0);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/index.tsx
@@ -1,6 +1,7 @@
 import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
 import { Icon, external } from '@wordpress/icons';
+import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
 
 import './style.scss';
@@ -12,6 +13,7 @@ interface Props {
 	url: string;
 	urlWithScheme: string;
 	closeSitePreviewPane?: () => void;
+	className?: string;
 }
 
 export default function SitePreviewPaneHeader( {
@@ -19,9 +21,10 @@ export default function SitePreviewPaneHeader( {
 	url,
 	urlWithScheme,
 	closeSitePreviewPane,
+	className,
 }: Props ) {
 	return (
-		<div className="site-preview__header">
+		<div className={ classNames( 'site-preview__header', className ) }>
 			<div className="site-preview__header-bg"></div>
 			<div className="sites-dataviews__site-favicon site-preview__header-favicon"></div>
 			<div className="site-preview__header-content">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/index.tsx
@@ -11,7 +11,7 @@ interface Props {
 	title: string;
 	url: string;
 	urlWithScheme: string;
-	closeSitePreviewPane: () => void;
+	closeSitePreviewPane?: () => void;
 }
 
 export default function SitePreviewPaneHeader( {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-tabs/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-tabs/index.tsx
@@ -1,26 +1,32 @@
 import { Button } from '@automattic/components';
+import classNames from 'classnames';
 import { FeatureTabInterface } from '../types';
 
 import './style.scss';
 
 export default function SitePreviewPaneTabs( {
 	featureTabs,
+	className,
 }: {
 	featureTabs: FeatureTabInterface[];
+	className?: string;
 } ) {
 	return (
 		<>
-			<div className="site-preview__tabs">
-				{ featureTabs.map( ( featureTab: FeatureTabInterface ) => (
-					<Button
-						key={ featureTab.label }
-						className={ 'site-preview__tab' + ( featureTab.selected ? ' is-selected' : '' ) }
-						onClick={ () => featureTab.onTabClick?.() }
-						borderless
-					>
-						{ featureTab.label }
-					</Button>
-				) ) }
+			<div className={ classNames( 'site-preview__tabs', className ) }>
+				{ featureTabs.map(
+					( featureTab: FeatureTabInterface ) =>
+						featureTab.visible && (
+							<Button
+								key={ featureTab.label }
+								className={ 'site-preview__tab' + ( featureTab.selected ? ' is-selected' : '' ) }
+								onClick={ () => featureTab.onTabClick?.() }
+								borderless
+							>
+								{ featureTab.label }
+							</Button>
+						)
+				) }
 			</div>
 		</>
 	);

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-tabs/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-tabs/index.tsx
@@ -1,5 +1,27 @@
+import { Button } from '@automattic/components';
+import { FeatureTabInterface } from '../types';
+
 import './style.scss';
 
-export default function SitePreviewPaneTabs() {
-	return <div className="site-preview__tabs">Tabs go here</div>;
+export default function SitePreviewPaneTabs( {
+	featureTabs,
+}: {
+	featureTabs: FeatureTabInterface[];
+} ) {
+	return (
+		<>
+			<div className="site-preview__tabs">
+				{ featureTabs.map( ( featureTab: FeatureTabInterface ) => (
+					<Button
+						key={ featureTab.label }
+						className={ 'site-preview__tab' + ( featureTab.selected ? ' is-selected' : '' ) }
+						onClick={ () => featureTab.onTabClick?.() }
+						borderless
+					>
+						{ featureTab.label }
+					</Button>
+				) ) }
+			</div>
+		</>
+	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-tabs/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-tabs/style.scss
@@ -1,4 +1,26 @@
 .site-preview__tabs {
+	display: flex;
+	justify-content: flex-start;
+	align-items: center;
 	height: 48px;
-	background-color: #add8e6;
+	padding: 0 32px;
+	border-bottom: 1px solid var(--studio-gray-0);
+
+	.button.is-borderless {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		gap: 8px;
+		padding: 0 16px;
+		height: 100%;
+		font-size: rem(14px);
+		font-weight: 500;
+		color: var(--studio-black);
+		border-radius: 0;
+
+		&.is-selected {
+			border-bottom: 1px solid var(--studio-black);
+		}
+	}
 }
+

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/types.ts
@@ -1,0 +1,24 @@
+import React from 'react';
+import { Site } from '../types';
+
+export interface FeaturePreviewInterface {
+	id: string;
+	tab: FeatureTabInterface;
+	preview?: React.ReactNode;
+}
+
+export interface FeatureTabInterface {
+	label: string;
+	countValue?: number;
+	countColor?: string;
+	selected?: boolean;
+	enabled?: boolean;
+	onTabClick?: () => void;
+}
+
+export interface SitePreviewPaneProps {
+	site: Site;
+	closeSitePreviewPane?: () => void;
+	selectedFeatureId?: string;
+	features?: FeaturePreviewInterface[];
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/types.ts
@@ -23,4 +23,6 @@ export interface SitePreviewPaneProps {
 	selectedFeatureId?: string;
 	features?: FeaturePreviewInterface[];
 	className?: string;
+	isSmallScreen?: boolean;
+	hasError?: boolean;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/types.ts
@@ -13,6 +13,7 @@ export interface FeatureTabInterface {
 	countValue?: number;
 	countColor?: string;
 	selected?: boolean;
+	visible?: boolean;
 	onTabClick?: () => void;
 }
 
@@ -21,4 +22,5 @@ export interface SitePreviewPaneProps {
 	closeSitePreviewPane?: () => void;
 	selectedFeatureId?: string;
 	features?: FeaturePreviewInterface[];
+	className?: string;
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/types.ts
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/types.ts
@@ -5,6 +5,7 @@ export interface FeaturePreviewInterface {
 	id: string;
 	tab: FeatureTabInterface;
 	preview?: React.ReactNode;
+	enabled?: boolean;
 }
 
 export interface FeatureTabInterface {
@@ -12,7 +13,6 @@ export interface FeatureTabInterface {
 	countValue?: number;
 	countColor?: string;
 	selected?: boolean;
-	enabled?: boolean;
 	onTabClick?: () => void;
 }
 

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
@@ -348,6 +348,8 @@ export default function SitesDashboardV2() {
 				<JetpackPreviewPane
 					site={ sitesViewState.selectedSite }
 					closeSitePreviewPane={ closeSitePreviewPane }
+					isSmallScreen={ ! isLargeScreen }
+					hasError={ isError }
 				/>
 			) }
 		</div>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
@@ -34,8 +34,8 @@ import useQueryProvisioningBlogIds from './hooks/use-query-provisioning-blog-ids
 import { DASHBOARD_PRODUCT_SLUGS_BY_TYPE } from './lib/constants';
 import SiteAddLicenseNotification from './site-add-license-notification';
 import SiteContentHeader from './site-content-header';
+import { JetpackPreviewPane } from './site-feature-previews/jetpack-preview-pane';
 import SiteNotifications from './site-notifications';
-import SitePreviewPane from './site-preview-pane';
 import SiteTopHeaderButtons from './site-top-header-buttons';
 import SitesDataViews from './sites-dataviews';
 import { SitesViewState } from './sites-dataviews/interfaces';
@@ -345,8 +345,8 @@ export default function SitesDashboardV2() {
 				) }
 			</div>
 			{ sitesViewState.selectedSite && (
-				<SitePreviewPane
-					selectedSite={ sitesViewState.selectedSite }
+				<JetpackPreviewPane
+					site={ sitesViewState.selectedSite }
 					closeSitePreviewPane={ closeSitePreviewPane }
 				/>
 			) }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
@@ -43,6 +43,9 @@
 
 		}
 	}
+	ul.dataviews-view-list li:hover {
+		background-color: var(--studio-gray-0);
+	}
 }
 
 .components-search-control input[type="search"].components-search-control__input {


### PR DESCRIPTION
Resolves: https://github.com/Automattic/jetpack-manage/issues/316
Resolves: https://github.com/Automattic/jetpack-manage/issues/293

## Proposed Changes

This PR adds the feature tabs bar to the Preview Pane:

![image](https://github.com/Automattic/wp-calypso/assets/9832440/f3147d90-4d5f-43e3-a85a-27edb7e5f012)


I designed the system to be agnostic from the context, so the features are assigned from an external component. For this context, Manage, I create the `JetpackPreviewPane` that wraps `SitePreviewPane` component to feed it with the features of the context.

- JetpackPreviewPane
    - Configures these Jetpack features with `id`, `tab`, `preview`
        - `JetpackBoostPreview`
        - `JetpackBackupPreview`
        - `JetpackStatsPreview`
        - `JetpackMonitorPreview`
    - Render:
        -  `SitePreviewPane` **props:** `site`, `features`, `closeSitePreviewPane`
            - It will render the Preview Pane: header, tabs, and the content (preview).

## Testing Instructions

- Check the code and how the Preview Pane with multiple features works.
- Test the UI/UX, click on the different tabs, and, with the Preview Pane opened, click on another site.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
