### PR TITLE
Remove Manage All Domains link in the /me sidebar

### DIFF
--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -1,7 +1,7 @@
 import config from '@automattic/calypso-config';
 import { Button, Gridicon } from '@automattic/components';
-import { englishLocales, localizeUrl } from '@automattic/i18n-utils';
-import i18n, { localize } from 'i18n-calypso';
+import { localizeUrl } from '@automattic/i18n-utils';
+import { localize } from 'i18n-calypso';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import { withCurrentRoute } from 'calypso/components/route';
@@ -81,7 +81,7 @@ class MeSidebar extends Component {
 	}
 
 	renderMenu( options = {} ) {
-		const { context, locale, translate } = this.props;
+		const { context, translate } = this.props;
 		const path = context.path.replace( '/me', '' ); // Remove base path.
 
 		const { isGlobal } = options;
@@ -161,16 +161,6 @@ class MeSidebar extends Component {
 						label={ translate( 'Manage Blogs' ) }
 						materialIcon="apps"
 					/>
-
-					{ ( englishLocales.includes( locale ) ||
-						i18n.hasTranslation( 'Manage All Domains' ) ) && (
-						<SidebarItem
-							link="/domains/manage"
-							label={ translate( 'Manage All Domains' ) }
-							materialIcon="language"
-							forceExternalLink
-						/>
-					) }
 
 					<SidebarItem
 						selected={ itemLinkMatches( '/notifications', path ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5863

## Proposed Changes

As discussed in pdtkmj-2rq-p2#comment-4493, we are no longer interested in having the link Manage All Domains in the /me sidebar.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/me`.
* Ensure that the link Manage All Domains is no longer there.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?