### PR TITLE
Devdocs: Alternative fix for TS2590 for Card

### DIFF
--- a/client/devdocs/design/wordpress-components-gallery/card.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/card.tsx
@@ -1,5 +1,3 @@
-/** @jsxImportSource react */
-
 import {
 	Button,
 	Card,
@@ -22,7 +20,7 @@ const CardExample = () => (
 
 		<CardBody>...</CardBody>
 
-		<CardDivider className="card-example" />
+		<CardDivider className="card-example" css="" />
 
 		<CardBody>...</CardBody>
 

--- a/client/devdocs/design/wordpress-components-gallery/card.tsx
+++ b/client/devdocs/design/wordpress-components-gallery/card.tsx
@@ -20,7 +20,7 @@ const CardExample = () => (
 
 		<CardBody>...</CardBody>
 
-		<CardDivider className="card-example" css="" />
+		<CardDivider className="card-example" />
 
 		<CardBody>...</CardBody>
 

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -3,8 +3,7 @@
 	"compilerOptions": {
 		"rootDir": ".",
 		"noEmit": true,
-		"types": [ "node", "@types/gtag.js" ],
-		"jsxImportSource": "@emotion/react",
+		"types": [ "node", "@types/gtag.js", "@emotion/react/types/css-prop" ],
 		"paths": {
 			"calypso/*": [ "./*" ],
 


### PR DESCRIPTION
## Proposed Changes

Fix a TS error in `Card` examples in devdocs alternatively, without setting `jsxImportSource` in runtime, but rather by specifying an empty `css` prop to the problematic component. That way we can continue using `@emotion/react` while not causing the `TS2590: Expression produces a union type that is too complex to represent` error.

## Testing Instructions

All checks should be green, specifically type checks.

