### PR TITLE
Untangle: Remove "Open WP Admin" cta on my home

### DIFF
--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -66,7 +66,6 @@ const Home = ( {
 	site,
 	siteId,
 	trackViewSiteAction,
-	trackOpenWPAdminAction,
 	isSiteWooExpressEcommerceTrial,
 	ssoModuleActive,
 	fetchingJetpackModules,
@@ -145,24 +144,16 @@ const Home = ( {
 		return <WooCommerceHomePlaceholder />;
 	}
 
-	const headerActions =
-		config.isEnabled( 'layout/dotcom-nav-redesign' ) &&
-		'wp-admin' === site?.options?.wpcom_admin_interface ? (
-			<>
-				<Button href={ site.URL } onClick={ trackViewSiteAction } target="_blank">
-					{ translate( 'View site' ) }
-				</Button>
-				<Button href={ site.URL + '/wp-admin' } onClick={ trackOpenWPAdminAction } primary>
-					{ translate( 'Open WP Admin' ) }
-				</Button>
-			</>
-		) : (
-			<>
-				<Button href={ site.URL } onClick={ trackViewSiteAction } target="_blank">
-					{ translate( 'Visit site' ) }
-				</Button>
-			</>
-		);
+	const headerActions = (
+		<>
+			<Button href={ site.URL } onClick={ trackViewSiteAction } target="_blank">
+				{ config.isEnabled( 'layout/dotcom-nav-redesign' ) &&
+				'wp-admin' === site?.options?.wpcom_admin_interface
+					? translate( 'View site' )
+					: translate( 'Visit site' ) }
+			</Button>
+		</>
+	);
 	const header = (
 		<div className="customer-home__heading">
 			<NavigationHeader
@@ -333,16 +324,9 @@ const trackViewSiteAction = ( isStaticHomePage ) =>
 		bumpStat( 'calypso_customer_home', 'my_site_view_site' )
 	);
 
-const trackOpenWPAdminAction = () =>
-	composeAnalytics(
-		recordTracksEvent( 'calypso_customer_home_my_site_open_wpadmin_click', {} ),
-		bumpStat( 'calypso_customer_home', 'my_site_open_wpadmin' )
-	);
-
 const mapDispatchToProps = {
 	trackViewSiteAction,
 	verifyIcannEmail,
-	trackOpenWPAdminAction,
 };
 
 const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
@@ -351,7 +335,6 @@ const mergeProps = ( stateProps, dispatchProps, ownProps ) => {
 		...ownProps,
 		...stateProps,
 		trackViewSiteAction: () => dispatchProps.trackViewSiteAction( isStaticHomePage ),
-		trackOpenWPAdminAction: () => dispatchProps.trackOpenWPAdminAction(),
 		handleVerifyIcannEmail: dispatchProps.verifyIcannEmail,
 	};
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5783

## Proposed Changes

* Remove "Open WP Admin" cta on my home

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/3f803f27-1ba7-45e6-8205-00e6fded5116) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/1ff98f39-088e-4093-922c-0b07c05b129c) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/home/<your_site>` on the site with the wp-admin interface
* Make sure the “Open WP Admin” button is gone

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?