### PR TITLE
Add-Ons: Hide the Add-Ons menu on the atomic sites

### DIFF
--- a/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
+++ b/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
@@ -5,12 +5,14 @@ import { translate } from 'i18n-calypso';
 export default function globalSiteSidebarMenu( {
 	showSiteMonitoring,
 	siteDomain,
+	shouldShowAddOns,
 	selectedSiteSlug,
 	isStagingSite,
 	isDesktop,
 }: {
 	showSiteMonitoring: boolean;
 	siteDomain: string;
+	shouldShowAddOns: boolean;
 	selectedSiteSlug: string;
 	isStagingSite: boolean;
 	isDesktop: boolean;
@@ -47,7 +49,7 @@ export default function globalSiteSidebarMenu( {
 			title: translate( 'Add-ons' ),
 			type: 'menu-item',
 			url: `/add-ons/${ siteDomain }`,
-			shouldHide: isStagingSite,
+			shouldHide: ! shouldShowAddOns,
 		},
 		{
 			slug: 'domains',

--- a/client/my-sites/sidebar/use-site-menu-items.js
+++ b/client/my-sites/sidebar/use-site-menu-items.js
@@ -77,7 +77,7 @@ const useSiteMenuItems = () => {
 
 	const shouldShowMailboxes = ! isP2;
 
-	const shouldShowAddOnsInFallbackMenu = isEnabled( 'my-sites/add-ons' ) && ! isAtomic;
+	const shouldShowAddOns = isEnabled( 'my-sites/add-ons' ) && ! isAtomic && ! isStagingSite;
 
 	const hasSiteWithPlugins = useSelector( canAnySiteHavePlugins );
 
@@ -123,7 +123,7 @@ const useSiteMenuItems = () => {
 	if ( shouldShowGlobalSiteSidebar ) {
 		return globalSiteSidebarMenu( {
 			siteDomain,
-			shouldShowAddOns: shouldShowAddOnsInFallbackMenu,
+			shouldShowAddOns,
 			showSiteMonitoring: isAtomic,
 			selectedSiteSlug,
 			isStagingSite,
@@ -162,7 +162,7 @@ const useSiteMenuItems = () => {
 		shouldShowWooCommerce,
 		shouldShowThemes,
 		shouldShowMailboxes,
-		shouldShowAddOns: shouldShowAddOnsInFallbackMenu,
+		shouldShowAddOns,
 		showSiteMonitoring: isAtomic,
 	};
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5839

## Proposed Changes

* Hide the menu on the atomic sites as all features are included, and people can upgrade their storage on the plans page

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/9b3cd28d-6063-40ba-8c80-675293a35401) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/36e481ad-db75-449f-9f9d-9ea4c7233164) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /home/<your_site> on your atomic sites
* Make sure the `Add-Ons` menu is gone

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?