### PR TITLE
GitHub deployments: Change popup uri

### DIFF
--- a/client/my-sites/github-deployments/deployments/authorize-button.tsx
+++ b/client/my-sites/github-deployments/deployments/authorize-button.tsx
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
-import { addQueryArgs } from '@wordpress/url';
 import { useState } from 'react';
 import SocialLogo from 'calypso/components/social-logo';
 import { useDispatch } from 'calypso/state';
@@ -11,9 +10,8 @@ import { useGithubInstallationsQuery } from '../use-github-installations-query';
 import { openPopup } from '../utils/open-popup';
 import { useSaveGitHubCredentialsMutation } from './use-save-github-credentials-mutation';
 
-const AUTHORIZE_URL = addQueryArgs( 'https://github.com/login/oauth/authorize', {
-	client_id: config( 'github_oauth_client_id' ),
-} );
+const AUTHORIZE_URL =
+	'https://public-api.wordpress.com/wpcom/v2/hosting/github/app-redirect?ux_mode=popup';
 
 const POPUP_ID = 'github-app-authorize';
 


### PR DESCRIPTION
## Proposed Changes

This PR changes the URL for the popup from directly calling `github.com/authorize` to the redirect endpoint. This endpoint takes care of adding the state parameter, which is later used in the app callback to verify if the callback originated from us.

Related diff: D140226-code 


## Testing Instructions

1. Apply this PR
2. Test authorizing GitHub in the GitHub deployments UI

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?