### PR TITLE
[Odie] Clear Wapuu chat on submission

### DIFF
--- a/packages/help-center/src/components/help-center-contact-form.tsx
+++ b/packages/help-center/src/components/help-center-contact-form.tsx
@@ -83,11 +83,16 @@ const getSupportedLanguages = ( supportType: string, locale: string ) => {
 
 type Mode = 'CHAT' | 'EMAIL' | 'FORUM';
 
-export const HelpCenterContactForm = () => {
+type HelpCenterContactFormProps = {
+	onSubmit?: () => void;
+};
+
+export const HelpCenterContactForm = ( props: HelpCenterContactFormProps ) => {
 	const { search } = useLocation();
 	const sectionName = useSelector( getSectionName );
 	const params = new URLSearchParams( search );
 	const mode = params.get( 'mode' ) as Mode;
+	const { onSubmit } = props;
 	const overflow = params.get( 'overflow' ) === 'true';
 	const wapuuFlow = params.get( 'wapuuFlow' ) === 'true';
 	const navigate = useNavigate();
@@ -283,6 +288,10 @@ export const HelpCenterContactForm = () => {
 		if ( wapuuFlow ) {
 			params.set( 'disable-gpt', 'true' );
 			params.set( 'show-gpt', 'false' );
+
+			if ( onSubmit ) {
+				onSubmit();
+			}
 		}
 
 		const productSlug = ( supportSite as HelpCenterSite )?.plan.product_slug;

--- a/packages/help-center/src/components/help-center-contact-page.tsx
+++ b/packages/help-center/src/components/help-center-contact-page.tsx
@@ -36,23 +36,18 @@ const ConditionalLink: FC< { active: boolean } & LinkProps > = ( { active, ...pr
 	return <span { ...props }></span>;
 };
 
-const noop = () => {};
 type ContactOption = 'chat' | 'forum' | 'email';
 const generateContactOnClickEvent = (
 	contactOption: ContactOption,
-	contactOptionEventName?: string,
-	onClick?: () => void
+	contactOptionEventName?: string
 ): ( () => void ) => {
-	if ( ! onClick || ! contactOptionEventName ) {
-		return noop;
-	}
-
 	return () => {
-		recordTracksEvent( contactOptionEventName, {
-			location: 'help-center',
-			contact_option: contactOption,
-		} );
-		onClick();
+		if ( contactOptionEventName ) {
+			recordTracksEvent( contactOptionEventName, {
+				location: 'help-center',
+				contact_option: contactOption,
+			} );
+		}
 	};
 };
 
@@ -73,7 +68,6 @@ type HelpCenterContactPageProps = {
 
 export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 	hideHeaders = false,
-	onClick,
 	trackEventName,
 } ) => {
 	const { __ } = useI18n();
@@ -183,9 +177,9 @@ export const HelpCenterContactPage: FC< HelpCenterContactPageProps > = ( {
 	const emailUrl = `/contact-form?${ emailUrlSearchParams.toString() }`;
 
 	const contactOptionsEventMap: Record< ContactOption, () => void > = {
-		chat: generateContactOnClickEvent( 'chat', trackEventName, onClick ),
-		forum: generateContactOnClickEvent( 'forum', trackEventName, onClick ),
-		email: generateContactOnClickEvent( 'email', trackEventName, onClick ),
+		chat: generateContactOnClickEvent( 'chat', trackEventName ),
+		forum: generateContactOnClickEvent( 'forum', trackEventName ),
+		email: generateContactOnClickEvent( 'email', trackEventName ),
 	};
 
 	return (

--- a/packages/help-center/src/components/help-center-content.tsx
+++ b/packages/help-center/src/components/help-center-content.tsx
@@ -89,7 +89,10 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 				/>
 				<Route path="/post" element={ <HelpCenterEmbedResult /> } />
 				<Route path="/contact-options" element={ <HelpCenterContactPage /> } />
-				<Route path="/contact-form" element={ <HelpCenterContactForm /> } />
+				<Route
+					path="/contact-form"
+					element={ <HelpCenterContactForm onSubmit={ () => clearOdieStorage( 'chat_id' ) } /> }
+				/>
 				<Route path="/success" element={ <SuccessScreen /> } />
 				<Route
 					path="/odie"
@@ -106,7 +109,6 @@ const HelpCenterContent: React.FC< { isRelative?: boolean; currentRoute?: string
 								<HelpCenterContactPage
 									hideHeaders
 									trackEventName="calypso_odie_extra_contact_option"
-									onClick={ () => clearOdieStorage( 'chat_id' ) }
 								/>
 							}
 						>


### PR DESCRIPTION
## Proposed Changes

Seems to be a better approach to clear the previous chat once we submit either the email, start the chat, or visit the public forum.

## Testing Instructions

- Add the Wapuu flag
- Start chatting with Wapuu
- Either ask for contact with human or downvote a message
- Once the channel selector is there, click on any option.
- Go back (without going further in the channel selected)
- Assert that the conversation is still present
- Pick again a channel and this time reach user support by any way method
- Go back to chat with Wapuu
- Assert that the chat has been cleared
