### PR TITLE
Plugins update manager: CRUD integration

### DIFF
--- a/client/blocks/plugins-update-manager/config.ts
+++ b/client/blocks/plugins-update-manager/config.ts
@@ -1,0 +1,2 @@
+export const MAX_SCHEDULES = 2;
+export const MAX_SELECTABLE_PLUGINS = 10;

--- a/client/blocks/plugins-update-manager/config.ts
+++ b/client/blocks/plugins-update-manager/config.ts
@@ -1,2 +1,3 @@
 export const MAX_SCHEDULES = 2;
 export const MAX_SELECTABLE_PLUGINS = 10;
+export const MOMENT_TIME_FORMAT = 'MMM D h:mm A zz';

--- a/client/blocks/plugins-update-manager/hooks/use-prepare-plugins-tooltip-info.tsx
+++ b/client/blocks/plugins-update-manager/hooks/use-prepare-plugins-tooltip-info.tsx
@@ -1,0 +1,26 @@
+import { createInterpolateElement } from '@wordpress/element';
+import { SitePlugin, useSitePluginsQuery } from 'calypso/data/plugins/use-site-plugins-query';
+import type { SiteSlug } from 'calypso/types';
+
+export function usePreparePluginsTooltipInfo( siteSlug: SiteSlug ) {
+	const { data: pluginsData } = useSitePluginsQuery( siteSlug );
+	const plugins = pluginsData?.plugins ?? [];
+
+	const preparePluginsTooltipInfo = ( pluginsArgs: string[] ) => {
+		const pluginsList = pluginsArgs
+			.map(
+				( plugin: string ) =>
+					plugins.find( ( { name }: SitePlugin ) => name === plugin )?.display_name
+			)
+			.join( '<br />' );
+
+		return createInterpolateElement( `<div>${ pluginsList }</div>`, {
+			div: <div className="tooltip--selected-plugins" />,
+			br: <br />,
+		} );
+	};
+
+	return {
+		preparePluginsTooltipInfo,
+	};
+}

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -36,7 +36,11 @@ export const PluginsUpdateManager = ( props: Props ) => {
 			</NavigationHeader>
 
 			{ context === 'list' && (
-				<ScheduleList onNavBack={ onNavBack } onCreateNewSchedule={ onCreateNewSchedule } />
+				<ScheduleList
+					siteSlug={ siteSlug }
+					onNavBack={ onNavBack }
+					onCreateNewSchedule={ onCreateNewSchedule }
+				/>
 			) }
 			{ context === 'create' && <ScheduleCreate siteSlug={ siteSlug } onNavBack={ onNavBack } /> }
 		</MainComponent>

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -2,6 +2,8 @@ import { Button } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
 import MainComponent from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
+import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updates-query';
+import { MAX_SCHEDULES } from './config';
 import { ScheduleCreate } from './schedule-create';
 import { ScheduleList } from './schedule-list';
 
@@ -15,6 +17,8 @@ interface Props {
 }
 export const PluginsUpdateManager = ( props: Props ) => {
 	const { siteSlug, context, onNavBack, onCreateNewSchedule } = props;
+	const { data: schedules = [] } = useScheduleUpdatesQuery( siteSlug );
+	const hideCreateButton = schedules.length === MAX_SCHEDULES || schedules.length === 0;
 
 	return (
 		<MainComponent wideLayout>
@@ -23,7 +27,7 @@ export const PluginsUpdateManager = ( props: Props ) => {
 				title="Plugin updates manager"
 				subtitle="Effortlessly schedule plugin auto-updates with built-in rollback logic."
 			>
-				{ context === 'list' && onCreateNewSchedule && (
+				{ context === 'list' && ! hideCreateButton && onCreateNewSchedule && (
 					<Button
 						__next40pxDefaultSize
 						icon={ plus }

--- a/client/blocks/plugins-update-manager/schedule-create.tsx
+++ b/client/blocks/plugins-update-manager/schedule-create.tsx
@@ -31,7 +31,7 @@ export const ScheduleCreate = ( props: Props ) => {
 				<div className="ch-placeholder"></div>
 			</CardHeader>
 			<CardBody>
-				<ScheduleForm siteSlug={ siteSlug } />
+				<ScheduleForm siteSlug={ siteSlug } onCreateSuccess={ () => onNavBack && onNavBack() } />
 			</CardBody>
 			<CardFooter>
 				<Button form="schedule" type="submit" variant="primary">

--- a/client/blocks/plugins-update-manager/schedule-form.const.ts
+++ b/client/blocks/plugins-update-manager/schedule-form.const.ts
@@ -1,5 +1,3 @@
-export const MAX_SELECTABLE_PLUGINS = 10;
-
 export const DAILY_OPTION = {
 	label: 'Daily',
 	value: 'daily',

--- a/client/blocks/plugins-update-manager/schedule-form.scss
+++ b/client/blocks/plugins-update-manager/schedule-form.scss
@@ -128,21 +128,20 @@
 		}
 	}
 
-	.components-text.validation-msg {
+	.components-text.validation-msg,
+	.components-text.info-msg {
 		display: block;
-		margin-bottom: 0.5rem;
+		min-height: 1rem;
 		font-size: 0.75rem;
+		margin-bottom: 0.5rem;
+	}
+
+	.components-text.validation-msg {
 		color: var(--studio-red-50);
 
 		svg {
 			fill: var(--studio-red-50);
 			margin-left: 0;
 		}
-	}
-
-	.components-text.info-msg {
-		display: block;
-		font-size: 0.75rem;
-		margin-bottom: 0.5rem;
 	}
 }

--- a/client/blocks/plugins-update-manager/schedule-form.scss
+++ b/client/blocks/plugins-update-manager/schedule-form.scss
@@ -65,7 +65,7 @@
 		> * {
 			margin-bottom: 0.875rem;
 
-			&:last-child {
+			&:last-child:not(.components-spinner) {
 				margin-bottom: 0;
 			}
 		}

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -94,14 +94,14 @@ export const ScheduleForm = ( props: Props ) => {
 	);
 
 	const onFormSubmit = () => {
-		const forValid = ! Object.values( validationErrors ).filter( ( e ) => !! e ).length;
+		const formValid = ! Object.values( validationErrors ).filter( ( e ) => !! e ).length;
 		setFieldTouched( {
 			name: true,
 			plugins: true,
 			timestamp: true,
 		} );
 
-		forValid &&
+		formValid &&
 			createScheduleUpdates( {
 				hook: name,
 				plugins: selectedPlugins,

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -238,7 +238,8 @@ export const ScheduleForm = ( props: Props ) => {
 					<div className="form-field">
 						<label htmlFor="plugins">Select plugins</label>
 						<span className="plugin-select-stats">
-							{ selectedPlugins.length }/{ MAX_SELECTABLE_PLUGINS }
+							{ selectedPlugins.length }/
+							{ plugins.length < MAX_SELECTABLE_PLUGINS ? plugins.length : MAX_SELECTABLE_PLUGINS }
 						</span>
 						{ fieldTouched?.plugins && validationErrors?.plugins ? (
 							<Text className="validation-msg">

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -52,7 +52,7 @@ export const ScheduleForm = ( props: Props ) => {
 	const [ day, setDay ] = useState< string >( '1' );
 	const [ hour, setHour ] = useState< string >( '6' );
 	const [ period, setPeriod ] = useState< string >( '1m' );
-	const [ timestamp, setTimestamp ] = useState( prepareTimestamp( frequency, day, hour, period ) );
+	const timestamp = prepareTimestamp( frequency, day, hour, period );
 	const [ pluginSearchTerm, setPluginSearchTerm ] = useState( '' );
 	const [ validationErrors, setValidationErrors ] = useState< Record< string, string > >( {
 		name: validateName( name ),
@@ -133,12 +133,6 @@ export const ScheduleForm = ( props: Props ) => {
 				timestamp: validateTimeSlot( { frequency, timestamp } ),
 			} ),
 		[ timestamp ]
-	);
-
-	// Prepare timestamp on frequency, day, hour, period change
-	useEffect(
-		() => setTimestamp( prepareTimestamp( frequency, day, hour, period ) ),
-		[ frequency, day, hour, period ]
 	);
 
 	return (

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -36,16 +36,19 @@ import './schedule-form.scss';
 
 interface Props {
 	siteSlug: SiteSlug;
+	onCreateSuccess?: () => void;
 }
 export const ScheduleForm = ( props: Props ) => {
-	const { siteSlug } = props;
+	const { siteSlug, onCreateSuccess } = props;
 	const {
 		data: dataPlugins,
 		isLoading: isPluginsFetching,
 		isFetched: isPluginsFetched,
 	} = useSitePluginsQuery( siteSlug );
 	const { data: schedules = [] } = useScheduleUpdatesQuery( siteSlug );
-	const { createScheduleUpdates } = useCreateScheduleUpdatesMutation( siteSlug );
+	const { createScheduleUpdates } = useCreateScheduleUpdatesMutation( siteSlug, {
+		onSuccess: () => onCreateSuccess && onCreateSuccess(),
+	} );
 	const { plugins = [] } = dataPlugins ?? {};
 
 	const [ name, setName ] = useState( '' );

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -59,10 +59,11 @@ export const ScheduleForm = ( props: Props ) => {
 		timestamp: schedule.timestamp,
 		frequency: schedule.schedule,
 	} ) );
+	const scheduledPlugins = schedules.map( ( schedule ) => schedule.args );
 	const [ pluginSearchTerm, setPluginSearchTerm ] = useState( '' );
 	const [ validationErrors, setValidationErrors ] = useState< Record< string, string > >( {
 		name: validateName( name ),
-		plugins: validatePlugins( selectedPlugins ),
+		plugins: validatePlugins( selectedPlugins, scheduledPlugins ),
 		timestamp: validateTimeSlot( { frequency, timestamp }, existingTimeSlots ),
 	} );
 	const [ fieldTouched, setFieldTouched ] = useState< Record< string, boolean > >( {} );
@@ -127,7 +128,10 @@ export const ScheduleForm = ( props: Props ) => {
 	// Plugin selection validation
 	useEffect(
 		() =>
-			setValidationErrors( { ...validationErrors, plugins: validatePlugins( selectedPlugins ) } ),
+			setValidationErrors( {
+				...validationErrors,
+				plugins: validatePlugins( selectedPlugins, scheduledPlugins ),
+			} ),
 		[ selectedPlugins ]
 	);
 

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -8,6 +8,7 @@ import {
 	Flex,
 	FlexItem,
 	FlexBlock,
+	Spinner,
 } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
@@ -37,7 +38,11 @@ interface Props {
 }
 export const ScheduleForm = ( props: Props ) => {
 	const { siteSlug } = props;
-	const { data: dataPlugins } = useSitePluginsQuery( siteSlug );
+	const {
+		data: dataPlugins,
+		isLoading: isPluginsFetching,
+		isFetched: isPluginsFetched,
+	} = useSitePluginsQuery( siteSlug );
 	const { createScheduleUpdates } = useCreateScheduleUpdatesMutation( siteSlug );
 	const { plugins = [] } = dataPlugins ?? {};
 
@@ -281,7 +286,8 @@ export const ScheduleForm = ( props: Props ) => {
 								value={ pluginSearchTerm }
 							/>
 							<div className="checkbox-options-container">
-								{ plugins.length <= MAX_SELECTABLE_PLUGINS && (
+								{ isPluginsFetching && <Spinner /> }
+								{ isPluginsFetched && plugins.length <= MAX_SELECTABLE_PLUGINS && (
 									<CheckboxControl
 										label="Select all"
 										indeterminate={
@@ -291,27 +297,28 @@ export const ScheduleForm = ( props: Props ) => {
 										onChange={ onPluginSelectAllChange }
 									/>
 								) }
-								{ plugins.map( ( plugin ) => (
-									<Fragment key={ plugin.name }>
-										{ plugin.display_name
-											.toLowerCase()
-											.includes( pluginSearchTerm.toLowerCase() ) && (
-											<CheckboxControl
-												key={ plugin.name }
-												label={ plugin.display_name }
-												checked={ selectedPlugins.includes( plugin.name ) }
-												disabled={ isPluginSelectionDisabled( plugin ) }
-												className={ classnames( {
-													disabled: isPluginSelectionDisabled( plugin ),
-												} ) }
-												onChange={ ( isChecked ) => {
-													setFieldTouched( { ...fieldTouched, plugins: true } );
-													onPluginSelectionChange( plugin, isChecked );
-												} }
-											/>
-										) }
-									</Fragment>
-								) ) }
+								{ isPluginsFetched &&
+									plugins.map( ( plugin ) => (
+										<Fragment key={ plugin.name }>
+											{ plugin.display_name
+												.toLowerCase()
+												.includes( pluginSearchTerm.toLowerCase() ) && (
+												<CheckboxControl
+													key={ plugin.name }
+													label={ plugin.display_name }
+													checked={ selectedPlugins.includes( plugin.name ) }
+													disabled={ isPluginSelectionDisabled( plugin ) }
+													className={ classnames( {
+														disabled: isPluginSelectionDisabled( plugin ),
+													} ) }
+													onChange={ ( isChecked ) => {
+														setFieldTouched( { ...fieldTouched, plugins: true } );
+														onPluginSelectionChange( plugin, isChecked );
+													} }
+												/>
+											) }
+										</Fragment>
+									) ) }
 							</div>
 						</div>
 					</div>

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -15,13 +15,13 @@ import { Fragment, useState, useCallback, useEffect } from 'react';
 import { useCreateScheduleUpdatesMutation } from 'calypso/data/plugins/use-schedule-updates-mutation';
 import { useSitePluginsQuery, type SitePlugin } from 'calypso/data/plugins/use-site-plugins-query';
 import { SiteSlug } from 'calypso/types';
+import { MAX_SELECTABLE_PLUGINS } from './config';
 import {
 	DAILY_OPTION,
 	DAY_OPTIONS,
 	HOUR_OPTIONS,
 	PERIOD_OPTIONS,
 	WEEKLY_OPTION,
-	MAX_SELECTABLE_PLUGINS,
 } from './schedule-form.const';
 import {
 	prepareTimestamp,

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -55,7 +55,7 @@ export const ScheduleForm = ( props: Props ) => {
 	const [ hour, setHour ] = useState< string >( '6' );
 	const [ period, setPeriod ] = useState< string >( '1m' );
 	const timestamp = prepareTimestamp( frequency, day, hour, period );
-	const existingTimeSlots = schedules.map( ( schedule ) => ( {
+	const scheduledTimeSlots = schedules.map( ( schedule ) => ( {
 		timestamp: schedule.timestamp,
 		frequency: schedule.schedule,
 	} ) );
@@ -64,7 +64,7 @@ export const ScheduleForm = ( props: Props ) => {
 	const [ validationErrors, setValidationErrors ] = useState< Record< string, string > >( {
 		name: validateName( name ),
 		plugins: validatePlugins( selectedPlugins, scheduledPlugins ),
-		timestamp: validateTimeSlot( { frequency, timestamp }, existingTimeSlots ),
+		timestamp: validateTimeSlot( { frequency, timestamp }, scheduledTimeSlots ),
 	} );
 	const [ fieldTouched, setFieldTouched ] = useState< Record< string, boolean > >( {} );
 
@@ -140,7 +140,7 @@ export const ScheduleForm = ( props: Props ) => {
 		() =>
 			setValidationErrors( {
 				...validationErrors,
-				timestamp: validateTimeSlot( { frequency, timestamp }, existingTimeSlots ),
+				timestamp: validateTimeSlot( { frequency, timestamp }, scheduledTimeSlots ),
 			} ),
 		[ timestamp ]
 	);

--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -1,67 +1,82 @@
 import { DropdownMenu, Tooltip } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
-import { Badge } from 'calypso/blocks/plugins-update-manager/badge';
+import { MOMENT_TIME_FORMAT } from 'calypso/blocks/plugins-update-manager/config';
+import { usePreparePluginsTooltipInfo } from 'calypso/blocks/plugins-update-manager/hooks/use-prepare-plugins-tooltip-info';
 import { ellipsis } from 'calypso/blocks/plugins-update-manager/icons';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updates-query';
 
 interface Props {
-	onRemoveClick: () => void;
+	siteSlug: string;
+	onRemoveClick: ( id: string ) => void;
 }
 export const ScheduleListCards = ( props: Props ) => {
-	const { onRemoveClick } = props;
+	const moment = useLocalizedMoment();
+	const { siteSlug, onRemoveClick } = props;
+	const { data: schedules = [] } = useScheduleUpdatesQuery( siteSlug );
+	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 
 	return (
 		<div className="schedule-list--cards">
-			<div className="schedule-list--card">
-				<DropdownMenu
-					className="schedule-list--card-actions"
-					controls={ [
-						{
-							title: 'Remove',
-							onClick: onRemoveClick,
-						},
-					] }
-					icon={ ellipsis }
-					label="More"
-				/>
+			{ schedules.map( ( schedule ) => (
+				<div className="schedule-list--card" key={ schedule.id }>
+					<DropdownMenu
+						className="schedule-list--card-actions"
+						controls={ [
+							{
+								title: 'Remove',
+								onClick: () => onRemoveClick( schedule.id ),
+							},
+						] }
+						icon={ ellipsis }
+						label="More"
+					/>
 
-				<div className="schedule-list--card-label">
-					<label htmlFor="name">Name</label>
-					<strong id="name">Move to WordPress.com plugin</strong>
-				</div>
+					<div className="schedule-list--card-label">
+						<label htmlFor="name">Name</label>
+						<strong id="name">{ schedule.hook }</strong>
+					</div>
 
-				<div className="schedule-list--card-label">
-					<label htmlFor="last-update">Last Update</label>
-					<span id="last-update">
-						Feb 28 7:00 PM UTC
-						<Badge type="success" />
-					</span>
-				</div>
+					<div className="schedule-list--card-label">
+						<label htmlFor="last-update">Last Update</label>
+						<span id="last-update"></span>
+					</div>
 
-				<div className="schedule-list--card-label">
-					<label htmlFor="next-update">Next update</label>
-					<span id="next-update">Feb 28 7:00 PM UTC</span>
-				</div>
+					<div className="schedule-list--card-label">
+						<label htmlFor="next-update">Next update</label>
+						<span id="next-update">
+							{ moment( schedule.timestamp * 1000 ).format( MOMENT_TIME_FORMAT ) }
+						</span>
+					</div>
 
-				<div className="schedule-list--card-label">
-					<label htmlFor="frequency">Frequency</label>
-					<span id="frequency">Daily</span>
-				</div>
+					<div className="schedule-list--card-label">
+						<label htmlFor="frequency">Frequency</label>
+						<span id="frequency">
+							{
+								{
+									daily: 'Daily',
+									weekly: 'Weekly',
+								}[ schedule.schedule ]
+							}
+						</span>
+					</div>
 
-				<div className="schedule-list--card-label">
-					<label htmlFor="plugins">Plugins</label>
-					<span id="plugins">
-						1
-						<Tooltip
-							text="Move to WordPress.com plugin"
-							position="middle right"
-							delay={ 0 }
-							hideOnClick={ false }
-						>
-							<Icon className="icon-info" icon={ info } size={ 16 } />
-						</Tooltip>
-					</span>
+					<div className="schedule-list--card-label">
+						<label htmlFor="plugins">Plugins</label>
+						<span id="plugins">
+							{ schedule?.args?.length }
+							<Tooltip
+								text={ preparePluginsTooltipInfo( schedule.args ) as unknown as string }
+								position="middle right"
+								delay={ 0 }
+								hideOnClick={ false }
+							>
+								<Icon className="icon-info" icon={ info } size={ 16 } />
+							</Tooltip>
+						</span>
+					</div>
 				</div>
-			</div>
+			) ) }
 		</div>
 	);
 };

--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -1,21 +1,36 @@
 import { DropdownMenu, Tooltip } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { Icon, info } from '@wordpress/icons';
-import { Badge } from './badge';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updates-query';
+import { useSitePluginsQuery, type SitePlugin } from 'calypso/data/plugins/use-site-plugins-query';
+import { MOMENT_TIME_FORMAT } from './config';
 import { ellipsis } from './icons';
 
 interface Props {
-	onRemoveClick: () => void;
+	siteSlug: string;
+	onRemoveClick: ( id: string ) => void;
 }
 export const ScheduleListTable = ( props: Props ) => {
-	const { onRemoveClick } = props;
-	const toolbarPluginsText = createInterpolateElement(
-		'<div>Move to WordPress.com<br />Akismet<br />Gravity Forms</div>',
-		{
+	const moment = useLocalizedMoment();
+	const { siteSlug, onRemoveClick } = props;
+	const { data: pluginsData } = useSitePluginsQuery( siteSlug );
+	const { data: schedules = [] } = useScheduleUpdatesQuery( siteSlug );
+	const plugins = pluginsData?.plugins ?? [];
+
+	const preparePluginsTooltipInfo = ( pluginsArgs: string[] ) => {
+		const pluginsList = pluginsArgs
+			.map(
+				( plugin: string ) =>
+					plugins.find( ( { name }: SitePlugin ) => name === plugin )?.display_name
+			)
+			.join( '<br />' );
+
+		return createInterpolateElement( `<div>${ pluginsList }</div>`, {
 			div: <div className="tooltip--selected-plugins" />,
 			br: <br />,
-		}
-	);
+		} );
+	};
 
 	/**
 	 * NOTE: If you update the table structure,
@@ -34,72 +49,47 @@ export const ScheduleListTable = ( props: Props ) => {
 				</tr>
 			</thead>
 			<tbody>
-				<tr>
-					<td className="name">Move to WordPress.com plugin</td>
-					<td>
-						<Badge type="success" />
-						Feb 27 7:00 PM UTC
-					</td>
-					<td>Feb 28 7:00 PM UTC</td>
-					<td>Daily</td>
-					<td>
-						1
-						<Tooltip
-							text="Move to WordPress.com plugin"
-							position="middle right"
-							delay={ 0 }
-							hideOnClick={ false }
-						>
-							<Icon className="icon-info" icon={ info } size={ 16 } />
-						</Tooltip>
-					</td>
-					<td style={ { textAlign: 'end' } }>
-						<DropdownMenu
-							popoverProps={ { position: 'bottom left' } }
-							controls={ [
+				{ schedules.map( ( schedule ) => (
+					<tr key={ schedule.id }>
+						<td className="name">{ schedule.hook }</td>
+						<td></td>
+						<td>{ moment( schedule.timestamp * 1000 ).format( MOMENT_TIME_FORMAT ) }</td>
+						<td>
+							{
 								{
-									title: 'Remove',
-									onClick: onRemoveClick,
-								},
-							] }
-							icon={ ellipsis }
-							label="More"
-						/>
-					</td>
-				</tr>
-				<tr>
-					<td className="name">Security plugins</td>
-					<td>
-						<Badge type="failed" />
-						Feb 21 7:00 PM UTC
-					</td>
-					<td>Feb 28 7:00 PM UTC</td>
-					<td>Weekly</td>
-					<td>
-						3
-						<Tooltip
-							text={ toolbarPluginsText as unknown as string }
-							position="middle right"
-							delay={ 0 }
-							hideOnClick={ false }
-						>
-							<Icon className="icon-info" icon={ info } size={ 16 } />
-						</Tooltip>
-					</td>
-					<td style={ { textAlign: 'end' } }>
-						<DropdownMenu
-							popoverProps={ { position: 'bottom left' } }
-							controls={ [
-								{
-									title: 'Remove',
-									onClick: onRemoveClick,
-								},
-							] }
-							icon={ ellipsis }
-							label="More"
-						/>
-					</td>
-				</tr>
+									daily: 'Daily',
+									weekly: 'Weekly',
+								}[ schedule.schedule ]
+							}
+						</td>
+						<td>
+							{ schedule?.args?.length }
+							{ schedule?.args && (
+								<Tooltip
+									text={ preparePluginsTooltipInfo( schedule.args ) as unknown as string }
+									position="middle right"
+									delay={ 0 }
+									hideOnClick={ false }
+								>
+									<Icon className="icon-info" icon={ info } size={ 16 } />
+								</Tooltip>
+							) }
+						</td>
+						<td style={ { textAlign: 'end' } }>
+							<DropdownMenu
+								popoverProps={ { position: 'bottom left' } }
+								controls={ [
+									{
+										title: 'Remove',
+										onClick: () => onRemoveClick( schedule.id ),
+									},
+								] }
+								icon={ ellipsis }
+								label="More"
+							/>
+						</td>
+					</tr>
+				) ) }
 			</tbody>
 		</table>
 	);

--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -1,10 +1,9 @@
 import { DropdownMenu, Tooltip } from '@wordpress/components';
-import { createInterpolateElement } from '@wordpress/element';
 import { Icon, info } from '@wordpress/icons';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updates-query';
-import { useSitePluginsQuery, type SitePlugin } from 'calypso/data/plugins/use-site-plugins-query';
 import { MOMENT_TIME_FORMAT } from './config';
+import { usePreparePluginsTooltipInfo } from './hooks/use-prepare-plugins-tooltip-info';
 import { ellipsis } from './icons';
 
 interface Props {
@@ -14,23 +13,8 @@ interface Props {
 export const ScheduleListTable = ( props: Props ) => {
 	const moment = useLocalizedMoment();
 	const { siteSlug, onRemoveClick } = props;
-	const { data: pluginsData } = useSitePluginsQuery( siteSlug );
 	const { data: schedules = [] } = useScheduleUpdatesQuery( siteSlug );
-	const plugins = pluginsData?.plugins ?? [];
-
-	const preparePluginsTooltipInfo = ( pluginsArgs: string[] ) => {
-		const pluginsList = pluginsArgs
-			.map(
-				( plugin: string ) =>
-					plugins.find( ( { name }: SitePlugin ) => name === plugin )?.display_name
-			)
-			.join( '<br />' );
-
-		return createInterpolateElement( `<div>${ pluginsList }</div>`, {
-			div: <div className="tooltip--selected-plugins" />,
-			br: <br />,
-		} );
-	};
+	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 
 	/**
 	 * NOTE: If you update the table structure,

--- a/client/blocks/plugins-update-manager/schedule-list.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list.tsx
@@ -30,8 +30,15 @@ export const ScheduleList = ( props: Props ) => {
 	const [ removeDialogOpen, setRemoveDialogOpen ] = useState( false );
 	const [ selectedScheduleId, setSelectedScheduleId ] = useState< undefined | string >();
 
-	const { deleteScheduleUpdates } = useDeleteScheduleUpdatesMutation( siteSlug );
-	const { data: schedules = [], isLoading, isFetched } = useScheduleUpdatesQuery( siteSlug );
+	const {
+		data: schedules = [],
+		isLoading,
+		isFetched,
+		refetch,
+	} = useScheduleUpdatesQuery( siteSlug );
+	const { deleteScheduleUpdates } = useDeleteScheduleUpdatesMutation( siteSlug, {
+		onSuccess: () => refetch(),
+	} );
 
 	const openRemoveDialog = ( id: string ) => {
 		setRemoveDialogOpen( true );

--- a/client/blocks/plugins-update-manager/schedule-list.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list.tsx
@@ -27,7 +27,7 @@ export const ScheduleList = ( props: Props ) => {
 
 	const { siteSlug, onNavBack, onCreateNewSchedule } = props;
 	const [ isConfirmOpen, setIsConfirmOpen ] = useState( false );
-	const { data: schedules = [], isFetching, isFetched } = useScheduleUpdatesQuery( siteSlug );
+	const { data: schedules = [], isLoading, isFetched } = useScheduleUpdatesQuery( siteSlug );
 
 	const closeConfirm = () => {
 		setIsConfirmOpen( false );
@@ -51,7 +51,7 @@ export const ScheduleList = ( props: Props ) => {
 					<div className="ch-placeholder"></div>
 				</CardHeader>
 				<CardBody>
-					{ isFetching && <Spinner /> }
+					{ isLoading && <Spinner /> }
 					{ isFetched && schedules.length === 0 && (
 						<ScheduleListEmpty onCreateNewSchedule={ onCreateNewSchedule } />
 					) }

--- a/client/blocks/plugins-update-manager/schedule-list.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list.tsx
@@ -84,7 +84,7 @@ export const ScheduleList = ( props: Props ) => {
 					{ isFetched && schedules.length > 0 && (
 						<>
 							{ isMobile ? (
-								<ScheduleListCards onRemoveClick={ () => setRemoveDialogOpen( true ) } />
+								<ScheduleListCards siteSlug={ siteSlug } onRemoveClick={ openRemoveDialog } />
 							) : (
 								<ScheduleListTable siteSlug={ siteSlug } onRemoveClick={ openRemoveDialog } />
 							) }

--- a/client/blocks/plugins-update-manager/schedule-list.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list.tsx
@@ -6,21 +6,28 @@ import {
 	Card,
 	CardBody,
 	CardHeader,
+	Spinner,
 } from '@wordpress/components';
 import { Icon, arrowLeft, info } from '@wordpress/icons';
 import { useState } from 'react';
+import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updates-query';
 import { ScheduleListCards } from './schedule-list-cards';
 import { ScheduleListEmpty } from './schedule-list-empty';
 import { ScheduleListTable } from './schedule-list-table';
+import type { SiteSlug } from 'calypso/types';
 
 interface Props {
+	siteSlug: SiteSlug;
 	onNavBack?: () => void;
 	onCreateNewSchedule?: () => void;
 }
 export const ScheduleList = ( props: Props ) => {
-	const { onNavBack, onCreateNewSchedule } = props;
+	const MAX_SCHEDULES = 2;
 	const isMobile = useMobileBreakpoint();
+
+	const { siteSlug, onNavBack, onCreateNewSchedule } = props;
 	const [ isConfirmOpen, setIsConfirmOpen ] = useState( false );
+	const { data: schedules = [], isFetching, isFetched } = useScheduleUpdatesQuery( siteSlug );
 
 	const closeConfirm = () => {
 		setIsConfirmOpen( false );
@@ -44,19 +51,25 @@ export const ScheduleList = ( props: Props ) => {
 					<div className="ch-placeholder"></div>
 				</CardHeader>
 				<CardBody>
-					<ScheduleListEmpty onCreateNewSchedule={ onCreateNewSchedule } />
-				</CardBody>
-				<CardBody>
-					{ isMobile ? (
-						<ScheduleListCards onRemoveClick={ () => setIsConfirmOpen( true ) } />
-					) : (
-						<ScheduleListTable onRemoveClick={ () => setIsConfirmOpen( true ) } />
+					{ isFetching && <Spinner /> }
+					{ isFetched && schedules.length === 0 && (
+						<ScheduleListEmpty onCreateNewSchedule={ onCreateNewSchedule } />
 					) }
-
-					<Text as="p">
-						<Icon className="icon-info" icon={ info } size={ 16 } />
-						The current feature implementation only allows to set up two schedules.
-					</Text>
+					{ isFetched && schedules.length > 0 && (
+						<>
+							{ isMobile ? (
+								<ScheduleListCards onRemoveClick={ () => setIsConfirmOpen( true ) } />
+							) : (
+								<ScheduleListTable onRemoveClick={ () => setIsConfirmOpen( true ) } />
+							) }
+						</>
+					) }
+					{ isFetched && schedules.length >= MAX_SCHEDULES && (
+						<Text as="p">
+							<Icon className="icon-info" icon={ info } size={ 16 } />
+							The current feature implementation only allows to set up two schedules.
+						</Text>
+					) }
 				</CardBody>
 			</Card>
 		</>

--- a/client/blocks/plugins-update-manager/styles.scss
+++ b/client/blocks/plugins-update-manager/styles.scss
@@ -23,6 +23,11 @@
 		margin-bottom: 0.5rem;
 	}
 
+	.components-spinner {
+		display: block;
+		margin: 3rem auto;
+	}
+
 	svg.icon-info {
 		fill: var(--studio-gray-60);
 		vertical-align: middle;

--- a/client/data/plugins/use-schedule-updates-mutation.ts
+++ b/client/data/plugins/use-schedule-updates-mutation.ts
@@ -1,0 +1,39 @@
+import { useMutation } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import wpcomRequest from 'wpcom-proxy-request';
+import type { SiteSlug } from 'calypso/types';
+
+export function useCreateScheduleUpdatesMutation( siteSlug: SiteSlug, queryOptions = {} ) {
+	const mutation = useMutation( {
+		mutationFn: ( params: object ) =>
+			wpcomRequest( {
+				path: `/sites/${ siteSlug }/update-schedules`,
+				apiNamespace: 'wpcom/v2',
+				method: 'POST',
+				body: params,
+			} ),
+		...queryOptions,
+	} );
+
+	const { mutate } = mutation;
+	const createScheduleUpdates = useCallback( ( params: object ) => mutate( params ), [ mutate ] );
+
+	return { createScheduleUpdates, ...mutation };
+}
+
+export function useDeleteScheduleUpdatesMutation( siteSlug: SiteSlug, queryOptions = {} ) {
+	const mutation = useMutation( {
+		mutationFn: ( id: string ) =>
+			wpcomRequest( {
+				path: `/sites/${ siteSlug }/update-schedules/${ id }`,
+				apiNamespace: 'wpcom/v2',
+				method: 'DELETE',
+			} ),
+		...queryOptions,
+	} );
+
+	const { mutate } = mutation;
+	const deleteScheduleUpdates = useCallback( ( id: string ) => mutate( id ), [ mutate ] );
+
+	return { deleteScheduleUpdates, ...mutation };
+}

--- a/client/data/plugins/use-schedule-updates-query.ts
+++ b/client/data/plugins/use-schedule-updates-query.ts
@@ -2,7 +2,17 @@ import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
 import type { SiteSlug } from 'calypso/types';
 
-export const useScheduleUpdatesQuery = ( siteSlug: SiteSlug ): UseQueryResult => {
+export type ScheduleUpdates = {
+	hook: string;
+	interval: number;
+	timestamp: number;
+	schedule: 'weekly' | 'daily';
+	args: string[];
+};
+
+export const useScheduleUpdatesQuery = (
+	siteSlug: SiteSlug
+): UseQueryResult< ScheduleUpdates[] > => {
 	return useQuery( {
 		queryKey: [ 'schedule-updates', siteSlug ],
 		queryFn: () =>

--- a/client/data/plugins/use-schedule-updates-query.ts
+++ b/client/data/plugins/use-schedule-updates-query.ts
@@ -1,0 +1,21 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import type { SiteSlug } from 'calypso/types';
+
+export const useScheduleUpdatesQuery = ( siteSlug: SiteSlug ): UseQueryResult => {
+	return useQuery( {
+		queryKey: [ 'schedule-updates', siteSlug ],
+		queryFn: () =>
+			wpcomRequest( {
+				path: `/sites/${ siteSlug }/update-schedules`,
+				apiNamespace: 'wpcom/v2',
+				method: 'GET',
+			} ),
+		meta: {
+			persist: false,
+		},
+		enabled: !! siteSlug,
+		retry: false,
+		refetchOnWindowFocus: false,
+	} );
+};

--- a/client/data/plugins/use-schedule-updates-query.ts
+++ b/client/data/plugins/use-schedule-updates-query.ts
@@ -3,6 +3,7 @@ import wpcomRequest from 'wpcom-proxy-request';
 import type { SiteSlug } from 'calypso/types';
 
 export type ScheduleUpdates = {
+	id: string;
 	hook: string;
 	interval: number;
 	timestamp: number;
@@ -16,11 +17,16 @@ export const useScheduleUpdatesQuery = (
 	return useQuery( {
 		queryKey: [ 'schedule-updates', siteSlug ],
 		queryFn: () =>
-			wpcomRequest( {
+			wpcomRequest< { [ key: string ]: Partial< ScheduleUpdates > } >( {
 				path: `/sites/${ siteSlug }/update-schedules`,
 				apiNamespace: 'wpcom/v2',
 				method: 'GET',
-			} ),
+			} ).then( ( response ) =>
+				Object.keys( response ).map( ( id ) => ( {
+					id,
+					...response[ id ],
+				} ) )
+			),
 		meta: {
 			persist: false,
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5544
Closes https://github.com/Automattic/dotcom-forge/issues/5646


## Proposed Changes

* Integrate fetching schedules endpoint
* Integrated create endpoint
* Integrated delete endpoint
* Fixed some small presentation bugs
* Shown spinner while fetching plugins and schedules
* Connected form validation with the existing scheduled timeslots and plugins

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/scheduled-updates/{WoA_SITE_SLUG}`
* Check if create action with validation works properly
* Check if deleting scheduled updates works properly

**NOTE:** In the next PRs, busy state while the action is in progress will be covered

![Screen Capture on 2024-03-04 at 12-56-55](https://github.com/Automattic/wp-calypso/assets/1241413/c23ece51-c668-48a5-8d4b-b02388ff44d8)

![Screen Capture on 2024-02-29 at 18-32-13](https://github.com/Automattic/wp-calypso/assets/1241413/0f5abb7c-743c-4e32-b012-04dc78b31b86)
![Screen Capture on 2024-02-29 at 18-26-12](https://github.com/Automattic/wp-calypso/assets/1241413/ca002037-a159-4611-9bd2-6ee9c495acf7)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?