### PR TITLE
Nav Redesign: Fix global sidebar font sizes

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -136,6 +136,12 @@ $brand-text: "SF Pro Text", $sans;
 			&:first-child {
 				margin-top: 4px;
 			}
+
+			.sidebar__menu.is-togglable .sidebar__heading,
+			.sidebar__expandable-content .sidebar__menu-link {
+				font-size: $default-font-size;
+				line-height: 15px;
+			}
 		}
 
 		li.sidebar__separator {
@@ -148,6 +154,8 @@ $brand-text: "SF Pro Text", $sans;
 
 		.sidebar__expandable-arrow {
 			fill: var(--studio-white);
+			height: 15px;
+			width: 15px;
 		}
 
 		.selected .sidebar__menu-link::after {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5843

## Proposed Changes

This PR updates the font sizes in the global sidebar to be more consistent. 

Desktop
| Before | After |
| --- | --- |
| ![Screenshot 2024-03-01 at 12 00 01 PM](https://github.com/Automattic/wp-calypso/assets/797888/012bbe4f-06f7-4b23-8479-11702e0a5eaa)| ![Screenshot 2024-03-01 at 11 58 57 AM](https://github.com/Automattic/wp-calypso/assets/797888/c364147d-41ce-4828-a34a-bd3ab035f86a) |

Mobile
| Before | After |
| --- | --- |
|![Screenshot 2024-03-01 at 12 01 04 PM](https://github.com/Automattic/wp-calypso/assets/797888/da1f0311-2b49-479f-972c-db3dd41511ff) |  ![Screenshot 2024-03-01 at 12 01 18 PM](https://github.com/Automattic/wp-calypso/assets/797888/4402b5b3-967f-4e76-ba2e-f5bc37563ccd)|


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/read`.
* Ensure that the font sizes are updated as shown above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?