### PR TITLE
GitHub Deployments: Update repository CTAs path and style

### DIFF
--- a/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
+++ b/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { Gridicon } from '@automattic/components';
+import { Button, Gridicon } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
 import { DropdownMenu, MenuGroup, MenuItem, Spinner } from '@wordpress/components';
 import { Fragment, useState } from '@wordpress/element';
@@ -104,13 +104,13 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 			<tr>
 				<td>
 					<div className="github-deployments-list__repository-details">
-						<a
-							target="_blank"
-							rel="noopener noreferrer"
-							href={ `https://github.com/${ deployment.repository_name }` }
+						<Button
+							onClick={ () => {
+								page( manageDeploymentPage( siteSlug!, deployment.id ) );
+							} }
 						>
 							{ repo }
-						</a>
+						</Button>
 						<span>{ installation }</span>
 					</div>
 				</td>

--- a/client/my-sites/github-deployments/deployments/styles.scss
+++ b/client/my-sites/github-deployments/deployments/styles.scss
@@ -49,6 +49,10 @@
 			white-space: nowrap;
 		}
 
+		.github-deployments-list__repository-details {
+			white-space: normal;
+		}
+
 		&:last-child {
 			padding-left: 32px;
 			padding-right: 0;
@@ -63,11 +67,15 @@
 		padding: 21px 0;
 		font-weight: 500;
 
-		a {
+		button {
+			text-align: left;
+			padding: 0;
+			border: none;
 			color: var(--studio-gray-100, #101517);
 
 			&:hover {
 				text-decoration: underline;
+				color: var(--studio-gray-100, #101517);
 			}
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Slack thread: p1708951271739149-slack-C04H4NY6STW

## Proposed Changes

* Fixed repository name break-line
* Fixed link path

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?