### PR TITLE
Command palette: Hide some commands on staging

### DIFF
--- a/packages/command-palette/src/commands/use-single-site-commands.tsx
+++ b/packages/command-palette/src/commands/use-single-site-commands.tsx
@@ -43,6 +43,7 @@ interface CapabilityCommand extends Command {
 	siteType?: SiteType;
 	isCustomDomain?: boolean;
 	filterP2?: boolean;
+	filterStaging?: boolean;
 }
 
 interface CustomWindow {
@@ -50,6 +51,7 @@ interface CustomWindow {
 		siteId: string;
 		isAdmin: boolean;
 		isAtomic: boolean;
+		isStaging: boolean;
 		isSelfHosted: boolean;
 		isSimple: boolean;
 		isP2: boolean;
@@ -65,6 +67,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 	const customWindow = window as CustomWindow | undefined;
 	const {
 		isAtomic = false,
+		isStaging = false,
 		isSelfHosted = false,
 		isSimple = false,
 		capabilities = {},
@@ -757,6 +760,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 			callback: commandNavigation( '/plans/:site' ),
 			capability: SiteCapabilities.MANAGE_OPTIONS,
 			filterP2: true,
+			filterStaging: true,
 			icon: creditCardIcon,
 		},
 		{
@@ -770,6 +774,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 			callback: commandNavigation( '/plans/my-plan/:site' ),
 			capability: SiteCapabilities.MANAGE_OPTIONS,
 			filterP2: true,
+			filterStaging: true,
 			icon: creditCardIcon,
 		},
 		{
@@ -921,6 +926,10 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 			}
 
 			if ( command?.filterP2 && isP2 ) {
+				return false;
+			}
+
+			if ( command?.filterStaging && isStaging ) {
 				return false;
 			}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/87942

## Proposed Changes

When in single site mode  on a staging site hide "Change site plan" and "Manage site plan" just like the multi-site commands do.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

## Testing Instructions

**Atomic sites**
- Apply the latest version of https://github.com/Automattic/jetpack/pull/35635 to your Atomic site
- Run `install-plugin.sh command-palette update/non-staging-commands` in your sandbox
- Sandbox `widgets.wp.com`
- Visit the WP Admin of your Atomic site
- Open the command palette
- Make sure that "Change site plan" and "Manage site plan" commands still exist

**Atomic staging sites**
- Run `install-plugin.sh command-palette update/non-staging-commands` in your sandbox
- Sandbox `widgets.wp.com`
- Go to /hosting-config and enable the staging site for your atomic site
- Press the button to manage the staging site
- Apply the latest version of https://github.com/Automattic/jetpack/pull/35635 to the staging site
- Open the command palette
- Make sure that "Change site plan" and "Manage site plan" commands **no longer exist**

**Simple sites**
- Apply the latest version of https://github.com/Automattic/jetpack/pull/35635 to your sandbox
- Run `install-plugin.sh command-palette update/non-staging-commands` in your sandbox
- Sandbox `widgets.wp.com`
- Visit the WP Admin of your simple site
- Open the command palette
- Make sure that "Change site plan" and "Manage site plan" commands still exist

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?