### PR TITLE
Pattern Library: Add category navigation

### DIFF
--- a/client/my-sites/patterns/components/localized-link.tsx
+++ b/client/my-sites/patterns/components/localized-link.tsx
@@ -1,0 +1,14 @@
+import { addLocaleToPathLocaleInFront } from '@automattic/i18n-utils';
+import { useSelector } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+
+export function LocalizedLink( { children, href = '', ...props }: JSX.IntrinsicElements[ 'a' ] ) {
+	const isLoggedIn = useSelector( isUserLoggedIn );
+	const localizedHref = ! isLoggedIn ? addLocaleToPathLocaleInFront( href ) : href;
+
+	return (
+		<a { ...props } href={ localizedHref }>
+			{ children }
+		</a>
+	);
+}

--- a/client/my-sites/patterns/components/pattern-preview-placeholder.tsx
+++ b/client/my-sites/patterns/components/pattern-preview-placeholder.tsx
@@ -1,4 +1,4 @@
-import type { Pattern } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types';
+import type { Pattern } from 'calypso/my-sites/patterns/types';
 
 import './pattern-preview.scss';
 

--- a/client/my-sites/patterns/components/pattern-preview.tsx
+++ b/client/my-sites/patterns/components/pattern-preview.tsx
@@ -3,7 +3,7 @@ import { usePatternsRendererContext } from '@automattic/block-renderer/src/compo
 import { useResizeObserver } from '@wordpress/compose';
 import classNames from 'classnames';
 import { encodePatternId } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/utils';
-import type { Pattern } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types';
+import type { Pattern } from 'calypso/my-sites/patterns/types';
 
 import './pattern-preview.scss';
 

--- a/client/my-sites/patterns/controller.tsx
+++ b/client/my-sites/patterns/controller.tsx
@@ -1,29 +1,5 @@
-import { getPatternsQueryOptions } from 'calypso/my-sites/patterns/hooks/use-patterns';
-import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
-import type { Context as PageJSContext } from '@automattic/calypso-router';
+import { PATTERN_CATEGORIES } from 'calypso/my-sites/patterns/hooks/use-pattern-categories';
 
-export type Next = ( error?: Error ) => void;
-
-export function fetchPatterns( context: PageJSContext, next: Next ) {
-	const { cachedMarkup, queryClient, lang, params, store } = context;
-
-	if ( cachedMarkup ) {
-		next();
-
-		return;
-	}
-
-	const locale = getCurrentUserLocale( store.getState() ) || lang || 'en';
-
-	// TODO: Get category from url
-	params.category = 'intro';
-
-	queryClient
-		.fetchQuery( getPatternsQueryOptions( locale, params.category ) )
-		.then( () => {
-			next();
-		} )
-		.catch( ( error: Error ) => {
-			next( error );
-		} );
+export function getPatternCategorySlugs() {
+	return PATTERN_CATEGORIES.join( '|' );
 }

--- a/client/my-sites/patterns/controller.tsx
+++ b/client/my-sites/patterns/controller.tsx
@@ -1,5 +1,7 @@
 import { PATTERN_CATEGORIES } from 'calypso/my-sites/patterns/hooks/use-pattern-categories';
 
+export const RENDERER_SITE_ID = 226011606; // assemblerdemo
+
 export function getPatternCategorySlugs() {
 	return PATTERN_CATEGORIES.join( '|' );
 }

--- a/client/my-sites/patterns/hooks/test/use-pattern-categories.tsx
+++ b/client/my-sites/patterns/hooks/test/use-pattern-categories.tsx
@@ -34,10 +34,9 @@ describe( 'usePatternCategories', () => {
 
 		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
 
-		expect( wpcom.req.get ).toHaveBeenCalledWith( {
-			path: '/sites/12345/block-patterns/categories',
+		expect( wpcom.req.get ).toHaveBeenCalledWith( '/sites/12345/block-patterns/categories', {
 			apiNamespace: 'wp/v2',
-			query: { locale: 'fr' },
+			_locale: 'fr',
 		} );
 		expect( result.current.data ).toEqual( [] );
 	} );

--- a/client/my-sites/patterns/hooks/test/use-pattern-categories.tsx
+++ b/client/my-sites/patterns/hooks/test/use-pattern-categories.tsx
@@ -6,18 +6,19 @@ import { renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
 import wpcom from 'calypso/lib/wp';
 import { usePatternCategories } from '../use-pattern-categories';
+import type { Category } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types';
 
 jest.mock( 'calypso/lib/wp', () => ( { req: { get: jest.fn() } } ) );
 
 describe( 'usePatternCategories', () => {
-	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
-
 	let wrapper: React.FC< React.PropsWithChildren< any > >;
 
 	beforeEach( () => {
 		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockReset();
 
-		wrapper = ( { children } ) => (
+		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+
+		wrapper = ( { children }: React.PropsWithChildren< any > ) => (
 			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
 		);
 	} );
@@ -42,7 +43,7 @@ describe( 'usePatternCategories', () => {
 	} );
 
 	test( 'returns the expected data when successful', async () => {
-		const categories = [
+		const categories: Category[] = [
 			{
 				name: 'about',
 				title: 'À propos',

--- a/client/my-sites/patterns/hooks/test/use-pattern-categories.tsx
+++ b/client/my-sites/patterns/hooks/test/use-pattern-categories.tsx
@@ -6,7 +6,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import React from 'react';
 import wpcom from 'calypso/lib/wp';
 import { usePatternCategories } from '../use-pattern-categories';
-import type { Category } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types';
+import type { Category } from 'calypso/my-sites/patterns/types';
 
 jest.mock( 'calypso/lib/wp', () => ( { req: { get: jest.fn() } } ) );
 

--- a/client/my-sites/patterns/hooks/test/use-pattern-categories.tsx
+++ b/client/my-sites/patterns/hooks/test/use-pattern-categories.tsx
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import wpcom from 'calypso/lib/wp';
+import { usePatternCategories } from '../use-pattern-categories';
+
+jest.mock( 'calypso/lib/wp', () => ( { req: { get: jest.fn() } } ) );
+
+describe( 'usePatternCategories', () => {
+	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
+
+	let wrapper: React.FC< React.PropsWithChildren< any > >;
+
+	beforeEach( () => {
+		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockReset();
+
+		wrapper = ( { children } ) => (
+			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+		);
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'calls the API endpoint with the right parameters', async () => {
+		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockResolvedValue( [] );
+
+		const { result } = renderHook( () => usePatternCategories( 'fr', 12345 ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( wpcom.req.get ).toHaveBeenCalledWith( {
+			path: '/sites/12345/block-patterns/categories',
+			apiNamespace: 'wp/v2',
+			query: { locale: 'fr' },
+		} );
+		expect( result.current.data ).toEqual( [] );
+	} );
+
+	test( 'returns the expected data when successful', async () => {
+		const categories = [
+			{
+				name: 'about',
+				title: 'À propos',
+				description: '',
+			},
+		];
+
+		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockResolvedValue(
+			categories
+		);
+
+		const { result } = renderHook( () => usePatternCategories( 'fr', 12345 ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
+
+		expect( result.current.data ).toEqual( categories );
+	} );
+} );

--- a/client/my-sites/patterns/hooks/test/use-patterns.tsx
+++ b/client/my-sites/patterns/hooks/test/use-patterns.tsx
@@ -10,12 +10,12 @@ import { usePatterns } from '../use-patterns';
 jest.mock( 'calypso/lib/wp', () => ( { req: { get: jest.fn() } } ) );
 
 describe( 'usePatterns', () => {
-	const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
-
 	let wrapper: React.FC< React.PropsWithChildren< any > >;
 
 	beforeEach( () => {
 		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockReset();
+
+		const queryClient = new QueryClient( { defaultOptions: { queries: { retry: false } } } );
 
 		wrapper = ( { children }: React.PropsWithChildren< any > ) => (
 			<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>

--- a/client/my-sites/patterns/hooks/use-pattern-categories.ts
+++ b/client/my-sites/patterns/hooks/use-pattern-categories.ts
@@ -1,0 +1,70 @@
+import { useQuery, UseQueryOptions } from '@tanstack/react-query';
+import wpcom from 'calypso/lib/wp';
+import type { Category } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types';
+
+export const PATTERN_CATEGORIES = [
+	'featured',
+	'intro',
+	'about',
+	// 'buttons',
+	// 'banner',
+	// 'query',
+	'blog',
+	'posts',
+	// 'call-to-action',
+	// 'columns',
+	// 'coming-soon',
+	'contact',
+	'footer',
+	'forms',
+	'gallery',
+	'header',
+	// 'link-in-bio',
+	// 'media',
+	'newsletter',
+	// 'podcast',
+	'portfolio', // For page patterns only in v1
+	// 'quotes',
+	'services',
+	'store',
+	// 'team',
+	'testimonials', // Reused as "Quotes"
+	// 'text',
+];
+
+export function getPatternCategoriesQueryOptions(
+	siteId: undefined | number,
+	queryOptions: Omit< UseQueryOptions< Category[] >, 'queryKey' > = {}
+): UseQueryOptions< Category[] > {
+	return {
+		queryKey: [ siteId, 'pattern-library', 'categories' ],
+		queryFn() {
+			return wpcom.req.get( {
+				path: `/sites/${ encodeURIComponent( siteId ?? '' ) }/block-patterns/categories`,
+				apiNamespace: 'wp/v2',
+			} );
+		},
+		select( categories ) {
+			const result = [];
+
+			for ( const name of PATTERN_CATEGORIES ) {
+				const category = categories.find( ( category ) => category.name === name );
+				if ( category ) {
+					result.push( category );
+				}
+			}
+
+			return result;
+		},
+		staleTime: Infinity,
+		...queryOptions,
+		enabled: !! siteId,
+	};
+}
+
+export function usePatternCategories(
+	siteId: undefined | number,
+	queryOptions: Omit< UseQueryOptions< Category[] >, 'queryKey' > = {}
+) {
+	return useQuery< Category[] >( getPatternCategoriesQueryOptions( siteId, queryOptions ) );
+}

--- a/client/my-sites/patterns/hooks/use-pattern-categories.ts
+++ b/client/my-sites/patterns/hooks/use-pattern-categories.ts
@@ -40,11 +40,13 @@ export function getPatternCategoriesQueryOptions(
 	return {
 		queryKey: [ locale, siteId, 'pattern-library', 'categories' ],
 		queryFn() {
-			return wpcom.req.get( {
-				path: `/sites/${ encodeURIComponent( siteId ?? '' ) }/block-patterns/categories`,
-				apiNamespace: 'wp/v2',
-				query: { locale },
-			} );
+			return wpcom.req.get(
+				`/sites/${ encodeURIComponent( siteId ?? '' ) }/block-patterns/categories`,
+				{
+					apiNamespace: 'wp/v2',
+					_locale: locale,
+				}
+			);
 		},
 		select( categories ) {
 			const result = [];

--- a/client/my-sites/patterns/hooks/use-pattern-categories.ts
+++ b/client/my-sites/patterns/hooks/use-pattern-categories.ts
@@ -1,6 +1,6 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
-import type { Category } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types';
+import type { Category } from 'calypso/my-sites/patterns/types';
 
 export const PATTERN_CATEGORIES = [
 	'featured',

--- a/client/my-sites/patterns/hooks/use-pattern-categories.ts
+++ b/client/my-sites/patterns/hooks/use-pattern-categories.ts
@@ -33,15 +33,17 @@ export const PATTERN_CATEGORIES = [
 ];
 
 export function getPatternCategoriesQueryOptions(
+	locale: string,
 	siteId: undefined | number,
 	queryOptions: Omit< UseQueryOptions< Category[] >, 'queryKey' > = {}
 ): UseQueryOptions< Category[] > {
 	return {
-		queryKey: [ siteId, 'pattern-library', 'categories' ],
+		queryKey: [ locale, siteId, 'pattern-library', 'categories' ],
 		queryFn() {
 			return wpcom.req.get( {
 				path: `/sites/${ encodeURIComponent( siteId ?? '' ) }/block-patterns/categories`,
 				apiNamespace: 'wp/v2',
+				query: { locale },
 			} );
 		},
 		select( categories ) {
@@ -63,8 +65,9 @@ export function getPatternCategoriesQueryOptions(
 }
 
 export function usePatternCategories(
+	locale: string,
 	siteId: undefined | number,
 	queryOptions: Omit< UseQueryOptions< Category[] >, 'queryKey' > = {}
 ) {
-	return useQuery< Category[] >( getPatternCategoriesQueryOptions( siteId, queryOptions ) );
+	return useQuery< Category[] >( getPatternCategoriesQueryOptions( locale, siteId, queryOptions ) );
 }

--- a/client/my-sites/patterns/hooks/use-patterns.ts
+++ b/client/my-sites/patterns/hooks/use-patterns.ts
@@ -5,7 +5,7 @@ import type { Pattern } from 'calypso/landing/stepper/declarative-flow/internals
 export function getPatternsQueryOptions(
 	locale: string,
 	category: string,
-	queryOptions: Omit< UseQueryOptions< any, unknown, Pattern[] >, 'queryKey' > = {}
+	queryOptions: Omit< UseQueryOptions< Pattern[] >, 'queryKey' > = {}
 ) {
 	return {
 		queryKey: [ 'patterns', 'library', locale, category ],
@@ -23,9 +23,7 @@ export function getPatternsQueryOptions(
 export function usePatterns(
 	locale: string,
 	category: string,
-	queryOptions: Omit< UseQueryOptions< any, unknown, Pattern[] >, 'queryKey' > = {}
+	queryOptions: Omit< UseQueryOptions< Pattern[] >, 'queryKey' > = {}
 ) {
-	return useQuery< any, unknown, Pattern[] >(
-		getPatternsQueryOptions( locale, category, queryOptions )
-	);
+	return useQuery< Pattern[] >( getPatternsQueryOptions( locale, category, queryOptions ) );
 }

--- a/client/my-sites/patterns/hooks/use-patterns.ts
+++ b/client/my-sites/patterns/hooks/use-patterns.ts
@@ -15,8 +15,8 @@ export function getPatternsQueryOptions(
 				post_type: 'wp_block',
 			} );
 		},
-		...queryOptions,
 		staleTime: Infinity,
+		...queryOptions,
 	};
 }
 

--- a/client/my-sites/patterns/hooks/use-patterns.ts
+++ b/client/my-sites/patterns/hooks/use-patterns.ts
@@ -1,6 +1,6 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
-import type { Pattern } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types';
+import type { Pattern } from 'calypso/my-sites/patterns/types';
 
 export function getPatternsQueryOptions(
 	locale: string,

--- a/client/my-sites/patterns/hooks/use-patterns.ts
+++ b/client/my-sites/patterns/hooks/use-patterns.ts
@@ -17,6 +17,7 @@ export function getPatternsQueryOptions(
 		},
 		staleTime: Infinity,
 		...queryOptions,
+		enabled: !! category,
 	};
 }
 

--- a/client/my-sites/patterns/index.node.tsx
+++ b/client/my-sites/patterns/index.node.tsx
@@ -8,16 +8,9 @@ import { getPatternsQueryOptions } from 'calypso/my-sites/patterns/hooks/use-pat
 import PatternsSSR from 'calypso/my-sites/patterns/patterns-ssr';
 import { serverRouter } from 'calypso/server/isomorphic-routing';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
-import type { Context as PageJSContext } from '@automattic/calypso-router';
-import type { QueryClient } from '@tanstack/react-query';
-import type {
-	Category,
-	Pattern,
-} from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types';
+import type { RouterContext, RouterNext, Category, Pattern } from 'calypso/my-sites/patterns/types';
 
-type Next = ( error?: Error ) => void;
-
-function renderPatterns( context: PageJSContext, next: Next ) {
+function renderPatterns( context: RouterContext, next: RouterNext ) {
 	context.primary = (
 		<PatternsSSR category={ context.params.category } isGridView={ !! context.query.grid } />
 	);
@@ -25,12 +18,7 @@ function renderPatterns( context: PageJSContext, next: Next ) {
 	next();
 }
 
-type Context = PageJSContext & {
-	cachedMarkup?: string;
-	queryClient: QueryClient;
-};
-
-function fetchPatterns( context: Context, next: Next ) {
+function fetchPatterns( context: RouterContext, next: RouterNext ) {
 	const { cachedMarkup, queryClient, lang, params, store } = context;
 
 	if ( cachedMarkup ) {

--- a/client/my-sites/patterns/index.node.tsx
+++ b/client/my-sites/patterns/index.node.tsx
@@ -1,8 +1,7 @@
-import { getPlaceholderSiteID } from '@automattic/data-stores/src/site/constants';
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
 import { makeLayout, ssrSetupLocale } from 'calypso/controller';
 import { setHrefLangLinks, setLocalizedCanonicalUrl } from 'calypso/controller/localized-links';
-import { getPatternCategorySlugs } from 'calypso/my-sites/patterns/controller';
+import { RENDERER_SITE_ID, getPatternCategorySlugs } from 'calypso/my-sites/patterns/controller';
 import { getPatternCategoriesQueryOptions } from 'calypso/my-sites/patterns/hooks/use-pattern-categories';
 import { getPatternsQueryOptions } from 'calypso/my-sites/patterns/hooks/use-patterns';
 import PatternsSSR from 'calypso/my-sites/patterns/patterns-ssr';
@@ -26,11 +25,10 @@ function fetchPatterns( context: RouterContext, next: RouterNext ) {
 		return;
 	}
 
-	const rendererSiteId = getPlaceholderSiteID();
 	const locale = getCurrentUserLocale( store.getState() ) || lang || 'en';
 
 	const categoryPromise = queryClient.fetchQuery< Category[] >(
-		getPatternCategoriesQueryOptions( locale, Number( rendererSiteId ), {
+		getPatternCategoriesQueryOptions( locale, RENDERER_SITE_ID, {
 			staleTime: 10 * 60 * 1000,
 		} )
 	);

--- a/client/my-sites/patterns/index.node.tsx
+++ b/client/my-sites/patterns/index.node.tsx
@@ -42,7 +42,9 @@ function fetchPatterns( context: Context, next: Next ) {
 	const locale = getCurrentUserLocale( store.getState() ) || lang || 'en';
 
 	const categoryPromise = queryClient.fetchQuery< Category[] >(
-		getPatternCategoriesQueryOptions( Number( rendererSiteId ), { staleTime: 10 * 60 * 1000 } )
+		getPatternCategoriesQueryOptions( locale, Number( rendererSiteId ), {
+			staleTime: 10 * 60 * 1000,
+		} )
 	);
 
 	const patternPromise = params.category

--- a/client/my-sites/patterns/index.node.tsx
+++ b/client/my-sites/patterns/index.node.tsx
@@ -1,10 +1,20 @@
+import { getPlaceholderSiteID } from '@automattic/data-stores/src/site/constants';
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
-import { makeLayout, ssrSetupLocale } from 'calypso/controller';
+import { makeLayout, ssrSetupLocale, notFound } from 'calypso/controller';
 import { setHrefLangLinks, setLocalizedCanonicalUrl } from 'calypso/controller/localized-links';
-import { fetchPatterns, Next } from 'calypso/my-sites/patterns/controller';
+import { getPatternCategoriesQueryOptions } from 'calypso/my-sites/patterns/hooks/use-pattern-categories';
+import { getPatternsQueryOptions } from 'calypso/my-sites/patterns/hooks/use-patterns';
 import PatternsSSR from 'calypso/my-sites/patterns/patterns-ssr';
 import { serverRouter } from 'calypso/server/isomorphic-routing';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import type { Context as PageJSContext } from '@automattic/calypso-router';
+import type { QueryClient } from '@tanstack/react-query';
+import type {
+	Category,
+	Pattern,
+} from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types';
+
+type Next = ( error?: Error ) => void;
 
 function renderPatterns( context: PageJSContext, next: Next ) {
 	context.primary = (
@@ -14,11 +24,53 @@ function renderPatterns( context: PageJSContext, next: Next ) {
 	next();
 }
 
+type Context = PageJSContext & {
+	cachedMarkup?: string;
+	queryClient: QueryClient;
+};
+
+async function fetchPatterns( context: Context, next: Next ): Promise< void > {
+	const { cachedMarkup, queryClient, lang, params, store } = context;
+
+	if ( cachedMarkup ) {
+		next();
+		return;
+	}
+
+	const rendererSiteId = getPlaceholderSiteID();
+	const locale = getCurrentUserLocale( store.getState() ) || lang || 'en';
+
+	try {
+		// Always fetch list of categories
+		const categories = await queryClient.fetchQuery< Category[] >(
+			getPatternCategoriesQueryOptions( Number( rendererSiteId ), { staleTime: 10 * 60 * 1000 } )
+		);
+
+		// Fetch patterns only if the user is requesting a category page
+		if ( params.category ) {
+			const categoryNames = categories.map( ( category ) => category.name );
+
+			if ( ! categoryNames.includes( params.category ) ) {
+				notFound( context, next );
+				return;
+			}
+
+			await queryClient.fetchQuery< Pattern[] >(
+				getPatternsQueryOptions( locale, params.category, { staleTime: 10 * 60 * 1000 } )
+			);
+		}
+	} catch ( error ) {
+		next( error as Error );
+	}
+
+	next();
+}
+
 export default function ( router: ReturnType< typeof serverRouter > ) {
 	const langParam = getLanguageRouteParam();
 
 	router(
-		[ '/patterns', `/${ langParam }/patterns` ],
+		[ `/${ langParam }/patterns/:category?`, '/patterns/:category?' ],
 		ssrSetupLocale,
 		setHrefLangLinks,
 		setLocalizedCanonicalUrl,

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -5,9 +5,10 @@ import {
 	redirectWithoutLocaleParamInFrontIfLoggedIn,
 	render as clientRender,
 } from 'calypso/controller/index.web';
-import { fetchPatterns, Next } from 'calypso/my-sites/patterns/controller';
 import Patterns from 'calypso/my-sites/patterns/patterns';
 import type { Context as PageJSContext } from '@automattic/calypso-router';
+
+type Next = ( error?: Error ) => void;
 
 function renderPatterns( context: PageJSContext, next: Next ) {
 	context.primary = (
@@ -19,8 +20,12 @@ function renderPatterns( context: PageJSContext, next: Next ) {
 
 export default function ( router: typeof clientRouter ) {
 	const langParam = getLanguageRouteParam();
-	const middleware = [ fetchPatterns, renderPatterns, makeLayout, clientRender ];
+	const middleware = [ renderPatterns, makeLayout, clientRender ];
 
-	router( `/${ langParam }/patterns`, redirectWithoutLocaleParamInFrontIfLoggedIn, ...middleware );
-	router( '/patterns', ...middleware );
+	router(
+		`/${ langParam }/patterns/:category?`,
+		redirectWithoutLocaleParamInFrontIfLoggedIn,
+		...middleware
+	);
+	router( '/patterns/:category?', ...middleware );
 }

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -5,6 +5,7 @@ import {
 	redirectWithoutLocaleParamInFrontIfLoggedIn,
 	render as clientRender,
 } from 'calypso/controller/index.web';
+import { getPatternCategorySlugs } from 'calypso/my-sites/patterns/controller';
 import Patterns from 'calypso/my-sites/patterns/patterns';
 import type { Context as PageJSContext } from '@automattic/calypso-router';
 
@@ -20,12 +21,13 @@ function renderPatterns( context: PageJSContext, next: Next ) {
 
 export default function ( router: typeof clientRouter ) {
 	const langParam = getLanguageRouteParam();
+	const categorySlugs = getPatternCategorySlugs();
 	const middleware = [ renderPatterns, makeLayout, clientRender ];
 
 	router(
-		`/${ langParam }/patterns/:category?`,
+		`/${ langParam }/patterns/:category(${ categorySlugs })?`,
 		redirectWithoutLocaleParamInFrontIfLoggedIn,
 		...middleware
 	);
-	router( '/patterns/:category?', ...middleware );
+	router( `/patterns/:category(${ categorySlugs })?`, ...middleware );
 }

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -7,11 +7,9 @@ import {
 } from 'calypso/controller/index.web';
 import { getPatternCategorySlugs } from 'calypso/my-sites/patterns/controller';
 import Patterns from 'calypso/my-sites/patterns/patterns';
-import type { Context as PageJSContext } from '@automattic/calypso-router';
+import type { RouterContext, RouterNext } from 'calypso/my-sites/patterns/types';
 
-type Next = ( error?: Error ) => void;
-
-function renderPatterns( context: PageJSContext, next: Next ) {
+function renderPatterns( context: RouterContext, next: RouterNext ) {
 	context.primary = (
 		<Patterns category={ context.params.category } isGridView={ !! context.query.grid } />
 	);

--- a/client/my-sites/patterns/patterns-ssr.tsx
+++ b/client/my-sites/patterns/patterns-ssr.tsx
@@ -14,7 +14,9 @@ type Props = {
 
 export default function PatternsSSR( { category, isGridView }: Props ) {
 	const locale = useLocale();
-	const { data: patterns } = usePatterns( locale, category );
+	const { data: patterns } = usePatterns( locale, category, {
+		enabled: !! category,
+	} );
 
 	return (
 		<Main isLoggedOut fullWidthLayout>

--- a/client/my-sites/patterns/patterns-ssr.tsx
+++ b/client/my-sites/patterns/patterns-ssr.tsx
@@ -2,7 +2,10 @@ import { useLocale } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
+import { LocalizedLink } from 'calypso/my-sites/patterns/components/localized-link';
 import { PatternPreviewPlaceholder } from 'calypso/my-sites/patterns/components/pattern-preview-placeholder';
+import { RENDERER_SITE_ID } from 'calypso/my-sites/patterns/controller';
+import { usePatternCategories } from 'calypso/my-sites/patterns/hooks/use-pattern-categories';
 import { usePatterns } from 'calypso/my-sites/patterns/hooks/use-patterns';
 
 import './style.scss';
@@ -14,6 +17,7 @@ type Props = {
 
 export default function PatternsSSR( { category, isGridView }: Props ) {
 	const locale = useLocale();
+	const { data: categories } = usePatternCategories( locale, RENDERER_SITE_ID );
 	const { data: patterns } = usePatterns( locale, category, {
 		enabled: !! category,
 	} );
@@ -23,6 +27,16 @@ export default function PatternsSSR( { category, isGridView }: Props ) {
 			<DocumentHead title="WordPress Patterns" />
 
 			<h1>Build your perfect site with patterns</h1>
+
+			<ul className="pattern-categories">
+				{ categories?.map( ( category ) => (
+					<li className="pattern-category" key={ category.name }>
+						<LocalizedLink href={ `/patterns/${ category.name }` }>
+							{ category.label }
+						</LocalizedLink>
+					</li>
+				) ) }
+			</ul>
 
 			<div className={ classNames( 'patterns', { patterns_grid: isGridView } ) }>
 				{ patterns?.map( ( pattern ) => (

--- a/client/my-sites/patterns/patterns-ssr.tsx
+++ b/client/my-sites/patterns/patterns-ssr.tsx
@@ -18,9 +18,7 @@ type Props = {
 export default function PatternsSSR( { category, isGridView }: Props ) {
 	const locale = useLocale();
 	const { data: categories } = usePatternCategories( locale, RENDERER_SITE_ID );
-	const { data: patterns } = usePatterns( locale, category, {
-		enabled: !! category,
-	} );
+	const { data: patterns } = usePatterns( locale, category );
 
 	return (
 		<Main isLoggedOut fullWidthLayout>

--- a/client/my-sites/patterns/patterns.tsx
+++ b/client/my-sites/patterns/patterns.tsx
@@ -3,14 +3,14 @@ import { useLocale } from '@automattic/i18n-utils';
 import classNames from 'classnames';
 import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
+import { LocalizedLink } from 'calypso/my-sites/patterns/components/localized-link';
 import { PatternPreview } from 'calypso/my-sites/patterns/components/pattern-preview';
 import { PatternPreviewPlaceholder } from 'calypso/my-sites/patterns/components/pattern-preview-placeholder';
+import { RENDERER_SITE_ID } from 'calypso/my-sites/patterns/controller';
 import { usePatternCategories } from 'calypso/my-sites/patterns/hooks/use-pattern-categories';
 import { usePatterns } from 'calypso/my-sites/patterns/hooks/use-patterns';
 
 import './style.scss';
-
-const RENDERER_SITE_ID = 226011606; // assemblerdemo
 
 type Props = {
 	category: string;
@@ -37,7 +37,9 @@ export default function Patterns( { category, isGridView }: Props ) {
 			<ul className="pattern-categories">
 				{ categories?.map( ( category ) => (
 					<li className="pattern-category" key={ category.name }>
-						<a href={ `/patterns/${ category.name }` }>{ category.label }</a>
+						<LocalizedLink href={ `/patterns/${ category.name }` }>
+							{ category.label }
+						</LocalizedLink>
 					</li>
 				) ) }
 			</ul>

--- a/client/my-sites/patterns/patterns.tsx
+++ b/client/my-sites/patterns/patterns.tsx
@@ -20,8 +20,10 @@ type Props = {
 export default function Patterns( { category, isGridView }: Props ) {
 	const locale = useLocale();
 
-	const { data: categories } = usePatternCategories( Number( RENDERER_SITE_ID ) );
-	const { data: patterns } = usePatterns( locale, category );
+	const { data: categories } = usePatternCategories( locale, Number( RENDERER_SITE_ID ) );
+	const { data: patterns } = usePatterns( locale, category, {
+		enabled: !! category,
+	} );
 
 	const patternIdsByCategory = {
 		intro: patterns?.map( ( { ID } ) => `${ ID }` ) ?? [],

--- a/client/my-sites/patterns/patterns.tsx
+++ b/client/my-sites/patterns/patterns.tsx
@@ -5,6 +5,7 @@ import DocumentHead from 'calypso/components/data/document-head';
 import Main from 'calypso/components/main';
 import { PatternPreview } from 'calypso/my-sites/patterns/components/pattern-preview';
 import { PatternPreviewPlaceholder } from 'calypso/my-sites/patterns/components/pattern-preview-placeholder';
+import { usePatternCategories } from 'calypso/my-sites/patterns/hooks/use-pattern-categories';
 import { usePatterns } from 'calypso/my-sites/patterns/hooks/use-patterns';
 
 import './style.scss';
@@ -18,6 +19,8 @@ type Props = {
 
 export default function Patterns( { category, isGridView }: Props ) {
 	const locale = useLocale();
+
+	const { data: categories } = usePatternCategories( Number( RENDERER_SITE_ID ) );
 	const { data: patterns } = usePatterns( locale, category );
 
 	const patternIdsByCategory = {
@@ -28,6 +31,14 @@ export default function Patterns( { category, isGridView }: Props ) {
 		<Main isLoggedOut fullWidthLayout>
 			<DocumentHead title="WordPress Patterns" />
 			<h1>Build your perfect site with patterns</h1>
+
+			<ul className="pattern-categories">
+				{ categories?.map( ( category ) => (
+					<li className="pattern-category" key={ category.name }>
+						<a href={ `/patterns/${ category.name }` }>{ category.label }</a>
+					</li>
+				) ) }
+			</ul>
 
 			<BlockRendererProvider
 				siteId={ RENDERER_SITE_ID }

--- a/client/my-sites/patterns/patterns.tsx
+++ b/client/my-sites/patterns/patterns.tsx
@@ -21,9 +21,7 @@ export default function Patterns( { category, isGridView }: Props ) {
 	const locale = useLocale();
 
 	const { data: categories } = usePatternCategories( locale, RENDERER_SITE_ID );
-	const { data: patterns } = usePatterns( locale, category, {
-		enabled: !! category,
-	} );
+	const { data: patterns } = usePatterns( locale, category );
 
 	const patternIdsByCategory = {
 		intro: patterns?.map( ( { ID } ) => `${ ID }` ) ?? [],

--- a/client/my-sites/patterns/patterns.tsx
+++ b/client/my-sites/patterns/patterns.tsx
@@ -10,7 +10,7 @@ import { usePatterns } from 'calypso/my-sites/patterns/hooks/use-patterns';
 
 import './style.scss';
 
-const RENDERER_SITE_ID = '226011606'; // assemblerdemo
+const RENDERER_SITE_ID = 226011606; // assemblerdemo
 
 type Props = {
 	category: string;
@@ -20,7 +20,7 @@ type Props = {
 export default function Patterns( { category, isGridView }: Props ) {
 	const locale = useLocale();
 
-	const { data: categories } = usePatternCategories( locale, Number( RENDERER_SITE_ID ) );
+	const { data: categories } = usePatternCategories( locale, RENDERER_SITE_ID );
 	const { data: patterns } = usePatterns( locale, category, {
 		enabled: !! category,
 	} );

--- a/client/my-sites/patterns/style.scss
+++ b/client/my-sites/patterns/style.scss
@@ -2,6 +2,19 @@
 	background: #e5f4ff;
 }
 
+.pattern-categories {
+	display: flex;
+	flex-wrap: nowrap;
+	gap: 16px;
+	list-style: none;
+	margin: 0;
+	overflow: auto;
+	padding: 0;
+}
+.pattern-category {
+	white-space: nowrap;
+}
+
 .patterns {
 	display: grid;
 	padding: 24px 0;

--- a/client/my-sites/patterns/types.ts
+++ b/client/my-sites/patterns/types.ts
@@ -1,0 +1,14 @@
+import type { Context } from '@automattic/calypso-router';
+import type { QueryClient } from '@tanstack/react-query';
+
+export type RouterNext = ( error?: Error ) => void;
+
+export type RouterContext = Context & {
+	cachedMarkup?: string;
+	queryClient: QueryClient;
+};
+
+export type {
+	Category,
+	Pattern,
+} from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5599

## Proposed Changes

This PR adds routing and basic navigation for categories in the pattern library. Categories are fetched from the `/sites/:site_id/block-patterns/categories` endpoint with a new `usePatternCategories` hook (which is based on the equivalent Assembler hook). We still have to filter and sort the returned categories, so I've also hard-coded a list of category slugs for this purpose.

There's a bunch of small improvements to data loading and SSR here as well.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Sandbox `public-api.wordpress.com`
2. Apply this back-end patch 33ae5-pb/#diff
3. Go to `/patterns`
4. Ensure that you see a list of category links at the top
5. Click on `About`
6. Ensure that you successfully navigate to `/patterns/about` and that the list of patterns updates
7. Refresh the page
8. Ensure that you see the same list of patterns
9. Open an incognito window and navigate to `/fr/patterns`
10. Ensure that the list of categories is now in French
11. Navigate to `/patterns/blabla`
12. Ensure that a 404 page is rendered

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?