### PR TITLE
Nav redesign: disable the global site view early release flag in stage & horizon

### DIFF
--- a/config/horizon.json
+++ b/config/horizon.json
@@ -70,7 +70,6 @@
 		"launchpad/navigator": false,
 		"launchpad/new-task-definition-parser": true,
 		"layout/app-banner": true,
-		"layout/dotcom-nav-redesign-early-release": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,

--- a/config/stage.json
+++ b/config/stage.json
@@ -89,7 +89,6 @@
 		"launchpad/new-task-definition-parser/build": true,
 		"launchpad/new-task-definition-parser/link-in-bio": true,
 		"layout/app-banner": true,
-		"layout/dotcom-nav-redesign-early-release": true,
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

- https://github.com/Automattic/dotcom-forge/issues/5858

## Proposed Changes

This is a follow-up to:

- https://github.com/Automattic/wp-calypso/pull/88063

We now refine the flag setup as follows:

|Env|Global View (`layout/doctom-nav-redesign`)|Global Site View (`layout/dotcom-nav-redesign-early-release`)|
|-|-|-|
|production & staging|false|false|
|horizon|true|false|
|wpcalypo & development & test|true|true|

The idea is to NOT touch production & staging with the early release flag, which is a "hack" to simulate the `$is_proxied` counterpart in Jetpack/wpcom side (so that it is enabled to all a12s).

We can use the Horizon environment to test for production release. Since the early release flag is false, the site needs to have the `wpcom_classic_early_release` site option.

When everything is OK, on D-day we can turn on the `layout/doctom-nav-redesign` in production, matching Horizon's (which is tested by that time).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

None. We need to merge this so that we can actually test in Horizon (and staging).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?