### PR TITLE
Help Center: Disable GPT response across all environments

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/config.js
@@ -40,7 +40,7 @@ window.configData = {
 	is_running_in_jetpack_site: false,
 	gutenboarding_url: '/new',
 	features: {
-		'help/gpt-response': true,
+		'help/gpt-response': false,
 	},
 	signup_url: '/',
 	wapuu: false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -48,7 +48,7 @@
 		"cookie-banner": false,
 		"google-my-business": true,
 		"help": true,
-		"help/gpt-response": true,
+		"help/gpt-response": false,
 		"i18n/empathy-mode": true,
 		"importer/site-backups": true,
 		"importer/unified": true,


### PR DESCRIPTION
Follow-up to #87964, which disabled this in production. However, there's a separate feature flag for the Editing Toolkit plugin. And, to make it less confusing for internal users, let's consistently disable it for staging environment as well.


## Proposed Changes

* Disable GPT response in staging and ETK.

## Testing Instructions

* For staging env, easiest would be to test if toggling this flag for dev environment does the same thing.
* For ETK, follow the testing instructions on the FieldGuide.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
