### PR TITLE
 A4A: Add simple filtering in the mocked license data to simulate the search filter.

### DIFF
--- a/client/a8c-for-agencies/data/purchases/use-fetch-licenses.ts
+++ b/client/a8c-for-agencies/data/purchases/use-fetch-licenses.ts
@@ -18,39 +18,47 @@ export default function useFetchLicenses(
 
 	const getLicenses = () => {
 		if ( showDummyData ) {
+			const items = [
+				{
+					licenseId: 1,
+					licenseKey: 'license-key',
+					product: 'dummy-product',
+					blogId: 1,
+					siteUrl: 'dummy-url',
+					hasDownloads: true,
+					issuedAt: '2021-01-01',
+					attachedAt: '2021-01-01',
+					quantity: 5,
+					revokedAt: null,
+					ownerType: 'jetpack_partner_key',
+					parentLicenseId: undefined,
+				},
+				{
+					licenseId: 2,
+					licenseKey: 'license-key-2',
+					product: 'dummy-product-2',
+					blogId: 1,
+					siteUrl: null,
+					hasDownloads: true,
+					issuedAt: '2021-01-01',
+					attachedAt: null,
+					quantity: undefined,
+					revokedAt: null,
+					ownerType: 'jetpack_partner_key',
+					parentLicenseId: undefined,
+				},
+			];
+
+			const result = search
+				? items.filter( ( item ) => {
+						return item.licenseKey.includes( search ) || item.product.includes( search );
+				  } )
+				: items;
+
 			return {
-				items: [
-					{
-						licenseId: 1,
-						licenseKey: 'license-key',
-						product: 'dummy-product',
-						blogId: 1,
-						siteUrl: 'dummy-url',
-						hasDownloads: true,
-						issuedAt: '2021-01-01',
-						attachedAt: '2021-01-01',
-						quantity: 5,
-						revokedAt: null,
-						ownerType: 'jetpack_partner_key',
-						parentLicenseId: undefined,
-					},
-					{
-						licenseId: 2,
-						licenseKey: 'license-key-2',
-						product: 'dummy-product-2',
-						blogId: 1,
-						siteUrl: null,
-						hasDownloads: true,
-						issuedAt: '2021-01-01',
-						attachedAt: null,
-						quantity: undefined,
-						revokedAt: null,
-						ownerType: 'jetpack_partner_key',
-						parentLicenseId: undefined,
-					},
-				],
-				total_pages: 1,
-				total_items: 2,
+				items: result,
+				total_pages: Math.ceil( result.length / LICENSES_PER_PAGE ),
+				total_items: result.length,
 				items_per_page: LICENSES_PER_PAGE,
 			};
 		}


### PR DESCRIPTION
 To test the search functionality in the Licenses page using mock data, we need to perform a simple search filter within the mock data. 

<img width="1730" alt="Screenshot 2024-02-29 at 3 35 03 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/41a0b7af-e0b4-4be2-b99e-abb275fe3b77">
<img width="1553" alt="Screenshot 2024-02-29 at 3 35 24 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/45761e73-38d5-40f3-bc1a-8ebc9ae82b20">

Closes https://github.com/Automattic/jetpack-genesis/issues/256

## Proposed Changes

* Add search filtering logic in the License mock data to test search functionality. Use product name and license key as filterable values.

## Testing Instructions

* Switch branch: `git checkout extend/a4a-license-mock-data-with-search-filter`
* Start the server by running `yarn start-a8c-for-agencies`.
* Go to http://agencies.localhost:3000/purchases/licenses
* Test the search field to see if it works correctly.


## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?