### PR TITLE
Global Sidebar: fix regression in my sites padding

### DIFF
--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -116,6 +116,9 @@ function sitesDashboard( context: PageJSContext, next: () => void ) {
 			background: #ffffff;
 
 			.layout__content {
+				// The page header background extends all the way to the edge of the screen
+				padding-inline: 0;
+
 				// Prevents the status dropdown from being clipped when the page content
 				// isn't tall enough
 				overflow: inherit;


### PR DESCRIPTION
Follow up to https://github.com/Automattic/wp-calypso/pull/87877

This fixes a regression introduced in PR above.

**Before**
<img width="1306" alt="Screenshot 2024-02-26 at 17 49 14" src="https://github.com/Automattic/wp-calypso/assets/5560595/2db0717b-28af-4381-a12b-83549e938c1a">

**After**
<img width="1315" alt="Screenshot 2024-02-26 at 17 53 56" src="https://github.com/Automattic/wp-calypso/assets/5560595/a59aed79-8ef4-4305-b1a5-91a956e18dae">


