### PR TITLE
Email: Ensure that domains are loaded before determining whether the selected domain can be found or not

### DIFF
--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -74,7 +74,7 @@ const EmailProvidersStackedComparison = ( {
 
 	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
 	const hasLoadedDomains = useSelector( ( state ) =>
-		hasLoadedSiteDomains( state, selectedSite?.ID )
+		hasLoadedSiteDomains( state, selectedSite?.ID ?? null )
 	);
 
 	const domain = getSelectedDomain( { domains, selectedDomainName } );

--- a/client/my-sites/email/email-providers-comparison/stacked/index.tsx
+++ b/client/my-sites/email/email-providers-comparison/stacked/index.tsx
@@ -40,7 +40,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { getProductBySlug } from 'calypso/state/products-list/selectors';
 import canUserPurchaseGSuite from 'calypso/state/selectors/can-user-purchase-gsuite';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
-import { getDomainsBySiteId } from 'calypso/state/sites/domains/selectors';
+import { getDomainsBySiteId, hasLoadedSiteDomains } from 'calypso/state/sites/domains/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 import './style.scss';
@@ -73,10 +73,11 @@ const EmailProvidersStackedComparison = ( {
 	const selectedSite = useSelector( getSelectedSite );
 
 	const domains = useSelector( ( state ) => getDomainsBySiteId( state, selectedSite?.ID ) );
-	const domain = getSelectedDomain( {
-		domains,
-		selectedDomainName: selectedDomainName,
-	} );
+	const hasLoadedDomains = useSelector( ( state ) =>
+		hasLoadedSiteDomains( state, selectedSite?.ID )
+	);
+
+	const domain = getSelectedDomain( { domains, selectedDomainName } );
 	const domainsWithForwards = getDomainsWithEmailForwards( domains );
 
 	const canPurchaseGSuite = useSelector( canUserPurchaseGSuite );
@@ -185,7 +186,7 @@ const EmailProvidersStackedComparison = ( {
 		);
 	};
 
-	if ( ! domain && ! isDomainInCart ) {
+	if ( hasLoadedDomains && ! domain && ! isDomainInCart ) {
 		return null;
 	}
 


### PR DESCRIPTION
## Proposed Changes

This PR fixes a scenario where the site domains are not yet loaded. This causes the component to render null since it exists early on the condition where the selected domain is not available (and that there are no domains in the checkout cart).

We add an extra check to ensure that the site domains are loaded before determining whether the selected domain is available or not.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Have a site where one of the domains do not have a custom email.
* Head to `/email/:site`.
* Ensure that the page renders the following component:
![Screenshot 2024-02-27 at 5 51 29 PM](https://github.com/Automattic/wp-calypso/assets/797888/2911412c-9414-4469-abe7-635d5a12dea8)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?