### PR TITLE
Site Migration: Add BundleTransfer step to the site-migration flow

### DIFF
--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -7,19 +7,19 @@ import { getFlowLocation, renderFlow } from './helpers';
 
 describe( 'Site Migration Flow', () => {
 	describe( 'navigation', () => {
-		it( 'migrate redirects from the import-from page to site-migration-plugin-install page', async () => {
+		it( 'migrate redirects from the import-from page to bundleTransfer step', async () => {
 			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
 
 			runUseStepNavigationSubmit( {
-				currentStep: STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug,
+				currentStep: STEPS.BUNDLE_TRANSFER.slug,
 				dependencies: {
 					destination: 'migrate',
 				},
 			} );
 
 			expect( getFlowLocation() ).toEqual( {
-				path: '/site-migration-plugin-install',
-				state: { siteSlug: 'example.wordpress.com' },
+				path: '/processing',
+				state: null,
 			} );
 		} );
 
@@ -35,23 +35,6 @@ describe( 'Site Migration Flow', () => {
 
 			expect( getFlowLocation() ).toEqual( {
 				path: '/site-migration-upgrade-plan',
-				state: { siteSlug: 'example.wordpress.com' },
-			} );
-		} );
-
-		// TODO - This will need to be updated once the flow has been updated to include these steps.
-		it( 'redirect from the processing page to the waitForPluginInstall when atomic waiting is finished', () => {
-			const { runUseStepNavigationSubmit } = renderFlow( siteMigrationFlow );
-
-			runUseStepNavigationSubmit( {
-				currentStep: 'processing',
-				dependencies: {
-					finishedWaitingForAtomic: true,
-				},
-			} );
-
-			expect( getFlowLocation() ).toEqual( {
-				path: '/waitForPluginInstall',
 				state: { siteSlug: 'example.wordpress.com' },
 			} );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #87906

## Proposed Changes

Previously, the site-migration-flow had separate steps for waiting for the Atomic transfer and plugin installation. Now we use the `BundleTransfer` step to handle both.

This removes those unused steps from the flow but leaves the files intact. Files will be removed in #87945.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to https://wordpress.com/start
* Create a site with the Creator plan. You can skip to the dashboard immediately.
* Don't install any plugins or do anything that will start the Atomic transfer.
* Run this branch locally or use the calypso.live url.
* Go to `http://calypso.localhost:3000/setup/site-migration/site-migration-import-or-migrate?flags=onboarding/new-migration-flow&siteSlug=:siteSlug&siteId=:siteId`
* Click the "Migrate" button.
* You should see the "Processing" step while your site is being transferred to Atomic and the plugins are installed.
* Once the transfer and install finishes, you should end on the "Setup Instructions" step.
* Go to the wp-admin for your site. The domain should now be a `wpcomstaging.com` domain and the migration plugin should be installed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
