### PR TITLE
Fix global sidebar reader styles

### DIFF
--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -164,47 +164,52 @@ html.touch #wpnc-panel {
 }
 
 div.reader-notifications__panel {
-	#wpnc-panel {
+	#wpnc-panel.wpnc__main {
+		min-width: 410px;
 
 		&.wpnt-open {
 			position: fixed;
 			top: var(--masterbar-height);
-			right: var(--sidebar-width-max);
+			right: auto;
 			left: var(--sidebar-width-max);
 			bottom: 0;
-			min-width: 400px;
-		}
-	}
 
-	.wpnc__main {
+			@media only screen and ( max-width: 783px ) {
+				left: 0;
+			}
+		}
+		.wpnc__list-view .wpnc__selected-note {
+			box-shadow: inset -4px 0 0 var(--color-primary);
+		}
+
 		&.wpnc__note-list {
 			right: auto;
 			left: 0;
 		}
+
+		.wpnc__list-view {
+			border: none;
+			border-right: 1px solid var(--color-neutral-0);
+		}
+
+		.wpnc__single-view {
+			min-width: 410px;
+		}
 	}
 
-	#wpnc-panel.wpnc__main {
-		background-color: unset;
+	@media only screen and ( min-width: 1114px ) {
+		#wpnc-panel.wpnc__main {
+			background-color: unset;
 
-		.wpnc__list-view .wpnc__selected-note {
-			box-shadow: inset -4px 0 0 var(--color-primary);
-		}
-		&.wpnt-open {
-			left: 272px;
-			right: unset;
-		}
-		.wpnc__note-list {
-			right: auto;
-			left: 0;
-		}
-		.wpnc__note-list:not(.is-note-open) {
-			box-shadow: 3px 1px 10px -2px rgba(var(--color-neutral-70-rgb), 0.075);
-		}
-		.wpnc__single-view {
-			animation-name: dedicated_wpnc__slideIn;
-			border-right: 1px solid var(--color-neutral-5);
-			left: 9px;
-			right: inherit;
+			.wpnc__note-list:not(.is-note-open) {
+				box-shadow: 3px 1px 10px -2px rgba(var(--color-neutral-70-rgb), 0.075);
+			}
+
+			.wpnc__single-view {
+				animation-name: dedicated_wpnc__slideIn;
+				border-right: 1px solid var(--color-neutral-5);
+				right: inherit;
+			}
 		}
 	}
 	@keyframes dedicated_wpnc__slideIn {
@@ -213,36 +218,6 @@ div.reader-notifications__panel {
 		}
 		to {
 			transform: translateX(100%);
-		}
-	}
-}
-@media only screen and (max-width: 783px) {
-	div.reader-notifications__panel #wpnc-panel.wpnc__main {
-		&.wpnt-open {
-			left: 0;
-			min-width: 100%;
-		}
-		.wpnc__list-view .wpnc__selected-note {
-			box-shadow: none;
-		}
-		.wpnc__note-list {
-			max-width: 400px;
-			right: 0;
-		}
-		.wpnc__single-view {
-			animation-name: wpnc__slideIn;
-			left: 0;
-		}
-	}
-}
-
-// Adjust the where the notifications panel is positioned when the global sidebar is visible
-.is-global-sidebar-visible {
-	div.reader-notifications__panel {
-		#wpnc-panel.wpnc__main {
-			&.wpnt-open {
-				left: 314px;
-			}
 		}
 	}
 }

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -1,6 +1,11 @@
 /**
  * Notifications
  */
+//
+$min_page_width: 800px; // Default min-width
+.is-global-sidebar-visible #wpnc-panel {
+	$min_page_width: 1114px; // Override min-width if .is-global-sidebar-visible is present
+}
 
 #wpnc-panel {
 	position: fixed;
@@ -110,13 +115,13 @@
 		left: inherit;
 		width: 400px;
 
-		@include breakpoint-deprecated( "<800px" ) {
+		@include breakpoint-deprecated( $min_page_width ) {
 			left: 0;
 			width: auto;
 		}
 	}
 
-	@include breakpoint-deprecated( "<800px" ) {
+	@include breakpoint-deprecated( $min_page_width ) {
 		&.wpnc__main header {
 			top: 47px;
 		}
@@ -216,7 +221,7 @@ div.reader-notifications__panel {
 		}
 	}
 }
-@media only screen and (max-width: 783px) {
+@media only screen and (max-width: calc(#{$min_page_width} - 17px) ) {
 	div.reader-notifications__panel #wpnc-panel.wpnc__main {
 		&.wpnt-open {
 			left: 0;

--- a/client/notifications/style.scss
+++ b/client/notifications/style.scss
@@ -1,11 +1,6 @@
 /**
  * Notifications
  */
-//
-$min_page_width: 800px; // Default min-width
-.is-global-sidebar-visible #wpnc-panel {
-	$min_page_width: 1114px; // Override min-width if .is-global-sidebar-visible is present
-}
 
 #wpnc-panel {
 	position: fixed;
@@ -115,13 +110,13 @@ $min_page_width: 800px; // Default min-width
 		left: inherit;
 		width: 400px;
 
-		@include breakpoint-deprecated( $min_page_width ) {
+		@include breakpoint-deprecated( "<800px" ) {
 			left: 0;
 			width: auto;
 		}
 	}
 
-	@include breakpoint-deprecated( $min_page_width ) {
+	@include breakpoint-deprecated( "<800px" ) {
 		&.wpnc__main header {
 			top: 47px;
 		}
@@ -221,7 +216,7 @@ div.reader-notifications__panel {
 		}
 	}
 }
-@media only screen and (max-width: calc(#{$min_page_width} - 17px) ) {
+@media only screen and (max-width: 783px) {
 	div.reader-notifications__panel #wpnc-panel.wpnc__main {
 		&.wpnt-open {
 			left: 0;

--- a/client/reader/conversations/stream.scss
+++ b/client/reader/conversations/stream.scss
@@ -2,7 +2,7 @@
 	margin: 0 auto;
 	max-width: 600px;
 	@media only screen and (max-width: 660px) {
-		padding: 0 30px;
+		padding: 30px 0 0 30px;
 	}
 }
 

--- a/client/reader/discover/discover-navigation.scss
+++ b/client/reader/discover/discover-navigation.scss
@@ -5,7 +5,7 @@
 		max-width: 968px; // Max width of dual column reader stream.
 	}
 	@media only screen and (max-width: 660px) {
-		padding: 0 30px;
+		padding: 30px 0 0 30px;
 	}
 }
 

--- a/client/reader/notifications/controller.jsx
+++ b/client/reader/notifications/controller.jsx
@@ -4,12 +4,14 @@ import DocumentHead from 'calypso/components/data/document-head';
 import { sectionify } from 'calypso/lib/route';
 import { trackPageLoad } from 'calypso/reader/controller-helper';
 import { recordTrack } from 'calypso/reader/stats';
+import { getShouldShowGlobalSidebar } from 'calypso/state/global-sidebar/selectors';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 
 export function notifications( context, next ) {
 	const basePath = sectionify( context.path );
 	const mcKey = 'notifications';
 	const state = context.store.getState();
+	const shouldShowGlobalSidebar = getShouldShowGlobalSidebar( state, null, 'reader' );
 
 	trackPageLoad( basePath, 'Reader > Notifications', mcKey );
 	recordTrack(
@@ -41,6 +43,7 @@ export function notifications( context, next ) {
 					checkToggle={ () => {} }
 					setIndicator={ () => {} }
 					placeholder={ null }
+					isGlobalSidebarVisible={ shouldShowGlobalSidebar }
 				/>
 			</div>
 		</>


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5760

Few issues with styling on Reader due to the global sidebar.

### Changes

- [x] Conversations header padding
- [x] Discover stream header padding
- [x] Notifications panel positioning 

### Before

https://github.com/Automattic/wp-calypso/assets/5560595/f7362788-2e2b-4700-9c09-31c253bd528b

### After

https://github.com/Automattic/wp-calypso/assets/5560595/0ead23be-497a-4720-a586-61e17a33e87c

### Test
* You can see issues from before video and by going to https://wpcalypso.wordpress.com/read/
* Test reader in calypso live link and confirm works as expected