### PR TITLE
My Sites page - update links to go to wp-admin for nav redesign classic view.

### DIFF
--- a/client/sites-dashboard/components/sites-grid-item.tsx
+++ b/client/sites-dashboard/components/sites-grid-item.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useSiteLaunchStatusLabel, getSiteLaunchStatus } from '@automattic/sites';
 import { css } from '@emotion/css';
@@ -127,9 +126,7 @@ export const SitesGridItem = memo( ( props: SitesGridItemProps ) => {
 	const siteDashboardUrlProps = showThumbnailLink
 		? {
 				href:
-					isAtomicSite &&
-					siteDefaultInterface( site ) === 'wp-admin' &&
-					! isEnabled( 'layout/dotcom-nav-redesign' )
+					isAtomicSite && siteDefaultInterface( site ) === 'wp-admin'
 						? wpAdminUrl || getDashboardUrl( site.slug )
 						: getDashboardUrl( site.slug ),
 				title: __( 'Visit Dashboard' ),

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -161,6 +161,14 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 		return siteId && hasSiteStatsQueryFailed( state, siteId, statType, query );
 	} );
 
+	const computeDashboardUrl = ( site, isAtomicSite ) => {
+		if ( isAtomicSite && siteDefaultInterface( site ) === 'wp-admin' ) {
+			return getSiteWpAdminUrl( site ) || getDashboardUrl( site.slug );
+		}
+		return getDashboardUrl( site.slug );
+	};
+	const dashboardUrl = computeDashboardUrl( site, isAtomicSite );
+
 	let siteUrl = site.URL;
 	if ( site.options?.is_redirect && site.options?.unmapped_url ) {
 		siteUrl = site.options?.unmapped_url;
@@ -174,27 +182,13 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 						min-width: 0;
 					` }
 					leading={
-						<ListTileLeading
-							href={
-								isAtomicSite && siteDefaultInterface( site ) === 'wp-admin'
-									? getSiteWpAdminUrl( site ) || getDashboardUrl( site.slug )
-									: getDashboardUrl( site.slug )
-							}
-							title={ __( 'Visit Dashboard' ) }
-						>
+						<ListTileLeading href={ dashboardUrl } title={ __( 'Visit Dashboard' ) }>
 							<SiteItemThumbnail displayMode="list" showPlaceholder={ ! inView } site={ site } />
 						</ListTileLeading>
 					}
 					title={
 						<ListTileTitle>
-							<SiteName
-								href={
-									isAtomicSite && siteDefaultInterface( site ) === 'wp-admin'
-										? getSiteWpAdminUrl( site ) || getDashboardUrl( site.slug )
-										: getDashboardUrl( site.slug )
-								}
-								title={ __( 'Visit Dashboard' ) }
-							>
+							<SiteName href={ dashboardUrl } title={ __( 'Visit Dashboard' ) }>
 								{ site.title }
 							</SiteName>
 							{ isP2Site && <SitesP2Badge>P2</SitesP2Badge> }

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -161,7 +161,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 		return siteId && hasSiteStatsQueryFailed( state, siteId, statType, query );
 	} );
 
-	const computeDashboardUrl = ( site, isAtomicSite ) => {
+	const computeDashboardUrl = ( site: SiteExcerptData, isAtomicSite: boolean | null ) => {
 		if ( isAtomicSite && siteDefaultInterface( site ) === 'wp-admin' ) {
 			return getSiteWpAdminUrl( site ) || getDashboardUrl( site.slug );
 		}

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -162,7 +162,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 	} );
 
 	const computeDashboardUrl = ( site: SiteExcerptData, isAtomicSite: boolean | null ) => {
-		if ( isAtomicSite && siteDefaultInterface( site ) === 'wp-admin' ) {
+		if ( siteDefaultInterface( site ) === 'wp-admin' ) {
 			return getSiteWpAdminUrl( site ) || getDashboardUrl( site.slug );
 		}
 		return getDashboardUrl( site.slug );

--- a/client/sites-dashboard/components/sites-table-row.tsx
+++ b/client/sites-dashboard/components/sites-table-row.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { ListTile, Popover } from '@automattic/components';
 import { useSiteLaunchStatusLabel } from '@automattic/sites';
 import { css } from '@emotion/css';
@@ -177,9 +176,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 					leading={
 						<ListTileLeading
 							href={
-								isAtomicSite &&
-								siteDefaultInterface( site ) === 'wp-admin' &&
-								! isEnabled( 'layout/dotcom-nav-redesign' )
+								isAtomicSite && siteDefaultInterface( site ) === 'wp-admin'
 									? getSiteWpAdminUrl( site ) || getDashboardUrl( site.slug )
 									: getDashboardUrl( site.slug )
 							}
@@ -192,9 +189,7 @@ export default memo( function SitesTableRow( { site }: SiteTableRowProps ) {
 						<ListTileTitle>
 							<SiteName
 								href={
-									isAtomicSite &&
-									siteDefaultInterface( site ) === 'wp-admin' &&
-									! isEnabled( 'layout/dotcom-nav-redesign' )
+									isAtomicSite && siteDefaultInterface( site ) === 'wp-admin'
 										? getSiteWpAdminUrl( site ) || getDashboardUrl( site.slug )
 										: getDashboardUrl( site.slug )
 								}


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # pfsHM7-gH-p2

## Proposed Changes

WoA sites with classic view were linked to global site view in this redesign. We want to change it back to the current classic veiw behavior, and have these link to wp-admin.

* Updates these links to go to wp-admin when in classic view, as spelled out by "
We need a Github PR to point the following /sites/ links to wp-admin for sites that have global classic view toggled on:" on the linked p2 above.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->



* Visit /sites with the redesign enabled `flags=layout/dotcom-nav-redesign`
* verify site links for atomic sites with classic view go to wp-admin in both grid and row views.
* visit /sites without redesign enabled `flags=-layout/dotcom-nav-redesign`
* verify site links for atomic sites with classic view still go to wp-admin.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?