### PR TITLE
Automattic for Agencies: Add Invoice initial layout with sections

### DIFF
--- a/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
+++ b/client/a8c-for-agencies/components/sidebar-menu/lib/constants.ts
@@ -7,3 +7,4 @@ export const A4A_MARKETPLACE_LINK = '/marketplace';
 export const A4A_PURCHASES_LINK = '/purchases';
 export const A4A_LICENSES_LINK = `${ A4A_PURCHASES_LINK }/licenses`;
 export const A4A_BILLING_LINK = `${ A4A_PURCHASES_LINK }/billing`;
+export const A4A_INVOICES_LINK = `${ A4A_PURCHASES_LINK }/invoices`;

--- a/client/a8c-for-agencies/components/sidebar-menu/purchases.tsx
+++ b/client/a8c-for-agencies/components/sidebar-menu/purchases.tsx
@@ -1,5 +1,5 @@
 import page from '@automattic/calypso-router';
-import { chevronLeft, key, store } from '@wordpress/icons';
+import { chevronLeft, key, store, receipt } from '@wordpress/icons';
 import { useTranslate } from 'i18n-calypso';
 import { useMemo } from 'react';
 import Sidebar from '../sidebar';
@@ -8,6 +8,7 @@ import {
 	A4A_PURCHASES_LINK,
 	A4A_LICENSES_LINK,
 	A4A_BILLING_LINK,
+	A4A_INVOICES_LINK,
 } from './lib/constants';
 import { createItem } from './lib/utils';
 
@@ -40,6 +41,18 @@ export default function ( { path }: Props ) {
 					title: translate( 'Billing' ),
 					trackEventProps: {
 						menu_item: 'Automattic for Agencies / Purchases / Billing',
+					},
+				},
+				path
+			),
+			createItem(
+				{
+					icon: receipt,
+					path: A4A_PURCHASES_LINK,
+					link: A4A_INVOICES_LINK,
+					title: translate( 'Invoices' ),
+					trackEventProps: {
+						menu_item: 'Automattic for Agencies / Purchases / Invoices',
 					},
 				},
 				path

--- a/client/a8c-for-agencies/sections/purchases/controller.tsx
+++ b/client/a8c-for-agencies/sections/purchases/controller.tsx
@@ -12,6 +12,7 @@ import {
 	LicenseSortField,
 } from 'calypso/jetpack-cloud/sections/partner-portal/types';
 import BillingDashboard from './billing/billing-dashboard';
+import InvoicesOverview from './invoices/invoices-overview';
 import LicensesOverview from './licenses/licenses-overview';
 
 export const purchasesContext: Callback = () => {
@@ -45,6 +46,13 @@ export const licensesContext: Callback = ( context, next ) => {
 export const billingContext: Callback = ( context, next ) => {
 	context.secondary = <PurchasesSidebar path={ context.path } />;
 	context.primary = <BillingDashboard />;
+
+	next();
+};
+
+export const invoicesContext: Callback = ( context, next ) => {
+	context.secondary = <PurchasesSidebar path={ context.path } />;
+	context.primary = <InvoicesOverview />;
 
 	next();
 };

--- a/client/a8c-for-agencies/sections/purchases/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/index.tsx
@@ -1,9 +1,11 @@
 import page from '@automattic/calypso-router';
 import { makeLayout, render as clientRender } from 'calypso/controller';
-import { purchasesContext, licensesContext, billingContext } from './controller';
+import { purchasesContext, licensesContext, billingContext, invoicesContext } from './controller';
 
 export default function () {
 	// FIXME: check access, TOS consent, and partner key selection
+
+	// Purchases
 	page( '/purchases', purchasesContext, makeLayout, clientRender );
 
 	// Licenses
@@ -13,9 +15,12 @@ export default function () {
 		makeLayout,
 		clientRender
 	);
-	// Redirect invalid license list filters back to the main portal page.
-	page( `/purchases/licenses/*`, '/purchases/licenses' );
+
+	page( `/purchases/licenses/*`, '/purchases/licenses' ); // Redirect invalid license list filters back to the main portal page.
 
 	// Billing
 	page( '/purchases/billing', billingContext, makeLayout, clientRender );
+
+	// Invoices
+	page( '/purchases/invoices', invoicesContext, makeLayout, clientRender );
 }

--- a/client/a8c-for-agencies/sections/purchases/invoices/invoices-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/invoices/invoices-overview/index.tsx
@@ -1,0 +1,29 @@
+import { useTranslate } from 'i18n-calypso';
+import Layout from 'calypso/a8c-for-agencies/components/layout';
+import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
+import LayoutHeader, {
+	LayoutHeaderTitle as Title,
+} from 'calypso/a8c-for-agencies/components/layout/header';
+import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
+import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
+import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+
+export default function InvoicesOverview() {
+	const translate = useTranslate();
+
+	const title = translate( 'Invoices' );
+
+	return (
+		<Layout title={ title } wide sidebarNavigation={ <MobileSidebarNavigation /> }>
+			<PageViewTracker title="Purchases > Invoices" path="/purchases/invoices" />
+
+			<LayoutTop>
+				<LayoutHeader>
+					<Title>{ title } </Title>
+				</LayoutHeader>
+			</LayoutTop>
+
+			<LayoutBody>Invoice List</LayoutBody>
+		</Layout>
+	);
+}

--- a/client/sections.js
+++ b/client/sections.js
@@ -730,7 +730,7 @@ const sections = [
 	},
 	{
 		name: 'a8c-for-agencies-purchases',
-		paths: [ '/purchases', 'purchases/licenses', 'purchases/billing' ],
+		paths: [ '/purchases', 'purchases/licenses', 'purchases/billing', 'purchases/invoices' ],
 		module: 'calypso/a8c-for-agencies/sections/purchases',
 		group: 'a8c-for-agencies',
 		enableLoggedOut: true,


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/270

## Proposed Changes

This PR adds:

- New "Purchases > Invoices" menu item
- Section for Invoices

## Testing Instructions

- Switch to the branch `git checkout add/a4a-invoice-initial-layout-with-sections`.
- Start the server by running `yarn start-a8c-for-agencies`.
- Click the `Purchases` menu item > Verify that you can see Invoices > Click Invoices and verify that you can see the below UI:

<img width="1147" alt="Screenshot 2024-03-04 at 11 19 30 AM" src="https://github.com/Automattic/wp-calypso/assets/10586875/b183b39c-b994-4480-aa0c-802588e5d2d3">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?