### PR TITLE
Fix congrats footer detail click tracking

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/domain-transfer-to-any-user/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/domain-transfer-to-any-user/index.tsx
@@ -22,7 +22,7 @@ const DomainTransferToAnyUser: React.FC< DomainTransferToAnyUserContainerProps >
 					'Domain transfers can take a few minutes, we’ll email you once it’s set up.'
 				) }
 				products={ <ThankYouDomainProduct domainName={ domain } /> }
-				footerDetails={ getDomainFooterDetails() }
+				footerDetails={ getDomainFooterDetails( 'transfer-to-user' ) }
 			/>
 		</Main>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/content/get-domain-footer-details.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/content/get-domain-footer-details.ts
@@ -28,7 +28,7 @@ export default function getDomainFooterDetails( limit?: number ): ThankYouFooter
 			buttonHref: '/support/category/domains-and-email/',
 			buttonOnClick: () => {
 				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
-					type: 'footer-domain-resources',
+					type: 'domain-resources',
 				} );
 			},
 		},

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/content/get-domain-footer-details.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/content/get-domain-footer-details.ts
@@ -18,7 +18,7 @@ export default function getDomainFooterDetails(
 			buttonOnClick: () => {
 				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
 					context: context,
-					type: 'footer-domain-essentials',
+					type: 'domain-essentials',
 				} );
 			},
 		},

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/content/get-domain-footer-details.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/content/get-domain-footer-details.ts
@@ -13,7 +13,9 @@ export default function getDomainFooterDetails( limit?: number ): ThankYouFooter
 			buttonText: translate( 'Learn the domain basics' ),
 			buttonHref: '/support/domains',
 			buttonOnClick: () => {
-				recordTracksEvent( 'calypso_thank_you_footer-domain-essentials' );
+				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
+					type: 'footer-domain-essentials',
+				} );
 			},
 		},
 		{
@@ -25,7 +27,9 @@ export default function getDomainFooterDetails( limit?: number ): ThankYouFooter
 			buttonText: translate( 'Domain support resources' ),
 			buttonHref: '/support/category/domains-and-email/',
 			buttonOnClick: () => {
-				recordTracksEvent( 'calypso_thank_you_footer-domain-resources' );
+				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
+					type: 'footer-domain-resources',
+				} );
 			},
 		},
 	];

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/content/get-domain-footer-details.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/content/get-domain-footer-details.ts
@@ -2,7 +2,10 @@ import { translate } from 'i18n-calypso';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { ThankYouFooterDetailProps } from 'calypso/components/thank-you-v2/footer';
 
-export default function getDomainFooterDetails( limit?: number ): ThankYouFooterDetailProps[] {
+export default function getDomainFooterDetails(
+	context: string,
+	limit?: number
+): ThankYouFooterDetailProps[] {
 	const details = [
 		{
 			key: 'footer-domain-essentials',
@@ -14,6 +17,7 @@ export default function getDomainFooterDetails( limit?: number ): ThankYouFooter
 			buttonHref: '/support/domains',
 			buttonOnClick: () => {
 				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
+					context: context,
 					type: 'footer-domain-essentials',
 				} );
 			},
@@ -28,6 +32,7 @@ export default function getDomainFooterDetails( limit?: number ): ThankYouFooter
 			buttonHref: '/support/category/domains-and-email/',
 			buttonOnClick: () => {
 				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
+					context: context,
 					type: 'domain-resources',
 				} );
 			},

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/domain-only.tsx
@@ -119,7 +119,7 @@ export default function DomainOnlyThankYou( { purchases, receiptId }: DomainOnly
 					}
 				) }
 				products={ products }
-				footerDetails={ getDomainFooterDetails() }
+				footerDetails={ getDomainFooterDetails( 'domain-only' ) }
 				upsellProps={ upsellProps }
 			/>
 		</>

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -42,7 +42,7 @@ export default function PlanOnlyThankYou( { primaryPurchase }: PlanOnlyThankYouP
 			buttonText: translate( 'Add members' ),
 			buttonHref: `/people/new/${ siteSlug }`,
 			buttonOnClick: () => {
-				recordTracksEvent( 'calypso_thank_you_footer_link_click', { type: 'footer-add-members' } );
+				recordTracksEvent( 'calypso_thank_you_footer_link_click', { type: 'add-members' } );
 			},
 		} );
 	} else if ( isMonthsOld( 6, siteCreatedTimeStamp ) ) {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -68,7 +68,7 @@ export default function PlanOnlyThankYou( { primaryPurchase }: PlanOnlyThankYouP
 		buttonText: translate( 'Explore support resources' ),
 		buttonHref: '/support',
 		buttonOnClick: () => {
-			recordTracksEvent( 'calypso_thank_you_footer_link_click', { type: 'footer-support' } );
+			recordTracksEvent( 'calypso_thank_you_footer_link_click', { type: 'support' } );
 		},
 	} );
 

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -42,7 +42,10 @@ export default function PlanOnlyThankYou( { primaryPurchase }: PlanOnlyThankYouP
 			buttonText: translate( 'Add members' ),
 			buttonHref: `/people/new/${ siteSlug }`,
 			buttonOnClick: () => {
-				recordTracksEvent( 'calypso_thank_you_footer_link_click', { type: 'add-members' } );
+				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
+					context: 'plan-only',
+					type: 'add-members',
+				} );
 			},
 		} );
 	} else if ( isMonthsOld( 6, siteCreatedTimeStamp ) ) {
@@ -56,7 +59,10 @@ export default function PlanOnlyThankYou( { primaryPurchase }: PlanOnlyThankYouP
 			buttonText: translate( 'Find your new theme' ),
 			buttonHref: `/themes/${ siteSlug }`,
 			buttonOnClick: () => {
-				recordTracksEvent( 'calypso_thank_you_footer_link_click', { type: 'site-refresh' } );
+				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
+					context: 'plan-only',
+					type: 'site-refresh',
+				} );
 			},
 		} );
 	}
@@ -68,7 +74,10 @@ export default function PlanOnlyThankYou( { primaryPurchase }: PlanOnlyThankYouP
 		buttonText: translate( 'Explore support resources' ),
 		buttonHref: '/support',
 		buttonOnClick: () => {
-			recordTracksEvent( 'calypso_thank_you_footer_link_click', { type: 'support' } );
+			recordTracksEvent( 'calypso_thank_you_footer_link_click', {
+				context: 'plan-only',
+				type: 'support',
+			} );
 		},
 	} );
 

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -42,7 +42,7 @@ export default function PlanOnlyThankYou( { primaryPurchase }: PlanOnlyThankYouP
 			buttonText: translate( 'Add members' ),
 			buttonHref: `/people/new/${ siteSlug }`,
 			buttonOnClick: () => {
-				recordTracksEvent( 'calypso_plan_thank_you_add_members_click' );
+				recordTracksEvent( 'calypso_thank_you_footer_link_click', { type: 'footer-add-members' } );
 			},
 		} );
 	} else if ( isMonthsOld( 6, siteCreatedTimeStamp ) ) {
@@ -56,7 +56,7 @@ export default function PlanOnlyThankYou( { primaryPurchase }: PlanOnlyThankYouP
 			buttonText: translate( 'Find your new theme' ),
 			buttonHref: `/themes/${ siteSlug }`,
 			buttonOnClick: () => {
-				recordTracksEvent( 'calypso_plan_thank_you_theme_click' );
+				recordTracksEvent( 'calypso_thank_you_footer_link_click', { type: 'footer-site-refresh' } );
 			},
 		} );
 	}
@@ -68,7 +68,7 @@ export default function PlanOnlyThankYou( { primaryPurchase }: PlanOnlyThankYouP
 		buttonText: translate( 'Explore support resources' ),
 		buttonHref: '/support',
 		buttonOnClick: () => {
-			recordTracksEvent( 'calypso_plan_thank_you_support_click' );
+			recordTracksEvent( 'calypso_thank_you_footer_link_click', { type: 'footer-support' } );
 		},
 	} );
 

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -56,7 +56,7 @@ export default function PlanOnlyThankYou( { primaryPurchase }: PlanOnlyThankYouP
 			buttonText: translate( 'Find your new theme' ),
 			buttonHref: `/themes/${ siteSlug }`,
 			buttonOnClick: () => {
-				recordTracksEvent( 'calypso_thank_you_footer_link_click', { type: 'footer-site-refresh' } );
+				recordTracksEvent( 'calypso_thank_you_footer_link_click', { type: 'site-refresh' } );
 			},
 		} );
 	}

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -71,7 +71,7 @@ const TitanSetUpThankYou = ( {
 			buttonHref: '/support/category/domains-and-email/email/',
 			buttonOnClick: () => {
 				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
-					type: 'footer-questions-email',
+					type: 'questions-email',
 				} );
 			},
 		},

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import ThankYouV2 from 'calypso/components/thank-you-v2';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { TITAN_CONTROL_PANEL_CONTEXT_GET_MOBILE_APP } from 'calypso/lib/titan/constants';
 import { ThankYouTitanProduct } from 'calypso/my-sites/checkout/checkout-thank-you/redesign-v2/products/titan-product';
 import { recordEmailAppLaunchEvent } from 'calypso/my-sites/email/email-management/home/utils';
@@ -55,6 +56,9 @@ const TitanSetUpThankYou = ( {
 					app: 'app',
 					context: 'checkout-thank-you',
 				} );
+				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
+					type: 'footer-manage-email',
+				} );
 			},
 		},
 		{
@@ -65,6 +69,11 @@ const TitanSetUpThankYou = ( {
 			),
 			buttonText: translate( 'Email support resources' ),
 			buttonHref: '/support/category/domains-and-email/email/',
+			buttonOnClick: () => {
+				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
+					type: 'footer-questions-email',
+				} );
+			},
 		},
 	];
 

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -57,6 +57,7 @@ const TitanSetUpThankYou = ( {
 					context: 'checkout-thank-you',
 				} );
 				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
+					context: 'titan-setup',
 					type: 'manage-email',
 				} );
 			},
@@ -71,6 +72,7 @@ const TitanSetUpThankYou = ( {
 			buttonHref: '/support/category/domains-and-email/email/',
 			buttonOnClick: () => {
 				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
+					context: 'titan-setup',
 					type: 'questions-email',
 				} );
 			},

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -43,7 +43,7 @@ const TitanSetUpThankYou = ( {
 
 	const footerDetails = [
 		{
-			key: 'footer-manage-email',
+			key: 'footer-get-the-app',
 			title: translate( 'Manage your email and site from anywhere' ),
 			description: translate(
 				'The Jetpack mobile app for iOS and Android makes managing your email, domain, and website even simpler.'
@@ -58,7 +58,7 @@ const TitanSetUpThankYou = ( {
 				} );
 				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
 					context: 'titan-setup',
-					type: 'manage-email',
+					type: 'get-the-app',
 				} );
 			},
 		},

--- a/client/my-sites/email/titan-set-up-thank-you/index.tsx
+++ b/client/my-sites/email/titan-set-up-thank-you/index.tsx
@@ -57,7 +57,7 @@ const TitanSetUpThankYou = ( {
 					context: 'checkout-thank-you',
 				} );
 				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
-					type: 'footer-manage-email',
+					type: 'manage-email',
 				} );
 			},
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 5794-gh-Automattic/dotcom-forge

## Proposed Changes

* Update the Tracks events for the Domain-only congrats page
* Update the Tracks events for the Plan-only congrats page
* Add footer tracking to the Titan congrats page
* Per [feedback](https://github.com/Automattic/wp-calypso/pull/87912#discussion_r1503885524), add a `context` event prop to all footer links

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Purchase a domain
* On the congrats page, confirm that clicking the two footer links fires a `calypso_thank_you_footer_link_click` tracks event
  * The link under **Dive into domain essentials** should carry a `type` prop of `footer-domain-essentials`
  * The link under **Domain support resources** should carry a `type` prop of `footer-domain-resources`
  * Both links should carry a `context` prop of `domain-only`
* Purchase a plan
* On the congrats page, confirm that clicking the two footer links fires a `calypso_thank_you_footer_link_click` tracks event
  * The link under **A site refresh** should carry a `type` prop of `footer-site-refresh`
  * The link under **Everything you need to know** should carry a `type` prop of `footer-support`
  * Both links should carry a `context` prop of `plan-only`
* Purchase Professional Email
* On the congrats page, confirm that clicking the two footer links fires a `calypso_thank_you_footer_link_click` tracks event
  * The link under **Manage your email and site from anywhere** should carry a `type` prop of `footer-manage-email`
  * The link under **Email questions? We have the answers** should carry a `type` prop of `footer-questions-email`
  * Both links should carry a `context` prop of `titan-setup`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?