### PR TITLE
Untangle: Update the link of theme page on the Theme Thank you page

### DIFF
--- a/client/layout/index.jsx
+++ b/client/layout/index.jsx
@@ -482,8 +482,8 @@ export default withCurrentRoute(
 				sidebarIsCollapsed: sectionName !== 'reader' && getSidebarIsCollapsed( state ),
 				userAllowedToHelpCenter,
 				currentRoute,
-				isGlobalSidebarVisible: shouldShowGlobalSidebar,
-				isGlobalSiteSidebarVisible: shouldShowGlobalSiteSidebar,
+				isGlobalSidebarVisible: shouldShowGlobalSidebar && ! sidebarIsHidden,
+				isGlobalSiteSidebarVisible: shouldShowGlobalSiteSidebar && ! sidebarIsHidden,
 				currentRoutePattern: getCurrentRoutePattern( state ),
 				userCapabilities: state.currentUser.capabilities,
 			};

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
@@ -57,9 +56,7 @@ export function useThemesThankYouData(
 
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 	const themeUrl =
-		adminInterface === 'wp-admin' && isEnabled( 'layout/dotcom-nav-redesign' )
-			? `${ siteAdminUrl }themes.php`
-			: `/themes/${ siteSlug }`;
+		adminInterface === 'wp-admin' ? `${ siteAdminUrl }themes.php` : `/themes/${ siteSlug }`;
 
 	useQueryThemes( 'wpcom', themeSlugs );
 	useQueryThemes( 'wporg', themeSlugs );

--- a/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/marketplace/use-themes-thank-you-data.tsx
@@ -1,9 +1,10 @@
+import { isEnabled } from '@automattic/calypso-config';
 import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
 import { useEffect, useMemo } from 'react';
 import { useQueryThemes } from 'calypso/components/data/query-theme';
 import { useDispatch, useSelector } from 'calypso/state';
-import { isJetpackSite } from 'calypso/state/sites/selectors';
+import { isJetpackSite, getSiteAdminUrl, getSiteOption } from 'calypso/state/sites/selectors';
 import { clearActivated } from 'calypso/state/themes/actions';
 import { getThemes } from 'calypso/state/themes/selectors';
 import { hasExternallyManagedThemes as getHasExternallyManagedThemes } from 'calypso/state/themes/selectors/is-externally-managed-theme';
@@ -50,6 +51,16 @@ export function useThemesThankYouData(
 
 	const isJetpack = useSelector( ( state ) => isJetpackSite( state, siteId ) );
 
+	const adminInterface = useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'wpcom_admin_interface' )
+	);
+
+	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
+	const themeUrl =
+		adminInterface === 'wp-admin' && isEnabled( 'layout/dotcom-nav-redesign' )
+			? `${ siteAdminUrl }themes.php`
+			: `/themes/${ siteSlug }`;
+
 	useQueryThemes( 'wpcom', themeSlugs );
 	useQueryThemes( 'wporg', themeSlugs );
 
@@ -75,7 +86,7 @@ export function useThemesThankYouData(
 
 	const goBackSection = (
 		<MasterbarStyled
-			onClick={ () => page( `/themes/${ siteSlug }` ) }
+			onClick={ () => page( themeUrl ) }
 			backText={ translate( 'Back to dashboard' ) }
 			canGoBack={ allThemesFetched }
 			showContact={ allThemesFetched }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5840

## Proposed Changes

* Point the link of the theme page to `/wp-admin/themes.php` on the Theme Thank you page
* Fix the condition of the`isGlobalSidebarVisible` and `isGlobalSiteSidebarVisible`

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/51f0e77c-d13c-4b12-89ad-5b8e6a1d18c2) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/3bf65b86-75f0-4b0f-9fa3-b557d4c3076a) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/marketplace/thank-you/<your_site>?themes=creatio` on your atomic site with wp-admin interface
* Make sure the Navigation bar is visible
* Make sure the `Back to Dashboard` button points to the `/wp-admin/themes.php`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?