### PR TITLE
Move query within test scope

### DIFF
--- a/client/my-sites/checkout/src/test/existing-credit-card.tsx
+++ b/client/my-sites/checkout/src/test/existing-credit-card.tsx
@@ -12,14 +12,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
+import { useMemo } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import { createExistingCardMethod } from 'calypso/my-sites/checkout/src/payment-methods/existing-credit-card';
 import { createReduxStore } from 'calypso/state';
 
-const queryClient = new QueryClient();
-
 function TestWrapper( { paymentMethods, paymentProcessors = undefined } ) {
 	const store = createReduxStore();
+	const queryClient = useMemo( () => new QueryClient(), [] );
 	return (
 		<ReduxProvider store={ store }>
 			<QueryClientProvider client={ queryClient }>

--- a/client/my-sites/checkout/src/test/netbanking.tsx
+++ b/client/my-sites/checkout/src/test/netbanking.tsx
@@ -12,7 +12,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useDispatch } from '@wordpress/data';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 import { Provider as ReduxProvider } from 'react-redux';
 import {
 	createNetBankingMethod,
@@ -20,10 +20,9 @@ import {
 } from 'calypso/my-sites/checkout/src/payment-methods/netbanking';
 import { createReduxStore } from 'calypso/state';
 
-const queryClient = new QueryClient();
-
 function TestWrapper( { paymentMethods, paymentProcessors = undefined } ) {
 	const store = createReduxStore();
+	const queryClient = useMemo( () => new QueryClient(), [] );
 	return (
 		<ReduxProvider store={ store }>
 			<QueryClientProvider client={ queryClient }>


### PR DESCRIPTION
It looks like an automated linter update (https://github.com/Automattic/wp-calypso/pull/87557) moved the queryClient outside of the test scope which shared the state between different tests and ultimately broke a few tests.

Related to https://github.com/Automattic/wp-calypso/pull/87557/files

## Proposed Changes

Move queryClient back within the test scope

## Testing Instructions

* Run tests found in this PR a couple times locally to ensure the test suites are still passing
