### PR TITLE
Adds a setup page for the Blaze Dashboard app

### DIFF
--- a/apps/blaze-dashboard/src/load-config.js
+++ b/apps/blaze-dashboard/src/load-config.js
@@ -5,6 +5,7 @@ if ( window.configData?.intial_state ) {
 }
 
 const isWooStore = window.configData?.is_woo_store || false;
+const needSetup = window.configData?.need_setup || false;
 
 // The JSON is filtered by `apps/blaze-dashboard/filter-json-config-loader.js`.
 import productionConfig from '../../../config/production.json';
@@ -15,6 +16,8 @@ productionConfig.features.is_running_in_jetpack_site =
 
 // Set is is_running_in_woo_site to true if the dashboard is running on the Woo Blaze plugin
 productionConfig.features.is_running_in_woo_site = isWooStore;
+
+productionConfig.features.blaze_setup_mode = needSetup;
 
 // The option enables loading of the whole translation file, and could be optimized by setting it to `true`, which needs the translation chunks in place.
 // @see https://github.com/Automattic/wp-calypso/blob/trunk/docs/translation-chunks.md

--- a/apps/blaze-dashboard/src/pages/controller.js
+++ b/apps/blaze-dashboard/src/pages/controller.js
@@ -1,0 +1,6 @@
+import BlazeSetup from './setup/main';
+
+export const setup = ( context, next ) => {
+	context.primary = <BlazeSetup />;
+	next();
+};

--- a/apps/blaze-dashboard/src/pages/setup/main.jsx
+++ b/apps/blaze-dashboard/src/pages/setup/main.jsx
@@ -1,0 +1,80 @@
+import config from '@automattic/calypso-config';
+import './style.scss';
+import { useTranslate } from 'i18n-calypso';
+import DocumentHead from 'calypso/components/data/document-head';
+import BlazePageViewTracker from 'calypso/my-sites/promote-post-i2/components/blaze-page-view-tracker';
+import MainWrapper from 'calypso/my-sites/promote-post-i2/components/main-wrapper';
+import PostsListBanner from 'calypso/my-sites/promote-post-i2/components/posts-list-banner';
+import WooBanner from 'calypso/my-sites/promote-post-i2/components/woo-banner';
+import { getAdvertisingDashboardPath } from 'calypso/my-sites/promote-post-i2/utils';
+import { useSelector } from 'calypso/state';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+import GenericHeader from '../../components/generic-header';
+
+export default function BlazeSetup() {
+	const selectedSiteData = useSelector( getSelectedSite );
+	const adminUrl = selectedSiteData?.options?.admin_url;
+
+	const isWooBlaze = config.isEnabled( 'is_running_in_woo_site' );
+	const translate = useTranslate();
+
+	const headerTitle = isWooBlaze
+		? translate( 'Blaze for WooCommerce' )
+		: translate( 'Advertising' );
+
+	return (
+		<MainWrapper>
+			<DocumentHead title={ headerTitle } />
+			<BlazePageViewTracker
+				path={ getAdvertisingDashboardPath( '/setup/:site' ) }
+				title="Advertising > Setup"
+			/>
+
+			<div className="promote-post-i2__top-bar">
+				<GenericHeader
+					brandFont
+					className="advertising__page-header advertising__page-header_has-banner"
+					headerText={ headerTitle }
+					align="left"
+				/>
+			</div>
+
+			{ isWooBlaze ? <WooBanner /> : <PostsListBanner /> }
+
+			<div className="promote-post-i2__aux-wrapper">
+				<div className="empty-promotion-list__container promote-post-i2__setup-container">
+					<h3 className="empty-promotion-list__title wp-brand-font">
+						{ translate( 'Set up Blaze and start promoting your store' ) }
+					</h3>
+					<p className="empty-promotion-list__body">
+						{ translate(
+							"You're on the brink of unleashing the advertising potential of your store. To get started, follow these simple steps below:"
+						) }
+					</p>
+
+					<ol className="promote-post-i2__active-steps">
+						<li>
+							{ translate( 'Go to the {{a}}traffic section{{/a}} of the Jetpack settings page.', {
+								components: {
+									a: (
+										<a
+											href={ `${ adminUrl }/admin.php?page=jetpack#/traffic` }
+											target="_blank"
+											rel="noreferrer"
+										/>
+									),
+								},
+							} ) }
+						</li>
+						<li>{ translate( 'Scroll down to the Blaze section and toggle it to active.' ) }</li>
+					</ol>
+					<p className="empty-promotion-list__body">
+						{ translate(
+							"After completing these steps, you're all set! Return here, refresh the page and start promoting your store with Blaze!"
+						) }
+					</p>
+				</div>
+			</div>
+		</MainWrapper>
+	);
+}

--- a/apps/blaze-dashboard/src/pages/setup/style.scss
+++ b/apps/blaze-dashboard/src/pages/setup/style.scss
@@ -1,0 +1,19 @@
+@import "@automattic/color-studio/dist/color-variables";
+
+.promote-post-i2 {
+	.empty-promotion-list__container.promote-post-i2__setup-container {
+		display: flex;
+		flex-direction: column;
+		margin-top: 40px;
+
+		.promote-post-i2__active-steps {
+			align-self: center;
+			text-align: justify;
+
+			li {
+				font-size: $font-body;
+				color: $studio-gray-50;
+			}
+		}
+	}
+}

--- a/apps/blaze-dashboard/src/styles/promote-widget.scss
+++ b/apps/blaze-dashboard/src/styles/promote-widget.scss
@@ -2,7 +2,8 @@
 div.MuiPopover-root,
 div.MuiPickersPopper-root,
 div.MuiDialog-root,
-div.MuiModal-root {
+div.MuiModal-root,
+div.MuiAutocomplete-popper {
 	z-index: 99999;
 }
 


### PR DESCRIPTION
We are adding a simple setup page to the Blaze dashboard. This page will be used mainly by the Woo Blaze plugin if we notice that Jetpack Blaze is disabled on the site.

![Screenshot 2024-03-01 at 11 14 27](https://github.com/Automattic/wp-calypso/assets/1258162/917ed845-f67d-4939-b6e8-3244d757ddbe)

## Proposed Changes

* Adds a new page in the Dashboard app to inform the user of the steps needed to enable Jetpack Blaze

## Testing Instructions
I will write down the steps to test this using a sandbox. If you don't have a sandbox, I can share a testing method using the Jetpack local environment.

* Connect to your sandbox and verify that you have the latest changes
* Checked out this branch
* Open a console and navigate to `wp-calypso/apps/blaze-dashboard`
* Execute `yarn dev --sync` to start syncing the dashboard to your sandbox
* Change your host file to move traffic from `widgets.wp.com` to your sandbox
* In a browser, go to any jetpack-connected self-hosted site (new or old)
* Go to Tools->Advertising and verify that the Jetpack Blaze Dashboard is working fine (do a small smoke test)
* Change these two lines in the file `apps/blaze-dashboard/src/load-config.js`:
```
const isWooStore = true;
const needSetup = true;
```
* Go to Tools->Advertising
* Verify that you see the dashboard setup page. Verify that the traffic link moves you to the correct jetpack settings page.

Thats it!

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?