### PR TITLE
Data_Point_Option: process_data_point: Fix fatal error when updating unexpected data

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/global-styles/includes/class-data-point-option.php
+++ b/apps/editing-toolkit/editing-toolkit-plugin/global-styles/includes/class-data-point-option.php
@@ -93,7 +93,15 @@ class Data_Point_Option implements Data_Point {
 		$result = $current_option_value;
 
 		if ( isset( $this->option_property ) ) {
-			$result[ $this->option_property ] = $new_value;
+			if ( is_array( $result ) ) {
+				$result[ $this->option_property ] = $new_value;
+			} else {
+				// Unexpected current option value. We were expecting an array,
+				// but it's something like a string or boolean and we can't
+				// update the single data point.  Throw away the current option
+				// value and make a new array.
+				$result = array( $this->option_property => $new_value );
+			}
 		} else {
 			$result = $new_value;
 		}


### PR DESCRIPTION
## Purpose

This is to fix the following error in PHP 8.1:
```
[29-Feb-2024 22:41:12 UTC] Fatal error: Uncaught TypeError: Cannot access offset of type string on string in ./wp-content/plugins/editing-toolkit-plugin/prod/global-styles/includes/class-data-point-option.php:98               
```

## What is `process_data_point()`?

This patch is to the `process_data_point()` in the `Data_Point_Option` class.  It lets you update one part of an array of options while keeping the rest untouched.  For example, if you had `my_settings` site option with a value of `['theme_color' => 'blue', 'font_size' => 'medium']`, and you only wanted to change the `theme_color` value while leaving the rest alone, you could use `process_data_point()` to only update the `theme_color.


## When is the fatal error happening?

It happens when a site has a "jetpack_global_styles" that is not a serialized array. Here is an example of a good site and a bad site:

```
> switch_to_blog( MY_WELL_FORMED_TEST_BLOG ); echo json_encode( get_option( 'jetpack_global_styles' ) );
{"font_base":"Montserrat","font_headings":"Arvo"}

> switch_to_blog( SITE_THAT_FATALS ); echo json_encode( get_option( 'jetpack_global_styles' ) );
"R"
```

On the bad site, if you attempt to update the global font styles, `process_data_point()` tries to run `$result[ $this->option_property ] = $new_value;`, but `$result` is only `'R'`, so trying to access `$result[ 'font_base' ]` causes the fatal error: `Cannot access offset of type string on string`.

## Proposed Changes

* Before trying to do the `$result[ $this->option_property ] = $new_value;` update, first check that `$result` is an array.  If it isn't, throw away the current `$result` and make a new one.  In my example above, it would mean throwing away the invalid jetpack_global_styles value of `"R"`.  I believe if you make it to this part of the code, and the $result is not an array, then something has gone wrong and that data doesn't need to be saved.

## Testing Instructions

* Start w/ public-api sandboxed and on trunk.
* On WPCOM simple, create or choose a testing site and change its theme to rockland.
* Check the value of its jetpack_global_styles option. Using wpsh:
```
switch_to_blog( TEST_BLOG_ID ); echo json_encode( get_option( 'jetpack_global_styles' ) );
```
* On wp.com, switch to the blog and visit the pages section. Edit the homepage.
* Access global styles and change the font and save.

![2024-02-29_16-40](https://github.com/Automattic/wp-calypso/assets/937354/ef49be37-de01-433e-882c-de6deb2dfce3)

![2024-02-29_16-41](https://github.com/Automattic/wp-calypso/assets/937354/f8059efa-042f-49ef-9f9c-1efa49496933)

* It should have saved correctly. Now check the value of the jetpack_global_styles option and see your new font in there.
* Now, let's create the error condition by writing a bad value to this option. In wpsh:
```
switch_to_blog( TEST_BLOG_ID ); 
update_option( 'jetpack_global_styles', 'R' );
```
* Make sure your sandbox is on php8.1 ( commands here: 33b0a-pb/#bash ) and you are on trunk.
* As above, access global styles and change the font and save.
* You should now fatal error and see that the font change was not saved.
* Apply the patch D140313-code, which is the same patch as this PR but for sandboxes.
* As above, access global styles and change the font and save.
* Now the fatal error will be fixed and the font change should be saved.