### PR TITLE
Jetpack Manage: Improve responsiveness of v2 dashboard

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-tabs/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-tabs/style.scss
@@ -5,9 +5,11 @@
 	height: 48px;
 	padding: 0 32px;
 	border-bottom: 1px solid var(--studio-gray-0);
+	overflow: auto;
 
 	.button.is-borderless {
 		display: flex;
+		flex-shrink: 0;
 		flex-direction: row;
 		align-items: center;
 		gap: 8px;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/sites-dataviews/style.scss
@@ -25,14 +25,14 @@
 		}
 
 		th {
-			padding: 16px 0;
+			padding: 16px 4px;
 			border-bottom: 1px solid var(--studio-gray-5);
 			font-size: rem(13px);
 			font-weight: 400;
 		}
 
 		td {
-			padding: 16px 0;
+			padding: 16px 4px;
 			border-bottom: 1px solid var(--studio-gray-5);
 			vertical-align: middle;
 		}

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style-dashboard-v2.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style-dashboard-v2.scss
@@ -160,13 +160,16 @@
 				display: none;
 			}
 		}
+	}
 
+	@media ( max-width: $break-wide ) {
 		.sites-dashboard__layout:not(.preview-hidden) {
 			flex-direction: column;
 			gap: 0;
 
 			.sites-overview__container {
 				min-height: 0;
+				overflow: hidden;
 			}
 
 			.sites-overview__content {
@@ -179,7 +182,7 @@
 		}
 	}
 
-	@media ( min-width: $break-large ) {
+	@media ( min-width: $break-wide ) {
 		.sites-dashboard__layout:not(.preview-hidden) {
 
 			.sites-overview {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

This PR aims to improve the responsive behaviour of the new DataViews dashboard (read: v2).

Resolves https://github.com/Automattic/jetpack-manage/issues/347

## Proposed Changes

* Show the preview pane as full width on larger screen sizes (the primary objective of this PR)
* Prevent preview tabs from shrinking and an unwanted gap to happen because we're force rendering an empty scroll bar
* Add horizontal spacing to columns

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/sites` and verify that:
  * We show the preview pane as for the full width of the content area at 1280px
  * We have horizontal column spacing
  * Preview tabs aren't shrinking

## Screenshots

### Show the preview pane as full width at 1280px to allow enough space

The best case here would be to collapse the navigation, but it's not supported and outside of scope to fix it (we should in A4A though)

_The header animation isn't super great, but I believe that will sort itself out when we port to A4A, so I've not spent time on it for this PR._

![Screenshot 2024-03-01 at 19 33 34](https://github.com/Automattic/wp-calypso/assets/3846700/0a5f9668-997b-4218-b722-6b0ef76dc661)

### Prevent preview tabs from shrinking

When preview tabs are allowed to shrink, they continue to blend into each other for way too long instead of showing the scroll bar.

![Screenshot 2024-03-01 at 19 23 12](https://github.com/Automattic/wp-calypso/assets/3846700/9c1c4f2a-045f-4b08-a7f5-670fa3519c70)

The same fix also correct an unwanted gap between the header and the preview pane on some widths.

![Screenshot 2024-03-01 at 19 43 11](https://github.com/Automattic/wp-calypso/assets/3846700/c004accc-1e28-4064-bad1-66dcfef77a1d)

### Add horizontal spacing between columns

Add horizontal spacing to columns so headings can still be read and make it easier to scan where cells belong vertically

**Before**
![Screenshot 2024-03-01 at 19 46 41](https://github.com/Automattic/wp-calypso/assets/3846700/324121c4-0887-4f8b-8be4-c743212d7b01)

**After**

![Screenshot 2024-03-01 at 19 47 51](https://github.com/Automattic/wp-calypso/assets/3846700/748c248b-3e8a-4484-8b12-71c63cafe3ca)

### List header goes outside of preview

_Practically speaking this doesn't happen anymore because we show the full width preview pane earlier, but highlighting it in case it's different in A4A when we actually collapse the navigation menu._

![Screenshot 2024-03-01 at 18 48 36](https://github.com/Automattic/wp-calypso/assets/3846700/402c54a9-f71e-4adb-aae2-ded4e137fb0f)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)