### PR TITLE
Fixes some minor styling issues in the Blaze Dashboard

### DIFF
--- a/apps/blaze-dashboard/src/app.scss
+++ b/apps/blaze-dashboard/src/app.scss
@@ -5,6 +5,7 @@
 @import "./styles/promote-widget.scss";
 @import "./styles/typography.scss";
 
+// Specific Jetpack Blaze styles
 .jp-blaze-dashboard {
 	.promote-post-notice {
 		margin: 0;
@@ -125,14 +126,14 @@
 		// Campaigns details
 		.campaign-item__container {
 			.campaign-item-header {
-				button.campaign-item-promote-again-button {
+				button.promote-again-button {
 					font-weight: 600;
 					font-size: 1rem;
 					padding: 8px 24px;
 					min-width: 110px;
 					line-height: 24px;
-					margin-top: 15px;
 					border-radius: 4px;
+					height: 100%;
 				}
 			}
 
@@ -142,13 +143,13 @@
 
 			.campaign-item-details__support-buttons-container {
 				.campaign-item-details__support-buttons a {
-					padding: 4px 8px;
+					padding: 10px;
 					background: none;
 					color: var(--color-accent);
 					border: 1.5px solid var(--color-accent);
 					font-weight: 600;
 					font-size: 0.75rem;
-					display: inline-flex;
+					// display: inline-flex;
 					align-items: center;
 					line-height: unset;
 				}
@@ -184,7 +185,7 @@ $break-medium-expanded-menu: $break-medium + 272px;
 	}
 }
 
-
+// Specific Woo Blaze styles
 .woo-blaze-dashboard {
 	.promote-post-i2 {
 		// Header
@@ -217,6 +218,26 @@ $break-medium-expanded-menu: $break-medium + 272px;
 					padding: 6px 12px;
 				}
 			}
+		}
+
+		// Campaigns details
+		.campaign-item__container {
+			.campaign-item-details__support-buttons-container {
+				.campaign-item-details__support-buttons a {
+					height: 100%;
+				}
+			}
+		}
+	}
+}
+
+// Shared styles
+.woo-blaze-dashboard,
+.jp-blaze-dashboard {
+	// Campaigns details
+	.campaign-item__container {
+		.campaign-item-details__ad-destination-url-container a {
+			background: none;
 		}
 	}
 }

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/index.tsx
@@ -390,9 +390,13 @@ export default function CampaignItemDetails( props: Props ) {
 									</Button>
 
 									{ ! canCancelCampaign( status ) && (
-										<Button primary className="promote-again-button" onClick={ onClickPromote }>
+										<WPButton
+											variant="primary"
+											className="promote-again-button"
+											onClick={ onClickPromote }
+										>
 											{ translate( 'Promote Again' ) }
-										</Button>
+										</WPButton>
 									) }
 
 									{ canCancelCampaign( status ) && (

--- a/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
+++ b/client/my-sites/promote-post-i2/components/campaign-item-details/style.scss
@@ -627,6 +627,8 @@ body.is-section-promote-post-i2 .layout__content .campaign-item-details.main {
 				align-items: center;
 				display: inline-flex;
 				line-height: unset;
+				border-radius: 4px;
+				box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
 			}
 
 			button:not(:last-child),


### PR DESCRIPTION
Fixes some minor styling issues in the Blaze Dashboard app.

![Screenshot 2024-02-28 at 18 08 44](https://github.com/Automattic/wp-calypso/assets/1258162/9ab2b540-8578-4c2a-8e07-e6e80addc77d)
![Screenshot 2024-02-28 at 18 09 50](https://github.com/Automattic/wp-calypso/assets/1258162/c9ab4c84-1cd6-4986-9ed2-097173cfead6)

## Proposed Changes

* Styling fixes

## Testing Instructions

I will write down the steps to test this using a sandbox. If you don't have a sandbox, I can share a testing method using the Jetpack local environment.

* Connect to your sandbox and verify that you have the latest changes
* Checked out this branch
* Open a console and navigate to wp-calypso/apps/blaze-dashboard
* Execute yarn dev --sync to start syncing the dashboard to your sandbox
* Change your host file to move traffic from widgets.wp.com to your sandbox
* In a browser, go to any jetpack-connected self-hosted site (new or old)
* Go to Tools->Advertising and verify that the page looks good, and that the fixes are solved.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?