### PR TITLE
GitHub Deployments: Updated WordPress with Captial P on github templates

### DIFF
--- a/client/my-sites/github-deployments/components/form-radio-with-template-select/templates.ts
+++ b/client/my-sites/github-deployments/components/form-radio-with-template-select/templates.ts
@@ -13,7 +13,7 @@ export const repositoryTemplates = {
 			link: 'https://github.com/Automattic/githubdeployments-wp-plugin-boilerplate',
 		},
 		{
-			name: 'Wordpress Plugin Template',
+			name: 'WordPress Plugin Template',
 			repositoryName: 'githubdeployments-wordpress-plugin-template',
 			link: 'https://github.com/Automattic/githubdeployments-wordpress-plugin-template',
 			workflowFilename: '.github/workflows/dotcom-build-artifact.yml',
@@ -64,7 +64,7 @@ export const repositoryTemplates = {
 	],
 	site: [
 		{
-			name: 'LocalWp',
+			name: 'Local',
 			repositoryName: 'githubdeployments-site-localwp',
 			link: 'https://github.com/Automattic/githubdeployments-site-localwp',
 		},
@@ -81,7 +81,7 @@ export const repositoryTemplates = {
 			workflowFilename: '.github/workflows/dotcom-build-artifact.yml',
 		},
 		{
-			name: 'Wordpress Playground',
+			name: 'WordPress Playground',
 			repositoryName: 'githubdeployments-site-wordpress-playground',
 			link: 'https://github.com/Automattic/githubdeployments-site-wordpress-playground',
 		},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1709240442839609-slack-C06D9M3CHMK

## Proposed Changes

* Updated WordPress names on repository templates


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?