### PR TITLE
A4A: Add Initial billing section.

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -6,3 +6,4 @@ export const A4A_PLUGINS_LINK = '/plugins';
 export const A4A_MARKETPLACE_LINK = '/marketplace';
 export const A4A_PURCHASES_LINK = '/purchases';
 export const A4A_LICENSES_LINK = `${ A4A_PURCHASES_LINK }/licenses`;
+export const A4A_BILLING_LINK = `${ A4A_PURCHASES_LINK }/billing`;

--- a/client/a8c-for-agencies/components/sidebar-menu/purchases.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/purchases.tsx
@@ -3,7 +3,12 @@ import { chevronLeft, key } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import Sidebar from '../sidebar';
-import { A4A_OVERVIEW_LINK, A4A_PURCHASES_LINK, A4A_LICENSES_LINK } from './lib/constants';
+import {
+	A4A_OVERVIEW_LINK,
+	A4A_PURCHASES_LINK,
+	A4A_LICENSES_LINK,
+	A4A_BILLING_LINK,
+} from './lib/constants';
 import { createItem } from './lib/utils';
 
 type Props = {
@@ -23,6 +28,18 @@ export default function ( { path }: Props ) {
 					title: translate( 'Licenses' ),
 					trackEventProps: {
 						menu_item: 'Automattic for Agencies / Purchases / Licenses',
+					},
+				},
+				path
+			),
+			createItem(
+				{
+					icon: key,
+					path: A4A_PURCHASES_LINK,
+					link: A4A_BILLING_LINK,
+					title: translate( 'Billing' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Purchases / Billing',
 					},
 				},
 				path

--- a/client/a8c-for-agencies/components/sidebar-menu/purchases.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/purchases.tsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { chevronLeft, key } from '@wordpress/icons';
+import { chevronLeft, key, store } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import Sidebar from '../sidebar';
@@ -34,7 +34,7 @@ export default function ( { path }: Props ) {
 			),
 			createItem(
 				{
-					icon: key,
+					icon: store,
 					path: A4A_PURCHASES_LINK,
 					link: A4A_BILLING_LINK,
 					title: translate( 'Billing' ),

--- a/client/a8c-for-agencies/sections/purchases/billing/billing-dashboard.tsx
+++ b/client/a8c-for-agencies/sections/purchases/billing/billing-dashboard.tsx
@@ -8,6 +8,7 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 
 export default function BillingDashboard() {
@@ -28,7 +29,7 @@ export default function BillingDashboard() {
 			wide
 			sidebarNavigation={ <MobileSidebarNavigation /> }
 		>
-			<PageViewTracker title="Partner Portal > Billing" path="/partner-portal/billing" />
+			<PageViewTracker title="Purchases > Billing" path="/purchases/billing" />
 
 			<LayoutTop>
 				<LayoutHeader>
@@ -36,7 +37,7 @@ export default function BillingDashboard() {
 					<Actions>
 						<Button
 							disabled={ ! partnerCanIssueLicense }
-							href={ partnerCanIssueLicense ? '/marketplace' : undefined }
+							href={ partnerCanIssueLicense ? A4A_MARKETPLACE_LINK : undefined }
 							onClick={ onIssueNewLicenseClick }
 							primary
 						>

--- a/client/a8c-for-agencies/sections/purchases/billing/billing-dashboard.tsx
+++ b/client/a8c-for-agencies/sections/purchases/billing/billing-dashboard.tsx
@@ -1,3 +1,52 @@
+import { Button } from '@automattic/components';
+import { useTranslate } from 'i18n-calypso';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderActions as Actions,
+	LayoutHeaderTitle as Title,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+
 export default function BillingDashboard() {
-	return <>Billing</>;
+	const translate = useTranslate();
+
+	const title = translate( 'Billing' );
+
+	const partnerCanIssueLicense = true; // FIXME: get this from state
+
+	const onIssueNewLicenseClick = () => {
+		// TODO: dispatch action to open issue license modal
+	};
+
+	return (
+		<Layout
+			className="billing-dashboard"
+			title={ title }
+			wide
+			sidebarNavigation={ <MobileSidebarNavigation /> }
+		>
+			<PageViewTracker title="Partner Portal > Billing" path="/partner-portal/billing" />
+
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ title } </Title>
+					<Actions>
+						<Button
+							disabled={ ! partnerCanIssueLicense }
+							href={ partnerCanIssueLicense ? '/marketplace' : undefined }
+							onClick={ onIssueNewLicenseClick }
+							primary
+						>
+							{ translate( 'Issue New License' ) }
+						</Button>
+					</Actions>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody>test</LayoutBody>
+		</Layout>
+	);
 }

--- a/client/a8c-for-agencies/sections/purchases/billing/billing-dashboard.tsx
+++ b/client/a8c-for-agencies/sections/purchases/billing/billing-dashboard.tsx
@@ -1,0 +1,3 @@
+export default function BillingDashboard() {
+	return <>Billing</>;
+}

--- a/client/a8c-for-agencies/sections/purchases/controller.tsx
+++ b/client/a8c-for-agencies/sections/purchases/controller.tsx
@@ -11,6 +11,7 @@ import {
 	LicenseSortDirection,
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
+import BillingDashboard from './billing/billing-dashboard';
 import LicensesOverview from './licenses/licenses-overview';
 
 export const purchasesContext: Callback = () => {
@@ -37,6 +38,13 @@ export const licensesContext: Callback = ( context, next ) => {
 			sortField={ sortField }
 		/>
 	);
+
+	next();
+};
+
+export const billingContext: Callback = ( context, next ) => {
+	context.secondary = <PurchasesSidebar path={ context.path } />;
+	context.primary = <BillingDashboard />;
 
 	next();
 };

--- a/client/a8c-for-agencies/sections/purchases/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/index.tsx
@@ -1,17 +1,21 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { purchasesContext, licensesContext } from './controller';
+import { purchasesContext, licensesContext, billingContext } from './controller';
 
 export default function () {
 	// FIXME: check access, TOS consent, and partner key selection
 	page( '/purchases', purchasesContext, makeLayout, clientRender );
+
+	// Licenses
 	page(
 		'/purchases/licenses/:filter(unassigned|assigned|revoked|standard)?',
 		licensesContext,
 		makeLayout,
 		clientRender
 	);
-
 	// Redirect invalid license list filters back to the main portal page.
 	page( `/purchases/licenses/*`, '/purchases/licenses' );
+
+	// Billing
+	page( '/purchases/billing', billingContext, makeLayout, clientRender );
 }

--- a/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/licenses/licenses-overview/index.tsx
@@ -8,6 +8,7 @@ import LayoutHeader, {
 } from 'calypso/a8c-for-agencies/components/layout/header';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import { A4A_MARKETPLACE_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import LicenseList from '../license-list';
 import LicenseSearch from '../license-search';
@@ -66,8 +67,8 @@ export default function LicensesOverview( {
 			sidebarNavigation={ <MobileSidebarNavigation /> }
 		>
 			<PageViewTracker
-				title="Partner Portal > Licenses"
-				path="/partner-portal/licenses/:filter"
+				title="Purchases > Licenses"
+				path="/purchases/licenses/:filter"
 				properties={ { filter } }
 			/>
 			{ /*  TODO: <FETCH_LICENSES_HERE /> */ }
@@ -79,7 +80,7 @@ export default function LicensesOverview( {
 							{ /* TODO: <SHOW_PARTNER_KEY_SELECTION_HERE /> */ }
 							<Button
 								disabled={ ! partnerCanIssueLicense }
-								href={ partnerCanIssueLicense ? '/marketplace' : undefined }
+								href={ partnerCanIssueLicense ? A4A_MARKETPLACE_LINK : undefined }
 								onClick={ onIssueNewLicenseClick }
 								primary
 								style={ { marginLeft: 'auto' } }

--- a/client/my-sites/sidebar/utils.js
+++ b/client/my-sites/sidebar/utils.js
@@ -1,3 +1,4 @@
+import { isEnabled } from '@automattic/calypso-config';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 
 const pathIncludes = ( currentPath, term, position ) =>
@@ -69,6 +70,11 @@ export const itemLinkMatches = ( path, currentPath ) => {
 			return fragmentIsEqual( path, '/partner-portal/licenses', 2 );
 		}
 
+		return fragmentIsEqual( path, currentPath, 2 );
+	}
+
+	// All URLs in the A4A Purchases start with 'purchases' will need to compare at the second position.
+	if ( isEnabled( 'a8c-for-agencies' ) && pathIncludes( currentPath, 'purchases', 1 ) ) {
 		return fragmentIsEqual( path, currentPath, 2 );
 	}
 

--- a/client/sections.js
+++ b/client/sections.js
@@ -730,7 +730,7 @@ const sections = [
 	},
 	{
 		name: 'a8c-for-agencies-purchases',
-		paths: [ '/purchases', 'purchases/licenses' ],
+		paths: [ '/purchases', 'purchases/licenses', 'purchases/billing' ],
 		module: 'calypso/a8c-for-agencies/sections/purchases',
 		group: 'a8c-for-agencies',
 		enableLoggedOut: true,


### PR DESCRIPTION
This pull request adds the billing section to the A4A portal.

<img width="1448" alt="Screenshot 2024-03-01 at 2 42 16 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/ad1914ba-36b2-4610-b167-05166a1aa048">

Closes https://github.com/Automattic/jetpack-genesis/issues/265
Closes https://github.com/Automattic/jetpack-genesis/issues/266

## Proposed Changes

* Add the Billing route and initial page content.
* Add the Billing menu item in the Purchases sidebar menu.

## Testing Instructions
* Switch branch: `git checkout add/a4a-billing-section`.
* Start the server by running `yarn start-a8c-for-agencies`.
* Go to `http://agencies.localhost:3000/purchases/billing`.
* Confirm the initial page is loaded.

## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?