### PR TITLE
Only trigger signup complete events for signup flows

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -14,6 +14,7 @@ import { useEffect, useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import { LoadingBar } from 'calypso/components/loading-bar';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
+import availableFlows from 'calypso/landing/stepper/declarative-flow/registered-flows';
 import { useRecordSignupComplete } from 'calypso/landing/stepper/hooks/use-record-signup-complete';
 import { ONBOARD_STORE } from 'calypso/landing/stepper/stores';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -98,12 +99,20 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 	// When the hasActionSuccessfullyRun flag turns on, run submit() and fire the sign-up completion event.
 	useEffect( () => {
 		if ( hasActionSuccessfullyRun ) {
-			recordSignupComplete();
+			// We should only trigger signup completion for signup flows, so check if we have one.
+			if ( availableFlows[ flow ] ) {
+				availableFlows[ flow ]().then( ( flowExport ) => {
+					if ( flowExport.default.isSignupFlow ) {
+						recordSignupComplete();
+					}
+				} );
+			}
+
 			submit?.( destinationState, ProcessingResult.SUCCESS );
 		}
 		// A change in submit() doesn't cause this effect to rerun.
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ hasActionSuccessfullyRun, recordSignupComplete ] );
+	}, [ hasActionSuccessfullyRun, recordSignupComplete, flow ] );
 
 	const getSubtitle = () => {
 		return props.subtitle || loadingMessages[ currentMessageIndex ]?.subtitle;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:
* https://github.com/Automattic/wp-calypso/pull/87758
* pbmxuV-3kA-p2

## Proposed Changes

* This PR updates the Stepper code responsible for triggering `calypso_signup_complete` Tracks events to check the `Flow.isSignupFlow` property added in https://github.com/Automattic/wp-calypso/pull/87758 before triggering the event. This should prevent the event being triggered for non-signup flows.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
This is mostly an exploratory contribution, so I am not 100% sure of the problematic symptoms we're trying to address.

My _suspicion_ is that something like the following should work:
* Run this branch locally or via Calypso.live
* Ensure you have Tracks Vigilante or some other way of inspecting Tracks events
* Navigate through one or more flows that are flagged with `isSignupFlow = true`, e.g. `/setup/ecommerce`, `/setup/free`, `/setup/link-in-bio`, or `/setup/design-first`. (You can reference the files in https://github.com/Automattic/wp-calypso/pull/87758 to get a sense for this.)
* Verify that after the flow completes, we trigger a `calypso_signup_complete` event.
* Navigate through one or more flows that are flagged with `isSignupFlow = false`, e.g. `/setup/blog`, `/setup/start-writing`, or `/setup/build` -- you may need to specify `siteSlug` as a URL parameter for these flows.
* Verify that you do _not_ see a `calypso_signup_complete` Tracks event triggered

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [N/A] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [N/A] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [N/A] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?