### PR TITLE
Odyssey Stats: Add Sentry support

### DIFF
--- a/apps/odyssey-stats/src/app.tsx
+++ b/apps/odyssey-stats/src/app.tsx
@@ -18,6 +18,7 @@ import { setStore } from 'calypso/state/redux-store';
 import sites from 'calypso/state/sites/reducer';
 import { combineReducers, addReducerEnhancer } from 'calypso/state/utils';
 import config from './lib/config-api';
+import initSentry from './lib/init-sentry';
 import setLocale from './lib/set-locale';
 import { setupContextMiddleware } from './page-middleware/setup-context';
 import registerStatsPages from './routes';
@@ -78,4 +79,6 @@ async function AppBoot() {
 	} );
 }
 
+// Caution: We're loading Sentry after initializing Webpack; Webpack load failures may not be captured.
+initSentry();
 AppBoot();

--- a/apps/odyssey-stats/src/lib/init-sentry.ts
+++ b/apps/odyssey-stats/src/lib/init-sentry.ts
@@ -1,0 +1,7 @@
+export default function initSentry() {
+	const script = document.createElement( 'script' );
+	// Uses unique DNS specific to Odyssey Stats.
+	script.src = 'https://js.sentry-cdn.com/332d216a4d31158057fb5277cd48f438.min.js';
+	script.crossOrigin = 'anonymous';
+	document.body.appendChild( script );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Adds minimal Sentry integration for Odyssey Stats. Note that we're not using Calypso's Sentry initialization, which is specific to the Calypso environment and uses a different Sentry project DNS.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Sandbox widgets.wp.com.
* Apply these changes to Odyssey Stats via `install-plugin.sh odyssey-stats add/sentry-to-odyssey-stats` on your sandbox.
* Navigate to the Stats dashboard at `/wp-admin/admin.php?page=stats` with your browser network panel open.
* Ensure you see a request for this asset: `https://js.sentry-cdn.com/332d216a4d31158057fb5277cd48f438.min.js`
* (optional) While using a local Jetpack development environment, intentionally trigger an error by adding the following to [this line](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/stats-admin/src/class-dashboard.php#L128):

```php
// setTimeout is necessary since our current Sentry instrumentation doesn't record errors that happen prior to Odyssey Stats mounting. 
wp_add_inline_script( 'jp-stats-dashboard', 'setTimeout(() => someUndefinedFunctionToThrowAnError(), 1000);' );
```
The above error should be recorded in the Jetpack Stats Sentry project like so:

> ![image](https://github.com/Automattic/wp-calypso/assets/4044428/91ef6a66-3e6d-4118-9b37-24e0c87344f9)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?