### PR TITLE
Stats: Add feature UTM tracking to the list on the Stats commercial purchase page

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -58,7 +58,7 @@ const StatsBenefitsCommercial = () => {
 	const translate = useTranslate();
 
 	const spikeInfoIconRef = useRef( null );
-	const OverageInfoIconRef = useRef( null );
+	const overageInfoIconRef = useRef( null );
 	const [ spikeInfoShow, setSpikeInfoShow ] = useState( false );
 	const handleSpikePopoverOpen = () => setSpikeInfoShow( true );
 	const handleSpikePopoverClose = () => setSpikeInfoShow( false );
@@ -89,7 +89,7 @@ const StatsBenefitsCommercial = () => {
 					{ translate( 'Overage forgiveness' ) }
 					<Icon
 						icon={ info }
-						ref={ OverageInfoIconRef }
+						ref={ overageInfoIconRef }
 						onMouseEnter={ handleOveragePopoverOpen }
 						onMouseLeave={ handleOveragePopoverClose }
 					/>
@@ -110,7 +110,7 @@ const StatsBenefitsCommercial = () => {
 			<Popover
 				position="right"
 				isVisible={ overageInfoShow }
-				context={ OverageInfoIconRef.current }
+				context={ overageInfoIconRef.current }
 				className="stats-purchase__info-popover"
 			>
 				<div className="stats-purchase__info-popover-content">

--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -80,15 +80,17 @@ const StatsBenefitsCommercial = () => {
 				<li>{ translate( 'Access to upcoming advanced features' ) }</li>
 				<li>{ translate( 'Priority support' ) }</li>
 				<li>{ translate( 'Commercial use' ) }</li>
-				<li>
-					{ translate( 'UTM tracking' ) }
-					<Icon
-						icon={ info }
-						ref={ trackingInfoIconRef }
-						onMouseEnter={ handleUTMTrackingPopoverOpen }
-						onMouseLeave={ handleUTMTrackingPopoverClose }
-					/>
-				</li>
+				{ config.isEnabled( 'stats/utm-module' ) && (
+					<li>
+						{ translate( 'UTM tracking' ) }
+						<Icon
+							icon={ info }
+							ref={ trackingInfoIconRef }
+							onMouseEnter={ handleUTMTrackingPopoverOpen }
+							onMouseLeave={ handleUTMTrackingPopoverClose }
+						/>
+					</li>
+				) }
 				<li>
 					{ translate( 'Traffic spike forgiveness' ) }
 					<Icon

--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -59,16 +59,16 @@ const StatsBenefitsCommercial = () => {
 
 	const spikeInfoIconRef = useRef( null );
 	const overageInfoIconRef = useRef( null );
-	const UTMTrackingInfoIconRef = useRef( null );
+	const trackingInfoIconRef = useRef( null );
 	const [ spikeInfoShow, setSpikeInfoShow ] = useState( false );
 	const handleSpikePopoverOpen = () => setSpikeInfoShow( true );
 	const handleSpikePopoverClose = () => setSpikeInfoShow( false );
 	const [ overageInfoShow, setOverageInfoShow ] = useState( false );
 	const handleOveragePopoverOpen = () => setOverageInfoShow( true );
 	const handleOveragePopoverClose = () => setOverageInfoShow( false );
-	const [ UTMTrackingInfoShow, setUTMTrackingInfoShow ] = useState( false );
-	const handleUTMTrackingPopoverOpen = () => setUTMTrackingInfoShow( true );
-	const handleUTMTrackingPopoverClose = () => setUTMTrackingInfoShow( false );
+	const [ trackingInfoShow, setTrackingInfoShow ] = useState( false );
+	const handleUTMTrackingPopoverOpen = () => setTrackingInfoShow( true );
+	const handleUTMTrackingPopoverClose = () => setTrackingInfoShow( false );
 
 	return (
 		<div className={ `${ COMPONENT_CLASS_NAME }__benefits` }>
@@ -84,7 +84,7 @@ const StatsBenefitsCommercial = () => {
 					{ translate( 'UTM tracking' ) }
 					<Icon
 						icon={ info }
-						ref={ UTMTrackingInfoIconRef }
+						ref={ trackingInfoIconRef }
 						onMouseEnter={ handleUTMTrackingPopoverOpen }
 						onMouseLeave={ handleUTMTrackingPopoverClose }
 					/>
@@ -134,8 +134,8 @@ const StatsBenefitsCommercial = () => {
 			</Popover>
 			<Popover
 				position="right"
-				isVisible={ UTMTrackingInfoShow }
-				context={ UTMTrackingInfoIconRef.current }
+				isVisible={ trackingInfoShow }
+				context={ trackingInfoIconRef.current }
 				className="stats-purchase__info-popover"
 			>
 				<div className="stats-purchase__info-popover-content">

--- a/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-shared.tsx
@@ -59,12 +59,16 @@ const StatsBenefitsCommercial = () => {
 
 	const spikeInfoIconRef = useRef( null );
 	const overageInfoIconRef = useRef( null );
+	const UTMTrackingInfoIconRef = useRef( null );
 	const [ spikeInfoShow, setSpikeInfoShow ] = useState( false );
 	const handleSpikePopoverOpen = () => setSpikeInfoShow( true );
 	const handleSpikePopoverClose = () => setSpikeInfoShow( false );
 	const [ overageInfoShow, setOverageInfoShow ] = useState( false );
 	const handleOveragePopoverOpen = () => setOverageInfoShow( true );
 	const handleOveragePopoverClose = () => setOverageInfoShow( false );
+	const [ UTMTrackingInfoShow, setUTMTrackingInfoShow ] = useState( false );
+	const handleUTMTrackingPopoverOpen = () => setUTMTrackingInfoShow( true );
+	const handleUTMTrackingPopoverClose = () => setUTMTrackingInfoShow( false );
 
 	return (
 		<div className={ `${ COMPONENT_CLASS_NAME }__benefits` }>
@@ -76,6 +80,15 @@ const StatsBenefitsCommercial = () => {
 				<li>{ translate( 'Access to upcoming advanced features' ) }</li>
 				<li>{ translate( 'Priority support' ) }</li>
 				<li>{ translate( 'Commercial use' ) }</li>
+				<li>
+					{ translate( 'UTM tracking' ) }
+					<Icon
+						icon={ info }
+						ref={ UTMTrackingInfoIconRef }
+						onMouseEnter={ handleUTMTrackingPopoverOpen }
+						onMouseLeave={ handleUTMTrackingPopoverClose }
+					/>
+				</li>
 				<li>
 					{ translate( 'Traffic spike forgiveness' ) }
 					<Icon
@@ -116,6 +129,18 @@ const StatsBenefitsCommercial = () => {
 				<div className="stats-purchase__info-popover-content">
 					{ translate(
 						'You will only be prompted to upgrade to higher tiers when you exceed the limit for three consecutive months.' // TODO: We need a 'learn more' link here.
+					) }
+				</div>
+			</Popover>
+			<Popover
+				position="right"
+				isVisible={ UTMTrackingInfoShow }
+				context={ UTMTrackingInfoIconRef.current }
+				className="stats-purchase__info-popover"
+			>
+				<div className="stats-purchase__info-popover-content">
+					{ translate(
+						'It enables you to measure and track traffic through UTM parameters in your URLs, providing a method to assess the success of your campaigns.'
 					) }
 				</div>
 			</Popover>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87579 

## Proposed Changes

* Add feature UTM tracking to the list on the Stats commercial purchase page.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change with the Calypso Live branch.
* Navigate to the Stats commercial purchase page: `/stats/purchase/{site-slug}?productType=commercial&flags=stats/utm-module`.
* Ensure the feature description `UTM tracking` and the hoverable info popover are on the feature list.

<img width="587" alt="截圖 2024-03-04 上午1 07 50" src="https://github.com/Automattic/wp-calypso/assets/6869813/d4e13cf6-704a-486e-bafd-5a988778a8d3">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?