### PR TITLE
GitHub Deployments: Improved the experience while seeing logs

### DIFF
--- a/client/my-sites/github-deployments/deployment-run-logs/deployment-run-logs.tsx
+++ b/client/my-sites/github-deployments/deployment-run-logs/deployment-run-logs.tsx
@@ -1,3 +1,4 @@
+import { translate } from 'i18n-calypso';
 import { useMemo, useState } from 'react';
 import { LogEntry } from './use-code-deployment-run-log-query';
 
@@ -41,7 +42,15 @@ const DeploymentRunLog = ( { entry }: { entry: LogEntry } ) => {
 				onClick={ detail ? openDetail : undefined }
 			>
 				{ entry.timestamp } { entry.level.toUpperCase() } { entry.message }
-				{ detail && '…' }
+				{ detail && (
+					<>
+						...
+						<span className="show-more">
+							{ ' ' }
+							{ detailExpanded ? translate( 'show less' ) : translate( 'show more' ) }
+						</span>
+					</>
+				) }
 			</button>
 			{ detailExpanded && detail && (
 				<pre

--- a/client/my-sites/github-deployments/deployment-run-logs/style.scss
+++ b/client/my-sites/github-deployments/deployment-run-logs/style.scss
@@ -47,6 +47,10 @@ td.github-deployments-logs-content {
 	.github-deployments-loading-placeholder {
 		margin-bottom: 0;
 	}
+
+	.show-more {
+		color: var(--color-link);
+	}
 }
 
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1709327020027399-slack-C06D9M3CHMK

## Proposed Changes

* Added "show more" and "show less" to logs:

<img width="1226" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1044309/af41d6e6-01a8-4227-a3b4-d6a4307c44b8">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?