### PR TITLE
A4A: Add an action menu in the Licenses table items.

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx
@@ -21,6 +21,8 @@ import { getSite } from 'calypso/state/sites/selectors';
 import LicenseDetails from '../license-details';
 import BundleDetails from '../license-details/bundle-details';
 import LicensesOverviewContext from '../licenses-overview/context';
+import LicenseActions from './license-actions';
+import LicenseBundleDropDown from './license-bundle-dropdown';
 
 import './style.scss';
 
@@ -230,18 +232,22 @@ export default function LicensePreview( {
 
 				<div>
 					{ isParentLicense && (
-						<>
-							{
-								// TODO: Add bundle actions
-							 }
-						</>
+						<LicenseBundleDropDown
+							product={ product }
+							licenseKey={ licenseKey }
+							bundleSize={ quantity }
+						/>
 					) }
 					{ isSiteAtomic ? (
-						<>
-							{
-								// TODO: Add actions for atomic sites
-							 }
-						</>
+						<LicenseActions
+							siteUrl={ siteUrl }
+							licenseKey={ licenseKey }
+							product={ product }
+							attachedAt={ attachedAt }
+							revokedAt={ revokedAt }
+							licenseType={ licenseType }
+							isChildLicense={ isChildLicense }
+						/>
 					) : (
 						<Button onClick={ open } className="license-preview__toggle" borderless>
 							<Gridicon icon={ isOpen ? 'chevron-up' : 'chevron-down' } />

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
@@ -1,0 +1,90 @@
+import { Button, Gridicon } from '@automattic/components';
+import classnames from 'classnames';
+import { useState, useRef } from 'react';
+import PopoverMenu from 'calypso/components/popover-menu';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import RevokeLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/revoke-license-dialog';
+import {
+	LicenseAction,
+	LicenseRole,
+	LicenseType,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import useLicenseActions from './use-license-actions';
+
+interface Props {
+	licenseKey: string;
+	product: string;
+	siteUrl: string | null;
+	attachedAt: string | null;
+	revokedAt: string | null;
+	licenseType: LicenseType;
+	isChildLicense?: boolean;
+}
+
+export default function LicenseActions( {
+	siteUrl,
+	licenseKey,
+	product,
+	attachedAt,
+	revokedAt,
+	licenseType,
+	isChildLicense,
+}: Props ) {
+	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
+
+	const [ isOpen, setIsOpen ] = useState( false );
+	const [ showRevokeDialog, setShowRevokeDialog ] = useState( false );
+
+	const licenseActions = useLicenseActions(
+		siteUrl,
+		attachedAt,
+		revokedAt,
+		licenseType,
+		isChildLicense
+	);
+
+	const handleActionClick = ( action: LicenseAction ) => {
+		action.onClick();
+		if ( action.type === 'revoke' ) {
+			setShowRevokeDialog( true );
+		}
+	};
+
+	return (
+		<>
+			<Button borderless compact onClick={ () => setIsOpen( true ) } ref={ buttonActionRef }>
+				<Gridicon icon="ellipsis" size={ 18 } />
+			</Button>
+			<PopoverMenu
+				context={ buttonActionRef.current }
+				isVisible={ isOpen }
+				onClose={ () => setIsOpen( false ) }
+				position="bottom left"
+			>
+				{ licenseActions
+					.filter( ( action ) => action.isEnabled )
+					.map( ( action ) => (
+						<PopoverMenuItem
+							key={ action.name }
+							isExternalLink={ action?.isExternalLink }
+							onClick={ () => handleActionClick( action ) }
+							href={ action?.href }
+							className={ classnames( 'license-actions__menu-item', action?.className ) }
+						>
+							{ action.name }
+						</PopoverMenuItem>
+					) ) }
+			</PopoverMenu>
+
+			{ showRevokeDialog && (
+				<RevokeLicenseDialog
+					licenseKey={ licenseKey }
+					product={ product }
+					siteUrl={ siteUrl }
+					onClose={ () => setShowRevokeDialog( false ) }
+					licenseRole={ isChildLicense ? LicenseRole.Child : LicenseRole.Single }
+				/>
+			) }
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
@@ -2,12 +2,12 @@ import { Button, Gridicon } from '@automattic/components';
 import { useState, useRef } from 'react';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import RevokeLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/revoke-license-dialog';
 import {
 	LicenseAction,
 	LicenseRole,
 	LicenseType,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import RevokeLicenseDialog from '../revoke-license-dialog';
 import useLicenseActions from './use-license-actions';
 
 interface Props {

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
@@ -1,5 +1,4 @@
 import { Button, Gridicon } from '@automattic/components';
-import classnames from 'classnames';
 import { useState, useRef } from 'react';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
@@ -70,7 +69,7 @@ export default function LicenseActions( {
 							isExternalLink={ action?.isExternalLink }
 							onClick={ () => handleActionClick( action ) }
 							href={ action?.href }
-							className={ classnames( 'license-actions__menu-item', action?.className ) }
+							className={ action?.className }
 						>
 							{ action.name }
 						</PopoverMenuItem>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-actions.tsx
@@ -56,6 +56,7 @@ export default function LicenseActions( {
 				<Gridicon icon="ellipsis" size={ 18 } />
 			</Button>
 			<PopoverMenu
+				className="license-actions__menu"
 				context={ buttonActionRef.current }
 				isVisible={ isOpen }
 				onClose={ () => setIsOpen( false ) }

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-bundle-dropdown.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-bundle-dropdown.tsx
@@ -4,10 +4,10 @@ import { useTranslate } from 'i18n-calypso';
 import { useCallback, useRef, useState } from 'react';
 import PopoverMenu from 'calypso/components/popover-menu';
 import PopoverMenuItem from 'calypso/components/popover-menu/item';
-import RevokeLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/revoke-license-dialog';
 import { LicenseRole } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import RevokeLicenseDialog from '../revoke-license-dialog';
 
 type Props = {
 	licenseKey: string;

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-bundle-dropdown.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-bundle-dropdown.tsx
@@ -54,17 +54,14 @@ export default function LicenseBundleDropDown( { licenseKey, product, bundleSize
 			</Button>
 
 			<PopoverMenu
-				className="license-bundle-dropdown__popover-menu"
+				className="license-actions__menu"
 				context={ buttonActionRef.current }
 				isVisible={ showContextMenu }
 				onClose={ onHideContextMenu }
 				position="bottom left"
 				focusOnShow={ false }
 			>
-				<PopoverMenuItem
-					onClick={ onShowRevokeDialog }
-					className="license-bundle-dropdown__popover-menu-item-revoke"
-				>
+				<PopoverMenuItem onClick={ onShowRevokeDialog } className="is-destructive">
 					{ translate( 'Revoke bundle' ) } <Icon className="gridicon" icon={ trash } size={ 24 } />
 				</PopoverMenuItem>
 			</PopoverMenu>

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-bundle-dropdown.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/license-bundle-dropdown.tsx
@@ -1,0 +1,84 @@
+import { Gridicon, Button } from '@automattic/components';
+import { Icon, trash } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback, useRef, useState } from 'react';
+import PopoverMenu from 'calypso/components/popover-menu';
+import PopoverMenuItem from 'calypso/components/popover-menu/item';
+import RevokeLicenseDialog from 'calypso/jetpack-cloud/sections/partner-portal/revoke-license-dialog';
+import { LicenseRole } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+type Props = {
+	licenseKey: string;
+	product: string;
+	bundleSize: number;
+};
+
+export default function LicenseBundleDropDown( { licenseKey, product, bundleSize }: Props ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const [ showRevokeDialog, setShowRevokeDialog ] = useState( false );
+	const [ showContextMenu, setShowContextMenu ] = useState( false );
+	const buttonActionRef = useRef< HTMLButtonElement | null >( null );
+
+	const onShowContextMenu = useCallback( () => {
+		setShowContextMenu( true );
+	}, [] );
+
+	const onHideContextMenu = useCallback( () => {
+		setShowContextMenu( false );
+	}, [] );
+
+	const onShowRevokeDialog = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_license_list_revoke_bundle_dialog_open' ) );
+		setShowRevokeDialog( true );
+	}, [ dispatch ] );
+
+	const onHideRevokeDialog = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_license_list_revoke_bundle_dialog_close' ) );
+		setShowRevokeDialog( false );
+	}, [ dispatch ] );
+
+	return (
+		<>
+			<Button
+				className="license-bundle-dropdown__button"
+				borderless
+				compact
+				onClick={ onShowContextMenu }
+				ref={ buttonActionRef }
+			>
+				<Gridicon icon="ellipsis" size={ 18 } />
+			</Button>
+
+			<PopoverMenu
+				className="license-bundle-dropdown__popover-menu"
+				context={ buttonActionRef.current }
+				isVisible={ showContextMenu }
+				onClose={ onHideContextMenu }
+				position="bottom left"
+				focusOnShow={ false }
+			>
+				<PopoverMenuItem
+					onClick={ onShowRevokeDialog }
+					className="license-bundle-dropdown__popover-menu-item-revoke"
+				>
+					{ translate( 'Revoke bundle' ) } <Icon className="gridicon" icon={ trash } size={ 24 } />
+				</PopoverMenuItem>
+			</PopoverMenu>
+
+			{ showRevokeDialog && (
+				<RevokeLicenseDialog
+					licenseRole={ LicenseRole.Parent }
+					licenseKey={ licenseKey }
+					product={ product }
+					siteUrl={ null }
+					onClose={ onHideRevokeDialog }
+					bundleSize={ bundleSize }
+				/>
+			) }
+		</>
+	);
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -151,44 +151,6 @@
 	}
 }
 
-.license-actions__menu .popover__menu {
-	padding: 8px 4px;
-}
-
-a.license-actions__menu-item,
-button.license-actions__menu-item {
-	font-size: 0.875rem;
-	height: 40px;
-	box-sizing: border-box;
-	color: var(--color-neutral);
-	display: flex;
-	align-items: center;
-	min-width: 200px;
-	padding: 8px 4px;
-	margin-block: 5px;
-	border: none;
-
-	&:hover,
-	&:focus {
-		background: var(--color-sidebar-text-alternative);
-		color: var(--color-text);
-		fill: var(--color-text);
-		cursor: pointer;
-		outline: none;
-	}
-
-	svg.gridicon {
-		vertical-align: middle;
-		position: absolute;
-		inset-inline-end: 10px;
-		inset-block-start: unset;
-	}
-
-	&.is-destructive {
-		color: var(--color-scary-50);
-	}
-}
-
 .card.license-preview__card.license-preview__card--child-license {
 	padding: 16px 32px;
 	background-color: #fafafa;
@@ -206,7 +168,7 @@ button.license-actions__menu-item {
 	}
 }
 
-.license-bundle-dropdown__popover-menu {
+.license-actions__menu {
 	font-size: rem(14px);
 	font-weight: 400;
 	border-radius: 2px;
@@ -223,6 +185,12 @@ button.license-actions__menu-item {
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
+		border: none;
+		outline: none;
+	}
+
+	.popover__menu-item .gridicon {
+		margin: 0;
 	}
 
 	.popover__menu-item:hover,
@@ -236,17 +204,8 @@ button.license-actions__menu-item {
 		}
 	}
 
-	.popover__menu-item .gridicon {
-		margin: 0;
-	}
-}
-
-.popover__menu-item.license-bundle-dropdown__popover-menu-item-revoke {
-	&,
-	&:hover,
-	&:focus {
-		color: var(--color-error-50);
-
+	.popover__menu-item.is-destructive {
+		color: var(--color-scary-50);
 		.gridicon {
 			fill: var(--color-error-50);
 		}

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -187,6 +187,9 @@
 		align-items: center;
 		border: none;
 		outline: none;
+		margin-block: 5px;
+		min-height: 40px;
+		box-sizing: border-box;
 	}
 
 	.popover__menu-item .gridicon {

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -214,7 +214,7 @@ button {
 	max-height: 24px;
 	&:hover,
 	&:focus {
-		background: var(--color-sidebar-menu-hover-background);
+		background: var(--color-sidebar-text-alternative);
 		color: var(--color-text);
 		fill: var(--color-text);
 	}
@@ -241,7 +241,7 @@ button {
 
 	.popover__menu-item:hover,
 	.popover__menu-item:focus {
-		background: var(--color-sidebar-menu-hover-background);
+		background: var(--color-sidebar-text-alternative);
 		color: var(--color-text);
 		fill: var(--color-text);
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/style.scss
@@ -151,55 +151,41 @@
 	}
 }
 
-a,
-button {
-	&.license-actions__menu-item {
-		margin: 0 -1px;
-		border-style: solid;
-		border-color: var(--color-neutral-5);
-		border-width: 0 0 1px;
-		font-size: 0.875rem;
-		height: 40px;
-		box-sizing: border-box;
-		color: var(--color-neutral);
-		display: flex;
-		align-items: center;
-		padding: 0 16px;
-		min-width: 200px;
+.license-actions__menu .popover__menu {
+	padding: 8px 4px;
+}
 
-		&:last-child {
-			margin-bottom: 5px;
-			border-bottom-width: 0;
-		}
+a.license-actions__menu-item,
+button.license-actions__menu-item {
+	font-size: 0.875rem;
+	height: 40px;
+	box-sizing: border-box;
+	color: var(--color-neutral);
+	display: flex;
+	align-items: center;
+	min-width: 200px;
+	padding: 8px 4px;
+	margin-block: 5px;
+	border: none;
 
-		&:first-child {
-			margin-block-start: 5px;
-		}
+	&:hover,
+	&:focus {
+		background: var(--color-sidebar-text-alternative);
+		color: var(--color-text);
+		fill: var(--color-text);
+		cursor: pointer;
+		outline: none;
+	}
 
-		&:hover,
-		&:focus {
-			border-style: solid;
-			border-color: var(--color-neutral-5);
-			border-width: 0 0 1px;
-			background: var(--color-neutral);
-			cursor: pointer;
-			color: var(--color-masterbar-item-hover-background);
+	svg.gridicon {
+		vertical-align: middle;
+		position: absolute;
+		inset-inline-end: 10px;
+		inset-block-start: unset;
+	}
 
-			&:last-child {
-				border-bottom-width: 0;
-			}
-		}
-
-		svg.gridicon {
-			vertical-align: middle;
-			position: absolute;
-			inset-inline-end: 10px;
-			inset-block-start: unset;
-		}
-
-		&.is-destructive {
-			color: var(--color-error-50);
-		}
+	&.is-destructive {
+		color: var(--color-scary-50);
 	}
 }
 

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
@@ -1,0 +1,85 @@
+import { useTranslate } from 'i18n-calypso';
+import { useMemo } from 'react';
+import getLicenseState from 'calypso/jetpack-cloud/sections/partner-portal/lib/get-license-state';
+import {
+	LicenseState,
+	LicenseAction,
+	LicenseType,
+} from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import { urlToSlug } from 'calypso/lib/url/http-utils';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+export default function useLicenseActions(
+	siteUrl: string | null,
+	attachedAt: string | null,
+	revokedAt: string | null,
+	licenseType: LicenseType,
+	isChildLicense?: boolean
+): LicenseAction[] {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	return useMemo( () => {
+		if ( ! siteUrl ) {
+			return [];
+		}
+
+		const siteSlug = urlToSlug( siteUrl );
+
+		const handleClickMenuItem = ( eventName: string ) => {
+			dispatch( recordTracksEvent( eventName ) );
+		};
+
+		const licenseState = getLicenseState( attachedAt, revokedAt );
+		return [
+			{
+				name: translate( 'Set up site' ),
+				href: `https://wordpress.com/home/${ siteSlug }`,
+				onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_site_set_up_click' ),
+				isExternalLink: true,
+				isEnabled: true,
+			},
+			{
+				name: translate( 'Change domain' ),
+				href: `https://wordpress.com/domains/manage/${ siteSlug }`,
+				onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_change_domain_click' ),
+				isExternalLink: true,
+				isEnabled: true,
+			},
+			{
+				name: translate( 'Hosting configuration' ),
+				href: `https://wordpress.com/hosting-config/${ siteSlug }`,
+				onClick: () =>
+					handleClickMenuItem( 'calypso_jetpack_licenses_hosting_configuration_click' ),
+				isExternalLink: true,
+				isEnabled: true,
+			},
+			{
+				name: translate( 'Edit site in WP Admin' ),
+				href: `${ siteUrl }/wp-admin/admin.php?page=jetpack#/dashboard`,
+				onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_edit_site_click' ),
+				isExternalLink: true,
+				isEnabled: true,
+			},
+			{
+				name: translate( 'Debug site' ),
+				href: `https://jptools.wordpress.com/debug/?url=${ siteUrl }`,
+				onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_debug_site_click' ),
+				isExternalLink: true,
+				isEnabled: licenseState === LicenseState.Attached,
+			},
+			{
+				name: translate( 'Revoke' ),
+				onClick: () =>
+					handleClickMenuItem( 'calypso_jetpack_licenses_hosting_configuration_click' ),
+				type: 'revoke',
+				isEnabled:
+					( isChildLicense
+						? licenseState === LicenseState.Attached
+						: licenseState !== LicenseState.Revoked ) && licenseType === LicenseType.Partner,
+				className: 'is-destructive',
+			},
+		];
+	}, [ attachedAt, dispatch, isChildLicense, licenseType, revokedAt, siteUrl, translate ] );
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-preview/use-license-actions.ts
@@ -6,7 +6,6 @@ import {
 	LicenseAction,
 	LicenseType,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
-import { urlToSlug } from 'calypso/lib/url/http-utils';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 
@@ -25,8 +24,6 @@ export default function useLicenseActions(
 			return [];
 		}
 
-		const siteSlug = urlToSlug( siteUrl );
-
 		const handleClickMenuItem = ( eventName: string ) => {
 			dispatch( recordTracksEvent( eventName ) );
 		};
@@ -35,44 +32,42 @@ export default function useLicenseActions(
 		return [
 			{
 				name: translate( 'Set up site' ),
-				href: `https://wordpress.com/home/${ siteSlug }`,
-				onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_site_set_up_click' ),
+				href: '', // FIXME: Add correct URL
+				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_site_set_up_click' ),
 				isExternalLink: true,
 				isEnabled: true,
 			},
 			{
 				name: translate( 'Change domain' ),
-				href: `https://wordpress.com/domains/manage/${ siteSlug }`,
-				onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_change_domain_click' ),
+				href: '', // FIXME: Add correct URL
+				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_change_domain_click' ),
 				isExternalLink: true,
 				isEnabled: true,
 			},
 			{
 				name: translate( 'Hosting configuration' ),
-				href: `https://wordpress.com/hosting-config/${ siteSlug }`,
-				onClick: () =>
-					handleClickMenuItem( 'calypso_jetpack_licenses_hosting_configuration_click' ),
+				href: '', // FIXME: Add correct URL
+				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_hosting_configuration_click' ),
 				isExternalLink: true,
 				isEnabled: true,
 			},
 			{
 				name: translate( 'Edit site in WP Admin' ),
-				href: `${ siteUrl }/wp-admin/admin.php?page=jetpack#/dashboard`,
-				onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_edit_site_click' ),
+				href: '', // FIXME: Add correct URL
+				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_edit_site_click' ),
 				isExternalLink: true,
 				isEnabled: true,
 			},
 			{
 				name: translate( 'Debug site' ),
-				href: `https://jptools.wordpress.com/debug/?url=${ siteUrl }`,
-				onClick: () => handleClickMenuItem( 'calypso_jetpack_licenses_debug_site_click' ),
+				href: '', // FIXME: Add correct URL
+				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_debug_site_click' ),
 				isExternalLink: true,
 				isEnabled: licenseState === LicenseState.Attached,
 			},
 			{
 				name: translate( 'Revoke' ),
-				onClick: () =>
-					handleClickMenuItem( 'calypso_jetpack_licenses_hosting_configuration_click' ),
+				onClick: () => handleClickMenuItem( 'calypso_a4a_licenses_hosting_configuration_click' ),
 				type: 'revoke',
 				isEnabled:
 					( isChildLicense

--- a/client/a8c-for-agencies/style.scss
+++ b/client/a8c-for-agencies/style.scss
@@ -16,6 +16,12 @@
 	--color-sidebar-text-alternative: #bbe0fa;
 	--color-sidebar-gridicon-fill: #bbe0fa;
 
+	--color-scary-0: var(--studio-red-0);
+	--color-scary-5: var(--studio-red-5);
+	--color-scary-40: var(--studio-red-40);
+	--color-scary-50: var(--studio-red-50);
+	--color-scary-60: var(--studio-red-60);
+	--color-scary-70: var(--studio-red-70);
 }
 
 .theme-a8c-for-agencies {


### PR DESCRIPTION
This pull request ports Jetpack Manage License actions and Bundle dropdown component to the A4A Licenses page.

Closes https://github.com/Automattic/jetpack-genesis/issues/253

## Proposed Changes

* Port the Jetpack Manage License actions and Bundle dropdown component to the A4A Licenses page.
* Improve styling by unifying the menu item CSS class.

## Testing Instructions

* Switch branch: `git checkout add/a4a-licenses-actions`
* Start the server by running `yarn start-a8c-for-agencies`.
* Go to http://agencies.localhost:3000/purchases/licenses
* Confirm that for the bundle license, the Bundle dropdown is visible.
<img width="317" alt="Screenshot 2024-02-29 at 3 03 35 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/53ff38c2-7513-43fe-aee0-d2eee7ca28f5">

* To test the Atomic site's dropdown menu, we must modify the [isSiteAtomic variable](https://github.com/Automattic/wp-calypso/blob/trunk/client/a8c-for-agencies/sections/purchases/licenses/license-preview/index.tsx#L118) to **true** to force the UI to render it. We still need to get a proper way to test this, and this is a workaround for us to test.
<img width="254" alt="Screenshot 2024-02-29 at 3 05 17 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/656a08de-baf1-44d7-8b0c-b5d514e0d18f">


## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?