### PR TITLE
Site Migration: Begin adding site migration instructions

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -1,13 +1,71 @@
 import { StepContainer } from '@automattic/onboarding';
+import { useTranslate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
 
 const SiteMigrationInstructions: Step = function () {
+	const translate = useTranslate();
 	const stepContent = (
 		<div>
-			<p>Site migration instructions go here.</p>
+			<ol>
+				<li>
+					{ translate( 'Install the {{a}}Migrate Guru plugin{{/a}} on your existing site.', {
+						components: {
+							a: (
+								<a
+									href="https://wordpress.org/plugins/migrate-guru/"
+									target="_blank"
+									rel="noreferrer"
+								/>
+							),
+						},
+					} ) }
+				</li>
+				<li>
+					{ translate(
+						'Click {{strong}}Copy Key{{/strong}} below to get your migration key - you will need that in a few minutes to start the migration.',
+						{
+							components: {
+								strong: <strong />,
+							},
+						}
+					) }
+				</li>
+				<li>
+					{ translate(
+						'Go to the Migrate Guru page on the source site, enter your email address, and click {{strong}}Migrate{{/strong}}.',
+						{
+							components: {
+								strong: <strong />,
+							},
+						}
+					) }
+				</li>
+				<li>
+					{ translate(
+						'You will see a screen showing multiple hosting providers. Select {{em}}Automattic{{/em}} as the destination host.',
+						{
+							components: {
+								em: <em />,
+							},
+						}
+					) }
+				</li>
+				<li>
+					{ translate(
+						'Find the {{em}}Migrate Guru Migration Key{{/em}} field, and paste the key you copied in step 2. Then click {{strong}}Migrate{{/strong}} to start your migration.',
+						{
+							components: {
+								em: <em />,
+								strong: <strong />,
+							},
+						}
+					) }
+				</li>
+				<li>{ translate( 'Migrate Guru will send you an email when the migration finishes.' ) }</li>
+			</ol>
 		</div>
 	);
 
@@ -20,7 +78,6 @@ const SiteMigrationInstructions: Step = function () {
 				className="is-step-site-migration-instructions"
 				hideSkip={ true }
 				hideBack={ true }
-				isHorizontalLayout
 				formattedHeader={
 					<FormattedHeader
 						id="site-migration-instructions-header"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -59,9 +59,16 @@ const SiteMigrationInstructions: Step = function () {
 				</li>
 				<li>
 					{ translate(
-						'Go to the Migrate Guru page on the source site, enter your email address, and click {{strong}}Migrate{{/strong}}.',
+						'Go to the {{a}}Migrate Guru page on the source site{{/a}}, enter your email address, and click {{strong}}Migrate{{/strong}}.',
 						{
 							components: {
+								a: (
+									<a
+										href="https://replacethiswiththerealsiteurl"
+										target="_blank"
+										rel="noreferrer"
+									/>
+								),
 								strong: <strong />,
 							},
 						}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -1,9 +1,11 @@
 import { StepContainer } from '@automattic/onboarding';
 import { ClipboardButton } from '@wordpress/components';
+import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
 import './style.scss';
@@ -11,6 +13,10 @@ import './style.scss';
 const SiteMigrationInstructions: Step = function () {
 	const translate = useTranslate();
 	const siteMigrationKey = 'Yjx3xUYYTm89s9xBFe7jitNA94noUg6tzgjnpx9zPVwGdbewfL';
+	const fromUrl = useQuery().get( 'from' ) || '';
+	const sourceSiteUrl = fromUrl
+		? addQueryArgs( fromUrl + '/wp-admin/admin.php', { page: 'migrateguru' } )
+		: '';
 	const [ buttonTextCopy, setButtonTextCopy ] = useState( false );
 	const onCopy = () => {
 		recordTracksEvent( 'calypso_migration_instructions_key_copy' );
@@ -61,13 +67,7 @@ const SiteMigrationInstructions: Step = function () {
 						'Go to the {{a}}Migrate Guru page on the source site{{/a}}, enter your email address, and click {{strong}}Migrate{{/strong}}.',
 						{
 							components: {
-								a: (
-									<a
-										href="https://replacethiswiththerealsiteurl/wp-admin/admin.php?page=migrateguru"
-										target="_blank"
-										rel="noreferrer"
-									/>
-								),
+								a: <a href={ sourceSiteUrl } target="_blank" rel="noreferrer" />,
 								strong: <strong />,
 							},
 						}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -14,7 +14,7 @@ const SiteMigrationInstructions: Step = function () {
 	const buttonTextCopy = translate( 'Copy key' );
 	const [ buttonText, setButtonText ] = useState( buttonTextCopy );
 	const onCopy = () => {
-		recordTracksEvent( 'calypso_site_migration_instructions_key_copied' );
+		recordTracksEvent( 'calypso_migration_instructions_key_copied' );
 		setButtonText( translate( 'Copied!' ) );
 		setTimeout( () => {
 			setButtonText( buttonTextCopy );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -1,15 +1,30 @@
 import { StepContainer } from '@automattic/onboarding';
+import { ClipboardButton } from '@wordpress/components';
 import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
+import FormTextInput from 'calypso/components/forms/form-text-input';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
+import './style.scss';
 
 const SiteMigrationInstructions: Step = function () {
 	const translate = useTranslate();
+	const siteMigrationKey = '1234567890';
+	const buttonTextCopy = translate( 'Copy key' );
+	const [ buttonText, setButtonText ] = useState( buttonTextCopy );
+	const onCopy = () => {
+		recordTracksEvent( 'calypso_site_migration_instructions_key_copied' );
+		setButtonText( translate( 'Copied!' ) );
+		setTimeout( () => {
+			setButtonText( buttonTextCopy );
+		}, 2000 );
+	};
+
 	const stepContent = (
 		<div>
-			<ol>
+			<ol className="site-migration-instructions__list">
 				<li>
 					{ translate( 'Install the {{a}}Migrate Guru plugin{{/a}} on your existing site.', {
 						components: {
@@ -32,6 +47,19 @@ const SiteMigrationInstructions: Step = function () {
 							},
 						}
 					) }
+					<div>
+						<FormTextInput
+							className="site-migration-instructions__migration-key"
+							value={ siteMigrationKey }
+						/>
+						<ClipboardButton
+							text={ siteMigrationKey }
+							className="site-migration-instructions__copy-key-button"
+							onCopy={ onCopy }
+						>
+							{ buttonText }
+						</ClipboardButton>
+					</div>
 				</li>
 				<li>
 					{ translate(
@@ -71,19 +99,27 @@ const SiteMigrationInstructions: Step = function () {
 
 	return (
 		<>
-			<DocumentHead title="Site migration instructions" />
+			<DocumentHead title={ translate( 'Migrate your site' ) } />
 			<StepContainer
 				stepName="site-migration-instructions"
 				shouldHideNavButtons={ false }
 				className="is-step-site-migration-instructions"
 				hideSkip={ true }
 				hideBack={ true }
+				isHorizontalLayout={ true }
 				formattedHeader={
-					<FormattedHeader
-						id="site-migration-instructions-header"
-						headerText="Site migration instructions"
-						align="left"
-					/>
+					<>
+						<FormattedHeader
+							id="site-migration-instructions-header"
+							headerText={ translate( 'Migrate your site' ) }
+							align="left"
+						/>
+						<p>
+							{ translate(
+								'Move your existing WordPress site to WordPress.com. Follow these steps to get started:'
+							) }
+						</p>
+					</>
 				}
 				stepContent={ stepContent }
 				recordTracksEvent={ recordTracksEvent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -64,7 +64,7 @@ const SiteMigrationInstructions: Step = function () {
 							components: {
 								a: (
 									<a
-										href="https://replacethiswiththerealsiteurl"
+										href="https://replacethiswiththerealsiteurl/wp-admin/admin.php?page=migrateguru"
 										target="_blank"
 										rel="noreferrer"
 									/>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -11,13 +11,12 @@ import './style.scss';
 const SiteMigrationInstructions: Step = function () {
 	const translate = useTranslate();
 	const siteMigrationKey = 'Yjx3xUYYTm89s9xBFe7jitNA94noUg6tzgjnpx9zPVwGdbewfL';
-	const buttonTextCopy = translate( 'Copy key' );
-	const [ buttonText, setButtonText ] = useState( buttonTextCopy );
+	const [ buttonTextCopy, setButtonTextCopy ] = useState( false );
 	const onCopy = () => {
 		recordTracksEvent( 'calypso_migration_instructions_key_copy' );
-		setButtonText( translate( 'Copied!' ) );
+		setButtonTextCopy( true );
 		setTimeout( () => {
-			setButtonText( buttonTextCopy );
+			setButtonTextCopy( false );
 		}, 2000 );
 	};
 
@@ -53,7 +52,7 @@ const SiteMigrationInstructions: Step = function () {
 							className="site-migration-instructions__copy-key-button is-primary"
 							onCopy={ onCopy }
 						>
-							{ buttonText }
+							{ buttonTextCopy ? translate( 'Copied!' ) : translate( 'Copy key' ) }
 						</ClipboardButton>
 					</div>
 				</li>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -4,14 +4,13 @@ import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
-import FormTextInput from 'calypso/components/forms/form-text-input';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
 import './style.scss';
 
 const SiteMigrationInstructions: Step = function () {
 	const translate = useTranslate();
-	const siteMigrationKey = '1234567890';
+	const siteMigrationKey = 'Yjx3xUYYTm89s9xBFe7jitNA94noUg6tzgjnpx9zPVwGdbewfL';
 	const buttonTextCopy = translate( 'Copy key' );
 	const [ buttonText, setButtonText ] = useState( buttonTextCopy );
 	const onCopy = () => {
@@ -40,21 +39,18 @@ const SiteMigrationInstructions: Step = function () {
 				</li>
 				<li>
 					{ translate(
-						'Click {{strong}}Copy Key{{/strong}} below to get your migration key - you will need that in a few minutes to start the migration.',
+						'Click {{strong}}Copy key{{/strong}} below to get your migration key - you will need that in a few minutes to start the migration.',
 						{
 							components: {
 								strong: <strong />,
 							},
 						}
 					) }
-					<div>
-						<FormTextInput
-							className="site-migration-instructions__migration-key"
-							value={ siteMigrationKey }
-						/>
+					<div className="site-migration-instructions__migration-key">
+						<code className="site-migration-instructions__key">{ siteMigrationKey }</code>
 						<ClipboardButton
 							text={ siteMigrationKey }
-							className="site-migration-instructions__copy-key-button"
+							className="site-migration-instructions__copy-key-button is-primary"
 							onCopy={ onCopy }
 						>
 							{ buttonText }
@@ -116,7 +112,7 @@ const SiteMigrationInstructions: Step = function () {
 						/>
 						<p>
 							{ translate(
-								'Move your existing WordPress site to WordPress.com. Follow these steps to get started:'
+								'Move your existing WordPress site to WordPress.com. Follow these steps to get started.'
 							) }
 						</p>
 					</>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -14,7 +14,7 @@ const SiteMigrationInstructions: Step = function () {
 	const buttonTextCopy = translate( 'Copy key' );
 	const [ buttonText, setButtonText ] = useState( buttonTextCopy );
 	const onCopy = () => {
-		recordTracksEvent( 'calypso_migration_instructions_key_copied' );
+		recordTracksEvent( 'calypso_migration_instructions_key_copy' );
 		setButtonText( translate( 'Copied!' ) );
 		setTimeout( () => {
 			setButtonText( buttonTextCopy );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
@@ -1,0 +1,16 @@
+.site-migration-instructions {
+	.site-migration-instructions__list {
+		li {
+			margin-bottom: 0.5rem;
+		}
+	}
+
+	.site-migration-instructions-header {
+		margin-bottom: 1.5rem;
+	}
+	.site-migration-instructions__migration-key {
+		background: --var(--color-primary);
+		margin-bottom: 1.5rem;
+		margin-right: 1.5rem;
+	}
+}

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
@@ -5,12 +5,23 @@
 		}
 	}
 
-	.site-migration-instructions-header {
-		margin-bottom: 1.5rem;
+	.step-container__header p {
+		margin-top: 1.5rem;
 	}
+
 	.site-migration-instructions__migration-key {
-		background: --var(--color-primary);
-		margin-bottom: 1.5rem;
-		margin-right: 1.5rem;
+		display: flex;
+		justify-content: space-between;
+		margin-top: 0.5rem;
+		max-width: 100%;
+	}
+
+	.site-migration-instructions__migration-key .site-migration-instructions__key {
+		background: var(--color-neutral-0);
+		display: inline-block;
+		margin-right: 0.75rem;
+		padding: 0.75rem 1rem;
+		width: 400px;
+		overflow-y: scroll;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/style.scss
@@ -22,6 +22,6 @@
 		margin-right: 0.75rem;
 		padding: 0.75rem 1rem;
 		width: 400px;
-		overflow-y: scroll;
+		overflow-x: scroll;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87393

## Proposed Changes

* Still need to grab the key (from an API?), but this PR sets up and begins styling the drafted instructions for handling a site migration.

<img width="1512" alt="Screenshot 2024-02-28 at 4 17 42 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/0a2b7db4-8a0d-4eba-900a-e145e33ab0ab">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Switch to this PR
* Navigate to `/setup/site-migration/site-migration-instructions?flags=onboarding/new-migration-flow&from=https%3A%2F%2Fyourtestsite.com` to see the instructions
* The "Copy key" button should copy a hard-coded key to the clipboard and the text should briefly change to "Copied!" when you click it
* When you click the "Copy key" button you should see a Tracks event fire in Tracks Vigilante/console: `calypso_migration_instructions_key_copy`
* Clicking on the "Migrate Guru page on the source site" link should point to `https://yourtestsite.com/wp-admin/admin.php?page=migrateguru`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?