### PR TITLE
GitHub Deployments: provide better UX when connecting a repository (WIP)

### DIFF
--- a/client/my-sites/github-deployments/components/automatic-activation-toggle/index.tsx
+++ b/client/my-sites/github-deployments/components/automatic-activation-toggle/index.tsx
@@ -1,0 +1,33 @@
+import { FormLabel } from '@automattic/components';
+import { FormToggle } from '@wordpress/components';
+import { useI18n } from '@wordpress/react-i18n';
+import FormFieldset from 'calypso/components/forms/form-fieldset';
+
+import './style.scss';
+
+interface AutomaticActivationToggleProps {
+	onChange( value: boolean ): void;
+	value: boolean;
+	type: string;
+}
+
+export const AutomaticActivationToggle = ( {
+	onChange,
+	value,
+	type,
+}: AutomaticActivationToggleProps ) => {
+	const { __ } = useI18n();
+	const text =
+		type === 'plugin'
+			? __( 'Activate plugin after first successful deployment' )
+			: __( 'Activate theme after first deployment' );
+	return (
+		<FormFieldset>
+			<FormLabel htmlFor="is-automated">{ __( 'Activate' ) }</FormLabel>
+			<div className="automated-deployments-toggle-switch">
+				<FormToggle id="is-automated" onChange={ () => onChange( ! value ) } checked={ value } />
+				{ text }
+			</div>
+		</FormFieldset>
+	);
+};

--- a/client/my-sites/github-deployments/components/automatic-activation-toggle/style.scss
+++ b/client/my-sites/github-deployments/components/automatic-activation-toggle/style.scss
@@ -1,0 +1,9 @@
+.automated-deployments-toggle-switch {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+
+	.components-form-toggle {
+		line-height: 1;
+	}
+}

--- a/client/my-sites/github-deployments/components/code-highlighter/index.tsx
+++ b/client/my-sites/github-deployments/components/code-highlighter/index.tsx
@@ -19,10 +19,12 @@ export const CodeHighlighter = ( { content }: CodeHighlighterProps ) => {
 	}, [ content ] );
 
 	return (
-		<pre className="code-highlighter">
-			<code ref={ yamlCodeRef } className="language-yaml">
-				{ content }
-			</code>
-		</pre>
+		<>
+			<pre className="github-workflow-code-highlighter">
+				<code ref={ yamlCodeRef } className="language-yaml">
+					{ content }
+				</code>
+			</pre>
+		</>
 	);
 };

--- a/client/my-sites/github-deployments/components/code-highlighter/style.scss
+++ b/client/my-sites/github-deployments/components/code-highlighter/style.scss
@@ -1,8 +1,9 @@
-.code-highlighter {
+.github-workflow-code-highlighter {
 	font-size: $font-body-small;
 	max-height: 20lh; /* stylelint-disable-line unit-allowed-list */
 	border-radius: 4px;
 	background: transparent !important;
+	position: relative;
 
 	.language-yaml {
 		color: var(--studio-wordpress-blue-60) !important;

--- a/client/my-sites/github-deployments/components/deployment-style/advanced-workflow-style.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/advanced-workflow-style.tsx
@@ -11,6 +11,7 @@ type AdvancedWorkflowStyleProps = {
 	workflows?: Workflow[];
 	isLoading: boolean;
 	isFetching: boolean;
+	useComposerWorkflow: boolean;
 	onWorkflowCreation( path: string ): void;
 	onNewWorkflowVerification( path: string ): void;
 	onChooseWorkflow( path: string ): void;
@@ -26,6 +27,7 @@ export const AdvancedWorkflowStyle = ( {
 	onWorkflowCreation,
 	onNewWorkflowVerification,
 	onChooseWorkflow,
+	useComposerWorkflow,
 }: AdvancedWorkflowStyleProps ) => {
 	const getContent = () => {
 		const workflow = workflows?.find( ( workflow ) => workflow.workflow_path === workflowPath );
@@ -39,6 +41,7 @@ export const AdvancedWorkflowStyle = ( {
 					repositoryBranch={ branchName }
 					onWorkflowVerification={ onNewWorkflowVerification }
 					onWorkflowCreated={ onWorkflowCreation }
+					useComposerWorkflow={ useComposerWorkflow }
 				/>
 			);
 		}

--- a/client/my-sites/github-deployments/components/deployment-style/index.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/index.tsx
@@ -17,9 +17,8 @@ type DeploymentStyleProps = {
 	branchName: string;
 	workflowPath?: string;
 	onChooseWorkflow( workflowFilename: string | undefined ): void;
+	useComposerWorkflow: boolean;
 } & DeploymentStyleContextProps;
-
-type DeploymentStyle = 'simple' | 'advanced';
 
 export const DeploymentStyle = ( {
 	isDisabled,
@@ -30,6 +29,7 @@ export const DeploymentStyle = ( {
 	isCheckingWorkflow,
 	onWorkflowVerify,
 	workflowCheckResult,
+	useComposerWorkflow,
 }: DeploymentStyleProps ) => {
 	const { __ } = useI18n();
 	const dispatch = useDispatch();
@@ -52,10 +52,10 @@ export const DeploymentStyle = ( {
 				disabled={ isDisabled }
 				items={ [
 					{
-						label: __( 'Simple' ),
+						label: __( 'Simple (copy repository contents to your site) ' ),
 						value: 'simple',
 					},
-					{ label: __( 'Advanced' ), value: 'advanced' },
+					{ label: __( 'Advanced (run a GitHub Workflow script)' ), value: 'advanced' },
 				] }
 				checked={ workflowPath ? 'advanced' : 'simple' }
 				onChange={ ( event ) => {
@@ -107,6 +107,7 @@ export const DeploymentStyle = ( {
 						workflows={ workflows }
 						isLoading={ isLoading }
 						isFetching={ isFetching }
+						useComposerWorkflow={ useComposerWorkflow }
 					/>
 				</DeploymentStyleContext.Provider>
 			) }

--- a/client/my-sites/github-deployments/components/deployment-style/index.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/index.tsx
@@ -1,6 +1,7 @@
 import { sprintf } from '@wordpress/i18n';
 import { useI18n } from '@wordpress/react-i18n';
 import FormRadiosBar from 'calypso/components/forms/form-radios-bar';
+import SupportInfo from 'calypso/components/support-info/index';
 import { GitHubRepositoryData } from 'calypso/my-sites/github-deployments/use-github-repositories-query';
 import { useDispatch } from 'calypso/state';
 import { errorNotice } from 'calypso/state/notices/actions';
@@ -45,17 +46,25 @@ export const DeploymentStyle = ( {
 
 	return (
 		<div className="github-deployments-deployment-style">
-			<h3 className="github-deployments-deployment-style__header">
-				{ __( 'Pick your deployment mode' ) }
-			</h3>
+			<div className="github-deployments-deployment-style__header">
+				<h3>{ __( 'Pick your deployment mode' ) }</h3>
+				<SupportInfo
+					text={ __(
+						'Simple deployments copy all of your repository files to the specified destination directory. ' +
+							'Advanced deployments use a Workflow script that allows you to run custom build steps, such as, install Composer dependencies, test your code before deploying, and control the files that are deployed to your site.'
+					) }
+					link="https://docs.github.com/en/actions/using-workflows"
+					privacyLink={ false }
+				/>
+			</div>
 			<FormRadiosBar
 				disabled={ isDisabled }
 				items={ [
 					{
-						label: __( 'Simple (copy repository contents to your site) ' ),
+						label: __( 'Simple' ),
 						value: 'simple',
 					},
-					{ label: __( 'Advanced (run a GitHub Workflow script)' ), value: 'advanced' },
+					{ label: __( 'Advanced' ), value: 'advanced' },
 				] }
 				checked={ workflowPath ? 'advanced' : 'simple' }
 				onChange={ ( event ) => {

--- a/client/my-sites/github-deployments/components/deployment-style/new-workflow-wizard.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/new-workflow-wizard.tsx
@@ -8,7 +8,7 @@ import { CodeHighlighter } from '../code-highlighter';
 import { useDeploymentStyleContext } from './context';
 import { useCreateWorkflow } from './use-create-workflow';
 import { Workflow } from './use-deployment-workflows-query';
-import { newWorkflowExample } from './workflow-yaml-examples';
+import { newComposerWorkflowExample, newWorkflowExample } from './workflow-yaml-examples';
 
 import './style.scss';
 
@@ -17,6 +17,7 @@ interface NewWorkflowWizardProps {
 	repositoryBranch: string;
 	isLoadingWorkflows: boolean;
 	workflows?: Workflow[];
+	useComposerWorkflow: boolean;
 	onWorkflowVerification( path: string ): void;
 	onWorkflowCreated( path: string ): void;
 }
@@ -31,12 +32,13 @@ export const NewWorkflowWizard = ( {
 	repositoryBranch,
 	onWorkflowVerification,
 	onWorkflowCreated,
+	useComposerWorkflow,
 }: NewWorkflowWizardProps ) => {
 	const { __ } = useI18n();
 
 	const { isCheckingWorkflow } = useDeploymentStyleContext();
 	const [ workflowPath, setWorkflowPath ] = useState( () => {
-		const existingWorkflow = !! workflows?.find(
+		const existingWorkflow = workflows?.find(
 			( workflow ) => workflow.workflow_path === RECOMMENDED_WORKFLOW_PATH
 		);
 
@@ -44,7 +46,7 @@ export const NewWorkflowWizard = ( {
 			return RECOMMENDED_WORKFLOW_PATH;
 		}
 
-		return WORKFLOWS_DIRECTORY;
+		return existingWorkflow.workflow_path;
 	} );
 
 	const { createWorkflow, isPending } = useCreateWorkflow( {
@@ -82,7 +84,9 @@ export const NewWorkflowWizard = ( {
 		setError( undefined );
 	}, [ workflows, workflowPath, __ ] );
 
-	const workflowContent = newWorkflowExample( repositoryBranch );
+	const workflowContent = useComposerWorkflow
+		? newComposerWorkflowExample( repositoryBranch )
+		: newWorkflowExample( repositoryBranch );
 
 	return (
 		<div className="github-deployments-new-workflow-wizard">

--- a/client/my-sites/github-deployments/components/deployment-style/style.scss
+++ b/client/my-sites/github-deployments/components/deployment-style/style.scss
@@ -8,10 +8,18 @@
 	height: fit-content;
 
 	&__header {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
 		font-weight: 500;
 		font-size: 1rem;
 		margin-bottom: 16px;
 		line-height: 24px;
+
+		.support-info {
+			margin-left: 0 !important;
+			margin-top: 4px;
+		}
 	}
 
 	&__repository {

--- a/client/my-sites/github-deployments/components/deployment-style/use-deployment-workflows-query.ts
+++ b/client/my-sites/github-deployments/components/deployment-style/use-deployment-workflows-query.ts
@@ -11,6 +11,8 @@ export interface Workflow {
 	workflow_path: string;
 }
 
+const childWorkflows = [ 'lint-css.yml', 'lint-js.yml', 'lint-php.yml' ];
+
 export const useDeploymentWorkflowsQuery = (
 	repository: GitHubRepositoryData,
 	branchName: string,
@@ -29,6 +31,8 @@ export const useDeploymentWorkflowsQuery = (
 				path,
 				apiNamespace: 'wpcom/v2',
 			} ),
+		select: ( workflows: Workflow[] ) =>
+			workflows.filter( ( workflow ) => ! childWorkflows.includes( workflow.file_name ) ),
 		meta: {
 			persist: false,
 		},

--- a/client/my-sites/github-deployments/components/deployment-style/workflow-yaml-examples.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/workflow-yaml-examples.tsx
@@ -19,7 +19,75 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: wpcom
-        path: .
+        path: |
+          .
+          !.DS_Store 
+          !.stylelintrc.json 
+          !.eslintrc 
+          !.git 
+          !.gitattributes 
+          !.github 
+          !.gitignore 
+          !README.md 
+          !composer.json 
+          !composer.lock 
+          !node_modules 
+          !vendor
+          !package-lock.json 
+          !package.json 
+          !.travis.yml 
+          !phpcs.xml.dist 
+          !sass 
+          !style.css.map 
+          !yarn.lock
+`.trim();
+};
+
+export const newComposerWorkflowExample = ( branch: string ) => {
+	return `
+name: Publish Website
+
+on:
+  push:
+    branches:
+      - ${ branch }
+  workflow_dispatch:
+jobs:
+  Build-Artifact-Action:
+    name: Build-Artifact-Action
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Install PHP dependencies
+      uses: php-actions/composer@v6
+      with:
+        dev: no
+        php_version: 8.2
+    - name: Upload the artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: wpcom
+        path: |
+          .
+          !.DS_Store 
+          !.stylelintrc.json 
+          !.eslintrc 
+          !.git 
+          !.gitattributes 
+          !.github 
+          !.gitignore 
+          !README.md 
+          !composer.json 
+          !composer.lock 
+          !node_modules 
+          !vendor
+          !package-lock.json 
+          !package.json 
+          !.travis.yml 
+          !phpcs.xml.dist 
+          !sass 
+          !style.css.map 
+          !yarn.lock
 `.trim();
 };
 
@@ -38,8 +106,28 @@ export const UploadArtifactExample = () => {
 	return `
 - name: Upload the artifact
   uses: actions/upload-artifact@v4
-  with:
-    name: wpcom
-    path: .
+	with:
+		name: wpcom
+		path: |
+			.
+			!.DS_Store 
+			!.stylelintrc.json 
+			!.eslintrc 
+			!.git 
+			!.gitattributes 
+			!.github 
+			!.gitignore 
+			!README.md 
+			!composer.json 
+			!composer.lock 
+			!node_modules 
+			!vendor
+			!package-lock.json 
+			!package.json 
+			!.travis.yml 
+			!phpcs.xml.dist 
+			!sass 
+			!style.css.map 
+			!yarn.lock
 `.trim();
 };

--- a/client/my-sites/github-deployments/components/github-connection-form/index.tsx
+++ b/client/my-sites/github-deployments/components/github-connection-form/index.tsx
@@ -6,7 +6,6 @@ import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
 import FormTextInput from 'calypso/components/forms/form-text-input';
-import { AutomaticActivationToggle } from 'calypso/my-sites/github-deployments/components/automatic-activation-toggle/index';
 import { GitHubInstallationData } from 'calypso/my-sites/github-deployments/use-github-installations-query';
 import { useGithubRepositoryBranchesQuery } from 'calypso/my-sites/github-deployments/use-github-repository-branches-query';
 import { useGithubRepositoryChecksQuery } from 'calypso/my-sites/github-deployments/use-github-repository-checks-query';
@@ -24,7 +23,6 @@ interface CodeDeploymentData {
 	installationId: number;
 	isAutomated: boolean;
 	workflowPath?: string;
-	isAutomaticallyActivated?: boolean;
 }
 
 interface InitialValues {
@@ -32,7 +30,6 @@ interface InitialValues {
 	destPath: string;
 	isAutomated: boolean;
 	workflowPath?: string;
-	isAutomaticallyActivated?: boolean;
 }
 
 interface GitHubConnectionFormProps {
@@ -53,7 +50,6 @@ export const GitHubConnectionForm = ( {
 		destPath: '/',
 		isAutomated: false,
 		workflowPath: undefined,
-		isAutomaticallyActivated: false,
 	},
 	changeRepository,
 	onSubmit,
@@ -61,9 +57,7 @@ export const GitHubConnectionForm = ( {
 	const [ branch, setBranch ] = useState( initialValues.branch );
 	const [ destPath, setDestPath ] = useState( initialValues.destPath );
 	const [ isAutoDeploy, setIsAutoDeploy ] = useState( initialValues.isAutomated );
-	const [ isAutomaticallyActivated, setIsAutomaticallyActivated ] = useState(
-		!! initialValues.isAutomaticallyActivated
-	);
+
 	const [ workflowPath, setWorkflowPath ] = useState< string | undefined >(
 		initialValues.workflowPath
 	);
@@ -114,10 +108,6 @@ export const GitHubConnectionForm = ( {
 	}
 
 	const submitDisabled = !! workflowPath && workflowCheckResult?.conclusion !== 'success';
-	const isPluginOrTheme =
-		repoChecks?.inferred_type === 'classic-theme' ||
-		repoChecks?.inferred_type === 'block-theme' ||
-		repoChecks?.inferred_type === 'plugin';
 
 	const useComposerWorkflow = repoChecks?.has_composer && ! repoChecks.has_vendor;
 
@@ -137,7 +127,6 @@ export const GitHubConnectionForm = ( {
 						installationId: installation.external_id,
 						isAutomated: isAutoDeploy,
 						workflowPath: workflowPath ?? undefined,
-						isAutomaticallyActivated,
 					} );
 				} finally {
 					setIsPending( false );
@@ -194,13 +183,6 @@ export const GitHubConnectionForm = ( {
 						{ __( 'This path is relative to the server root' ) }
 					</FormSettingExplanation>
 				</FormFieldset>
-				{ isPluginOrTheme && (
-					<AutomaticActivationToggle
-						onChange={ setIsAutomaticallyActivated }
-						value={ isAutomaticallyActivated }
-						type={ repoChecks.inferred_type }
-					/>
-				) }
 				<AutomatedDeploymentsToggle
 					onChange={ setIsAutoDeploy }
 					value={ isAutoDeploy }

--- a/client/my-sites/github-deployments/components/github-connection-form/index.tsx
+++ b/client/my-sites/github-deployments/components/github-connection-form/index.tsx
@@ -8,6 +8,7 @@ import FormSettingExplanation from 'calypso/components/forms/form-setting-explan
 import FormTextInput from 'calypso/components/forms/form-text-input';
 import { GitHubInstallationData } from 'calypso/my-sites/github-deployments/use-github-installations-query';
 import { useGithubRepositoryBranchesQuery } from 'calypso/my-sites/github-deployments/use-github-repository-branches-query';
+import { useGithubRepositoryChecksQuery } from 'calypso/my-sites/github-deployments/use-github-repository-checks-query';
 import { GitHubRepositoryData } from '../../use-github-repositories-query';
 import { AutomatedDeploymentsToggle } from '../automated-deployments-toggle';
 import { DeploymentStyle } from '../deployment-style';
@@ -90,6 +91,14 @@ export const GitHubConnectionForm = ( {
 			enabled: !! workflowPath,
 			refetchOnWindowFocus: false,
 		}
+	);
+
+	//TODO use the response here to pre-populated fields, show warnings, and make suggestions
+	useGithubRepositoryChecksQuery(
+		installation.external_id,
+		repository.owner,
+		repository.name,
+		branch
 	);
 
 	const submitDisabled = !! workflowPath && workflowCheckResult?.conclusion !== 'success';

--- a/client/my-sites/github-deployments/deployment-creation/deployment-creation-form.tsx
+++ b/client/my-sites/github-deployments/deployment-creation/deployment-creation-form.tsx
@@ -82,7 +82,6 @@ export const GitHubDeploymentCreationForm = ( {
 				installationId,
 				isAutomated,
 				workflowPath,
-				isAutomaticallyActivated,
 			} ) =>
 				createDeployment( {
 					externalRepositoryId,
@@ -91,7 +90,6 @@ export const GitHubDeploymentCreationForm = ( {
 					installationId,
 					isAutomated,
 					workflowPath,
-					isAutomaticallyActivated,
 				} )
 			}
 		/>

--- a/client/my-sites/github-deployments/deployment-creation/deployment-creation-form.tsx
+++ b/client/my-sites/github-deployments/deployment-creation/deployment-creation-form.tsx
@@ -54,10 +54,11 @@ export const GitHubDeploymentCreationForm = ( {
 				)
 			);
 		},
-		onSettled: ( _, error ) => {
+		onSettled: ( data, error ) => {
 			dispatch(
 				recordTracksEvent( 'calypso_hosting_github_create_deployment_success', {
 					connected: ! error,
+					deployment_type: getDeploymentTypeFromPath( data.target_dir ),
 				} )
 			);
 		},
@@ -95,3 +96,14 @@ export const GitHubDeploymentCreationForm = ( {
 		/>
 	);
 };
+
+function getDeploymentTypeFromPath( path: string ) {
+	if ( path === '/' ) {
+		return 'root';
+	} else if ( path === '/wp-content' ) {
+		return 'wp-content';
+	} else if ( path.includes( 'wp-content/plugins' ) ) {
+		return 'plugin';
+	}
+	return 'theme';
+}

--- a/client/my-sites/github-deployments/deployment-creation/deployment-creation-form.tsx
+++ b/client/my-sites/github-deployments/deployment-creation/deployment-creation-form.tsx
@@ -82,6 +82,7 @@ export const GitHubDeploymentCreationForm = ( {
 				installationId,
 				isAutomated,
 				workflowPath,
+				isAutomaticallyActivated,
 			} ) =>
 				createDeployment( {
 					externalRepositoryId,
@@ -90,6 +91,7 @@ export const GitHubDeploymentCreationForm = ( {
 					installationId,
 					isAutomated,
 					workflowPath,
+					isAutomaticallyActivated,
 				} )
 			}
 		/>

--- a/client/my-sites/github-deployments/deployment-creation/deployment-creation-form.tsx
+++ b/client/my-sites/github-deployments/deployment-creation/deployment-creation-form.tsx
@@ -58,7 +58,7 @@ export const GitHubDeploymentCreationForm = ( {
 			dispatch(
 				recordTracksEvent( 'calypso_hosting_github_create_deployment_success', {
 					connected: ! error,
-					deployment_type: getDeploymentTypeFromPath( data.target_dir ),
+					deployment_type: data ? getDeploymentTypeFromPath( data.target_dir ) : null,
 				} )
 			);
 		},

--- a/client/my-sites/github-deployments/deployment-creation/use-create-code-deployment.ts
+++ b/client/my-sites/github-deployments/deployment-creation/use-create-code-deployment.ts
@@ -15,6 +15,7 @@ export interface MutationVariables {
 
 interface MutationResponse {
 	message: string;
+	target_dir: string;
 }
 
 interface MutationError {
@@ -55,6 +56,7 @@ export const useCreateCodeDeployment = (
 			await queryClient.invalidateQueries( {
 				queryKey: [ GITHUB_DEPLOYMENTS_QUERY_KEY, CODE_DEPLOYMENTS_QUERY_KEY, siteId ],
 			} );
+
 			options.onSuccess?.( ...args );
 		},
 	} );

--- a/client/my-sites/github-deployments/deployment-creation/use-create-code-deployment.ts
+++ b/client/my-sites/github-deployments/deployment-creation/use-create-code-deployment.ts
@@ -11,6 +11,7 @@ export interface MutationVariables {
 	installationId: number;
 	isAutomated: boolean;
 	workflowPath?: string;
+	isAutomaticallyActivated?: boolean;
 }
 
 interface MutationResponse {
@@ -35,6 +36,7 @@ export const useCreateCodeDeployment = (
 			installationId,
 			isAutomated,
 			workflowPath,
+			isAutomaticallyActivated,
 		}: MutationVariables ) =>
 			wp.req.post(
 				{
@@ -48,6 +50,7 @@ export const useCreateCodeDeployment = (
 					installation_id: installationId,
 					is_automated: isAutomated,
 					workflow_path: workflowPath,
+					is_automatically_activated: isAutomaticallyActivated,
 				}
 			),
 		...options,

--- a/client/my-sites/github-deployments/deployment-creation/use-create-code-deployment.ts
+++ b/client/my-sites/github-deployments/deployment-creation/use-create-code-deployment.ts
@@ -11,7 +11,6 @@ export interface MutationVariables {
 	installationId: number;
 	isAutomated: boolean;
 	workflowPath?: string;
-	isAutomaticallyActivated?: boolean;
 }
 
 interface MutationResponse {
@@ -36,7 +35,6 @@ export const useCreateCodeDeployment = (
 			installationId,
 			isAutomated,
 			workflowPath,
-			isAutomaticallyActivated,
 		}: MutationVariables ) =>
 			wp.req.post(
 				{
@@ -50,7 +48,6 @@ export const useCreateCodeDeployment = (
 					installation_id: installationId,
 					is_automated: isAutomated,
 					workflow_path: workflowPath,
-					is_automatically_activated: isAutomaticallyActivated,
 				}
 			),
 		...options,

--- a/client/my-sites/github-deployments/use-github-repository-checks-query.ts
+++ b/client/my-sites/github-deployments/use-github-repository-checks-query.ts
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query';
+import { addQueryArgs } from '@wordpress/url';
+import wp from 'calypso/lib/wp';
+import { GITHUB_DEPLOYMENTS_QUERY_KEY } from './constants';
+
+const GITHUB_BRANCHES_QUERY_KEY = 'github-repository-checks';
+
+export const useGithubRepositoryChecksQuery = (
+	installationId: number,
+	repositoryOwner: string,
+	repositoryName: string,
+	repositoryBranch: string
+) => {
+	return useQuery< string[] >( {
+		queryKey: [
+			GITHUB_DEPLOYMENTS_QUERY_KEY,
+			GITHUB_BRANCHES_QUERY_KEY,
+			installationId,
+			repositoryOwner,
+			repositoryName,
+			repositoryBranch,
+		],
+		queryFn: (): string[] =>
+			wp.req.get( {
+				path: addQueryArgs( '/hosting/github/repository/pre-connect-checks', {
+					installation_id: installationId,
+					repository_owner: repositoryOwner,
+					repository_name: repositoryName,
+					repository_branch: repositoryBranch,
+				} ),
+				apiNamespace: 'wpcom/v2',
+			} ),
+		meta: {
+			persist: false,
+		},
+	} );
+};

--- a/client/my-sites/github-deployments/use-github-repository-checks-query.ts
+++ b/client/my-sites/github-deployments/use-github-repository-checks-query.ts
@@ -5,13 +5,21 @@ import { GITHUB_DEPLOYMENTS_QUERY_KEY } from './constants';
 
 const GITHUB_BRANCHES_QUERY_KEY = 'github-repository-checks';
 
+export type RepositoryChecks = {
+	inferred_type: string;
+	has_composer: boolean;
+	has_vendor: boolean;
+	suggested_directory: string;
+	protected_paths: string[];
+};
+
 export const useGithubRepositoryChecksQuery = (
 	installationId: number,
 	repositoryOwner: string,
 	repositoryName: string,
 	repositoryBranch: string
 ) => {
-	return useQuery< string[] >( {
+	return useQuery< RepositoryChecks >( {
 		queryKey: [
 			GITHUB_DEPLOYMENTS_QUERY_KEY,
 			GITHUB_BRANCHES_QUERY_KEY,
@@ -20,7 +28,7 @@ export const useGithubRepositoryChecksQuery = (
 			repositoryName,
 			repositoryBranch,
 		],
-		queryFn: (): string[] =>
+		queryFn: (): RepositoryChecks =>
 			wp.req.get( {
 				path: addQueryArgs( '/hosting/github/repository/pre-connect-checks', {
 					installation_id: installationId,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5855

<img width="1253" alt="Screenshot 2567-03-05 at 13 59 36" src="https://github.com/Automattic/wp-calypso/assets/6851384/312eecf1-6092-47e9-8906-a3f3e081f958">


## Proposed Changes

Need to discuss some of these changes with Javier and others. So far have this:

* Add a hint to deployment type. It wont be obvious what "Simple" means
* Automatically set the dest directory
* ~~If theme or plugin repo then offer to activate after first deployment~~ dropped after design feedback
* If repo contains `composer.json` but not `vendor` folder then use a Composer action in workflow when the user selects "new workflow"
* Include ignore file list on example workflows
* Some other tweaks and fixes like ignoring lint workflows and ensuring workflow script name is set 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply patch D140370-code
* Connect a repo and observe payload of `/wpcom/v2/hosting/github/repository/pre-connect-checks`

<img width="770" alt="Screenshot 2567-03-01 at 18 12 57" src="https://github.com/Automattic/wp-calypso/assets/6851384/0919f09d-3a78-47f9-a01c-ecf054d1574e">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?