### PR TITLE
Renovate: Temporarily ignore @wordpress/dataviews

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -77,7 +77,12 @@
 			enabled: false,
 		},
 	],
-	ignoreDeps: [ 'electron-builder' ],
+	ignoreDeps: [
+		'electron-builder',
+		// We're intentionally locking to v0.4.1, see https://github.com/Automattic/wp-calypso/pull/87956
+		// @TODO: Remove once updated to use the latest version
+		'@wordpress/dataviews',
+	],
 	regexManagers: [
 		// Update the renovate-version in the action itself.
 		// See also https://github.com/renovatebot/github-action/issues/756


### PR DESCRIPTION
## Proposed Changes

This PR suggests that we temporarily ignore `@wordpress/dataviews` with Renovate. 

Context: https://github.com/Automattic/wp-calypso/pull/87956

Without this, renovate will still try to keep it up to date: https://github.com/Automattic/wp-calypso/pull/87971