### PR TITLE
Help Center: Improve spacing on article <ul>

### DIFF
--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -572,6 +572,7 @@
 			color: var(--color-neutral-80);
 			list-style-type: circle;
 			list-style-position: inside;
+			margin: 0 0 1.5em 1.5em;
 		}
 
 		span.noticon.noticon-star {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88074

## Proposed Changes

* Improve list `ul` spacing on Helpcenter resource articles. It decreases from `3rem to 1.5rem`.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use live link 
* Navigate to any site you have
* Check the Helpcenter and search for `elasticsearch queries` or any other resources that contains `ul` list
* The spacing should be improved like bellow

Before
<img width="417" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/eb4d09d3-8bf4-4b84-9bc0-f7fa8360e8cf">

<img width="792" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/b4987770-cc23-47ab-9158-3c9ebb8150bc">

After
<img width="410" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/4299bad0-915a-4da9-a05f-32d9d4e007ec">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?