### PR TITLE
Odyssey Widget: link to Odyssey Stats from widget for Atomic sites

### DIFF
--- a/apps/odyssey-stats/src/lib/selectors/get-site-stats-base-url.ts
+++ b/apps/odyssey-stats/src/lib/selectors/get-site-stats-base-url.ts
@@ -1,10 +1,5 @@
-import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
-import config from '../config-api';
 import getOdysseyStatsBaseUrl from './get-odyssey-stats-base-url';
 
-const getSiteStatsBaseUrl = ( siteId: number ): string =>
-	isSiteWpcomAtomic( config( 'intial_state' ), siteId )
-		? 'https://wordpress.com'
-		: `${ getOdysseyStatsBaseUrl() }#!`;
+const getSiteStatsBaseUrl = (): string => `${ getOdysseyStatsBaseUrl() }#!`;
 
 export default getSiteStatsBaseUrl;

--- a/apps/odyssey-stats/src/widget/index.tsx
+++ b/apps/odyssey-stats/src/widget/index.tsx
@@ -20,7 +20,7 @@ export function init() {
 	const currentSiteId = config( 'blog_id' );
 	const localeSlug = config( 'i18n_locale_slug' ) || config( 'i18n_default_locale_slug' ) || 'en';
 
-	const statsBaseUrl = getSiteStatsBaseUrl( currentSiteId );
+	const statsBaseUrl = getSiteStatsBaseUrl();
 	const adminBaseUrl = getSiteAdminUrl( currentSiteId );
 
 	const queryClient = new QueryClient();


### PR DESCRIPTION
Related: #87866

## Proposed Changes

* Link to Odyssey Stats from the stats widget in WP-Admin, because Odyssey Stats is turned on there now! https://github.com/Automattic/jetpack/pull/35528

## Testing Instructions

* Install Jetpack Beta on an Atomic site
* Enable Jetpack bleeding edge from Jetpack Beta
* Install `update/link-to-odyssey-stats-from-widget` on your sandbox
* Sandbox `widgets.wp.com`
* Open `/wp-admin/`
* Click `View all stats`, bars, `View all posts & pages stats`, `View all referrer stats`
* Ensure you are taken to Odyssey Stats (Jetpack Stats winthin WP-Admin)

![image](https://github.com/Automattic/wp-calypso/assets/1425433/c6002342-d7a6-47f6-b3d5-2690bcdd52c4)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?