### PR TITLE
Basic comparison grid component

### DIFF
--- a/packages/components/src/standalone-comparison-grid/README.md
+++ b/packages/components/src/standalone-comparison-grid/README.md
@@ -1,0 +1,3 @@
+# StandaloneComparisonGrid
+
+TODO

--- a/packages/components/src/standalone-comparison-grid/index.stories.jsx
+++ b/packages/components/src/standalone-comparison-grid/index.stories.jsx
@@ -1,3 +1,4 @@
+import { Button } from '@wordpress/components';
 import { StandAloneComparisonGrid, Column } from '.';
 import './stories.scss';
 
@@ -14,8 +15,11 @@ const columns = [
 		],
 		introCopy:
 			'Import your site content, without themes, customizations, or plugins. You will probably have to do some work to get things looking exactly the same.',
-		actionCopy: 'Import my website content',
-		action: () => {},
+		controls: (
+			<Button variant="primary" onClick={ () => {} }>
+				Import my website content
+			</Button>
+		),
 	},
 	{
 		title: 'Migrate',
@@ -32,7 +36,11 @@ const columns = [
 			'Import all WooCommerce products and orders',
 		],
 		introCopy: 'Available with the Creator Plan from $NN/month',
-		actionCopy: 'Migrate my website',
+		controls: (
+			<Button variant="primary" onClick={ () => {} }>
+				Migrate my website
+			</Button>
+		),
 		action: () => {},
 	},
 ];

--- a/packages/components/src/standalone-comparison-grid/index.stories.jsx
+++ b/packages/components/src/standalone-comparison-grid/index.stories.jsx
@@ -1,4 +1,4 @@
-import StandaloneComparisonGrid from '.';
+import StandaloneComparisonGrid, { StandAloneComparisonGridColumn } from '.';
 import './stories.scss';
 
 export default { title: 'packages/components/StandaloneComparisonGrid' };
@@ -39,7 +39,10 @@ const columns = [
 
 const GridVariations = () => (
 	<>
-		<StandaloneComparisonGrid columns={ columns } />
+		<StandaloneComparisonGrid>
+			<StandAloneComparisonGridColumn { ...columns[ 0 ] } />
+			<StandAloneComparisonGridColumn { ...columns[ 1 ] } />
+		</StandaloneComparisonGrid>
 	</>
 );
 

--- a/packages/components/src/standalone-comparison-grid/index.stories.jsx
+++ b/packages/components/src/standalone-comparison-grid/index.stories.jsx
@@ -1,0 +1,46 @@
+import StandaloneComparisonGrid from '.';
+import './stories.scss';
+
+export default { title: 'packages/components/StandaloneComparisonGrid' };
+
+const columns = [
+	{
+		title: 'Import',
+		rows: [
+			'Import your pages and posts',
+			'Import your uploaded images and files',
+			'Import your users**',
+			'Import your menus** and FSE templates**',
+		],
+		intro_copy:
+			'Import your site content, without themes, customizations, or plugins. You will probably have to do some work to get things looking exactly the same.',
+		action_copy: 'Import my website content',
+		action: () => {},
+	},
+	{
+		title: 'Migrate',
+		rows: [
+			'Import your pages and posts',
+			'Import your uploaded images and files',
+			'Import your users',
+			'Import your menus and FSE templates',
+			'Import your theme and exact layout',
+			'Import your plugins and existing setup',
+			'Custom blocks from all plugins keep working',
+			'Import custom files and PHP code',
+			'Import content from page builders like Elementor, Divi, or WP Bakery',
+			'Import all WooCommerce products and orders',
+		],
+		intro_copy: 'Available with the Creator Plan from $NN/month',
+		action_copy: 'Migrate my website',
+		action: () => {},
+	},
+];
+
+const GridVariations = () => (
+	<>
+		<StandaloneComparisonGrid columns={ columns } />
+	</>
+);
+
+export const Normal = () => <GridVariations />;

--- a/packages/components/src/standalone-comparison-grid/index.stories.jsx
+++ b/packages/components/src/standalone-comparison-grid/index.stories.jsx
@@ -1,4 +1,4 @@
-import StandaloneComparisonGrid, { StandAloneComparisonGridColumn } from '.';
+import { StandAloneComparisonGrid, Column } from '.';
 import './stories.scss';
 
 export default { title: 'packages/components/StandaloneComparisonGrid' };
@@ -38,12 +38,10 @@ const columns = [
 ];
 
 const GridVariations = () => (
-	<>
-		<StandaloneComparisonGrid>
-			<StandAloneComparisonGridColumn { ...columns[ 0 ] } />
-			<StandAloneComparisonGridColumn { ...columns[ 1 ] } />
-		</StandaloneComparisonGrid>
-	</>
+	<StandAloneComparisonGrid>
+		<Column { ...columns[ 0 ] } />
+		<Column { ...columns[ 1 ] } />
+	</StandAloneComparisonGrid>
 );
 
 export const Normal = () => <GridVariations />;

--- a/packages/components/src/standalone-comparison-grid/index.stories.jsx
+++ b/packages/components/src/standalone-comparison-grid/index.stories.jsx
@@ -6,7 +6,7 @@ export default { title: 'packages/components/StandaloneComparisonGrid' };
 const columns = [
 	{
 		title: 'Import',
-		rows: [
+		features: [
 			'Import your pages and posts',
 			'Import your uploaded images and files',
 			'Import your users**',
@@ -19,7 +19,7 @@ const columns = [
 	},
 	{
 		title: 'Migrate',
-		rows: [
+		features: [
 			'Import your pages and posts',
 			'Import your uploaded images and files',
 			'Import your users',

--- a/packages/components/src/standalone-comparison-grid/index.stories.jsx
+++ b/packages/components/src/standalone-comparison-grid/index.stories.jsx
@@ -12,9 +12,9 @@ const columns = [
 			'Import your users**',
 			'Import your menus** and FSE templates**',
 		],
-		intro_copy:
+		introCopy:
 			'Import your site content, without themes, customizations, or plugins. You will probably have to do some work to get things looking exactly the same.',
-		action_copy: 'Import my website content',
+		actionCopy: 'Import my website content',
 		action: () => {},
 	},
 	{
@@ -31,8 +31,8 @@ const columns = [
 			'Import content from page builders like Elementor, Divi, or WP Bakery',
 			'Import all WooCommerce products and orders',
 		],
-		intro_copy: 'Available with the Creator Plan from $NN/month',
-		action_copy: 'Migrate my website',
+		introCopy: 'Available with the Creator Plan from $NN/month',
+		actionCopy: 'Migrate my website',
 		action: () => {},
 	},
 ];

--- a/packages/components/src/standalone-comparison-grid/index.tsx
+++ b/packages/components/src/standalone-comparison-grid/index.tsx
@@ -12,7 +12,7 @@ interface StandAloneComparisonGridColumn {
 
 export interface StandAloneComparisonGridProps {
 	children:
-		| React.ReactElement< typeof StandAloneComparisonGridColumn >
+		| ReactElement< typeof StandAloneComparisonGridColumn >
 		| React.ReactElement< typeof StandAloneComparisonGridColumn >[];
 }
 

--- a/packages/components/src/standalone-comparison-grid/index.tsx
+++ b/packages/components/src/standalone-comparison-grid/index.tsx
@@ -1,9 +1,10 @@
 import { Button } from '@wordpress/components';
 import './style.scss';
+import { ReactNode } from 'react';
 
 interface StandAloneComparisonGridColumn {
 	title: string;
-	rows: string[];
+	features: ReactNode[];
 	intro_copy?: string;
 	action_copy: string;
 	action: () => void;
@@ -20,44 +21,26 @@ const StandAloneComparisonGrid = ( props: StandAloneComparisonGridProps ) => {
 		<div className="standalone-comparison-grid">
 			{ columns.map( ( column, index ) => {
 				return (
-					<div className="standalone-comparison-grid__column" key={ `scd_${ index }` }>
-						<table className="standalone-comparison-grid__body">
-							<tbody>
-								<tr>
-									<td className="standalone-comparison-grid__title">
-										<h1>{ column.title }</h1>
-									</td>
-								</tr>
-								<tr>
-									<td className="standalone-comparison-grid__intro">
-										{ column.intro_copy && column.intro_copy }
-									</td>
-								</tr>
-
-								<tr>
-									<td className="standalone-comparison-grid__action">
-										<Button variant="primary" onClick={ column.action }>
-											{ column.action_copy }
-										</Button>
-									</td>
-								</tr>
-
-								<tr className="standalone-comparison-grid__row">
-									<td>
-										{ column.rows.map( ( row, index ) => {
-											return (
-												<div
-													key={ `scdi_${ index }` }
-													className="standalone-comparison-grid__row-item"
-												>
-													{ row }
-												</div>
-											);
-										} ) }
-									</td>
-								</tr>
-							</tbody>
-						</table>
+					<div
+						className="standalone-comparison-grid__column standalone-comparison-grid__body"
+						key={ `scd_${ index }` }
+					>
+						<h2 className="standalone-comparison-grid__title">{ column.title }</h2>
+						<p className="standalone-comparison-grid__intro">{ column.intro_copy }</p>
+						<Button
+							className="standalone-comparison-grid__action"
+							variant="primary"
+							onClick={ column.action }
+						>
+							{ column.action_copy }
+						</Button>
+						<ul className="standalone-comparison-grid__row-list">
+							{ column.features.map( ( feature, index ) => (
+								<li key={ `scdi_${ index }` } className="standalone-comparison-grid__row-item">
+									{ feature }
+								</li>
+							) ) }
+						</ul>
 					</div>
 				);
 			} ) }

--- a/packages/components/src/standalone-comparison-grid/index.tsx
+++ b/packages/components/src/standalone-comparison-grid/index.tsx
@@ -11,41 +11,40 @@ interface StandAloneComparisonGridColumn {
 }
 
 export interface StandAloneComparisonGridProps {
-	columns: StandAloneComparisonGridColumn[];
+	children:
+		| React.ReactElement< typeof StandAloneComparisonGridColumn >
+		| React.ReactElement< typeof StandAloneComparisonGridColumn >[];
 }
 
-const StandAloneComparisonGrid = ( props: StandAloneComparisonGridProps ) => {
-	const { columns } = props;
-
+const StandAloneComparisonGridColumn = ( {
+	title,
+	intro_copy,
+	action,
+	action_copy,
+	features,
+}: StandAloneComparisonGridColumn ) => {
 	return (
-		<div className="standalone-comparison-grid">
-			{ columns.map( ( column, index ) => {
-				return (
-					<div
-						className="standalone-comparison-grid__column standalone-comparison-grid__body"
-						key={ `scd_${ index }` }
-					>
-						<h2 className="standalone-comparison-grid__title">{ column.title }</h2>
-						<p className="standalone-comparison-grid__intro">{ column.intro_copy }</p>
-						<Button
-							className="standalone-comparison-grid__action"
-							variant="primary"
-							onClick={ column.action }
-						>
-							{ column.action_copy }
-						</Button>
-						<ul className="standalone-comparison-grid__row-list">
-							{ column.features.map( ( feature, index ) => (
-								<li key={ `scdi_${ index }` } className="standalone-comparison-grid__row-item">
-									{ feature }
-								</li>
-							) ) }
-						</ul>
-					</div>
-				);
-			} ) }
+		<div className="standalone-comparison-grid__column standalone-comparison-grid__body">
+			<h2 className="standalone-comparison-grid__title">{ title }</h2>
+			<p className="standalone-comparison-grid__intro">{ intro_copy }</p>
+			<Button className="standalone-comparison-grid__action" variant="primary" onClick={ action }>
+				{ action_copy }
+			</Button>
+			<ul className="standalone-comparison-grid__row-list">
+				{ features.map( ( feature, index ) => (
+					<li key={ `scdi_${ index }` } className="standalone-comparison-grid__row-item">
+						{ feature }
+					</li>
+				) ) }
+			</ul>
 		</div>
 	);
+};
+
+export { StandAloneComparisonGridColumn };
+
+const StandAloneComparisonGrid: React.FC< StandAloneComparisonGridProps > = ( { children } ) => {
+	return <div className="standalone-comparison-grid">{ children }</div>;
 };
 
 export default StandAloneComparisonGrid;

--- a/packages/components/src/standalone-comparison-grid/index.tsx
+++ b/packages/components/src/standalone-comparison-grid/index.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@wordpress/components';
 import './style.scss';
 import { ReactElement, type ReactNode } from 'react';
 
@@ -6,8 +5,7 @@ interface StandAloneComparisonGridColumn {
 	title: string;
 	features: ReactNode[];
 	introCopy?: string;
-	actionCopy: string;
-	action: () => void;
+	controls: ReactNode;
 }
 
 interface Props {
@@ -17,17 +15,14 @@ interface Props {
 export const Column = ( {
 	title,
 	introCopy,
-	action,
-	actionCopy,
+	controls,
 	features,
 }: StandAloneComparisonGridColumn ) => {
 	return (
 		<div className="standalone-comparison-grid__column standalone-comparison-grid__body">
 			<h2 className="standalone-comparison-grid__title">{ title }</h2>
 			<p className="standalone-comparison-grid__intro">{ introCopy }</p>
-			<Button className="standalone-comparison-grid__action" variant="primary" onClick={ action }>
-				{ actionCopy }
-			</Button>
+			{ controls }
 			<ul className="standalone-comparison-grid__row-list">
 				{ features.map( ( feature, index ) => (
 					<li key={ `scdi_${ index }` } className="standalone-comparison-grid__row-item">

--- a/packages/components/src/standalone-comparison-grid/index.tsx
+++ b/packages/components/src/standalone-comparison-grid/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@wordpress/components';
 import './style.scss';
-import { type ReactNode } from 'react';
+import { ReactElement, type ReactNode } from 'react';
 
 interface StandAloneComparisonGridColumn {
 	title: string;
@@ -10,13 +10,11 @@ interface StandAloneComparisonGridColumn {
 	action: () => void;
 }
 
-export interface StandAloneComparisonGridProps {
-	children:
-		| ReactElement< typeof StandAloneComparisonGridColumn >
-		| React.ReactElement< typeof StandAloneComparisonGridColumn >[];
+interface Props {
+	children: ReactElement< typeof Column > | ReactElement< typeof Column >[];
 }
 
-const StandAloneComparisonGridColumn = ( {
+export const Column = ( {
 	title,
 	introCopy,
 	action,
@@ -41,10 +39,6 @@ const StandAloneComparisonGridColumn = ( {
 	);
 };
 
-export { StandAloneComparisonGridColumn };
-
-const StandAloneComparisonGrid: React.FC< StandAloneComparisonGridProps > = ( { children } ) => {
+export const StandAloneComparisonGrid: React.FC< Props > = ( { children } ) => {
 	return <div className="standalone-comparison-grid">{ children }</div>;
 };
-
-export default StandAloneComparisonGrid;

--- a/packages/components/src/standalone-comparison-grid/index.tsx
+++ b/packages/components/src/standalone-comparison-grid/index.tsx
@@ -1,0 +1,68 @@
+import { Button } from '@wordpress/components';
+import './style.scss';
+
+interface StandAloneComparisonGridColumn {
+	title: string;
+	rows: string[];
+	intro_copy?: string;
+	action_copy: string;
+	action: () => void;
+}
+
+export interface StandAloneComparisonGridProps {
+	columns: StandAloneComparisonGridColumn[];
+}
+
+const StandAloneComparisonGrid = ( props: StandAloneComparisonGridProps ) => {
+	const { columns } = props;
+
+	return (
+		<div className="standalone-comparison-grid">
+			{ columns.map( ( column, index ) => {
+				return (
+					<div className="standalone-comparison-grid__column" key={ `scd_${ index }` }>
+						<table className="standalone-comparison-grid__body">
+							<tbody>
+								<tr>
+									<td className="standalone-comparison-grid__title">
+										<h1>{ column.title }</h1>
+									</td>
+								</tr>
+								<tr>
+									<td className="standalone-comparison-grid__intro">
+										{ column.intro_copy && column.intro_copy }
+									</td>
+								</tr>
+
+								<tr>
+									<td className="standalone-comparison-grid__action">
+										<Button variant="primary" onClick={ column.action }>
+											{ column.action_copy }
+										</Button>
+									</td>
+								</tr>
+
+								<tr className="standalone-comparison-grid__row">
+									<td>
+										{ column.rows.map( ( row, index ) => {
+											return (
+												<div
+													key={ `scdi_${ index }` }
+													className="standalone-comparison-grid__row-item"
+												>
+													{ row }
+												</div>
+											);
+										} ) }
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+				);
+			} ) }
+		</div>
+	);
+};
+
+export default StandAloneComparisonGrid;

--- a/packages/components/src/standalone-comparison-grid/index.tsx
+++ b/packages/components/src/standalone-comparison-grid/index.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@wordpress/components';
 import './style.scss';
-import { ReactNode } from 'react';
+import { type ReactNode } from 'react';
 
 interface StandAloneComparisonGridColumn {
 	title: string;

--- a/packages/components/src/standalone-comparison-grid/index.tsx
+++ b/packages/components/src/standalone-comparison-grid/index.tsx
@@ -5,8 +5,8 @@ import { ReactNode } from 'react';
 interface StandAloneComparisonGridColumn {
 	title: string;
 	features: ReactNode[];
-	intro_copy?: string;
-	action_copy: string;
+	introCopy?: string;
+	actionCopy: string;
 	action: () => void;
 }
 
@@ -18,17 +18,17 @@ export interface StandAloneComparisonGridProps {
 
 const StandAloneComparisonGridColumn = ( {
 	title,
-	intro_copy,
+	introCopy,
 	action,
-	action_copy,
+	actionCopy,
 	features,
 }: StandAloneComparisonGridColumn ) => {
 	return (
 		<div className="standalone-comparison-grid__column standalone-comparison-grid__body">
 			<h2 className="standalone-comparison-grid__title">{ title }</h2>
-			<p className="standalone-comparison-grid__intro">{ intro_copy }</p>
+			<p className="standalone-comparison-grid__intro">{ introCopy }</p>
 			<Button className="standalone-comparison-grid__action" variant="primary" onClick={ action }>
-				{ action_copy }
+				{ actionCopy }
 			</Button>
 			<ul className="standalone-comparison-grid__row-list">
 				{ features.map( ( feature, index ) => (

--- a/packages/components/src/standalone-comparison-grid/stories.scss
+++ b/packages/components/src/standalone-comparison-grid/stories.scss
@@ -1,0 +1,3 @@
+.standalone-comparison-grid {
+	margin: 1rem;
+}

--- a/packages/components/src/standalone-comparison-grid/style.scss
+++ b/packages/components/src/standalone-comparison-grid/style.scss
@@ -4,15 +4,13 @@
 @import "../styles/typography.scss";
 
 .standalone-comparison-grid {
-	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(293px, 1fr));
+	display: flex;
+	flex-wrap: wrap;
 	gap: 20px;
 	padding: 20px;
 
 	.standalone-comparison-grid__column {
-		display: flex;
-		flex-direction: column;
-		gap: 10px;
+		flex: 1 1 293px;
 	}
 
 	.standalone-comparison-grid__body {

--- a/packages/components/src/standalone-comparison-grid/style.scss
+++ b/packages/components/src/standalone-comparison-grid/style.scss
@@ -15,7 +15,7 @@
 		gap: 10px;
 	}
 
-	.standalone-comparison-grid__body {
+	.&_body {
 		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 		border-collapse: collapse;
 		font-size: 0.875rem;

--- a/packages/components/src/standalone-comparison-grid/style.scss
+++ b/packages/components/src/standalone-comparison-grid/style.scss
@@ -4,16 +4,19 @@
 @import "../styles/typography.scss";
 
 .standalone-comparison-grid {
-	display: flex;
-	flex-direction: row;
+	display: grid;
+	grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+	gap: 20px;
+	padding: 20px;
 
 	.standalone-comparison-grid__column {
-		width: 45%;
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
 	}
 
 	.standalone-comparison-grid__body {
 		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
-		vertical-align: baseline;
 		border-collapse: collapse;
 		font-size: 0.875rem;
 		color: var(--color-text-subtle);
@@ -24,16 +27,11 @@
 		border-spacing: 0;
 		width: 100%;
 		margin: 0;
+		display: block;
+		min-height: 485px;
+		padding: 1rem;
 
-		tbody {
-			display: block;
-			min-height: 485px;
-			padding: 1rem;
-		}
-	}
-
-	.standalone-comparison-grid__title {
-		h1 {
+		h2.standalone-comparison-grid__title {
 			margin-top: 0;
 			margin-bottom: 15px;
 			font-size: 2rem;
@@ -41,11 +39,11 @@
 			font-weight: 400;
 			font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
 		}
-	}
-
-	.standalone-comparison-grid__intro {
-		display: block;
-		min-height: 7rem;
+		.standalone-comparison-grid__intro {
+			display: block;
+			min-height: 4rem;
+			margin-bottom: 0;
+		}
 	}
 
 	.standalone-comparison-grid__action {
@@ -53,10 +51,14 @@
 		margin-bottom: 1rem;
 	}
 
-	.standalone-comparison-grid__row {
-		.standalone-comparison-grid__row-item {
-			font-size: 0.75rem;
-			line-height: 24px;
-		}
+	.standalone-comparison-grid__row-list {
+		margin: 0;
+	}
+	.standalone-comparison-grid__row-item {
+		font-size: 0.75rem;
+		line-height: 24px;
+		list-style-type: none;
+		margin: 0;
+		padding: 0;
 	}
 }

--- a/packages/components/src/standalone-comparison-grid/style.scss
+++ b/packages/components/src/standalone-comparison-grid/style.scss
@@ -41,7 +41,7 @@
 		}
 		.standalone-comparison-grid__intro {
 			display: block;
-			min-height: 4rem;
+			min-height: 6rem;
 			margin-bottom: 0;
 		}
 	}

--- a/packages/components/src/standalone-comparison-grid/style.scss
+++ b/packages/components/src/standalone-comparison-grid/style.scss
@@ -5,7 +5,7 @@
 
 .standalone-comparison-grid {
 	display: grid;
-	grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+	grid-template-columns: repeat(auto-fit, minmax(293px, 1fr));
 	gap: 20px;
 	padding: 20px;
 

--- a/packages/components/src/standalone-comparison-grid/style.scss
+++ b/packages/components/src/standalone-comparison-grid/style.scss
@@ -43,13 +43,9 @@
 		}
 	}
 
-	.standalone-comparison-grid__action {
-		display: block;
-		margin-bottom: 1rem;
-	}
-
 	.standalone-comparison-grid__row-list {
 		margin: 0;
+		margin-top: 1rem;
 	}
 	.standalone-comparison-grid__row-item {
 		font-size: 0.75rem;

--- a/packages/components/src/standalone-comparison-grid/style.scss
+++ b/packages/components/src/standalone-comparison-grid/style.scss
@@ -9,7 +9,7 @@
 	gap: 20px;
 	padding: 20px;
 
-	.standalone-comparison-grid__column {
+	.&__column {
 		display: flex;
 		flex-direction: column;
 		gap: 10px;

--- a/packages/components/src/standalone-comparison-grid/style.scss
+++ b/packages/components/src/standalone-comparison-grid/style.scss
@@ -1,0 +1,62 @@
+// ==========================================================================
+// Comparison Grid
+// ==========================================================================
+@import "../styles/typography.scss";
+
+.standalone-comparison-grid {
+	display: flex;
+	flex-direction: row;
+
+	.standalone-comparison-grid__column {
+		width: 45%;
+	}
+
+	.standalone-comparison-grid__body {
+		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+		vertical-align: baseline;
+		border-collapse: collapse;
+		font-size: 0.875rem;
+		color: var(--color-text-subtle);
+		table-layout: fixed;
+		border: 1px solid #e0e0e0;
+		border-radius: 4px;
+		background-color: #fff;
+		border-spacing: 0;
+		width: 100%;
+		margin: 0;
+
+		tbody {
+			display: block;
+			min-height: 485px;
+			padding: 1rem;
+		}
+	}
+
+	.standalone-comparison-grid__title {
+		h1 {
+			margin-top: 0;
+			margin-bottom: 15px;
+			font-size: 2rem;
+			line-height: 0.7;
+			font-weight: 400;
+			font-family: Recoleta, "Noto Serif", Georgia, "Times New Roman", Times, serif;
+		}
+	}
+
+	.standalone-comparison-grid__intro {
+		display: block;
+		min-height: 7rem;
+	}
+
+	.standalone-comparison-grid__action {
+		display: block;
+		margin-bottom: 1rem;
+	}
+
+	.standalone-comparison-grid__row {
+		.standalone-comparison-grid__row-item {
+			font-size: 0.75rem;
+			line-height: 24px;
+		}
+	}
+}

--- a/packages/components/src/standalone-comparison-grid/style.scss
+++ b/packages/components/src/standalone-comparison-grid/style.scss
@@ -25,7 +25,6 @@
 		border-radius: 4px;
 		background-color: #fff;
 		border-spacing: 0;
-		width: 100%;
 		margin: 0;
 		display: block;
 		min-height: 485px;

--- a/packages/components/src/standalone-comparison-grid/style.scss
+++ b/packages/components/src/standalone-comparison-grid/style.scss
@@ -9,13 +9,13 @@
 	gap: 20px;
 	padding: 20px;
 
-	.&__column {
+	.standalone-comparison-grid__column {
 		display: flex;
 		flex-direction: column;
 		gap: 10px;
 	}
 
-	.&_body {
+	.standalone-comparison-grid__body {
 		font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
 		border-collapse: collapse;
 		font-size: 0.875rem;


### PR DESCRIPTION
The only existing comparison grid components we have currently are heavily tied to the plans page. This adds a basic component that's more generic. (Currently only tested with 2 columns)

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87905

## Proposed Changes

For the new Site Migration flow, we have a step which will show the benefits of migrating over importing and we need some basic UI for it. I envisioned a comparison grid like the Plans pages. Unfortunately, all of the existing components are _heavily_ tied to the Plans page.

This adds a new component to display a more generic comparison grid.

The goal here is to get some feedback about the component itself and any tweaks we might need to make. For the first iteration, we're only going to worry about having 2 columns. We'll mobile styles next (in a separate PR) and then larger numbers of columns.
<img width="1156" alt="image" src="https://github.com/Automattic/wp-calypso/assets/375980/33afb52a-697c-4eb1-bffb-ae44c0566865">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Clone this branch locally.
* Run `yarn run storybook:start`.
* Once Storybook is fully running, go to http://localhost:6006/?path=/story/packages-components-standalonecomparisongrid--normal

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?