### PR TITLE
Remove cache commands when site is ineligible

### DIFF
--- a/packages/command-palette/src/commands/use-single-site-commands.tsx
+++ b/packages/command-palette/src/commands/use-single-site-commands.tsx
@@ -41,6 +41,7 @@ enum SiteType {
 interface CapabilityCommand extends Command {
 	capability?: string;
 	siteType?: SiteType;
+	publicOnly?: boolean;
 	isCustomDomain?: boolean;
 	filterP2?: boolean;
 }
@@ -52,6 +53,8 @@ interface CustomWindow {
 		isAtomic: boolean;
 		isSelfHosted: boolean;
 		isSimple: boolean;
+		isPrivate: boolean;
+		isComingSoon: boolean;
 		isP2: boolean;
 		capabilities: {
 			[ key: string ]: string;
@@ -67,6 +70,8 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 		isAtomic = false,
 		isSelfHosted = false,
 		isSimple = false,
+		isPrivate = false,
+		isComingSoon = false,
 		capabilities = {},
 		isP2 = false,
 	} = customWindow?.commandPaletteConfig || {};
@@ -118,6 +123,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 			callback: commandNavigation( '/hosting-config/:site#edge' ),
 			capability: SiteCapabilities.MANAGE_OPTIONS,
 			siteType: SiteType.ATOMIC,
+			publicOnly: true,
 			icon: cacheIcon,
 		},
 		{
@@ -126,6 +132,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 			callback: commandNavigation( '/hosting-config/:site#edge' ),
 			capability: SiteCapabilities.MANAGE_OPTIONS,
 			siteType: SiteType.ATOMIC,
+			publicOnly: true,
 			icon: cacheIcon,
 		},
 		{
@@ -917,6 +924,10 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 			}
 
 			if ( command?.isCustomDomain && ! isCustomDomain( window.location.host ) ) {
+				return false;
+			}
+
+			if ( command?.publicOnly && ( isPrivate || isComingSoon ) ) {
 				return false;
 			}
 


### PR DESCRIPTION


<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87941

## Proposed Changes

Making the single site and multi-site commands consistent in the command palette by filtering out the Enable / Disable edge cache commands when the site is private or coming soon.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

### Coming soon
1. Apply the latest version of
https://github.com/Automattic/jetpack/pull/35635 to your Atomic site 
2. Run install-plugin.sh command-palette update/palette-cache in your sandbox
3. Sandbox widgets.wp.com
4. Go to wordpress.com/settings/general/:siteSlug and set the Privacy setting to 'Coming soon'
5. Open a wp-admin page for your atomic site and open the command palette
7. Make sure that "Enable edge cache" and "Disable edge cache" commands **do not** exist

### Public
4. Go to wordpress.com/settings/general/:siteSlug and set the Privacy setting to 'Public'
5. Open a wp-admin page for your atomic site and open the command palette
6. Make sure that "Enable edge cache" and "Disable edge cache" commands **do** exist

### Private
4. Go to wordpress.com/settings/general/:siteSlug and set the Privacy setting to 'Private'
5. Open a wp-admin page for your atomic site and open the command palette
7. Make sure that "Enable edge cache" and "Disable edge cache" commands **do not** exist
## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?