### PR TITLE
Fix localize theme feature links

### DIFF
--- a/client/my-sites/theme/theme-features-card.js
+++ b/client/my-sites/theme/theme-features-card.js
@@ -1,5 +1,5 @@
 import { Card } from '@automattic/components';
-import { getLocaleSlug, localize } from 'i18n-calypso';
+import { localize } from 'i18n-calypso';
 import { get, isEmpty } from 'lodash';
 import { connect } from 'react-redux';
 import QueryThemeFilters from 'calypso/components/data/query-theme-filters';
@@ -10,7 +10,7 @@ import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { isAmbiguousThemeFilterTerm } from 'calypso/state/themes/selectors';
 import { isDelistedTaxonomyTermSlug } from 'calypso/state/themes/utils';
 
-const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate, onClick } ) => {
+const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate, onClick, locale } ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
 	if ( isEmpty( features ) ) {
 		return null;
@@ -23,9 +23,9 @@ const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate, onCli
 			<Card>
 				<ul className="theme__sheet-features-list">
 					{ features.map( ( { name, slug, term } ) => {
-						const themePath = localizeThemesPath(
+						const filterPath = localizeThemesPath(
 							`/themes/filter/${ term }/${ siteSlug || '' }`,
-							getLocaleSlug(),
+							locale,
 							! isLoggedIn
 						);
 						return (
@@ -34,7 +34,7 @@ const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate, onCli
 								role="presentation"
 								onClick={ () => onClick?.( slug ) }
 							>
-								{ ! isWpcomTheme ? <span>{ name }</span> : <a href={ themePath }>{ name }</a> }
+								{ ! isWpcomTheme ? <span>{ name }</span> : <a href={ filterPath }>{ name }</a> }
 							</li>
 						);
 					} ) }

--- a/client/my-sites/theme/theme-features-card.js
+++ b/client/my-sites/theme/theme-features-card.js
@@ -1,18 +1,17 @@
 import { Card } from '@automattic/components';
-import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { getLocaleSlug, localize } from 'i18n-calypso';
 import { get, isEmpty } from 'lodash';
 import { connect } from 'react-redux';
 import QueryThemeFilters from 'calypso/components/data/query-theme-filters';
 import SectionHeader from 'calypso/components/section-header';
-import { useIsLoggedIn } from 'calypso/lib/request-with-subkey-fallback';
+import { localizeThemesPath } from 'calypso/my-sites/themes/helpers';
+import { useSelector } from 'calypso/state';
+import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { isAmbiguousThemeFilterTerm } from 'calypso/state/themes/selectors';
 import { isDelistedTaxonomyTermSlug } from 'calypso/state/themes/utils';
 
 const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate, onClick } ) => {
-	const localizeUrl = useLocalizeUrl();
-	const { isLoggedIn } = useIsLoggedIn();
-
+	const isLoggedIn = useSelector( isUserLoggedIn );
 	if ( isEmpty( features ) ) {
 		return null;
 	}
@@ -23,27 +22,22 @@ const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate, onCli
 			<SectionHeader label={ translate( 'Features' ) } />
 			<Card>
 				<ul className="theme__sheet-features-list">
-					{ features.map( ( { name, slug, term } ) => (
-						<li
-							key={ 'theme-features-item-' + slug }
-							role="presentation"
-							onClick={ () => onClick?.( slug ) }
-						>
-							{ ! isWpcomTheme ? (
-								<span>{ name }</span>
-							) : (
-								<a
-									href={ localizeUrl(
-										`https://wordpress.com/themes/filter/${ term }/${ siteSlug || '' }`,
-										getLocaleSlug(),
-										isLoggedIn
-									) }
-								>
-									{ name }
-								</a>
-							) }
-						</li>
-					) ) }
+					{ features.map( ( { name, slug, term } ) => {
+						const themePath = localizeThemesPath(
+							`/themes/filter/${ term }/${ siteSlug || '' }`,
+							getLocaleSlug(),
+							! isLoggedIn
+						);
+						return (
+							<li
+								key={ 'theme-features-item-' + slug }
+								role="presentation"
+								onClick={ () => onClick?.( slug ) }
+							>
+								{ ! isWpcomTheme ? <span>{ name }</span> : <a href={ themePath }>{ name }</a> }
+							</li>
+						);
+					} ) }
 				</ul>
 			</Card>
 		</div>

--- a/client/my-sites/theme/theme-features-card.js
+++ b/client/my-sites/theme/theme-features-card.js
@@ -1,15 +1,17 @@
 import { Card } from '@automattic/components';
 import { useLocalizeUrl } from '@automattic/i18n-utils';
-import { localize } from 'i18n-calypso';
+import { getLocaleSlug, localize } from 'i18n-calypso';
 import { get, isEmpty } from 'lodash';
 import { connect } from 'react-redux';
 import QueryThemeFilters from 'calypso/components/data/query-theme-filters';
 import SectionHeader from 'calypso/components/section-header';
+import { useIsLoggedIn } from 'calypso/lib/request-with-subkey-fallback';
 import { isAmbiguousThemeFilterTerm } from 'calypso/state/themes/selectors';
 import { isDelistedTaxonomyTermSlug } from 'calypso/state/themes/utils';
 
 const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate, onClick } ) => {
 	const localizeUrl = useLocalizeUrl();
+	const { isLoggedIn } = useIsLoggedIn();
 
 	if ( isEmpty( features ) ) {
 		return null;
@@ -32,7 +34,9 @@ const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate, onCli
 							) : (
 								<a
 									href={ localizeUrl(
-										`https://wordpress.com/themes/filter/${ term }/${ siteSlug || '' }`
+										`https://wordpress.com/themes/filter/${ term }/${ siteSlug || '' }`,
+										getLocaleSlug(),
+										isLoggedIn
 									) }
 								>
 									{ name }

--- a/client/my-sites/theme/theme-features-card.js
+++ b/client/my-sites/theme/theme-features-card.js
@@ -1,4 +1,5 @@
 import { Card } from '@automattic/components';
+import { useLocalizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
 import { get, isEmpty } from 'lodash';
 import { connect } from 'react-redux';
@@ -8,6 +9,8 @@ import { isAmbiguousThemeFilterTerm } from 'calypso/state/themes/selectors';
 import { isDelistedTaxonomyTermSlug } from 'calypso/state/themes/utils';
 
 const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate, onClick } ) => {
+	const localizeUrl = useLocalizeUrl();
+
 	if ( isEmpty( features ) ) {
 		return null;
 	}
@@ -27,7 +30,13 @@ const ThemeFeaturesCard = ( { isWpcomTheme, siteSlug, features, translate, onCli
 							{ ! isWpcomTheme ? (
 								<span>{ name }</span>
 							) : (
-								<a href={ `/themes/filter/${ term }/${ siteSlug || '' }` }>{ name }</a>
+								<a
+									href={ localizeUrl(
+										`https://wordpress.com/themes/filter/${ term }/${ siteSlug || '' }`
+									) }
+								>
+									{ name }
+								</a>
 							) }
 						</li>
 					) ) }


### PR DESCRIPTION
## Proposed Changes

* The links in the Features section aren't localized on loggeg-out home pages. This commit fixes this.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Visit `/es/theme/nook` while logged out, and verify that the `Features`/`Funcionalidades` links are localized.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?