### PR TITLE
Global Site view: Implement early release mechanism

### DIFF
--- a/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
+++ b/client/my-sites/customer-home/cards/actions/quick-links/index.jsx
@@ -30,6 +30,7 @@ import {
 	getSiteFrontPage,
 	getCustomizerUrl,
 	getSiteOption,
+	isGlobalSiteViewEnabled as getIsGlobalSiteViewEnabled,
 	isNewSite,
 	getSitePlanSlug,
 	getSite,
@@ -106,6 +107,9 @@ export const QuickLinks = ( {
 		) : null;
 
 	const usesWpAdminInterface = adminInterface === 'wp-admin';
+	const isGlobalSiteViewEnabled = useSelector( ( state ) =>
+		getIsGlobalSiteViewEnabled( state, siteId )
+	);
 
 	const quickLinks = (
 		<div className="quick-links__boxes">
@@ -279,7 +283,7 @@ export const QuickLinks = ( {
 			{ isAtomic && hasBackups && (
 				<ActionBox
 					href={
-						config.isEnabled( 'layout/dotcom-nav-redesign' ) && usesWpAdminInterface
+						isGlobalSiteViewEnabled
 							? `https://jetpack.com/redirect/?source=calypso-backups&site=${ siteSlug }`
 							: `/backup/${ siteSlug }`
 					}

--- a/client/my-sites/customer-home/main.jsx
+++ b/client/my-sites/customer-home/main.jsx
@@ -1,4 +1,3 @@
-import config from '@automattic/calypso-config';
 import { Button } from '@automattic/components';
 import { localizeUrl } from '@automattic/i18n-utils';
 import { useQueryClient } from '@tanstack/react-query';
@@ -49,6 +48,7 @@ import {
 	canCurrentUserUseCustomerHome,
 	getSitePlan,
 	getSiteOption,
+	isGlobalSiteViewEnabled as getIsGlobalSiteViewEnabled,
 } from 'calypso/state/sites/selectors';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSite, getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -75,6 +75,9 @@ const Home = ( {
 	const [ launchedSiteId, setLaunchedSiteId ] = useState( null );
 	const queryClient = useQueryClient();
 	const translate = useTranslate();
+	const isGlobalSiteViewEnabled = useSelector( ( state ) =>
+		getIsGlobalSiteViewEnabled( state, siteId )
+	);
 
 	const { data: layout, isLoading, error: homeLayoutError } = useHomeLayoutQuery( siteId );
 
@@ -147,10 +150,7 @@ const Home = ( {
 	const headerActions = (
 		<>
 			<Button href={ site.URL } onClick={ trackViewSiteAction } target="_blank">
-				{ config.isEnabled( 'layout/dotcom-nav-redesign' ) &&
-				'wp-admin' === site?.options?.wpcom_admin_interface
-					? translate( 'View site' )
-					: translate( 'Visit site' ) }
+				{ isGlobalSiteViewEnabled ? translate( 'View site' ) : translate( 'Visit site' ) }
 			</Button>
 		</>
 	);

--- a/client/my-sites/site-monitoring/main.tsx
+++ b/client/my-sites/site-monitoring/main.tsx
@@ -1,4 +1,3 @@
-import { isEnabled } from '@automattic/calypso-config';
 import { translate } from 'i18n-calypso';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
@@ -6,7 +5,7 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import Main from 'calypso/components/main';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import { useSelector } from 'calypso/state';
-import { getSiteOption } from 'calypso/state/sites/selectors';
+import { isGlobalSiteViewEnabled as getIsGlobalSiteViewEnabled } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { SiteMonitoringTabPanel } from './components/site-monitoring-tab-panel';
 import { LogsTab } from './logs-tab';
@@ -21,14 +20,13 @@ interface SiteMetricsProps {
 
 export function SiteMetrics( { tab = 'metrics' }: SiteMetricsProps ) {
 	const siteId = useSelector( ( state ) => getSelectedSiteId( state ) );
-	const adminInterface = useSelector( ( state ) =>
-		getSiteOption( state, siteId, 'wpcom_admin_interface' )
+	const isGlobalSiteViewEnabled = useSelector( ( state ) =>
+		getIsGlobalSiteViewEnabled( state, siteId )
 	);
 
-	const titleHeader =
-		isEnabled( 'layout/dotcom-nav-redesign' ) && adminInterface === 'wp-admin'
-			? translate( 'Monitoring' )
-			: translate( 'Site Monitoring' );
+	const titleHeader = isGlobalSiteViewEnabled
+		? translate( 'Monitoring' )
+		: translate( 'Site Monitoring' );
 
 	return (
 		<Main className="site-monitoring" fullWidthLayout>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -49,6 +49,7 @@ import {
 } from 'calypso/state/sites/plans/selectors';
 import {
 	getSiteOption,
+	isGlobalSiteViewEnabled,
 	isJetpackSite,
 	isCurrentPlanPaid,
 	getCustomizerUrl,
@@ -658,13 +659,13 @@ export class SiteSettingsFormGeneral extends Component {
 
 const connectComponent = connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
-	const isClassicView = getSiteOption( state, siteId, 'wpcom_admin_interface' ) === 'wp-admin';
 	return {
 		customizerUrl: getCustomizerUrl( state, siteId, 'identity' ),
 		hasNoWpcomBranding: siteHasFeature( state, siteId, WPCOM_FEATURES_NO_WPCOM_BRANDING ),
 		isAtomicAndEditingToolkitDeactivated:
 			isAtomicSite( state, siteId ) &&
 			getSiteOption( state, siteId, 'editing_toolkit_is_active' ) === false,
+		isClassicView: isGlobalSiteViewEnabled( state, siteId ),
 		isComingSoon: isSiteComingSoon( state, siteId ),
 		isP2HubSite: isSiteP2Hub( state, siteId ),
 		isPaidPlan: isCurrentPlanPaid( state, siteId ),
@@ -683,7 +684,6 @@ const connectComponent = connect( ( state ) => {
 		isSiteOnMigrationTrial: getIsSiteOnMigrationTrial( state, siteId ),
 		isLaunchable:
 			! getIsSiteOnECommerceTrial( state, siteId ) && ! getIsSiteOnMigrationTrial( state, siteId ),
-		isClassicView,
 	};
 } );
 

--- a/client/my-sites/site-settings/main.jsx
+++ b/client/my-sites/site-settings/main.jsx
@@ -10,7 +10,7 @@ import { JetpackConnectionHealthBanner } from 'calypso/components/jetpack/connec
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { withJetpackConnectionProblem } from 'calypso/state/jetpack-connection-health/selectors/is-jetpack-connection-problem.js';
-import { getSiteOption } from 'calypso/state/sites/selectors';
+import { isGlobalSiteViewEnabled } from 'calypso/state/sites/selectors';
 import isJetpackSite from 'calypso/state/sites/selectors/is-jetpack-site';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import JetpackDevModeNotice from './jetpack-dev-mode-notice';
@@ -73,10 +73,9 @@ SiteSettingsComponent.propTypes = {
 
 export default connect( ( state ) => {
 	const siteId = getSelectedSiteId( state );
-	const isClassicView = getSiteOption( state, siteId, 'wpcom_admin_interface' ) === 'wp-admin';
 	return {
 		siteId,
 		isJetpack: isJetpackSite( state, siteId ),
-		isClassicView,
+		isClassicView: isGlobalSiteViewEnabled( state, siteId ),
 	};
 } )( localize( withJetpackConnectionProblem( SiteSettingsComponent ) ) );

--- a/client/state/global-sidebar/selectors.ts
+++ b/client/state/global-sidebar/selectors.ts
@@ -1,5 +1,5 @@
 import { isEnabled } from '@automattic/calypso-config';
-import { getSiteOption } from '../sites/selectors';
+import { isGlobalSiteViewEnabled } from '../sites/selectors';
 import type { AppState } from 'calypso/types';
 
 export const getShouldShowGlobalSidebar = ( _: AppState, siteId: number, sectionGroup: string ) => {
@@ -19,12 +19,6 @@ export const getShouldShowGlobalSiteSidebar = (
 	siteId: number,
 	sectionGroup: string
 ) => {
-	let shouldShowGlobalSiteSidebar = false;
-	if ( isEnabled( 'layout/dotcom-nav-redesign' ) ) {
-		// Global Site View should be limited to classic interface users only for now.
-		const adminInterface = getSiteOption( state, siteId, 'wpcom_admin_interface' );
-		shouldShowGlobalSiteSidebar =
-			adminInterface === 'wp-admin' && sectionGroup === 'sites' && !! siteId;
-	}
-	return shouldShowGlobalSiteSidebar;
+	// Global Site View should be limited to classic interface users only for now.
+	return isGlobalSiteViewEnabled( state, siteId ) && sectionGroup === 'sites' && !! siteId;
 };

--- a/client/state/sites/selectors/index.js
+++ b/client/state/sites/selectors/index.js
@@ -74,3 +74,4 @@ export { default as getJetpackAdminUrl } from './get-jetpack-admin-url';
 export { default as isSimpleSite } from './is-simple-site';
 export { default as getJetpackStatsAdminVersion } from './get-jetpack-stats-admin-version';
 export { default as isWooCYSEligibleSite } from './is-woo-cys-eligible-site';
+export { default as isGlobalSiteViewEnabled } from './is-global-site-view-enabled';

--- a/client/state/sites/selectors/is-global-site-view-enabled.ts
+++ b/client/state/sites/selectors/is-global-site-view-enabled.ts
@@ -1,0 +1,29 @@
+import { isEnabled } from '@automattic/calypso-config';
+import getSiteOption from './get-site-option';
+import type { AppState } from 'calypso/types';
+
+/**
+ * Returns true if site has the nav redesign Global Site view enabled, false if it is not enabled.
+ *
+ * @param  {Object}    state  Global state tree
+ * @param  {?number}   siteId Site ID
+ * @returns {?boolean}        Whether site has the nav redesign enabled
+ */
+export default function isGlobalSiteViewEnabled( state: AppState, siteId: number | null ) {
+	if ( ! isEnabled( 'layout/dotcom-nav-redesign' ) ) {
+		return false;
+	}
+
+	const isAdminInterfaceWPAdmin =
+		getSiteOption( state, siteId, 'wpcom_admin_interface' ) === 'wp-admin';
+	const isClassicEarlyRelease = !! getSiteOption( state, siteId, 'wpcom_classic_early_release' );
+
+	// A site is eliglible if:
+	// 1. The Calypso environment has the feature flag "layout/docom-nav-redesign-early-release".
+	//    This flag is not meant to be enabled in production and it serves as a faux proxy mechanism.
+	// 2. The site has the site option "wpcom_classic_early_release".
+	const isNavRedesignEligible =
+		isEnabled( 'layout/dotcom-nav-redesign-early-release' ) || isClassicEarlyRelease;
+
+	return isAdminInterfaceWPAdmin && isNavRedesignEligible;
+}

--- a/config/development.json
+++ b/config/development.json
@@ -118,6 +118,7 @@
 		"launchpad/new-task-definition-parser/videopress": true,
 		"launchpad/new-task-definition-parser/link-in-bio": true,
 		"layout/app-banner": true,
+		"layout/dotcom-nav-redesign-early-release": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,

--- a/config/horizon.json
+++ b/config/horizon.json
@@ -70,6 +70,7 @@
 		"launchpad/navigator": false,
 		"launchpad/new-task-definition-parser": true,
 		"layout/app-banner": true,
+		"layout/dotcom-nav-redesign-early-release": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,

--- a/config/production.json
+++ b/config/production.json
@@ -94,6 +94,7 @@
 		"launchpad/new-task-definition-parser/newsletter": true,
 		"launchpad/new-task-definition-parser/link-in-bio": true,
 		"layout/app-banner": true,
+		"layout/dotcom-nav-redesign-early-release": false,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -89,6 +89,7 @@
 		"launchpad/new-task-definition-parser/build": true,
 		"launchpad/new-task-definition-parser/link-in-bio": true,
 		"layout/app-banner": true,
+		"layout/dotcom-nav-redesign-early-release": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,

--- a/config/test.json
+++ b/config/test.json
@@ -72,6 +72,7 @@
 		"launchpad/new-task-definition-parser/build": true,
 		"launchpad/new-task-definition-parser/link-in-bio": true,
 		"layout/app-banner": true,
+		"layout/dotcom-nav-redesign-early-release": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,

--- a/config/wpcalypso.json
+++ b/config/wpcalypso.json
@@ -87,6 +87,7 @@
 		"launchpad-updates": false,
 		"launchpad/navigator": false,
 		"layout/app-banner": true,
+		"layout/dotcom-nav-redesign-early-release": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5858

## Proposed Changes

This PR adds the flag `layout/dotcom-nav-redesign-early-release`, all environments with this flag enabled will get the Global Site view when the admin interface is set to Classic. Note that the production environment MUST NEVER enable this flag since we will check for the site option `wpcom_classic_early_release` instead.

This PR also adds the Redux selector `isGlobalSiteViewEnabled`, which determines whether the Global Site view is enabled for a site. There are two conditions in which the Global Site view is enabled:

1. The site's admin interface is set to Classic AND the Calypso environment enables the nav redesign by default.
2. The site's admin interface is set to Classic AND the site option `wpcom_classic_early_release` exists.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that the calypso.live and wpcalypso environments has the Global Site view enabled as before.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?