### PR TITLE
Adding "reset" as incompatible plugin

### DIFF
--- a/client/my-sites/plugins/plugin-compatibility.js
+++ b/client/my-sites/plugins/plugin-compatibility.js
@@ -24,6 +24,7 @@ const incompatiblePlugins = new Set( [
 	'plugins-garbage-collector',
 	'post-type-switcher',
 	'reset-wp',
+	'reset',
 	'secure-file-manager',
 	'ultimate-reset',
 	'ultimate-wp-reset',


### PR DESCRIPTION
Related to p9F6qB-eqZ-p2

## Proposed Changes

* Add "reset" to the incompatible plugins list

## Testing Instructions

1. Create a new Business site, mark it as a WoA Dev site, and take it Atomic.
2. Try to install https://wordpress.org/plugins/reset/ to the site