### PR TITLE
Fix casing of 'WordPress hosting'

### DIFF
--- a/client/site-profiler/components/hosting-intro/index.tsx
+++ b/client/site-profiler/components/hosting-intro/index.tsx
@@ -10,7 +10,7 @@ export default function HostingIntro() {
 	return (
 		<div className="l-block-col-2">
 			<div className="l-block-content">
-				<h2>{ translate( 'The best WordPress Hosting on the planet' ) }</h2>
+				<h2>{ translate( 'The best WordPress hosting on the planet' ) }</h2>
 				<p>
 					{ translate(
 						'Whatever you’re building, WordPress.com has everything you need: ' +


### PR DESCRIPTION
See p1709042342831599-slack-C042CJ2NH

## Proposed Changes

Fixes casing of 'WordPress hosting'

### Before

![CleanShot 2024-02-27 at 14 58 47@2x](https://github.com/Automattic/wp-calypso/assets/36432/f6df76f0-e6c2-42a1-91cf-c0de5ae5f7c6)

### After

![CleanShot 2024-02-27 at 14 58 56@2x](https://github.com/Automattic/wp-calypso/assets/36432/61d62f1e-1e9c-43de-81f4-69481c56871e)


## Testing Instructions

N/A
