### PR TITLE
A4A: Add empty state for the Licenses overview page.

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/empty-state.tsx
@@ -1,0 +1,8 @@
+import { useTranslate } from 'i18n-calypso';
+
+export default function EmptyState() {
+	const translate = useTranslate();
+	return (
+		<div className="licenses-overview__empty-message">{ translate( 'No licenses found.' ) }</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
@@ -1,5 +1,4 @@
 import { Button } from '@automattic/components';
-import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
@@ -13,11 +12,14 @@ import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import LicenseSearch from '../license-search';
 import LicenseStateFilter from '../license-state-filter';
 import LicensesOverviewContext from './context';
+import EmptyState from './empty-state';
 import type {
 	LicenseFilter,
 	LicenseSortDirection,
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+
+import './style.scss';
 
 interface Props {
 	filter: LicenseFilter;
@@ -55,7 +57,13 @@ export default function LicensesOverview( {
 	const showEmptyStateContent = false; // FIXME: get this from state
 
 	return (
-		<Layout title={ title } wide withBorder sidebarNavigation={ <MobileSidebarNavigation /> }>
+		<Layout
+			className="licenses-overview"
+			title={ title }
+			wide
+			withBorder
+			sidebarNavigation={ <MobileSidebarNavigation /> }
+		>
 			<PageViewTracker
 				title="Partner Portal > Licenses"
 				path="/partner-portal/licenses/:filter"
@@ -87,13 +95,7 @@ export default function LicensesOverview( {
 					<LicenseStateFilter />
 				</LayoutTop>
 
-				<LayoutBody>
-					{ showEmptyStateContent ? (
-						<div>{ /* TODO: <SHOW_EMPTY_CONTENT_HERE /> */ }</div>
-					) : (
-						<LicenseSearch />
-					) }
-				</LayoutBody>
+				<LayoutBody>{ showEmptyStateContent ? <EmptyState /> : <LicenseSearch /> }</LayoutBody>
 			</LicensesOverviewContext.Provider>
 		</Layout>
 	);

--- a/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/style.scss
@@ -1,0 +1,4 @@
+.licenses-overview__empty-message {
+	margin: 32px auto;
+	text-align: center;
+}


### PR DESCRIPTION
This pull request adds an empty state to the Licenses overview page.

<img width="1575" alt="Screenshot 2024-02-27 at 1 55 37 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/fa6422cc-dd27-4de5-aaeb-64665da95a9a">

Closes https://github.com/Automattic/jetpack-genesis/issues/251

## Proposed Changes

* Add the `EmptyState` component to render the empty message. * Render the `EmptyState` component when `showEmptyStateContent` is **true**.
* Add the class name and styling file for the Licenses overview component.


## Testing Instructions

* Switch branch: `git checkout add/a4a-licenses-empty-message`
* Start the server by running `yarn start-a8c-for-agencies`.
* Change [showEmptyStateContent](https://github.com/Automattic/wp-calypso/blob/trunk/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx#L49) to true to force the page to show the empty state.
* Go to http://agencies.localhost:3000/purchases/licenses
* Confirm that you see the Assign License page similar to the Jetpack Manage version.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?