### PR TITLE
Sites Dashboard: Set table background color

### DIFF
--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -90,6 +90,7 @@ const DashboardHeading = styled.h1( {
 } );
 
 const sitesMarginTable = css( {
+	backgroundColor: 'var( --studio-white )',
 	marginBlockStart: '14px',
 	marginInline: 0,
 	marginBlockEnd: '1.5em',

--- a/client/sites-dashboard/components/sites-table.tsx
+++ b/client/sites-dashboard/components/sites-table.tsx
@@ -26,6 +26,7 @@ const THead = styled.thead< { blockOffset: number } >( ( { blockOffset } ) => ( 
 		display: 'none',
 	},
 
+	backgroundColor: 'inherit',
 	position: 'sticky',
 	zIndex: 3,
 	insetBlockStart: `${ blockOffset }px`,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5771

## Proposed Changes

This PR sets the background color of the Sites Dashboard table to white, preventing the sticky table header to be transparent.

| Before | After | 
| --- | --- |
| ![Screenshot 2024-02-26 at 2 50 06 PM](https://github.com/Automattic/wp-calypso/assets/797888/c1935e15-2a95-484f-8cf4-6d7c4285af0e) |  ![Screenshot 2024-02-26 at 2 49 35 PM](https://github.com/Automattic/wp-calypso/assets/797888/dd4e8670-5ef3-49d7-9ba1-355489260598) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/sites`.
* Scroll down the table and ensure that the table header is no longer transparent.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?