### PR TITLE
Purchases: Add fallback for Intl.ListFormat in calypso-products

### DIFF
--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1009,20 +1009,18 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 
 	// Intl.ListFormat is not available in Mac OS Safari before Big Sur, so we
 	// provide a fallback.
-	let socialNetworksList = translate(
-		'Facebook, Instagram, LinkedIn, Nextdoor, Mastodon & Tumblr'
-	);
+	const socialNetworksForSharing = [
+		translate( 'Facebook' ),
+		translate( 'Instagram' ),
+		translate( 'LinkedIn' ),
+		translate( 'Mastodon' ),
+		translate( 'Tumblr' ),
+		translate( 'Nextdoor' ),
+	];
+	let socialNetworksList = socialNetworksForSharing.join( ', ' );
 	if ( 'ListFormat' in Intl ) {
 		const listFormatter = new Intl.ListFormat( getLocaleSlug() || 'en' );
-
-		socialNetworksList = listFormatter.format( [
-			translate( 'Facebook' ),
-			translate( 'Instagram' ),
-			translate( 'LinkedIn' ),
-			translate( 'Mastodon' ),
-			translate( 'Tumblr' ),
-			translate( 'Nextdoor' ),
-		] );
+		socialNetworksList = listFormatter.format( socialNetworksForSharing );
 	}
 
 	const socialBasicIncludesInfo = [

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1009,7 +1009,9 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 
 	// Intl.ListFormat is not available in Mac OS Safari before Big Sur, so we
 	// provide a fallback.
-	let socialNetworksList = translate( 'Facebook, Instagram, LinkedIn, Mastodon & Tumblr' );
+	let socialNetworksList = translate(
+		'Facebook, Instagram, LinkedIn, Nextdoor, Mastodon & Tumblr'
+	);
 	if ( 'ListFormat' in Intl ) {
 		const listFormatter = new Intl.ListFormat( getLocaleSlug() || 'en' );
 

--- a/packages/calypso-products/src/translations.tsx
+++ b/packages/calypso-products/src/translations.tsx
@@ -1007,16 +1007,21 @@ export const getJetpackProductsWhatIsIncluded = (): Record< string, Array< Trans
 		translate( 'Lazy image loading' ),
 	];
 
-	const listFormatter = new Intl.ListFormat( getLocaleSlug() || 'en' );
+	// Intl.ListFormat is not available in Mac OS Safari before Big Sur, so we
+	// provide a fallback.
+	let socialNetworksList = translate( 'Facebook, Instagram, LinkedIn, Mastodon & Tumblr' );
+	if ( 'ListFormat' in Intl ) {
+		const listFormatter = new Intl.ListFormat( getLocaleSlug() || 'en' );
 
-	const socialNetworksList = listFormatter.format( [
-		translate( 'Facebook' ),
-		translate( 'Instagram' ),
-		translate( 'LinkedIn' ),
-		translate( 'Mastodon' ),
-		translate( 'Tumblr' ),
-		translate( 'Nextdoor' ),
-	] );
+		socialNetworksList = listFormatter.format( [
+			translate( 'Facebook' ),
+			translate( 'Instagram' ),
+			translate( 'LinkedIn' ),
+			translate( 'Mastodon' ),
+			translate( 'Tumblr' ),
+			translate( 'Nextdoor' ),
+		] );
+	}
 
 	const socialBasicIncludesInfo = [
 		translate( 'Automatically share your posts and products on social media' ),


### PR DESCRIPTION
In https://github.com/Automattic/wp-calypso/pull/85766 the `@automattic/calypso-products` package was modified to format a list of social networks for a string with `Intl.ListFormat`. That feature is available in all modern versions of Safari, but only if the user is using Mac OS Big Sur (released in 2020) or later. This means that users who visit pages using this package (eg: the Manage Purchases page) who are using Safari in an earlier OS will get a fatal error `TypeError: undefined is not a constructor`. We've seen this error a small number of times recently, but it is consistent.

## Proposed Changes

Calypso supports the last two browser versions, but it says nothing about OS versions, so we might want to think twice before using `Intl.ListFormat` so readily. In this case, I don't think the Manage Purchases page (a very important part of calypso for customers) should crash just because we can't reliably add some commas in a list.

In this PR I've added a fallback if `Intl.ListFormat` doesn't exist. The fallback uses commas to separate the words.

> [!NOTE]
> This does not touch other uses of `Intl.ListFormat` in calypso like the "add ssh key" page and the "trial acknowledge" page). Those pages will still suffer fatal errors if viewed in the Mac OS before Big Sur.

## Testing Instructions

* Checkout this PR and run `yarn start-jetpack-cloud` OR click in the Jetpack Cloud live link below.
* Goto `http://jetpack.cloud.localhost:3000/pricing` or `/pricing` on the Jetpack Cloud Live link.
* Click on "More about Social" to open the features list modal
* Confirm that the networks list is displayed as expected
* Confirm that "Nextdoor" is in the list