### PR TITLE
Scheduled Updates: Rename url path from plugin-manager to scheduled-updates

### DIFF
--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -120,7 +120,7 @@ export function updatesManager( context, next ) {
 			context.primary = createElement( PluginsUpdateManager, {
 				siteSlug,
 				context: 'create',
-				onNavBack: () => page.redirect( `/plugins/update-manager/${ siteSlug }` ),
+				onNavBack: () => page.redirect( `/plugins/scheduled-updates/${ siteSlug }` ),
 			} );
 			break;
 
@@ -129,7 +129,8 @@ export function updatesManager( context, next ) {
 			context.primary = createElement( PluginsUpdateManager, {
 				siteSlug,
 				context: 'list',
-				onCreateNewSchedule: () => page.redirect( `/plugins/update-manager/create/${ siteSlug }` ),
+				onCreateNewSchedule: () =>
+					page.redirect( `/plugins/scheduled-updates/create/${ siteSlug }` ),
 			} );
 			break;
 	}

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -141,8 +141,8 @@ export default function ( router ) {
 
 	router(
 		[
-			`/${ langParam }/plugins/update-manager/:site_slug?`,
-			`/${ langParam }/plugins/update-manager/:action/:site_slug?`,
+			`/${ langParam }/plugins/scheduled-updates/:site_slug?`,
+			`/${ langParam }/plugins/scheduled-updates/:action/:site_slug?`,
 		],
 		redirectLoggedOut,
 		siteSelection,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88120

## Proposed Changes

* Update the url path from `/plugins/update-manager/{ATOMIC_SITE_SLUG}` to `/plugins/scheduled-updates/{ATOMIC_SITE_SLUG}`
* Update the url path from `/plugins/update-manager/create/{ATOMIC_SITE_SLUG}` to `/plugins/scheduled-updates/create/{ATOMIC_SITE_SLUG}`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `http://calypso.localhost:3000/plugins/scheduled-updates/{ATOMIC_SITE_SLUG}` and make sure the screen shows up correctly.
* Navigate to `http://calypso.localhost:3000/plugins/scheduled-updates/create/{ATOMIC_SITE_SLUG}` and make sure the screen shows up correctly.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?