### PR TITLE
Masterbar: Set --masterbar-height to 0 when it's hidden

### DIFF
--- a/client/layout/masterbar/empty.jsx
+++ b/client/layout/masterbar/empty.jsx
@@ -1,3 +1,16 @@
-const EmptyMasterbar = () => <header id="header" className="masterbar" />;
+import { Global, css } from '@emotion/react';
+
+const EmptyMasterbar = () => (
+	<>
+		<Global
+			styles={ css`
+				:root {
+					--masterbar-height: 0px !important;
+				}
+			` }
+		/>
+		<header id="header" className="masterbar" />
+	</>
+);
 
 export default EmptyMasterbar;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5844

## Proposed Changes

* Update the value CSS variable, `--masterbar-height`, when the masterbar is hidden

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/5efc724c-b3ec-4617-a60f-7f20cd094f50) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/76b7e75e-bb98-426b-a44f-1785044c25b5) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /me
* When the Auth modal is shown, make sure the backdrop covers full window without the gap of the masterbar

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?