### PR TITLE
Workflow: Notify on blocker triaged issue only

### DIFF
--- a/.github/workflows/notify-high-priority-triaged-issues.yml
+++ b/.github/workflows/notify-high-priority-triaged-issues.yml
@@ -8,15 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     if: >
       (
-        github.event.label.name == '[Pri] High' ||
         github.event.label.name == '[Pri] Blocker' ||
         github.event.label.name == 'Triaged'
       ) &&
       contains(github.event.issue.labels.*.name, 'Triaged') &&
-      (
-        contains(github.event.issue.labels.*.name, '[Pri] High') ||
-        contains(github.event.issue.labels.*.name, '[Pri] Blocker')
-      )
+      contains(github.event.issue.labels.*.name, '[Pri] Blocker')
     steps:
       - name: Set variables based on event type
         id: set-vars


### PR DESCRIPTION


## Proposed Changes

Notifying on both blocker and and high priority issues seems like it could be noisy for the escalations channel.  Pulling back to only blocker issues for now and will reconsider high priority in the future.

## Testing Instructions

Deploy and test.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?