### PR TITLE
Only offer to fix email DNS issues automatically when an automatic fix is possible

### DIFF
--- a/client/lib/domains/types.ts
+++ b/client/lib/domains/types.ts
@@ -201,5 +201,6 @@ export type DomainDiagnostics = {
 		is_using_wpcom_name_servers: boolean;
 		all_essential_email_dns_records_are_correct: boolean;
 		dismissed_email_dns_issues_notice: boolean;
+		should_offer_automatic_fixes: boolean;
 	};
 };

--- a/client/my-sites/domains/domain-management/settings/cards/domain-diagnostics-card.tsx
+++ b/client/my-sites/domains/domain-management/settings/cards/domain-diagnostics-card.tsx
@@ -118,16 +118,6 @@ export default function DomainDiagnosticsCard( { domain }: { domain: ResponseDom
 		return null;
 	};
 
-	const renderFixInstructions = () => {
-		return (
-			<p>
-				{ translate(
-					"To fix these issues, you should go to your domain's DNS provider and add the records above to your domain's DNS settings."
-				) }
-			</p>
-		);
-	};
-
 	const fixDnsIssues = () => {
 		setIsRestoringDefaultRecords( true );
 
@@ -142,7 +132,7 @@ export default function DomainDiagnosticsCard( { domain }: { domain: ResponseDom
 			.then( () => {
 				dispatch(
 					successNotice(
-						translate( 'The default email DNS records were successfully fixed!' ),
+						translate( 'The default email DNS records were successfully restored!' ),
 						noticeOptions
 					)
 				);
@@ -163,19 +153,6 @@ export default function DomainDiagnosticsCard( { domain }: { domain: ResponseDom
 			} );
 	};
 
-	const renderFixButton = () => {
-		return (
-			<Button
-				busy={ isRestoringDefaultRecords }
-				disabled={ isRestoringDefaultRecords }
-				onClick={ fixDnsIssues }
-				primary
-			>
-				{ translate( 'Fix DNS issues automatically' ) }
-			</Button>
-		);
-	};
-
 	const noticeText = translate(
 		'If you use this domain name to send email from your WordPress.com website, the following email records are required. {{a}}Learn more{{/a}}.',
 		{
@@ -184,6 +161,31 @@ export default function DomainDiagnosticsCard( { domain }: { domain: ResponseDom
 			},
 		}
 	);
+
+	const renderFixInstructions = () => {
+		if ( ! emailDnsDiagnostics.is_using_wpcom_name_servers ) {
+			return (
+				<p>
+					{ translate(
+						"To fix these issues, you should go to your domain's DNS provider and add the records above to your domain's DNS settings."
+					) }
+				</p>
+			);
+		}
+
+		if ( emailDnsDiagnostics.should_offer_automatic_fixes ) {
+			return (
+				<Button
+					busy={ isRestoringDefaultRecords }
+					disabled={ isRestoringDefaultRecords }
+					onClick={ fixDnsIssues }
+					primary
+				>
+					{ translate( 'Fix DNS issues automatically' ) }
+				</Button>
+			);
+		}
+	};
 
 	return (
 		<>
@@ -208,9 +210,7 @@ export default function DomainDiagnosticsCard( { domain }: { domain: ResponseDom
 						) }
 					</Notice>
 					<ul>{ recordsToCheck.map( renderDiagnosticForRecord ) }</ul>
-					{ emailDnsDiagnostics.is_using_wpcom_name_servers
-						? renderFixButton()
-						: renderFixInstructions() }
+					{ renderFixInstructions() }
 				</div>
 			</Accordion>
 		</>


### PR DESCRIPTION
### Issue:

Some of the issues that we can detect as part of the DNS diagnostics tool can only be fixed manually. When that's the case, we still show the "Fix DNS issues Automatically", which is confusing.

![image](https://github.com/Automattic/wp-calypso/assets/1080253/28a85e9e-4c47-4661-abe5-a6e98843f277)

### Fix:

This PR relies on a new property (introduced in D140087-code) to hide the "Fix DNS issues Automatically" button when none of the issues found can be fixed automatically.

<img width="707" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1080253/786a6baf-925d-4283-8c83-f5d74499c3b2">

### Testing:

* The easiest way to test this is to have a domain with SPF records.
* Go to the [DNS records](https://wordpress.com/support/domains/custom-dns/) page for any of your domains.
* Add one or more `SPF` records so that you end up with a total of two or more SPF records. An example of an SPF record can be `v=spf1 a`, which should be added as a `TXT` record on the root zone.
* Now navigate back to the Domain Management page (go to Upgrades → [Domains](https://wordpress.com/domains/manage/), then click on the domain you just added SPF records for.
* Look for and expand the Diagnostics card.