### PR TITLE
GitHub Deployments: Showing admin accounts only for repository creation

### DIFF
--- a/client/my-sites/github-deployments/components/installations-dropdown/use-live-installations.ts
+++ b/client/my-sites/github-deployments/components/installations-dropdown/use-live-installations.ts
@@ -42,7 +42,7 @@ export const useLiveInstallations = ( {
 			}
 		}
 
-		setInstallation( installations[ 0 ] );
+		setInstallation( installations.find( ( installation ) => installation.is_admin === true ) );
 	}, [ installations, installation, initialInstallationId ] );
 
 	const onNewInstallationRequest = () => {

--- a/client/my-sites/github-deployments/create-repository/create-repository-form.tsx
+++ b/client/my-sites/github-deployments/create-repository/create-repository-form.tsx
@@ -102,7 +102,9 @@ export const CreateRepositoryForm = ( {
 							) : (
 								<GitHubInstallationsDropdown
 									onAddInstallation={ onNewInstallationRequest }
-									installations={ installations }
+									installations={ installations.filter(
+										( installation ) => installation.is_admin === true
+									) }
 									value={ installation }
 									onChange={ setInstallation }
 								/>

--- a/client/my-sites/github-deployments/use-github-installations-query.ts
+++ b/client/my-sites/github-deployments/use-github-installations-query.ts
@@ -17,6 +17,7 @@ export interface GitHubInstallationData {
 	external_id: number;
 	account_name: string;
 	management_url: string;
+	is_admin: boolean;
 }
 
 export const useGithubInstallationsQuery = (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1709138581067669-slack-C06D9M3CHMK
Task-related: https://github.com/Automattic/dotcom-forge/issues/5828

## Proposed Changes

- Only allow Create a repository from an admin account
- Pre-selects the admin account in the dropdown

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this diff: D140315-code
* On a second GH account, share a repository with your main account
* Accept it 
* Ensure you still see the other accounts on the Connect repository screen:

	![image](https://github.com/Automattic/wp-calypso/assets/1044309/ce483a8c-08ad-4f93-bbfe-15ace762cd6f)

* On the Create repository screen, you should only see the account you have write access:

	![image](https://github.com/Automattic/wp-calypso/assets/1044309/72819afc-7d2a-4285-8964-d04e8580f4a2)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?