### PR TITLE
Update Woo "Continue as Existing user" screen

### DIFF
--- a/client/blocks/login/continue-as-user.jsx
+++ b/client/blocks/login/continue-as-user.jsx
@@ -111,19 +111,20 @@ function ContinueAsUser( {
 							className="continue-as-user__change-user-link"
 							onClick={ onChangeAccount }
 						>
-							{ translate( 'Log in with a different WordPress.com account' ) }
+							{ translate( 'Sign in as a different user' ) }
 						</button>
 					</div>
-					<Button
-						busy={ isLoading }
-						primary
-						href={ validatedRedirectUrlFromQuery || validatedRedirectPath || '/' }
-					>
-						{ `${ translate( 'Continue as', {
-							context: 'Continue as an existing WordPress.com user',
-						} ) } ${ userName }` }
-					</Button>
 				</div>
+				<Button
+					primary
+					busy={ isLoading }
+					className="continue-as-user__continue-button"
+					href={ validatedRedirectUrlFromQuery || validatedRedirectPath || '/' }
+				>
+					{ `${ translate( 'Continue as', {
+						context: 'Continue as an existing WordPress.com user',
+					} ) } ${ userName }` }
+				</Button>
 			</div>
 		);
 	}

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -421,6 +421,13 @@ class Login extends Component {
 							) }
 						</p>
 					);
+				} else if ( this.showContinueAsUser() ) {
+					headerText = <h3>{ translate( 'Get started in minutes' ) }</h3>;
+					postHeader = (
+						<p className="login__header-subtitle">
+							{ translate( 'First, select the account you’d like to use.' ) }
+						</p>
+					);
 				} else {
 					headerText = <h3>{ translate( "Let's get started" ) }</h3>;
 					const poweredByWpCom =
@@ -430,9 +437,11 @@ class Login extends Component {
 								<br />
 							</>
 						) : null;
-					const accountSelectionOrLoginToContinue = this.showContinueAsUser()
-						? translate( "First, select the account you'd like to use." )
-						: translate(
+
+					postHeader = (
+						<p className="login__header-subtitle">
+							{ poweredByWpCom }
+							{ translate(
 								"Please, log in to continue. Don't have an account? {{signupLink}}Sign up{{/signupLink}}",
 								{
 									components: {
@@ -440,11 +449,7 @@ class Login extends Component {
 										br: <br />,
 									},
 								}
-						  );
-					postHeader = (
-						<p className="login__header-subtitle">
-							{ poweredByWpCom }
-							{ accountSelectionOrLoginToContinue }
+							) }
 						</p>
 					);
 				}
@@ -782,7 +787,7 @@ class Login extends Component {
 		if ( this.showContinueAsUser() ) {
 			if ( isWoo ) {
 				return (
-					<Fragment>
+					<div className="login__body login__body--continue-as-user">
 						<ContinueAsUser
 							onChangeAccount={ this.handleContinueAsAnotherUser }
 							isWooOAuth2Client={ isWoo }
@@ -802,7 +807,7 @@ class Login extends Component {
 							showSocialLoginFormOnly={ true }
 							sendMagicLoginLink={ this.sendMagicLoginLink }
 						/>
-					</Fragment>
+					</div>
 				);
 			}
 

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -794,17 +794,8 @@
 		}
 	}
 
-	.signup-form,
-	.login {
-		.auth-form__separator-text {
-			background: #fff;
-			padding: 0 27px !important;
-		}
-	}
-
 	.auth-form__separator .auth-form__separator-text {
-		padding: 0 27px;
-		height: 24px;
+		padding: 0 27px !important;
 		background: #fff;
 	}
 

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -18,12 +18,13 @@
 	$woo-form-divider-border: 1px solid #e6e6e6;
 	$gray-60: #50575e;
 	$gray-50: #646970;
+	$woo-inter-font:  "Inter", -apple-system, system-ui, sans-serif;
 
 	background: #fff;
 	min-height: 100%;
 
 	* {
-		font-family: proxima-nova, sans-serif;
+		font-family: $woo-inter-font;
 	}
 
 	&.layout.is-section-login {
@@ -93,17 +94,22 @@
 	.button.is-primary,
 	.login .button.is-primary,
 	.magic-login.is-white-login .magic-login__form-action .button.is-primary:not([disabled]) {
-		background-color: $woo-purple-60;
+		background-color: $woo-purple-50;
 		border: none;
 		color: #fff;
 		width: 100%;
+		font-family: $woo-inter-font;
+		font-size: 1rem;
+		font-style: normal;
+		font-weight: 500;
+		line-height: 28px;
 
 		&.is-busy {
 			background-image: none;
 		}
 
 		&:hover {
-			background-color: $woo-purple-40;
+			background-color: $woo-purple-70;
 			color: #fff;
 		}
 
@@ -249,7 +255,7 @@
 
 	&.is-section-signup .layout__content,
 	.layout__content {
-		padding-top: 85px;
+		padding-top: 72px;
 
 		@media screen and ( max-width: 660px ) {
 			padding-top: 50px;
@@ -282,7 +288,7 @@
 
 	.login__form-header {
 		margin-top: 0;
-		margin-bottom: 8px;
+		margin-bottom: 12px;
 
 		@media screen and ( max-width: 660px ) {
 			margin-bottom: 16px;
@@ -308,9 +314,14 @@
 
 		h1,
 		h3 {
-			font-weight: 600;
-			font-size: 2.75rem;
-			line-height: 52px;
+			color: var(--studio-gray-100);
+			font-feature-settings: "ss01" on, "salt" on;
+			font-family: proxima-nova, sans-serif;
+			text-align: center;
+			font-size: 2.25rem;
+			font-weight: 700;
+			line-height: 39.6px;
+			letter-spacing: -0.72px;
 
 			@media screen and ( max-width: 660px ) {
 				text-align: left;
@@ -321,10 +332,12 @@
 	.login__header-subtitle,
 	.formatted-header__subtitle {
 		color: $gray-60;
-		font-size: $font-body;
+		font-size: $font-body-large;
 		padding-bottom: 0;
 		margin: 0;
-		line-height: 24px;
+		font-weight: 400;
+		line-height: 27px;
+		letter-spacing: -0.025px;
 		-webkit-font-smoothing: subpixel-antialiased;
 
 		a {
@@ -361,12 +374,12 @@
 			padding-bottom: 0;
 			padding-left: 0;
 			padding-right: 0;
-			width: 196px;
 
 			svg {
 				border: 1px solid var(--studio-gray-10);
 				border-radius: 24px; /* stylelint-disable-line scales/radii */
 				padding: 12px;
+				margin: 0;
 			}
 		}
 
@@ -413,7 +426,7 @@
 	.step-wrapper,
 	.jetpack-connect__main-logo {
 		box-sizing: border-box;
-		padding: 60px 0 0;
+		padding: 48px 0 0;
 		width: 100%;
 
 		@media screen and ( max-width: 660px ) {
@@ -484,51 +497,161 @@
 		text-align: center;
 	}
 
+	.auth-form__social {
+		max-width: 100%;
+		padding: 40px 0 14px;
+		border-top: 0;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+
+		@media screen and ( max-width: 660px ) {
+			align-items: flex-start;
+		}
+
+		p {
+			color: var(--studio-gray-60);
+			font-size: $woo-font-size-small;
+		}
+
+		a {
+			font-size: $woo-font-size-small;
+		}
+
+		button {
+			padding: 0;
+		}
+
+		.auth-form__social-buttons-tos {
+			margin-top: 24px;
+			font-size: $woo-font-size-small;
+			line-height: 18px;
+			color: $gray-50;
+			text-align: left;
+
+			a {
+				color: $gray-50;
+				line-height: 18px;
+				font-size: inherit;
+			}
+		}
+	}
+
+	.login__body--continue-as-user {
+		width: 100%;
+		margin: 48px auto 0;
+		max-width: 327px;
+		display: flex;
+		flex-direction: column;
+
+		.auth-form__social {
+			max-width: 100%;
+			padding: 40px 0 14px;
+			border-top: 0;
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+
+			.auth-form__social-buttons {
+				width: 100%;
+
+				.auth-form__social-buttons-container {
+					gap: 16px;
+				}
+
+				button.social-buttons__button.button {
+					display: flex;
+					height: 48px;
+					padding: 8px 16px;
+					align-items: center;
+					gap: 60px;
+					align-self: stretch;
+					border-radius: 8px; // stylelint-disable-line scales/radii
+					border: 2px solid var(--studio-gray-10);
+					width: 100%;
+					margin: 0;
+				}
+
+				.social-buttons__service-name {
+					font-size: 1rem;
+					font-style: normal;
+					font-weight: 500;
+					line-height: 24px;
+					color: var(--studio-gray-100);
+					margin: 0;
+				}
+
+				.social-icons {
+					border: 0;
+					padding: 0;
+				}
+
+				.login__social-tos {
+					margin: 0 auto 2.5em;
+					max-width: 100%;
+					order: -1;
+
+					a {
+						font-size: inherit;
+						line-height: inherit;
+					}
+				}
+			}
+		}
+
+		.auth-form__social-buttons-tos {
+			display: none;
+		}
+	}
+
 	.continue-as-user {
-		max-width: 472px;
-		margin: 54px auto 0;
+		margin: 0;
 		height: unset;
 		min-height: 238px;
 
+		.continue-as-user__user-info {
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+			align-items: center;
+			gap: 8px;
+			align-self: stretch;
+			border-radius: 8px; // stylelint-disable-line scales/radii
+			border: 2px solid #dcdcde;
+			height: 221px;
+			box-sizing: border-box;
+		}
+
 		~ .auth-form__separator {
-			margin: -10px auto;
-			max-width: 472px;
+			margin: 32px auto;
 		}
 
 		~ .card.auth-form__social.is-login {
-			max-width: 472px;
+			margin: 0;
+			padding: 0;
 		}
 
 		.continue-as-user__gravatar-link {
 			pointer-events: auto;
-			display: grid;
-			grid-template-columns: 56px 1fr;
-			grid-template-areas:
-				"gravatar username"
-				"gravatar email";
-			flex-direction: row;
-			justify-items: flex-start;
+			display: flex;
+			flex-direction: column;
 			align-items: center;
-			padding: 16px 24px;
 			background: #fff;
-			border: 1px solid #c3c4c7;
-			border-radius: 4px;
 			text-decoration: none;
-			margin: 0 0 16px;
+			margin: 0 0 8px;
 
 			.gravatar.continue-as-user__gravatar {
-				width: 40px;
-				height: 40px;
-				grid-area: gravatar;
+				width: 80px;
+				height: 80px;
+				box-sizing: border-box;
 			}
 
 			.continue-as-user__username {
 				font-size: 1rem;
+				font-style: normal;
 				font-weight: 600;
 				line-height: 24px;
-				color: var(--color-gray-100);
-				grid-area: username;
-				margin-top: 0;
+				margin-top: 8px;
 
 				&:hover {
 					color: var(--color-gray-100);
@@ -536,36 +659,40 @@
 			}
 
 			.continue-as-user__email {
-				font-size: 1rem;
-				line-height: 24px;
+				font-size: 0.875rem;
+				line-height: 21px;
 				font-weight: 400;
-				color: $gray-60;
-				grid-area: email;
-				margin-bottom: 0;
+				color: $gray-50;
 				text-overflow: ellipsis;
 				width: 100%;
 				overflow: hidden;
 				white-space: nowrap;
-				text-align: left;
-			}
-
-		}
-
-		.continue-as-user__user-info {
-			.button {
+				text-align: center;
 				margin: 0;
 			}
+
 		}
 
 		.continue-as-user__not-you {
-			margin-bottom: 32px;
+			margin-bottom: 0;
 			position: initial;
 		}
 
 		.continue-as-user__change-user-link {
-			color: $gray-60;
-			font-weight: 400;
-			text-decoration: underline;
+			text-decoration: none;
+			color: $woo-purple-50;
+			font-size: 0.875rem;
+			font-style: normal;
+			font-weight: 500;
+			line-height: 21px;
+
+			&:hover {
+				color: $woo-purple-70;
+			}
+		}
+
+		.continue-as-user__continue-button {
+			margin-top: 24px;
 		}
 	}
 
@@ -677,6 +804,7 @@
 
 	.auth-form__separator .auth-form__separator-text {
 		padding: 0 27px;
+		height: 24px;
 		background: #fff;
 	}
 
@@ -686,19 +814,6 @@
 
 	.app-promo.magic-link-app-promo {
 		padding: 24px;
-	}
-
-	.auth-form__social-buttons-tos {
-		margin-top: 24px;
-		font-size: $woo-font-size-small;
-		line-height: 18px;
-		color: $gray-50;
-		text-align: left;
-
-		a {
-			color: $gray-50;
-			font-size: inherit;
-		}
 	}
 
 	.login .login__form-forgot-password {
@@ -743,7 +858,6 @@
 
 	.formatted-header__title {
 		font-size: $font-title-medium;
-		font-family: $sans;
 		margin: 0 0 8px;
 		padding: 0;
 
@@ -782,54 +896,6 @@
 
 	.signup-form__woo-wrapper .gridicon {
 		color: var(--color-primary);
-	}
-
-	.auth-form__social {
-		max-width: 100%;
-		padding: 40px 0 14px;
-		border-top: 0;
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-
-		@media screen and ( max-width: 660px ) {
-			align-items: flex-start;
-		}
-
-		p {
-			color: var(--studio-gray-60);
-			font-size: $woo-font-size-small;
-		}
-
-		a {
-			font-size: $woo-font-size-small;
-		}
-
-		button {
-			padding: 0;
-		}
-
-		.auth-form__social-buttons-tos {
-			text-align: left;
-			color: $gray-50;
-
-			a {
-				line-height: 18px;
-			}
-		}
-	}
-
-	.auth-form__social-buttons button {
-		text-align: start;
-		box-shadow: none;
-		border: 0;
-
-		svg {
-			border: 1px solid var(--studio-gray-10);
-			border-radius: 24px; /* stylelint-disable-line scales/radii */
-			padding: 12px;
-			margin-top: 0;
-		}
 	}
 
 	&.is-woocommerce-core-profiler-flow {
@@ -1019,19 +1085,6 @@
 			font-weight: 600;
 		}
 
-		.auth-form__social-buttons-tos {
-			text-align: center;
-			line-height: 16px;
-
-			@media screen and ( max-width: 660px ) {
-				text-align: start;
-			}
-
-			a {
-				line-height: 16px;
-			}
-		}
-
 		.jetpack-connect__logged-in-content {
 			@media screen and ( max-width: 660px ) {
 				padding-left: $woo-form-whitespace-660;
@@ -1047,10 +1100,6 @@
 
 		.signup-form {
 			padding-top: 24px;
-		}
-
-		button.social-buttons__button.button {
-			width: 100%;
 		}
 
 		// Log in link on signup page


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Close https://github.com/Automattic/wp-calypso/issues/87633

## Proposed Changes

This PR updates the "Continue as Existing user" screen to match the new design.

- Just visual and copy changes, no functionality changes.
- Update font and button colors to match the new Woo.com styles. We're now only using Proxima for header titles. Body copy and buttons are now using Inter.

Before:

![Image](https://github.com/Automattic/wp-calypso/assets/4344253/2730e6c7-678c-4d74-9cf1-6ee6f1fa4044)

After:

<img width="780px" alt="03  Existing user - Logged in" src="https://github.com/Automattic/wp-calypso/assets/4344253/6e0d4ca7-9f0f-49a1-af2f-dbb7c9793530">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Test "Continue as Existing user" screen

1. Logg in to WP.com but Log out of Woo.com 
2. Go to the Woo Express site creation flow (https://woo.com/start/#/installation > Try Woo Express for free)
3. Observe that the "Continue as Existing user" screen matches the new design (4ixWMlzrxllx93tSFsCW6k-fi-9483%3A13771)
4.  Click on "Continue as ..." and observe that you are redirected back to the Woo Express flow

<img width="1350" alt="Screenshot 2024-02-27 at 19 14 07" src="https://github.com/Automattic/wp-calypso/assets/4344253/27351a08-fb4f-4a3e-9232-795fb10f8b40">

### Confirm signup and login screens still look good

1. Use incognito mode
2. Go to the Woo Express site creation flow 
3. Observe that signup screen looks good
4. Click on "Log in" and observe that login screen looks good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?