### PR TITLE
Notifications: Allow min-width to be set dynamically

### DIFF
--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -1,6 +1,49 @@
-$min_page_width: 800px; // Default min-width
-.is-global-sidebar-visible .wpnc__main {
-	$min_page_width: 1114px; // Override min-width if .is-global-sidebar-visible is present
+$no-sidebar-min-page-width: 800px;
+$with-sidebar-min-page-width: 1114px;
+
+@mixin setToggleNoteBehaviour {
+	.wpnc__list-view.wpnc__current {
+		display: block;
+
+		.wpnc__selected-note {
+			animation-name: wpnc__selectIn;
+			animation-timing-function: ease-in;
+			animation-duration: 0.4s;
+			animation-iteration-count: 1;
+		}
+
+		box-shadow: none;
+	}
+
+	.wpnc__note-list {
+		left: auto;
+		width: 410px;
+	}
+
+	.wpnc__single-view {
+		right: 410px;
+		left: 10px;
+		top: 0;
+		bottom: 0;
+		z-index: -1;
+
+		header {
+			nav {
+				display: none;
+			}
+		}
+
+		.wpnc__note {
+			margin-top: 0;
+		}
+
+		-webkit-transform: translate3d(0, 0, 0); // fix for getting scrollbar in right z-index
+		animation-name: wpnc__slideIn;
+		animation-timing-function: ease-out;
+		animation-fill-mode: forwards;
+		animation-duration: 0.2s;
+		animation-iteration-count: 1;
+	}
 }
 
 .wpnc {
@@ -900,48 +943,17 @@ $min_page_width: 800px; // Default min-width
 		padding: $wpnc__padding-large $wpnc__padding-medium 0;
 	}
 
-	@media only screen and ( min-width: #{$min_page_width} ) {
-		.wpnc__list-view.wpnc__current {
-			display: block;
-
-			.wpnc__selected-note {
-				animation-name: wpnc__selectIn;
-				animation-timing-function: ease-in;
-				animation-duration: 0.4s;
-				animation-iteration-count: 1;
-			}
-
-			box-shadow: none;
+	// Check if global-sidebar-visible not present
+	&:not(.global-sidebar-visible) {
+		@media only screen and ( min-width: $no-sidebar-min-page-width ) {
+			@include setToggleNoteBehaviour;
 		}
+	}
 
-		.wpnc__note-list {
-			left: auto;
-			width: 410px;
-		}
-
-		.wpnc__single-view {
-			right: 410px;
-			left: 10px;
-			top: 0;
-			bottom: 0;
-			z-index: -1;
-
-			header {
-				nav {
-					display: none;
-				}
-			}
-
-			.wpnc__note {
-				margin-top: 0;
-			}
-
-			-webkit-transform: translate3d(0, 0, 0); // fix for getting scrollbar in right z-index
-			animation-name: wpnc__slideIn;
-			animation-timing-function: ease-out;
-			animation-fill-mode: forwards;
-			animation-duration: 0.2s;
-			animation-iteration-count: 1;
+	// Override the CSS variable value if .global-sidebar-visible is present
+	&.global-sidebar-visible {
+		@media only screen and ( min-width: $with-sidebar-min-page-width ) {
+			@include setToggleNoteBehaviour;
 		}
 	}
 

--- a/apps/notifications/src/panel/boot/stylesheets/main.scss
+++ b/apps/notifications/src/panel/boot/stylesheets/main.scss
@@ -1,3 +1,8 @@
+$min_page_width: 800px; // Default min-width
+.is-global-sidebar-visible .wpnc__main {
+	$min_page_width: 1114px; // Override min-width if .is-global-sidebar-visible is present
+}
+
 .wpnc {
 	margin: 0;
 }
@@ -895,7 +900,7 @@
 		padding: $wpnc__padding-large $wpnc__padding-medium 0;
 	}
 
-	@media only screen and ( min-width: 800px ) {
+	@media only screen and ( min-width: #{$min_page_width} ) {
 		.wpnc__list-view.wpnc__current {
 			display: block;
 

--- a/client/layout/global-sidebar/menu-items/notifications/index.jsx
+++ b/client/layout/global-sidebar/menu-items/notifications/index.jsx
@@ -134,6 +134,7 @@ class SidebarNotifications extends Component {
 						isShowing={ this.props.isNotificationsOpen }
 						checkToggle={ this.checkToggleNotes }
 						setIndicator={ this.setNotesIndicator }
+						isGlobalSidebarVisible={ true }
 						placeholder={ null }
 					/>
 				</div>

--- a/client/notifications/index.jsx
+++ b/client/notifications/index.jsx
@@ -259,6 +259,7 @@ export class Notifications extends Component {
 				className={ classNames( 'wide', 'wpnc__main', {
 					'wpnt-open': this.props.isShowing,
 					'wpnt-closed': ! this.props.isShowing,
+					'global-sidebar-visible': this.props.isGlobalSidebarVisible ?? false,
 				} ) }
 			>
 				<NotificationsPanel

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -1,6 +1,11 @@
 /**
  * Notifications
  */
+//
+$min_page_width: 800px; // Default min-width
+.is-global-sidebar-visible #wpnc-panel {
+	$min_page_width: 1114px; // Override min-width if .is-global-sidebar-visible is present
+}
 
 #wpnc-panel {
 	position: fixed;
@@ -110,13 +115,13 @@
 		left: inherit;
 		width: 400px;
 
-		@include breakpoint-deprecated( "<800px" ) {
+		@include breakpoint-deprecated( $min_page_width ) {
 			left: 0;
 			width: auto;
 		}
 	}
 
-	@include breakpoint-deprecated( "<800px" ) {
+	@include breakpoint-deprecated( $min_page_width ) {
 		&.wpnc__main header {
 			top: 47px;
 		}
@@ -216,7 +221,7 @@ div.reader-notifications__panel {
 		}
 	}
 }
-@media only screen and (max-width: 783px) {
+@media only screen and (max-width: calc(#{$min_page_width} - 17px) ) {
 	div.reader-notifications__panel #wpnc-panel.wpnc__main {
 		&.wpnt-open {
 			left: 0;

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -1,11 +1,6 @@
 /**
  * Notifications
  */
-//
-$min_page_width: 800px; // Default min-width
-.is-global-sidebar-visible #wpnc-panel {
-	$min_page_width: 1114px; // Override min-width if .is-global-sidebar-visible is present
-}
 
 #wpnc-panel {
 	position: fixed;
@@ -115,13 +110,13 @@ $min_page_width: 800px; // Default min-width
 		left: inherit;
 		width: 400px;
 
-		@include breakpoint-deprecated( $min_page_width ) {
+		@include breakpoint-deprecated( "<800px" ) {
 			left: 0;
 			width: auto;
 		}
 	}
 
-	@include breakpoint-deprecated( $min_page_width ) {
+	@include breakpoint-deprecated( "<800px" ) {
 		&.wpnc__main header {
 			top: 47px;
 		}
@@ -221,7 +216,7 @@ div.reader-notifications__panel {
 		}
 	}
 }
-@media only screen and (max-width: calc(#{$min_page_width} - 17px) ) {
+@media only screen and (max-width: 783px) {
 	div.reader-notifications__panel #wpnc-panel.wpnc__main {
 		&.wpnt-open {
 			left: 0;


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5796

The issue centers around how the notification component decides on when to slide out/open a note and when it decides to not slide out, but instead overlap the note list with the note summary.

This is based on the min-width that the component is working with.

It basically defaults to overlapping the note summary on top of the note list when a note has been clicked.
If the page is wider than 800px, the `main.css` sets CSS to slide out the note as it assumes it has room to do so.

The issue is that when the global sidebar is on the page, it overlaps the sidebar.

To avoid this, we need to increase the min-width in the `main.css` to account for the global sidebar width -> 800px + 314px = 1114px.

I tried and failed to find a simpler way to do this but from trial and error this is how I got things to work.

This PR adds a `isGlobalSidebarVisible` prop to the notification component. If set, this will add a `global-sidebar-visible` class to the `wpnc-panel` container. This will allow us to handle the CSS difference in the `main.css` file.

We can now change the slideout behaviour depending on when the `isGlobalSidebarVisible ` is set.

### Before

https://github.com/Automattic/wp-calypso/assets/5560595/20151a81-3653-4a55-803d-419b513fcbc0

### After

https://github.com/Automattic/wp-calypso/assets/5560595/2aae6d48-5f6a-4a82-8e3d-bbe7f7a8248d

## Testing Instructions
- Start this branch on your local calypso.
- Open http://calypso.localhost:3000/
- Click on the bell icon on the top right of the page.
- Change the screen resolution/size and confirm that the slide out/open note is displayed as you would expect


