### PR TITLE
Backup: add tracks event for backup failed contact support link

### DIFF
--- a/client/components/jetpack/daily-backup-status/status-card/backup-failed.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-failed.jsx
@@ -34,8 +34,12 @@ const BackupFailed = ( { backup } ) => {
 
 	const dispatch = useDispatch();
 	const onContactSupportClick = useCallback( () => {
-		dispatch( recordTracksEvent( 'calypso_jetpack_backup_failed_contact_support_click' ) );
-	}, [ dispatch ] );
+		dispatch(
+			recordTracksEvent( 'calypso_jetpack_backup_failed_contact_support_click', {
+				reason: mayBeBlockedByHost ? 'blocked_by_host' : 'other',
+			} )
+		);
+	}, [ dispatch, mayBeBlockedByHost ] );
 
 	return (
 		<>

--- a/client/components/jetpack/daily-backup-status/status-card/backup-failed.jsx
+++ b/client/components/jetpack/daily-backup-status/status-card/backup-failed.jsx
@@ -1,9 +1,12 @@
 import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import Button from 'calypso/components/forms/form-button';
 import { getBackupErrorCode } from 'calypso/lib/jetpack/backup-utils';
 import contactSupportUrl from 'calypso/lib/jetpack/contact-support-url';
 import { applySiteOffset } from 'calypso/lib/site/timezone';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions/record';
 import getSiteGmtOffset from 'calypso/state/selectors/get-site-gmt-offset';
 import getSiteTimezoneValue from 'calypso/state/selectors/get-site-timezone-value';
 import getSiteUrl from 'calypso/state/sites/selectors/get-site-url';
@@ -11,7 +14,6 @@ import getSelectedSiteId from 'calypso/state/ui/selectors/get-selected-site-id';
 import useGetDisplayDate from '../use-get-display-date';
 import BackupSupportLinks from './backup-support-links';
 import cloudErrorIcon from './icons/cloud-error.svg';
-
 import './style.scss';
 
 const BackupFailed = ( { backup } ) => {
@@ -29,6 +31,11 @@ const BackupFailed = ( { backup } ) => {
 	const displayTime = backupDate.format( 'LT' );
 
 	const mayBeBlockedByHost = getBackupErrorCode( backup ) === 'NOT_ACCESSIBLE';
+
+	const dispatch = useDispatch();
+	const onContactSupportClick = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_jetpack_backup_failed_contact_support_click' ) );
+	}, [ dispatch ] );
 
 	return (
 		<>
@@ -93,6 +100,7 @@ const BackupFailed = ( { backup } ) => {
 					target="_blank"
 					rel="noopener noreferrer"
 					isPrimary={ false }
+					onClick={ onContactSupportClick }
 				>
 					{ translate( 'Contact support' ) }
 				</Button>


### PR DESCRIPTION
Related to p1HpG7-rqN-p2

## Proposed Changes

* Add `calypso_jetpack_backup_failed_contact_support_click` track event for backup failed contact support link

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
* The easy way to test it is locally, by adding the following code to the line 112 of `client/components/jetpack/daily-backup-status/index.jsx`:

```javascript
return <BackupFailed backup={ backup } />;
```
* Open the Network tab in your developer tools 
* Navigate to Jetpack Cloud > Backup
* Pick a site with backups completed
* You should see the `Backup failed` card with a `Contact support` button
* Click on `Contact support` and ensure it opens a new tab with the contact support page, and you see a request to `t.gif` with the `calypso_jetpack_backup_failed_contact_support_click` event.

![CleanShot 2024-03-01 at 20 01 44@2x](https://github.com/Automattic/wp-calypso/assets/1488641/232c9569-8ad0-4bdd-9522-b631f16c1092)

https://github.com/Automattic/wp-calypso/assets/1488641/d7071c79-8d13-457c-96b3-750055c5663f

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?