### PR TITLE
Stats: add whether site is commercial prop for purchase page view event

### DIFF
--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -159,22 +159,22 @@ const StatsPurchasePage = ( {
 	return (
 		<Main fullWidthLayout>
 			<DocumentHead title={ translate( 'Jetpack Stats' ) } />
-			<PageViewTracker
-				path="/stats/purchase/:site"
-				title="Stats > Purchase"
-				from={ query.from ?? '' }
-				// properties={
-				// 	isTierUpgradeSliderEnabled
-				// 		? {
-				// 				variant:
-				// 					( ! isForceProductRedirect && isCommercial ) || redirectToCommercial
-				// 						? 'commercial'
-				// 						: 'personal',
-				// 				is_upgrade: isCommercialOwned,
-				// 		  }
-				// 		: null
-				// }
-			/>
+			{ ! isLoading && (
+				<PageViewTracker
+					path="/stats/purchase/:site"
+					title="Stats > Purchase"
+					from={ query.from ?? '' }
+					variant={
+						( ! isForceProductRedirect &&
+							( isCommercial || isCommercial === null || isCommercialOwned ) ) ||
+						redirectToCommercial
+							? 'commercial'
+							: 'personal'
+					}
+					is_upgrade={ +supportCommercialUse }
+					is_site_commercial={ isCommercial === null ? '' : +isCommercial }
+				/>
+			) }
 			<div
 				className={ classNames( 'stats', 'stats-purchase-page', {
 					'stats-purchase-page--is-wpcom': isTypeDetectionEnabled && isWPCOMSite,

--- a/client/my-sites/stats/pages/purchase/index.tsx
+++ b/client/my-sites/stats/pages/purchase/index.tsx
@@ -66,6 +66,7 @@ const StatsPurchasePage = ( {
 		isCommercialOwned,
 		supportCommercialUse,
 		isLegacyCommercialLicense,
+		hasLoadedSitePurchases,
 	} = useStatsPurchases( siteId );
 
 	useEffect( () => {
@@ -118,7 +119,11 @@ const StatsPurchasePage = ( {
 	) as ProductsList.RawAPIProduct | null;
 
 	const isLoading =
-		! commercialProduct || ! commercialMonthlyProduct || ! pwywProduct || isRequestingSitePurchases;
+		! commercialProduct ||
+		! commercialMonthlyProduct ||
+		! pwywProduct ||
+		isRequestingSitePurchases ||
+		! hasLoadedSitePurchases;
 
 	const [ initialStep, initialSiteType ] = useMemo( () => {
 		// if the site is detected as commercial
@@ -156,6 +161,26 @@ const StatsPurchasePage = ( {
 	// We show purchase page if there is no plan owned or if we are forcing a product redirect
 	const showPurchasePage = noPlanOwned || isForceProductRedirect || allowCommercialTierUpgrade;
 
+	const variant = useMemo( () => {
+		let pageVariant = 'personal';
+		if ( ! showPurchasePage ) {
+			pageVariant = 'notice';
+		} else if (
+			( ! isForceProductRedirect &&
+				( isCommercial || isCommercial === null || isCommercialOwned ) ) ||
+			redirectToCommercial
+		) {
+			pageVariant = 'commercial';
+		}
+		return pageVariant;
+	}, [
+		showPurchasePage,
+		isCommercial,
+		isCommercialOwned,
+		redirectToCommercial,
+		isForceProductRedirect,
+	] );
+
 	return (
 		<Main fullWidthLayout>
 			<DocumentHead title={ translate( 'Jetpack Stats' ) } />
@@ -164,13 +189,7 @@ const StatsPurchasePage = ( {
 					path="/stats/purchase/:site"
 					title="Stats > Purchase"
 					from={ query.from ?? '' }
-					variant={
-						( ! isForceProductRedirect &&
-							( isCommercial || isCommercial === null || isCommercialOwned ) ) ||
-						redirectToCommercial
-							? 'commercial'
-							: 'personal'
-					}
+					variant={ variant }
 					is_upgrade={ +supportCommercialUse }
 					is_site_commercial={ isCommercial === null ? '' : +isCommercial }
 				/>

--- a/client/my-sites/stats/stats-page-view-tracker/index.tsx
+++ b/client/my-sites/stats/stats-page-view-tracker/index.tsx
@@ -10,6 +10,9 @@ export interface StatsPageViewTrackerProps {
 	properties?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 	options?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
 	from?: string;
+	variant?: string;
+	is_upgrade?: string | number;
+	is_site_commercial?: string | number;
 }
 
 // This component will pass through all properties to PageViewTracker from the analytics library.


### PR DESCRIPTION
Related to #85181 

## Proposed Changes

* Add `is_site_commercial`, `is_upgrade` and `variant` to purchase page view event

## Testing Instructions

* Open Calypso Live Branch
* Inspect network requests
* Open `/stats/purchase/slug.com`
* Filter with `calypso_stats_page_view`
* Ensure you see properties like the following, which reflects the status of the site 

<img width="156" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/92d62a29-b457-467f-9297-bd1441c0dcbf">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?