### PR TITLE
A4A: Fix Layout Mobile view spacing and sticky header.

### DIFF
--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -8,6 +8,8 @@
 	border-radius: 8px; /* stylelint-disable-line scales/radii */
 
 	header.current-section {
+		margin-block-end: 16px;
+
 		button {
 			padding: 20px 8px;
 		}
@@ -66,10 +68,6 @@
 	@include breakpoint-deprecated( "<1280px" ) {
 		flex-wrap: wrap;
 
-		> * {
-			width: 100%;
-		}
-
 		> * + * {
 			margin-inline-start: 0;
 		}
@@ -79,6 +77,22 @@
 .a4a-layout__header.has-actions > .a4a-layout__header-main {
 	@include breakpoint-deprecated( "660px-1280px" ) {
 		margin-block-end: 16px;
+	}
+}
+
+.a4a-layout__header-actions {
+	width: 100%;
+	display: flex;
+
+	> * {
+		flex-grow: 1;
+	}
+
+	@include break-medium {
+		width: auto;
+		> * {
+			flex-grow: 0;
+		}
 	}
 }
 

--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -75,7 +75,7 @@
 }
 
 .a4a-layout__header.has-actions > .a4a-layout__header-main {
-	@include breakpoint-deprecated( "660px-1280px" ) {
+	@include breakpoint-deprecated( "<1280px" ) {
 		margin-block-end: 16px;
 	}
 }
@@ -152,7 +152,7 @@
 
 .a4a-layout__header-title {
 	font-size: 2.25rem;
-	margin-block-end: 8px;
+	margin-block-end: 0;
 	font-weight: 600;
 	line-height: 1.2;
 }

--- a/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
@@ -76,20 +76,16 @@ export default function LicensesOverview( {
 					<LayoutHeader>
 						<Title>{ title } </Title>
 						<Actions>
-							<div className="issue-license__controls">
-								<div className="issue-license__actions">
-									{ /* TODO: <SHOW_PARTNER_KEY_SELECTION_HERE /> */ }
-									<Button
-										disabled={ ! partnerCanIssueLicense }
-										href={ partnerCanIssueLicense ? '/marketplace' : undefined }
-										onClick={ onIssueNewLicenseClick }
-										primary
-										style={ { marginLeft: 'auto' } }
-									>
-										{ translate( 'Issue New License' ) }
-									</Button>
-								</div>
-							</div>
+							{ /* TODO: <SHOW_PARTNER_KEY_SELECTION_HERE /> */ }
+							<Button
+								disabled={ ! partnerCanIssueLicense }
+								href={ partnerCanIssueLicense ? '/marketplace' : undefined }
+								onClick={ onIssueNewLicenseClick }
+								primary
+								style={ { marginLeft: 'auto' } }
+							>
+								{ translate( 'Issue New License' ) }
+							</Button>
 						</Actions>
 					</LayoutHeader>
 


### PR DESCRIPTION
This pull request resolves the issue of A4A Layout header spacing in mobile view and addresses how to handle mobile view actions.

**Before**
<img width="385" alt="Screenshot 2024-02-29 at 6 17 13 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/8174b265-c3b5-47b2-ae3d-8655bb2f0bac">
<img width="414" alt="Screenshot 2024-02-29 at 3 45 18 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/9941b9a9-1683-4083-be5a-755fe4219b6b">


**After**
<img width="424" alt="Screenshot 2024-02-29 at 6 17 27 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/cedd3748-840e-4b68-a580-9dd63715f4f2">


Closes https://github.com/Automattic/jetpack-genesis/issues/254

## Proposed Changes

* Add a margin-bottom on Mobile navigation.
* Stretch out all child elements. Within the Header actions component.
* Additionally, remove the class name that causes the CTA in the Licenses page to be sticky when in mobile view.

## Testing Instructions

* Switch branch: `git checkout fix/a4a-mobile-view-spacing`
* Start the server by running `yarn start-a8c-for-agencies`.
* Go to http://agencies.localhost:3000/purchases/licenses
* Set your browser to mobile view.
* Test that the header CTA works as expected.
* Please also test the rest of screens' header responsiveness if nothing has been broken with this change. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?