### PR TITLE
Untangle: Fix layout on 782px

### DIFF
--- a/client/layout/global-sidebar/index.jsx
+++ b/client/layout/global-sidebar/index.jsx
@@ -18,7 +18,7 @@ const GlobalSidebar = ( { children, onClick = undefined, className = '', ...prop
 	const isRequestingMenu = useSelector( getIsRequestingAdminMenu );
 	const translate = useTranslate();
 	const currentUser = useSelector( getCurrentUser );
-	const isDesktop = useBreakpoint( '>782px' );
+	const isDesktop = useBreakpoint( '>=782px' );
 
 	const handleWheel = useCallback( ( event ) => {
 		const bodyEl = bodyRef.current;

--- a/client/my-sites/domains/domain-management/list/style.scss
+++ b/client/my-sites/domains/domain-management/list/style.scss
@@ -138,7 +138,7 @@
 // Custom layout width for the bulk domains pages
 .is-bulk-domains-page {
 	.layout__content {
-		overflow: unset;
+		overflow: auto;
 	}
 
 	main {

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -117,7 +117,9 @@ function sitesDashboard( context: PageJSContext, next: () => void ) {
 
 			.layout__content {
 				// The page header background extends all the way to the edge of the screen
-				padding-inline: 0;
+				@media only screen and ( min-width: 782px ) {
+					padding-inline: 0;
+				}
 
 				// Prevents the status dropdown from being clipped when the page content
 				// isn't tall enough


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fix the sidebar header is missing on 782px
* Push the content to the right, and make sure the desktop view works as before (we have an https://github.com/Automattic/wp-calypso/pull/87910 before). 
* Fix the sidebar footer isn't in the viewport on domains page

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/8563a340-6001-40f6-82a9-5007a8e1b3b1) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/146b5b3f-c741-4208-bbf3-4a8bc7b5d323) |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/e1092efa-4d4e-471e-aa29-5ef9ebe46efa) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/0a4c15d4-01c2-40b9-bde0-e187c48ed293) |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/e742745b-2c96-4322-85e1-e7ecbac92b41) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/e742745b-2c96-4322-85e1-e7ecbac92b41) |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/97ba7ca0-5b90-4aac-9488-5a301b54a907) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/dd263e10-fc68-4679-a0dd-c2cce8b8a1ca) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites on 782px
* Make sure you can see the sidebar header
* Adjust the viewport width to 781px or below
* Make sure the sidebar pushes the content to the right when it opens
* Go to /domains
* Make sure you can see the sidebar footer without scrolling down

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?