### PR TITLE
Optionally cancel subscriptions on product deletion

### DIFF
--- a/client/my-sites/earn/memberships/delete-plan-modal.tsx
+++ b/client/my-sites/earn/memberships/delete-plan-modal.tsx
@@ -21,7 +21,7 @@ const RecurringPaymentsPlanDeleteModal = ( {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const dispatch = useDispatch();
-	const [ cancel, setCancel ] = useState( false );
+	const [ cancelSubscriptions, setCancelSubscriptions ] = useState( false );
 
 	const onClose = ( action?: string ) => {
 		if ( action === 'delete' ) {
@@ -30,7 +30,8 @@ const RecurringPaymentsPlanDeleteModal = ( {
 					siteId,
 					product,
 					annualProduct,
-					translate( '"%s" was deleted.', { args: product.title } )
+					translate( '"%s" was deleted.', { args: product.title } ),
+					cancelSubscriptions
 				)
 			);
 		}
@@ -70,7 +71,10 @@ const RecurringPaymentsPlanDeleteModal = ( {
 			</p>
 			<p>
 				<FormLabel htmlFor="toggle">
-					<FormInputCheckbox id="toggle" onClick={ () => setCancel( ! cancel ) } />
+					<FormInputCheckbox
+						id="toggle"
+						onClick={ () => setCancelSubscriptions( ! cancelSubscriptions ) }
+					/>
 					<span>{ translate( 'Cancel the subscription for existing subscribers' ) }</span>
 				</FormLabel>
 			</p>

--- a/client/my-sites/earn/memberships/delete-plan-modal.tsx
+++ b/client/my-sites/earn/memberships/delete-plan-modal.tsx
@@ -1,5 +1,7 @@
-import { Dialog } from '@automattic/components';
+import { Dialog, FormLabel } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import { useDispatch, useSelector } from 'calypso/state';
 import { requestDeleteProduct } from 'calypso/state/memberships/product-list/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -19,6 +21,7 @@ const RecurringPaymentsPlanDeleteModal = ( {
 	const translate = useTranslate();
 	const siteId = useSelector( getSelectedSiteId );
 	const dispatch = useDispatch();
+	const [ cancel, setCancel ] = useState( false );
 
 	const onClose = ( action?: string ) => {
 		if ( action === 'delete' ) {
@@ -34,6 +37,7 @@ const RecurringPaymentsPlanDeleteModal = ( {
 		closeDialog();
 	};
 
+	// Cancel the subscription for existing subscribers
 	return (
 		<Dialog
 			isVisible={ true }
@@ -55,7 +59,7 @@ const RecurringPaymentsPlanDeleteModal = ( {
 			<h1>{ translate( 'Delete offering?' ) }</h1>
 			<p>
 				{ translate(
-					'Deleting this offering ({{strong}}%s{{/strong}}) will not affect existing subscribers, which means they will continue to be charged. You can cancel existing subscriptions on the Supporters screen.',
+					"Deleting this offering ({{strong}}%s{{/strong}}) won't affect existing subscribers, which means they'll continue to be charged. If you want to cancel existing subscriptions altogether, please check the box below.",
 					{
 						args: product?.title,
 						components: {
@@ -63,6 +67,12 @@ const RecurringPaymentsPlanDeleteModal = ( {
 						},
 					}
 				) }
+			</p>
+			<p>
+				<FormLabel htmlFor="toggle">
+					<FormInputCheckbox id="toggle" onClick={ () => setCancel( ! cancel ) } />
+					<span>{ translate( 'Cancel the subscription for existing subscribers' ) }</span>
+				</FormLabel>
 			</p>
 		</Dialog>
 	);

--- a/client/state/memberships/product-list/actions.js
+++ b/client/state/memberships/product-list/actions.js
@@ -126,7 +126,13 @@ export const requestUpdateProduct = ( siteId, product, noticeText ) => {
 	};
 };
 
-export const requestDeleteProduct = ( siteId, product, annualProduct, noticeText ) => {
+export const requestDeleteProduct = (
+	siteId,
+	product,
+	annualProduct,
+	noticeText,
+	cancelSubscriptions
+) => {
 	return ( dispatch ) => {
 		dispatch( {
 			type: MEMBERSHIPS_PRODUCT_DELETE,
@@ -143,20 +149,30 @@ export const requestDeleteProduct = ( siteId, product, annualProduct, noticeText
 		}
 
 		const requests = [
-			wpcom.req.post( {
-				method: 'DELETE',
-				path: `/sites/${ siteId }/memberships/product/${ product.ID }`,
-				apiNamespace: 'wpcom/v2',
-			} ),
+			wpcom.req.post(
+				{
+					method: 'DELETE',
+					path: `/sites/${ siteId }/memberships/product/${ product.ID }`,
+					apiNamespace: 'wpcom/v2',
+				},
+				{
+					cancel_subscriptions: Boolean( cancelSubscriptions ),
+				}
+			),
 		];
 
 		if ( annualProduct ) {
 			requests.push(
-				wpcom.req.post( {
-					method: 'DELETE',
-					path: `/sites/${ siteId }/memberships/product/${ annualProduct.ID }`,
-					apiNamespace: 'wpcom/v2',
-				} )
+				wpcom.req.post(
+					{
+						method: 'DELETE',
+						path: `/sites/${ siteId }/memberships/product/${ annualProduct.ID }`,
+						apiNamespace: 'wpcom/v2',
+					},
+					{
+						cancel_subscriptions: Boolean( cancelSubscriptions ),
+					}
+				)
 			);
 		}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/gold/issues/263

## Proposed Changes

* Updates plan deletion modal to add and explain a new checkbox to cancel subscriptions of the plan
* Passes the checkbox state to the API through a new passed argument

## Testing Instructions

* Enable store sandbox (PCYsg-IA-p2) and point public-api.wordpress.com and subscribe.wordpress.com at your sandbox
* Apply D139715-code
* Apply the Jetpack patch using `~/public_html/bin/jetpack-downloader test jetpack add/product-delete-cancel-subscriptions` (Answer "N" to checking out trunk, "Y" to apply the patch, use `~/public_html/bin/jetpack-downloader reset jetpack` to remove)
* Create a Jurassic Ninja site using the Jetpack PR (https://github.com/Automattic/jetpack/pull/35735 using "Enable WordPress.com Sandbox Access") or with an existing Jetpack site using the `add/product-delete-cancel-subscriptions` branch
* Set `JETPACK__SANDBOX_DOMAIN` in Settings => Jetpack Constants to your sandbox
* Finish setting up Jetpack (free plan is fine)
* Edit plans through https://[calypso.live]/earn/payments/[subdomain].jurassic.ninja
* Create a page with Payment Buttons and the following plans:
    * monthly recurring
    * yearly recurring
    * Two paid newsletter tiers
* Subscribe to all plans, for paid newsletter sign up for one monthly the other as a yearly
* Visit your purchases page on https://[calypso.live]/me/purchases
    * You should see all subscriptions
* Go back to editing your plans using the above URL
* Delete the monthly without checking "Cancel the subscription for existing subscribers"
* Delete the other plans, checking "Cancel the subscription for existing subscribers"
* Visit your purchases page on https://[calypso.live]/me/purchases
    * Monthly should still be there with an expiration date
    * None of the other plans should remain
* You should have received emails about the cancellation of the plans that were removed
* Cancel the one remaining subscription manually (cancel using "Stop [Plan] subscription", don't just disable auto-renew)
* You should receive an email that this subscription has ended

<img width="667" alt="Screenshot 2024-02-13 at 9 54 44 AM" src="https://github.com/Automattic/wp-calypso/assets/38750/a0151e03-e0c4-4cb1-af3e-b96679b739ce">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?