### PR TITLE
Update Woo passwordless signup UI & copy

### DIFF
--- a/client/blocks/authentication/social/social-tos.jsx
+++ b/client/blocks/authentication/social/social-tos.jsx
@@ -1,9 +1,7 @@
 import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { connect } from 'react-redux';
-import { isWooOAuth2Client } from 'calypso/lib/oauth2-clients';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
-import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 
 const toSLinks = {
 	components: {
@@ -29,29 +27,14 @@ function getToSComponent( content ) {
 }
 
 function SocialAuthToS( props ) {
-	let content = props.translate(
-		'If you continue with Google or Apple, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
+	const content = props.translate(
+		'If you continue with Google, Apple or GitHub, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
 		toSLinks
 	);
-
-	if ( props.isWooCoreProfilerFlow ) {
-		content = props.translate(
-			'If you continue with Google or Apple, you agree to our {{tosLink}}Terms of Service{{/tosLink}}, and have read our {{privacyLink}}Privacy Policy{{/privacyLink}}.',
-			toSLinks
-		);
-	}
-
-	if ( isWooOAuth2Client( props.oauth2Client ) ) {
-		content = props.translate(
-			"If you continue with Google or Apple and don't already have a WordPress.com account, you are creating an account and you agree to our {{tosLink}}Terms of Service{{/tosLink}}.",
-			toSLinks
-		);
-	}
 
 	return getToSComponent( content );
 }
 
 export default connect( ( state ) => ( {
 	oauth2Client: getCurrentOAuth2Client( state ),
-	isWooCoreProfilerFlow: isWooCommerceCoreProfilerFlow( state ),
 } ) )( localize( SocialAuthToS ) );

--- a/client/blocks/signup-form/index.jsx
+++ b/client/blocks/signup-form/index.jsx
@@ -2,6 +2,7 @@ import config from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { Button, FormInputValidation, FormLabel } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
+import { Spinner } from '@wordpress/components';
 import classNames from 'classnames';
 import debugModule from 'debug';
 import { localize } from 'i18n-calypso';
@@ -22,7 +23,7 @@ import {
 	isEmpty,
 } from 'lodash';
 import PropTypes from 'prop-types';
-import { Component, useEffect, Fragment } from 'react';
+import { Component, useEffect } from 'react';
 import { connect } from 'react-redux';
 import { FormDivider } from 'calypso/blocks/authentication';
 import ContinueAsUser from 'calypso/blocks/login/continue-as-user';
@@ -1230,20 +1231,33 @@ class SignupForm extends Component {
 		const isGravatar = this.props.isGravatar;
 		const emailErrorMessage = this.getErrorMessagesWithLogin( 'email' );
 		const showSeparator =
-			! config.isEnabled( 'desktop' ) && this.isHorizontal() && ! this.userCreationComplete();
+			( ! config.isEnabled( 'desktop' ) && this.isHorizontal() && ! this.userCreationComplete() ) ||
+			this.props.isWoo;
 
 		if (
 			( this.props.isPasswordless &&
 				( 'wpcc' !== this.props.flowName || this.props.wooPasswordless ) ) ||
 			isGravatar
 		) {
-			const gravatarProps = isGravatar
-				? {
+			let formProps = {
+				submitButtonLabel: this.props.submitButtonLabel,
+			};
+
+			switch ( true ) {
+				case isGravatar:
+					formProps = {
 						inputPlaceholder: this.props.translate( 'Enter your email address' ),
 						submitButtonLabel: this.props.translate( 'Continue' ),
 						submitButtonLoadingLabel: this.props.translate( 'Continue' ),
-				  }
-				: {};
+					};
+					break;
+				case this.props.isWoo:
+					formProps = {
+						inputPlaceholder: null,
+						submitButtonLabel: this.props.translate( 'Continue with email' ),
+						submitButtonLoadingLabel: <Spinner />,
+					};
+			}
 
 			return (
 				<div
@@ -1264,12 +1278,11 @@ class SignupForm extends Component {
 						disableSubmitButton={ this.props.disableSubmitButton || emailErrorMessage }
 						queryArgs={ this.props.queryArgs }
 						userEmail={ this.getEmailValue() }
-						{ ...gravatarProps }
-						submitButtonLabel={ this.props.submitButtonLabel }
 						isInviteLoggedOutForm={ this.props.isInviteLoggedOutForm }
 						labelText={ this.props.labelText }
 						onInputBlur={ this.handleBlur }
 						onInputChange={ this.handleChangeEvent }
+						{ ...formProps }
 					>
 						{ emailErrorMessage && (
 							<ValidationFieldset errorMessages={ [ emailErrorMessage ] }></ValidationFieldset>
@@ -1287,6 +1300,7 @@ class SignupForm extends Component {
 									socialServiceResponse={ this.props.socialServiceResponse }
 									isReskinned={ this.props.isReskinned }
 									redirectToAfterLoginUrl={ this.props.redirectToAfterLoginUrl }
+									compact={ this.props.isWoo }
 								/>
 							) }
 							{ this.props.footerLink || this.footerLink() }
@@ -1317,18 +1331,15 @@ class SignupForm extends Component {
 				{ showSeparator && <FormDivider /> }
 
 				{ this.props.isSocialSignupEnabled && ! this.userCreationComplete() && (
-					<Fragment>
-						{ this.props.isWoo && <FormDivider /> }
-						<SocialSignupForm
-							handleResponse={ this.props.handleSocialResponse }
-							socialService={ this.props.socialService }
-							socialServiceResponse={ this.props.socialServiceResponse }
-							isReskinned={ this.props.isReskinned }
-							flowName={ this.props.flowName }
-							compact={ this.props.isWoo }
-							redirectToAfterLoginUrl={ this.props.redirectToAfterLoginUrl }
-						/>
-					</Fragment>
+					<SocialSignupForm
+						handleResponse={ this.props.handleSocialResponse }
+						socialService={ this.props.socialService }
+						socialServiceResponse={ this.props.socialServiceResponse }
+						isReskinned={ this.props.isReskinned }
+						flowName={ this.props.flowName }
+						compact={ this.props.isWoo }
+						redirectToAfterLoginUrl={ this.props.redirectToAfterLoginUrl }
+					/>
 				) }
 
 				{ this.props.footerLink || this.footerLink() }

--- a/client/blocks/signup-form/signup-form-social-first.tsx
+++ b/client/blocks/signup-form/signup-form-social-first.tsx
@@ -89,7 +89,7 @@ const SignupFormSocialFirst = ( {
 		} else if ( currentStep === 'initial' ) {
 			tosText = createInterpolateElement(
 				__(
-					'If you continue with Google or Apple, you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
+					'If you continue with Google, Apple or GitHub, you agree to our <tosLink>Terms of Service</tosLink> and have read our <privacyLink>Privacy Policy</privacyLink>.'
 				),
 				options
 			);

--- a/client/jetpack-connect/test/__snapshots__/signup.js.snap
+++ b/client/jetpack-connect/test/__snapshots__/signup.js.snap
@@ -242,7 +242,7 @@ exports[`JetpackSignup should render 1`] = `
             <p
               class="auth-form__social-buttons-tos"
             >
-              If you continue with Google or Apple, you agree to our 
+              If you continue with Google, Apple or GitHub, you agree to our 
               <a
                 href="https://wordpress.com/tos/"
                 rel="noopener noreferrer"
@@ -540,7 +540,7 @@ exports[`JetpackSignup should render with locale suggestions 1`] = `
             <p
               class="auth-form__social-buttons-tos"
             >
-              If you continue with Google or Apple, you agree to our 
+              If you continue with Google, Apple or GitHub, you agree to our 
               <a
                 href="https://wordpress.com/tos/"
                 rel="noopener noreferrer"

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -11,8 +11,8 @@
 	$woo-gray-40: #787c82;
 	$woo-font-size-small: $font-body-extra-small;
 	$woo-font-size-base: $font-body-small;
-	$woo-font-size-input: $font-body-small;
-	$woo-radius-input: 4px;
+	$woo-font-size-input: $font-body;
+	$woo-radius-input: 8px;
 	$woo-form-whitespace: 60px;
 	$woo-form-whitespace-660: 20px;
 	$woo-form-divider-border: 1px solid #e6e6e6;
@@ -38,24 +38,28 @@
 	input[type="tel"].form-text-input,
 	textarea.form-text-input {
 		background-color: #fff;
-		border: 1px solid #c3c4c7;
 		border-radius: $woo-radius-input;
 		box-sizing: border-box;
-		color: $woo-gray-100;
-		padding: 12px 16px;
-		transition: all ease-in-out 0.2s;
-		width: 100%;
-		font-weight: 400;
+		border: 2px solid var(--studio-gray-10);
+		height: 48px;
+		padding: 8px 16px;
 		font-size: $woo-font-size-input;
-		line-height: 18px;
+		font-style: normal;
+		font-weight: 400;
+		line-height: 24px;
 		margin-bottom: 16px;
 
 		&:focus,
 		&:hover,
 		&:focus:hover {
-			border-color: $woo-purple-50;
 			outline: none;
-			box-shadow: 0 0 0 2px #e5cfe8;
+			border: 2px solid $woo-purple-50;
+			box-shadow: none;
+		}
+
+		&:disabled {
+			border: 2px solid var(--studio-gray-5);
+			background: var(--studio-gray-0);
 		}
 	}
 
@@ -116,6 +120,21 @@
 		&:disabled {
 			background-color: var(--studio-gray-0);
 			color: var(--studio-gray-20);
+		}
+	}
+
+	.validation-fieldset {
+		.validation-fieldset__validation-message p {
+			font-size: rem(14px);
+			font-style: normal;
+			font-weight: 400;
+			line-height: 21px;
+		}
+
+		&:has(.is-error) {
+			input {
+				border: 2px solid  #e26f56;
+			}
 		}
 	}
 
@@ -303,6 +322,20 @@
 		text-align: left;
 	}
 
+	.form-input-validation.is-error {
+		color: #8a2424;
+		font-size: rem(14px);
+		font-style: normal;
+		font-weight: 400;
+		line-height: 21px;
+		padding: 0;
+		margin-top: 8px;
+
+		svg {
+			display: none;
+		}
+	}
+
 
 	.jetpack-connect__logged-in-form .formatted-header,
 	.jetpack-connect__authorize-form .formatted-header,
@@ -338,13 +371,15 @@
 		font-weight: 400;
 		line-height: 27px;
 		letter-spacing: -0.025px;
-		-webkit-font-smoothing: subpixel-antialiased;
 
 		a {
-			color: $woo-purple-70;
-			font-weight: 400;
-			font-size: 1rem;
+			color: $woo-purple-50;
+			font-size: rem(18px);
 			text-decoration: none;
+			font-style: normal;
+			font-weight: 500;
+			line-height: 27px;
+			letter-spacing: -0.025px;
 
 			&:hover {
 				color: $woo-purple-40;
@@ -537,9 +572,11 @@
 		}
 	}
 
+	.is-woo-passwordless .signup-form,
 	.login__body--continue-as-user {
 		width: 100%;
 		margin: 48px auto 0;
+		padding: 0;
 		max-width: 327px;
 		display: flex;
 		flex-direction: column;
@@ -559,7 +596,7 @@
 					gap: 16px;
 				}
 
-				button.social-buttons__button.button {
+				.social-buttons__button.button {
 					display: flex;
 					height: 48px;
 					padding: 8px 16px;
@@ -570,6 +607,10 @@
 					border: 2px solid var(--studio-gray-10);
 					width: 100%;
 					margin: 0;
+
+					&:hover {
+						background: var(--studio-gray-0, #f6f7f7);
+					}
 				}
 
 				.social-buttons__service-name {
@@ -597,10 +638,10 @@
 					}
 				}
 			}
-		}
 
-		.auth-form__social-buttons-tos {
-			display: none;
+			.auth-form__social-buttons-tos {
+				margin-top: 32px;
+			}
 		}
 	}
 
@@ -889,6 +930,55 @@
 		color: var(--color-primary);
 	}
 
+	.is-woo-passwordless {
+		.signup-form {
+			input[type="email"].form-text-input {
+				margin-bottom: 0;
+			}
+
+			.signup-form__passwordless-form-wrapper .logged-out-form__footer {
+				padding: 0;
+				margin-top: 24px;
+			}
+		}
+
+		.logged-out-form {
+			padding: 0;
+			margin: 0;
+
+			label.form-label {
+				color: var(--color-gray-100);
+				font-size: 1rem;
+				font-style: normal;
+				font-weight: 600;
+				line-height: 24px;
+				margin-bottom: 16px;
+			}
+		}
+
+		.auth-form__separator + .auth-form__social.card {
+			border: 0;
+			padding: 0;
+		}
+
+		.formatted-header__title {
+			@media screen and ( max-width: 660px ) {
+				padding: 0;
+				max-width: 327px;
+				margin: 0 auto 16px;
+			}
+		}
+
+		.formatted-header__subtitle {
+			@media screen and ( max-width: 660px ) {
+				padding: 0;
+				max-width: 327px;
+				margin: 0 auto;
+				width: 100%;
+			}
+		}
+	}
+
 	&.is-woocommerce-core-profiler-flow {
 		background: #fff;
 
@@ -985,6 +1075,7 @@
 		.login__header-subtitle,
 		.formatted-header__subtitle {
 			color: $gray-700;
+			-webkit-font-smoothing: subpixel-antialiased;
 
 			@media screen and ( max-width: 660px ) {
 				width: auto;

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -123,21 +123,6 @@
 		}
 	}
 
-	.validation-fieldset {
-		.validation-fieldset__validation-message p {
-			font-size: rem(14px);
-			font-style: normal;
-			font-weight: 400;
-			line-height: 21px;
-		}
-
-		&:has(.is-error) {
-			input {
-				border: 2px solid  #e26f56;
-			}
-		}
-	}
-
 	button {
 		background-color: initial;
 	}
@@ -328,7 +313,7 @@
 		font-style: normal;
 		font-weight: 400;
 		line-height: 21px;
-		padding: 0;
+		padding: 0 24px 11px 0;
 		margin-top: 8px;
 
 		svg {
@@ -336,6 +321,13 @@
 		}
 	}
 
+	.validation-fieldset {
+		&:has(.is-error) {
+			input {
+				border: 2px solid  #e26f56;
+			}
+		}
+	}
 
 	.jetpack-connect__logged-in-form .formatted-header,
 	.jetpack-connect__authorize-form .formatted-header,

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -209,7 +209,7 @@ export class UserStep extends Component {
 						break;
 					case 'nux':
 						subHeaderText = translate(
-							'All Woo Express stores are powered by WordPress.com.{{br/}}Please create an account to continue. Already registered? {{a}}Log in{{/a}}',
+							'All Woo Express stores are powered by WordPress.com. Please create an account to continue. Already registered? {{a}}Log in{{/a}}',
 							{
 								components: {
 									a: <a href={ loginUrl } />,
@@ -486,7 +486,7 @@ export class UserStep extends Component {
 
 			return (
 				<div className={ classNames( 'signup-form__woo-wrapper' ) }>
-					<h3>{ translate( "Let's get started" ) }</h3>
+					<h3>{ translate( 'Create an account' ) }</h3>
 				</div>
 			);
 		}
@@ -605,6 +605,7 @@ export class UserStep extends Component {
 					isReskinned={ isReskinned }
 					shouldDisplayUserExistsError={ ! isWooOAuth2Client( oauth2Client ) }
 					isSocialFirst={ this.props.isSocialFirst }
+					labelText={ this.props.wooPasswordless ? this.props.translate( 'Your email' ) : null }
 				/>
 				<div id="g-recaptcha"></div>
 			</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Close https://github.com/Automattic/wp-calypso/issues/87627

## Proposed Changes

1. Update Woo Passwordless signup flow to match the design in the Figma file.
2. Update the input component to match new Woo.com design system. 4ixWMlzrxllx93tSFsCW6k-fi-9483%3A4707
3. Update social auth TOS since Github has been added.
4. Update heading from `Let's get started` to `Create an account`

Default state:

![Screenshot 2024-02-28 at 17 11 39](https://github.com/Automattic/wp-calypso/assets/4344253/22a4bad0-60a0-48b0-a3d7-9da9b7c4e8d6)

Error state:

![Screenshot 2024-02-28 at 17 11 27](https://github.com/Automattic/wp-calypso/assets/4344253/bdb0e513-91cf-4122-8366-8c282c4eeb76)

Loading state:

![Screenshot 2024-02-28 at 17 12 04](https://github.com/Automattic/wp-calypso/assets/4344253/02ae12f4-59f4-4454-bd2a-f87aa0717539)

Mobile View (Design is no available but just following the same pattern in previous designs)

<img src="https://github.com/Automattic/wp-calypso/assets/4344253/c0a7865f-fced-4779-a67f-266337385191" width="300px" />


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Set up the `woocommerce-start-dev-env`, spin up this https://github.com/Automattic/woocommerce.com/pull/19759 to test the coordinated `woo-passwordless` flow without having to modify the URL.

Log out of your WP.com and Woo.com or Use incognito mode to test sign-up flow.

#### Passwordless Signup

1. Observe that the passwordless link shows the sign up screen without a password field and matches the design in the Figma file except for TOS which I think it's necessary but not included in the design.
2. Enter an invalid email and observe the error message that appears.
3. Confirm error message style matches the design
5. Enter a valid email and click on "Continue with email"
6. Observe that your account is created and you are redirected to the next step in the flow.

#### Non-Passwordless Signup

* [Non-passwordless signup link](https://wordpress.com/start/wpcc/oauth2-user?ref=oauth2&oauth2_redirect=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50019%26state%3D322bf51766a1dd76fb52f57ffa81f6a5c886b3a0b51afc54afa5e52f880648e4%26redirect_uri%3Dhttps%253A%252F%252Fwoocommerce.test%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252Fstart%25252F%252523%25252Finstallation%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%3Dnux%26calypso_env%3Dproduction%26jetpack-code%26jetpack-user-id%3D0%26action%3Doauth2-login%26from-calypso%3D1&oauth2_client_id=50019) 


1. Observe that the non-passwordless link shows the sign up screen with a password field as before
2. Observe that except for headings, input, button, and error message styles, nothing else has changed in the non-passwordless flow.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?