### PR TITLE
Command Palette: Wait for help icon to be visible before clicking

### DIFF
--- a/packages/command-palette/src/commands/use-single-site-commands.tsx
+++ b/packages/command-palette/src/commands/use-single-site-commands.tsx
@@ -67,6 +67,16 @@ interface CustomWindow {
 	};
 }
 
+const waitForElementAndClick = ( selector: string, attempt = 1 ) => {
+	const element = document.querySelector< HTMLElement >( selector );
+	if ( element ) {
+		element.click();
+	} else if ( attempt <= 5 ) {
+		// Try again in 250ms, but no more than 5 times.
+		setTimeout( () => waitForElementAndClick( selector, attempt + 1 ), 250 );
+	}
+};
+
 const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ): Command[] => {
 	const { __, _x } = useI18n();
 	const commandNavigation = useCommandNavigation( { navigate, currentRoute } );
@@ -116,7 +126,7 @@ const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ):
 			].join( ' ' ),
 			callback: ( { close }: CommandCallBackParams ) => {
 				close();
-				document?.getElementById( 'wp-admin-bar-help-center' )?.click();
+				waitForElementAndClick( '#wp-admin-bar-help-center' );
 			},
 			icon: helpIcon,
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Wait for the help icon to be visible before clicking
* This should fix a failing test.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the command palette on wp-admin.
* Use the Help command.
* The help center should open.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?