### PR TITLE
Untangle: Hide the header of the global sidebar on mobile

### DIFF
--- a/client/layout/global-sidebar/index.jsx
+++ b/client/layout/global-sidebar/index.jsx
@@ -1,4 +1,5 @@
 import { Spinner, Gridicon } from '@automattic/components';
+import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
 import { useCallback, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
@@ -17,6 +18,7 @@ const GlobalSidebar = ( { children, onClick = undefined, className = '', ...prop
 	const isRequestingMenu = useSelector( getIsRequestingAdminMenu );
 	const translate = useTranslate();
 	const currentUser = useSelector( getCurrentUser );
+	const isDesktop = useBreakpoint( '>782px' );
 
 	const handleWheel = useCallback( ( event ) => {
 		const bodyEl = bodyRef.current;
@@ -48,7 +50,7 @@ const GlobalSidebar = ( { children, onClick = undefined, className = '', ...prop
 
 	return (
 		<div className="global-sidebar" ref={ wrapperRef }>
-			<GlobalSidebarHeader />
+			{ isDesktop && <GlobalSidebarHeader /> }
 			<div className="sidebar__body" ref={ bodyRef }>
 				<Sidebar className={ className } { ...sidebarProps } onClick={ onClick }>
 					{ requireBackLink && (

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -64,7 +64,8 @@ $brand-text: "SF Pro Text", $sans;
 
 	.sidebar__header {
 		align-items: center;
-		display: flex;
+		// Hide the header when the masterbar is visible.
+		display: none;
 		gap: 8px;
 		padding: 30px 24px 29px;
 
@@ -122,7 +123,7 @@ $brand-text: "SF Pro Text", $sans;
 		@include custom-scrollbars-on-hover(transparent, $gray-600);
 		flex: 1;
 		overflow-y: auto;
-
+		padding-top: 12px;
 
 		.sidebar,
 		.sidebar__menu:not(.is-togglable) {
@@ -320,5 +321,15 @@ $brand-text: "SF Pro Text", $sans;
 		padding-top: 0;
 		margin-top: 0;
 		top: 0;
+	}
+
+	.global-sidebar {
+		.sidebar__header {
+			display: flex;
+		}
+
+		.sidebar__body {
+			padding-top: 0;
+		}
 	}
 }

--- a/client/layout/masterbar/item.tsx
+++ b/client/layout/masterbar/item.tsx
@@ -62,7 +62,7 @@ class MasterbarItem extends Component< MasterbarItemProps > {
 					<span className="masterbar__item-bubble" aria-label="You have unseen content" />
 				) }
 				{ !! icon && ( typeof icon !== 'string' ? icon : <Gridicon icon={ icon } size={ 24 } /> ) }
-				<span className="masterbar__item-content">{ children }</span>
+				{ children && <span className="masterbar__item-content">{ children }</span> }
 			</Fragment>
 		);
 	}

--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -15,6 +15,8 @@ import wpcom from 'calypso/lib/wp';
 import { domainManagementList } from 'calypso/my-sites/domains/paths';
 import { preload } from 'calypso/sections-helper';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { openCommandPalette } from 'calypso/state/command-palette/actions';
+import { isCommandPaletteOpen as getIsCommandPaletteOpen } from 'calypso/state/command-palette/selectors';
 import {
 	getCurrentUser,
 	getCurrentUserDate,
@@ -503,6 +505,23 @@ class MasterbarLoggedIn extends Component {
 		);
 	}
 
+	renderCommandPaletteSearch() {
+		const handleClick = () => {
+			this.props.recordTracksEvent( 'calypso_masterbar_command_palette_search_clicked' );
+			this.props.openCommandPalette();
+		};
+
+		return (
+			<Item
+				className="masterbar__item-menu"
+				icon="search"
+				tooltip={ this.props.translate( 'Jump to…' ) }
+				isActive={ this.props.isCommandPaletteOpen }
+				onClick={ handleClick }
+			/>
+		);
+	}
+
 	renderMenu() {
 		const { menuBtnRef } = this.state;
 		const { translate, hasDismissedThePopover, isFetchingPrefs, isUserNewerThanNewNavigation } =
@@ -610,6 +629,7 @@ class MasterbarLoggedIn extends Component {
 						<div className="masterbar__section masterbar__section--right">
 							{ this.renderSearch() }
 							{ this.renderCart() }
+							{ this.renderCommandPaletteSearch() }
 							{ this.renderNotifications() }
 						</div>
 					</Masterbar>
@@ -733,6 +753,7 @@ export default connect(
 			isSiteTrialExpired: isTrialExpired( state, siteId ),
 			isMobileGlobalNavVisible:
 				( shouldShowGlobalSidebar || shouldShowGlobalSiteSidebar ) && ! isDesktop,
+			isCommandPaletteOpen: getIsCommandPaletteOpen( state ),
 		};
 	},
 	{
@@ -741,5 +762,6 @@ export default connect(
 		updateSiteMigrationMeta,
 		activateNextLayoutFocus,
 		savePreference,
+		openCommandPalette,
 	}
 )( localize( MasterbarLoggedIn ) );

--- a/client/layout/style.scss
+++ b/client/layout/style.scss
@@ -320,7 +320,6 @@ body.is-mobile-app-view {
 .layout.focus-content .layout__secondary {
 	@media only screen and ( max-width: 781px ) {
 		transform: translateX(-100%);
-		padding: 71px 24px 24px;
 	}
 }
 

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -806,7 +806,7 @@ $font-size: rem(14px);
 	}
 }
 
-@media screen and ( max-width: 782px ) {
+@media screen and ( max-width: 781px ) {
 	// client/layout/sidebar/style.scss
 	.theme-default {
 		.focus-content .layout__content {

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -116,9 +116,6 @@ function sitesDashboard( context: PageJSContext, next: () => void ) {
 			background: #ffffff;
 
 			.layout__content {
-				// The page header background extends all the way to the edge of the screen
-				padding-inline: 0;
-
 				// Prevents the status dropdown from being clipped when the page content
 				// isn't tall enough
 				overflow: inherit;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5767

## Proposed Changes

* Add the search icon of the command palette to the masterbar on mobile behind the feature flag
* Hide the header of the global sidebar on mobile

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/55ff33c1-92ea-47ff-814c-2b7ad1a9484d) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/819f729e-541c-4e4d-b587-fc3ea1c63ea8) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* On the mobile view
  * Make sure you can see the search icon on the masterbar
  * Make sure the header of the global sidebar is gone

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?