### PR TITLE
Automattic for Agencies: Add Horizon env file and update other envs

### DIFF
--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -1,19 +1,13 @@
 {
-	"env": "development",
-	"env_id": "a8c-for-agencies-development",
-	"favicon_url": "/calypso/images/favicons/favicon-a4a-dev.ico",
+	"env": "production",
+	"env_id": "a8c-for-agencies-horizon",
+	"favicon_url": "/calypso/images/favicons/favicon-a4a-stage.ico",
 	"client_slug": "browser",
-	"protocol": "http",
-	"hostname": "agencies.localhost",
+	"hostname": "agencies.automattic.com",
 	"i18n_default_locale_slug": "en",
-	"port": 3000,
 	"site_name": "Automattic For Agencies",
-	"oauth_client_id": 95928,
 	"features": {
 		"a8c-for-agencies": true,
-		"always_use_logout_url": true,
-		"dev/auth-helper": true,
-		"dev/preferences-helper": true,
 		"oauth": true
 	},
 	"enable_all_sections": false,

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -19,6 +19,6 @@
 	"site_filter": [],
 	"theme": "a8c-for-agencies",
 	"restricted_me_access": false,
-	"theme_color": "#2fb41f",
+	"theme_color": "#029CD7",
 	"hotjar_enabled": true
 }

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -1,7 +1,7 @@
 {
 	"env": "production",
 	"env_id": "a8c-for-agencies-stage",
-	"favicon_url": "/calypso/images/favicons/favicon-a4a-prod.ico",
+	"favicon_url": "/calypso/images/favicons/favicon-a4a-stage.ico",
 	"client_slug": "browser",
 	"protocol": "http",
 	"hostname": "agencies.automattic.com",
@@ -14,11 +14,16 @@
 	},
 	"enable_all_sections": false,
 	"sections": {
-		"a8c-for-agencies": true
+		"a8c-for-agencies": true,
+		"a8c-for-agencies-auth": true,
+		"a8c-for-agencies-overview": true,
+		"a8c-for-agencies-plugins": true,
+		"a8c-for-agencies-sites": true,
+		"a8c-for-agencies-marketplace": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",
 	"restricted_me_access": false,
-	"theme_color": "#2fb41f",
+	"theme_color": "#029CD7",
 	"hotjar_enabled": true
 }


### PR DESCRIPTION
## Proposed Changes

This PR:

- Adds the Horizon env file
- Updates theme_color on all the other env files
- Updates favicon_url & enables all sections on the Staging env file.

## Testing Instructions

- Verify all the changes look good.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?