### PR TITLE
Checkoutv2: Refactor sidebar promotions into CheckoutSidebarNudge

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -30,7 +30,7 @@ import { keyframes } from '@emotion/react';
 import { useSelect, useDispatch } from '@wordpress/data';
 import debugFactory from 'debug';
 import i18n, { useTranslate } from 'i18n-calypso';
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback } from 'react';
 import MaterialIcon from 'calypso/components/material-icon';
 import isAkismetCheckout from 'calypso/lib/akismet/is-akismet-checkout';
 import {
@@ -248,10 +248,7 @@ function CheckoutSidebarNudge( {
 	const isDIFMInCart = hasDIFMProduct( responseCart );
 	const hasMonthlyProduct = responseCart?.products?.some( isMonthlyProduct );
 	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
-	const isPurchaseRenewal = useMemo(
-		() => responseCart?.products?.some?.( ( product ) => product.is_renewal ),
-		[ responseCart ]
-	);
+	const isPurchaseRenewal = responseCart?.products?.some?.( ( product ) => product.is_renewal );
 	const selectedSite = useSelector( ( state ) => getSelectedSite( state ) );
 
 	const domainWithoutPlanInCartOrSite =

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -256,14 +256,6 @@ function CheckoutSidebarNudge( {
 		return null;
 	}
 
-	if ( isDIFMInCart ) {
-		return (
-			<CheckoutSidebarNudgeWrapper>
-				<CheckoutNextSteps responseCart={ responseCart } />
-			</CheckoutSidebarNudgeWrapper>
-		);
-	}
-
 	/**
 	 * TODO !hasMonthlyProduct can likely be removed after checkout v2 is merged
 	 * V2 checkout handles monthly products in the CheckoutSidebarPlanUpsell so this condition is not needed
@@ -271,8 +263,14 @@ function CheckoutSidebarNudge( {
 	if ( ! hasMonthlyProduct || shouldUseCheckoutV2 ) {
 		return (
 			<CheckoutSidebarNudgeWrapper>
-				<CheckoutSidebarPlanUpsell />
-				<JetpackAkismetCheckoutSidebarPlanUpsell />
+				{ isDIFMInCart ? (
+					<CheckoutNextSteps responseCart={ responseCart } />
+				) : (
+					<>
+						<CheckoutSidebarPlanUpsell />
+						<JetpackAkismetCheckoutSidebarPlanUpsell />
+					</>
+				) }
 				{ shouldUseCheckoutV2 && (
 					<CheckoutSummaryFeaturedList
 						responseCart={ responseCart }

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -230,7 +230,10 @@ function CheckoutSidebarNudge( { responseCart }: { responseCart: ResponseCart } 
 	const hasMonthlyProduct = responseCart?.products?.some( isMonthlyProduct );
 	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 
-	if ( ! isWcMobile && ! isDIFMInCart && ! hasMonthlyProduct ) {
+	if (
+		( ! isWcMobile && ! isDIFMInCart && ! hasMonthlyProduct ) ||
+		( shouldUseCheckoutV2 && ! isWcMobile && ! isDIFMInCart )
+	) {
 		return (
 			<CheckoutSidebarNudgeWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 				<CheckoutSidebarPlanUpsell />
@@ -240,6 +243,7 @@ function CheckoutSidebarNudge( { responseCart }: { responseCart: ResponseCart } 
 	}
 	return null;
 }
+
 export default function CheckoutMainContent( {
 	addItemToCart,
 	changeSelection,

--- a/client/my-sites/checkout/src/components/checkout-main-content.tsx
+++ b/client/my-sites/checkout/src/components/checkout-main-content.tsx
@@ -258,16 +258,19 @@ function CheckoutSidebarNudge( {
 
 	if ( isDIFMInCart ) {
 		return (
-			<CheckoutSidebarNudgeWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
+			<CheckoutSidebarNudgeWrapper>
 				<CheckoutNextSteps responseCart={ responseCart } />
 			</CheckoutSidebarNudgeWrapper>
 		);
 	}
 
-	// TODO !hasMonthlyProduct can likely be removed after checkout v2 is merged
+	/**
+	 * TODO !hasMonthlyProduct can likely be removed after checkout v2 is merged
+	 * V2 checkout handles monthly products in the CheckoutSidebarPlanUpsell so this condition is not needed
+	 */
 	if ( ! hasMonthlyProduct || shouldUseCheckoutV2 ) {
 		return (
-			<CheckoutSidebarNudgeWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
+			<CheckoutSidebarNudgeWrapper>
 				<CheckoutSidebarPlanUpsell />
 				<JetpackAkismetCheckoutSidebarPlanUpsell />
 				{ shouldUseCheckoutV2 && (
@@ -900,16 +903,18 @@ const CheckoutSummaryBody = styled.div< { shouldUseCheckoutV2: boolean } >`
 	}
 `;
 
-const CheckoutSidebarNudgeWrapper = styled.div< { shouldUseCheckoutV2: boolean } >`
-${ ( props ) =>
-	props.shouldUseCheckoutV2 &&
-	`display: flex;
+const CheckoutSidebarNudgeWrapper = styled.div`
+	display: flex;
 	flex-direction: column;
 	grid-area: nudge;
-	row-gap: 36px;
-	
+	row-gap: 16px;
+
 	& > * {
-	max-width: 288px;` }
+		max-width: 288px;
+	}
+
+	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
+		row-gap: 36px;
 	}
 `;
 

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -6,7 +6,7 @@ import {
 } from '@automattic/calypso-products';
 import { FormStatus, useFormStatus } from '@automattic/composite-checkout';
 import formatCurrency from '@automattic/format-currency';
-import { ResponseCart, useShoppingCart } from '@automattic/shopping-cart';
+import { ResponseCartProduct, useShoppingCart } from '@automattic/shopping-cart';
 import styled from '@emotion/styled';
 import { Button } from '@wordpress/components';
 import { createElement, createInterpolateElement, useState } from '@wordpress/element';
@@ -59,18 +59,18 @@ const PromoCardV2 = styled.div`
 
 const CheckoutPromoCard: React.FC< {
 	onUpgradeClick: () => void;
-	responseCart: ResponseCart;
+	plan: ResponseCartProduct;
+	domainRegistrationOrTransferInCart: ResponseCartProduct | undefined;
 	currentVariant: WPCOMProductVariant;
 	percentSavings: number;
-} > = ( { onUpgradeClick, responseCart, currentVariant, percentSavings } ) => {
+} > = ( {
+	onUpgradeClick,
+	plan,
+	domainRegistrationOrTransferInCart,
+	currentVariant,
+	percentSavings,
+} ) => {
 	const translate = useTranslate();
-	const plan = responseCart.products.find(
-		( product ) => isPlan( product ) && ! isJetpackPlan( product )
-	);
-
-	const domainRegistrationOrTransferInCart = responseCart.products.find(
-		( product ) => isDomainRegistration( product ) || isDomainTransfer( product )
-	);
 
 	const isMonthly = currentVariant?.termIntervalInMonths === 1;
 	const isYearly = currentVariant?.termIntervalInMonths === 12;
@@ -148,6 +148,10 @@ export function CheckoutSidebarPlanUpsell() {
 		( product ) => isPlan( product ) && ! isJetpackPlan( product )
 	);
 
+	const domainRegistrationOrTransferInCart = responseCart.products.find(
+		( product ) => isDomainRegistration( product ) || isDomainTransfer( product )
+	);
+
 	const variants = useGetProductVariants( plan );
 	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 
@@ -189,7 +193,7 @@ export function CheckoutSidebarPlanUpsell() {
 		return null;
 	}
 
-	if ( biennialVariant.productId === plan.product_id ) {
+	if ( biennialVariant.productId === plan?.product_id ) {
 		debug( 'plan in cart is already biennial' );
 		return null;
 	}
@@ -274,7 +278,8 @@ export function CheckoutSidebarPlanUpsell() {
 			{ shouldUseCheckoutV2 ? (
 				<CheckoutPromoCard
 					onUpgradeClick={ onUpgradeClick }
-					responseCart={ responseCart }
+					plan={ plan }
+					domainRegistrationOrTransferInCart={ domainRegistrationOrTransferInCart }
 					currentVariant={ currentVariant }
 					percentSavings={ percentSavings }
 				/>

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -79,6 +79,7 @@ const CheckoutPromoCard: React.FC< {
 
 	let labelText;
 
+	// TODO: this currently doesn't work because the !plan guard found in CheckoutSidebarPlanUpsell disallows this to be reached.
 	if ( ! plan && domainRegistrationOrTransferInCart ) {
 		labelText = translate(
 			'Longer plan billing cycles save you money and include a custom domain for free for the first year.'

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -59,13 +59,11 @@ const PromoCardV2 = styled.div`
 
 const CheckoutPromoCard: React.FC< {
 	onUpgradeClick: () => void;
-	plan: ResponseCartProduct;
 	domainRegistrationOrTransferInCart: ResponseCartProduct | undefined;
 	currentVariant: WPCOMProductVariant;
 	percentSavings: number;
 } > = ( {
 	onUpgradeClick,
-	plan,
 	domainRegistrationOrTransferInCart,
 	currentVariant,
 	percentSavings,
@@ -74,30 +72,39 @@ const CheckoutPromoCard: React.FC< {
 
 	const isMonthly = currentVariant?.termIntervalInMonths === 1;
 	const isYearly = currentVariant?.termIntervalInMonths === 12;
-	const isBiennially = currentVariant?.termIntervalInMonths === 24;
-	const isTriennially = currentVariant?.termIntervalInMonths === 36;
 
-	let labelText;
+	const labelText = ( () => {
+		// TODO: After v2 merger, refactor free plan upsell into this section
 
-	// TODO: this currently doesn't work because the !plan guard found in CheckoutSidebarPlanUpsell disallows this to be reached.
-	if ( ! plan && domainRegistrationOrTransferInCart ) {
-		labelText = translate(
-			'Longer plan billing cycles save you money and include a custom domain for free for the first year.'
-		);
-	}
+		if ( isMonthly ) {
+			if ( domainRegistrationOrTransferInCart ) {
+				return translate(
+					'Save money with longer billing cycles and get %(domainMeta)s free for the first year by {{upgradeLink}}switching to an annual plan.{{/upgradeLink}}',
+					{
+						comment: '"domainMeta" is the domain name and TLD, like "example.com" or "example.org"',
+						args: {
+							domainMeta: domainRegistrationOrTransferInCart.meta,
+						},
+						components: {
+							upgradeLink: <Button onClick={ onUpgradeClick } variant="link" />,
+						},
+					}
+				);
+			}
 
-	if ( isMonthly ) {
-		labelText = translate(
-			'Longer plan billing cycles save you money and include a custom domain for free for the first year.'
-		);
+			return translate(
+				'Longer plan billing cycles save you money and include a custom domain for free for the first year.'
+			);
+		}
 
-		if ( domainRegistrationOrTransferInCart ) {
-			labelText = translate(
-				'Save money with longer billing cycles and get %(domainMeta)s free for the first year by {{upgradeLink}}switching to an annual plan.{{/upgradeLink}}',
+		if ( isYearly ) {
+			return translate(
+				"Save up to %(savingsPercentage)s% on longer billing cycles! It's hassle-free and easy on your wallet. {{upgradeLink}}Switch to a two-year plan and save.{{/upgradeLink}}",
 				{
-					comment: '"domainMeta" is the domain name and TLD, like "example.com" or "example.org"',
+					comment:
+						'"savingsPercentage is the savings percentage for the upgrade as a number, like "20" for 20%"',
 					args: {
-						domainMeta: domainRegistrationOrTransferInCart.meta,
+						savingsPercentage: percentSavings,
 					},
 					components: {
 						upgradeLink: <Button onClick={ onUpgradeClick } variant="link" />,
@@ -105,34 +112,18 @@ const CheckoutPromoCard: React.FC< {
 				}
 			);
 		}
-	}
 
-	if ( isYearly ) {
-		labelText = translate(
-			"Save up to %(savingsPercentage)s% on longer billing cycles! It's hassle-free and easy on your wallet. {{upgradeLink}}Switch to a two-year plan and save.{{/upgradeLink}}",
-			{
-				comment:
-					'"savingsPercentage is the savings percentage for the upgrade as a number, like "20" for 20%"',
-				args: {
-					savingsPercentage: percentSavings,
-				},
-				components: {
-					upgradeLink: <Button onClick={ onUpgradeClick } variant="link" />,
-				},
-			}
-		);
-	}
-
-	if ( isBiennially || isTriennially ) {
 		return null;
-	}
+	} )();
 
 	return (
-		<PromoCardV2>
-			<div className="checkout-sidebar-plan-upsell__v2-wrapper">
-				<p>{ labelText }</p>
-			</div>
-		</PromoCardV2>
+		labelText && (
+			<PromoCardV2>
+				<div className="checkout-sidebar-plan-upsell__v2-wrapper">
+					<p>{ labelText }</p>
+				</div>
+			</PromoCardV2>
+		)
 	);
 };
 
@@ -278,7 +269,6 @@ export function CheckoutSidebarPlanUpsell() {
 			{ shouldUseCheckoutV2 ? (
 				<CheckoutPromoCard
 					onUpgradeClick={ onUpgradeClick }
-					plan={ plan }
 					domainRegistrationOrTransferInCart={ domainRegistrationOrTransferInCart }
 					currentVariant={ currentVariant }
 					percentSavings={ percentSavings }

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -86,7 +86,7 @@ const CheckoutPromoCard: React.FC< {
 
 	if ( isYearly ) {
 		labelText = translate(
-			'Longer plan billing cycles save you money and include a custom domain for free for the first year.'
+			`Save up to XX% on longer billing cycles! It's hassle-free and easy on your wallet. Don't miss out!`
 		);
 	}
 
@@ -274,6 +274,12 @@ export function CheckoutSidebarPlanUpsell() {
 							busy: isBusy(),
 							text: __( 'Switch to a two-year plan' ),
 							action: onUpgradeClick,
+						} }
+						learnMoreLink={ {
+							url: '#',
+							onClick: onUpgradeClick,
+							selfTarget: true,
+							label: 'Switch to a two-year plan',
 						} }
 					/>
 				</PromoCard>

--- a/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
+++ b/client/my-sites/checkout/src/components/checkout-sidebar-plan-upsell/index.tsx
@@ -251,8 +251,12 @@ export function CheckoutSidebarPlanUpsell() {
 	);
 	return (
 		<>
-			{ plan && shouldUseCheckoutV2 ? (
-				<CheckoutPromoCard responseCart={ responseCart } variants={ variants } />
+			{ shouldUseCheckoutV2 ? (
+				<CheckoutPromoCard
+					onUpgradeClick={ onUpgradeClick }
+					responseCart={ responseCart }
+					variants={ [ biennialVariant, currentVariant ] }
+				/>
 			) : (
 				<PromoCard title={ cardTitle } className="checkout-sidebar-plan-upsell">
 					<div className="checkout-sidebar-plan-upsell__plan-grid">

--- a/client/my-sites/checkout/src/components/secondary-cart-promotions.tsx
+++ b/client/my-sites/checkout/src/components/secondary-cart-promotions.tsx
@@ -1,6 +1,6 @@
 import config from '@automattic/calypso-config';
 import styled from '@emotion/styled';
-import { FunctionComponent, useMemo } from 'react';
+import { FunctionComponent } from 'react';
 import CartFreeUserPlanUpsell from 'calypso/my-sites/checkout/cart/cart-free-user-plan-upsell';
 import UpcomingRenewalsReminder from 'calypso/my-sites/checkout/cart/upcoming-renewals-reminder';
 import { useSelector } from 'calypso/state';
@@ -13,6 +13,7 @@ interface Props {
 	responseCart: PartialCart;
 	addItemToCart: ( item: MinimalRequestCartProduct ) => void;
 	isCartPendingUpdate?: boolean;
+	isPurchaseRenewal?: boolean;
 }
 
 type DivProps = {
@@ -72,13 +73,10 @@ const SecondaryCartPromotions: FunctionComponent< Props > = ( {
 	responseCart,
 	addItemToCart,
 	isCartPendingUpdate,
+	isPurchaseRenewal,
 } ) => {
 	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) as number );
-	const isPurchaseRenewal = useMemo(
-		() => responseCart?.products?.some?.( ( product ) => product.is_renewal ),
-		[ responseCart ]
-	);
 
 	if (
 		config.isEnabled( 'upgrades/upcoming-renewals-notices' ) &&

--- a/client/my-sites/checkout/src/components/secondary-cart-promotions.tsx
+++ b/client/my-sites/checkout/src/components/secondary-cart-promotions.tsx
@@ -5,6 +5,7 @@ import CartFreeUserPlanUpsell from 'calypso/my-sites/checkout/cart/cart-free-use
 import UpcomingRenewalsReminder from 'calypso/my-sites/checkout/cart/upcoming-renewals-reminder';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import { useCheckoutV2 } from '../hooks/use-checkout-v2';
 import type { ResponseCart, MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 export type PartialCart = Partial< ResponseCart > & Pick< ResponseCart, 'products' >;
@@ -16,6 +17,7 @@ interface Props {
 
 type DivProps = {
 	theme?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
+	shouldUseCheckoutV2?: boolean;
 };
 const UpsellWrapper = styled.div< DivProps >`
 	background: ${ ( props ) => props.theme.colors.surface };
@@ -28,7 +30,7 @@ const UpsellWrapper = styled.div< DivProps >`
 
 		@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 			border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-			margin-top: 24px;
+			${ ( props ) => ( props.shouldUseCheckoutV2 ? `margin-top: 0` : `margin-top: 24px` ) }
 		}
 	}
 
@@ -71,6 +73,7 @@ const SecondaryCartPromotions: FunctionComponent< Props > = ( {
 	addItemToCart,
 	isCartPendingUpdate,
 } ) => {
+	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) as number );
 	const isPurchaseRenewal = useMemo(
 		() => responseCart?.products?.some?.( ( product ) => product.is_renewal ),
@@ -90,7 +93,7 @@ const SecondaryCartPromotions: FunctionComponent< Props > = ( {
 	}
 
 	return (
-		<UpsellWrapper>
+		<UpsellWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
 			<CartFreeUserPlanUpsell
 				cart={ responseCart }
 				addItemToCart={ addItemToCart }

--- a/client/my-sites/checkout/src/components/secondary-cart-promotions.tsx
+++ b/client/my-sites/checkout/src/components/secondary-cart-promotions.tsx
@@ -5,7 +5,6 @@ import CartFreeUserPlanUpsell from 'calypso/my-sites/checkout/cart/cart-free-use
 import UpcomingRenewalsReminder from 'calypso/my-sites/checkout/cart/upcoming-renewals-reminder';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import { useCheckoutV2 } from '../hooks/use-checkout-v2';
 import type { ResponseCart, MinimalRequestCartProduct } from '@automattic/shopping-cart';
 
 export type PartialCart = Partial< ResponseCart > & Pick< ResponseCart, 'products' >;
@@ -18,7 +17,6 @@ interface Props {
 
 type DivProps = {
 	theme?: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-	shouldUseCheckoutV2?: boolean;
 };
 const UpsellWrapper = styled.div< DivProps >`
 	background: ${ ( props ) => props.theme.colors.surface };
@@ -31,7 +29,7 @@ const UpsellWrapper = styled.div< DivProps >`
 
 		@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
 			border: 1px solid ${ ( props ) => props.theme.colors.borderColorLight };
-			${ ( props ) => ( props.shouldUseCheckoutV2 ? `margin-top: 0` : `margin-top: 24px` ) }
+			margin-top: 0;
 		}
 	}
 
@@ -75,7 +73,6 @@ const SecondaryCartPromotions: FunctionComponent< Props > = ( {
 	isCartPendingUpdate,
 	isPurchaseRenewal,
 } ) => {
-	const shouldUseCheckoutV2 = useCheckoutV2() === 'treatment';
 	const selectedSiteId = useSelector( ( state ) => getSelectedSiteId( state ) as number );
 
 	if (
@@ -91,7 +88,7 @@ const SecondaryCartPromotions: FunctionComponent< Props > = ( {
 	}
 
 	return (
-		<UpsellWrapper shouldUseCheckoutV2={ shouldUseCheckoutV2 }>
+		<UpsellWrapper>
 			<CartFreeUserPlanUpsell
 				cart={ responseCart }
 				addItemToCart={ addItemToCart }

--- a/client/my-sites/checkout/src/components/test/secondary-cart-promotions.tsx
+++ b/client/my-sites/checkout/src/components/test/secondary-cart-promotions.tsx
@@ -41,6 +41,7 @@ describe( 'SecondaryCartPromotions', () => {
 							<SecondaryCartPromotions
 								responseCart={ responseCartWithRenewal }
 								addItemToCart={ jest.fn() }
+								isPurchaseRenewal={ true }
 							/>
 						</ThemeProvider>
 					</ReduxProvider>
@@ -68,6 +69,7 @@ describe( 'SecondaryCartPromotions', () => {
 							<SecondaryCartPromotions
 								responseCart={ responseCartWithRenewal }
 								addItemToCart={ mockAddItemToCart }
+								isPurchaseRenewal={ true }
 							/>
 						</ThemeProvider>
 					</ReduxProvider>

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -854,7 +854,7 @@ const CheckoutSummaryFeatures = styled.div< { shouldUseCheckoutV2: boolean } >`
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-		padding: 24px 0;
+		padding: 0;
 	}
 `;
 

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -854,7 +854,7 @@ const CheckoutSummaryFeatures = styled.div< { shouldUseCheckoutV2: boolean } >`
 	}
 
 	@media ( ${ ( props ) => props.theme.breakpoints.desktopUp } ) {
-		padding: 0;
+		${ ( props ) => ( props.shouldUseCheckoutV2 ? `padding: 0;` : `padding: 24px 0;` ) }
 	}
 `;
 

--- a/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
+++ b/client/my-sites/checkout/src/components/wp-checkout-order-summary.tsx
@@ -161,9 +161,14 @@ export function CheckoutSummaryFeaturedList( {
 					/>
 				) }
 			</CheckoutSummaryFeatures>
-			{ ! isCartUpdating && ! hasRenewalInCart && ! isWcMobile && plan && hasMonthlyPlanInCart && (
-				<CheckoutSummaryAnnualUpsell plan={ plan } onChangeSelection={ onChangeSelection } />
-			) }
+			{ ! shouldUseCheckoutV2 &&
+				! isCartUpdating &&
+				! hasRenewalInCart &&
+				! isWcMobile &&
+				plan &&
+				hasMonthlyPlanInCart && (
+					<CheckoutSummaryAnnualUpsell plan={ plan } onChangeSelection={ onChangeSelection } />
+				) }
 		</>
 	);
 }


### PR DESCRIPTION
This PR consolidates a number of separate sidebar promotional components into one 'CheckoutSidebarNudge' wrapper component. There are a number of components that should be refactored, but this PR specifically handles plan interval upsells - see here for full list https://github.com/Automattic/payments-shilling/issues/2422#issuecomment-1965647926

Part of these changes include changing the upsell component from a CTA button to a word bubble with an inline text link CTA:

| v1 | v2 |
| ----- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/16580129/d69383ae-7d73-4eee-bfc4-139799102c62) | ![image](https://github.com/Automattic/wp-calypso/assets/16580129/e01a45a8-8fb8-4ec3-81dd-8d62a2bf1f7b) |

| v1 | v2 |
| ----- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/16580129/53089d5c-36f0-427a-a1f5-2043d69f2f91) | ![image](https://github.com/Automattic/wp-calypso/assets/16580129/9315e8d6-048c-4850-a2fb-826570a73621) |

Related to https://github.com/Automattic/payments-shilling/issues/2422

#### Note - I intend to merge this for both v1 and v2, since the sidebar wrapper is already in production and these changes will benefit v1 as well

## Proposed Changes

* Update the `PromoCard` component to a newer `CheckoutPromoCard` which can handle multiple upgrade levels
* Move the monthly -> annual upsell from the Features List to the new checkout word bubble
* Update the `onUpgradeClick` function to handle more than annual -> biennial upgrades
* Styling changes to the word bubble in v2 design along with handling style regressions of other sidebar components such as the ones found in `SecondaryCartPromotions`
* Change `CheckoutSidebarNudgeWrapper` to flex and remove margin from nudge components

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Since the onUpgradeClick function has been modified for both checkout v1 (currently in production) and v2, we'll need to check that the function works as expected in both checkout flows - so the following tests need to be done for both v1 and v2 of checkout

**Test DotCom plans**
* Add a monthly plan to your cart and go to checkout - you should see an upsell nudge that reads `Longer plan billing cycles save you money and include a custom domain for free for the first year.`
* Add a monthly plan and a domain, you should be prompted to switch to an annual plan to receive your domain free for the first year (including your domain being listed in the sidebar) `Save money with longer billing cycles and get %(domainMeta)s free for the first year by {{upgradeLink}}switching to an annual plan.{{/upgradeLink}}`
* Click on sidebar upgrade link to switch to annual plan
* Now that you have an annual plan in the cart you should see the following nudge `Save up to %(savingsPercentage)s% on longer billing cycles! It's hassle-free and easy on your wallet. {{upgradeLink}}Switch to a two-year plan and save.{{/upgradeLink}}`, click on sidebar upgrade link to switch to two year plan
* At this stage we stop showing upgrade nudges for biennial -> triennial plans terms.

**Test Jetpack and Akismet Plans**
* Jetpack and Akismet do not use the new word bubble upsell yet, so at this time please add a Jetpack or Akismet product and ensure the old nudge is still showing as expected

**DIFM**
* Go to `http://calypso.localhost:3000/start/do-it-for-me/new-or-existing-site` and continue through the onboarding steps until you reach checkout
* You should see in the sidebar the DIFM `What's next?` stepper and no other upsell nudges

**Upcoming Renewals**
* This one is trickier, you'll need a site with multiple purchases from around the same date with similar expirations
* When you go to manually renew one of your purchases, Checkout should prompt you renew the others

