### PR TITLE
Show Footer Credit setting on the Global Site View

### DIFF
--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -28,7 +28,6 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import SiteLanguagePicker from 'calypso/components/language-picker/site-language-picker';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
-import SitePreviewLink from 'calypso/components/site-preview-link';
 import Timezone from 'calypso/components/timezone';
 import { preventWidows } from 'calypso/lib/formatting';
 import scrollToAnchor from 'calypso/lib/scroll-to-anchor';
@@ -610,49 +609,47 @@ export class SiteSettingsFormGeneral extends Component {
 					urlRef="unlaunched-settings"
 				/>
 				{ ! isWpcomStagingSite && this.giftOptions() }
-				{ ! isWPForTeamsSite &&
-					! ( siteIsJetpack && ! siteIsAtomic ) &&
-					! ( isEnabled( 'layout/dotcom-nav-redesign' ) && isClassicView ) && (
-						<div className="site-settings__footer-credit-container">
-							<SettingsSectionHeader
-								title={ translate( 'Footer credit' ) }
-								id="site-settings__footer-credit-header"
-							/>
-							<CompactCard className="site-settings__footer-credit-explanation">
-								<p>
-									{ preventWidows(
-										translate(
-											'You can customize your website by changing the footer credit in customizer.'
-										),
-										2
-									) }
-								</p>
-								<div>
-									<Button className="site-settings__footer-credit-change" href={ customizerUrl }>
-										{ translate( 'Change footer credit' ) }
-									</Button>
-								</div>
-							</CompactCard>
-							{ ! hasNoWpcomBranding && (
-								<UpsellNudge
-									feature={ WPCOM_FEATURES_NO_WPCOM_BRANDING }
-									plan={ PLAN_BUSINESS }
-									title={ translate(
-										'Remove the footer credit entirely with WordPress.com %(businessPlanName)s',
+				{ ! isWPForTeamsSite && ! ( siteIsJetpack && ! siteIsAtomic ) && (
+					<div className="site-settings__footer-credit-container">
+						<SettingsSectionHeader
+							title={ translate( 'Footer credit' ) }
+							id="site-settings__footer-credit-header"
+						/>
+						<CompactCard className="site-settings__footer-credit-explanation">
+							<p>
+								{ preventWidows(
+									translate(
+										'You can customize your website by changing the footer credit in customizer.'
+									),
+									2
+								) }
+							</p>
+							<div>
+								<Button className="site-settings__footer-credit-change" href={ customizerUrl }>
+									{ translate( 'Change footer credit' ) }
+								</Button>
+							</div>
+						</CompactCard>
+						{ ! hasNoWpcomBranding && (
+							<UpsellNudge
+								feature={ WPCOM_FEATURES_NO_WPCOM_BRANDING }
+								plan={ PLAN_BUSINESS }
+								title={ translate(
+									'Remove the footer credit entirely with WordPress.com %(businessPlanName)s',
 
-										{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
-									) }
-									description={ translate(
-										'Upgrade to remove the footer credit, use advanced SEO tools and more'
-									) }
-									showIcon={ true }
-									event="settings_remove_footer"
-									tracksImpressionName="calypso_upgrade_nudge_impression"
-									tracksClickName="calypso_upgrade_nudge_cta_click"
-								/>
-							) }
-						</div>
-					) }
+									{ args: { businessPlanName: getPlan( PLAN_BUSINESS ).getTitle() } }
+								) }
+								description={ translate(
+									'Upgrade to remove the footer credit, use advanced SEO tools and more'
+								) }
+								showIcon={ true }
+								event="settings_remove_footer"
+								tracksImpressionName="calypso_upgrade_nudge_impression"
+								tracksClickName="calypso_upgrade_nudge_cta_click"
+							/>
+						) }
+					</div>
+				) }
 				{ this.toolbarOption() }
 			</div>
 		);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
- https://github.com/Automattic/dotcom-forge/issues/5778
- https://github.com/Automattic/jetpack/pull/36017
- https://github.com/Automattic/wp-calypso/pull/87709/
- p1708076551278669/1708074040.068309-slack-C06DN6QQVAQ, p1708512753476879/1708511150.525579-slack-C06DN6QQVAQ
- https://github.com/Automattic/wp-calypso/pull/60734

## Proposed Changes

This PR changes to show the “Footer Credit” section to the Site Setting page when the Global Site View is enabled. 

<img width="1432" alt="Screenshot 2024-02-29 at 10 22 09" src="https://github.com/Automattic/wp-calypso/assets/5287479/79c01c5f-966b-4d60-85eb-bfc8e14defb9">

We're hiding the Customizer menu in https://github.com/Automattic/jetpack/pull/36017. Since changing the Footer Credit can only be done in the Customizer currently (c.f., p58i-f7m-p2), hiding the Customizer menu gives users no way to get there. The Footer Credit Setting was removed for the Global Site View in https://github.com/Automattic/wp-calypso/pull/87709, so this PR brings that back. 

This Footer Credit section could be "interim" --- it can be removed after implementing the Footer Credit feature outside of the Customizer. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live
* Prepare a site with the classic view
* Go to `/settings/general/<your-site>`
* See the setting is displayed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?