### PR TITLE
Checkout coupons: Remove delete button if a recurring coupon has been added to the cart

### DIFF
--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -213,7 +213,7 @@ export function WPOrderReviewLineItems( {
 					<CouponLineItem
 						lineItem={ couponLineItem }
 						isSummary={ isSummary }
-						hasDeleteButton
+						hasDeleteButton={ couponLineItem.hasDeleteButton }
 						removeProductFromCart={ removeCoupon }
 						createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
 						isPwpoUser={ isPwpoUser }

--- a/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
+++ b/client/my-sites/checkout/src/components/wp-order-review-line-items.tsx
@@ -234,7 +234,7 @@ export function WPOrderReviewLineItems( {
 				<CostOverridesList
 					costOverridesList={ costOverridesList }
 					currency={ responseCart.currency }
-					removeCoupon={ removeCoupon }
+					removeCoupon={ couponLineItem?.hasDeleteButton ? removeCoupon : undefined }
 					couponCode={ responseCart.coupon }
 					showOnlyCoupons
 				/>

--- a/packages/mini-cart/src/mini-cart-line-items.tsx
+++ b/packages/mini-cart/src/mini-cart-line-items.tsx
@@ -65,7 +65,7 @@ export function MiniCartLineItems( {
 						lineItem={ couponLineItem }
 						removeProductFromCart={ removeCoupon }
 						createUserAndSiteBeforeTransaction={ createUserAndSiteBeforeTransaction }
-						hasDeleteButton
+						hasDeleteButton={ couponLineItem.hasDeleteButton }
 					/>
 				</MiniCartLineItemWrapper>
 			) }

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -19,6 +19,7 @@ export function getEmptyResponseCart(): ResponseCart {
 		allowed_payment_methods: [],
 		coupon: '',
 		is_coupon_applied: false,
+		is_coupon_recurring: false,
 		locale: 'en-us',
 		tax: { location: {}, display_taxes: false },
 		is_signup: false,

--- a/packages/shopping-cart/src/empty-carts.ts
+++ b/packages/shopping-cart/src/empty-carts.ts
@@ -19,7 +19,7 @@ export function getEmptyResponseCart(): ResponseCart {
 		allowed_payment_methods: [],
 		coupon: '',
 		is_coupon_applied: false,
-		is_coupon_recurring: false,
+		has_auto_renew_coupon_been_automatically_applied: false,
 		locale: 'en-us',
 		tax: { location: {}, display_taxes: false },
 		is_signup: false,

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -298,7 +298,7 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	allowed_payment_methods: string[];
 	coupon: string;
 	is_coupon_applied: boolean;
-	is_coupon_recurring: boolean;
+	has_auto_renew_coupon_been_automatically_applied: boolean;
 	locale: string;
 	is_signup: boolean;
 	messages?: ResponseCartMessages;

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -298,6 +298,7 @@ export interface ResponseCart< P = ResponseCartProduct > {
 	allowed_payment_methods: string[];
 	coupon: string;
 	is_coupon_applied: boolean;
+	is_coupon_recurring: boolean;
 	locale: string;
 	is_signup: boolean;
 	messages?: ResponseCartMessages;

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -36,6 +36,7 @@ export function getCouponLineItemFromCart( responseCart: ResponseCart ): LineIte
 	}
 	return {
 		id: 'coupon-line-item',
+		hasDeleteButton: ! responseCart.is_coupon_recurring,
 		// translators: The label of the coupon line item in checkout, including the coupon code
 		label: String(
 			translate( 'Coupon: %(couponCode)s', { args: { couponCode: responseCart.coupon } } )

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -36,7 +36,7 @@ export function getCouponLineItemFromCart( responseCart: ResponseCart ): LineIte
 	}
 	return {
 		id: 'coupon-line-item',
-		hasDeleteButton: ! responseCart.is_coupon_recurring,
+		hasDeleteButton: ! responseCart.has_auto_renew_coupon_been_automatically_applied,
 		// translators: The label of the coupon line item in checkout, including the coupon code
 		label: String(
 			translate( 'Coupon: %(couponCode)s', { args: { couponCode: responseCart.coupon } } )

--- a/packages/wpcom-checkout/src/types.ts
+++ b/packages/wpcom-checkout/src/types.ts
@@ -272,6 +272,7 @@ export interface LineItemType {
 	type: string;
 	label: string;
 	formattedAmount: string;
+	hasDeleteButton?: boolean;
 }
 
 export interface WPCOMCart {

--- a/packages/wpcom-checkout/test/transformations.ts
+++ b/packages/wpcom-checkout/test/transformations.ts
@@ -110,6 +110,26 @@ describe( 'getCouponLineItemFromCart', function () {
 			type: 'coupon',
 			label: 'Coupon: ABCD',
 			formattedAmount: '- ¥300',
+			hasDeleteButton: true,
+		};
+
+		expect( getCouponLineItemFromCart( cartWithCoupon ) ).toStrictEqual( expected );
+	} );
+
+	it( 'hides delete button for recurring coupons', () => {
+		const cartWithCoupon = {
+			...cart,
+			coupon: 'ABCD',
+			coupon_savings_total_integer: 300,
+			is_coupon_recurring: true,
+		};
+
+		const expected: LineItemType = {
+			id: 'coupon-line-item',
+			type: 'coupon',
+			label: 'Coupon: ABCD',
+			formattedAmount: '- ¥300',
+			hasDeleteButton: false,
 		};
 
 		expect( getCouponLineItemFromCart( cartWithCoupon ) ).toStrictEqual( expected );

--- a/packages/wpcom-checkout/test/transformations.ts
+++ b/packages/wpcom-checkout/test/transformations.ts
@@ -121,7 +121,7 @@ describe( 'getCouponLineItemFromCart', function () {
 			...cart,
 			coupon: 'ABCD',
 			coupon_savings_total_integer: 300,
-			is_coupon_recurring: true,
+			has_auto_renew_coupon_been_automatically_applied: true,
 		};
 
 		const expected: LineItemType = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/2740

## Proposed Changes
When recurring coupons are applied to the shopping cart for renewal of a product, we'd like to prevent users from removing said coupon from cart.  This is because, for v1 of the recurring coupons project, we won't have a mechanism to remove recurring coupons from a billing ownership. pau2Xa-5At-p2

We add the `is_coupon_recurring` flag to the shopping cart API response in D139635-code that signals to Calypso whether or not to hide the delete button.

## Screenshots

Note that the remove coupon from cart button is now hidden

| Checkout Page Before     | Checkout Page Before    |
| ----- | ----- |
| <img width="1420" alt="Screenshot 2024-03-02 at 4 20 40 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/52332213-7d7b-4cdf-b073-b4c95750033c">      | <img width="1413" alt="Screenshot 2024-03-02 at 3 40 45 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/3edd002e-bd6a-4f58-b223-d145c6b7d75c">      |

| Mini Cart Before     | Mini Cart After    |
| ----- | ----- |
| <img width="1433" alt="Screenshot 2024-03-02 at 4 20 53 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/b3a527ec-a598-48c5-9a58-0b7ce9e37728"> | <img width="1430" alt="Screenshot 2024-03-02 at 4 17 32 PM" src="https://github.com/Automattic/wp-calypso/assets/5414230/63d5235f-27c7-45e1-8a1c-eb2077615f19"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Apply D139635-code and sandbox the API and ensure that the store sandbox is enabled PCYsg-IA-p2
- Go to https://wordpress.com/start and select a paid plan.
- Apply the `testautorenew` coupon.
- Confirm that the purchase is made successfully.
- Navigate to the /plans page, Click on the tab "My Plan", Click on "Manage plan", and Click on the "Renew now" CTA
- Confirm that the recurring coupon is automatically added to the cart.
- Confirm that the remove coupon from cart button is hidden
- Return to the Calypso admin dashboard and open the mini cart modal by clicking on the cart icon at the top right of the page
- Confirm that the remove coupon from cart button is hidden

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?