### PR TITLE
DIFM: log cart extra validation error

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -359,7 +359,11 @@ function addDIFMLiteProductToCart( callback, dependencies, step, reduxStore ) {
 	if ( step.lastKnownFlow === 'do-it-for-me-store' ) {
 		dependencies.isStoreFlow = true;
 	}
-	const extra = buildDIFMCartExtrasObject( dependencies, siteSlug );
+	const extra = buildDIFMCartExtrasObject(
+		dependencies,
+		siteSlug,
+		`step-actions-flow-${ step.lastKnownFlow }`
+	);
 	const cartItem = {
 		product_slug: WPCOM_DIFM_LITE,
 		extra,

--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -362,7 +362,7 @@ function addDIFMLiteProductToCart( callback, dependencies, step, reduxStore ) {
 	const extra = buildDIFMCartExtrasObject(
 		dependencies,
 		siteSlug,
-		`step-actions-flow-${ step.lastKnownFlow }`
+		`step-actions-flow-${ step.lastKnownFlow || '' }`
 	);
 	const cartItem = {
 		product_slug: WPCOM_DIFM_LITE,

--- a/client/signup/steps/page-picker/index.tsx
+++ b/client/signup/steps/page-picker/index.tsx
@@ -375,11 +375,13 @@ function OneClickPurchaseModal( {
 	siteSlug,
 	selectedPages,
 	isStoreFlow,
+	flowName,
 }: {
 	onClose: () => void;
 	siteSlug: SiteSlug;
 	selectedPages: string[];
 	isStoreFlow: boolean;
+	flowName: string;
 } ) {
 	const translate = useTranslate();
 	const signupDependencies = useSelector( getSignupDependencyStore );
@@ -392,11 +394,12 @@ function OneClickPurchaseModal( {
 					selectedPageTitles: selectedPages,
 					isStoreFlow,
 				},
-				siteSlug
+				siteSlug,
+				`page-picker-one-click-modal-flow-${ flowName }`
 			),
 			quantity: selectedPages.length,
 		} );
-	}, [ isStoreFlow, selectedPages, signupDependencies, siteSlug ] );
+	}, [ flowName, isStoreFlow, selectedPages, signupDependencies, siteSlug ] );
 
 	return (
 		<CalypsoShoppingCartProvider>
@@ -560,6 +563,7 @@ function DIFMPagePicker( props: StepProps ) {
 							siteSlug={ siteSlug }
 							selectedPages={ selectedPages }
 							isStoreFlow={ isStoreFlow }
+							flowName={ flowName }
 						/>
 					) }
 					<PageSelector

--- a/client/signup/steps/page-picker/use-cart-for-difm.tsx
+++ b/client/signup/steps/page-picker/use-cart-for-difm.tsx
@@ -286,7 +286,8 @@ export function useCartForDIFM(
 						selectedPageTitles: selectedPages,
 						isStoreFlow,
 					},
-					siteSlug
+					siteSlug,
+					'use-cart-for-difm'
 				),
 				quantity: selectedPages.length,
 			};

--- a/client/state/difm/assemblers.ts
+++ b/client/state/difm/assemblers.ts
@@ -1,4 +1,6 @@
+import config from '@automattic/calypso-config';
 import { mapRecordKeysRecursively, camelToSnakeCase } from '@automattic/js-utils';
+import { logToLogstash } from 'calypso/lib/logstash';
 import { addQueryArgs } from 'calypso/lib/url';
 import type {
 	DIFMDependencies,
@@ -7,9 +9,27 @@ import type {
 } from 'calypso/state/signup/steps/website-content/types';
 import type { SiteSlug } from 'calypso/types';
 
+const logValidationFailure = (
+	message: string,
+	context: string,
+	dependencies: Partial< DIFMDependencies >
+) => {
+	logToLogstash( {
+		feature: 'calypso_client',
+		message,
+		severity: config( 'env_id' ) === 'production' ? 'error' : 'debug',
+		properties: {
+			type: 'calypso_difm_extras_validation_failure',
+			dependencies: JSON.stringify( dependencies ),
+			context,
+		},
+	} );
+};
+
 export function buildDIFMCartExtrasObject(
 	dependencies: Partial< DIFMDependencies >,
-	siteSlug: SiteSlug
+	siteSlug: SiteSlug,
+	context: string
 ) {
 	const {
 		newOrExistingSiteChoice,
@@ -31,9 +51,17 @@ export function buildDIFMCartExtrasObject(
 		isStoreFlow,
 	} = dependencies;
 
+	if ( ! siteTitle ) {
+		logValidationFailure( 'siteTitle does not exist', context, dependencies );
+	}
+
+	if ( ! selectedPageTitles?.length ) {
+		logValidationFailure( 'selectedPageTitles does not exist', context, dependencies );
+	}
+
 	return {
 		new_or_existing_site_choice: newOrExistingSiteChoice,
-		site_title: siteTitle,
+		site_title: siteTitle || 'NO_SITE_TITLE',
 		site_description: siteDescription || tagline,
 		search_terms: searchTerms,
 		selected_design: selectedDesign?.theme,

--- a/client/state/difm/test/assemblers.ts
+++ b/client/state/difm/test/assemblers.ts
@@ -19,7 +19,7 @@ describe( 'assembler', () => {
 			selectedPageTitles: [ 'test1', 'test2' ],
 		};
 		const siteSlug = 'testsiteslug';
-		expect( buildDIFMCartExtrasObject( dependencies, siteSlug ) ).toEqual( {
+		expect( buildDIFMCartExtrasObject( dependencies, siteSlug, 'test-context' ) ).toEqual( {
 			twitter_url: 'test twitterUrl',
 			facebook_url: 'test facebookUrl',
 			linkedin_url: 'test linkedinUrl',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

In a few cases, (33afd-pb), the `site_title` is not added to the `extra` object of the cart product. The changes in this PR are a step to debug this issue.

* Adds an extra argument, `context` to `buildDIFMCartExtrasObject`.
* This is used to log if the `siteTitle` or `selectedPageTitles` is absent. This will be further used to debug issues with the signup dependency store.
* Also adds a default site title if it does not exist in the dependency store.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/start/do-it-for-me` and purchase the product.
* Confirm that there are no errors.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?