### PR TITLE
Masterbar: Move the menu icon to left on mobile

### DIFF
--- a/client/layout/masterbar/logged-in.jsx
+++ b/client/layout/masterbar/logged-in.jsx
@@ -675,6 +675,7 @@ class MasterbarLoggedIn extends Component {
 					{ this.renderPopupSearch() }
 					<Masterbar>
 						<div className="masterbar__section masterbar__section--left">
+							{ config.isEnabled( 'layout/dotcom-nav-redesign' ) && this.renderMenu() }
 							{ this.renderMySites() }
 							{ this.renderReader( false ) }
 							{ this.renderLanguageSwitcher() }
@@ -684,7 +685,7 @@ class MasterbarLoggedIn extends Component {
 							{ this.renderCart() }
 							{ this.renderNotifications() }
 							{ loadHelpCenterIcon && this.renderHelpCenter() }
-							{ this.renderMenu() }
+							{ ! config.isEnabled( 'layout/dotcom-nav-redesign' ) && this.renderMenu() }
 						</div>
 					</Masterbar>
 				</>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5843

## Proposed Changes

* Move the menu icon of masterbar to left to align the new global view

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/7fdda166-18f4-4b11-b63c-4b2485a520b7) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/cf5d4564-2d81-4047-b74e-bd44df9d2615) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to your site that uses the default interface on mobile
* Make sure the menu icon is moved to left

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?