### PR TITLE
Untangle: Hide the "Manage all domains" on the site-specific domain page

### DIFF
--- a/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
+++ b/client/my-sites/domains/domain-management/list/bulk-site-domains.tsx
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { useSiteDomainsQuery } from '@automattic/data-stores';
 import { DomainsTable, ResponseDomain, useDomainsTable } from '@automattic/domains-table';
@@ -82,6 +83,7 @@ export default function BulkSiteDomains( props: BulkSiteDomainsProps ) {
 	// If user has more than 1 domain on more than 1 site, show manage all domains CTA.
 	const { domains: allDomains } = useDomainsTable( fetchAllDomains );
 	const showManageAllDomainsCTA =
+		! isEnabled( 'layout/dotcom-nav-redesign' ) &&
 		( allDomains || [] ).length > 1 &&
 		[ ...new Set( ( allDomains || [] ).map( ( domain ) => domain.blog_id ) ) ].length > 1;
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5774

## Proposed Changes

* Hide the “Manage all domains” section on the site-specific domain page when the `layout/dotcom-nav-redesign` flag is enabled

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/82a8a80f-8f8a-4909-a84b-6d474d5b13b5) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/eacd5126-b0f7-40b5-9ebc-6ddbdd7d0af2) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/domains/manage/<your_site>`
* Make sure the “Manage all domains” section is gone

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?