### PR TITLE
Untangle: point some links in Quick Links in My Home to wp-admin for classic view

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -72,6 +72,7 @@ export const QuickLinks = ( {
 	isFSEActive,
 	siteEditorUrl,
 	isAtomic,
+	adminInterface,
 } ) => {
 	const translate = useTranslate();
 	const [
@@ -102,6 +103,8 @@ export const QuickLinks = ( {
 			/>
 		) : null;
 
+	const usesWpAdminInterface = adminInterface === 'wp-admin';
+
 	const quickLinks = (
 		<div className="quick-links__boxes">
 			{ isFSEActive && canManageSite ? (
@@ -116,7 +119,7 @@ export const QuickLinks = ( {
 				customizerLinks
 			) }
 			<ActionBox
-				href={ `/post/${ siteSlug }` }
+				href={ usesWpAdminInterface ? `${ siteAdminUrl }post-new.php` : `/post/${ siteSlug }` }
 				hideLinkIndicator
 				onClick={ trackWritePostAction }
 				label={ translate( 'Write blog post' ) }
@@ -133,7 +136,9 @@ export const QuickLinks = ( {
 			) }
 			{ ! isStaticHomePage && canModerateComments && (
 				<ActionBox
-					href={ `/comments/${ siteSlug }` }
+					href={
+						usesWpAdminInterface ? `${ siteAdminUrl }edit-comments.php` : `/comments/${ siteSlug }`
+					}
 					hideLinkIndicator
 					onClick={ trackManageCommentsAction }
 					label={ translate( 'Manage comments' ) }
@@ -142,7 +147,11 @@ export const QuickLinks = ( {
 			) }
 			{ canEditPages && (
 				<ActionBox
-					href={ `/page/${ siteSlug }` }
+					href={
+						usesWpAdminInterface
+							? `${ siteAdminUrl }post-new.php?post_type=page`
+							: `/page/${ siteSlug }`
+					}
 					hideLinkIndicator
 					onClick={ trackAddPageAction }
 					label={ translate( 'Add a page' ) }
@@ -217,7 +226,9 @@ export const QuickLinks = ( {
 			{ canManageSite && (
 				<>
 					<ActionBox
-						href={ `/plugins/${ siteSlug }` }
+						href={
+							usesWpAdminInterface ? `${ siteAdminUrl }plugins.php` : `/plugins/${ siteSlug }`
+						}
 						hideLinkIndicator
 						onClick={ trackExplorePluginsAction }
 						label={ translate( 'Explore Plugins' ) }
@@ -265,7 +276,11 @@ export const QuickLinks = ( {
 			) }
 			{ isAtomic && hasBackups && (
 				<ActionBox
-					href={ `/backup/${ siteSlug }` }
+					href={
+						config.isEnabled( 'layout/dotcom-nav-redesign' ) && usesWpAdminInterface
+							? `https://jetpack.com/redirect/?source=calypso-backups&site=${ siteSlug }`
+							: `/backup/${ siteSlug }`
+					}
 					hideLinkIndicator
 					label={ translate( 'Restore a backup' ) }
 					iconComponent={ <JetpackLogo monochrome className="quick-links__action-box-icon" /> }
@@ -477,6 +492,7 @@ const mapStateToProps = ( state ) => {
 		isExpanded: getPreference( state, 'homeQuickLinksToggleStatus' ) !== 'collapsed',
 		siteAdminUrl: getSiteAdminUrl( state, siteId ),
 		siteEditorUrl: getSiteEditorUrl( state, siteId ),
+		adminInterface: getSiteOption( state, siteId, 'wpcom_admin_interface' ),
 	};
 };
 


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/5723

## Proposed Changes

This PR fixes the following links in My Home to go to wp-admin version, for sites with classic admin interface:

<img width="400" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/9e62a1d4-1189-4440-8ff9-6ec1de1a1451">

|Link|Default view|Classic view|
|-|-|-|
|Write blog post|`/post/:site`|`/wp-admin/post-new.php`|
|Manage comments|`/comments/:site`|`/wp-admin/edit-comments.php`|
|Add a page|`/page/:site`|`/wp-admin/post-new.php?post_type=page`|
|Explore Plugins|`/plugins/:site`|`/wp-admin/plugins.php`|
|Restore a backup|`/backup/:site`|`https://jetpack.com/redirect/?source=calypso-backups&site=:site`<br>(only if `layout/dotcom-nav-redesign` is also enabled)|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Prepare an Atomic site.
2. Set admin interface as Default view, then verify the links in the table above.
2. Set admin interface as Classic view, then verify the links in the table above.
   - Verify that the links actually go to the correct wp-admin/Jetpack page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?