### PR TITLE
Automattic for Agencies: Implement Invoice list with actions using mock data

### DIFF
--- a/client/a8c-for-agencies/data/purchases/use-fetch-invoices.ts
+++ b/client/a8c-for-agencies/data/purchases/use-fetch-invoices.ts
@@ -1,0 +1,78 @@
+import config from '@automattic/calypso-config';
+import { useQuery, UseQueryOptions, UseQueryResult } from '@tanstack/react-query';
+import type { APIInvoices, Invoices } from 'calypso/state/partner-portal/types';
+
+interface QueryError {
+	code?: string;
+}
+
+interface Pagination {
+	starting_after: string;
+	ending_before: string;
+}
+
+const showDummyData = config.isEnabled( 'a4a/mock-api-data' );
+
+function queryInvoices() {
+	if ( showDummyData ) {
+		return {
+			items: [
+				{
+					id: 'in_test',
+					number: 'TEST-0132',
+					due_date: null,
+					status: 'paid',
+					total: 0,
+					currency: 'usd',
+					invoice_pdf: 'www.example.com/invoice.pdf',
+				},
+				{
+					id: 'in_test2',
+					number: 'TEST-0131',
+					due_date: null,
+					status: 'void',
+					total: 0,
+					currency: 'usd',
+					invoice_pdf: 'www.example.com/invoice.pdf',
+				},
+			],
+			has_more: false,
+		} as APIInvoices;
+	}
+	return {
+		items: [],
+		has_more: false,
+	};
+}
+
+function selectInvoices( api: APIInvoices ): Invoices {
+	return {
+		items: api.items.map( ( apiInvoice ) => ( {
+			id: apiInvoice.id,
+			number: apiInvoice.number,
+			dueDate: apiInvoice.due_date,
+			created: apiInvoice.created,
+			effectiveAt: apiInvoice.effective_at,
+			status: apiInvoice.status,
+			total: apiInvoice.total,
+			currency: apiInvoice.currency,
+			pdfUrl: apiInvoice.invoice_pdf,
+		} ) ),
+		hasMore: api.has_more,
+	};
+}
+
+export default function useFetchInvoices(
+	pagination: Pagination,
+	options?: UseQueryOptions< APIInvoices, QueryError, Invoices >
+): UseQueryResult< Invoices, QueryError > {
+	const activeKeyId = 'test'; // FIXME: Get active key ID from state
+
+	return useQuery< APIInvoices, QueryError, Invoices >( {
+		queryKey: [ 'a4a', 'invoices', activeKeyId, pagination ],
+		queryFn: queryInvoices,
+		refetchOnWindowFocus: false,
+		select: selectInvoices,
+		...options,
+	} );
+}

--- a/client/a8c-for-agencies/sections/purchases/invoices/hooks/use-pay-invoice-mutation.ts
+++ b/client/a8c-for-agencies/sections/purchases/invoices/hooks/use-pay-invoice-mutation.ts
@@ -1,0 +1,18 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import type { APIInvoice } from 'calypso/state/partner-portal/types';
+
+interface PayInvoiceMutationVariables {
+	invoiceId: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const noop = () => Promise.resolve() as unknown as Promise< APIInvoice >;
+
+export default function usePayInvoiceMutation< TContext = unknown >(
+	options?: UseMutationOptions< APIInvoice, Error, PayInvoiceMutationVariables, TContext >
+): UseMutationResult< APIInvoice, Error, PayInvoiceMutationVariables, TContext > {
+	return useMutation< APIInvoice, Error, PayInvoiceMutationVariables, TContext >( {
+		mutationFn: noop, // Implement actual API call
+		...options,
+	} );
+}

--- a/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-card/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-card/index.tsx
@@ -1,0 +1,87 @@
+import { Badge, Button, Gridicon } from '@automattic/components';
+import formatCurrency from '@automattic/format-currency';
+import { useTranslate } from 'i18n-calypso';
+import { memo, useCallback } from 'react';
+import FormattedDate from 'calypso/components/formatted-date';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import usePayInvoiceMutation from '../hooks/use-pay-invoice-mutation';
+import InvoicesListRow from '../invoices-list-row';
+import type { BadgeType } from '@automattic/components';
+import type { Invoice } from 'calypso/state/partner-portal/types';
+
+import './style.scss';
+
+function InvoicesListCard( { id, number, dueDate, status, total, currency, pdfUrl }: Invoice ) {
+	const translate = useTranslate();
+	const moment = useLocalizedMoment();
+	const dueDateMoment = moment( dueDate );
+	const payInvoice = usePayInvoiceMutation();
+
+	const pay = useCallback(
+		() => payInvoice.mutate( { invoiceId: id } ),
+		[ id, payInvoice.mutate ]
+	);
+
+	let badgeType: BadgeType = 'info';
+	let badgeLabel = translate( 'Draft' );
+
+	switch ( status ) {
+		case 'open':
+			badgeType = 'info-blue';
+			badgeLabel = translate( 'Open' );
+
+			if ( dueDateMoment.isBefore( moment() ) ) {
+				badgeType = 'warning';
+				badgeLabel = translate( 'Past due' );
+			}
+			break;
+
+		case 'paid':
+			badgeType = 'success';
+			badgeLabel = translate( 'Paid' );
+			break;
+
+		case 'uncollectible':
+			badgeType = 'error';
+			badgeLabel = translate( 'Uncollectible' );
+			break;
+
+		case 'void':
+			badgeType = 'info';
+			badgeLabel = translate( 'Void' );
+			break;
+	}
+
+	return (
+		<InvoicesListRow>
+			<div>{ number }</div>
+
+			<div>
+				{ dueDate && <FormattedDate date={ moment( dueDate ) } format="ll" /> }
+				{ ! dueDate && <Gridicon icon="minus" /> }
+			</div>
+
+			<div>
+				<Badge type={ badgeType }>{ badgeLabel }</Badge>
+			</div>
+
+			<div>{ formatCurrency( total, currency.toUpperCase() ) }</div>
+
+			<div className="invoices-list-card__actions">
+				{ status === 'open' && (
+					<Button compact primary busy={ payInvoice.isPending } onClick={ pay }>
+						{ translate( 'Pay' ) }
+					</Button>
+				) }
+
+				{ pdfUrl && (
+					<Button compact href={ pdfUrl } target="_blank" download>
+						{ translate( 'Download' ) }
+					</Button>
+				) }
+			</div>
+		</InvoicesListRow>
+	);
+}
+
+export default memo( InvoicesListCard );

--- a/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-card/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-card/style.scss
@@ -14,7 +14,7 @@
 		}
 
 		+ .button {
-			margin-left: 12px;
+			margin-inline-start: 12px;
 		}
 	}
 }

--- a/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-card/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-card/style.scss
@@ -1,0 +1,20 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.invoices-list-card__actions {
+	text-align: left;
+
+	@include break-xlarge() {
+		text-align: right;
+	}
+
+	.button {
+		&:focus {
+			border-width: 1px;
+		}
+
+		+ .button {
+			margin-left: 12px;
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-row/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-row/index.tsx
@@ -1,0 +1,25 @@
+import { Card } from '@automattic/components';
+import classnames from 'classnames';
+import { memo } from 'react';
+import type { PropsWithChildren } from 'react';
+
+import './style.scss';
+
+type Props = PropsWithChildren< {
+	header?: boolean;
+} >;
+
+function InvoicesListRow( { header, children }: Props ) {
+	return (
+		<Card
+			compact
+			className={ classnames( 'invoices-list-row', {
+				'invoices-list-row__header': header,
+			} ) }
+		>
+			<div className="invoices-list-row__content">{ children }</div>
+		</Card>
+	);
+}
+
+export default memo( InvoicesListRow );

--- a/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-row/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-row/style.scss
@@ -1,0 +1,30 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+
+.invoices-list-row__header {
+	display: none;
+
+	* {
+		font-weight: 400;
+		font-size: 0.875rem;
+		color: var(--studio-gray-70);
+	}
+
+	@include break-xlarge() {
+		display: block;
+	}
+}
+
+.invoices-list-row__content {
+	display: grid;
+	grid-template-columns: calc(34% - 16px) calc(34% - 16px) calc(34% - 16px);
+	align-items: center;
+	grid-gap: 24px;
+	font-size: 1.25rem;
+
+	@include break-xlarge() {
+		grid-template-columns: 160px 1fr 100px 100px 128px;
+	}
+}
+

--- a/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-row/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/invoices/invoices-list-row/style.scss
@@ -8,7 +8,7 @@
 	* {
 		font-weight: 400;
 		font-size: 0.875rem;
-		color: var(--studio-gray-70);
+		color: var(--color-neutral-70);
 	}
 
 	@include break-xlarge() {

--- a/client/a8c-for-agencies/sections/purchases/invoices/invoices-list/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/invoices/invoices-list/index.tsx
@@ -1,0 +1,150 @@
+import classnames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { memo, useCallback, useEffect, useState } from 'react';
+import TextPlaceholder from 'calypso/a8c-for-agencies/components/text-placeholder';
+import useFetchInvoices from 'calypso/a8c-for-agencies/data/purchases/use-fetch-invoices';
+import Pagination from 'calypso/components/pagination';
+import { useCursorPagination } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
+import { useDispatch } from 'calypso/state';
+import { errorNotice } from 'calypso/state/notices/actions';
+import InvoicesListCard from '../invoices-list-card';
+import InvoicesListRow from '../invoices-list-row';
+
+import './style.scss';
+
+const InvoicePlaceholderCard = memo( () => {
+	return (
+		<InvoicesListRow>
+			<div>
+				<TextPlaceholder />
+			</div>
+
+			<div>
+				<TextPlaceholder />
+			</div>
+
+			<div>
+				<TextPlaceholder />
+			</div>
+
+			<div>
+				<TextPlaceholder />
+			</div>
+
+			<div>
+				<TextPlaceholder />
+			</div>
+		</InvoicesListRow>
+	);
+} );
+
+export default function InvoicesList() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+	const [ pagination, setPagination ] = useState( { starting_after: '', ending_before: '' } );
+	const invoices = useFetchInvoices( pagination );
+
+	useEffect( () => {
+		if ( invoices.isError ) {
+			dispatch(
+				errorNotice( translate( 'We were unable to retrieve your invoices.' ), {
+					id: 'partner-portal-invoices-failure',
+					duration: 5000,
+				} )
+			);
+		}
+	}, [ dispatch, translate, invoices.isError ] );
+
+	const hasMore = invoices.isSuccess ? invoices.data.hasMore : false;
+	const onNavigateCallback = useCallback(
+		( page: number, direction: 'next' | 'prev' ) => {
+			if ( ! invoices.isSuccess || invoices.data.items.length === 0 ) {
+				return;
+			}
+
+			if ( page <= 1 ) {
+				setPagination( {
+					starting_after: '',
+					ending_before: '',
+				} );
+				return;
+			}
+
+			const items = invoices.data?.items;
+
+			setPagination(
+				direction === 'next'
+					? {
+							starting_after: items[ items.length - 1 ].id,
+							ending_before: '',
+					  }
+					: {
+							starting_after: '',
+							ending_before: items[ 0 ].id,
+					  }
+			);
+		},
+		[ invoices.isSuccess, invoices.data?.items, setPagination ]
+	);
+	const [ page, showPagination, onNavigate ] = useCursorPagination(
+		! invoices.isFetching,
+		hasMore,
+		onNavigateCallback
+	);
+
+	return (
+		<div className="invoices-list">
+			<InvoicesListRow header>
+				<div>{ translate( 'Number' ) }</div>
+				<div>{ translate( 'Due Date' ) }</div>
+				<div>{ translate( 'Status' ) }</div>
+				<div>{ translate( 'Total' ) }</div>
+				<div />
+			</InvoicesListRow>
+
+			{ invoices.isSuccess &&
+				! invoices.isFetching &&
+				invoices.data.items.map( ( invoice ) => (
+					<InvoicesListCard
+						key={ invoice.id }
+						id={ invoice.id }
+						number={ invoice.number }
+						dueDate={ invoice.dueDate }
+						created={ invoice.created }
+						effectiveAt={ invoice.effectiveAt }
+						status={ invoice.status }
+						total={ invoice.total }
+						currency={ invoice.currency }
+						pdfUrl={ invoice.pdfUrl }
+					/>
+				) ) }
+
+			{ invoices.isFetching && (
+				<>
+					<InvoicePlaceholderCard />
+					<InvoicePlaceholderCard />
+					<InvoicePlaceholderCard />
+					<InvoicePlaceholderCard />
+					<InvoicePlaceholderCard />
+					<InvoicePlaceholderCard />
+					<InvoicePlaceholderCard />
+					<InvoicePlaceholderCard />
+					<InvoicePlaceholderCard />
+					<InvoicePlaceholderCard />
+				</>
+			) }
+
+			{ showPagination && (
+				<Pagination
+					className={ classnames( 'invoices-list__pagination', {
+						'invoices-list__pagination--has-prev': page > 1,
+						'invoices-list__pagination--has-next': invoices.isFetching || hasMore,
+					} ) }
+					pageClick={ onNavigate }
+					page={ page }
+					perPage={ 10 }
+				/>
+			) }
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/purchases/invoices/invoices-list/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/invoices/invoices-list/style.scss
@@ -1,0 +1,7 @@
+@import "calypso/jetpack-cloud/sections/partner-portal/mixins.scss";
+
+.invoices-list__pagination {
+	margin: 64px 0;
+
+	@include licensing-portal-cursor-pagination();
+}

--- a/client/a8c-for-agencies/sections/purchases/invoices/invoices-overview/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/invoices/invoices-overview/index.tsx
@@ -7,6 +7,7 @@ import LayoutHeader, {
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import InvoicesList from '../invoices-list';
 
 export default function InvoicesOverview() {
 	const translate = useTranslate();
@@ -20,10 +21,13 @@ export default function InvoicesOverview() {
 			<LayoutTop>
 				<LayoutHeader>
 					<Title>{ title } </Title>
+					{ /* TODO: <SHOW_PARTNER_KEY_SELECTION_HERE /> */ }
 				</LayoutHeader>
 			</LayoutTop>
 
-			<LayoutBody>Invoice List</LayoutBody>
+			<LayoutBody>
+				<InvoicesList />
+			</LayoutBody>
 		</Layout>
 	);
 }


### PR DESCRIPTION
Resolves https://github.com/Automattic/jetpack-genesis/issues/271
Resolves https://github.com/Automattic/jetpack-genesis/issues/272

## Proposed Changes

This PR implements an invoice list with actions with mock data.

NOTE: 

- The invoice data is not real. They are mocked on the client side
- The "Pay" action for the invoice does nothing and will be implemented later.

## Testing Instructions

- Switch to the branch `git checkout add/implement-a4a-invoice-list`.
- Start the server by running `yarn start-a8c-for-agencies`.
- Click the `Purchases` menu item  > Click Invoices and verify that you can see the below UI:

<img width="1147" alt="Screenshot 2024-03-04 at 12 41 35 PM" src="https://github.com/Automattic/wp-calypso/assets/10586875/631cf72a-659c-4206-9068-7b9f9c48b24c">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?