### PR TITLE
Jetpack Manage: Sites Dashboard Preview Pane style tweaks

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/index.tsx
@@ -10,6 +10,7 @@ import { Site } from '../../types';
 import './style.scss';
 
 const ICON_SIZE = 24;
+
 interface Props {
 	site: Site;
 	closeSitePreviewPane?: () => void;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/index.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-header/index.tsx
@@ -1,5 +1,6 @@
 import { Gridicon } from '@automattic/components';
 import { Button } from '@wordpress/components';
+import { useMediaQuery } from '@wordpress/compose';
 import { Icon, external } from '@wordpress/icons';
 import classNames from 'classnames';
 import { translate } from 'i18n-calypso';
@@ -9,7 +10,6 @@ import { Site } from '../../types';
 import './style.scss';
 
 const ICON_SIZE = 24;
-
 interface Props {
 	site: Site;
 	closeSitePreviewPane?: () => void;
@@ -17,10 +17,12 @@ interface Props {
 }
 
 export default function SitePreviewPaneHeader( { site, closeSitePreviewPane, className }: Props ) {
+	const isLargerThan960px = useMediaQuery( '(min-width: 960px)' );
+	const size = isLargerThan960px ? 64 : 50;
 	return (
 		<div className={ classNames( 'site-preview__header', className ) }>
 			<div className="site-preview__header-content">
-				<SiteFavicon site={ site } className="site-preview__header-favicon" size={ 64 } />
+				<SiteFavicon site={ site } className="site-preview__header-favicon" size={ size } />
 				<div className="site-preview__header-title-summary">
 					<div className="site-preview__header-title">{ site.blogname }</div>
 					<div className="site-preview__header-summary">

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/style.scss
@@ -1,4 +1,12 @@
 .site-preview__pane {
 	display: flex;
 	flex-direction: column;
+
+	.site-preview__tabs {
+		overflow: scroll;
+
+		.site-preview__tab {
+			overflow: visible;
+		}
+	}
 }

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
@@ -107,3 +107,11 @@
 .dataviews-pagination {
 	margin-bottom: 2rem;
 }
+
+
+.dataviews-wrapper {
+	.dataviews-no-results,
+	.dataviews-loading {
+		padding-left: 16px;
+	}
+}


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/342
Related to https://github.com/Automattic/jetpack-manage/issues/345

## Proposed Changes

* This PR fixes a few style issues related to the sites dashboard preview pane:
  * The “No results” text in the sites dashboard table content section was partially hidden under the sidebar when opening the preview pane (or on smaller screens), this PR adds padding so this and the loading text aligns more with the 'Sites' text and does not get chopped off.
  * The site icon within the preview pane on smaller screens was quite large. This PR reduces that size from 64px to 50px.
  * The feature tab labels in the preview pane were also being chopped off due to overflow: hidden. This PR make sure they remain visible, and adds an overflow: scroll to their parent so they can all be read via scroll on smaller screens.

## Testing Instructions

* To test, apply this PR and test the above scenarios when opening the preview pane from the sites dashboard - `http://jetpack.cloud.localhost:3000/sites`

**Screenshots**

Site icon and tabs in the preview pane before:
<img width="262" alt="Screenshot 2024-03-01 at 16 42 54" src="https://github.com/Automattic/wp-calypso/assets/16754605/f08068a3-2cbd-4d6d-9292-54228ae05d5b">


Site icon and tab in the preview pane after:

<img width="201" alt="Screenshot 2024-03-01 at 16 40 48" src="https://github.com/Automattic/wp-calypso/assets/16754605/30cde570-f84e-4ca5-b5e0-dad40fdd6d6a">


No results and Loading text before:

<img width="300" alt="Screenshot 2024-03-01 at 16 42 45" src="https://github.com/Automattic/wp-calypso/assets/16754605/402ab34b-2430-4b18-9f5c-4a438503199c">
<img width="272" alt="Screenshot 2024-03-01 at 16 42 38" src="https://github.com/Automattic/wp-calypso/assets/16754605/a012697e-4766-4a18-97e2-89503d376823">


No results and Loading text after:

<img width="262" alt="Screenshot 2024-03-01 at 16 41 35" src="https://github.com/Automattic/wp-calypso/assets/16754605/549cb0a6-53dd-4a9c-ba02-acd45e09da7e">
<img width="244" alt="Screenshot 2024-03-01 at 16 42 03" src="https://github.com/Automattic/wp-calypso/assets/16754605/2ba15a88-480a-4406-ada5-910796118634">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?