### PR TITLE
add: woo passwordless feature toggle via url param

### DIFF
--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -58,6 +58,7 @@ import { createSocialUserFailed } from 'calypso/state/login/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
+import getWooPasswordless from 'calypso/state/selectors/get-woo-passwordless';
 import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 import { resetSignup } from 'calypso/state/signup/actions';
 import { getSectionName } from 'calypso/state/ui/selectors';
@@ -1231,7 +1232,11 @@ class SignupForm extends Component {
 		const showSeparator =
 			! config.isEnabled( 'desktop' ) && this.isHorizontal() && ! this.userCreationComplete();
 
-		if ( ( this.props.isPasswordless && 'wpcc' !== this.props.flowName ) || isGravatar ) {
+		if (
+			( this.props.isPasswordless &&
+				( 'wpcc' !== this.props.flowName || this.props.wooPasswordless ) ) ||
+			isGravatar
+		) {
 			const gravatarProps = isGravatar
 				? {
 						inputPlaceholder: this.props.translate( 'Enter your email address' ),
@@ -1354,6 +1359,7 @@ export default connect(
 			isJetpackWooDnaFlow: wooDnaConfig( getCurrentQueryArguments( state ) ).isWooDnaFlow(),
 			from: get( getCurrentQueryArguments( state ), 'from' ),
 			wccomFrom: getWccomFrom( state ),
+			wooPasswordless: getWooPasswordless( state ),
 			isWoo: isWooOAuth2Client( oauth2Client ) || isWooCoreProfilerFlow,
 			isWooCoreProfilerFlow,
 			isP2Flow:

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -58,6 +58,7 @@ import {
 } from 'calypso/state/current-user/selectors';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
+import getWooPasswordless from 'calypso/state/selectors/get-woo-passwordless';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isUserRegistrationDaysWithinRange from 'calypso/state/selectors/is-user-registration-days-within-range';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
@@ -91,7 +92,6 @@ import {
 } from './utils';
 import WpcomLoginForm from './wpcom-login-form';
 import './style.scss';
-import getWooPasswordless from 'calypso/state/selectors/get-woo-passwordless';
 
 const debug = debugModule( 'calypso:signup' );
 
@@ -900,7 +900,7 @@ class Signup extends Component {
 			<>
 				<div
 					className={ `signup is-${ kebabCase( this.props.flowName ) } ${
-						this.props.isWooPasswordless ? 'is-woo-passwordless' : ''
+						this.props.wooPasswordless ? 'is-woo-passwordless' : ''
 					}` }
 				>
 					<DocumentHead title={ this.props.pageTitle } />
@@ -971,7 +971,7 @@ export default connect(
 			oauth2Client,
 			isGravatar: isGravatarOAuth2Client( oauth2Client ),
 			hostingFlow,
-			isWooPasswordless: getWooPasswordless( state ),
+			wooPasswordless: getWooPasswordless( state ),
 		};
 	},
 	{

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -91,6 +91,7 @@ import {
 } from './utils';
 import WpcomLoginForm from './wpcom-login-form';
 import './style.scss';
+import getWooPasswordless from 'calypso/state/selectors/get-woo-passwordless';
 
 const debug = debugModule( 'calypso:signup' );
 
@@ -897,7 +898,11 @@ class Signup extends Component {
 
 		return (
 			<>
-				<div className={ `signup is-${ kebabCase( this.props.flowName ) }` }>
+				<div
+					className={ `signup is-${ kebabCase( this.props.flowName ) } ${
+						this.props.isWooPasswordless ? 'is-woo-passwordless' : ''
+					}` }
+				>
 					<DocumentHead title={ this.props.pageTitle } />
 					{ showPageHeader && (
 						<SignupHeader
@@ -966,6 +971,7 @@ export default connect(
 			oauth2Client,
 			isGravatar: isGravatarOAuth2Client( oauth2Client ),
 			hostingFlow,
+			isWooPasswordless: getWooPasswordless( state ),
 		};
 	},
 	{

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -45,6 +45,7 @@ import { fetchOAuth2ClientData } from 'calypso/state/oauth2-clients/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
+import getWooPasswordless from 'calypso/state/selectors/get-woo-passwordless';
 import { getSuggestedUsername } from 'calypso/state/signup/optional-dependencies/selectors';
 import { saveSignupStep, submitSignupStep } from 'calypso/state/signup/progress/actions';
 
@@ -557,11 +558,13 @@ export class UserStep extends Component {
 	}
 
 	renderSignupForm() {
+		const isWooPasswordLess = this.props.wooPasswordless;
 		const { oauth2Client, isReskinned } = this.props;
 		const isPasswordless =
 			isMobile() ||
 			this.props.isPasswordless ||
-			isNewsletterFlow( this.props?.queryObject?.variationName );
+			isNewsletterFlow( this.props?.queryObject?.variationName ) ||
+			isWooPasswordLess;
 		let socialService;
 		let socialServiceResponse;
 		let isSocialSignupEnabled = this.props.isSocialSignupEnabled;
@@ -733,6 +736,7 @@ const ConnectedUser = connect(
 			oauth2Client: getCurrentOAuth2Client( state ),
 			suggestedUsername: getSuggestedUsername( state ),
 			wccomFrom: getWccomFrom( state ),
+			wooPasswordless: getWooPasswordless( state ),
 			from: get( getCurrentQueryArguments( state ), 'from' ),
 			userLoggedIn: isUserLoggedIn( state ),
 		};

--- a/client/state/selectors/get-param-from-url-or-oauth2-redirect.ts
+++ b/client/state/selectors/get-param-from-url-or-oauth2-redirect.ts
@@ -1,0 +1,32 @@
+import { get } from 'lodash';
+import 'calypso/state/route/init';
+import getCurrentQueryArguments from './get-current-query-arguments';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Return the value of the given search query argument.
+ *
+ * Login flow and signup flow use different query arguments to pass the `wccom-from` or `woo-passwordless` values.
+ * Login flow uses the parameter in the url directly, while signup flow uses `oauth2_redirect` to pass the parameter.
+ */
+export const getParamFromUrlOrOauth2Redirect = (
+	state: AppState,
+	paramName: string
+): string | null => {
+	const currentQuery = getCurrentQueryArguments( state );
+	const wccomFrom = get( currentQuery, paramName ) as string | null;
+
+	if ( wccomFrom ) {
+		return wccomFrom;
+	}
+
+	try {
+		const queryOauth2Redirect = currentQuery?.oauth2_redirect;
+		const oauth2RedirectUrl = new URL( queryOauth2Redirect as string );
+		return oauth2RedirectUrl.searchParams.get( paramName );
+	} catch ( e ) {
+		// ignore
+	}
+
+	return null;
+};

--- a/client/state/selectors/get-param-from-url-or-oauth2-redirect.ts
+++ b/client/state/selectors/get-param-from-url-or-oauth2-redirect.ts
@@ -14,10 +14,10 @@ export const getParamFromUrlOrOauth2Redirect = (
 	paramName: string
 ): string | null => {
 	const currentQuery = getCurrentQueryArguments( state );
-	const wccomFrom = get( currentQuery, paramName ) as string | null;
+	const paramValue = get( currentQuery, paramName ) as string | null;
 
-	if ( wccomFrom ) {
-		return wccomFrom;
+	if ( paramValue ) {
+		return paramValue;
 	}
 
 	try {

--- a/client/state/selectors/get-wccom-from.ts
+++ b/client/state/selectors/get-wccom-from.ts
@@ -1,6 +1,5 @@
-import { get } from 'lodash';
 import 'calypso/state/route/init';
-import getCurrentQueryArguments from './get-current-query-arguments';
+import { getParamFromUrlOrOauth2Redirect } from './get-param-from-url-or-oauth2-redirect';
 import type { AppState } from 'calypso/types';
 
 /**
@@ -10,20 +9,5 @@ import type { AppState } from 'calypso/types';
  * Login flow uses `wccom-from` directly, while signup flow uses `oauth2_redirect` to pass the `wccom-from` value.
  */
 export default function getWccomFrom( state: AppState ): string | null {
-	const currentQuery = getCurrentQueryArguments( state );
-	const wccomFrom = get( currentQuery, 'wccom-from' ) as string | null;
-
-	if ( wccomFrom ) {
-		return wccomFrom;
-	}
-
-	try {
-		const queryOauth2Redirect = currentQuery?.oauth2_redirect;
-		const oauth2RedirectUrl = new URL( queryOauth2Redirect as string );
-		return oauth2RedirectUrl.searchParams.get( 'wccom-from' );
-	} catch ( e ) {
-		// ignore
-	}
-
-	return null;
+	return getParamFromUrlOrOauth2Redirect( state, 'wccom-from' );
 }

--- a/client/state/selectors/get-woo-passwordless.ts
+++ b/client/state/selectors/get-woo-passwordless.ts
@@ -1,0 +1,11 @@
+import 'calypso/state/route/init';
+import { getParamFromUrlOrOauth2Redirect } from './get-param-from-url-or-oauth2-redirect';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Return the value of the `woo-passwordless` query argument.
+ *
+ */
+export default function getWooPasswordless( state: AppState ): string | null {
+	return getParamFromUrlOrOauth2Redirect( state, 'woo-passwordless' );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/87635

## Proposed Changes

* Adds a check for `woo-passwordless` query param in the signup area so that we can feature toggle this on for development and later on for discriminating by experimental assignment

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

If you have the `woocommerce-start-dev-env`, spin up this https://github.com/Automattic/woocommerce.com/pull/19759 to test the coordinated `woo-passwordless` flow without having to modify the URL.


- [Passwordless signup link](https://wordpress.com/start/wpcc/oauth2-user?ref=oauth2&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50019%26state%3D322bf51766a1dd76fb52f57ffa81f6a5c886b3a0b51afc54afa5e52f880648e4%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.test%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252Fstart%25252F%252523%25252Finstallation%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%3Dnux%26calypso_env%3Dproduction%26woo-passwordless%3Dtrue%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login%26from-calypso%3D1&oauth2_client_id=50019)
* [Non-passwordless signup link](https://wordpress.com/start/wpcc/oauth2-user?ref=oauth2&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50019%26state%3D322bf51766a1dd76fb52f57ffa81f6a5c886b3a0b51afc54afa5e52f880648e4%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.test%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252Fstart%25252F%252523%25252Finstallation%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%3Dnux%26calypso_env%3Dproduction%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login%26from-calypso%3D1&oauth2_client_id=50019) 

1. Observe that the passwordless link shows the sign up screen without a password field. This is not the final iteration but the design and copy changes are not within the scope of this PR, look at https://github.com/Automattic/wp-calypso/issues/87627 for that
2. Observe that the non-passwordless link shows the sign up screen with a password field as before, and nothing should be different.
3. Observe that in the passwordless instantiation, there is a div with class `.signup.is-woo-passwordless` that we can use for CSS that targets this feature

<img width="713" alt="image" src="https://github.com/Automattic/wp-calypso/assets/27843274/db1cc21e-b087-485a-9295-c001f8da3a67">

<img width="584" alt="image" src="https://github.com/Automattic/wp-calypso/assets/27843274/ff72f705-71a7-4d19-8d12-99a1a63e6e4d">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?