### PR TITLE
Command Palette: Add WP Admin app to Team City build

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -42,6 +42,7 @@ object WPComPlugins : Project({
 					"wpcom-block-editor-release-build",
 					"o2-blocks-release-build",
 					"happy-blocks-release-build",
+					"command-palette-wp-admin-release-build",
 				)
 			}
 			dataToKeep = everything()
@@ -123,6 +124,7 @@ object CalypsoApps: BuildType({
 		apps/o2-blocks/release-files => o2-blocks.zip
 		apps/happy-blocks/release-files => happy-blocks.zip
 		apps/editing-toolkit/editing-toolkit-plugin => editing-toolkit.zip
+		apps/command-palette-wp-admin/dist => command-palette-wp-admin.zip
 	""".trimIndent()
 
 	steps {

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -124,7 +124,7 @@ object CalypsoApps: BuildType({
 		apps/o2-blocks/release-files => o2-blocks.zip
 		apps/happy-blocks/release-files => happy-blocks.zip
 		apps/editing-toolkit/editing-toolkit-plugin => editing-toolkit.zip
-		apps/command-palette-wp-admin/dist => command-palette-wp-admin.zip
+		apps/command-palette-wp-admin/dist => command-palette.zip
 	""".trimIndent()
 
 	steps {

--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -42,7 +42,7 @@ object WPComPlugins : Project({
 					"wpcom-block-editor-release-build",
 					"o2-blocks-release-build",
 					"happy-blocks-release-build",
-					"command-palette-wp-admin-release-build",
+					"command-palette-release-build",
 				)
 			}
 			dataToKeep = everything()


### PR DESCRIPTION
## Proposed Changes

This PR adds the Command Palette WP Admin app to the Build Calypso Apps script in TC, so the built .zip is available as an artifact that will be downloaded by the `install-plugin.sh` script in `wpcom`.

## Testing Instructions

Unsure if this can be tested before merging, but we can check the "Build Calypso Apps" script and see if the build is there.