### PR TITLE
Migration flow: Add new success migration screen

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -237,11 +237,10 @@ export class ImportEverything extends SectionMigrate {
 	}
 
 	renderMigrationSuccessScreen() {
-		const { translate, targetSite, recordTracksEvent } = this.props;
+		const { targetSite, recordTracksEvent } = this.props;
 		return (
 			<div className="import__heading import__heading-center migration-success">
 				<AsyncLoad
-					translate={ translate }
 					targetSite={ targetSite }
 					recordTracksEvent={ recordTracksEvent }
 					require="./migration-success"

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -9,6 +9,7 @@ import { localize } from 'i18n-calypso';
 import { get } from 'lodash';
 import { connect } from 'react-redux';
 import PreMigrationScreen from 'calypso/blocks/importer/wordpress/import-everything/pre-migration';
+import AsyncLoad from 'calypso/components/async-load';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import { EVERY_FIVE_SECONDS, Interval } from 'calypso/lib/interval';
 import { SectionMigrate } from 'calypso/my-sites/migrate/section-migrate';
@@ -212,12 +213,10 @@ export class ImportEverything extends SectionMigrate {
 
 	renderMigrationComplete() {
 		const { isMigrateFromWp } = this.props;
-		return (
-			<Hooray>
-				{ ! isMigrateFromWp
-					? this.renderDefaultHoorayScreen()
-					: this.renderHoorayScreenWithDomainInfo() }
-			</Hooray>
+		return ! isMigrateFromWp ? (
+			this.renderMigrationSuccessScreen()
+		) : (
+			<Hooray>{ this.renderHoorayScreenWithDomainInfo() }</Hooray>
 		);
 	}
 
@@ -239,21 +238,15 @@ export class ImportEverything extends SectionMigrate {
 		);
 	}
 
-	renderDefaultHoorayScreen() {
-		const { translate, stepNavigator } = this.props;
-
+	renderMigrationSuccessScreen() {
+		const { translate, targetSite, recordTracksEvent } = this.props;
 		return (
-			<div className="import__heading import__heading-center">
-				<Title>{ translate( 'Hooray!' ) }</Title>
-				<SubTitle>
-					{ translate( 'Congratulations. Your content was successfully imported.' ) }
-				</SubTitle>
-				<DoneButton
-					label={ translate( 'View site' ) }
-					onSiteViewClick={ () => {
-						this.props.recordTracksEvent( 'calypso_site_importer_view_site' );
-						stepNavigator?.goToSiteViewPage?.();
-					} }
+			<div className="import__heading import__heading-center migration-success">
+				<AsyncLoad
+					translate={ translate }
+					targetSite={ targetSite }
+					recordTracksEvent={ recordTracksEvent }
+					require="./migration-success"
 				/>
 			</div>
 		);

--- a/client/blocks/importer/wordpress/import-everything/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/index.tsx
@@ -213,11 +213,9 @@ export class ImportEverything extends SectionMigrate {
 
 	renderMigrationComplete() {
 		const { isMigrateFromWp } = this.props;
-		return ! isMigrateFromWp ? (
-			this.renderMigrationSuccessScreen()
-		) : (
-			<Hooray>{ this.renderHoorayScreenWithDomainInfo() }</Hooray>
-		);
+		return ! isMigrateFromWp
+			? this.renderMigrationSuccessScreen()
+			: this.renderHoorayScreenWithDomainInfo();
 	}
 
 	renderMigrationError( status: MigrationStatusError | null = null ) {
@@ -255,35 +253,37 @@ export class ImportEverything extends SectionMigrate {
 	renderHoorayScreenWithDomainInfo() {
 		const { translate, stepNavigator, targetSite } = this.props;
 		return (
-			<div className="import__heading import__heading-center">
-				<Title>{ translate( "Migration done! You're all set!" ) }</Title>
-				<SubTitle>
-					{ createInterpolateElement(
-						translate(
-							'You have a temporary domain name on WordPress.com.<br />We recommend updating your domain name.'
-						),
-						{ br: createElement( 'br' ) }
-					) }
-				</SubTitle>
-				<DomainInfo domain={ targetSite.slug } />
-				<DoneButton
-					className="is-normal-width"
-					label={ translate( 'Update domain name' ) }
-					onSiteViewClick={ () => {
-						this.props.recordTracksEvent( 'calypso_site_importer_click_add_domain' );
-						stepNavigator?.goToAddDomainPage?.();
-					} }
-				/>
-				<DoneButton
-					className="is-normal-width"
-					label={ translate( 'View your dashboard' ) }
-					isPrimary={ false }
-					onSiteViewClick={ () => {
-						this.props.recordTracksEvent( 'calypso_site_importer_view_site' );
-						stepNavigator?.goToSiteViewPage?.();
-					} }
-				/>
-			</div>
+			<Hooray>
+				<div className="import__heading import__heading-center">
+					<Title>{ translate( "Migration done! You're all set!" ) }</Title>
+					<SubTitle>
+						{ createInterpolateElement(
+							translate(
+								'You have a temporary domain name on WordPress.com.<br />We recommend updating your domain name.'
+							),
+							{ br: createElement( 'br' ) }
+						) }
+					</SubTitle>
+					<DomainInfo domain={ targetSite.slug } />
+					<DoneButton
+						className="is-normal-width"
+						label={ translate( 'Update domain name' ) }
+						onSiteViewClick={ () => {
+							this.props.recordTracksEvent( 'calypso_site_importer_click_add_domain' );
+							stepNavigator?.goToAddDomainPage?.();
+						} }
+					/>
+					<DoneButton
+						className="is-normal-width"
+						label={ translate( 'View your dashboard' ) }
+						isPrimary={ false }
+						onSiteViewClick={ () => {
+							this.props.recordTracksEvent( 'calypso_site_importer_view_site' );
+							stepNavigator?.goToSiteViewPage?.();
+						} }
+					/>
+				</div>
+			</Hooray>
 		);
 	}
 

--- a/client/blocks/importer/wordpress/import-everything/migration-success/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/migration-success/index.tsx
@@ -117,7 +117,7 @@ export default function MigrationSuccess( {
 						) }
 						target="_blank"
 						rel="noopener noreferrer"
-						title="Migration support resources"
+						title={ translate( 'Migration support resources' ) }
 					>
 						{ translate( 'Migration support resources' ) }
 					</Link>

--- a/client/blocks/importer/wordpress/import-everything/migration-success/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/migration-success/index.tsx
@@ -1,0 +1,128 @@
+import { Card } from '@automattic/components';
+import { type SiteDetails } from '@automattic/data-stores';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { SubTitle, Title } from '@automattic/onboarding';
+import {
+	CardBody,
+	FlexItem,
+	Flex,
+	__experimentalHStack as HStack,
+	__experimentalVStack as VStack,
+	Button,
+} from '@wordpress/components';
+import { Link } from 'react-router-dom';
+import './style.scss';
+
+interface MigrationSuccessProps {
+	translate: ( text: string ) => string;
+	recordTracksEvent: ( eventName: string, eventProperties?: object ) => void;
+	targetSite: SiteDetails;
+}
+
+const redirect = ( url: string, isWpAdmin = false ): void => {
+	const finalUrl = isWpAdmin ? `${ url }/wp-admin` : url;
+	window.location.href = finalUrl;
+};
+
+export default function MigrationSuccess( {
+	translate,
+	targetSite,
+	recordTracksEvent,
+}: MigrationSuccessProps ) {
+	const navigateToSite =
+		( url: string, isWpAdmin = false ) =>
+		( e: React.MouseEvent< HTMLButtonElement > ): void => {
+			e.preventDefault();
+			isWpAdmin
+				? recordTracksEvent( 'calypso_site_importer_navigate_wp_admin' )
+				: recordTracksEvent( 'calypso_site_importer_navigate_site' );
+			redirect( url, isWpAdmin );
+		};
+
+	return (
+		<>
+			<Title> { translate( 'Say hello to your new home' ) } </Title>
+			<SubTitle>{ translate( 'All set! Your content was successfully imported.' ) }</SubTitle>
+
+			<Card size="small">
+				<CardBody>
+					<HStack spacing={ 3 } justify="space-between">
+						<Flex
+							className="migration-success__ctas"
+							direction={ [ 'column', 'row' ] }
+							expanded={ true }
+							align="center"
+						>
+							<FlexItem>
+								<p className="migration-success__site">{ targetSite.domain }</p>
+							</FlexItem>
+
+							<FlexItem>
+								<Flex gap={ 4 }>
+									<Button variant="primary" onClick={ navigateToSite( targetSite.URL ) }>
+										{ translate( 'View site' ) }
+									</Button>
+									<Button variant="secondary" onClick={ navigateToSite( targetSite.URL, true ) }>
+										{ translate( 'Go to WP Admin' ) }
+									</Button>
+								</Flex>
+							</FlexItem>
+						</Flex>
+					</HStack>
+				</CardBody>
+			</Card>
+
+			<div className="migration-success-links-wrapper">
+				<VStack
+					spacing="1"
+					className="screen-confirmation__list-item-wrapper"
+					justify="space-between"
+				>
+					<strong className="screen-confirmation__list-item-title">
+						{ translate( 'Manage your site from anywhere' ) }
+					</strong>
+					<p className="screen-confirmation__list-item-description">
+						{ translate(
+							'The Jetpack mobile app for iOS and Android makes managing your email, domain, and website even simpler.'
+						) }
+					</p>
+					<Link
+						className="migration-success-links-wrapper__link"
+						to={ localizeUrl( 'https://apps.wordpress.com/mobile/' ) }
+						target="_blank"
+						rel="noopener noreferrer"
+						title={ translate( 'Get the app' ) }
+					>
+						{ translate( 'Get the app' ) }
+					</Link>
+				</VStack>
+
+				<VStack
+					spacing="1"
+					className="screen-confirmation__list-item-wrapper"
+					justify="space-between"
+				>
+					<strong className="screen-confirmation__list-item-title">
+						{ translate( 'Migration questions? find answers' ) }
+					</strong>
+					<p className="screen-confirmation__list-item-description">
+						{ translate(
+							'Explore our comprehensive support guides and find solutions to all your email inquiries.'
+						) }
+					</p>
+					<Link
+						className="migration-success-links-wrapper__link"
+						to={ localizeUrl(
+							'https://wordpress.com/support/import/import-a-sites-content/#after-importing'
+						) }
+						target="_blank"
+						rel="noopener noreferrer"
+						title="Migration support resources"
+					>
+						{ translate( 'Migration support resources' ) }
+					</Link>
+				</VStack>
+			</div>
+		</>
+	);
+}

--- a/client/blocks/importer/wordpress/import-everything/migration-success/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/migration-success/index.tsx
@@ -1,6 +1,6 @@
 import { Card } from '@automattic/components';
 import { type SiteDetails } from '@automattic/data-stores';
-import { localizeUrl } from '@automattic/i18n-utils';
+import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
 import { SubTitle, Title } from '@automattic/onboarding';
 import {
 	CardBody,
@@ -10,11 +10,11 @@ import {
 	__experimentalVStack as VStack,
 	Button,
 } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
 import { Link } from 'react-router-dom';
 import './style.scss';
 
 interface MigrationSuccessProps {
-	translate: ( text: string ) => string;
 	recordTracksEvent: ( eventName: string, eventProperties?: object ) => void;
 	targetSite: SiteDetails;
 }
@@ -25,10 +25,11 @@ const redirect = ( url: string, isWpAdmin = false ): void => {
 };
 
 export default function MigrationSuccess( {
-	translate,
 	targetSite,
 	recordTracksEvent,
 }: MigrationSuccessProps ) {
+	const { __, hasTranslation } = useI18n();
+	const isEnglishLocale = useIsEnglishLocale();
 	const navigateToSite =
 		( url: string, isWpAdmin = false ) =>
 		( e: React.MouseEvent< HTMLButtonElement > ): void => {
@@ -39,10 +40,25 @@ export default function MigrationSuccess( {
 			redirect( url, isWpAdmin );
 		};
 
+	const linkText =
+		isEnglishLocale || hasTranslation( 'Migration support resources' )
+			? __( 'Migration support resources' )
+			: 'Explore support resources'; //Temporary fallback
+
+	const titleText =
+		isEnglishLocale || hasTranslation( 'Say hello to your new home' )
+			? __( 'Say hello to your new home' )
+			: __( 'Hooray' ); //Temporary fallback
+
+	const subtitleText =
+		isEnglishLocale || hasTranslation( 'All set! Your content was successfully imported.' )
+			? __( 'All set! Your content was successfully imported.' )
+			: __( 'Congratulations. Your content was successfully imported.' ); //Temporary fallback
+
 	return (
 		<>
-			<Title> { translate( 'Say hello to your new home' ) } </Title>
-			<SubTitle>{ translate( 'All set! Your content was successfully imported.' ) }</SubTitle>
+			<Title> { titleText } </Title>
+			<SubTitle>{ subtitleText }</SubTitle>
 
 			<Card size="small">
 				<CardBody>
@@ -60,10 +76,10 @@ export default function MigrationSuccess( {
 							<FlexItem className="migration-success-ctas__buttons">
 								<Flex gap={ 4 }>
 									<Button variant="primary" onClick={ navigateToSite( targetSite.URL ) }>
-										{ translate( 'View site' ) }
+										{ __( 'View site' ) }
 									</Button>
 									<Button variant="secondary" onClick={ navigateToSite( targetSite.URL, true ) }>
-										{ translate( 'Go to WP Admin' ) }
+										{ __( 'Go to WP Admin' ) }
 									</Button>
 								</Flex>
 							</FlexItem>
@@ -83,10 +99,10 @@ export default function MigrationSuccess( {
 					justify="space-between"
 				>
 					<strong className="screen-confirmation__list-item-title">
-						{ translate( 'Manage your site from anywhere' ) }
+						{ __( 'Manage your site from anywhere' ) }
 					</strong>
 					<p className="screen-confirmation__list-item-description">
-						{ translate(
+						{ __(
 							'The Jetpack mobile app for iOS and Android makes managing your email, domain, and website even simpler.'
 						) }
 					</p>
@@ -95,9 +111,9 @@ export default function MigrationSuccess( {
 						to={ localizeUrl( 'https://apps.wordpress.com/mobile/' ) }
 						target="_blank"
 						rel="noopener noreferrer"
-						title={ translate( 'Get the app' ) }
+						title={ __( 'Get the app' ) }
 					>
-						{ translate( 'Get the app' ) }
+						{ __( 'Get the app' ) }
 					</Link>
 				</VStack>
 
@@ -107,10 +123,10 @@ export default function MigrationSuccess( {
 					justify="space-between"
 				>
 					<strong className="screen-confirmation__list-item-title">
-						{ translate( 'Migration questions? find answers' ) }
+						{ __( 'Migration questions? find answers' ) }
 					</strong>
 					<p className="screen-confirmation__list-item-description">
-						{ translate(
+						{ __(
 							'Explore our comprehensive support guides and find solutions to all your email inquiries.'
 						) }
 					</p>
@@ -121,9 +137,9 @@ export default function MigrationSuccess( {
 						) }
 						target="_blank"
 						rel="noopener noreferrer"
-						title={ translate( 'Migration support resources' ) }
+						title={ linkText }
 					>
-						{ translate( 'Migration support resources' ) }
+						{ linkText }
 					</Link>
 				</VStack>
 			</Flex>

--- a/client/blocks/importer/wordpress/import-everything/migration-success/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/migration-success/index.tsx
@@ -72,7 +72,11 @@ export default function MigrationSuccess( {
 				</CardBody>
 			</Card>
 
-			<div className="migration-success-links-wrapper">
+			<Flex
+				className="migration-success-links-wrapper"
+				direction={ [ 'column', 'row' ] }
+				gap={ 10 }
+			>
 				<VStack
 					spacing="1"
 					className="screen-confirmation__list-item-wrapper"
@@ -122,7 +126,7 @@ export default function MigrationSuccess( {
 						{ translate( 'Migration support resources' ) }
 					</Link>
 				</VStack>
-			</div>
+			</Flex>
 		</>
 	);
 }

--- a/client/blocks/importer/wordpress/import-everything/migration-success/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/migration-success/index.tsx
@@ -57,7 +57,7 @@ export default function MigrationSuccess( {
 								<p className="migration-success__site">{ targetSite.domain }</p>
 							</FlexItem>
 
-							<FlexItem>
+							<FlexItem className="migration-success-ctas__buttons">
 								<Flex gap={ 4 }>
 									<Button variant="primary" onClick={ navigateToSite( targetSite.URL ) }>
 										{ translate( 'View site' ) }

--- a/client/blocks/importer/wordpress/import-everything/migration-success/style.scss
+++ b/client/blocks/importer/wordpress/import-everything/migration-success/style.scss
@@ -12,11 +12,14 @@
 		width: 100%;
 		.migration-success-ctas__buttons {
 			min-width: 220px;
+			button {
+				border-radius: 4px;
+			}
 		}
 	}
 	.card {
-		margin: 50px 0;
-		padding: 20px 25px;
+		margin: 3.125rem 0;
+		padding: 1.25rem 1.563rem;
 		.components-card__body {
 			padding: 0;
 			.components-button {
@@ -28,19 +31,14 @@
 		}
 	}
 	.migration-success-links-wrapper {
-		display: flex;
 		text-align: left;
-		flex-direction: column;
-		gap: 40px;
 		@include break-medium {
-			padding: 0 25px 0 25px;
-			flex-direction: row;
+			padding: 0 1.563rem 0 1.563rem;
 		}
 		.migration-success-links-wrapper__link {
-			margin-top: 16px;
+			margin-top: 1rem;
 			text-decoration: underline;
 			text-underline-offset: 4px;
 		}
 	}
-
 }

--- a/client/blocks/importer/wordpress/import-everything/migration-success/style.scss
+++ b/client/blocks/importer/wordpress/import-everything/migration-success/style.scss
@@ -10,6 +10,9 @@
 		}
 		flex-direction: column;
 		width: 100%;
+		.migration-success-ctas__buttons {
+			min-width: 220px;
+		}
 	}
 	.card {
 		margin: 50px 0;

--- a/client/blocks/importer/wordpress/import-everything/migration-success/style.scss
+++ b/client/blocks/importer/wordpress/import-everything/migration-success/style.scss
@@ -1,0 +1,43 @@
+@import "@wordpress/base-styles/mixins";
+@import "@wordpress/base-styles/breakpoints";
+.migration-success {
+	.migration-success__site {
+		overflow-wrap: break-word;
+	}
+	.migration-success__ctas {
+		@include break-medium {
+			flex-direction: row;
+		}
+		flex-direction: column;
+		width: 100%;
+	}
+	.card {
+		margin: 50px 0;
+		padding: 20px 25px;
+		.components-card__body {
+			padding: 0;
+			.components-button {
+				margin-bottom: 0;
+				&.is-secondary {
+					color: var(--studio-gray-100);
+				}
+			}
+		}
+	}
+	.migration-success-links-wrapper {
+		display: flex;
+		text-align: left;
+		flex-direction: column;
+		gap: 40px;
+		@include break-medium {
+			padding: 0 25px 0 25px;
+			flex-direction: row;
+		}
+		.migration-success-links-wrapper__link {
+			margin-top: 16px;
+			text-decoration: underline;
+			text-underline-offset: 4px;
+		}
+	}
+
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87008

## Proposed Changes

* Instead of showing the `Hooray` success screen, this PR introduces a new success screen with more options to users.
Please check the proposed design in the https://github.com/Automattic/wp-calypso/issues/87008.

<img width="2047" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/bbef441e-470e-4352-9115-d80e8f8b29e3">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull and run this branch or use live link
* Navigate to `http://calypso.localhost:3000/sites?hosting-flow=true` and choose `migrate a site`
* For simplicity, I use https://tastewp.com/ and create a site there that I can use as the site to be imported
* Select to which site you want to import the one you created above
* If you would like to be faster, [open this file](https://github.com/Automattic/wp-calypso/blob/trunk/client/blocks/importer/wordpress/import-everything/index.tsx#L307) and comment out line 307 `return this.renderMigrationConfirm();`
* Add right below this return `return this.renderMigrationComplete();` 
**It will save you time and skip directly to the success screen, but it is optional.**
* After finishing the migration, you should see the screenshot above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?