### PR TITLE
Help-Center: Disable AI answers.

### DIFF
--- a/config/development.json
+++ b/config/development.json
@@ -71,7 +71,7 @@
 		"google-drive": true,
 		"google-my-business": true,
 		"help": true,
-		"help/gpt-response": true,
+		"help/gpt-response": false,
 		"home/layout-dev": true,
 		"hosting/datacenter-picker": true,
 		"i18n/community-translator": false,

--- a/config/production.json
+++ b/config/production.json
@@ -50,7 +50,7 @@
 		"cookie-banner": true,
 		"google-my-business": true,
 		"help": true,
-		"help/gpt-response": true,
+		"help/gpt-response": false,
 		"i18n/empathy-mode": false,
 		"i18n/translation-scanner": true,
 		"importer/site-backups": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -55,7 +55,7 @@
 		"cookie-banner": true,
 		"google-my-business": true,
 		"help": true,
-		"help/gpt-response": true,
+		"help/gpt-response": false,
 		"home/layout-dev": true,
 		"hosting/datacenter-picker": true,
 		"i18n/translation-scanner": true,


### PR DESCRIPTION
Temporarily disabling AI answers in the Help Center. 

See p1709065856583879-slack-C061MR40SPK


## Proposed Changes

* Turn off the `help/gpt-response` feature flag

## Testing Instructions
- Open the Help Center
- Click on Still need help
- Click on email
- Enter on subject and message
- Click on continue
- You'll be presented with recommended resources related to your message (but you will *NOT* see an AI generated answer)
- The button turns into "still email us"


<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?