### PR TITLE
LiTS Survey v2: Update survey for March

### DIFF
--- a/client/my-sites/themes/survey/index.tsx
+++ b/client/my-sites/themes/survey/index.tsx
@@ -6,6 +6,7 @@ import './survey.scss';
 export enum SurveyType {
 	DECEMBER_2023 = 'DECEMBER_2023',
 	FEBRUARY_2024 = 'FEBRUARY_2024',
+	MARCH_2024 = 'MARCH_2024',
 }
 
 const surveys = new Map< SurveyType, { eventName: string; eventUrl: string } >( [
@@ -21,6 +22,13 @@ const surveys = new Map< SurveyType, { eventName: string; eventUrl: string } >( 
 		{
 			eventName: 'theme-showcase-february-2024',
 			eventUrl: 'https://automattic.survey.fm/lits-survey-v2',
+		},
+	],
+	[
+		SurveyType.MARCH_2024,
+		{
+			eventName: 'theme-showcase-march-2024',
+			eventUrl: 'https://automattic.survey.fm/lits-survey-v2-march',
 		},
 	],
 ] );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -602,7 +602,7 @@ class ThemeShowcase extends Component {
 				/>
 				{ isLoggedIn && (
 					<ThemeShowcaseSurvey
-						survey={ SurveyType.FEBRUARY_2024 }
+						survey={ SurveyType.MARCH_2024 }
 						condition={ () => lastNonEditorRoute.includes( 'theme/' ) }
 					/>
 				) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

* Updated the survey from February to March.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the Calypso live link
* Go to the LiTS
* Click on a theme and navigate back
* You should see the survey banner, click on it.
* You should see the March 2024 survey loaded.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?