### PR TITLE
Untangle: Move the Modern to the first of the color scheme list

### DIFF
--- a/client/blocks/color-scheme-picker/constants.js
+++ b/client/blocks/color-scheme-picker/constants.js
@@ -26,7 +26,15 @@ import sunsetImg from 'calypso/assets/images/color-schemes/color-scheme-thumbnai
 export default function ( translate ) {
 	return [
 		{
-			label: translate( 'Default' ),
+			label: translate( 'Modern' ),
+			value: 'modern',
+			thumbnail: {
+				cssClass: 'is-modern',
+				imageUrl: modernImg,
+			},
+		},
+		{
+			label: translate( 'Classic Dark' ),
 			value: 'classic-dark',
 			thumbnail: {
 				cssClass: 'is-classic-dark',
@@ -103,14 +111,6 @@ export default function ( translate ) {
 			thumbnail: {
 				cssClass: 'is-midnight',
 				imageUrl: midnightImg,
-			},
-		},
-		{
-			label: translate( 'Modern' ),
-			value: 'modern',
-			thumbnail: {
-				cssClass: 'is-modern',
-				imageUrl: modernImg,
 			},
 		},
 		{

--- a/client/blocks/color-scheme-picker/constants.js
+++ b/client/blocks/color-scheme-picker/constants.js
@@ -34,14 +34,6 @@ export default function ( translate ) {
 			},
 		},
 		{
-			label: translate( 'Classic Dark' ),
-			value: 'classic-dark',
-			thumbnail: {
-				cssClass: 'is-classic-dark',
-				imageUrl: classicDarkImg,
-			},
-		},
-		{
 			label: translate( 'Aquatic' ),
 			value: 'aquatic',
 			thumbnail: {
@@ -71,6 +63,14 @@ export default function ( translate ) {
 			thumbnail: {
 				cssClass: 'is-classic-bright',
 				imageUrl: classicBrightImg,
+			},
+		},
+		{
+			label: translate( 'Classic Dark' ),
+			value: 'classic-dark',
+			thumbnail: {
+				cssClass: 'is-classic-dark',
+				imageUrl: classicDarkImg,
 			},
 		},
 		{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5776

## Proposed Changes

* Move `Modern` to the first of the color scheme list
* Rename `Default` to `Classic Dark`

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/0cc9e7a6-4ee5-48a5-8b77-c31223799507) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/757eef11-68a9-4c97-b856-53a124962e48) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /me/account
* Scroll into the `Dashboard color scheme` section
* Make sure the `Modern` is the first option of the list
* Make sure the `Default` is renamed to `Classic Dark`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?