### PR TITLE
`ThemesList`: Prompt user to choose site when clicking on the "Design your own" banner

### DIFF
--- a/client/components/themes-list/index.jsx
+++ b/client/components/themes-list/index.jsx
@@ -119,13 +119,17 @@ export const ThemesList = ( { tabFilter, ...props } ) => {
 			is_logged_in: isLoggedIn,
 		} );
 
-		const destinationUrl = getSiteAssemblerUrl( {
-			isLoggedIn,
-			selectedSite,
-			shouldGoToAssemblerStep,
-			siteEditorUrl,
-		} );
-		window.location.assign( destinationUrl );
+		if ( props.onDesignYourOwnClick ) {
+			props.onDesignYourOwnClick();
+		} else {
+			const destinationUrl = getSiteAssemblerUrl( {
+				isLoggedIn,
+				selectedSite,
+				shouldGoToAssemblerStep,
+				siteEditorUrl,
+			} );
+			window.location.assign( destinationUrl );
+		}
 	};
 
 	const [ openWarningModal, setOpenWarningModal ] = useState( false );

--- a/client/my-sites/themes/theme-showcase.jsx
+++ b/client/my-sites/themes/theme-showcase.jsx
@@ -370,11 +370,17 @@ class ThemeShowcase extends Component {
 	};
 
 	onDesignYourOwnClick = () => {
-		const { isLoggedIn, siteCount, siteId } = this.props;
+		const { isLoggedIn } = this.props;
 
 		recordTracksEvent( 'calypso_themeshowcase_pattern_assembler_top_button_click', {
 			is_logged_in: isLoggedIn,
 		} );
+
+		this.onDesignYourOwnCallback();
+	};
+
+	onDesignYourOwnCallback = () => {
+		const { isLoggedIn, siteCount, siteId } = this.props;
 
 		if ( shouldSelectSite( { isLoggedIn, siteCount, siteId } ) ) {
 			this.setState( { isDesignThemeModalVisible: true } );
@@ -424,7 +430,10 @@ class ThemeShowcase extends Component {
 
 		return (
 			<div className="theme-showcase__all-themes">
-				<ThemesSelection { ...themesSelectionProps }>
+				<ThemesSelection
+					{ ...themesSelectionProps }
+					onDesignYourOwnClick={ this.onDesignYourOwnCallback }
+				>
 					{ this.shouldShowCollections() && (
 						<>
 							<ShowcaseThemeCollection
@@ -538,7 +547,12 @@ class ThemeShowcase extends Component {
 
 		switch ( tabKey ) {
 			case staticFilters.MYTHEMES?.key:
-				return <ThemesSelection { ...themeProps } />;
+				return (
+					<ThemesSelection
+						{ ...themeProps }
+						onDesignYourOwnClick={ this.onDesignYourOwnCallback }
+					/>
+				);
 			default:
 				return this.allThemes( { themeProps } );
 		}

--- a/client/my-sites/themes/themes-selection.jsx
+++ b/client/my-sites/themes/themes-selection.jsx
@@ -63,6 +63,7 @@ class ThemesSelection extends Component {
 		source: PropTypes.oneOfType( [ PropTypes.number, PropTypes.oneOf( [ 'wpcom', 'wporg' ] ) ] ),
 		themes: PropTypes.array,
 		forceWpOrgSearch: PropTypes.bool,
+		onDesignYourOwnClick: PropTypes.func,
 		themeShowcaseEventRecorder: PropTypes.shape( {
 			recordThemeClick: PropTypes.func,
 			recordThemeStyleVariationClick: PropTypes.func,
@@ -235,6 +236,7 @@ class ThemesSelection extends Component {
 			shouldFetchWpOrgThemes,
 			wpOrgQuery,
 			wpOrgThemes,
+			onDesignYourOwnClick,
 			tier,
 		} = this.props;
 
@@ -264,6 +266,7 @@ class ThemesSelection extends Component {
 					loading={ isRequesting }
 					placeholderCount={ this.props.placeholderCount }
 					bookmarkRef={ this.props.bookmarkRef }
+					onDesignYourOwnClick={ onDesignYourOwnClick }
 					siteId={ siteId }
 					searchTerm={ query.search }
 					tabFilter={ tabFilter }


### PR DESCRIPTION
https://github.com/Automattic/wp-calypso/pull/87660 followup

There's another "Design your own" CTA on the `/themes` page that I missed on the previous PR, and it needs to show the site selector to users as well:

![image](https://github.com/Automattic/wp-calypso/assets/8511199/f0856790-4385-450d-8326-be3f38e8ec4a)

## Proposed Changes

* Pass the logic that handles the site selector modal down to the `ThemesList` component

## Testing Instructions

* Open the PR preview with a user that has multiple sites.
* Enter the Theme Showcase page without site fragment (`/themes`).
* Scroll down until you see the "Design your own" banner from the screenshot shown at the beginning of this PR's description, and click on the "Get started" button.
* Check that a modal lets you choose between creating a new site or selecting one of yours.
* Go back to the top, choose a theme category (e.g. `Blog`), and repeat the previous steps.

![image](https://github.com/Automattic/wp-calypso/assets/8511199/00cbc478-4aca-4a23-9e71-4c107f741b0a)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?