### PR TITLE
Allow Stepper flows to return custom signup start event props

### DIFF
--- a/client/landing/stepper/README.md
+++ b/client/landing/stepper/README.md
@@ -38,7 +38,7 @@ To create a flow, you only have to implement `useSteps` and `useStepNavigation`.
 
 There is also an optional `useSideEffect` hook. You can implement this hook to run any side-effects to the flow. You can prefetch information, send track events when something changes, etc...
 
-There is a required `isSignupFlow` flag that _MUST be `true` for signup flows_ (generally where a new site may be created), and should be `false` for other flows. The `isSignupFlow` flag controls whether we'll trigger a `calypso_signup_start` Tracks event when the flow starts.
+There is a required `isSignupFlow` flag that _MUST be `true` for signup flows_ (generally where a new site may be created), and should be `false` for other flows. The `isSignupFlow` flag controls whether we'll trigger a `calypso_signup_start` Tracks event when the flow starts. For signup flows, you can also supply additional event props to the `calypso_signup_start` event by implementing the optional `useSignupStartEventProps()` hook on the flow.
 
 ```tsx
 // prettier-ignore

--- a/client/landing/stepper/declarative-flow/internals/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/index.tsx
@@ -158,9 +158,13 @@ export const FlowRenderer: React.FC< { flow: Flow } > = ( { flow } ) => {
 		window.scrollTo( 0, 0 );
 	}, [ location ] );
 
+	// Get any flow-specific event props to include in the
+	// `calypso_signup_start` Tracks event triggerd in the effect below.
+	const signupStartEventProps = flow.useSignupStartEventProps?.() ?? {};
+
 	useEffect( () => {
 		if ( flow.isSignupFlow && isFlowStart() ) {
-			recordSignupStart( flow.name, ref );
+			recordSignupStart( flow.name, ref, signupStartEventProps );
 		}
 	}, [ flow, ref, isFlowStart ] );
 

--- a/client/landing/stepper/declarative-flow/internals/types.ts
+++ b/client/landing/stepper/declarative-flow/internals/types.ts
@@ -106,6 +106,7 @@ export type Flow = {
 	 * Required flag to indicate if the flow is a signup flow.
 	 */
 	isSignupFlow: boolean;
+	useSignupStartEventProps?: () => Record< string, string | number >;
 	useSteps: UseStepsHook;
 	useStepNavigation: UseStepNavigationHook< ReturnType< Flow[ 'useSteps' ] > >;
 	useAssertConditions?: UseAssertConditionsHook< ReturnType< Flow[ 'useSteps' ] > >;

--- a/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
+++ b/client/landing/stepper/declarative-flow/tailored-ecommerce-flow.ts
@@ -48,20 +48,16 @@ function getPlanFromRecurType( recurType: string ) {
 
 const ecommerceFlow: Flow = {
 	name: ECOMMERCE_FLOW,
-	/* This is technically a signup flow, but we're manually triggering an event in useSteps()
-	 * for now, so we're disabling the centralised tracking for calypso_signup_start events.
-	 */
-	isSignupFlow: false,
-	useSteps() {
-		const recurType = useSelect(
+	isSignupFlow: true,
+	useSignupStartEventProps() {
+		const recur = useSelect(
 			( select ) => ( select( ONBOARD_STORE ) as OnboardSelect ).getEcommerceFlowRecurType(),
 			[]
 		);
 
-		useEffect( () => {
-			recordTracksEvent( 'calypso_signup_start', { flow: this.name, recur: recurType } );
-		}, [] );
-
+		return { recur };
+	},
+	useSteps() {
 		return [
 			{
 				slug: 'storeProfiler',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* https://github.com/Automattic/automattic-analytics/issues/406
* https://github.com/Automattic/wp-calypso/pull/87758

## Proposed Changes

* This PR adds a new, optional `Flow.useSignupStartEventProps()` hook to allow Stepper signup flows to specify additional event props to include in the `calypso_signup_start` Tracks event that gets triggered at the start of the flow.
  - By adding this new implementation, we can remove the dedicated/non-standard Tracks event in the ecommerce flow.
* The PR builds on https://github.com/Automattic/wp-calypso/pull/87758, which added a new `Flow.isSignupFlow` flag, and included an earlier iteration of this code that we removed before merging.

## Testing Instructions

* Run this branch locally or via Calypso.live
* Ensure you have Tracks Vigilante or some other tool set up to inspect Tracks events
* Navigate to `/setup/ecommerce`
* Verify that we log a `calypso_signup_start` Tracks event with `recur` set to no value
* Verify that there aren't any error or warning messages in the console stemming from the hook implementation.
* Navigate to `/setup/ecommerce?recur=monthly`
* Verify that we log a `calypso_signup_start` Tracks event with `recur` set to `monthly`
* Verify that there aren't any error or warning messages in the console stemming from the hook implementation.
* Navigate to another onboarding flow that's classified as a signup flow (e.g. `/setup/free`, `/setup/design-first`, or `/setup/newsletter`)
* Verify that you see a `calypso_signup_start` Tracks event logged and no related console errors or warnings.
* Navigate to another onboarding flow that is not classified as a signup flow (e.g. `/setup/blog`)
* Verify that you do not see a `calypso_signup_start` Tracks event logged, nor should you see any related console errors or warnings.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?