### PR TITLE
Github Deployments: Temporarily gate github command palette to feature availability 

### DIFF
--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -751,8 +751,13 @@ export const useCommandsArrayWpcom = ( {
 							_x( 'deployments', 'Keyword for the Open GitHub Deployments command' ),
 						].join( ' ' ),
 						siteFunctions: {
-							onClick: ( param ) =>
-								commandNavigation( `/github-deployments/${ param.site.slug }` )( param ),
+							onClick: (
+								param: Pick< CommandCallBackParams, 'close' | 'command' > & {
+									site: SiteExcerptData;
+								}
+							) => {
+								return commandNavigation( `/github-deployments/${ param.site.slug }` )( param );
+							},
 							...siteFilters.hostingEnabled,
 						},
 						icon: <GitHubIcon width={ 18 } height={ 18 } />,

--- a/client/sites-dashboard/components/wpcom-smp-commands.tsx
+++ b/client/sites-dashboard/components/wpcom-smp-commands.tsx
@@ -42,12 +42,14 @@ import {
 } from 'calypso/data/hosting/use-cache';
 import { useAddNewSiteUrl } from 'calypso/lib/paths/use-add-new-site-url';
 import wpcom from 'calypso/lib/wp';
+import { useIsGitHubDeploymentsAvailableQuery } from 'calypso/my-sites/github-deployments/use-is-feature-available';
 import { useOpenPhpMyAdmin } from 'calypso/my-sites/hosting/phpmyadmin-card';
-import { useDispatch } from 'calypso/state';
+import { useDispatch, useSelector } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { clearWordPressCache } from 'calypso/state/hosting/actions';
 import { createNotice, removeNotice } from 'calypso/state/notices/actions';
 import { NoticeStatus } from 'calypso/state/notices/types';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { generateSiteInterfaceLink, isCustomDomain, isNotAtomicJetpack, isP2Site } from '../utils';
 import type {
 	Command,
@@ -103,6 +105,11 @@ export const useCommandsArrayWpcom = ( {
 	const dispatch = useDispatch();
 
 	const { setEdgeCache } = useSetEdgeCacheMutation();
+	//temporary patch to not add github deployments to the command palette if feature is not available, will be removed.
+	const selectedSiteId = useSelector( getSelectedSiteId );
+	const { data } = useIsGitHubDeploymentsAvailableQuery( {
+		siteId: selectedSiteId || 0,
+	} );
 
 	const displayNotice = (
 		message: string,
@@ -729,25 +736,29 @@ export const useCommandsArrayWpcom = ( {
 			},
 			icon: statsIcon,
 		},
-		{
-			name: 'openGitHubDeployments',
-			label: __( 'Open GitHub Deployments' ),
-			callback: setStateCallback(
-				'openGitHubDeployments',
-				__( 'Select site to open GitHub Deployments' )
-			),
-			searchLabel: [
-				_x( 'open github deployments', 'Keyword for the Open GitHub Deployments command' ),
-				_x( 'github', 'Keyword for the Open GitHub Deployments command' ),
-				_x( 'deployments', 'Keyword for the Open GitHub Deployments command' ),
-			].join( ' ' ),
-			siteFunctions: {
-				onClick: ( param ) =>
-					commandNavigation( `/github-deployments/${ param.site.slug }` )( param ),
-				...siteFilters.hostingEnabled,
-			},
-			icon: <GitHubIcon width={ 18 } height={ 18 } />,
-		},
+		...( data?.available
+			? [
+					{
+						name: 'openGitHubDeployments',
+						label: __( 'Open GitHub Deployments' ),
+						callback: setStateCallback(
+							'openGitHubDeployments',
+							__( 'Select site to open GitHub Deployments' )
+						),
+						searchLabel: [
+							_x( 'open github deployments', 'Keyword for the Open GitHub Deployments command' ),
+							_x( 'github', 'Keyword for the Open GitHub Deployments command' ),
+							_x( 'deployments', 'Keyword for the Open GitHub Deployments command' ),
+						].join( ' ' ),
+						siteFunctions: {
+							onClick: ( param ) =>
+								commandNavigation( `/github-deployments/${ param.site.slug }` )( param ),
+							...siteFilters.hostingEnabled,
+						},
+						icon: <GitHubIcon width={ 18 } height={ 18 } />,
+					},
+			  ]
+			: [] ),
 		{
 			name: 'openPHPLogs',
 			label: __( 'Open PHP logs' ),


### PR DESCRIPTION

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* get availability status from endpoint to determine if command palette should be added.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* use a non-a8c account and search for `github` it should not be found in the palette
* use a a8c account and perform the same test `/sites` the command should be found

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)