### PR TITLE
Remove Podcasting menu item from global site nav

### DIFF
--- a/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
+++ b/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
@@ -82,12 +82,6 @@ export default function globalSiteSidebarMenu( {
 			url: `/earn/${ siteDomain }`,
 		},
 		{
-			slug: 'options-podcasting-php',
-			title: translate( 'Podcasting' ),
-			type: 'menu-item',
-			url: `/settings/podcasting/${ siteDomain }`,
-		},
-		{
 			slug: 'subscribers',
 			title: translate( 'Subscribers' ),
 			type: 'menu-item',


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5463

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/jetpack/pull/35925 & pfsHM7-gH-p2

## Proposed Changes

* Remove the Podcasting menu item from the global site navigation.

Before | After
--|--
<img width="332" alt="Screenshot 2024-02-25 at 7 51 14 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/3fec2273-44a9-4b73-8ab7-307f8b7b20fb"> |  <img width="706" alt="Screenshot 2024-02-25 at 7 49 55 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/9bb31dca-97c2-4d39-906c-0ca5b7014219">




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Load this PR
* Got to [http://calypso.localhost:3000/home/[site_slug]?flags=layout/dotcom-nav-redesign](http://calypso.localhost:3000/home/%5Bsite_slug%5D?flags=layout/dotcom-nav-redesign)
* View Podcasting menu item is removed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?