### PR TITLE
Update Woo "Check your email" screen

### DIFF
--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -71,8 +71,7 @@
 	a,
 	.wp-login__links a,
 	.wp-login__links button,
-	.button:not(.social-buttons__button),
-	.magic-login__footer a {
+	.button:not(.social-buttons__button) {
 		font-size: $woo-font-size-base;
 		line-height: 28px;
 		text-align: center;
@@ -383,11 +382,6 @@
 		}
 	}
 
-	.magic-login__form-action {
-		text-align: center;
-		margin-top: 25px;
-	}
-
 	.auth-form__social-buttons {
 		align-items: center;
 
@@ -444,10 +438,6 @@
 		background-color: initial;
 	}
 
-	.magic-login {
-		margin-top: 50px;
-	}
-
 	.wp-login__container,
 	.magic-login,
 	.step-wrapper,
@@ -499,29 +489,117 @@
 		}
 	}
 
-	.magic-login__form-header {
-		margin-bottom: 0;
-	}
+	.magic-login {
+		h1.magic-login__form-header {
+			color: var(--studio-gray-100);
+			font-feature-settings: "ss01" on, "salt" on;
+			font-family: proxima-nova, sans-serif;
+			text-align: center;
+			font-size: 2.25rem;
+			font-weight: 700;
+			line-height: 39.6px;
+			letter-spacing: -0.72px;
+			margin: 0;
 
-	.magic-login__form {
-		border: none;
-		.logged-out-form {
-			max-width: 100%;
-			box-shadow: none;
-			padding-left: 0;
-			padding-right: 0;
-			padding-bottom: 32px;
+			@media screen and ( max-width: 660px ) {
+				text-align: left;
+				max-width: 327px;
+				margin: 0 auto;
+			}
+		}
+
+		.magic-login__form-action {
+			margin-top: 8px;
+		}
+
+		.magic-login__form {
+			border: none;
+			padding: 0;
 
 			p {
 				text-align: center;
-				max-width: 415px;
-				margin: 0 auto 24px;
+			}
+
+			.logged-out-form {
+				max-width: 100%;
+				padding: 0;
+				box-shadow: none;
+
+				form {
+					max-width: 327px;
+				}
+			}
+
+			label.form-label {
+				color: var(--studio-gray-100);
+				font-size: 1rem;
+				font-style: normal;
+				font-weight: 600;
+				line-height: 24px;
+				margin-bottom: 16px;
 			}
 		}
-	}
 
-	.magic-login__request-link .magic-login__form > p {
-		text-align: center;
+		.magic-login__form p.magic-login__form-sub-header,
+		.magic-login__form-text {
+			color: var(--studio-gray-60);
+			text-align: center;
+			font-size: rem(18px);
+			font-style: normal;
+			font-weight: 400;
+			line-height: 27px;
+			letter-spacing: -0.025px;
+			margin: 12px auto 48px;
+
+			strong {
+				font-weight: 600;
+			}
+		}
+
+		.magic-login__emails-list {
+			max-width: 327px;
+			margin-inline: auto;
+
+			li {
+				border-radius: 8px; // stylelint-disable-line scales/radii
+				border: 2px solid var(--studio-gray-10);
+			}
+
+			a {
+				color: var(--studio-gray-100);
+				text-decoration: none;
+				font-size: 1rem;
+				font-style: normal;
+				font-weight: 500;
+				line-height: 24px;
+			}
+		}
+
+		.magic-login__footer {
+			margin: 0;
+			max-width: 327px;
+			margin-inline: auto;
+
+			p {
+				color: var(--studio-gray-60);
+				text-align: center;
+
+				font-family: "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+				font-size: rem(14px);
+				font-style: normal;
+				font-weight: 400;
+				line-height: 20px;
+			}
+
+			a {
+				text-decoration: none;
+				color: $woo-purple-50;
+				font-size: rem(14px);
+				font-style: normal;
+				font-weight: 500;
+				line-height: 20px;
+			}
+		}
 	}
 
 	.auth-form__social {

--- a/client/login/magic-login/index.jsx
+++ b/client/login/magic-login/index.jsx
@@ -133,7 +133,11 @@ class MagicLogin extends Component {
 	};
 
 	renderLinks() {
-		const { isJetpackLogin, locale, showCheckYourEmail, translate } = this.props;
+		const { isJetpackLogin, locale, showCheckYourEmail, translate, isWoo } = this.props;
+
+		if ( isWoo ) {
+			return null;
+		}
 
 		if ( showCheckYourEmail ) {
 			return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/87636

## Proposed Changes

* Update the CSS to match the new design 4ixWMlzrxllx93tSFsCW6k-fi-9483%3A8624
* Remove Jetpack promotion for Woo



![Screenshot 2024-02-29 at 14 28 09](https://github.com/Automattic/wp-calypso/assets/4344253/1830c068-40da-4c05-b39a-114deff86732)

![Screenshot 2024-02-29 at 14 42 37](https://github.com/Automattic/wp-calypso/assets/4344253/2aa0bc17-d5c8-4dde-94a8-659bdf0e8c45)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Set up the [`woocommerce-start-dev-env`](https://github.com/woocommerce/woocommerce-start-dev-env/tree/trunk) or use "Calypso Live" link
* Logout from wordpress.com and woo.com
* Go to `/log-in/link?redirect_to=https%3A%2F%2Fpublic-api.wordpress.com%2Foauth2%2Fauthorize%2F%3Fresponse_type%3Dcode%26client_id%3D50916%26state%3Dcc209140df814f02119fcc56e3662fbb82d946f1631feeca2c5290f408c83029%26redirect_uri%3Dhttps%253A%252F%252Fwoo.com%252Fwc-api%252Fwpcom-signin%253Fnext%253D%25252F%26blog_id%3D0%26wpcom_connect%3D1%26wccom-from%26calypso_env%3Dproduction%26from-calypso%3D1&client_id=50916`
* Enter an email or username (non-a8c account) and click "Send link"
* Observe that the "Check your email" screen is updated and the Jetpack promotion is removed
* Please note that the "Open in ..." button is only shown for known domains (gmail, yahoo, aol, apple, outlook)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?