### PR TITLE
Github Deployments: Add GitHub deployments to command palette

### DIFF
--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -32,6 +32,7 @@ import {
 } from '@wordpress/icons';
 import { useI18n } from '@wordpress/react-i18n';
 import { useCallback } from 'react';
+import GitHubIcon from 'calypso/components/social-icons/github';
 import WooCommerceLogo from 'calypso/components/woocommerce-logo';
 import {
 	EDGE_CACHE_ENABLE_DISABLE_NOTICE_ID,
@@ -727,6 +728,25 @@ export const useCommandsArrayWpcom = ( {
 				...siteFilters.hostingEnabled,
 			},
 			icon: statsIcon,
+		},
+		{
+			name: 'openGitHubDeployments',
+			label: __( 'Open GitHub Deployments' ),
+			callback: setStateCallback(
+				'openGitHubDeployments',
+				__( 'Select site to open GitHub Deployments' )
+			),
+			searchLabel: [
+				_x( 'open github deployments', 'Keyword for the Open GitHub Deployments command' ),
+				_x( 'github', 'Keyword for the Open GitHub Deployments command' ),
+				_x( 'deployments', 'Keyword for the Open GitHub Deployments command' ),
+			].join( ' ' ),
+			siteFunctions: {
+				onClick: ( param ) =>
+					commandNavigation( `/github-deployments/${ param.site.slug }` )( param ),
+				...siteFilters.hostingEnabled,
+			},
+			icon: <GitHubIcon width={ 18 } height={ 18 } />,
 		},
 		{
 			name: 'openPHPLogs',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5818

## Proposed Changes

* Add github deployments to command palette

![Screenshot 2024-03-01 at 2 35 16 PM](https://github.com/Automattic/wp-calypso/assets/47489215/c3687864-c11f-4df0-aa8b-64d9f3320c91)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* From` /sites`, open the command palette and type `github`. select AT site and you should be directed to the deployments page
* From `/home/%s`,open the command palette and type `github`, select command and you should be directed to deployments page.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?