### PR TITLE
Fix issue with a loop creating sites on error

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/use-plan-selection.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/use-plan-selection.ts
@@ -99,7 +99,7 @@ export const usePlanSelection = ( {
 
 	// Auto-select YEARLY plan when coming from senseilms.com site.
 	useEffect( () => {
-		if ( undefined === getDefaultPlan() ) {
+		if ( undefined === getDefaultPlan() || status === Status.Error ) {
 			return;
 		}
 
@@ -107,7 +107,7 @@ export const usePlanSelection = ( {
 			setStatus( Status.Bundling );
 		}
 
-		if ( ! isLoadingPlans && status !== Status.Error ) {
+		if ( ! isLoadingPlans ) {
 			onPlanSelect();
 		}
 	}, [ isLoadingPlans, status, setStatus, onPlanSelect ] );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/use-plan-selection.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/use-plan-selection.ts
@@ -107,7 +107,7 @@ export const usePlanSelection = ( {
 			setStatus( Status.Bundling );
 		}
 
-		if ( ! isLoadingPlans ) {
+		if ( ! isLoadingPlans && status !== Status.Error ) {
 			onPlanSelect();
 		}
 	}, [ isLoadingPlans, status, setStatus, onPlanSelect ] );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* We had some occurrences of cases with errors creating many sites. This PR fixes it. The reason for that happen is that when an error happened it tried to select the plan again, which would try to create another site. Now when an error happens, it won't auto-select the plan.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Update the file `client/landing/stepper/declarative-flow/internals/steps-repository/sensei-plan/create-sensei-site.ts`, in the line `105` with the following code to force an error:
```js
getStyleVariations( 1, 'COURSE_THEME' ),
getSiteTheme( 1, 'COURSE_THEME' ),
```
* Navigate to http://calypso.localhost:3000/setup/sensei/senseiSetup?ref=senseilms&plan=ANNUALLY.
* Give a site name and select a domain.
* Make sure in the next step it goes to an error screen instead of going in a loop creating many sites.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?