### PR TITLE
Jetpack Manage: Add missing Jetpack feature tabs: Scan, Plugins and Activity with its content

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-activity.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-activity.tsx
@@ -1,6 +1,5 @@
 import ActivityLogV2 from 'calypso/my-sites/activity/activity-log-v2';
 import SitePreviewPaneContent from '../site-preview-pane/site-preview-pane-content';
-import SitePreviewPaneFooter from '../site-preview-pane/site-preview-pane-footer';
 
 import 'calypso/my-sites/activity/activity-log-v2/style.scss';
 
@@ -16,7 +15,6 @@ export function JetpackActivityPreview( { isLoading = true }: Props ) {
 					{ isLoading ? <div>Loading Activity page...</div> : <ActivityLogV2 /> }
 				</div>
 			</SitePreviewPaneContent>
-			<SitePreviewPaneFooter />
 		</>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-activity.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-activity.tsx
@@ -1,0 +1,22 @@
+import ActivityLogV2 from 'calypso/my-sites/activity/activity-log-v2';
+import SitePreviewPaneContent from '../site-preview-pane/site-preview-pane-content';
+import SitePreviewPaneFooter from '../site-preview-pane/site-preview-pane-footer';
+
+import 'calypso/my-sites/activity/activity-log-v2/style.scss';
+
+type Props = {
+	isLoading: boolean;
+};
+
+export function JetpackActivityPreview( { isLoading = true }: Props ) {
+	return (
+		<>
+			<SitePreviewPaneContent>
+				<div style={ { textAlign: 'left' } }>
+					{ isLoading ? <div>Loading Activity page...</div> : <ActivityLogV2 /> }
+				</div>
+			</SitePreviewPaneContent>
+			<SitePreviewPaneFooter />
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-plugins.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-plugins.tsx
@@ -12,8 +12,8 @@ export function JetpackPluginsPreview( { featureText, link, linkLabel }: Props )
 	return (
 		<>
 			<SitePreviewPaneContent>
-				<div>{ featureText }</div>
-				<div style={ { marginTop: '20px' } }>
+				<h3>{ featureText }</h3>
+				<div style={ { marginTop: '40px' } }>
 					<Button href={ link } primary>
 						{ linkLabel }
 					</Button>

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-plugins.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-plugins.tsx
@@ -1,0 +1,25 @@
+import { Button } from '@automattic/components';
+import SitePreviewPaneContent from '../site-preview-pane/site-preview-pane-content';
+import SitePreviewPaneFooter from '../site-preview-pane/site-preview-pane-footer';
+
+type Props = {
+	featureText: string | React.ReactNode;
+	link: string;
+	linkLabel: string;
+};
+
+export function JetpackPluginsPreview( { featureText, link, linkLabel }: Props ) {
+	return (
+		<>
+			<SitePreviewPaneContent>
+				<div>{ featureText }</div>
+				<div style={ { marginTop: '20px' } }>
+					<Button href={ link } primary>
+						{ linkLabel }
+					</Button>
+				</div>
+			</SitePreviewPaneContent>
+			<SitePreviewPaneFooter />
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
@@ -1,12 +1,17 @@
-import page from '@automattic/calypso-router';
 import { useTranslate } from 'i18n-calypso';
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useJetpackAgencyDashboardRecordTrackEvent } from '../../hooks';
 import SitePreviewPane, { createFeaturePreview } from '../site-preview-pane';
 import { SitePreviewPaneProps } from '../site-preview-pane/types';
+import { JetpackActivityPreview } from './jetpack-activity';
 import { JetpackBackupPreview } from './jetpack-backup';
 import { JetpackBoostPreview } from './jetpack-boost';
 import { JetpackMonitorPreview } from './jetpack-monitor';
+import { JetpackPluginsPreview } from './jetpack-plugins';
+import { JetpackScanPreview } from './jetpack-scan';
 import { JetpackStatsPreview } from './jetpack-stats';
 
 export function JetpackPreviewPane( {
@@ -18,6 +23,15 @@ export function JetpackPreviewPane( {
 }: SitePreviewPaneProps ) {
 	const translate = useTranslate();
 	const recordEvent = useJetpackAgencyDashboardRecordTrackEvent( [ site ], ! isSmallScreen );
+
+	const dispatch = useDispatch();
+	const selectedSiteId = useSelector( getSelectedSiteId );
+
+	useEffect( () => {
+		if ( site ) {
+			dispatch( setSelectedSiteId( site.blog_id ) );
+		}
+	}, [ site ] );
 
 	const trackEvent = ( eventName: string ) => {
 		recordEvent( eventName );
@@ -45,12 +59,34 @@ export function JetpackPreviewPane( {
 				<JetpackBackupPreview site={ site } trackEvent={ trackEvent } hasError={ hasError } />
 			),
 			createFeaturePreview(
+				'jetpack_scan',
+				'Scan',
+				true,
+				selectedFeatureId,
+				setSelectedFeatureId,
+				<JetpackScanPreview sideId={ site.blog_id } />
+			),
+			createFeaturePreview(
 				'jetpack_monitor',
 				'Monitor',
 				true,
 				selectedFeatureId,
 				setSelectedFeatureId,
 				<JetpackMonitorPreview site={ site } trackEvent={ trackEvent } hasError={ hasError } />
+			),
+			createFeaturePreview(
+				'jetpack_plugins',
+				'Plugins',
+				true,
+				selectedFeatureId,
+				setSelectedFeatureId,
+				<JetpackPluginsPreview
+					link={ '/plugins/manage/' + site.url }
+					linkLabel={ translate( 'Manage Plugins' ) }
+					featureText={ translate( 'Manage all plugins installed on %(siteUrl)s', {
+						args: { siteUrl: site.url },
+					} ) }
+				/>
 			),
 			createFeaturePreview(
 				'jetpack_stats',
@@ -61,20 +97,12 @@ export function JetpackPreviewPane( {
 				<JetpackStatsPreview site={ site } trackEvent={ trackEvent } />
 			),
 			createFeaturePreview(
-				'jetpack_scan',
-				'Scan',
+				'jetpack_activity',
+				translate( 'Activity' ),
 				true,
 				selectedFeatureId,
-				() => page( '/scan/' + site.url ),
-				null
-			),
-			createFeaturePreview(
-				'jetpack_plugins',
-				'Plugins',
-				true,
-				selectedFeatureId,
-				() => page( '/plugins/manage/' + site.url ),
-				null
+				setSelectedFeatureId,
+				<JetpackActivityPreview isLoading={ ! selectedSiteId } />
 			),
 		],
 		[ site, selectedFeatureId, translate ]

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-scan.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-scan.tsx
@@ -6,7 +6,6 @@ import {
 	scan,
 } from 'calypso/my-sites/scan/controller';
 import SitePreviewPaneContent from '../site-preview-pane/site-preview-pane-content';
-import SitePreviewPaneFooter from '../site-preview-pane/site-preview-pane-footer';
 
 import 'calypso/my-sites/scan/style.scss';
 
@@ -49,7 +48,6 @@ export function JetpackScanPreview( { sideId }: Props ) {
 			<SitePreviewPaneContent>
 				{ sideId ? context.primary : <div>Loading Scan page...</div> }
 			</SitePreviewPaneContent>
-			<SitePreviewPaneFooter />
 		</>
 	);
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-scan.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-scan.tsx
@@ -1,0 +1,34 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import ScanPage from 'calypso/my-sites/scan/main';
+import { setSelectedSiteId } from 'calypso/state/ui/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import SitePreviewPaneContent from '../site-preview-pane/site-preview-pane-content';
+import SitePreviewPaneFooter from '../site-preview-pane/site-preview-pane-footer';
+import { Site } from '../types';
+
+import 'calypso/my-sites/scan/style.scss';
+
+type Props = {
+	site: Site;
+};
+
+export function JetpackScanPreview( { site }: Props ) {
+	const dispatch = useDispatch();
+	const siteId = useSelector( getSelectedSiteId );
+
+	useEffect( () => {
+		if ( site ) {
+			dispatch( setSelectedSiteId( site.blog_id ) );
+		}
+	}, [ site ] );
+
+	return (
+		<>
+			<SitePreviewPaneContent>
+				{ siteId ? <ScanPage /> : <div>Loading Scan page...</div> }
+			</SitePreviewPaneContent>
+			<SitePreviewPaneFooter />
+		</>
+	);
+}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-content/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-content/style.scss
@@ -3,6 +3,7 @@
 	background-color: var(--studio-white);
 	padding: 48px;
 	text-align: center;
+	overflow-y: auto;
 
 	.expanded-card {
 		max-width: 320px;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style-dashboard-v2.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style-dashboard-v2.scss
@@ -298,7 +298,7 @@
 	display: flex;
 	flex-wrap: nowrap;
 	gap: 16px;
-	max-height: calc(100vh - 12px);
+	max-height: calc(100vh - 32px);
 
 	.dataviews-wrapper {
 		.components-button:focus:not(:disabled) {

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style-dashboard-v2.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style-dashboard-v2.scss
@@ -298,6 +298,7 @@
 	display: flex;
 	flex-wrap: nowrap;
 	gap: 16px;
+	max-height: calc(100vh - 12px);
 
 	.dataviews-wrapper {
 		.components-button:focus:not(:disabled) {


### PR DESCRIPTION
Resolve: https://github.com/Automattic/jetpack-manage/issues/338

## Proposed Changes

This PR adds 2 more Jetpack feature Preview Pane, with content. It needs some tweaks, but this PR is an example of how we could add feature content by reusing existing components.

This is mainly a proof of concept; not all the buttons or CTA work properly. If the idea goes forward, we can implement it component by component to have more control over them.

**Scan**

![image](https://github.com/Automattic/wp-calypso/assets/9832440/ab65ac78-5c05-4944-b259-6690a4eff900)

**Note:** There are buttons that take you to the Scan page, like the History tab.

**Activity**

![image](https://github.com/Automattic/wp-calypso/assets/9832440/975edd0b-07e3-4d8a-b7c2-cdc021b888f9)

**Plugins**

![image](https://github.com/Automattic/wp-calypso/assets/9832440/cfc27c4d-5d53-4c6e-a7ba-9a083f8cb3fc)

## Testing Instructions

- Check the code
- Open the Scan tab and check it. You should see the Scan data of the site; only the main tab, the History tab, will take you to the Scan page.
- Open the Activity tab and check it. You should see the site activity site.
- Open the Plugins tab and check it. You should see the message and a CTA button that takes you to the Plugins page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
