### PR TITLE
Automattic for Agencies: Implement redirect to LP Page in Production

### DIFF
--- a/client/a8c-for-agencies/controller.tsx
+++ b/client/a8c-for-agencies/controller.tsx
@@ -1,5 +1,12 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page, { type Callback } from '@automattic/calypso-router';
 
 export const redirectToOverviewContext: Callback = () => {
-	page( '/overview' );
+	const isA4AEnabled = isEnabled( 'a8c-for-agencies' );
+	if ( isA4AEnabled ) {
+		page( '/overview' );
+		return;
+	}
+	window.location.href = 'https://automattic.com/for/agencies';
+	return;
 };

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -14,7 +14,7 @@
 	},
 	"enable_all_sections": false,
 	"sections": {
-		"a8c-for-agencies": false
+		"a8c-for-agencies": true
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",

--- a/config/a8c-for-agencies-production.json
+++ b/config/a8c-for-agencies-production.json
@@ -9,12 +9,12 @@
 	"site_name": "Automattic For Agencies",
 	"oauth_client_id": 95932,
 	"features": {
-		"a8c-for-agencies": true,
-		"oauth": true
+		"a8c-for-agencies": false,
+		"oauth": false
 	},
 	"enable_all_sections": false,
 	"sections": {
-		"a8c-for-agencies": true
+		"a8c-for-agencies": false
 	},
 	"site_filter": [],
 	"theme": "a8c-for-agencies",


### PR DESCRIPTION
## Proposed Changes

This PR implements redirection to the LP Page (https://automattic.com/for/agencies) when visiting the A4A page in the production environment. 

## Testing Instructions

- Switch to the branch `git checkout update/redirect-prod-to-a4a-lp-page`.
- Start the server by running `yarn start-a8c-for-agencies`.
- Open http://agencies.localhost:3000/ and verify that you are redirected to the `/overview` page.
- Set `a8c-for-agencies` and `oauth` in the `features` node in the`a8c-for-agencies-development.json` file to `false` > Restart the server > Open http://agencies.localhost:3000/ in incognito again and verify that are redirect to https://automattic.com/for/agencies. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?