### PR TITLE
Global Sidebar: Update spacing on email no content/domain page

### DIFF
--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -473,19 +473,16 @@
 	}
 }
 
-.empty-content {
-	display: flex;
-	flex-direction: column;
-	row-gap: 32px;
-	max-width: 700px;
+.is-section-email {
+	.empty-content {
+		.empty-content__illustration {
+			margin-top: 100px;
+		}
 
-	.empty-content__action,
-	.empty-content__illustration {
-		width: auto;
-		margin: 0 auto;
-	}
-
-	.empty-content__illustration {
-		margin-top: 100px;
+		.empty-content__title,
+		.empty-content__line,
+		.empty-content__action {
+			margin-top: 32px;
+		}
 	}
 }

--- a/client/my-sites/email/email-management/style.scss
+++ b/client/my-sites/email/email-management/style.scss
@@ -472,3 +472,20 @@
 		}
 	}
 }
+
+.empty-content {
+	display: flex;
+	flex-direction: column;
+	row-gap: 32px;
+	max-width: 700px;
+
+	.empty-content__action,
+	.empty-content__illustration {
+		width: auto;
+		margin: 0 auto;
+	}
+
+	.empty-content__illustration {
+		margin-top: 100px;
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5756

Add some spacing to the email content in the emails Calypso page.

* No domain and needs upgrade

**Before**
![Image](https://github.com/Automattic/dotcom-forge/assets/5560595/d7179b66-f77a-4aa2-8e8a-fb53c6707ea1)

**After**
<img width="1440" alt="Screenshot 2024-02-26 at 14 37 16" src="https://github.com/Automattic/wp-calypso/assets/5560595/7249ba1c-d8a0-47eb-8b80-9f52ac54684d">


* No domain but has available domain credits

**Before**
![Image](https://github.com/Automattic/dotcom-forge/assets/5560595/9b44afb1-3a02-45b5-bcc7-b45b8a231417)

**After**
<img width="1440" alt="Screenshot 2024-02-26 at 14 38 20" src="https://github.com/Automattic/wp-calypso/assets/5560595/9acfcccb-f4db-44e7-8933-7fb5a48c83ee">

* No domain

**Before**
![Image](https://github.com/Automattic/dotcom-forge/assets/5560595/df956bd1-0e7e-47e5-91e0-410dedba113d)

**After**
<img width="1440" alt="Screenshot 2024-02-26 at 14 37 52" src="https://github.com/Automattic/wp-calypso/assets/5560595/58d1e3cf-092d-4181-a34d-4bddf61e6381">
