### PR TITLE
Odyssey: Enable the utm route

### DIFF
--- a/apps/odyssey-stats/src/routes.ts
+++ b/apps/odyssey-stats/src/routes.ts
@@ -81,6 +81,7 @@ export default function ( pageBase = '/' ) {
 		'filedownloads',
 		'searchterms',
 		'annualstats',
+		'utm',
 	].join( '|' );
 
 	page.base( pageBase );


### PR DESCRIPTION
Enables the View details link in the UTM module.

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87883.

## Proposed Changes

Enables the `/utm` route in Odyssey stats. Without this change the "View details" link on the UTM module will not work. With this in place, it should load the UTM summary page (as it does in Calypso).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Follow steps from FG to test locally:

PCYsg-Pp7-p2

1. Spin up your local Jetpack.
2. Spin up Odyssey stats with this branch.
3. Visit the Traffic page.
4. Enable the UTM module: `&flags=stats/utm-module`
5. Confirm the UTM module loads below the other modules.
6. Click the View details link.
7. Confirm the UTM summary page loads correctly.

**Note:** The module doesn't currently load as the API calls are blocked. That is being addressed separately in #87567.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?