### PR TITLE
i18n: Localize Backup activity button in business trial features

### DIFF
--- a/client/my-sites/plans/current-plan/trials/use-business-trial-included-features.ts
+++ b/client/my-sites/plans/current-plan/trials/use-business-trial-included-features.ts
@@ -60,7 +60,7 @@ export default function useBusinessTrialIncludedFeatures(
 			),
 			illustration: jetpackBackupsAndRestores,
 			showButton: true,
-			buttonText: 'View your backup activity',
+			buttonText: translate( 'View your backup activity' ),
 			buttonClick: () => page( `/backup/${ siteSlug }` ),
 		},
 		{


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 745-gh-Automattic/i18n-issues

## Proposed Changes

* Wrap `View your backup activity` in `useBusinessTrialIncludedFeatures` in a `translate()` call.

![VYxwe8hHj1lAvJ4C](https://github.com/Automattic/wp-calypso/assets/2722412/40549898-2f92-4c09-960d-53beaa1ba66e)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* Confirm the string is present in the `localci-new-strings.pot` TeamCity artifact.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?