### PR TITLE
Enabled Add-Ons rename Hosting to Configuration

### DIFF
--- a/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
+++ b/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
@@ -4,13 +4,11 @@ import { translate } from 'i18n-calypso';
  * Menu items for the Global Site View sidebar.
  */
 export default function globalSiteSidebarMenu( {
-	shouldShowAddOns,
 	showSiteMonitoring,
 	siteDomain,
 	selectedSiteSlug,
 	isStagingSite,
 }: {
-	shouldShowAddOns: boolean;
 	showSiteMonitoring: boolean;
 	siteDomain: string;
 	selectedSiteSlug: string;
@@ -40,7 +38,7 @@ export default function globalSiteSidebarMenu( {
 			title: translate( 'Add-Ons' ),
 			type: 'menu-item',
 			url: `/add-ons/${ siteDomain }`,
-			shouldHide: ! shouldShowAddOns,
+			shouldHide: isStagingSite,
 		},
 		{
 			slug: 'domains',
@@ -66,7 +64,7 @@ export default function globalSiteSidebarMenu( {
 		},
 		{
 			slug: 'options-hosting-configuration-php',
-			title: translate( 'Hosting' ),
+			title: translate( 'Configuration' ),
 			type: 'menu-item',
 			url: `/hosting-config/${ siteDomain }`,
 		},

--- a/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
+++ b/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
@@ -35,7 +35,7 @@ export default function globalSiteSidebarMenu( {
 		},
 		{
 			slug: 'Add-Ons',
-			title: translate( 'Add-Ons' ),
+			title: translate( 'Add-ons' ),
 			type: 'menu-item',
 			url: `/add-ons/${ siteDomain }`,
 			shouldHide: isStagingSite,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/35925 & pfsHM7-gH-p2

## Proposed Changes

* Update Global Site Navigation to include Add-Ons and rename Hosting to Configuration

<img width="698" alt="Screenshot 2024-02-25 at 7 02 58 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/5b1ba37c-4414-4ee0-a390-66661afe56ad">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* Got to http://calypso.localhost:3000/home/[site_slug]?flags=layout/dotcom-nav-redesign
* View the menu includes Add-Ons and Hosting is renamed to Configuration

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?