### PR TITLE
Automattic for Agencies: Implement license counts API mock

### DIFF
--- a/client/a8c-for-agencies/data/purchases/use-fetch-license-counts.ts
+++ b/client/a8c-for-agencies/data/purchases/use-fetch-license-counts.ts
@@ -1,0 +1,34 @@
+import config from '@automattic/calypso-config';
+import { useQuery } from '@tanstack/react-query';
+
+export default function useFetchLicenseCounts() {
+	const showDummyData = config.isEnabled( 'a4a/mock-api-data' );
+
+	const getLicenseCounts = () => {
+		if ( showDummyData ) {
+			return {
+				attached: 1,
+				detached: 1,
+				revoked: 0,
+				not_revoked: 2,
+				standard: 0,
+				all: 2,
+				products: {},
+			};
+		}
+		return {
+			attached: 0,
+			detached: 0,
+			revoked: 0,
+			not_revoked: 0,
+			standard: 0,
+			all: 0,
+			products: {},
+		}; // FIXME: This is a placeholder for the actual API call.
+	};
+
+	return useQuery( {
+		queryKey: [ 'a4a-license-counts' ],
+		queryFn: () => getLicenseCounts(),
+	} );
+}

--- a/client/a8c-for-agencies/sections/purchases/licenses/license-state-filter/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/license-state-filter/index.tsx
@@ -4,6 +4,7 @@ import LayoutNavigation, {
 	LayoutNavigationTabs,
 } from 'calypso/a8c-for-agencies/components/layout/nav';
 import { A4A_LICENSES_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import useFetchLicenseCounts from 'calypso/a8c-for-agencies/data/purchases/use-fetch-license-counts';
 import { internalToPublicLicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/lib/license-filters';
 import { LicenseFilter } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import { useDispatch } from 'calypso/state';
@@ -14,6 +15,8 @@ function LicenseStateFilter() {
 	const dispatch = useDispatch();
 	const translate = useTranslate();
 	const { filter } = useContext( LicenseListContext );
+
+	const { data } = useFetchLicenseCounts();
 
 	const navItems = [
 		{
@@ -38,7 +41,7 @@ function LicenseStateFilter() {
 		},
 	].map( ( navItem ) => ( {
 		...navItem,
-		count: 0, // FIXME: get this from state
+		count: data?.[ navItem.key ] || 0,
 		selected: filter === navItem.key,
 		path: `${ A4A_LICENSES_LINK }/${ internalToPublicLicenseFilter( navItem.key ) }`,
 		onClick: () => {


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/255

## Proposed Changes

<img width="1524" alt="Screenshot 2024-02-29 at 1 11 52 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/ea159963-d438-4d67-86cd-80d557114427">


This PR implements license counts API mock.

## Testing Instructions

- Switch to the branch ### `git checkout add/implement-a4a-license-counts-api-mock`.
- Start the server by running `yarn start-a8c-for-agencies`.
- Click the Purchases menu item > Verify that you can see the Licenses page with counts on top header(All Active, Usasigned, etc.)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?