### PR TITLE
Automattic for Agencies: Implement license list view with mock data

### DIFF
--- a/client/a8c-for-agencies/data/purchases/use-fetch-licenses.ts
+++ b/client/a8c-for-agencies/data/purchases/use-fetch-licenses.ts
@@ -1,0 +1,63 @@
+import config from '@automattic/calypso-config';
+import { useQuery } from '@tanstack/react-query';
+import { LICENSES_PER_PAGE } from 'calypso/a8c-for-agencies/sections/purchases/lib/constants';
+import {
+	LicenseFilter,
+	LicenseSortDirection,
+	LicenseSortField,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
+
+export default function useFetchLicenses(
+	filter: LicenseFilter,
+	search: string,
+	sortField: LicenseSortField,
+	sortDirection: LicenseSortDirection,
+	page: number
+) {
+	const showDummyData = config.isEnabled( 'a4a/mock-api-data' );
+
+	const getLicenses = () => {
+		if ( showDummyData ) {
+			return {
+				items: [
+					{
+						licenseId: 1,
+						licenseKey: 'license-key',
+						product: 'dummy-product',
+						blogId: 1,
+						siteUrl: 'dummy-url',
+						hasDownloads: true,
+						issuedAt: '2021-01-01',
+						attachedAt: '2021-01-01',
+						quantity: undefined,
+						revokedAt: null,
+						ownerType: 'jetpack_partner_key',
+						parentLicenseId: null,
+					},
+				],
+				total_pages: 1,
+				total_items: 1,
+				items_per_page: LICENSES_PER_PAGE,
+			};
+		}
+		return {
+			items: [],
+			total_pages: 0,
+			total_items: 0,
+			items_per_page: LICENSES_PER_PAGE,
+		}; // FIXME: This is a placeholder for the actual API call.
+	};
+
+	return useQuery( {
+		queryKey: [ 'a4a-licenses', filter, search, sortField, sortDirection, page ],
+		queryFn: () => getLicenses(),
+		select: ( data ) => {
+			return {
+				items: data.items,
+				total: data.total_items,
+				perPage: data.items_per_page,
+				totalPages: data.total_pages,
+			};
+		},
+	} );
+}

--- a/client/a8c-for-agencies/sections/purchases/lib/constants.ts
+++ b/client/a8c-for-agencies/sections/purchases/lib/constants.ts
@@ -1,0 +1,1 @@
+export const LICENSES_PER_PAGE = 50;

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/index.tsx
@@ -1,0 +1,126 @@
+import page from '@automattic/calypso-router';
+import { PropsWithChildren, useContext, useCallback } from 'react';
+import CSSTransition from 'react-transition-group/CSSTransition';
+import TransitionGroup from 'react-transition-group/TransitionGroup';
+import useFetchLicenses from 'calypso/a8c-for-agencies/data/purchases/use-fetch-licenses';
+import Pagination from 'calypso/components/pagination';
+import LicenseListEmpty from 'calypso/jetpack-cloud/sections/partner-portal/license-list/empty'; // FIXME: Fix for A4A
+import LicenseListHeader from 'calypso/jetpack-cloud/sections/partner-portal/license-list/header'; // FIXME: Fix for A4A
+import { LicensePreviewPlaceholder } from 'calypso/jetpack-cloud/sections/partner-portal/license-preview';
+import { LicenseType } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { addQueryArgs } from 'calypso/lib/route';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { LICENSES_PER_PAGE } from 'calypso/state/partner-portal/licenses/constants';
+import LicensePreview from '../license-preview';
+import LicensesOverviewContext from '../licenses-overview/context';
+
+import './style.scss';
+
+function setPage( pageNumber: number ): void {
+	const queryParams = { page: pageNumber };
+	const currentPath = window.location.pathname + window.location.search;
+
+	page( addQueryArgs( queryParams, currentPath ) );
+}
+
+interface LicenseTransitionProps {
+	key?: string;
+	exit?: boolean;
+}
+
+const LicenseTransition = ( props: PropsWithChildren< LicenseTransitionProps > ) => (
+	<CSSTransition { ...props } classNames="license-list__license-transition" timeout={ 150 } />
+);
+
+export default function LicenseList() {
+	const dispatch = useDispatch();
+	const { filter, search, sortField, sortDirection, currentPage } =
+		useContext( LicensesOverviewContext );
+
+	const { data, isFetching, status } = useFetchLicenses(
+		filter,
+		search,
+		sortField,
+		sortDirection,
+		currentPage
+	);
+	const licenses = data?.items;
+
+	const hasFetched = status === 'success';
+	const showLicenses = hasFetched && ! isFetching && !! licenses;
+	const showPagination = showLicenses && data.totalPages > 1;
+	const showNoResults = hasFetched && ! isFetching && licenses?.length === 0;
+
+	const onPageClick = useCallback(
+		( pageNumber: number ) => {
+			setPage( pageNumber );
+			dispatch(
+				recordTracksEvent( 'calypso_a4a_license_list_pagination_page_click', {
+					page: pageNumber,
+				} )
+			);
+		},
+		[ dispatch ]
+	);
+
+	return (
+		<div className="license-list">
+			<TransitionGroup className="license-list__transition-group">
+				{ ! showNoResults && (
+					<LicenseTransition>
+						<LicenseListHeader />
+					</LicenseTransition>
+				) }
+
+				{ showLicenses &&
+					licenses.map( ( license ) => (
+						<LicenseTransition key={ license.licenseKey }>
+							<LicensePreview
+								parentLicenseId={ license.licenseId }
+								licenseKey={ license.licenseKey }
+								product={ license.product }
+								blogId={ license.blogId }
+								siteUrl={ license.siteUrl }
+								hasDownloads={ license.hasDownloads }
+								issuedAt={ license.issuedAt }
+								attachedAt={ license.attachedAt }
+								revokedAt={ license.revokedAt }
+								licenseType={
+									license.ownerType === LicenseType.Standard
+										? LicenseType.Standard
+										: LicenseType.Partner
+								}
+								quantity={ license.quantity }
+								isChildLicense={ !! license.parentLicenseId }
+							/>
+						</LicenseTransition>
+					) ) }
+
+				{ isFetching && (
+					<LicenseTransition>
+						<LicensePreviewPlaceholder />
+					</LicenseTransition>
+				) }
+
+				{ showPagination && (
+					<LicenseTransition>
+						<Pagination
+							className="license-list__pagination"
+							page={ currentPage }
+							perPage={ LICENSES_PER_PAGE }
+							total={ data.total }
+							pageClick={ onPageClick }
+						/>
+					</LicenseTransition>
+				) }
+
+				{ showNoResults && (
+					<LicenseTransition key={ filter } exit={ false }>
+						<LicenseListEmpty filter={ filter } />
+					</LicenseTransition>
+				) }
+			</TransitionGroup>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/style.scss
@@ -24,14 +24,14 @@
 		font-size: $font-body;
 
 		a {
-			color: var(--studio-gray-80);
+			color: var(--color-neutral-80);
 			text-decoration: underline;
 		}
 	}
 
 	.button {
 		margin-block: 1.75rem;
-		color: var(--color-accent);
+		color: var(--color-neutral);
 	}
 }
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-list/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-list/style.scss
@@ -1,0 +1,75 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.license-list__header.card.is-compact {
+	display: none;
+
+	@include break-xlarge() {
+		display: block;
+		padding-block: 0;
+	}
+}
+
+.license-list__empty-list {
+	text-align: center;
+
+	h2 {
+		margin-block-start: 3rem;
+		margin-block-end: 1rem;
+		font-size: $font-title-medium;
+	}
+
+	p {
+		margin-block-end: 1rem;
+		font-size: $font-body;
+
+		a {
+			color: var(--studio-gray-80);
+			text-decoration: underline;
+		}
+	}
+
+	.button {
+		margin-block: 1.75rem;
+		color: var(--color-accent);
+	}
+}
+
+.license-list__license-transition-enter {
+	display: none;
+
+	&-active {
+		animation: license-list__transition-enter 0.15s linear;
+	}
+}
+
+.license-list__license-transition-exit {
+	opacity: 1;
+
+	&-active {
+		opacity: 0.01;
+		transition: opacity 0.15s linear;
+	}
+}
+
+.license-list__pagination {
+	margin: 64px 0;
+}
+
+@keyframes license-list__transition-enter {
+	0% {
+		display: none;
+		opacity: 0;
+	}
+	50% {
+		display: none;
+		opacity: 0;
+	}
+	51% {
+		display: block;
+		opacity: 0.01;
+	}
+	100% {
+		opacity: 1;
+	}
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -1,0 +1,211 @@
+import page from '@automattic/calypso-router';
+import { getUrlParts } from '@automattic/calypso-url';
+import { Badge, Button, Gridicon } from '@automattic/components';
+import { getQueryArg, removeQueryArgs } from '@wordpress/url';
+import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useEffect, useContext } from 'react';
+import FormattedDate from 'calypso/components/formatted-date';
+import getLicenseState from 'calypso/jetpack-cloud/sections/partner-portal/lib/get-license-state';
+import LicenseListContext from 'calypso/jetpack-cloud/sections/partner-portal/license-list-context';
+import LicenseListItem from 'calypso/jetpack-cloud/sections/partner-portal/license-list-item';
+import {
+	LicenseState,
+	LicenseFilter,
+	LicenseType,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { addQueryArgs } from 'calypso/lib/url';
+import { useDispatch, useSelector } from 'calypso/state';
+import { errorNotice } from 'calypso/state/notices/actions';
+import { doesPartnerRequireAPaymentMethod } from 'calypso/state/partner-portal/partner/selectors';
+
+import './style.scss';
+
+interface Props {
+	licenseKey: string;
+	product: string;
+	blogId: number | null;
+	siteUrl: string | null;
+	hasDownloads: boolean;
+	issuedAt: string;
+	attachedAt: string | null;
+	revokedAt: string | null;
+	licenseType: LicenseType;
+	parentLicenseId?: number | null;
+	quantity?: number | null;
+	isChildLicense?: boolean;
+}
+
+export default function LicensePreview( {
+	licenseKey,
+	product,
+	siteUrl,
+	issuedAt,
+	attachedAt,
+	revokedAt,
+	licenseType,
+	parentLicenseId,
+	quantity,
+	isChildLicense,
+}: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const { filter } = useContext( LicenseListContext );
+
+	const isHighlighted = getQueryArg( window.location.href, 'highlight' ) === licenseKey;
+
+	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
+	const licenseState = getLicenseState( attachedAt, revokedAt );
+	const domain = siteUrl ? getUrlParts( siteUrl ).hostname || siteUrl : '';
+
+	const assign = useCallback( () => {
+		const redirectUrl = addQueryArgs( { key: licenseKey }, '/partner-portal/assign-license' );
+		if ( paymentMethodRequired ) {
+			const noticeLinkHref = addQueryArgs(
+				{
+					return: redirectUrl,
+				},
+				'/partner-portal/payment-methods/add'
+			);
+			const errorMessage = translate(
+				'A primary payment method is required.{{br/}} ' +
+					'{{a}}Try adding a new payment method{{/a}} or contact support.',
+				{
+					components: {
+						a: <a href={ noticeLinkHref } />,
+						br: <br />,
+					},
+				}
+			);
+
+			dispatch( errorNotice( errorMessage ) );
+			return;
+		}
+
+		page.redirect( redirectUrl );
+	}, [ paymentMethodRequired, translate, dispatch, licenseKey ] );
+
+	useEffect( () => {
+		if ( isHighlighted ) {
+			page.redirect(
+				removeQueryArgs( window.location.pathname + window.location.search, 'highlight' )
+			);
+		}
+	}, [] );
+
+	const isParentLicense = quantity && parentLicenseId;
+
+	const bundleCountContent = quantity && (
+		<Badge className="license-preview__license-count" type="info">
+			{ translate( '%(quantity)d License Bundle', {
+				context: 'bundle license count',
+				args: {
+					quantity,
+				},
+			} ) }
+		</Badge>
+	);
+
+	return (
+		<div
+			className={ classnames( {
+				'license-preview': true,
+			} ) }
+		>
+			<LicenseListItem
+				className={ classnames( {
+					'license-preview__card': true,
+					'license-preview__card--is-detached': licenseState === LicenseState.Detached,
+					'license-preview__card--is-revoked': licenseState === LicenseState.Revoked,
+					'license-preview__card--child-license': isChildLicense,
+				} ) }
+			>
+				<div>
+					<span className="license-preview__product">{ product }</span>
+				</div>
+
+				<div>
+					{ quantity ? (
+						<div className="license-preview__bundle">
+							<Gridicon icon="minus" className="license-preview__no-value" />
+							<div className="license-preview__product-small">{ product }</div>
+							<div>{ bundleCountContent }</div>
+						</div>
+					) : (
+						<>
+							<div className="license-preview__product-small">{ product }</div>
+							{ domain }
+							{ ! domain && licenseState === LicenseState.Detached && (
+								<span>
+									<Badge type="warning">{ translate( 'Unassigned' ) }</Badge>
+									{ licenseType === LicenseType.Partner && (
+										<Button
+											className="license-preview__assign-button"
+											borderless
+											compact
+											onClick={ assign }
+										>
+											{ translate( 'Assign' ) }
+										</Button>
+									) }
+								</span>
+							) }
+							{ revokedAt && (
+								<span>
+									<Badge type="error">{ translate( 'Revoked' ) }</Badge>
+								</span>
+							) }
+						</>
+					) }
+				</div>
+
+				<div>
+					{ quantity ? (
+						<Gridicon icon="minus" className="license-preview__no-value" />
+					) : (
+						<>
+							<div className="license-preview__label">{ translate( 'Issued on:' ) }</div>
+
+							<FormattedDate date={ issuedAt } format="YYYY-MM-DD" />
+						</>
+					) }
+				</div>
+
+				{ filter !== LicenseFilter.Revoked ? (
+					<div>
+						<div className="license-preview__label">{ translate( 'Assigned on:' ) }</div>
+
+						{ licenseState === LicenseState.Attached && (
+							<FormattedDate date={ attachedAt } format="YYYY-MM-DD" />
+						) }
+
+						{ licenseState !== LicenseState.Attached && (
+							<Gridicon icon="minus" className="license-preview__no-value" />
+						) }
+					</div>
+				) : (
+					<div>
+						<div className="license-preview__label">{ translate( 'Revoked on:' ) }</div>
+
+						{ licenseState === LicenseState.Revoked && (
+							<FormattedDate date={ revokedAt } format="YYYY-MM-DD" />
+						) }
+
+						{ licenseState !== LicenseState.Revoked && (
+							<Gridicon icon="minus" className="license-preview__no-value" />
+						) }
+					</div>
+				) }
+
+				<div className="license-preview__badge-container">
+					{ isParentLicense
+						? bundleCountContent
+						: LicenseType.Standard === licenseType && (
+								<Badge type="success">{ translate( 'Standard license' ) }</Badge>
+						  ) }
+				</div>
+			</LicenseListItem>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -6,7 +6,7 @@
 	font-size: 0.875rem;
 	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	line-height: 1.25rem;
-	color: var(--studio-gray-70);
+	color: var(--color-neutral-70);
 	transition: margin 0.2s ease;
 
 	// Matching bottom margin of Card component.
@@ -44,7 +44,7 @@
 	font-weight: normal;
 	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
 	line-height: 1.75rem;
-	color: var(--studio-gray-100);
+	color: var(--color-neutral-100);
 	overflow: hidden;
 	word-break: break-all;
 
@@ -71,7 +71,7 @@
 
 	&--is-just-issued,
 	&--is-assigned {
-		color: var(--studio-green-50);
+		color: var(--color-link);
 		opacity: 0;
 		animation: hide-just-issued-tag 5s linear;
 	}
@@ -81,7 +81,7 @@
 	}
 
 	&--is-revoked {
-		color: var(--studio-red-60);
+		color: var(--color-scary-60);
 	}
 
 	svg {
@@ -113,7 +113,7 @@
 .license-preview__copy-license-key {
 	&.button {
 		font-weight: 600;
-		color: var(--studio-gray-80);
+		color: var(--color-neutral-80);
 		border-color: var(--color-text-subtle);
 	}
 }
@@ -156,12 +156,12 @@ button {
 	&.license-actions__menu-item {
 		margin: 0 -1px;
 		border-style: solid;
-		border-color: var(--studio-gray-5);
+		border-color: var(--color-neutral-5);
 		border-width: 0 0 1px;
 		font-size: 0.875rem;
 		height: 40px;
 		box-sizing: border-box;
-		color: var(--studio-black);
+		color: var(--color-neutral);
 		display: flex;
 		align-items: center;
 		padding: 0 16px;
@@ -179,11 +179,11 @@ button {
 		&:hover,
 		&:focus {
 			border-style: solid;
-			border-color: var(--studio-gray-5);
+			border-color: var(--color-neutral-5);
 			border-width: 0 0 1px;
-			background: var(--studio-black);
+			background: var(--color-neutral);
 			cursor: pointer;
-			color: var(--studio-white);
+			color: var(--color-masterbar-item-hover-background);
 
 			&:last-child {
 				border-bottom-width: 0;
@@ -198,7 +198,7 @@ button {
 		}
 
 		&.is-destructive {
-			color: var(--studio-red-50);
+			color: var(--color-scary-50);
 		}
 	}
 }
@@ -259,10 +259,10 @@ button {
 	&,
 	&:hover,
 	&:focus {
-		color: var(--studio-red-50);
+		color: var(--color-scary-50);
 
 		.gridicon {
-			fill: var(--studio-red-50);
+			fill: var(--color-scary-50);
 		}
 	}
 }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -1,0 +1,268 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.license-preview {
+	margin: 0;
+	font-size: 0.875rem;
+	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+	line-height: 1.25rem;
+	color: var(--studio-gray-70);
+	transition: margin 0.2s ease;
+
+	// Matching bottom margin of Card component.
+	&--is-open {
+		margin-block: 10px;
+
+		@include breakpoint-deprecated( ">480px" ) {
+			margin-block: 16px;
+		}
+	}
+}
+
+.license-preview__card {
+	// Increased specificity to override card styles.
+	&--is-detached.card.is-compact,
+	&--is-revoked.card.is-compact {
+		// Reduce padding to fit the extra border width on the left so columns are still aligned perfectly.
+		padding-inline-start: 13px;
+
+		@include break-mobile {
+			padding-inline-start: 21px;
+		}
+	}
+}
+
+.license-preview__no-value {
+	position: relative;
+	inset-block-start: 3px;
+}
+
+.license-preview__domain {
+	padding: 0;
+	margin: 0 0 4px;
+	font-size: 1.25rem;
+	font-weight: normal;
+	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+	line-height: 1.75rem;
+	color: var(--studio-gray-100);
+	overflow: hidden;
+	word-break: break-all;
+
+	span + span {
+		margin-inline-start: 12px;
+
+		@include break-xlarge() {
+			display: block;
+			margin-inline-start: 0;
+		}
+
+		@include break-wide() {
+			display: inline;
+			margin-inline-start: 12px;
+		}
+	}
+}
+
+.license-preview__tag {
+	white-space: nowrap;
+	font-size: 0.875rem;
+	/* stylelint-disable-next-line declaration-property-unit-allowed-list */
+	line-height: 1rem;
+
+	&--is-just-issued,
+	&--is-assigned {
+		color: var(--studio-green-50);
+		opacity: 0;
+		animation: hide-just-issued-tag 5s linear;
+	}
+
+	&--is-detached {
+		color: var(--studio-orange-40);
+	}
+
+	&--is-revoked {
+		color: var(--studio-red-60);
+	}
+
+	svg {
+		position: relative;
+		inset-block-start: 3px;
+		margin-inline-end: 4px;
+	}
+}
+
+.license-preview__product {
+	span {
+		display: none;
+
+		@include break-wide() {
+			display: inline;
+		}
+	}
+}
+
+.license-preview__label {
+	font-weight: 600;
+	white-space: nowrap;
+
+	@include break-xlarge() {
+		display: none;
+	}
+}
+
+.license-preview__copy-license-key {
+	&.button {
+		font-weight: 600;
+		color: var(--studio-gray-80);
+		border-color: var(--color-text-subtle);
+	}
+}
+
+.license-preview__toggle {
+	padding: 0;
+}
+
+.license-preview__assign-button {
+	font-size: 0.75rem;
+	font-weight: 400;
+	text-decoration: underline;
+	margin-inline-start: 10px;
+}
+
+.license-preview--placeholder {
+	.license-preview__domain,
+	.license-preview__product,
+	.license-preview__label + div,
+	.license-preview__copy-license-key {
+		@include placeholder( --color-neutral-10 );
+	}
+}
+
+@keyframes hide-just-issued-tag {
+	0% {
+		display: inline;
+		opacity: 1;
+	}
+	50% {
+		opacity: 1;
+	}
+	100% {
+		opacity: 0;
+	}
+}
+
+a,
+button {
+	&.license-actions__menu-item {
+		margin: 0 -1px;
+		border-style: solid;
+		border-color: var(--studio-gray-5);
+		border-width: 0 0 1px;
+		font-size: 0.875rem;
+		height: 40px;
+		box-sizing: border-box;
+		color: var(--studio-black);
+		display: flex;
+		align-items: center;
+		padding: 0 16px;
+		min-width: 200px;
+
+		&:last-child {
+			margin-bottom: 5px;
+			border-bottom-width: 0;
+		}
+
+		&:first-child {
+			margin-block-start: 5px;
+		}
+
+		&:hover,
+		&:focus {
+			border-style: solid;
+			border-color: var(--studio-gray-5);
+			border-width: 0 0 1px;
+			background: var(--studio-black);
+			cursor: pointer;
+			color: var(--studio-white);
+
+			&:last-child {
+				border-bottom-width: 0;
+			}
+		}
+
+		svg.gridicon {
+			vertical-align: middle;
+			position: absolute;
+			inset-inline-end: 10px;
+			inset-block-start: unset;
+		}
+
+		&.is-destructive {
+			color: var(--studio-red-50);
+		}
+	}
+}
+
+.card.license-preview__card.license-preview__card--child-license {
+	padding: 16px 32px;
+	background-color: #fafafa;
+}
+
+.button.is-borderless.license-bundle-dropdown__button {
+	text-overflow: clip;
+	padding: 4px;
+	max-height: 24px;
+	&:hover,
+	&:focus {
+		background: var(--color-sidebar-menu-hover-background);
+		color: var(--color-text);
+		fill: var(--color-text);
+	}
+}
+
+.license-bundle-dropdown__popover-menu {
+	font-size: rem(14px);
+	font-weight: 400;
+	border-radius: 2px;
+
+	.popover__arrow {
+		display: none;
+	}
+
+	.popover__menu {
+		padding: 8px 4px;
+	}
+
+	.popover__menu-item {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	.popover__menu-item:hover,
+	.popover__menu-item:focus {
+		background: var(--color-sidebar-menu-hover-background);
+		color: var(--color-text);
+		fill: var(--color-text);
+
+		.gridicon {
+			fill: var(--color-text);
+		}
+	}
+
+	.popover__menu-item .gridicon {
+		margin: 0;
+	}
+}
+
+.popover__menu-item.license-bundle-dropdown__popover-menu-item-revoke {
+	&,
+	&:hover,
+	&:focus {
+		color: var(--studio-red-50);
+
+		.gridicon {
+			fill: var(--studio-red-50);
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/context.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/context.ts
@@ -4,9 +4,9 @@ import {
 	LicenseSortDirection,
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
-import { LicenseListContext as LicensesOverviewContext } from 'calypso/state/partner-portal/types';
+import { LicenseListContext } from 'calypso/state/partner-portal/types';
 
-const LicensesOverview = createContext< LicensesOverviewContext >( {
+const LicensesOverviewContext = createContext< LicenseListContext >( {
 	currentPage: 1,
 	search: '',
 	filter: LicenseFilter.NotRevoked,
@@ -14,4 +14,4 @@ const LicensesOverview = createContext< LicensesOverviewContext >( {
 	sortDirection: LicenseSortDirection.Descending,
 } );
 
-export default LicensesOverview;
+export default LicensesOverviewContext;

--- a/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
@@ -9,6 +9,7 @@ import LayoutHeader, {
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import LicenseList from '../license-list';
 import LicenseSearch from '../license-search';
 import LicenseStateFilter from '../license-state-filter';
 import LicensesOverviewContext from './context';
@@ -95,7 +96,16 @@ export default function LicensesOverview( {
 					<LicenseStateFilter />
 				</LayoutTop>
 
-				<LayoutBody>{ showEmptyStateContent ? <EmptyState /> : <LicenseSearch /> }</LayoutBody>
+				<LayoutBody>
+					{ showEmptyStateContent ? (
+						<EmptyState />
+					) : (
+						<>
+							<LicenseSearch />
+							<LicenseList />
+						</>
+					) }
+				</LayoutBody>
 			</LicensesOverviewContext.Provider>
 		</Layout>
 	);

--- a/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
+++ b/client/jetpack-cloud/sections/partner-portal/license-list-item/style.scss
@@ -76,10 +76,6 @@ $grid-wide: 0.5fr 0.5fr 128px 128px 128px 74px;
 	@include break-wide() {
 		grid-template-columns: $grid-wide;
 
-		> *:last-child {
-			margin-left: 12px;
-		}
-
 		.license-preview__product-small {
 			display: none;
 		}

--- a/config/a8c-for-agencies-development.json
+++ b/config/a8c-for-agencies-development.json
@@ -14,7 +14,8 @@
 		"always_use_logout_url": true,
 		"dev/auth-helper": true,
 		"dev/preferences-helper": true,
-		"oauth": true
+		"oauth": true,
+		"a4a/mock-api-data": true
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-horizon.json
+++ b/config/a8c-for-agencies-horizon.json
@@ -8,7 +8,8 @@
 	"site_name": "Automattic For Agencies",
 	"features": {
 		"a8c-for-agencies": true,
-		"oauth": true
+		"oauth": true,
+		"a4a/mock-api-data": false
 	},
 	"enable_all_sections": false,
 	"sections": {

--- a/config/a8c-for-agencies-stage.json
+++ b/config/a8c-for-agencies-stage.json
@@ -10,7 +10,8 @@
 	"oauth_client_id": 95931,
 	"features": {
 		"a8c-for-agencies": true,
-		"oauth": true
+		"oauth": true,
+		"a4a/mock-api-data": false
 	},
 	"enable_all_sections": false,
 	"sections": {


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/249
Resolves https://github.com/Automattic/jetpack-genesis/issues/250



## Proposed Changes

This PR implements:

- List view for Licenses, a few components/style is imported from Jetpack Cloud
- Mock API data for licenses

## Testing Instructions

NOTE: Please note the license data is mocked in the UI currently, it will be loaded only in the UI until the feature flag is enabled on other ENVs.

- Switch to the branch `git checkout add/a4a-licenses-list-view`.
- Start the server by running `yarn start-a8c-for-agencies`.
- Click the Purchases menu item > Verify that you can see the Licenses page as shown above.

<img width="1548" alt="Screenshot 2024-02-27 at 12 48 11 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/c926d8fe-3038-4d3d-a554-3ca31901041b">

<img width="1548" alt="Screenshot 2024-02-27 at 12 48 51 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/2b3325f3-7e5e-4534-b37f-1766bf4bb422">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?