### PR TITLE
Jetpack Manage: Lock the package "@wordpress/dataviews" to version 0.4.1

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -92,7 +92,7 @@
 		"@wordpress/components": "^27.0.0",
 		"@wordpress/compose": "^6.29.0",
 		"@wordpress/data": "^9.22.0",
-		"@wordpress/dataviews": "0.6.0",
+		"@wordpress/dataviews": "0.4.1",
 		"@wordpress/dom": "^3.52.0",
 		"@wordpress/edit-post": "^7.29.0",
 		"@wordpress/element": "^5.29.0",

--- a/package.json
+++ b/package.json
@@ -341,6 +341,7 @@
 		"@wordpress/customize-widgets": "4.29.0",
 		"@wordpress/data-controls": "3.21.0",
 		"@wordpress/data": "^9.22.0",
+		"@wordpress/dataviews": "0.4.1",
 		"@wordpress/date": "4.52.0",
 		"@wordpress/dependency-extraction-webpack-plugin": "5.3.0",
 		"@wordpress/deprecated": "3.52.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9259,26 +9259,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wordpress/dataviews@npm:0.6.0, @wordpress/dataviews@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "@wordpress/dataviews@npm:0.6.0"
+"@wordpress/dataviews@npm:0.4.1":
+  version: 0.4.1
+  resolution: "@wordpress/dataviews@npm:0.4.1"
   dependencies:
-    "@ariakit/react": "npm:^0.3.12"
     "@babel/runtime": "npm:^7.16.0"
-    "@wordpress/a11y": "npm:^3.52.0"
-    "@wordpress/components": "npm:^27.0.0"
-    "@wordpress/compose": "npm:^6.29.0"
-    "@wordpress/element": "npm:^5.29.0"
-    "@wordpress/i18n": "npm:^4.52.0"
-    "@wordpress/icons": "npm:^9.43.0"
-    "@wordpress/keycodes": "npm:^3.52.0"
-    "@wordpress/primitives": "npm:^3.50.0"
-    "@wordpress/private-apis": "npm:^0.34.0"
+    "@wordpress/a11y": "npm:^3.50.0"
+    "@wordpress/components": "npm:^25.16.0"
+    "@wordpress/compose": "npm:^6.27.0"
+    "@wordpress/element": "npm:^5.27.0"
+    "@wordpress/i18n": "npm:^4.50.0"
+    "@wordpress/icons": "npm:^9.41.0"
+    "@wordpress/keycodes": "npm:^3.50.0"
+    "@wordpress/primitives": "npm:^3.48.0"
+    "@wordpress/private-apis": "npm:^0.32.0"
     classnames: "npm:^2.3.1"
     remove-accents: "npm:^0.5.0"
   peerDependencies:
     react: ^18.0.0
-  checksum: 300852c19dac518281befa7ce8532ca4f709b2f00ed232a50497a1d8283024c459e1beaaa716801d3337b7bd981189b7ac7b3ecfc48168f510ffa1951855f7de
+  checksum: 00f5be7dc18de659bb52587380d5d88f0eda5fa99309bcc16bb02b9a4a7a51c82654bbf69aa0f7831e8f64df3e5c378d121874b795b7d3d60155d73a0f5adc1b
   languageName: node
   linkType: hard
 
@@ -12150,7 +12149,7 @@ __metadata:
     "@wordpress/components": "npm:^27.0.0"
     "@wordpress/compose": "npm:^6.29.0"
     "@wordpress/data": "npm:^9.22.0"
-    "@wordpress/dataviews": "npm:0.6.0"
+    "@wordpress/dataviews": "npm:0.4.1"
     "@wordpress/dom": "npm:^3.52.0"
     "@wordpress/edit-post": "npm:^7.29.0"
     "@wordpress/element": "npm:^5.29.0"


### PR DESCRIPTION
**Context:** p1709055188435409-slack-C7YPUHBB2

## Proposed Changes

Back to the previous version of the `@wordpress/dataviews` package, v0.4.1. This PR updates the package version in `/client/package.json` (dependencies) and `/package.json` (resolutions).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?