### PR TITLE
`ThemePreview`: Hide on unmount

### DIFF
--- a/client/my-sites/themes/theme-preview.jsx
+++ b/client/my-sites/themes/theme-preview.jsx
@@ -36,6 +36,11 @@ class ThemePreview extends Component {
 			this.props.hideThemePreview();
 		}
 	}
+
+	componentWillUnmount() {
+		this.props.hideThemePreview();
+	}
+
 	getStyleVariationOption = () => {
 		return this.props.themeOptions?.styleVariation;
 	};


### PR DESCRIPTION
There's a bug on production: if you open a demo site on a theme and then navigate back, the demo stays open over the theme showcase.

![Screenshot from 2024-02-29 12-46-54](https://github.com/Automattic/wp-calypso/assets/8511199/96e1b32f-31de-4c78-a682-bbedee93aaef)


## Proposed Changes

I'm hiding the theme preview whenever the component unmounts so it doesn't show up where it shouldn't.

## Testing Instructions

- Open the PR preview
- Go to `/themes`
- Click on any theme
- Click on `Demo site`, the demo preview will open
- Navigate back the browser, check that the preview disappears
- Click on any theme, check that the previous preview is not open
- Click on `Demo site`, the correct demo preview will open

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?