### PR TITLE
Command Palette: Fix app slug in TC

### DIFF
--- a/.teamcity/_self/projects/WPComPlugins.kt
+++ b/.teamcity/_self/projects/WPComPlugins.kt
@@ -42,7 +42,7 @@ object WPComPlugins : Project({
 					"wpcom-block-editor-release-build",
 					"o2-blocks-release-build",
 					"happy-blocks-release-build",
-					"command-palette-release-build",
+					"command-palette-wp-admin-release-build",
 				)
 			}
 			dataToKeep = everything()
@@ -124,7 +124,7 @@ object CalypsoApps: BuildType({
 		apps/o2-blocks/release-files => o2-blocks.zip
 		apps/happy-blocks/release-files => happy-blocks.zip
 		apps/editing-toolkit/editing-toolkit-plugin => editing-toolkit.zip
-		apps/command-palette-wp-admin/dist => command-palette.zip
+		apps/command-palette-wp-admin/dist => command-palette-wp-admin.zip
 	""".trimIndent()
 
 	steps {


### PR DESCRIPTION
## Proposed Changes

Fixes the app slug in the Calypso Build Apps script for the Command Palette app.

## Testing Instructions

N/A