### PR TITLE
Site Migration/Importer: Add label for to connect the form label and the form input

### DIFF
--- a/client/blocks/import/capture/capture-input.tsx
+++ b/client/blocks/import/capture/capture-input.tsx
@@ -72,8 +72,11 @@ const CaptureInput: FunctionComponent< Props > = ( props ) => {
 	return (
 		<form className="import__capture" onSubmit={ onFormSubmit }>
 			<FormFieldset>
-				<FormLabel>{ translate( 'Enter the URL of the site:' ) }</FormLabel>
+				<FormLabel htmlFor="capture-site-url">
+					{ translate( 'Enter the URL of the site:' ) }
+				</FormLabel>
 				<FormTextInput
+					id="capture-site-url"
 					type="text"
 					className={ classnames( { 'is-error': showValidationMsg } ) }
 					// eslint-disable-next-line jsx-a11y/no-autofocus

--- a/client/blocks/import/capture/test/index.tsx
+++ b/client/blocks/import/capture/test/index.tsx
@@ -1,0 +1,29 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { MemoryRouter } from 'react-router';
+import CaptureInput from '../capture-input';
+
+describe( 'CaptureInput', () => {
+	it( 'captures the site url', async () => {
+		const onInputEnter = jest.fn();
+		render(
+			<MemoryRouter>
+				<CaptureInput onInputEnter={ onInputEnter } />
+			</MemoryRouter>
+		);
+
+		await userEvent.type(
+			screen.getByLabelText( /Enter the URL of the site/ ),
+			'https://example.wordpress.com'
+		);
+
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+
+		expect( onInputEnter ).toHaveBeenCalledWith( 'https://example.wordpress.com' );
+	} );
+} );

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-identify/test/index.tsx
@@ -5,7 +5,7 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import nock from 'nock';
 import React from 'react';
-import SiteMigrationIdentify from'..';
+import SiteMigrationIdentify from '..';
 import { UrlData } from '../../../../../../../blocks/import/types';
 import { StepProps } from '../../../types';
 import { RenderStepOptions, mockStepProps, renderStep } from '../../test/helpers';
@@ -47,7 +47,10 @@ describe( 'SiteMigrationIdentify', () => {
 			.query( { site_url: 'https://example.com' } )
 			.reply( 200, API_RESPONSE_WORDPRESS_PLATFORM );
 
-		await userEvent.type( screen.getByRole( 'textbox' ), 'https://example.com' );
+		await userEvent.type(
+			screen.getByLabelText( /Enter the URL of the site/ ),
+			'https://example.com'
+		);
 
 		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
 
@@ -65,7 +68,11 @@ describe( 'SiteMigrationIdentify', () => {
 			.query( { site_url: 'https://example.com' } )
 			.reply( 200, API_RESPONSE_WITH_OTHER_PLATFORM );
 
-		await userEvent.type( screen.getByRole( 'textbox' ), 'https://example.com' );
+		await userEvent.type(
+			screen.getByLabelText( /Enter the URL of the site/ ),
+			'https://example.com'
+		);
+
 		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
 
 		await waitFor( () =>
@@ -82,7 +89,11 @@ describe( 'SiteMigrationIdentify', () => {
 			.query( { site_url: 'https://example.com' } )
 			.reply( 500, new Error( 'Internal Server Error' ) );
 
-		await userEvent.type( screen.getByRole( 'textbox' ), 'https://example.com' );
+		await userEvent.type(
+			screen.getByLabelText( /Enter the URL of the site/ ),
+			'https://example.com'
+		);
+
 		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
 
 		await waitFor( () =>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes
During PR #87999, I noticed our label and input field were not associated with the input text vai the "for" attributes, as explained [here](https://www.w3.org/WAI/tutorials/forms/labels/#:~:text=a%20form%20control.-,Associating%20labels%20explicitly,-Whenever%20possible%2C%20use) it is important to screen readers.
In this PR add the label for the attribute and introduce tests to ensure they are associated.



## Testing Instructions
NOTE: No visual or behavior changes are expected and automated tests are covering this change, specially https://github.com/Automattic/wp-calypso/pull/88082/commits/0e485938830cefc1272de87cbf61b4c77571a800#diff-95821bfdbf53cc162aa4a36d8f7a542c504f37a72eacded53080aefeb9c9152cR20-R23 ,  but if you want to test it manual the instructions above can be used.

* Open the `setup/site-migration/site-migration-identify?flags=onboarding/new-migration-flow`
* Click on the `Enter the URL of the site:` label 
* Check if the browser is setting the focus on the field automatically


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into the trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?