### PR TITLE
Payment methods: Pass existingCardMethods to CreditCardLabel

### DIFF
--- a/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.tsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.tsx
@@ -45,7 +45,7 @@ export default function useCreateAssignablePaymentMethods(
 		allowEditingTaxInfo: true,
 		isTaxInfoRequired: true,
 	} );
-
+	const hasExistingCardMethods = existingCardMethods && existingCardMethods.length > 0;
 	const stripeMethod = useCreateCreditCard( {
 		isStripeLoading,
 		stripeLoadingError,
@@ -55,7 +55,7 @@ export default function useCreateAssignablePaymentMethods(
 			<PaymentMethodSelectorSubmitButtonContent text={ translate( 'Save card' ) } />
 		),
 		allowUseForAllSubscriptions: true,
-		existingCardMethods,
+		hasExistingCardMethods,
 	} );
 
 	const payPalMethod = useCreatePayPal( {

--- a/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.tsx
+++ b/client/me/purchases/manage-purchase/change-payment-method/use-create-assignable-payment-methods.tsx
@@ -33,26 +33,8 @@ export default function useCreateAssignablePaymentMethods(
 		error: allowedPaymentMethodsError,
 	} = useFetchAvailablePaymentMethods();
 
-	const stripeMethod = useCreateCreditCard( {
-		isStripeLoading,
-		stripeLoadingError,
-		shouldUseEbanx: false,
-		shouldShowTaxFields: true,
-		submitButtonContent: (
-			<PaymentMethodSelectorSubmitButtonContent text={ translate( 'Save card' ) } />
-		),
-		allowUseForAllSubscriptions: true,
-	} );
-
-	const payPalMethod = useCreatePayPal( {
-		shouldShowTaxFields: true,
-		labelText:
-			currentPaymentMethodId === 'paypal-existing'
-				? String( translate( 'New PayPal account' ) )
-				: String( translate( 'PayPal' ) ),
-	} );
-
 	const { paymentMethods: storedCards } = useStoredPaymentMethods( { type: 'card' } );
+
 	const existingCardMethods = useCreateExistingCards( {
 		isStripeLoading,
 		stripeLoadingError,
@@ -62,6 +44,26 @@ export default function useCreateAssignablePaymentMethods(
 		),
 		allowEditingTaxInfo: true,
 		isTaxInfoRequired: true,
+	} );
+
+	const stripeMethod = useCreateCreditCard( {
+		isStripeLoading,
+		stripeLoadingError,
+		shouldUseEbanx: false,
+		shouldShowTaxFields: true,
+		submitButtonContent: (
+			<PaymentMethodSelectorSubmitButtonContent text={ translate( 'Save card' ) } />
+		),
+		allowUseForAllSubscriptions: true,
+		existingCardMethods,
+	} );
+
+	const payPalMethod = useCreatePayPal( {
+		shouldShowTaxFields: true,
+		labelText:
+			currentPaymentMethodId === 'paypal-existing'
+				? String( translate( 'New PayPal account' ) )
+				: String( translate( 'PayPal' ) ),
 	} );
 
 	const paymentMethods = useMemo(

--- a/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
+++ b/client/me/purchases/manage-purchase/payment-method-selector/index.tsx
@@ -74,6 +74,7 @@ const TOSItemWrapper = styled.div`
 	padding-left: 24px;
 	position: relative;
 	font-size: 12px;
+	margin: 1.5em auto 0;
 
 	> svg {
 		position: absolute;

--- a/client/me/purchases/manage-purchase/test/change-payment-method.tsx
+++ b/client/me/purchases/manage-purchase/test/change-payment-method.tsx
@@ -207,6 +207,9 @@ describe( 'ChangePaymentMethod', () => {
 		const queryClient = new QueryClient();
 
 		const paymentMethods: Partial< StoredPaymentMethod >[] = [ storedCard1 ];
+		const hasExistingCardMethods = paymentMethods.length > 0;
+		let labelText = 'Credit or debit card';
+
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.2/me/payment-methods?type=card&expired=exclude' )
 			.reply( 200, paymentMethods );
@@ -229,7 +232,11 @@ describe( 'ChangePaymentMethod', () => {
 			</ReduxProvider>
 		);
 
-		expect( await screen.findByLabelText( 'Credit or debit card' ) ).toBeInTheDocument();
+		if ( hasExistingCardMethods ) {
+			labelText = 'New credit or debit card';
+		}
+
+		expect( await screen.findByLabelText( labelText ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders a PayPal payment method', async () => {

--- a/client/me/purchases/manage-purchase/test/change-payment-method.tsx
+++ b/client/me/purchases/manage-purchase/test/change-payment-method.tsx
@@ -203,12 +203,39 @@ describe( 'ChangePaymentMethod', () => {
 		expect( await screen.findByLabelText( new RegExp( storedCard1.name ) ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders a new credit card payment method', async () => {
+	it( 'renders a new credit card payment method that reads "Credit or debit card"', async () => {
 		const queryClient = new QueryClient();
 
 		const paymentMethods: Partial< StoredPaymentMethod >[] = [ storedCard1 ];
-		const hasExistingCardMethods = paymentMethods.length > 0;
-		let labelText = 'Credit or debit card';
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.2/me/payment-methods?type=card&expired=exclude' )
+			.reply( 200, paymentMethods );
+		nock( 'https://public-api.wordpress.com' )
+			.get( '/rest/v1.1/me/stripe-configuration' )
+			.reply( 200, stripeConfiguration );
+
+		render(
+			<ReduxProvider store={ createTestReduxStore() }>
+				<QueryClientProvider client={ queryClient }>
+					<ChangePaymentMethod
+						getManagePurchaseUrlFor={ ( siteSlug: string, purchaseId: number ) =>
+							`/manage-purchase-url/${ siteSlug }/${ purchaseId }`
+						}
+						purchaseId={ 1 }
+						purchaseListUrl="purchase-list-url"
+						siteSlug="example.com"
+					/>
+				</QueryClientProvider>
+			</ReduxProvider>
+		);
+
+		expect( await screen.findByLabelText( 'New credit or debit card' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders a new credit card payment method that reads "New credit or debit card"', async () => {
+		const queryClient = new QueryClient();
+
+		const paymentMethods: Partial< StoredPaymentMethod >[] = [];
 
 		nock( 'https://public-api.wordpress.com' )
 			.get( '/rest/v1.2/me/payment-methods?type=card&expired=exclude' )
@@ -232,11 +259,7 @@ describe( 'ChangePaymentMethod', () => {
 			</ReduxProvider>
 		);
 
-		if ( hasExistingCardMethods ) {
-			labelText = 'New credit or debit card';
-		}
-
-		expect( await screen.findByLabelText( labelText ) ).toBeInTheDocument();
+		expect( await screen.findByLabelText( 'Credit or debit card' ) ).toBeInTheDocument();
 	} );
 
 	it( 'renders a PayPal payment method', async () => {

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -74,6 +74,7 @@ export function useCreateCreditCard( {
 	submitButtonContent,
 	initialUseForAllSubscriptions,
 	allowUseForAllSubscriptions,
+	existingCardMethods,
 }: {
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
@@ -82,6 +83,7 @@ export function useCreateCreditCard( {
 	submitButtonContent: ReactNode;
 	initialUseForAllSubscriptions?: boolean;
 	allowUseForAllSubscriptions?: boolean;
+	existingCardMethods?: PaymentMethod[];
 } ): PaymentMethod | null {
 	const shouldLoadStripeMethod = ! isStripeLoading && ! stripeLoadingError;
 	const stripePaymentMethodStore = useMemo(
@@ -101,6 +103,7 @@ export function useCreateCreditCard( {
 						shouldShowTaxFields,
 						submitButtonContent,
 						allowUseForAllSubscriptions,
+						existingCardMethods,
 				  } )
 				: null,
 		[
@@ -110,6 +113,7 @@ export function useCreateCreditCard( {
 			shouldShowTaxFields,
 			submitButtonContent,
 			allowUseForAllSubscriptions,
+			existingCardMethods,
 		]
 	);
 	return stripeMethod;
@@ -465,6 +469,13 @@ export default function useCreatePaymentMethods( {
 		stripeLoadingError,
 	} );
 
+	const existingCardMethods = useCreateExistingCards( {
+		isStripeLoading,
+		stripeLoadingError,
+		storedCards,
+		submitButtonContent: <CheckoutSubmitButtonContent />,
+	} );
+
 	const shouldUseEbanx = responseCart.allowed_payment_methods.includes(
 		translateCheckoutPaymentMethodToWpcomPaymentMethod( 'ebanx' ) ?? ''
 	);
@@ -480,6 +491,7 @@ export default function useCreatePaymentMethods( {
 		shouldUseEbanx,
 		allowUseForAllSubscriptions,
 		submitButtonContent: <CheckoutSubmitButtonContent />,
+		existingCardMethods,
 	} );
 
 	const freePaymentMethod = useCreateFree();
@@ -505,13 +517,6 @@ export default function useCreatePaymentMethods( {
 		razorpayLoadingError,
 		razorpayConfiguration,
 		cartKey,
-	} );
-
-	const existingCardMethods = useCreateExistingCards( {
-		isStripeLoading,
-		stripeLoadingError,
-		storedCards,
-		submitButtonContent: <CheckoutSubmitButtonContent />,
 	} );
 
 	// The order is the order of Payment Methods in Checkout.

--- a/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
+++ b/client/my-sites/checkout/src/hooks/use-create-payment-methods/index.tsx
@@ -74,7 +74,7 @@ export function useCreateCreditCard( {
 	submitButtonContent,
 	initialUseForAllSubscriptions,
 	allowUseForAllSubscriptions,
-	existingCardMethods,
+	hasExistingCardMethods,
 }: {
 	isStripeLoading: boolean;
 	stripeLoadingError: StripeLoadingError;
@@ -83,7 +83,7 @@ export function useCreateCreditCard( {
 	submitButtonContent: ReactNode;
 	initialUseForAllSubscriptions?: boolean;
 	allowUseForAllSubscriptions?: boolean;
-	existingCardMethods?: PaymentMethod[];
+	hasExistingCardMethods?: boolean;
 } ): PaymentMethod | null {
 	const shouldLoadStripeMethod = ! isStripeLoading && ! stripeLoadingError;
 	const stripePaymentMethodStore = useMemo(
@@ -103,7 +103,7 @@ export function useCreateCreditCard( {
 						shouldShowTaxFields,
 						submitButtonContent,
 						allowUseForAllSubscriptions,
-						existingCardMethods,
+						hasExistingCardMethods,
 				  } )
 				: null,
 		[
@@ -113,7 +113,7 @@ export function useCreateCreditCard( {
 			shouldShowTaxFields,
 			submitButtonContent,
 			allowUseForAllSubscriptions,
-			existingCardMethods,
+			hasExistingCardMethods,
 		]
 	);
 	return stripeMethod;
@@ -476,6 +476,8 @@ export default function useCreatePaymentMethods( {
 		submitButtonContent: <CheckoutSubmitButtonContent />,
 	} );
 
+	const hasExistingCardMethods = existingCardMethods && existingCardMethods.length > 0;
+
 	const shouldUseEbanx = responseCart.allowed_payment_methods.includes(
 		translateCheckoutPaymentMethodToWpcomPaymentMethod( 'ebanx' ) ?? ''
 	);
@@ -491,7 +493,7 @@ export default function useCreatePaymentMethods( {
 		shouldUseEbanx,
 		allowUseForAllSubscriptions,
 		submitButtonContent: <CheckoutSubmitButtonContent />,
-		existingCardMethods,
+		hasExistingCardMethods,
 	} );
 
 	const freePaymentMethod = useCreateFree();

--- a/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
@@ -21,43 +21,6 @@ import type { ReactNode } from 'react';
 
 export { createCreditCardPaymentMethodStore } from './store';
 
-export function createCreditCardMethod( {
-	store,
-	shouldUseEbanx,
-	shouldShowTaxFields,
-	submitButtonContent,
-	allowUseForAllSubscriptions,
-}: {
-	store: CardStoreType;
-	shouldUseEbanx?: boolean;
-	shouldShowTaxFields?: boolean;
-	submitButtonContent: ReactNode;
-	allowUseForAllSubscriptions?: boolean;
-} ): PaymentMethod {
-	return {
-		id: 'card',
-		paymentProcessorId: 'card',
-		label: <CreditCardLabel />,
-		hasRequiredFields: true,
-		activeContent: (
-			<CreditCardFields
-				shouldUseEbanx={ shouldUseEbanx }
-				shouldShowTaxFields={ shouldShowTaxFields }
-				allowUseForAllSubscriptions={ allowUseForAllSubscriptions }
-			/>
-		),
-		submitButton: (
-			<CreditCardPayButton
-				store={ store }
-				shouldUseEbanx={ shouldUseEbanx }
-				submitButtonContent={ submitButtonContent }
-			/>
-		),
-		inactiveContent: <CreditCardSummary />,
-		getAriaLabel: ( __: ( text: string ) => string ) => __( 'Credit Card' ),
-	};
-}
-
 function CreditCardSummary() {
 	const fields: CardFieldState = useSelect(
 		( select ) => ( select( 'wpcom-credit-card' ) as WpcomCreditCardSelectors ).getFields(),
@@ -79,15 +42,21 @@ function CreditCardSummary() {
 	);
 }
 
-function CreditCardLabel() {
+const CreditCardLabel: React.FC< { hasExistingCardMethods: boolean | undefined } > = ( {
+	hasExistingCardMethods,
+} ) => {
 	const { __ } = useI18n();
 	return (
 		<Fragment>
-			<span>{ __( 'Credit or debit card' ) }</span>
+			{ hasExistingCardMethods ? (
+				<span>{ __( 'New credit or debit card' ) }</span>
+			) : (
+				<span>{ __( 'Credit or debit card' ) }</span>
+			) }
 			<CreditCardLogos />
 		</Fragment>
 	);
-}
+};
 
 function CreditCardLogos() {
 	return (
@@ -97,4 +66,44 @@ function CreditCardLogos() {
 			<AmexLogo />
 		</PaymentMethodLogos>
 	);
+}
+
+export function createCreditCardMethod( {
+	store,
+	shouldUseEbanx,
+	shouldShowTaxFields,
+	submitButtonContent,
+	allowUseForAllSubscriptions,
+	existingCardMethods,
+}: {
+	store: CardStoreType;
+	shouldUseEbanx?: boolean;
+	shouldShowTaxFields?: boolean;
+	submitButtonContent: ReactNode;
+	allowUseForAllSubscriptions?: boolean;
+	existingCardMethods?: PaymentMethod[];
+} ): PaymentMethod {
+	const hasExistingCardMethods = existingCardMethods && existingCardMethods.length > 0;
+	return {
+		id: 'card',
+		paymentProcessorId: 'card',
+		label: <CreditCardLabel hasExistingCardMethods={ hasExistingCardMethods } />,
+		hasRequiredFields: true,
+		activeContent: (
+			<CreditCardFields
+				shouldUseEbanx={ shouldUseEbanx }
+				shouldShowTaxFields={ shouldShowTaxFields }
+				allowUseForAllSubscriptions={ allowUseForAllSubscriptions }
+			/>
+		),
+		submitButton: (
+			<CreditCardPayButton
+				store={ store }
+				shouldUseEbanx={ shouldUseEbanx }
+				submitButtonContent={ submitButtonContent }
+			/>
+		),
+		inactiveContent: <CreditCardSummary />,
+		getAriaLabel: ( __: ( text: string ) => string ) => __( 'Credit Card' ),
+	};
 }

--- a/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
+++ b/client/my-sites/checkout/src/payment-methods/credit-card/index.tsx
@@ -74,16 +74,15 @@ export function createCreditCardMethod( {
 	shouldShowTaxFields,
 	submitButtonContent,
 	allowUseForAllSubscriptions,
-	existingCardMethods,
+	hasExistingCardMethods,
 }: {
 	store: CardStoreType;
 	shouldUseEbanx?: boolean;
 	shouldShowTaxFields?: boolean;
 	submitButtonContent: ReactNode;
 	allowUseForAllSubscriptions?: boolean;
-	existingCardMethods?: PaymentMethod[];
+	hasExistingCardMethods?: boolean | undefined;
 } ): PaymentMethod {
-	const hasExistingCardMethods = existingCardMethods && existingCardMethods.length > 0;
 	return {
 		id: 'card',
 		paymentProcessorId: 'card',


### PR DESCRIPTION
This PR passes the `existingPaymentMethods` object to the `CreditCardLabel` in checkout. This allows us to conditionally set the credit and debit card text based on whether the account already has existing cards on file.

This change applies to checkout and 'change payment method' sections, but I decided to not apply it to 'add new payment method' since the new method form doesn't include any references to existing references, so it doesn't really need to be added there.

| **Before - no cards on the account** | **After - with cards on the account (note the 'new credit or debit card`)** |
| ----- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/16580129/d9112155-8050-4d77-a5b2-d2c2505f4cd1) | ![image](https://github.com/Automattic/wp-calypso/assets/16580129/83681375-c7dd-4ecf-8cdf-03adbe909b1f) |

Additionally, this resolves a small CSS bug for the 'Change payment method' TOS:


**Before**

![image](https://github.com/Automattic/wp-calypso/assets/16580129/538164da-d8aa-473c-b02b-84a9fe8e792d)

**After**

![image](https://github.com/Automattic/wp-calypso/assets/16580129/a2546de9-b89f-489f-91f7-d7c836a4f111)


Related to https://github.com/Automattic/wp-calypso/issues/74688

## Testing Instructions

* Go to checkout with an account that has cards and one that does not
* Check that the label for 'Credit or debit card' is labeled correctly depending on the account
* Then go to `http://calypso.localhost:3000/me/purchases/` and select a purchase with a card - click on change payment method and check the credit or debit card label there too