### PR TITLE
Untangle: allow wpcom_classic_early_release to redux store

### DIFF
--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -85,4 +85,5 @@ export const SITE_REQUEST_OPTIONS = [
 	'can_blaze',
 	'is_commercial',
 	'wpcom_admin_interface',
+	'wpcom_classic_early_release',
 ].join();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to:

- https://github.com/Automattic/dotcom-forge/issues/5857

## Proposed Changes

This adds `wpcom_classic_early_release` to the `sites` store in redux, allowing our selectors to actually select it.

## Testing Instructions

1. Apply the site option via https://github.com/Automattic/jetpack/pull/36111
2. Run this branch locally
3. Go to console
4. Type `state.sites.items[<your site id].options`
5. Verify that the `wpcom_classic_early_release` option is listed

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?