### PR TITLE
Checkout: Show simpler introductory offer discount for renewals

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -174,6 +174,14 @@ function LineItemCostOverrideIntroOfferDueDate( { product }: { product: Response
 	if ( ! doesIntroductoryOfferHaveDifferentTermLengthThanProduct( product ) ) {
 		return null;
 	}
+
+	// Introductory offer manual renewals often have prorated prices that are
+	// difficult to display as a simple discount so we keep their display
+	// simple.
+	if ( product.is_renewal ) {
+		return null;
+	}
+
 	const tosData = responseCart.terms_of_service?.find( ( tos ) => {
 		if ( ! new RegExp( `product_id:${ product.product_id }` ).test( tos.key ) ) {
 			return false;

--- a/packages/wpcom-checkout/src/introductory-offer.ts
+++ b/packages/wpcom-checkout/src/introductory-offer.ts
@@ -161,6 +161,13 @@ export function getItemIntroductoryOfferDisplay(
 	translate: typeof i18n.translate,
 	product: ResponseCartProduct
 ) {
+	// Introductory offer manual renewals often have prorated prices that are
+	// difficult to display as a simple discount so we keep their display
+	// simple.
+	if ( product.is_renewal ) {
+		return null;
+	}
+
 	if ( product.introductory_offer_terms?.reason ) {
 		const text = translate( 'Order not eligible for introductory discount' );
 		return { enabled: false, text };

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -223,20 +223,29 @@ function makeIntroductoryOfferCostOverrideUnique(
 	translate: ReturnType< typeof useTranslate >,
 	allowFreeText: boolean
 ): ResponseCartCostOverride {
+	if ( 'introductory-offer' !== costOverride.override_code || ! product.introductory_offer_terms ) {
+		return costOverride;
+	}
+
 	// Replace introductory offer cost override text with wording specific to
-	// that offer.
-	if ( 'introductory-offer' === costOverride.override_code && product.introductory_offer_terms ) {
+	// that offer, but not for renewals because an introductory offer manual
+	// renewal can be hard to explain simply and saying "Discount for first 3
+	// months" may not be accurate.
+	if ( product.is_renewal ) {
 		return {
 			...costOverride,
-			human_readable_reason: getDiscountReasonForIntroductoryOffer(
-				product,
-				product.introductory_offer_terms,
-				translate,
-				allowFreeText
-			),
+			human_readable_reason: translate( 'Prorated introductory offer renewal' ),
 		};
 	}
-	return costOverride;
+	return {
+		...costOverride,
+		human_readable_reason: getDiscountReasonForIntroductoryOffer(
+			product,
+			product.introductory_offer_terms,
+			translate,
+			allowFreeText
+		),
+	};
 }
 
 function getDiscountForCostOverrideForDisplay( costOverride: ResponseCartCostOverride ): number {
@@ -300,6 +309,16 @@ export function filterCostOverridesForLineItem(
 				makeIntroductoryOfferCostOverrideUnique( costOverride, product, translate, true )
 			)
 			.map( ( costOverride ) => {
+				// Introductory offers which are renewals may have a prorated
+				// discount amount which is hard to display as a simple
+				// discount, so we will hide the discounted amount here.
+				if ( costOverride.override_code === 'introductory-offer' && product.is_renewal ) {
+					return {
+						humanReadableReason: costOverride.human_readable_reason,
+						overrideCode: costOverride.override_code,
+					};
+				}
+
 				// Introductory offer discounts with term lengths that differ from
 				// the term length of the product (eg: a 3 month discount for an
 				// annual plan) need to be displayed differently because the

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -234,7 +234,7 @@ function makeIntroductoryOfferCostOverrideUnique(
 	if ( product.is_renewal ) {
 		return {
 			...costOverride,
-			human_readable_reason: translate( 'Prorated introductory offer renewal' ),
+			human_readable_reason: translate( 'Prorated renewal discount' ),
 		};
 	}
 	return {


### PR DESCRIPTION
## Proposed Changes

Introductory offer discounts are applied as cost overrides (shopping cart item discounts) for new purchases. However, it's possible to manually renew a product which is being affected by an introductory offer before the offer ends. In this case, the price of the product gets modified by a prorated discount based on the time left in the offer; this discount is applied as an original cost override which means it's hidden from the user.

This system is heavy-handed and presents some challenges; in D139958-code we will change it so that manual renewals of introductory offers will be added as regular cost overrides. Unfortunately all the introductory offer cost override messaging in checkout assumes that introductory offers are happening for a new purchase. For example, they might display "Discount for first 3 months" even if the renewal is happening 2 months after that discount started; this is not clear. 

In this PR, we modify the introductory offer cost override messaging to instead display "Prorated renewal discount" and exclude some of the more complex additional info added in https://github.com/Automattic/wp-calypso/pull/87732.

> [!NOTE]
> This won't have any effect until D139958-code is merged, but this should be merged first.

Before D139958-code (v1 checkout)  | Before (v1 checkout)             |  After (v1 checkout)
:-------------------------:|:-------------------------:|:-------------------------:
<img width="1005" alt="Screenshot 2024-02-29 at 5 56 57 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/e9b43dcf-8c10-487c-89e6-e05510a4c02a"> | <img width="1013" alt="Screenshot 2024-02-29 at 4 55 22 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/31d9534e-c407-40cd-8155-154575e153c9"> | <img width="1012" alt="Screenshot 2024-02-29 at 4 42 25 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/099a045c-110d-4fa0-959b-72731701eb71">

Before D139958-code (v2 checkout)  |Before (v2 checkout)             |  After (v2 checkout)
:-------------------------:|:-------------------------:|:-------------------------:
<img width="319" alt="Screenshot 2024-02-29 at 5 56 16 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/e3ae41db-be59-4e32-b950-f5a1ec94644e"> | <img width="336" alt="Screenshot 2024-02-29 at 4 56 34 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/9599456b-40ea-4212-b535-fa153608d723"> | <img width="329" alt="Screenshot 2024-02-29 at 4 57 03 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/59c9ca91-de11-4043-b775-a6ea443bd641">

## Testing Instructions

- Apply D139958-code and sandbox the API.
- Purchase a Titan Mail subscription.
- Visit your purchase management page for the subscription and click "Renew now".
- Verify that the way the price is displayed in checkout is not too confusing.