### PR TITLE
GitHub Deployments: Ignore linter warning in example workflow file

### DIFF
--- a/client/my-sites/github-deployments/components/deployment-style/workflow-yaml-examples.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/workflow-yaml-examples.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable inclusive-language/use-inclusive-words */
+
 export const newWorkflowExample = ( branch: string ) => {
 	return `
 name: Publish Website


### PR DESCRIPTION
The workflow file mentions `checkout@master` and we can't remove that otherwise the checkout action won't work. This PR disables that linter warning.