### PR TITLE
Fix site selector modal not being visible on theme preview

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -155,6 +155,7 @@ $z-layers: (
 		".wplink__dialog.dialog.card": 100200,
 		".web-preview": 100200,
 		".theme-site-selector-modal": 100201,
+		".is-section-theme .global-notices": 100201,
 		".popover.ellipsis-menu__menu": 100201,
 		".popover.plugin-action__disabled-info": 100202,
 		".design-picker__premium-badge-tooltip": 100300,

--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -154,6 +154,7 @@ $z-layers: (
 		".theme-preview-modal": 100200,
 		".wplink__dialog.dialog.card": 100200,
 		".web-preview": 100200,
+		".theme-site-selector-modal": 100201,
 		".popover.ellipsis-menu__menu": 100201,
 		".popover.plugin-action__disabled-info": 100202,
 		".design-picker__premium-badge-tooltip": 100300,

--- a/client/components/theme-site-selector-modal/index.jsx
+++ b/client/components/theme-site-selector-modal/index.jsx
@@ -36,7 +36,7 @@ export default function ThemeSiteSelectorModal( { isOpen, navigateOnClose = true
 
 	return (
 		<Modal
-			className="theme-site-selector-modal"
+			overlayClassName="theme-site-selector-modal"
 			onRequestClose={ onClose }
 			size="medium"
 			title={ translate( 'Select a site', {

--- a/client/components/theme-site-selector-modal/style.scss
+++ b/client/components/theme-site-selector-modal/style.scss
@@ -1,3 +1,7 @@
+.theme-site-selector-modal {
+	z-index: z-index("root", ".theme-site-selector-modal");
+}
+
 .theme-site-selector-modal__content {
 	.site-icon {
 		margin-right: 12px;

--- a/client/my-sites/theme/style.scss
+++ b/client/my-sites/theme/style.scss
@@ -4,6 +4,13 @@ $theme-sheet-content-max-width: 1462px;
 $button-border: 4px;
 
 .is-section-theme {
+	// overwrite notices z-index so they are visible on top of the theme preview
+	.global-notices {
+		// This should be - z-index: z-index("root", ".is-section-theme .global-notices")
+		// but the @automattic/onboarding/styles/mixins import overwrites the z-index function on client/assets/stylesheets/shared/functions/_z-index.scss
+		z-index: 100201;
+	}
+
 	&.theme-default.color-scheme {
 		--color-surface-backdrop: var(--studio-white);
 	}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5385

There's a bug on production:

If you go to a theme page (e.g. https://wordpress.com/theme/cakely) without having selected a site to work with (on accounts with multiple sites), and then click on the `Demo site` button you'll see this banner:

![image](https://github.com/Automattic/wp-calypso/assets/8511199/f6ea1ece-8afa-4865-9f36-357bcecbfc2c)

Clicking it apparently does nothing, which is frustrating. What's really happening is that the site selector released on https://github.com/Automattic/wp-calypso/pull/87260 is opened but not visible due to it having a lower `z-index` than the demo overlay.

## Proposed Changes

* Adjust the `z-index` of the site selector and the global notices so the user can see what's going on

## Testing Instructions

1. Open the PR preview with an account that has multiple sites
2. Go to `/theme/cakely`
3. Click on `Demo site`
4. Click on the `Access this theme for FREE with a Explorer or Creator plan!` banner
5. Check that you see the site selector
6. Select a site
7. Check that you see the success notice

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?