### PR TITLE
Site Migration: Redirect user to the site migration if the target site platform was not identified

### DIFF
--- a/client/landing/stepper/declarative-flow/helpers/index.ts
+++ b/client/landing/stepper/declarative-flow/helpers/index.ts
@@ -3,7 +3,7 @@ import { STEPS } from '../internals/steps';
 export const shouldRedirectToSiteMigration = (
 	step: string,
 	platform: string,
-	origin: string | null
+	origin?: string | null
 ) => {
 	return (
 		step === STEPS.IMPORT_LIST.slug &&

--- a/client/landing/stepper/declarative-flow/helpers/index.ts
+++ b/client/landing/stepper/declarative-flow/helpers/index.ts
@@ -1,0 +1,13 @@
+import { STEPS } from '../internals/steps';
+
+export const shouldRedirectToSiteMigration = (
+	step: string,
+	platform: string,
+	origin: string | null
+) => {
+	return (
+		step === STEPS.IMPORT_LIST.slug &&
+		platform === 'wordpress' &&
+		origin === STEPS.SITE_MIGRATION_IDENTIFY.slug
+	);
+};

--- a/client/landing/stepper/declarative-flow/helpers/test/index.ts
+++ b/client/landing/stepper/declarative-flow/helpers/test/index.ts
@@ -6,7 +6,7 @@ describe( 'DeclarativeFlowHelpers', () => {
 			shouldRedirectToSiteMigration(
 				STEPS.IMPORT_LIST.slug,
 				'wordpress',
-				'site-migration-identify'
+				STEPS.SITE_MIGRATION_IDENTIFY.slug
 			)
 		).toBe( true );
 	} );
@@ -22,15 +22,19 @@ describe( 'DeclarativeFlowHelpers', () => {
 			shouldRedirectToSiteMigration(
 				STEPS.IMPORT_LIST.slug,
 				'other-platform',
-				'site-migration-identify'
+				STEPS.SITE_MIGRATION_IDENTIFY.slug
 			)
 		).toBe( false );
 	} );
 
 	it( 'returns false when the origin is not set', () => {
-		expect( shouldRedirectToSiteMigration( STEPS.IMPORT_LIST.slug, 'other-platform', null ) ).toBe(
-			false
-		);
+		expect(
+			shouldRedirectToSiteMigration(
+				STEPS.IMPORT_LIST.slug,
+				STEPS.SITE_MIGRATION_IDENTIFY.slug,
+				null
+			)
+		).toBe( false );
 	} );
 
 	it( 'returns false when the origin is not the site-migration-identify', () => {

--- a/client/landing/stepper/declarative-flow/helpers/test/index.ts
+++ b/client/landing/stepper/declarative-flow/helpers/test/index.ts
@@ -11,7 +11,7 @@ describe( 'DeclarativeFlowHelpers', () => {
 		).toBe( true );
 	} );
 
-	it( 'returns false when current step is not importLimit', () => {
+	it( 'returns false when current step is not importList', () => {
 		expect(
 			shouldRedirectToSiteMigration( 'other-step', 'wordpress', 'site-migration-identify' )
 		).toBe( false );

--- a/client/landing/stepper/declarative-flow/helpers/test/index.ts
+++ b/client/landing/stepper/declarative-flow/helpers/test/index.ts
@@ -26,4 +26,16 @@ describe( 'DeclarativeFlowHelpers', () => {
 			)
 		).toBe( false );
 	} );
+
+	it( 'returns false when the origin is not set', () => {
+		expect( shouldRedirectToSiteMigration( STEPS.IMPORT_LIST.slug, 'other-platform', null ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'returns false when the origin is not the site-migration-identify', () => {
+		expect(
+			shouldRedirectToSiteMigration( STEPS.IMPORT_LIST.slug, 'wordpress', 'other-origin' )
+		).toBe( false );
+	} );
 } );

--- a/client/landing/stepper/declarative-flow/helpers/test/index.ts
+++ b/client/landing/stepper/declarative-flow/helpers/test/index.ts
@@ -1,0 +1,29 @@
+import { shouldRedirectToSiteMigration } from '..';
+import { STEPS } from '../../internals/steps';
+describe( 'DeclarativeFlowHelpers', () => {
+	it( 'returns true when current step, platform and origin as set properly', () => {
+		expect(
+			shouldRedirectToSiteMigration(
+				STEPS.IMPORT_LIST.slug,
+				'wordpress',
+				'site-migration-identify'
+			)
+		).toBe( true );
+	} );
+
+	it( 'returns false when current step is not importLimit', () => {
+		expect(
+			shouldRedirectToSiteMigration( 'other-step', 'wordpress', 'site-migration-identify' )
+		).toBe( false );
+	} );
+
+	it( 'returns false when platform is not wordpress', () => {
+		expect(
+			shouldRedirectToSiteMigration(
+				STEPS.IMPORT_LIST.slug,
+				'other-platform',
+				'site-migration-identify'
+			)
+		).toBe( false );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -159,7 +159,10 @@ const siteMigration: Flow = {
 					}
 
 					return exitFlow(
-						addQueryArgs( { siteId, siteSlug, from }, '/setup/site-setup/importList' )
+						addQueryArgs(
+							{ siteId, siteSlug, from, origin: STEPS.SITE_MIGRATION_IDENTIFY.slug },
+							'/setup/site-setup/importList'
+						)
 					);
 				}
 				case STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug: {

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -15,6 +15,7 @@ import { useIsPluginBundleEligible } from '../hooks/use-is-plugin-bundle-eligibl
 import { useSiteData } from '../hooks/use-site-data';
 import { useCanUserManageOptions } from '../hooks/use-user-can-manage-options';
 import { ONBOARD_STORE, SITE_STORE, USER_STORE, STEPPER_INTERNAL_STORE } from '../stores';
+import { shouldRedirectToSiteMigration } from './helpers';
 import { recordSubmitStep } from './internals/analytics/record-submit-step';
 import { STEPS } from './internals/steps';
 import { redirect } from './internals/steps-repository/import/util';
@@ -127,7 +128,7 @@ const siteSetupFlow: Flow = {
 
 		const origin = urlQueryParams.get( 'origin' );
 		const from = urlQueryParams.get( 'from' );
-		const hasOriginOnSiteMigrationFlow = origin === STEPS.SITE_MIGRATION_IDENTIFY.slug;
+
 		const adminUrl = useSelect(
 			( select ) =>
 				site && ( select( SITE_STORE ) as SiteSelect ).getSiteOption( site.ID, 'admin_url' ),
@@ -383,9 +384,9 @@ const siteSetupFlow: Flow = {
 				case 'importList':
 				case 'importReady': {
 					const depUrl = ( providedDependencies?.url as string ) || '';
-					const isWordpress = providedDependencies?.platform === 'wordpress';
-					const isImportList = currentStep === STEPS.IMPORT_LIST.slug;
-					if ( hasOriginOnSiteMigrationFlow && isWordpress && isImportList ) {
+					const { platform } = providedDependencies as { platform: ImporterMainPlatform };
+
+					if ( shouldRedirectToSiteMigration( currentStep, platform, origin ) ) {
 						return window.location.assign(
 							addQueryArgs(
 								{ siteSlug, siteId, from },

--- a/client/landing/stepper/declarative-flow/site-setup-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-setup-flow.ts
@@ -125,6 +125,9 @@ const siteSetupFlow: Flow = {
 		const urlQueryParams = useQuery();
 		const isPluginBundleEligible = useIsPluginBundleEligible();
 
+		const origin = urlQueryParams.get( 'origin' );
+		const from = urlQueryParams.get( 'from' );
+		const hasOriginOnSiteMigrationFlow = origin === STEPS.SITE_MIGRATION_IDENTIFY.slug;
 		const adminUrl = useSelect(
 			( select ) =>
 				site && ( select( SITE_STORE ) as SiteSelect ).getSiteOption( site.ID, 'admin_url' ),
@@ -380,6 +383,16 @@ const siteSetupFlow: Flow = {
 				case 'importList':
 				case 'importReady': {
 					const depUrl = ( providedDependencies?.url as string ) || '';
+					const isWordpress = providedDependencies?.platform === 'wordpress';
+					const isImportList = currentStep === STEPS.IMPORT_LIST.slug;
+					if ( hasOriginOnSiteMigrationFlow && isWordpress && isImportList ) {
+						return window.location.assign(
+							addQueryArgs(
+								{ siteSlug, siteId, from },
+								'/setup/site-migration/' + STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug
+							)
+						);
+					}
 
 					if (
 						depUrl.startsWith( 'http' ) ||

--- a/client/landing/stepper/declarative-flow/test/helpers/index.tsx
+++ b/client/landing/stepper/declarative-flow/test/helpers/index.tsx
@@ -38,9 +38,13 @@ export const renderFlow = ( flow: Flow ) => {
 	};
 
 	// The Flow>useStepNavigation>submit function needs to be called from inside a component
-	const runUseStepNavigationSubmit = ( { currentStep, dependencies } ) => {
+	const runUseStepNavigationSubmit = ( {
+		currentStep,
+		dependencies,
+		currentURL = '/some-path?siteSlug=example.wordpress.com',
+	} ) => {
 		renderWithProvider(
-			<MemoryRouter initialEntries={ [ '/some-path?siteSlug=example.wordpress.com' ] }>
+			<MemoryRouter initialEntries={ [ currentURL ] }>
 				<FakeStepRender currentStep={ currentStep } dependencies={ dependencies } />
 			</MemoryRouter>
 		);

--- a/client/landing/stepper/declarative-flow/test/helpers/index.tsx
+++ b/client/landing/stepper/declarative-flow/test/helpers/index.tsx
@@ -4,6 +4,7 @@
 import { screen } from '@testing-library/react';
 import React, { useEffect } from 'react';
 import { MemoryRouter, useNavigate, useLocation } from 'react-router';
+import themeReducer from 'calypso/state/themes/reducer';
 import { renderWithProvider } from '../../../../../test-helpers/testing-library';
 import type { Flow } from '../../internals/types';
 
@@ -46,7 +47,13 @@ export const renderFlow = ( flow: Flow ) => {
 		renderWithProvider(
 			<MemoryRouter initialEntries={ [ currentURL ] }>
 				<FakeStepRender currentStep={ currentStep } dependencies={ dependencies } />
-			</MemoryRouter>
+			</MemoryRouter>,
+			{
+				initialState: { themes: { queries: [] } },
+				reducers: {
+					themes: themeReducer,
+				},
+			}
 		);
 	};
 

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -46,7 +46,7 @@ describe( 'Site Migration Flow', () => {
 			} );
 
 			expect( window.location.assign ).toHaveBeenCalledWith(
-				'/setup/site-setup/importList?siteSlug=example.wordpress.com&from=https%3A%2F%2Fexample-to-be-migrated.com'
+				'/setup/site-setup/importList?siteSlug=example.wordpress.com&from=https%3A%2F%2Fexample-to-be-migrated.com&origin=site-migration-identify'
 			);
 		} );
 

--- a/client/landing/stepper/declarative-flow/test/site-setup-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-setup-flow.tsx
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment jsdom
+ */
+import { STEPS } from '../internals/steps';
+import siteSetupFlow from '../site-setup-flow';
+import { renderFlow } from './helpers';
+// we need to save the original object for later to not affect tests from other files
+const originalLocation = window.location;
+
+describe( 'Site Setup Flow', () => {
+	beforeAll( () => {
+		Object.defineProperty( window, 'location', {
+			value: { assign: jest.fn() },
+		} );
+	} );
+
+	afterAll( () => {
+		Object.defineProperty( window, 'location', originalLocation );
+	} );
+
+	beforeEach( () => {
+		jest.resetAllMocks();
+	} );
+
+	describe( 'when the current step is importListing', () => {
+		it( 'redirects the user to the site-migration-import-or-content step when the origin param is set as site-migration-identify', async () => {
+			const { runUseStepNavigationSubmit } = renderFlow( siteSetupFlow );
+
+			runUseStepNavigationSubmit( {
+				currentURL:
+					'/some-path?origin=site-migration-identify&siteSlug=example.wordpress.com&siteId=123',
+				currentStep: STEPS.IMPORT_LIST.slug,
+				dependencies: {
+					platform: 'wordpress',
+				},
+			} );
+
+			expect( window.location.assign ).toHaveBeenCalledWith(
+				'/setup/site-migration/site-migration-import-or-migrate?siteSlug=example.wordpress.com&siteId=123'
+			);
+		} );
+
+		it( 'continues the regular flow when the origin param is not available', async () => {
+			const { runUseStepNavigationSubmit } = renderFlow( siteSetupFlow );
+
+			runUseStepNavigationSubmit( {
+				currentStep: STEPS.IMPORT_LIST.slug,
+				dependencies: {
+					platform: 'wordpress',
+				},
+			} );
+
+			expect( window.location.assign ).not.toHaveBeenCalledWith(
+				expect.stringContaining( '/setup/site-migration/' )
+			);
+		} );
+	} );
+
+	//It is important because importReady and importListing are sharing the same logic
+	describe( 'when the current step is not importReady', () => {
+		it( 'ignores origin param', async () => {
+			const { runUseStepNavigationSubmit } = renderFlow( siteSetupFlow );
+
+			runUseStepNavigationSubmit( {
+				currentURL:
+					'/some-path?origin=site-migration-identify&siteSlug=example.wordpress.com&siteId=123',
+				currentStep: STEPS.IMPORT_READY.slug,
+				dependencies: {
+					platform: 'wordpress',
+				},
+			} );
+
+			expect( window.location.assign ).not.toHaveBeenCalledWith(
+				expect.stringContaining( '/setup/site-migration/' )
+			);
+		} );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, to avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88021

## Proposed Changes
The new site migration flow tries to identify the source site platform, if the platform is not identified we redirect the user to the "Import content from another platform" screen where the user can manually select "Wordpress". 

This pull request enhances the flow by redirecting users to the new "import or migrate" screen when they manually select WordPress as the source platform, and we are unable to identify the actual source platform.

## Tech details
I am using a new "origin" query parameter to identify if the user is coming from the new site-migration flow. Based on that, I will redirect them to the appropriate step only when the WordPress platform and the origin param is set properly.

## Testing Instructions
### Scenario 1: Fail to identify the platform. 
1. Enable the feature flag in your session using `window.sessionStorage.setItem('flags', 'onboarding/new-migration-flow')`
2. Start the site migration flow `/setup/site-migration/site-migration-identify?siteSlug=[WPCOM_SITE]`
3. Set `tumblr.com` on the field `Enter the URL of the site`
4. Click on the "Continue" button
5. Check if you were redirected to the  'Import content from another platform`
6. Click on the WordPress platform
7 Check if you were redirected to the "import or migrate" step 

### Scenario 2:  Success to identify the platform
1. Enable the feature flag in your session using `window.sessionStorage.setItem('flags', 'onboarding/new-migration-flow')`
2. Start the site migration flow `/setup/site-migration/site-migration-identify?siteSlug=[WPCOM_SITE]`
3. Set `https://test-vanilla-wp.godaddy.test-wpcom-migrations.net/` on the field `Enter the URL of the site`
4. Check if you were redirected directly to the " "import or migrate"  step 

### Scenario 3: Use the  'Import content from another platform` from another flow
1. Access the importList directly `/setup/site-setup/importList?siteSlug=XXX.wpcomstaging.com'
2. Select `WordPress` 
3. Check you were redirected to the `Import content from WordPress` screen directly. 



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?