### PR TITLE
Migration: Slow down url check tracking event

### DIFF
--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -62,7 +62,7 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 		isValid && onInputEnter( urlValue );
 		setSubmitted( true );
 
-		if ( ! isValid ) {
+		if ( ! isValid && urlValue?.length > 4 ) {
 			recordTracksEvent( 'calypso_importer_capture_input_invalid', {
 				url: urlValue,
 			} );


### PR DESCRIPTION
The `calypso_importer_capture_input_invalid` fires even for empty url, and we should avoid that.

## Testing steps

1. Checkout branch or Live link.
2. Visit `/sites?hosting-flow=true` and click on `Migrate a site`
3. Check events triggered (console or by Tracks Vigilante)
4. Event should be fired only for urls longer than 4 