### PR TITLE
Global Site View sidebar - replace 'all sites' link with WP Admin

### DIFF
--- a/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
+++ b/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
@@ -19,23 +19,14 @@ export default function globalSiteSidebarMenu( {
 	return [
 		{
 			icon: 'dashicons-arrow-left-alt2',
-			slug: 'all-sites',
-			title: translate( 'All sites' ),
-			type: 'menu-item',
-			url: `/sites`,
-			className: 'sidebar__menu-item-all-sites',
+			slug: 'wp-admin',
+			title: translate( 'WP Admin' ),
+			url: `https://${ selectedSiteSlug }/wp-admin`,
+			className: 'sidebar__menu-item-wp-admin',
 		},
 		{
 			type: 'current-site',
 			url: `/home/${ siteDomain }`,
-		},
-		{
-			slug: 'wp-admin',
-			title: translate( 'WP Admin' ),
-			type: 'menu-item',
-			url: `https://${ selectedSiteSlug }/wp-admin`,
-			className: 'sidebar__menu-item-wp-admin',
-			forceShowExternalIcon: true,
 		},
 		{
 			type: 'separator',

--- a/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
+++ b/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
@@ -29,9 +29,6 @@ export default function globalSiteSidebarMenu( {
 			url: `/home/${ siteDomain }`,
 		},
 		{
-			type: 'separator',
-		},
-		{
 			slug: 'upgrades',
 			title: translate( 'Plans' ),
 			type: 'menu-item',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pfsHM7-gH-p 2

## Proposed Changes

Before:

<img width="296" alt="Screenshot 2024-02-24 at 7 18 00 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/bec44e7a-988c-4369-94c9-abfed5f63031">

After:

<img width="293" alt="Screenshot 2024-02-24 at 7 24 21 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/64b8393f-c0e4-4dcd-8676-c348281d2ca5">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch, visit Global site view for the new nav (atomic site w/ classic view"
* verify the "All sites" button is gone and "WP Admin" is in place.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?