### PR TITLE
My plan: Prevent text orphans

### DIFF
--- a/client/components/purchase-detail/style.scss
+++ b/client/components/purchase-detail/style.scss
@@ -145,6 +145,7 @@
 .purchase-detail__text {
 	flex-grow: 1;
 	word-break: break-word;
+	text-wrap: pretty;
 }
 
 .purchase-detail__body {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5777

## Proposed Changes

This PR adds the CSS property `text-wrap: pretty` to prevent text orphans.

| Before | After |
| --- | --- |
| ![Screenshot 2024-02-26 at 8 35 14 AM](https://github.com/Automattic/wp-calypso/assets/797888/8404d7da-9c88-4333-a354-f4768bf8e443) | ![Screenshot 2024-02-26 at 8 35 21 AM](https://github.com/Automattic/wp-calypso/assets/797888/365d6b62-aa69-4555-9d8a-2cb261281d6b) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/plans/my-plan/:site`.
* Ensure that text in the feature cards no longer have orphans.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?