### PR TITLE
Jetpack Manage: Fix the new sites dashboard back navigation issue

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dashboard-v2.tsx
@@ -11,6 +11,7 @@ import SidebarNavigation from 'calypso/components/sidebar-navigation';
 import useFetchDashboardSites from 'calypso/data/agency-dashboard/use-fetch-dashboard-sites';
 import useFetchMonitorVerfiedContacts from 'calypso/data/agency-dashboard/use-fetch-monitor-verified-contacts';
 import { AgencyDashboardFilterMap } from 'calypso/jetpack-cloud/sections/agency-dashboard/sites-overview/types';
+import { sitesPath } from 'calypso/lib/jetpack/paths';
 import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import {
@@ -112,6 +113,9 @@ export default function SitesDashboardV2() {
 
 	// Filter selection
 	useEffect( () => {
+		if ( isLoading || isError || window.location.pathname !== sitesPath() ) {
+			return;
+		}
 		const filtersSelected =
 			sitesViewState.filters?.map( ( filter ) => {
 				const filterType =
@@ -122,12 +126,15 @@ export default function SitesDashboardV2() {
 			} ) || [];
 
 		updateDashboardURLQueryArgs( { filter: filtersSelected || [] } );
-	}, [ sitesViewState.filters ] );
+	}, [ isLoading, isError, sitesViewState.filters ] );
 
 	// Search query
 	useEffect( () => {
+		if ( isLoading || isError || window.location.pathname !== sitesPath() ) {
+			return;
+		}
 		updateDashboardURLQueryArgs( { search: sitesViewState.search } );
-	}, [ sitesViewState.search ] );
+	}, [ isLoading, isError, sitesViewState.search ] );
 
 	// Set or clear filter depending on sites submenu path selected
 	useEffect( () => {

--- a/client/state/jetpack-agency-dashboard/actions.ts
+++ b/client/state/jetpack-agency-dashboard/actions.ts
@@ -46,7 +46,7 @@ export const updateDashboardURLQueryArgs = ( {
 	const sortField = sort ? sort.field : params.get( 'sort_field' );
 	const sortDirection = sort ? sort.direction : params.get( 'sort_direction' );
 
-	page(
+	page.replace(
 		addQueryArgs(
 			{
 				...( searchQuery && { s: searchQuery } ),


### PR DESCRIPTION
Resolve: https://github.com/Automattic/jetpack-manage/issues/330

## Proposed Changes

This PR fixes an issue when you go back to the Overview section and click on the Sites menu; it doesn't work the first time, but on the second click, it works. It seems that the URL (browser, `window.location`) is not loaded on time, and the Sites Dashboard state conflicts with the page call.

## Testing Instructions

- Check the code
- Check that now you can go back to any other section in Manage and then go again to the Sites section without any problem.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
