### PR TITLE
Add filter to show or not the welcome tour

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/wpcom-block-editor-nux/src/block-editor-nux.js
@@ -7,6 +7,7 @@ import { LocaleProvider, i18nDefaultLocaleSlug } from '@automattic/i18n-utils';
 import { Guide, GuidePage } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useState } from '@wordpress/element';
+import { applyFilters } from '@wordpress/hooks';
 import { registerPlugin } from '@wordpress/plugins';
 import { __dangerousOptInToUnstableAPIsOnlyForCoreModules } from '@wordpress/private-apis';
 import { getQueryArg } from '@wordpress/url';
@@ -82,7 +83,9 @@ function WelcomeTour() {
 		}
 	}, [ fetchWelcomeGuideStatus, isLoaded ] );
 
-	if ( ! show || isNewPageLayoutModalOpen ) {
+	const filteredShow = applyFilters( 'a8c.WpcomBlockEditorWelcomeTour.show', show );
+
+	if ( ! filteredShow || isNewPageLayoutModalOpen ) {
 		return null;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/sensei/pull/7511

## Proposed Changes

* We wanted a way to not show the welcome tour on new Courses and Lessons (post types) with Sensei LMS while displaying a custom wizard in the editor. I tried some alternatives, but I didn't find a good way to implement it without changing the Editing Toolkit plugin, so I decided to add this filter.

Considered alternative: I thought about passing some context arguments to the `wpcom_block_editor_nux_get_status` filter in the backend, like post type and if it's a new post or not, but I decided to do it in the JS, so we could play more with it in real-time. Although the filter is not a reactive variable, we could play with the `setShowWelcomeGuide`, which would re-render the component re-checking the filter. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. With a new site, or after running `wp.data.dispatch( 'automattic/wpcom-welcome-guide' ).setShowWelcomeGuide( true )`, add a custom code to your test site, using this filter to hide the welcome tour:
    1.1. `addFilter( 'a8c.WpcomBlockEditorWelcomeTour.show', false );`
2. Open the editor, and make sure the tour is not displayed.
3. Remove the filter.
4. Open the editor again, and make sure it's displayed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?