### PR TITLE
Add-Ons: Migrate site media-storage query to data-stores. Refactor all usages

### DIFF
--- a/client/blocks/plan-storage/README.md
+++ b/client/blocks/plan-storage/README.md
@@ -21,11 +21,11 @@ media storage limits are fetched.
 
 ```javascript
 import PlanStorageBar from 'calypso/blocks/plan-storage/bar';
-import useMediaStorageQuery from 'calypso/data/media-storage/use-media-storage-query';
+import { Site } from '@automattic/data-stores';
 
 function MyComponent( { site, siteId } ) {
 	const planName = site.plan.product_name_short;
-	const { data: mediaStorage } = useMediaStorageQuery( siteId );
+	const { data: mediaStorage } = Site.useSiteMediaStorage( { siteIdOrSlug: siteId } );
 
 	return <PlanStorageBar sitePlanName={ planName } mediaStorage={ this.props.mediaStorage } />;
 }

--- a/client/blocks/plan-storage/bar.jsx
+++ b/client/blocks/plan-storage/bar.jsx
@@ -24,13 +24,13 @@ export class PlanStorageBar extends Component {
 			return null;
 		}
 
-		if ( ! mediaStorage || mediaStorage.max_storage_bytes === -1 ) {
+		if ( ! mediaStorage || mediaStorage.maxStorageBytes === -1 ) {
 			return null;
 		}
 
 		const percent = Math.min(
 			Math.round(
-				( ( mediaStorage.storage_used_bytes / mediaStorage.max_storage_bytes ) * 1000 ) / 10
+				( ( mediaStorage.storageUsedBytes / mediaStorage.maxStorageBytes ) * 1000 ) / 10
 			),
 			100
 		);
@@ -40,7 +40,7 @@ export class PlanStorageBar extends Component {
 			'is-warn': percent > WARN_PERCENT && percent <= ALERT_PERCENT,
 		} );
 
-		const max = filesize( mediaStorage.max_storage_bytes, { round: 0 } );
+		const max = filesize( mediaStorage.maxStorageBytes, { round: 0 } );
 
 		return (
 			<div className={ classes }>

--- a/client/blocks/plan-storage/docs/example.jsx
+++ b/client/blocks/plan-storage/docs/example.jsx
@@ -15,16 +15,16 @@ import PlanStorage from '../index';
 const PlanStorageExample = ( { siteId, siteSlug } ) => {
 	const mediaStorage = {
 		red: {
-			storage_used_bytes: 11362335981,
-			max_storage_bytes: 13958643712,
+			storageUsedBytes: 11362335981,
+			maxStorageBytes: 13958643712,
 		},
 		yellow: {
-			storage_used_bytes: 1971389988,
-			max_storage_bytes: 3221225472,
+			storageUsedBytes: 1971389988,
+			maxStorageBytes: 3221225472,
 		},
 		green: {
-			storage_used_bytes: 167503724,
-			max_storage_bytes: 3221225472,
+			storageUsedBytes: 167503724,
+			maxStorageBytes: 3221225472,
 		},
 	};
 

--- a/client/blocks/plan-storage/index.jsx
+++ b/client/blocks/plan-storage/index.jsx
@@ -11,12 +11,12 @@ import {
 	isProPlan,
 } from '@automattic/calypso-products';
 import { Tooltip } from '@automattic/components';
+import { Site } from '@automattic/data-stores';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import PropTypes from 'prop-types';
 import { useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
-import useMediaStorageQuery from 'calypso/data/media-storage/use-media-storage-query';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import hasWpcomStagingSite from 'calypso/state/selectors/has-wpcom-staging-site';
 import isLegacySiteWithHigherLimits from 'calypso/state/selectors/is-legacy-site-with-higher-limits';
@@ -39,7 +39,7 @@ export function PlanStorage( { children, className, siteId } ) {
 	);
 	const canViewBar = useSelector( ( state ) => canCurrentUser( state, siteId, 'publish_posts' ) );
 	const translate = useTranslate();
-	const { data: mediaStorage } = useMediaStorageQuery( siteId );
+	const { data: mediaStorage } = Site.useSiteMediaStorage( { siteIdOrSlug: siteId } );
 	const legacySiteWithHigherLimits = useSelector( ( state ) =>
 		isLegacySiteWithHigherLimits( state, siteId )
 	);
@@ -63,17 +63,17 @@ export function PlanStorage( { children, className, siteId } ) {
 		if (
 			( sitePlanSlug === PLAN_FREE || sitePlanSlug === PLAN_WPCOM_FLEXIBLE ) &&
 			! legacySiteWithHigherLimits &&
-			mediaStorage.max_storage_bytes === 3072 * 1024 * 1024
+			mediaStorage.maxStorageBytes === 3072 * 1024 * 1024
 		) {
-			mediaStorage.max_storage_bytes = 1024 * 1024 * 1024;
+			mediaStorage.maxStorageBytes = 1024 * 1024 * 1024;
 		}
 
 		if ( sitePlanSlug === PLAN_WPCOM_PRO ) {
-			mediaStorage.max_storage_bytes = 50 * 1024 * 1024 * 1024;
+			mediaStorage.maxStorageBytes = 50 * 1024 * 1024 * 1024;
 		}
 
 		if ( sitePlanSlug === PLAN_WPCOM_STARTER ) {
-			mediaStorage.max_storage_bytes = 6 * 1024 * 1024 * 1024;
+			mediaStorage.maxStorageBytes = 6 * 1024 * 1024 * 1024;
 		}
 	}
 

--- a/client/blocks/plan-storage/test/bar.jsx
+++ b/client/blocks/plan-storage/test/bar.jsx
@@ -22,8 +22,8 @@ describe( 'PlanStorageBar basic tests', () => {
 	const props = {
 		translate,
 		mediaStorage: {
-			storage_used_bytes: 100,
-			max_storage_bytes: 1000,
+			storageUsedBytes: 100,
+			maxStorageBytes: 1000,
 		},
 		siteSlug: 'example.com',
 		sitePlanSlug: PLAN_FREE,
@@ -88,19 +88,19 @@ describe( 'PlanStorageBar basic tests', () => {
 		expect( ecom2Container.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 1 );
 	} );
 
-	test( 'should not render when storage has valid max_storage_bytes', () => {
+	test( 'should not render when storage has valid maxStorageBytes', () => {
 		const { container: storage1 } = render(
-			<PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: 1 } } />
+			<PlanStorageBar { ...props } mediaStorage={ { maxStorageBytes: 1 } } />
 		);
 		expect( storage1.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 1 );
 
 		const { container: storage0 } = render(
-			<PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: 0 } } />
+			<PlanStorageBar { ...props } mediaStorage={ { maxStorageBytes: 0 } } />
 		);
 		expect( storage0.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 1 );
 
 		const { container: storage50 } = render(
-			<PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: 50 } } />
+			<PlanStorageBar { ...props } mediaStorage={ { maxStorageBytes: 50 } } />
 		);
 		expect( storage50.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 1 );
 	} );
@@ -120,7 +120,7 @@ describe( 'PlanStorageBar basic tests', () => {
 		expect( storageNull.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 0 );
 
 		const { container: storageUnlimited } = render(
-			<PlanStorageBar { ...props } mediaStorage={ { max_storage_bytes: -1 } } />
+			<PlanStorageBar { ...props } mediaStorage={ { maxStorageBytes: -1 } } />
 		);
 		expect( storageUnlimited.getElementsByClassName( 'plan-storage__bar' ) ).toHaveLength( 0 );
 	} );

--- a/client/data/media-storage/with-media-storage.js
+++ b/client/data/media-storage/with-media-storage.js
@@ -1,12 +1,12 @@
+import { Site } from '@automattic/data-stores';
 import { createHigherOrderComponent } from '@wordpress/compose';
 import { useSelector } from 'react-redux';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import useMediaStorageQuery from './use-media-storage-query';
 
 const withMediaStorage = createHigherOrderComponent(
 	( Wrapped ) => ( props ) => {
 		const siteId = useSelector( getSelectedSiteId );
-		const { data } = useMediaStorageQuery( siteId );
+		const { data } = Site.useSiteMediaStorage( { siteIdOrSlug: siteId } );
 
 		return <Wrapped { ...props } mediaStorage={ data ?? {} } />;
 	},

--- a/client/my-sites/add-ons/hooks/use-add-ons.ts
+++ b/client/my-sites/add-ons/hooks/use-add-ons.ts
@@ -14,7 +14,6 @@ import {
 } from '@automattic/data-stores';
 import { useMemo } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import useMediaStorageQuery from 'calypso/data/media-storage/use-media-storage-query';
 import { STORAGE_LIMIT } from '../constants';
 import customDesignIcon from '../icons/custom-design';
 import jetpackAIIcon from '../icons/jetpack-ai';
@@ -147,8 +146,8 @@ interface Props {
 
 const useAddOns = ( { selectedSiteId }: Props = {} ): ( AddOnMeta | null )[] => {
 	const activeAddOns = useActiveAddOnsDefs( selectedSiteId );
-	const mediaStorage = useMediaStorageQuery( selectedSiteId );
 	const productsList = ProductsList.useProducts();
+	const mediaStorage = Site.useSiteMediaStorage( { siteIdOrSlug: selectedSiteId } );
 	const siteFeatures = Site.useSiteFeatures( { siteIdOrSlug: selectedSiteId } );
 	const sitePurchases = Purchases.useSitePurchases( { siteId: selectedSiteId } );
 	const spaceUpgradesPurchased = Purchases.useSitePurchasesByProductSlug( {
@@ -233,7 +232,9 @@ const useAddOns = ( { selectedSiteId }: Props = {} ): ( AddOnMeta | null )[] => 
 						 * If the current storage add-on option is greater than the available upgrade.
 						 * TODO: This is also potentially a candidate for `use-add-on-purchase-status`.
 						 */
-						const currentMaxStorage = mediaStorage.data?.max_storage_bytes / Math.pow( 1024, 3 );
+						const currentMaxStorage = mediaStorage.data?.maxStorageBytes
+							? mediaStorage.data.maxStorageBytes / Math.pow( 1024, 3 )
+							: 0;
 						const availableStorageUpgrade = STORAGE_LIMIT - currentMaxStorage;
 						if ( ( addOn.quantity ?? 0 ) > availableStorageUpgrade ) {
 							return {
@@ -256,7 +257,7 @@ const useAddOns = ( { selectedSiteId }: Props = {} ): ( AddOnMeta | null )[] => 
 				} ),
 		[
 			activeAddOns,
-			mediaStorage.data?.max_storage_bytes,
+			mediaStorage.data?.maxStorageBytes,
 			productsList.data,
 			productsList.isLoading,
 			siteFeatures.data?.active,

--- a/client/my-sites/exporter/export-media-card/index.js
+++ b/client/my-sites/exporter/export-media-card/index.js
@@ -1,10 +1,10 @@
 import { Button, FoldableCard } from '@automattic/components';
+import { Site } from '@automattic/data-stores';
 import { useTranslate } from 'i18n-calypso';
 import { Fragment } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import QueryMediaExport from 'calypso/components/data/query-media-export';
 import InlineSupportLink from 'calypso/components/inline-support-link';
-import useMediaStorageQuery from 'calypso/data/media-storage/use-media-storage-query';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import getMediaExportUrl from 'calypso/state/selectors/get-media-export-url';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -12,8 +12,8 @@ import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 function ExportMediaCard() {
 	const siteId = useSelector( getSelectedSiteId );
 	const mediaExportUrl = useSelector( getMediaExportUrl );
-	const { data: mediaStorage } = useMediaStorageQuery( siteId );
-	const hasNoMediaFiles = mediaStorage?.storage_used_bytes === 0;
+	const { data: mediaStorage } = Site.useSiteMediaStorage( { siteIdOrSlug: siteId } );
+	const hasNoMediaFiles = mediaStorage?.storageUsedBytes === 0;
 	const dispatch = useDispatch();
 	const recordMediaExportClick = () =>
 		dispatch( recordTracksEvent( 'calypso_export_media_download_button_click' ) );

--- a/client/my-sites/site-settings/media-settings-performance.jsx
+++ b/client/my-sites/site-settings/media-settings-performance.jsx
@@ -4,6 +4,7 @@ import {
 	WPCOM_FEATURES_VIDEOPRESS_UNLIMITED_STORAGE,
 } from '@automattic/calypso-products';
 import { Card } from '@automattic/components';
+import { localizeUrl } from '@automattic/i18n-utils';
 import filesize from 'filesize';
 import { localize } from 'i18n-calypso';
 import PropTypes from 'prop-types';
@@ -49,7 +50,7 @@ class MediaSettingsPerformance extends Component {
 					text={ translate( 'Hosts your video files on the global WordPress.com servers.' ) }
 					link={
 						siteIsAtomic
-							? 'https://wordpress.com/support/videopress/'
+							? localizeUrl( 'https://wordpress.com/support/videopress/' )
 							: 'https://jetpack.com/support/videopress/'
 					}
 					privacyLink={ ! siteIsAtomic }
@@ -96,8 +97,8 @@ class MediaSettingsPerformance extends Component {
 					siteSlug={ siteSlug }
 					sitePlanSlug={ sitePlanSlug }
 					mediaStorage={ {
-						max_storage_bytes: mediaStorageLimit,
-						storage_used_bytes: mediaStorageUsed,
+						maxStorageBytes: mediaStorageLimit,
+						storageUsedBytes: mediaStorageUsed,
 					} }
 				/>
 			) );
@@ -146,8 +147,8 @@ export default withMediaStorage(
 			hasVideoPress:
 				siteHasFeature( state, siteId, WPCOM_FEATURES_VIDEOPRESS ) ||
 				siteHasFeature( state, siteId, WPCOM_FEATURES_VIDEOPRESS_UNLIMITED_STORAGE ),
-			mediaStorageLimit: mediaStorage?.max_storage_bytes ?? null,
-			mediaStorageUsed: mediaStorage?.storage_used_bytes ?? null,
+			mediaStorageLimit: mediaStorage?.maxStorageBytes ?? null,
+			mediaStorageUsed: mediaStorage?.storageUsedBytes ?? null,
 			sitePlanSlug: getSitePlanSlug( state, siteId ),
 			siteSlug: getSiteSlug( state, siteId ),
 		};

--- a/packages/data-stores/src/site/index.ts
+++ b/packages/data-stores/src/site/index.ts
@@ -35,3 +35,4 @@ export function register( clientCreds: WpcomClientCredentials ): typeof STORE_KE
  */
 export { default as useSite } from './queries/use-site';
 export { default as useSiteFeatures } from './queries/use-site-features';
+export { default as useSiteMediaStorage } from './queries/use-site-media-storage';

--- a/packages/data-stores/src/site/queries/lib/use-query-keys-factory.ts
+++ b/packages/data-stores/src/site/queries/lib/use-query-keys-factory.ts
@@ -1,6 +1,10 @@
 const useQueryKeysFactory = () => ( {
 	site: ( siteIdOrSlug?: string | number | null ) => [ 'site', siteIdOrSlug ],
 	siteFeatures: ( siteIdOrSlug?: string | number | null ) => [ 'site-features', siteIdOrSlug ],
+	siteMediaStorage: ( siteIdOrSlug?: string | number | null ) => [
+		'site-media-storage',
+		siteIdOrSlug,
+	],
 } );
 
 export default useQueryKeysFactory;

--- a/packages/data-stores/src/site/queries/use-site-media-storage.ts
+++ b/packages/data-stores/src/site/queries/use-site-media-storage.ts
@@ -1,0 +1,36 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import useQueryKeysFactory from './lib/use-query-keys-factory';
+import type { SiteMediaStorage, RawSiteMediaStorage } from '../types';
+
+interface Props {
+	siteIdOrSlug: string | number | null | undefined;
+}
+
+/**
+ * Site media storage from `/sites/[ siteIdOrSlug ]/media-storage` endpoint
+ * transposed to camelCase format
+ */
+function useSiteMediaStorage( {
+	siteIdOrSlug,
+}: Props ): UseQueryResult< SiteMediaStorage | undefined > {
+	const queryKeys = useQueryKeysFactory();
+
+	return useQuery( {
+		queryKey: queryKeys.siteMediaStorage( siteIdOrSlug ),
+		queryFn: async (): Promise< SiteMediaStorage | undefined > => {
+			const mediaStorage: RawSiteMediaStorage = await wpcomRequest( {
+				path: `/sites/${ encodeURIComponent( siteIdOrSlug as string ) }/media-storage`,
+				apiVersion: '1.1',
+			} );
+
+			return {
+				maxStorageBytes: Number( mediaStorage.max_storage_bytes ),
+				storageUsedBytes: Number( mediaStorage.storage_used_bytes ),
+			};
+		},
+		enabled: !! siteIdOrSlug,
+	} );
+}
+
+export default useSiteMediaStorage;

--- a/packages/data-stores/src/site/queries/use-site-media-storage.ts
+++ b/packages/data-stores/src/site/queries/use-site-media-storage.ts
@@ -19,7 +19,7 @@ function useSiteMediaStorage( {
 	return useQuery( {
 		queryKey: queryKeys.siteMediaStorage( siteIdOrSlug ),
 		queryFn: async (): Promise< SiteMediaStorage | undefined > => {
-			const mediaStorage: RawSiteMediaStorage = await wpcomRequest( {
+			const mediaStorage = await wpcomRequest< RawSiteMediaStorage >( {
 				path: `/sites/${ encodeURIComponent( siteIdOrSlug as string ) }/media-storage`,
 				apiVersion: '1.1',
 			} );

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -658,3 +658,19 @@ export interface AssembleSiteOptions {
 	canReplaceContent?: boolean;
 	siteSetupOption?: string;
 }
+
+/**
+ * Site media storage from `/sites/[ siteIdOrSlug ]/media-storage` endpoint
+ */
+export interface RawSiteMediaStorage {
+	max_storage_bytes: number;
+	storage_used_bytes: number;
+}
+
+/**
+ * Site media storage transformed for frontend use
+ */
+export interface SiteMediaStorage {
+	maxStorageBytes: number;
+	storageUsedBytes: number;
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/87530

## Proposed Changes

Part of revamping the add-ons metadata compilation to come from data-stores package. This would allow us to port the plans-grid outside of Calypso (and also deal with most of the work needed to untangle the add-ons page down the line, if we decide to do so).

- Migrates media-storage query under Site in data-stores package. This can happen for many other individual queries that target the `/sites/[ siteId ]/*` endpoints. The exception to this "rule" being the bigger chunks of state, like `Purchases` of `SitePlans`, which deserve their own unique slice/directory in the package.
- Updates types and refactors all other usages in Calypso to go through this new data-stores hook
- Removes the previous one

## Media

### In `/devdocs/blocks/plan-storage`

<img width="400" alt="Screenshot 2024-03-04 at 3 48 22 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/1de5ac95-2a1f-4092-97e5-1ab757366380">

### In `/media/[ site ]`

<img width="233" alt="Screenshot 2024-03-04 at 3 46 30 PM" src="https://github.com/Automattic/wp-calypso/assets/1705499/cab7c3c7-0196-439d-b2e6-90682dd9cf87">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure when site upgraded with storage, the add-ons exceeding the storage limit (200GB) will not be rendered e.g. upgrading Creator with 100GB will no longer render the 50GB upgrade in `/add-ons/[ creator site with 100GB space upgrade purchased ]`
* There are a few usages across Calypso that we need to confirm. I will add details later, but here's the list irrespective (see media above for the places confirmed):
    * plan-storage block
    * media-storage
    * add-ons
    * exporter
    * site settings (doesn't look like it's currently actually called/populated)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?