### PR TITLE
The command that opens WooCommerce setting is now aware of if the sto…

### DIFF
--- a/packages/command-palette/src/commands/use-single-site-commands.tsx
+++ b/packages/command-palette/src/commands/use-single-site-commands.tsx
@@ -56,6 +56,7 @@ interface CustomWindow {
 		capabilities: {
 			[ key: string ]: string;
 		};
+		isWpcomStore: boolean;
 	};
 }
 
@@ -69,6 +70,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 		isSimple = false,
 		capabilities = {},
 		isP2 = false,
+		isWpcomStore = false,
 	} = customWindow?.commandPaletteConfig || {};
 
 	let siteType: SiteType | null = null;
@@ -841,18 +843,10 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 		{
 			name: 'openWooCommerceSettings',
 			label: __( 'Open WooCommerce settings', __i18n_text_domain__ ),
-			callback: commandNavigation( '/wp-admin/admin.php?page=wc-admin' ),
+			callback: isWpcomStore
+				? commandNavigation( '/wp-admin/admin.php?page=wc-admin' )
+				: commandNavigation( '/woocommerce-installation/:site' ),
 			capability: SiteCapabilities.MANAGE_OPTIONS,
-			siteType: SiteType.ATOMIC,
-			filterP2: true,
-			icon: <WooCommerceWooLogo className="woo-command-palette" />,
-		},
-		{
-			name: 'openWooCommerceSettings',
-			label: __( 'Open WooCommerce settings', __i18n_text_domain__ ),
-			callback: commandNavigation( '/woocommerce-installation/:site' ),
-			capability: SiteCapabilities.MANAGE_OPTIONS,
-			siteType: SiteType.SIMPLE,
 			filterP2: true,
 			icon: <WooCommerceWooLogo className="woo-command-palette" />,
 		},


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
thelinked issue.
-->

Related to 
- https://github.com/Automattic/wp-calypso/issues/87937

## Proposed Changes

* Leveraged the `commandPaletteConfig` to include if the site is a wpcom store or not and redirect to the correct location.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* The usual setup for these command issues.
* Go to a simple site and run the command, you should be redirected to the installation page.
* On an Atomic site you'll be redirected to either the installation or admin page depending on if the plugin is installed or not.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?