### PR TITLE
Jetpack Manage: Table Atelier - Add preview pane subroute

### DIFF
--- a/client/state/jetpack-agency-dashboard/actions.ts
+++ b/client/state/jetpack-agency-dashboard/actions.ts
@@ -32,10 +32,18 @@ export const updateDashboardURLQueryArgs = ( {
 	filter,
 	sort,
 	search,
+	activePage,
+	perPage,
+	selectedSiteUrl,
+	selectedPreviewTab,
 }: {
 	filter?: AgencyDashboardFilterOption[];
 	sort?: DashboardSortInterface;
 	search?: string;
+	activePage?: number;
+	perPage?: number;
+	selectedSiteUrl?: string;
+	selectedPreviewTab?: number;
 } ) => {
 	const params = new URLSearchParams( window.location.search );
 
@@ -45,7 +53,12 @@ export const updateDashboardURLQueryArgs = ( {
 		: ( params.getAll( 'issue_types' ) as AgencyDashboardFilterOption[] );
 	const sortField = sort ? sort.field : params.get( 'sort_field' );
 	const sortDirection = sort ? sort.direction : params.get( 'sort_direction' );
+	const newActivePage = activePage ?? params.get( 'active_page' );
+	const newPerPage = perPage ?? params.get( 'per_page' );
+	const newSelectedSiteUrl = selectedSiteUrl;
+	const newSelectedPreviewTab = selectedPreviewTab;
 
+	// We omit pagination and tab information from the URL when we're on the first page or the first tab to streamline the URL.
 	page.replace(
 		addQueryArgs(
 			{
@@ -53,6 +66,12 @@ export const updateDashboardURLQueryArgs = ( {
 				...filterStateToQuery( filterOptions ),
 				...( sortField && { sort_field: sortField } ),
 				...( sortDirection && { sort_direction: sortDirection } ),
+				...( newActivePage && newActivePage !== 1 && { active_page: newActivePage } ),
+				...( newPerPage && newActivePage !== 1 && { per_page: newPerPage } ),
+				...( newSelectedSiteUrl && { selected_site_url: newSelectedSiteUrl } ),
+				...( newSelectedSiteUrl &&
+					newSelectedPreviewTab &&
+					newSelectedPreviewTab !== 1 && { selected_site_preview_tab: newSelectedPreviewTab } ),
 			},
 			window.location.pathname
 		)


### PR DESCRIPTION
This is a draft.


Related to #

## Proposed Changes

*

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?