### PR TITLE
GitHub deployments: Improve deployment trigger instructions

### DIFF
--- a/client/my-sites/github-deployments/components/automated-deployments-toggle/index.tsx
+++ b/client/my-sites/github-deployments/components/automated-deployments-toggle/index.tsx
@@ -1,0 +1,36 @@
+import { FormLabel } from '@automattic/components';
+import { FormToggle } from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+
+import './style.scss';
+
+interface AutomatedDeploymentsToggleProps {
+	onChange( value: boolean ): void;
+	value: boolean;
+	hasWorkflowPath: boolean;
+}
+
+export const AutomatedDeploymentsToggle = ( {
+	onChange,
+	value,
+	hasWorkflowPath,
+}: AutomatedDeploymentsToggleProps ) => {
+	const { __ } = useI18n();
+
+	return (
+		<FormFieldset>
+			<FormLabel htmlFor="is-automated">{ __( 'Automatic deployments' ) }</FormLabel>
+			<div className="automated-deployments-toggle-switch">
+				<FormToggle id="is-automated" onChange={ () => onChange( ! value ) } checked={ value } />
+				{
+					// Translators: %(condition)s is the when we are going to deploy the changes
+					sprintf( __( 'Deploy changes on %(condition)s' ), {
+						condition: hasWorkflowPath ? __( 'workflow run completion' ) : __( 'push' ),
+					} )
+				}
+			</div>
+		</FormFieldset>
+	);
+};

--- a/client/my-sites/github-deployments/components/automated-deployments-toggle/style.scss
+++ b/client/my-sites/github-deployments/components/automated-deployments-toggle/style.scss
@@ -1,0 +1,9 @@
+.automated-deployments-toggle-switch {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+
+	.components-form-toggle {
+		line-height: 1;
+	}
+}

--- a/client/my-sites/github-deployments/components/github-connection-form/index.tsx
+++ b/client/my-sites/github-deployments/components/github-connection-form/index.tsx
@@ -1,6 +1,6 @@
 import { Button, FormLabel, Spinner } from '@automattic/components';
-import { ExternalLink, FormToggle } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { ExternalLink } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
 import { ChangeEvent, useMemo, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
@@ -9,6 +9,7 @@ import FormTextInput from 'calypso/components/forms/form-text-input';
 import { GitHubInstallationData } from 'calypso/my-sites/github-deployments/use-github-installations-query';
 import { useGithubRepositoryBranchesQuery } from 'calypso/my-sites/github-deployments/use-github-repository-branches-query';
 import { GitHubRepositoryData } from '../../use-github-repositories-query';
+import { AutomatedDeploymentsToggle } from '../automated-deployments-toggle';
 import { DeploymentStyle } from '../deployment-style';
 import { useCheckWorkflowQuery } from '../deployment-style/use-check-workflow-query';
 
@@ -58,6 +59,7 @@ export const GitHubConnectionForm = ( {
 	const [ workflowPath, setWorkflowPath ] = useState< string | undefined >(
 		initialValues.workflowPath
 	);
+	const { __ } = useI18n();
 
 	const { data: branches, isLoading: isFetchingBranches } = useGithubRepositoryBranchesQuery(
 		installation.external_id,
@@ -164,22 +166,11 @@ export const GitHubConnectionForm = ( {
 						{ __( 'This path is relative to the server root' ) }
 					</FormSettingExplanation>
 				</FormFieldset>
-				<FormFieldset className="github-deployments-connect-repository__automatic-deploys">
-					<FormLabel htmlFor="is-automated">{ __( 'Automatic deploys' ) }</FormLabel>
-					<div className="github-deployments-connect-repository__automatic-deploys-switch">
-						<FormToggle
-							id="is-automated"
-							checked={ isAutoDeploy }
-							onChange={ () => setIsAutoDeploy( ! isAutoDeploy ) }
-						/>
-						{
-							// Translators: %(condition)s is the when we are going to deploy the changes
-							sprintf( __( 'Deploy changes on %(condition)s' ), {
-								condition: workflowPath ? __( 'workflow run' ) : __( 'push' ),
-							} )
-						}
-					</div>
-				</FormFieldset>
+				<AutomatedDeploymentsToggle
+					onChange={ setIsAutoDeploy }
+					value={ isAutoDeploy }
+					hasWorkflowPath={ !! workflowPath }
+				/>
 				<Button type="submit" primary busy={ isPending } disabled={ isPending || submitDisabled }>
 					{ ctaLabel }
 				</Button>

--- a/client/my-sites/github-deployments/components/github-connection-form/index.tsx
+++ b/client/my-sites/github-deployments/components/github-connection-form/index.tsx
@@ -1,6 +1,6 @@
 import { Button, FormLabel, Spinner } from '@automattic/components';
 import { ExternalLink, FormToggle } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { ChangeEvent, useMemo, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
@@ -172,7 +172,12 @@ export const GitHubConnectionForm = ( {
 							checked={ isAutoDeploy }
 							onChange={ () => setIsAutoDeploy( ! isAutoDeploy ) }
 						/>
-						<span>{ __( 'Deploy changes on push' ) }</span>
+						{
+							// Translators: %(condition)s is the when we are going to deploy the changes
+							sprintf( __( 'Deploy changes on %(condition)s' ), {
+								condition: workflowPath ? __( 'workflow run' ) : __( 'push' ),
+							} )
+						}
 					</div>
 				</FormFieldset>
 				<Button type="submit" primary busy={ isPending } disabled={ isPending || submitDisabled }>

--- a/client/my-sites/github-deployments/components/github-connection-form/style.scss
+++ b/client/my-sites/github-deployments/components/github-connection-form/style.scss
@@ -49,14 +49,4 @@
 			flex: 1;
 		}
 	}
-
-	&__automatic-deploys-switch {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-
-		.components-form-toggle {
-			line-height: 1;
-		}
-	}
 }

--- a/client/my-sites/github-deployments/create-repository/create-repository-form.tsx
+++ b/client/my-sites/github-deployments/create-repository/create-repository-form.tsx
@@ -1,5 +1,6 @@
 import { Button, FormInputValidation, FormLabel } from '@automattic/components';
 import { FormToggle, Spinner } from '@wordpress/components';
+import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { ChangeEvent, FormEventHandler, useEffect, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -201,7 +202,12 @@ export const CreateRepositoryForm = ( {
 							checked={ isAutomated }
 							onChange={ () => setIsAutomated( ! isAutomated ) }
 						/>
-						{ __( 'Deploy changes on push' ) }
+						{
+							// Translators: %(condition)s is the when we are going to deploy the changes
+							sprintf( __( 'Deploy changes on %(condition)s' ), {
+								condition: template.workflowFilename ? __( 'workflow run' ) : __( 'push' ),
+							} )
+						}
 					</div>
 				</FormFieldset>
 				<Button

--- a/client/my-sites/github-deployments/create-repository/create-repository-form.tsx
+++ b/client/my-sites/github-deployments/create-repository/create-repository-form.tsx
@@ -1,6 +1,5 @@
 import { Button, FormInputValidation, FormLabel } from '@automattic/components';
 import { FormToggle, Spinner } from '@wordpress/components';
-import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import { ChangeEvent, FormEventHandler, useEffect, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
@@ -8,6 +7,7 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { GitHubInstallationsDropdown } from 'calypso/my-sites/github-deployments/components/installations-dropdown';
 import { useLiveInstallations } from 'calypso/my-sites/github-deployments/components/installations-dropdown/use-live-installations';
+import { AutomatedDeploymentsToggle } from '../components/automated-deployments-toggle';
 import {
 	FormRadioWithTemplateSelect,
 	ProjectType,
@@ -194,22 +194,11 @@ export const CreateRepositoryForm = ( {
 						{ __( 'This path is relative to the server root' ) }
 					</FormSettingExplanation>
 				</FormFieldset>
-				<FormFieldset>
-					<FormLabel htmlFor="is-automated">{ __( 'Automatic deploys' ) }</FormLabel>
-					<div className="github-deployments-create-repository__switch">
-						<FormToggle
-							id="is-automated"
-							checked={ isAutomated }
-							onChange={ () => setIsAutomated( ! isAutomated ) }
-						/>
-						{
-							// Translators: %(condition)s is the when we are going to deploy the changes
-							sprintf( __( 'Deploy changes on %(condition)s' ), {
-								condition: template.workflowFilename ? __( 'workflow run' ) : __( 'push' ),
-							} )
-						}
-					</div>
-				</FormFieldset>
+				<AutomatedDeploymentsToggle
+					onChange={ setIsAutomated }
+					value={ isAutomated }
+					hasWorkflowPath={ !! template.workflowFilename }
+				/>
 				<Button
 					primary
 					type="submit"

--- a/client/my-sites/github-deployments/create-repository/style.scss
+++ b/client/my-sites/github-deployments/create-repository/style.scss
@@ -44,8 +44,7 @@
 		gap: 8px;
 
 		.components-form-toggle {
-			margin-left: 5px;
-			margin-top: 1px;
+			line-height: 1;
 		}
 	}
 

--- a/client/my-sites/github-deployments/create-repository/style.scss
+++ b/client/my-sites/github-deployments/create-repository/style.scss
@@ -38,16 +38,6 @@
 		}
 	}
 
-	&__switch {
-		display: flex;
-		align-items: center;
-		gap: 8px;
-
-		.components-form-toggle {
-			line-height: 1;
-		}
-	}
-
 	&__deployment-style {
 		flex: 1;
 	}

--- a/client/my-sites/github-deployments/deployment-run-logs/use-code-deployment-run-query.ts
+++ b/client/my-sites/github-deployments/deployment-run-logs/use-code-deployment-run-query.ts
@@ -23,7 +23,7 @@ export interface DeploymentRun {
 	started_on: string;
 	completed_on: string;
 	status: DeploymentRunStatus;
-	failure_code: string;
+	failure_code: string | null;
 	triggered_by_user_id: number;
 	metadata: Metadata;
 	code_deployment?: CodeDeploymentData;

--- a/client/my-sites/github-deployments/deployments/deployment-starter-message.tsx
+++ b/client/my-sites/github-deployments/deployments/deployment-starter-message.tsx
@@ -1,0 +1,115 @@
+import { createInterpolateElement } from '@wordpress/element';
+import { sprintf } from '@wordpress/i18n';
+import { useI18n } from '@wordpress/react-i18n';
+import { addQueryArgs } from '@wordpress/url';
+import { CodeDeploymentData } from './use-code-deployments-query';
+
+type WorkflowRunStatus = 'in_progress' | 'eligible' | 'error';
+
+interface WithWorkflowRunStatus {
+	workflow_run_status?: WorkflowRunStatus;
+}
+
+interface DeploymentStarterMessageProps {
+	deployment: CodeDeploymentData & WithWorkflowRunStatus;
+}
+
+export const DeploymentStarterMessage = ( { deployment }: DeploymentStarterMessageProps ) => {
+	const { __ } = useI18n();
+
+	const getManualDeploymentMessage = () => {
+		if ( ! deployment.workflow_path ) {
+			return __( 'Trigger a deployment from the ellipsis menu whenever you are ready.' );
+		}
+
+		const workflowName = deployment.workflow_path.replace( '.github/workflows/', '' );
+		const workflowUrl = addQueryArgs(
+			`https://github.com/${ deployment.repository_name }/actions/workflows/${ workflowName }`,
+			{
+				query: `branch=${ deployment.branch_name }`,
+			}
+		);
+
+		const workflowLink = <a href={ workflowUrl } target="_blank" rel="noopener noreferrer" />;
+
+		if ( ! deployment.workflow_run_status ) {
+			return createInterpolateElement(
+				sprintf(
+					// Translators: %(workflowName)s is the workflow file name from GitHub.
+					__(
+						'Trigger a workflow run for ‘<workflowLink>%(workflowName)s</workflowLink>’. After it succeeds, you will be able to deploy the artifact to your site.'
+					),
+					{
+						workflowName,
+					}
+				),
+				{
+					workflowLink,
+				}
+			);
+		}
+
+		if ( deployment.workflow_run_status === 'in_progress' ) {
+			return createInterpolateElement(
+				sprintf(
+					// Translators: %(workflowName)s is the workflow file name from GitHub.
+					__(
+						'Workflow running for ‘<workflowLink>%(workflowName)s</workflowLink>’. You will be able to deploy the artifact to your site once it succeeds.'
+					),
+					{
+						workflowName,
+					}
+				),
+				{
+					workflowLink,
+				}
+			);
+		}
+
+		if ( deployment.workflow_run_status === 'error' ) {
+			return createInterpolateElement(
+				sprintf(
+					// Translators: %(workflowName)s is the workflow file name from GitHub.
+					__(
+						'Workflow run failed for ‘<workflowLink>%(workflowName)s</workflowLink>’. You will be able to deploy the artifact to your site once it succeeds.'
+					),
+					{
+						workflowName,
+					}
+				),
+				{
+					workflowLink,
+				}
+			);
+		}
+
+		return createInterpolateElement(
+			sprintf(
+				// Translators: %(workflowName)s is the workflow file name from GitHub.
+				__(
+					'Workflow run for ‘<workflowLink>%(workflowName)s</workflowLink>’ succeeded! Trigger a deployment from the ellipsis menu whenever you are ready.'
+				),
+				{
+					workflowName,
+				}
+			),
+			{
+				workflowLink,
+			}
+		);
+	};
+
+	return (
+		<td colSpan={ 4 }>
+			<i css={ { color: 'var(--Gray-Gray-40, #50575E)' } }>
+				{ deployment.is_automated
+					? // Translators: %(branch)s is the branch name of the repository, %(repo)s is the repository name
+					  sprintf( __( 'Push something to the ‘%(branch)s’ branch of ‘%(repo)s’.' ), {
+							branch: deployment.branch_name,
+							repo: deployment.repository_name,
+					  } )
+					: getManualDeploymentMessage() }
+			</i>
+		</td>
+	);
+};

--- a/client/my-sites/github-deployments/deployments/deployment-starter-message.tsx
+++ b/client/my-sites/github-deployments/deployments/deployment-starter-message.tsx
@@ -4,14 +4,8 @@ import { useI18n } from '@wordpress/react-i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { CodeDeploymentData } from './use-code-deployments-query';
 
-type WorkflowRunStatus = 'in_progress' | 'eligible' | 'error';
-
-interface WithWorkflowRunStatus {
-	workflow_run_status?: WorkflowRunStatus;
-}
-
 interface DeploymentStarterMessageProps {
-	deployment: CodeDeploymentData & WithWorkflowRunStatus;
+	deployment: CodeDeploymentData;
 }
 
 export const DeploymentStarterMessage = ( { deployment }: DeploymentStarterMessageProps ) => {

--- a/client/my-sites/github-deployments/deployments/deployment-starter-message.tsx
+++ b/client/my-sites/github-deployments/deployments/deployment-starter-message.tsx
@@ -13,7 +13,7 @@ export const DeploymentStarterMessage = ( { deployment }: DeploymentStarterMessa
 
 	const getManualDeploymentMessage = () => {
 		if ( ! deployment.workflow_path ) {
-			return __( 'Trigger a deployment from the ellipsis menu whenever you are ready.' );
+			return __( 'Trigger a deployment from the ellipsis menu.' );
 		}
 
 		const workflowName = deployment.workflow_path.replace( '.github/workflows/', '' );
@@ -26,62 +26,11 @@ export const DeploymentStarterMessage = ( { deployment }: DeploymentStarterMessa
 
 		const workflowLink = <a href={ workflowUrl } target="_blank" rel="noopener noreferrer" />;
 
-		if ( ! deployment.workflow_run_status ) {
-			return createInterpolateElement(
-				sprintf(
-					// Translators: %(workflowName)s is the workflow file name from GitHub.
-					__(
-						'Trigger a workflow run for ‘<workflowLink>%(workflowName)s</workflowLink>’. After it succeeds, you will be able to deploy the artifact to your site.'
-					),
-					{
-						workflowName,
-					}
-				),
-				{
-					workflowLink,
-				}
-			);
-		}
-
-		if ( deployment.workflow_run_status === 'in_progress' ) {
-			return createInterpolateElement(
-				sprintf(
-					// Translators: %(workflowName)s is the workflow file name from GitHub.
-					__(
-						'Workflow running for ‘<workflowLink>%(workflowName)s</workflowLink>’. You will be able to deploy the artifact to your site once it succeeds.'
-					),
-					{
-						workflowName,
-					}
-				),
-				{
-					workflowLink,
-				}
-			);
-		}
-
-		if ( deployment.workflow_run_status === 'error' ) {
-			return createInterpolateElement(
-				sprintf(
-					// Translators: %(workflowName)s is the workflow file name from GitHub.
-					__(
-						'Workflow run failed for ‘<workflowLink>%(workflowName)s</workflowLink>’. You will be able to deploy the artifact to your site once it succeeds.'
-					),
-					{
-						workflowName,
-					}
-				),
-				{
-					workflowLink,
-				}
-			);
-		}
-
 		return createInterpolateElement(
 			sprintf(
 				// Translators: %(workflowName)s is the workflow file name from GitHub.
 				__(
-					'Workflow run for ‘<workflowLink>%(workflowName)s</workflowLink>’ succeeded! Trigger a deployment from the ellipsis menu whenever you are ready.'
+					'Make sure there is a successful run for ‘<workflowLink>%(workflowName)s</workflowLink>’, then trigger a deployment from the ellipsis menu.'
 				),
 				{
 					workflowName,

--- a/client/my-sites/github-deployments/deployments/deployments-list-item-actions.tsx
+++ b/client/my-sites/github-deployments/deployments/deployments-list-item-actions.tsx
@@ -22,16 +22,12 @@ export const DeploymentsListItemActions = ( {
 }: DeploymentsListItemActionsProps ) => {
 	const { __ } = useI18n();
 
-	const canManualDeploy =
-		! deployment.workflow_path || deployment.workflow_run_status === 'eligible';
-
 	return (
 		<DropdownMenu icon={ <Gridicon icon="ellipsis" /> } label={ __( 'Deployment actions' ) }>
 			{ ( { onClose } ) => (
 				<Fragment>
 					<MenuGroup>
 						<MenuItem
-							disabled={ ! canManualDeploy }
 							onClick={ () => {
 								onManualDeployment();
 								onClose();

--- a/client/my-sites/github-deployments/deployments/deployments-list-item-actions.tsx
+++ b/client/my-sites/github-deployments/deployments/deployments-list-item-actions.tsx
@@ -1,0 +1,76 @@
+import page from '@automattic/calypso-router';
+import { Gridicon } from '@automattic/components';
+import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
+import { Icon, linkOff } from '@wordpress/icons';
+import { useI18n } from '@wordpress/react-i18n';
+import { manageDeploymentPage, viewDeploymentLogs } from '../routes';
+import { CodeDeploymentData } from './use-code-deployments-query';
+
+interface DeploymentsListItemActionsProps {
+	siteSlug: string;
+	onManualDeployment(): void;
+	onDisconnectRepository(): void;
+	deployment: CodeDeploymentData;
+}
+
+export const DeploymentsListItemActions = ( {
+	siteSlug,
+	onManualDeployment,
+	onDisconnectRepository,
+	deployment,
+}: DeploymentsListItemActionsProps ) => {
+	const { __ } = useI18n();
+
+	const canManualDeploy =
+		! deployment.workflow_path || deployment.workflow_run_status === 'eligible';
+
+	return (
+		<DropdownMenu icon={ <Gridicon icon="ellipsis" /> } label={ __( 'Deployment actions' ) }>
+			{ ( { onClose } ) => (
+				<Fragment>
+					<MenuGroup>
+						<MenuItem
+							disabled={ ! canManualDeploy }
+							onClick={ () => {
+								onManualDeployment();
+								onClose();
+							} }
+						>
+							{ __( 'Trigger manual deployment' ) }
+						</MenuItem>
+						<MenuItem
+							disabled={ !! deployment.current_deployment_run }
+							onClick={ () => {
+								page( viewDeploymentLogs( siteSlug, deployment.id ) );
+								onClose();
+							} }
+						>
+							{ __( 'See deployment runs' ) }
+						</MenuItem>
+						<MenuItem
+							onClick={ () => {
+								page( manageDeploymentPage( siteSlug, deployment.id ) );
+								onClose();
+							} }
+						>
+							{ __( 'Configure repository' ) }
+						</MenuItem>
+					</MenuGroup>
+					<MenuGroup>
+						<MenuItem
+							className="github-deployments-list__menu-item-danger"
+							onClick={ () => {
+								onDisconnectRepository();
+								onClose();
+							} }
+						>
+							<Icon icon={ linkOff } />
+							{ __( 'Disconnect repository' ) }
+						</MenuItem>
+					</MenuGroup>
+				</Fragment>
+			) }
+		</DropdownMenu>
+	);
+};

--- a/client/my-sites/github-deployments/deployments/deployments-list-item-actions.tsx
+++ b/client/my-sites/github-deployments/deployments/deployments-list-item-actions.tsx
@@ -40,7 +40,7 @@ export const DeploymentsListItemActions = ( {
 							{ __( 'Trigger manual deployment' ) }
 						</MenuItem>
 						<MenuItem
-							disabled={ !! deployment.current_deployment_run }
+							disabled={ ! deployment.current_deployment_run }
 							onClick={ () => {
 								page( viewDeploymentLogs( siteSlug, deployment.id ) );
 								onClose();

--- a/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
+++ b/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
@@ -1,10 +1,9 @@
 import page from '@automattic/calypso-router';
-import { Button, Gridicon } from '@automattic/components';
+import { Button } from '@automattic/components';
 import { useLocale } from '@automattic/i18n-utils';
-import { DropdownMenu, MenuGroup, MenuItem, Spinner } from '@wordpress/components';
-import { Fragment, useState } from '@wordpress/element';
+import { Spinner } from '@wordpress/components';
+import { useState } from '@wordpress/element';
 import { sprintf } from '@wordpress/i18n';
-import { Icon, linkOff } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { DeploymentCommitDetails } from 'calypso/my-sites/github-deployments/deployments/deployment-commit-details';
 import { DeploymentDuration } from 'calypso/my-sites/github-deployments/deployments/deployment-duration';
@@ -18,9 +17,10 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { useDispatch, useSelector } from '../../../state';
-import { manageDeploymentPage, viewDeploymentLogs } from '../routes';
+import { manageDeploymentPage } from '../routes';
 import { DeleteDeploymentDialog } from './delete-deployment-dialog';
 import { DeploymentStarterMessage } from './deployment-starter-message';
+import { DeploymentsListItemActions } from './deployments-list-item-actions';
 import { CodeDeploymentData } from './use-code-deployments-query';
 
 const noticeOptions = {
@@ -86,9 +86,6 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 		<DeploymentStarterMessage deployment={ deployment } />
 	);
 
-	const canManualDeploy =
-		! deployment.workflow_path || deployment.workflow_run_status === 'eligible';
-
 	return (
 		<>
 			<tr>
@@ -109,55 +106,12 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 					{ isTriggeringDeployment ? (
 						<Spinner />
 					) : (
-						<DropdownMenu
-							icon={ <Gridicon icon="ellipsis" /> }
-							label={ __( 'Deployment actions' ) }
-						>
-							{ ( { onClose } ) => (
-								<Fragment>
-									<MenuGroup>
-										<MenuItem
-											disabled={ ! canManualDeploy }
-											onClick={ () => {
-												triggerManualDeployment();
-												onClose();
-											} }
-										>
-											{ __( 'Trigger manual deploy' ) }
-										</MenuItem>
-										<MenuItem
-											disabled={ ! run }
-											onClick={ () => {
-												page( viewDeploymentLogs( siteSlug!, deployment.id ) );
-												onClose();
-											} }
-										>
-											{ __( 'See deployment runs' ) }
-										</MenuItem>
-										<MenuItem
-											onClick={ () => {
-												page( manageDeploymentPage( siteSlug!, deployment.id ) );
-												onClose();
-											} }
-										>
-											{ __( 'Configure repository' ) }
-										</MenuItem>
-									</MenuGroup>
-									<MenuGroup>
-										<MenuItem
-											className="github-deployments-list__menu-item-danger"
-											onClick={ () => {
-												setDisconnectRepositoryDialogVisibility( true );
-												onClose();
-											} }
-										>
-											<Icon icon={ linkOff } />
-											{ __( 'Disconnect repository' ) }
-										</MenuItem>
-									</MenuGroup>
-								</Fragment>
-							) }
-						</DropdownMenu>
+						<DeploymentsListItemActions
+							siteSlug={ siteSlug! }
+							deployment={ deployment }
+							onManualDeployment={ triggerManualDeployment }
+							onDisconnectRepository={ () => setDisconnectRepositoryDialogVisibility( true ) }
+						/>
 					) }
 				</td>
 			</tr>

--- a/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
+++ b/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
@@ -109,7 +109,10 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 					{ isTriggeringDeployment ? (
 						<Spinner />
 					) : (
-						<DropdownMenu icon={ <Gridicon icon="ellipsis" /> } label="Select a direction">
+						<DropdownMenu
+							icon={ <Gridicon icon="ellipsis" /> }
+							label={ __( 'Deployment actions' ) }
+						>
 							{ ( { onClose } ) => (
 								<Fragment>
 									<MenuGroup>

--- a/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
+++ b/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
@@ -20,6 +20,7 @@ import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { useDispatch, useSelector } from '../../../state';
 import { manageDeploymentPage, viewDeploymentLogs } from '../routes';
 import { DeleteDeploymentDialog } from './delete-deployment-dialog';
+import { DeploymentStarterMessage } from './deployment-starter-message';
 import { CodeDeploymentData } from './use-code-deployments-query';
 
 const noticeOptions = {
@@ -72,18 +73,6 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 	const run = deployment.current_deployment_run;
 	const [ installation, repo ] = deployment.repository_name.split( '/' );
 
-	const getStarterMessage = () => {
-		if ( deployment.is_automated ) {
-			// Translators: %(branch)s is the branch name of the repository, %(repo)s is the repository name
-			return sprintf( __( 'Push something to the ‘%(branch)s’ branch of ‘%(repo)s’' ), {
-				branch: deployment.branch_name,
-				repo: deployment.repository_name,
-			} );
-		}
-
-		return __( 'Whenever you are ready, trigger a deployment from the ellipsis menu' );
-	};
-
 	const columns = run ? (
 		<>
 			<td>{ run && <DeploymentCommitDetails run={ run } deployment={ deployment } /> }</td>
@@ -94,9 +83,7 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 			<td>{ run && <DeploymentDuration run={ run } /> }</td>
 		</>
 	) : (
-		<td colSpan={ 4 }>
-			<i css={ { color: 'var(--Gray-Gray-40, #50575E)' } }>{ getStarterMessage() }</i>
-		</td>
+		<DeploymentStarterMessage deployment={ deployment } />
 	);
 
 	return (

--- a/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
+++ b/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
@@ -86,6 +86,9 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 		<DeploymentStarterMessage deployment={ deployment } />
 	);
 
+	const canManualDeploy =
+		! deployment.workflow_path || deployment.workflow_run_status === 'eligible';
+
 	return (
 		<>
 			<tr>
@@ -111,6 +114,7 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 								<Fragment>
 									<MenuGroup>
 										<MenuItem
+											disabled={ ! canManualDeploy }
 											onClick={ () => {
 												triggerManualDeployment();
 												onClose();
@@ -118,16 +122,15 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 										>
 											{ __( 'Trigger manual deploy' ) }
 										</MenuItem>
-										{ run && (
-											<MenuItem
-												onClick={ () => {
-													page( viewDeploymentLogs( siteSlug!, deployment.id ) );
-													onClose();
-												} }
-											>
-												{ __( 'See deployment runs' ) }
-											</MenuItem>
-										) }
+										<MenuItem
+											disabled={ ! run }
+											onClick={ () => {
+												page( viewDeploymentLogs( siteSlug!, deployment.id ) );
+												onClose();
+											} }
+										>
+											{ __( 'See deployment runs' ) }
+										</MenuItem>
 										<MenuItem
 											onClick={ () => {
 												page( manageDeploymentPage( siteSlug!, deployment.id ) );

--- a/client/my-sites/github-deployments/deployments/test/deployment-starter-message.test.tsx
+++ b/client/my-sites/github-deployments/deployments/test/deployment-starter-message.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render as testRenderer } from '@testing-library/react';
+import { ReactNode } from 'react';
+import { DeploymentStarterMessage } from '../deployment-starter-message';
+import { CodeDeploymentData } from '../use-code-deployments-query';
+
+const createDeployment = ( args?: Partial< CodeDeploymentData > ): CodeDeploymentData => ( {
+	id: 1,
+	blog_id: 1,
+	branch_name: 'trunk',
+	created_by: {
+		id: 1,
+		name: 'Luis Felipe Zaguini',
+	},
+	created_by_user_id: 1,
+	created_on: new Date().toString(),
+	external_repository_id: 1,
+	installation_id: 1,
+	is_automated: true,
+	repository_name: 'repository',
+	target_dir: '/',
+	updated_on: new Date().toString(),
+	...args,
+} );
+
+const render = ( element: ReactNode ) => {
+	const tr = document.createElement( 'tr' );
+
+	return testRenderer( element, { container: document.body.appendChild( tr ) } );
+};
+
+describe( 'DeploymentStarterMessage', () => {
+	test( 'instructs the user to push something on automated deployments', () => {
+		const { getByText } = render(
+			<DeploymentStarterMessage
+				deployment={ createDeployment( {
+					repository_name: 'repository',
+					branch_name: 'trunk',
+					is_automated: true,
+				} ) }
+			/>
+		);
+
+		expect(
+			getByText( 'Push something to the ‘trunk’ branch of ‘repository’.' )
+		).toBeInTheDocument();
+	} );
+
+	test( 'instructs the user to push something on manual deployments on push', () => {
+		const { getByText } = render(
+			<DeploymentStarterMessage
+				deployment={ createDeployment( {
+					is_automated: false,
+				} ) }
+			/>
+		);
+
+		expect(
+			getByText( 'Trigger a deployment from the ellipsis menu whenever you are ready.' )
+		).toBeInTheDocument();
+	} );
+
+	describe( 'manual deployments on workflow run completion', () => {
+		const workflow_path = '.github/workflows/workflow.yml';
+
+		test( 'instructs the user to start a workflow run', () => {
+			const { getByText } = render(
+				<DeploymentStarterMessage
+					deployment={ createDeployment( {
+						is_automated: false,
+						workflow_path,
+					} ) }
+				/>
+			);
+
+			const element = getByText( 'Trigger a workflow run', { exact: false } );
+
+			expect( element ).toHaveTextContent(
+				'Trigger a workflow run for ‘workflow.yml’. After it succeeds, you will be able to deploy the artifact to your site.'
+			);
+		} );
+
+		test( 'tells the user to wait until the workflow run succeeds', () => {
+			const { getByText } = render(
+				<DeploymentStarterMessage
+					deployment={ createDeployment( {
+						is_automated: false,
+						workflow_path,
+						workflow_run_status: 'in_progress',
+					} ) }
+				/>
+			);
+
+			const element = getByText( 'Workflow running for', { exact: false } );
+
+			expect( element ).toHaveTextContent(
+				'Workflow running for ‘workflow.yml’. You will be able to deploy the artifact to your site once it succeeds.'
+			);
+		} );
+
+		test( 'tells the user to that the workflow run failed and therefore they cannot manually deploy', () => {
+			const { getByText } = render(
+				<DeploymentStarterMessage
+					deployment={ createDeployment( {
+						is_automated: false,
+						workflow_path,
+						workflow_run_status: 'error',
+					} ) }
+				/>
+			);
+
+			const element = getByText( 'Workflow run failed for', { exact: false } );
+
+			expect( element ).toHaveTextContent(
+				'Workflow run failed for ‘workflow.yml’. You will be able to deploy the artifact to your site once it succeeds.'
+			);
+		} );
+
+		test( 'instructs the user to start a manual deployment after the workflow run succeeded', () => {
+			const { getByText } = render(
+				<DeploymentStarterMessage
+					deployment={ createDeployment( {
+						is_automated: false,
+						workflow_path,
+						workflow_run_status: 'eligible',
+					} ) }
+				/>
+			);
+
+			const element = getByText( 'Workflow run for', { exact: false } );
+
+			expect( element ).toHaveTextContent(
+				'Workflow run for ‘workflow.yml’ succeeded! Trigger a deployment from the ellipsis menu whenever you are ready.'
+			);
+		} );
+	} );
+} );

--- a/client/my-sites/github-deployments/deployments/test/deployment-starter-message.test.tsx
+++ b/client/my-sites/github-deployments/deployments/test/deployment-starter-message.test.tsx
@@ -4,26 +4,7 @@
 import { render as testRenderer } from '@testing-library/react';
 import { ReactNode } from 'react';
 import { DeploymentStarterMessage } from '../deployment-starter-message';
-import { CodeDeploymentData } from '../use-code-deployments-query';
-
-const createDeployment = ( args?: Partial< CodeDeploymentData > ): CodeDeploymentData => ( {
-	id: 1,
-	blog_id: 1,
-	branch_name: 'trunk',
-	created_by: {
-		id: 1,
-		name: 'Luis Felipe Zaguini',
-	},
-	created_by_user_id: 1,
-	created_on: new Date().toString(),
-	external_repository_id: 1,
-	installation_id: 1,
-	is_automated: true,
-	repository_name: 'repository',
-	target_dir: '/',
-	updated_on: new Date().toString(),
-	...args,
-} );
+import { createDeployment } from './utils';
 
 const render = ( element: ReactNode ) => {
 	const tr = document.createElement( 'tr' );
@@ -48,7 +29,7 @@ describe( 'DeploymentStarterMessage', () => {
 		).toBeInTheDocument();
 	} );
 
-	test( 'instructs the user to push something on manual deployments on push', () => {
+	test( 'instructs the user to create a manual deployment for simple connections', () => {
 		const { getByText } = render(
 			<DeploymentStarterMessage
 				deployment={ createDeployment( {
@@ -57,83 +38,25 @@ describe( 'DeploymentStarterMessage', () => {
 			/>
 		);
 
-		expect(
-			getByText( 'Trigger a deployment from the ellipsis menu whenever you are ready.' )
-		).toBeInTheDocument();
+		expect( getByText( 'Trigger a deployment from the ellipsis menu.' ) ).toBeInTheDocument();
 	} );
 
-	describe( 'manual deployments on workflow run completion', () => {
+	test( 'instructs the user to create a manual deployment for advanced connections', () => {
 		const workflow_path = '.github/workflows/workflow.yml';
 
-		test( 'instructs the user to start a workflow run', () => {
-			const { getByText } = render(
-				<DeploymentStarterMessage
-					deployment={ createDeployment( {
-						is_automated: false,
-						workflow_path,
-					} ) }
-				/>
-			);
+		const { getByText } = render(
+			<DeploymentStarterMessage
+				deployment={ createDeployment( {
+					is_automated: false,
+					workflow_path,
+				} ) }
+			/>
+		);
 
-			const element = getByText( 'Trigger a workflow run', { exact: false } );
+		const element = getByText( 'Make sure there is a successful run', { exact: false } );
 
-			expect( element ).toHaveTextContent(
-				'Trigger a workflow run for ‘workflow.yml’. After it succeeds, you will be able to deploy the artifact to your site.'
-			);
-		} );
-
-		test( 'tells the user to wait until the workflow run succeeds', () => {
-			const { getByText } = render(
-				<DeploymentStarterMessage
-					deployment={ createDeployment( {
-						is_automated: false,
-						workflow_path,
-						workflow_run_status: 'in_progress',
-					} ) }
-				/>
-			);
-
-			const element = getByText( 'Workflow running for', { exact: false } );
-
-			expect( element ).toHaveTextContent(
-				'Workflow running for ‘workflow.yml’. You will be able to deploy the artifact to your site once it succeeds.'
-			);
-		} );
-
-		test( 'tells the user to that the workflow run failed and therefore they cannot manually deploy', () => {
-			const { getByText } = render(
-				<DeploymentStarterMessage
-					deployment={ createDeployment( {
-						is_automated: false,
-						workflow_path,
-						workflow_run_status: 'error',
-					} ) }
-				/>
-			);
-
-			const element = getByText( 'Workflow run failed for', { exact: false } );
-
-			expect( element ).toHaveTextContent(
-				'Workflow run failed for ‘workflow.yml’. You will be able to deploy the artifact to your site once it succeeds.'
-			);
-		} );
-
-		test( 'instructs the user to start a manual deployment after the workflow run succeeded', () => {
-			const { getByText } = render(
-				<DeploymentStarterMessage
-					deployment={ createDeployment( {
-						is_automated: false,
-						workflow_path,
-						workflow_run_status: 'eligible',
-					} ) }
-				/>
-			);
-
-			const element = getByText( 'Workflow run for', { exact: false } );
-
-			expect( element ).toHaveTextContent(
-				'Workflow run for ‘workflow.yml’ succeeded! Trigger a deployment from the ellipsis menu whenever you are ready.'
-			);
-		} );
+		expect( element ).toHaveTextContent(
+			'Make sure there is a successful run for ‘workflow.yml’, then trigger a deployment from the ellipsis menu.'
+		);
 	} );
 } );

--- a/client/my-sites/github-deployments/deployments/test/deployment-starter-message.test.tsx
+++ b/client/my-sites/github-deployments/deployments/test/deployment-starter-message.test.tsx
@@ -3,8 +3,8 @@
  */
 import { render as testRenderer } from '@testing-library/react';
 import { ReactNode } from 'react';
+import { createDeployment } from '../../test-utils';
 import { DeploymentStarterMessage } from '../deployment-starter-message';
-import { createDeployment } from './utils';
 
 const render = ( element: ReactNode ) => {
 	const tr = document.createElement( 'tr' );

--- a/client/my-sites/github-deployments/deployments/test/deployments-list-item-actions.test.tsx
+++ b/client/my-sites/github-deployments/deployments/test/deployments-list-item-actions.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { fireEvent, render } from '@testing-library/react';
-import { createDeployment } from '../../test-utils';
+import { createDeployment, createDeploymentRun } from '../../test-utils';
 import { DeploymentsListItemActions } from '../deployments-list-item-actions';
 
 const siteSlug = 'mysite.wpcomstaging.com';

--- a/client/my-sites/github-deployments/deployments/test/deployments-list-item-actions.test.tsx
+++ b/client/my-sites/github-deployments/deployments/test/deployments-list-item-actions.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * @jest-environment jsdom
+ */
+import { fireEvent, render } from '@testing-library/react';
+import { DeploymentsListItemActions } from '../deployments-list-item-actions';
+import { CodeDeploymentData } from '../use-code-deployments-query';
+
+const createDeployment = ( args?: Partial< CodeDeploymentData > ): CodeDeploymentData => ( {
+	id: 1,
+	blog_id: 1,
+	branch_name: 'trunk',
+	created_by: {
+		id: 1,
+		name: 'Luis Felipe Zaguini',
+	},
+	created_by_user_id: 1,
+	created_on: new Date().toString(),
+	external_repository_id: 1,
+	installation_id: 1,
+	is_automated: true,
+	repository_name: 'repository',
+	target_dir: '/',
+	updated_on: new Date().toString(),
+	...args,
+} );
+
+const siteSlug = 'mysite.wpcomstaging.com';
+
+describe( 'DeploymentsListItemActions', () => {
+	test( 'lets the user trigger a manual deployment on simple connections', () => {
+		const onManualDeployment = jest.fn();
+
+		const { getByText, getByLabelText } = render(
+			<DeploymentsListItemActions
+				siteSlug={ siteSlug }
+				deployment={ createDeployment( {
+					workflow_path: undefined,
+				} ) }
+				onManualDeployment={ onManualDeployment }
+				onDisconnectRepository={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( getByLabelText( 'Deployment actions' ) );
+
+		const triggerManualDeployButton = getByText( 'Trigger manual deployment' );
+
+		expect( triggerManualDeployButton ).toBeInTheDocument();
+
+		fireEvent.click( triggerManualDeployButton );
+		expect( onManualDeployment ).toHaveBeenCalled();
+	} );
+
+	test( 'does not the user trigger a manual deployment on ineligible advanced connections', () => {
+		const onManualDeployment = jest.fn();
+
+		const { getByText, getByLabelText } = render(
+			<DeploymentsListItemActions
+				siteSlug={ siteSlug }
+				deployment={ createDeployment( {
+					workflow_path: '.github/workflows/workflow.yml',
+				} ) }
+				onManualDeployment={ onManualDeployment }
+				onDisconnectRepository={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( getByLabelText( 'Deployment actions' ) );
+
+		const triggerManualDeployButton = getByText( 'Trigger manual deployment' );
+
+		expect( triggerManualDeployButton ).toBeInTheDocument();
+
+		fireEvent.click( triggerManualDeployButton );
+		expect( onManualDeployment ).not.toHaveBeenCalled();
+	} );
+
+	test( 'lets the user trigger a manual deployment on eligible advanced connections', () => {
+		const onManualDeployment = jest.fn();
+
+		const { getByText, getByLabelText } = render(
+			<DeploymentsListItemActions
+				siteSlug={ siteSlug }
+				deployment={ createDeployment( {
+					workflow_path: '.github/workflows/workflow.yml',
+					workflow_run_status: 'eligible',
+				} ) }
+				onManualDeployment={ onManualDeployment }
+				onDisconnectRepository={ jest.fn() }
+			/>
+		);
+
+		fireEvent.click( getByLabelText( 'Deployment actions' ) );
+
+		const triggerManualDeployButton = getByText( 'Trigger manual deployment' );
+
+		expect( triggerManualDeployButton ).toBeInTheDocument();
+
+		fireEvent.click( triggerManualDeployButton );
+		expect( onManualDeployment ).toHaveBeenCalled();
+	} );
+} );

--- a/client/my-sites/github-deployments/deployments/test/deployments-list-item-actions.test.tsx
+++ b/client/my-sites/github-deployments/deployments/test/deployments-list-item-actions.test.tsx
@@ -2,8 +2,8 @@
  * @jest-environment jsdom
  */
 import { fireEvent, render } from '@testing-library/react';
+import { createDeployment } from '../../test-utils';
 import { DeploymentsListItemActions } from '../deployments-list-item-actions';
-import { createDeployment, createDeploymentRun } from './utils';
 
 const siteSlug = 'mysite.wpcomstaging.com';
 

--- a/client/my-sites/github-deployments/deployments/test/utils.ts
+++ b/client/my-sites/github-deployments/deployments/test/utils.ts
@@ -1,0 +1,44 @@
+import { DeploymentRun } from '../../deployment-run-logs/use-code-deployment-run-query';
+import { CodeDeploymentData } from '../use-code-deployments-query';
+
+export const createDeployment = ( args?: Partial< CodeDeploymentData > ): CodeDeploymentData => ( {
+	id: 1,
+	blog_id: 1,
+	branch_name: 'trunk',
+	created_by: {
+		id: 1,
+		name: 'Luis Felipe Zaguini',
+	},
+	created_by_user_id: 1,
+	created_on: new Date().toString(),
+	external_repository_id: 1,
+	installation_id: 1,
+	is_automated: true,
+	repository_name: 'repository',
+	target_dir: '/',
+	updated_on: new Date().toString(),
+	...args,
+} );
+
+export const createDeploymentRun = ( args?: Partial< DeploymentRun > ): DeploymentRun => ( {
+	id: 1,
+	status: 'success',
+	started_on: new Date().toString(),
+	metadata: {
+		job_id: 1,
+		commit_sha: '123abc45',
+		commit_message: 'My message',
+		author: {
+			id: 1,
+			name: 'Luis Felipe Zaguini',
+			profile_url: 'https://github.com/user',
+			avatar_url: 'https://github.com/user.jpg',
+		},
+	},
+	triggered_by_user_id: 1,
+	failure_code: null,
+	code_deployment_id: 1,
+	completed_on: new Date().toString(),
+	created_on: new Date().toString(),
+	...args,
+} );

--- a/client/my-sites/github-deployments/deployments/use-code-deployments-query.ts
+++ b/client/my-sites/github-deployments/deployments/use-code-deployments-query.ts
@@ -22,7 +22,7 @@ export interface CodeDeploymentData {
 	created_by: CreatedBy;
 	current_deployed_run?: DeploymentRun;
 	current_deployment_run?: DeploymentRun;
-	workflow_path: string;
+	workflow_path?: string; // @todo The actual value here is string | null
 	workflow_run_status?: WorkflowRunStatus;
 }
 

--- a/client/my-sites/github-deployments/deployments/use-code-deployments-query.ts
+++ b/client/my-sites/github-deployments/deployments/use-code-deployments-query.ts
@@ -5,8 +5,6 @@ import type { DeploymentRun } from '../deployment-run-logs/use-code-deployment-r
 
 export const CODE_DEPLOYMENTS_QUERY_KEY = 'code-deployments';
 
-type WorkflowRunStatus = 'in_progress' | 'eligible' | 'error';
-
 export interface CodeDeploymentData {
 	id: number;
 	blog_id: number;
@@ -23,7 +21,6 @@ export interface CodeDeploymentData {
 	current_deployed_run?: DeploymentRun;
 	current_deployment_run?: DeploymentRun;
 	workflow_path?: string; // @todo The actual value here is string | null
-	workflow_run_status?: WorkflowRunStatus;
 }
 
 export interface CreatedBy {

--- a/client/my-sites/github-deployments/deployments/use-code-deployments-query.ts
+++ b/client/my-sites/github-deployments/deployments/use-code-deployments-query.ts
@@ -5,6 +5,8 @@ import type { DeploymentRun } from '../deployment-run-logs/use-code-deployment-r
 
 export const CODE_DEPLOYMENTS_QUERY_KEY = 'code-deployments';
 
+type WorkflowRunStatus = 'in_progress' | 'eligible' | 'error';
+
 export interface CodeDeploymentData {
 	id: number;
 	blog_id: number;
@@ -21,6 +23,7 @@ export interface CodeDeploymentData {
 	current_deployed_run?: DeploymentRun;
 	current_deployment_run?: DeploymentRun;
 	workflow_path: string;
+	workflow_run_status?: WorkflowRunStatus;
 }
 
 export interface CreatedBy {

--- a/client/my-sites/github-deployments/test-utils.ts
+++ b/client/my-sites/github-deployments/test-utils.ts
@@ -1,5 +1,5 @@
-import { DeploymentRun } from '../../deployment-run-logs/use-code-deployment-run-query';
-import { CodeDeploymentData } from '../use-code-deployments-query';
+import { DeploymentRun } from './deployment-run-logs/use-code-deployment-run-query';
+import { CodeDeploymentData } from './deployments/use-code-deployments-query';
 
 export const createDeployment = ( args?: Partial< CodeDeploymentData > ): CodeDeploymentData => ( {
 	id: 1,


### PR DESCRIPTION
## Proposed Changes

This PR gives more specific instructions on how to trigger a deployment run. It relies on the `deployment.workflow_run_status` parameter, yet to be implemented on the back-end, to decide which status to show to the user.

For now we'll go with a simple copy. We might implement a link button somewhere so they don't need to click the ellipsis menu. However, doing that will introduce multiple points for the same action, which might lead to a confusing experience.

This change addresses this point (pet6gk-Xe-p2#comment-835):

>Given that, we should make it extremely clear that deployment runs are manual by default, and improve the experience for these kind of deployments.

## Testing Instructions

The unit tests are a good playbook. You can run them with `yarn test-client client/my-sites/github-deployments/deployments/test`