### PR TITLE
Include `was_skipped` to the submitting step event props

### DIFF
--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -135,6 +135,7 @@ export function submitSignupStep( step, providedDependencies, optionalProps ) {
 			recordSubmitStep( lastKnownFlow, step.stepName, providedDependencies, {
 				intent,
 				...optionalProps,
+				...( step.wasSkipped && { wasSkipped: step.wasSkipped } ),
 			} )
 		);
 

--- a/client/state/signup/progress/actions.js
+++ b/client/state/signup/progress/actions.js
@@ -135,7 +135,7 @@ export function submitSignupStep( step, providedDependencies, optionalProps ) {
 			recordSubmitStep( lastKnownFlow, step.stepName, providedDependencies, {
 				intent,
 				...optionalProps,
-				...( step.wasSkipped && { wasSkipped: step.wasSkipped } ),
+				...( step.wasSkipped && { was_skipped: step.wasSkipped } ),
 			} )
 		);
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

In #87560 and #87995, we introduced the new user survey step to the main onboarding flow. Depending on the assigned variation of `calypso_signup_onboarding_site_goals_survey` and whether the user is new, the survey step either shows or is skipped. However, when it is skipped, it's actually still submitted behind the scene, which is introducing lots of non-relevant empty values that make further analyzing extremely hard.

This PR adds `was_skipped`value to the event prop, so we can filter these unwanted value out without altering the framework behavior. 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Go through `/start/` with the network inspector opened. Search for `submit` and monitor `t.gif` entries:

1. When the survey step is skipped, confirm that `was_skipped` is true. The easiest way to achieve this is to log in as an existing account. 
2. For any other steps, there shouldn't be a `was_skipped` flag. 

![CleanShot 2024-03-01 at 12 14 47@2x](https://github.com/Automattic/wp-calypso/assets/1842898/ccf6b6b6-ca5b-4089-8ce5-829351941e15)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
