### PR TITLE
Site Migration: Update so the Plan Upgrade step navigates to BundleTransfer

### DIFF
--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -188,7 +188,7 @@ const siteMigration: Flow = {
 								flags: 'onboarding/new-migration-flow',
 								siteSlug,
 							},
-							'/setup/site-migration/site-migration-instructions'
+							`/setup/site-migration/${ STEPS.BUNDLE_TRANSFER.slug }`
 						);
 						goToCheckout( {
 							flowName: 'site-migration',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #87982

## Proposed Changes

Previously, as a placeholder, we were just going straight to the setup instructions. Now, upon checkout from the Plan Upgrade, we go to BundleTransfer to transfer the site to Atomic and install the plugin

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit http://calypso.localhost:3000/start (our use the calypso.live url)
* Select a Free plan.
* When you reach the Goals step, add `&flags=onboarding/new-migration-flow` to the url and refresh.
* Select the "Import existing content or website" goal and click "Continue".
* Click the "Upgrade to migrate" button.
* Click "Continue" to purchase a Creator plan.
* After completing checkout, you should be redirected to the `bundleTransfer` step and then the `processing` step.
* You should end up on the Setup Instructions step once processing is complete.
* Verify that your site is Atomic and the migration plugin is installed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
