### PR TITLE
Move the coupon filed to a less prominent place

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -75,6 +75,7 @@ import badgeSecurity from './assets/icons/security.svg';
 import { CheckoutCompleteRedirecting } from './checkout-complete-redirecting';
 import CheckoutNextSteps from './checkout-next-steps';
 import { CheckoutSidebarPlanUpsell } from './checkout-sidebar-plan-upsell';
+import CouponFieldArea from './coupon-field-area';
 import { EmptyCart, shouldShowEmptyCartPage } from './empty-cart';
 import { GoogleDomainsCopy } from './google-transfers-copy';
 import JetpackAkismetCheckoutSidebarPlanUpsell from './jetpack-akismet-checkout-sidebar-plan-upsell';
@@ -281,12 +282,14 @@ export default function CheckoutMainContent( {
 	const cartKey = useCartKey();
 	const {
 		responseCart,
+		couponStatus,
 		applyCoupon,
 		updateLocation,
 		replaceProductInCart,
 		isPendingUpdate: isCartPendingUpdate,
 	} = useShoppingCart( cartKey );
 	const translate = useTranslate();
+	const [ isCouponFieldVisible, setCouponFieldVisible ] = useState( false );
 	const couponFieldStateProps = useCouponFieldState( applyCoupon );
 	const reduxDispatch = useReduxDispatch();
 	usePresalesChat( getPresalesChatKey( responseCart ), responseCart?.products?.length > 0 );
@@ -652,6 +655,15 @@ export default function CheckoutMainContent( {
 							return Boolean( paymentMethod ) && ! paymentMethod?.hasRequiredFields;
 						} }
 					/>
+					{ ! isAkismetCheckout() && (
+						<CouponFieldArea
+							isCouponFieldVisible={ isCouponFieldVisible }
+							setCouponFieldVisible={ setCouponFieldVisible }
+							isPurchaseFree={ responseCart.total_cost_integer === 0 }
+							couponStatus={ couponStatus }
+							couponFieldStateProps={ couponFieldStateProps }
+						/>
+					) }
 					<CheckoutTermsAndCheckboxes
 						is3PDAccountConsentAccepted={ is3PDAccountConsentAccepted }
 						setIs3PDAccountConsentAccepted={ setIs3PDAccountConsentAccepted }

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -544,8 +544,8 @@ export default function CheckoutMainContent( {
 							completeStepContent={
 								<WPCheckoutOrderReview
 									removeProductFromCart={ removeProductFromCart }
+									removeCoupon={ removeCouponAndClearField }
 									replaceProductInCart={ replaceProductInCart }
-									couponFieldStateProps={ couponFieldStateProps }
 									onChangeSelection={ changeSelection }
 									siteUrl={ siteUrl }
 									createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
@@ -686,7 +686,7 @@ export default function CheckoutMainContent( {
 							couponFieldStateProps={ couponFieldStateProps }
 						/>
 					) }
-					{ ! shouldUseCheckoutV2 && couponLineItem && (
+					{ couponLineItem && (
 						<CouponLineItem
 							lineItem={ couponLineItem }
 							hasDeleteButton

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -1,4 +1,3 @@
-import { FormStatus, useFormStatus, Button } from '@automattic/composite-checkout';
 import formatCurrency from '@automattic/format-currency';
 import {
 	type ResponseCart,
@@ -13,8 +12,6 @@ import {
 import styled from '@emotion/styled';
 import { useTranslate } from 'i18n-calypso';
 import useCartKey from '../../use-cart-key';
-import { useCheckoutV2 } from '../hooks/use-checkout-v2';
-import type { Theme } from '@automattic/composite-checkout';
 import type {
 	CostOverrideForDisplay,
 	LineItemCostOverrideForDisplay,
@@ -63,12 +60,6 @@ const CostOverridesListStyle = styled.div`
 	}
 `;
 
-const DeleteButton = styled( Button )< { theme?: Theme; shouldUseCheckoutV2: boolean } >`
-	width: auto;
-	font-size: ${ ( props ) => ( props.shouldUseCheckoutV2 ? '12px' : 'inherit' ) };
-	color: ${ ( props ) => props.theme.colors.textColorLight };
-`;
-
 export function CostOverridesList( {
 	costOverridesList,
 	currency,
@@ -82,8 +73,6 @@ export function CostOverridesList( {
 	couponCode: ResponseCart[ 'coupon' ];
 	showOnlyCoupons?: boolean;
 } ) {
-	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
-
 	const translate = useTranslate();
 	// Let's put the coupon code last because it will have its own "Remove" button.
 	const nonCouponOverrides = costOverridesList.filter(
@@ -92,8 +81,6 @@ export function CostOverridesList( {
 	const couponOverrides = costOverridesList.filter(
 		( override ) => override.overrideCode === 'coupon-discount'
 	);
-	const { formStatus } = useFormStatus();
-	const isDisabled = formStatus !== FormStatus.READY;
 	return (
 		<CostOverridesListStyle>
 			{ ! showOnlyCoupons &&
@@ -144,18 +131,6 @@ export function CostOverridesList( {
 								{ formatCurrency( -costOverride.discountAmount, currency, {
 									isSmallestUnit: true,
 								} ) }
-							</span>
-							<span className="cost-overrides-list-item__actions">
-								<DeleteButton
-									buttonType="text-button"
-									disabled={ isDisabled }
-									className="cost-overrides-list-item__actions-remove"
-									onClick={ removeCoupon }
-									aria-label={ translate( 'Remove coupon' ) }
-									shouldUseCheckoutV2={ shouldUseCheckoutV2 }
-								>
-									{ translate( 'Remove' ) }
-								</DeleteButton>
 							</span>
 						</div>
 					);

--- a/client/my-sites/checkout/src/components/coupon-field-area.tsx
+++ b/client/my-sites/checkout/src/components/coupon-field-area.tsx
@@ -1,0 +1,91 @@
+import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
+import { styled } from '@automattic/wpcom-checkout';
+import { useTranslate } from 'i18n-calypso';
+import { useEffect } from 'react';
+import { useCheckoutV2 } from '../hooks/use-checkout-v2';
+import Coupon from './coupon';
+import type { CouponFieldStateProps } from '../hooks/use-coupon-field-state';
+import type { CouponStatus } from '@automattic/shopping-cart';
+
+const CouponLinkWrapper = styled.div< { shouldUseCheckoutV2: boolean } >`
+	${ ( props ) => ( props.shouldUseCheckoutV2 ? `font-size: 12px;` : `font-size: 14px;` ) }
+`;
+
+const CouponAreaWrapper = styled.div< { shouldUseCheckoutV2: boolean } >`
+	padding-bottom: ${ ( props ) => ( props.shouldUseCheckoutV2 ? '12px' : 'inherit' ) };
+`;
+
+const CouponField = styled( Coupon )``;
+
+const CouponEnableButton = styled.button< { shouldUseCheckoutV2: boolean } >`
+	cursor: pointer;
+	text-decoration: underline;
+	color: ${ ( props ) => props.theme.colors.highlight };
+
+	&.wp-checkout-order-review__show-coupon-field-button {
+		${ ( props ) => ( props.shouldUseCheckoutV2 ? `font-size: 12px` : `font-size: 14px;` ) }
+	}
+	:hover {
+		text-decoration: none;
+	}
+`;
+
+function CouponFieldArea( {
+	isCouponFieldVisible,
+	setCouponFieldVisible,
+	isPurchaseFree,
+	couponStatus,
+	couponFieldStateProps,
+}: {
+	isCouponFieldVisible: boolean;
+	setCouponFieldVisible: ( visible: boolean ) => void;
+	isPurchaseFree: boolean;
+	couponStatus: CouponStatus;
+	couponFieldStateProps: CouponFieldStateProps;
+} ) {
+	const { formStatus } = useFormStatus();
+	const translate = useTranslate();
+	const { setCouponFieldValue } = couponFieldStateProps;
+	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
+
+	useEffect( () => {
+		if ( couponStatus === 'applied' ) {
+			// Clear the field value when the coupon is applied
+			setCouponFieldValue( '' );
+		}
+	}, [ couponStatus, setCouponFieldValue ] );
+
+	if ( isPurchaseFree || couponStatus === 'applied' ) {
+		return null;
+	}
+
+	if ( isCouponFieldVisible ) {
+		return (
+			<CouponAreaWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
+				<CouponField
+					id="order-review-coupon"
+					disabled={ formStatus !== FormStatus.READY }
+					couponStatus={ couponStatus }
+					couponFieldStateProps={ couponFieldStateProps }
+				/>
+			</CouponAreaWrapper>
+		);
+	}
+
+	return (
+		<CouponAreaWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
+			<CouponLinkWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
+				{ translate( 'Have a coupon? ' ) }{ ' ' }
+				<CouponEnableButton
+					className="wp-checkout-order-review__show-coupon-field-button"
+					onClick={ () => setCouponFieldVisible( true ) }
+					shouldUseCheckoutV2={ shouldUseCheckoutV2 }
+				>
+					{ translate( 'Add a coupon code' ) }
+				</CouponEnableButton>
+			</CouponLinkWrapper>
+		</CouponAreaWrapper>
+	);
+}
+
+export default CouponFieldArea;

--- a/client/my-sites/checkout/src/components/coupon-field-area.tsx
+++ b/client/my-sites/checkout/src/components/coupon-field-area.tsx
@@ -75,13 +75,12 @@ function CouponFieldArea( {
 	return (
 		<CouponAreaWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 			<CouponLinkWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
-				{ translate( 'Have a coupon? ' ) }{ ' ' }
 				<CouponEnableButton
 					className="wp-checkout-order-review__show-coupon-field-button"
 					onClick={ () => setCouponFieldVisible( true ) }
 					shouldUseCheckoutV2={ shouldUseCheckoutV2 }
 				>
-					{ translate( 'Add a coupon code' ) }
+					{ translate( 'Have a coupon?' ) }
 				</CouponEnableButton>
 			</CouponLinkWrapper>
 		</CouponAreaWrapper>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -3,11 +3,10 @@ import {
 	isDomainRegistration,
 	isDomainTransfer,
 } from '@automattic/calypso-products';
-import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled, joinClasses } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useCallback } from 'react';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import { hasP2PlusPlan } from 'calypso/lib/cart-values/cart-items';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
@@ -19,7 +18,7 @@ import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/s
 import { getWpComDomainBySiteId } from 'calypso/state/sites/domains/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import { useCheckoutV2 } from '../hooks/use-checkout-v2';
-import Coupon from './coupon';
+import CouponFieldArea from './coupon-field-area';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
 import type { OnChangeItemVariant } from './item-variation-picker';
 import type { CouponFieldStateProps } from '../hooks/use-coupon-field-state';
@@ -28,7 +27,6 @@ import type {
 	ResponseCart,
 	RemoveProductFromCart,
 	ReplaceProductInCart,
-	CouponStatus,
 } from '@automattic/shopping-cart';
 
 const SiteSummary = styled.div`
@@ -43,29 +41,6 @@ const SiteSummary = styled.div`
 
 	@media ( ${ ( props ) => props.theme.breakpoints.tabletUp } ) {
 		margin-top: -8px;
-	}
-`;
-
-const CouponLinkWrapper = styled.div< { shouldUseCheckoutV2: boolean } >`
-	${ ( props ) => ( props.shouldUseCheckoutV2 ? `font-size: 12px;` : `font-size: 14px;` ) }
-`;
-
-const CouponAreaWrapper = styled.div< { shouldUseCheckoutV2: boolean } >`
-	padding-bottom: ${ ( props ) => ( props.shouldUseCheckoutV2 ? '12px' : 'inherit' ) };
-`;
-
-const CouponField = styled( Coupon )``;
-
-const CouponEnableButton = styled.button< { shouldUseCheckoutV2: boolean } >`
-	cursor: pointer;
-	text-decoration: underline;
-	color: ${ ( props ) => props.theme.colors.highlight };
-
-	&.wp-checkout-order-review__show-coupon-field-button {
-		${ ( props ) => ( props.shouldUseCheckoutV2 ? `font-size: 12px` : `font-size: 14px;` ) }
-	}
-	:hover {
-		text-decoration: none;
 	}
 `;
 
@@ -231,64 +206,6 @@ export default function WPCheckoutOrderReview( {
 				) }
 			</div>
 		</>
-	);
-}
-
-function CouponFieldArea( {
-	isCouponFieldVisible,
-	setCouponFieldVisible,
-	isPurchaseFree,
-	couponStatus,
-	couponFieldStateProps,
-}: {
-	isCouponFieldVisible: boolean;
-	setCouponFieldVisible: ( visible: boolean ) => void;
-	isPurchaseFree: boolean;
-	couponStatus: CouponStatus;
-	couponFieldStateProps: CouponFieldStateProps;
-} ) {
-	const { formStatus } = useFormStatus();
-	const translate = useTranslate();
-	const { setCouponFieldValue } = couponFieldStateProps;
-	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
-
-	useEffect( () => {
-		if ( couponStatus === 'applied' ) {
-			// Clear the field value when the coupon is applied
-			setCouponFieldValue( '' );
-		}
-	}, [ couponStatus, setCouponFieldValue ] );
-
-	if ( isPurchaseFree || couponStatus === 'applied' ) {
-		return null;
-	}
-
-	if ( isCouponFieldVisible ) {
-		return (
-			<CouponAreaWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
-				<CouponField
-					id="order-review-coupon"
-					disabled={ formStatus !== FormStatus.READY }
-					couponStatus={ couponStatus }
-					couponFieldStateProps={ couponFieldStateProps }
-				/>
-			</CouponAreaWrapper>
-		);
-	}
-
-	return (
-		<CouponAreaWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
-			<CouponLinkWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
-				{ translate( 'Have a coupon? ' ) }{ ' ' }
-				<CouponEnableButton
-					className="wp-checkout-order-review__show-coupon-field-button"
-					onClick={ () => setCouponFieldVisible( true ) }
-					shouldUseCheckoutV2={ shouldUseCheckoutV2 }
-				>
-					{ translate( 'Add a coupon code' ) }
-				</CouponEnableButton>
-			</CouponLinkWrapper>
-		</CouponAreaWrapper>
 	);
 }
 

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -6,8 +6,7 @@ import {
 import { useShoppingCart } from '@automattic/shopping-cart';
 import { styled, joinClasses } from '@automattic/wpcom-checkout';
 import { useTranslate } from 'i18n-calypso';
-import { useState, useCallback } from 'react';
-import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
+import { useCallback } from 'react';
 import { hasP2PlusPlan } from 'calypso/lib/cart-values/cart-items';
 import useCartKey from 'calypso/my-sites/checkout/use-cart-key';
 import SitePreview from 'calypso/my-sites/customer-home/cards/features/site-preview';
@@ -18,7 +17,6 @@ import { currentUserHasFlag, getCurrentUser } from 'calypso/state/current-user/s
 import { getWpComDomainBySiteId } from 'calypso/state/sites/domains/selectors';
 import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import { useCheckoutV2 } from '../hooks/use-checkout-v2';
-import CouponFieldArea from './coupon-field-area';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
 import type { OnChangeItemVariant } from './item-variation-picker';
 import type { CouponFieldStateProps } from '../hooks/use-coupon-field-state';
@@ -94,10 +92,8 @@ export default function WPCheckoutOrderReview( {
 	createUserAndSiteBeforeTransaction?: boolean;
 } ) {
 	const translate = useTranslate();
-	const [ isCouponFieldVisible, setCouponFieldVisible ] = useState( false );
 	const cartKey = useCartKey();
-	const { responseCart, removeCoupon, couponStatus } = useShoppingCart( cartKey );
-	const isPurchaseFree = responseCart.total_cost_integer === 0;
+	const { responseCart, removeCoupon } = useShoppingCart( cartKey );
 	const reduxDispatch = useDispatch();
 	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 
@@ -194,16 +190,6 @@ export default function WPCheckoutOrderReview( {
 						onRemoveProductCancel={ onRemoveProductCancel }
 					/>
 				</WPOrderReviewSection>
-
-				{ ! isAkismetCheckout() && (
-					<CouponFieldArea
-						isCouponFieldVisible={ isCouponFieldVisible }
-						setCouponFieldVisible={ setCouponFieldVisible }
-						isPurchaseFree={ isPurchaseFree }
-						couponStatus={ couponStatus }
-						couponFieldStateProps={ couponFieldStateProps }
-					/>
-				) }
 			</div>
 		</>
 	);

--- a/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-review.tsx
@@ -19,11 +19,11 @@ import getSelectedSite from 'calypso/state/ui/selectors/get-selected-site';
 import { useCheckoutV2 } from '../hooks/use-checkout-v2';
 import { WPOrderReviewLineItems, WPOrderReviewSection } from './wp-order-review-line-items';
 import type { OnChangeItemVariant } from './item-variation-picker';
-import type { CouponFieldStateProps } from '../hooks/use-coupon-field-state';
 import type { SiteDetails } from '@automattic/data-stores';
 import type {
 	ResponseCart,
 	RemoveProductFromCart,
+	RemoveCouponFromCart,
 	ReplaceProductInCart,
 } from '@automattic/shopping-cart';
 
@@ -75,8 +75,8 @@ const SitePreviewWrapper = styled.div`
 export default function WPCheckoutOrderReview( {
 	className,
 	removeProductFromCart,
+	removeCoupon,
 	replaceProductInCart,
-	couponFieldStateProps,
 	onChangeSelection,
 	siteUrl,
 	isSummary,
@@ -84,8 +84,8 @@ export default function WPCheckoutOrderReview( {
 }: {
 	className?: string;
 	removeProductFromCart?: RemoveProductFromCart;
+	removeCoupon: RemoveCouponFromCart;
 	replaceProductInCart?: ReplaceProductInCart;
-	couponFieldStateProps: CouponFieldStateProps;
 	onChangeSelection?: OnChangeItemVariant;
 	siteUrl?: string;
 	isSummary?: boolean;
@@ -93,7 +93,7 @@ export default function WPCheckoutOrderReview( {
 } ) {
 	const translate = useTranslate();
 	const cartKey = useCartKey();
-	const { responseCart, removeCoupon } = useShoppingCart( cartKey );
+	const { responseCart } = useShoppingCart( cartKey );
 	const reduxDispatch = useDispatch();
 	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 
@@ -130,12 +130,6 @@ export default function WPCheckoutOrderReview( {
 
 	// This is what will be displayed at the top of checkout prefixed by "Site: ".
 	const domainUrl = getDomainToDisplayInCheckoutHeader( responseCart, selectedSiteData, siteUrl );
-
-	const removeCouponAndClearField = () => {
-		couponFieldStateProps.setCouponFieldValue( '' );
-		setCouponFieldVisible( false );
-		return removeCoupon();
-	};
 
 	const planIsP2Plus = hasP2PlusPlan( responseCart );
 
@@ -179,7 +173,7 @@ export default function WPCheckoutOrderReview( {
 					<WPOrderReviewLineItems
 						removeProductFromCart={ removeProductFromCart }
 						replaceProductInCart={ replaceProductInCart }
-						removeCoupon={ removeCouponAndClearField }
+						removeCoupon={ removeCoupon }
 						onChangeSelection={ onChangeSelection }
 						isSummary={ isSummary }
 						createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -8,11 +8,9 @@ import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import { isCopySiteFlow } from '@automattic/onboarding';
 import {
 	canItemBeRemovedFromCart,
-	getCouponLineItemFromCart,
 	getCreditsLineItemFromCart,
 	isWpComProductRenewal,
 	joinClasses,
-	CouponLineItem,
 	NonProductLineItem,
 	LineItem,
 	getPartnerCoupon,
@@ -97,7 +95,6 @@ export function WPOrderReviewLineItems( {
 	const reduxDispatch = useDispatch();
 	const translate = useTranslate();
 	const creditsLineItem = getCreditsLineItemFromCart( responseCart );
-	const couponLineItem = getCouponLineItemFromCart( responseCart );
 	const { formStatus } = useFormStatus();
 	const isDisabled = formStatus !== FormStatus.READY;
 	const hasPartnerCoupon = getPartnerCoupon( {
@@ -208,19 +205,6 @@ export function WPOrderReviewLineItems( {
 					akQuantityOpenId={ akQuantityOpenId }
 				/>
 			) ) }
-			{ ! shouldUseCheckoutV2 && couponLineItem && (
-				<WPOrderReviewListItem key={ couponLineItem.id }>
-					<CouponLineItem
-						lineItem={ couponLineItem }
-						isSummary={ isSummary }
-						hasDeleteButton
-						removeProductFromCart={ removeCoupon }
-						createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
-						isPwpoUser={ isPwpoUser }
-						hasPartnerCoupon={ hasPartnerCoupon }
-					/>
-				</WPOrderReviewListItem>
-			) }
 			{ ! shouldUseCheckoutV2 && creditsLineItem && responseCart.sub_total_integer > 0 && (
 				<NonProductLineItem
 					subtotal


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/martech#2753

## Proposed Changes

WIP

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
