### PR TITLE
i18n: Localize tabs labels in StatsDetailsNavigation

### DIFF
--- a/client/my-sites/stats/stats-details-navigation/index.tsx
+++ b/client/my-sites/stats/stats-details-navigation/index.tsx
@@ -1,4 +1,6 @@
+import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
+import { useCallback, useMemo } from 'react';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
@@ -10,32 +12,43 @@ interface propTypes {
 	givenSiteId: string | number;
 }
 
-const tabs = { highlights: 'Highlights', opens: 'Email opens', clicks: 'Email clicks' };
-
-const navItems = (
-	postId: number,
-	period: string | undefined = 'day',
-	statType: string | undefined,
-	givenSiteId: string | number
-) => {
-	return Object.keys( tabs ).map( ( item ) => {
-		const selected = statType ? statType === item : 'highlights' === item;
-		const pathParam = [ 'opens', 'clicks' ].includes( item )
-			? `email/${ item }/${ period }`
-			: `post`;
-		const attr = {
-			key: item,
-			path: `/stats/${ pathParam }/${ postId }/${ givenSiteId }`,
-			selected,
-		};
-		const label = tabs[ item as keyof typeof tabs ];
-
-		// uppercase first character of item
-		return <NavItem { ...attr }>{ label }</NavItem>;
-	} );
-};
-
 function StatsDetailsNavigation( { postId, period, statType, givenSiteId }: propTypes ) {
+	const translate = useTranslate();
+	const tabs = useMemo(
+		() => ( {
+			highlights: translate( 'Highlights' ),
+			opens: translate( 'Email opens' ),
+			clicks: translate( 'Email clicks' ),
+		} ),
+		[ translate ]
+	);
+
+	const navItems = useCallback(
+		(
+			postId: number,
+			period: string | undefined = 'day',
+			statType: string | undefined,
+			givenSiteId: string | number
+		) => {
+			return Object.keys( tabs ).map( ( item ) => {
+				const selected = statType ? statType === item : 'highlights' === item;
+				const pathParam = [ 'opens', 'clicks' ].includes( item )
+					? `email/${ item }/${ period }`
+					: `post`;
+				const attr = {
+					key: item,
+					path: `/stats/${ pathParam }/${ postId }/${ givenSiteId }`,
+					selected,
+				};
+				const label = tabs[ item as keyof typeof tabs ];
+
+				// uppercase first character of item
+				return <NavItem { ...attr }>{ label }</NavItem>;
+			} );
+		},
+		[ tabs ]
+	);
+
 	return (
 		<SectionNav>
 			<NavTabs label="Stats">{ navItems( postId, period, statType, givenSiteId ) }</NavTabs>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 746-gh-Automattic/i18n-issues

## Proposed Changes

* Localize tabs labels in `StatsDetailsNavigation` used on the email stats page.

**Before:**
![QEfM6gFF8mX4Ych4](https://github.com/Automattic/wp-calypso/assets/2722412/0e54c951-a593-4e8d-9fc5-61720eb2854d)

**After:**
![jFGfZKIj3TMbIe1w](https://github.com/Automattic/wp-calypso/assets/2722412/d8d8e438-125d-4d9a-8a49-3db949c1b017)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* Switch UI to a Mag-16 language.
* Run locally or use calypso.live build.
* Navigate to `/stats/email/opens/day/{id}/{site}`, where `{id}` is a page id of a `{site}` that has subscribers. See related issue for an example site to test with.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?