### PR TITLE
Migration success screen: Remove translation machinery

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/migration-success/index.tsx
+++ b/client/blocks/importer/wordpress/import-everything/migration-success/index.tsx
@@ -1,6 +1,6 @@
 import { Card } from '@automattic/components';
 import { type SiteDetails } from '@automattic/data-stores';
-import { localizeUrl, useIsEnglishLocale } from '@automattic/i18n-utils';
+import { localizeUrl } from '@automattic/i18n-utils';
 import { SubTitle, Title } from '@automattic/onboarding';
 import {
 	CardBody,
@@ -28,8 +28,7 @@ export default function MigrationSuccess( {
 	targetSite,
 	recordTracksEvent,
 }: MigrationSuccessProps ) {
-	const { __, hasTranslation } = useI18n();
-	const isEnglishLocale = useIsEnglishLocale();
+	const { __ } = useI18n();
 	const navigateToSite =
 		( url: string, isWpAdmin = false ) =>
 		( e: React.MouseEvent< HTMLButtonElement > ): void => {
@@ -40,25 +39,10 @@ export default function MigrationSuccess( {
 			redirect( url, isWpAdmin );
 		};
 
-	const linkText =
-		isEnglishLocale || hasTranslation( 'Migration support resources' )
-			? __( 'Migration support resources' )
-			: 'Explore support resources'; //Temporary fallback
-
-	const titleText =
-		isEnglishLocale || hasTranslation( 'Say hello to your new home' )
-			? __( 'Say hello to your new home' )
-			: __( 'Hooray' ); //Temporary fallback
-
-	const subtitleText =
-		isEnglishLocale || hasTranslation( 'All set! Your content was successfully imported.' )
-			? __( 'All set! Your content was successfully imported.' )
-			: __( 'Congratulations. Your content was successfully imported.' ); //Temporary fallback
-
 	return (
 		<>
-			<Title> { titleText } </Title>
-			<SubTitle>{ subtitleText }</SubTitle>
+			<Title> { __( 'Say hello to your new home' ) } </Title>
+			<SubTitle>{ __( 'All set! Your content was successfully imported.' ) }</SubTitle>
 
 			<Card size="small">
 				<CardBody>
@@ -137,9 +121,9 @@ export default function MigrationSuccess( {
 						) }
 						target="_blank"
 						rel="noopener noreferrer"
-						title={ linkText }
+						title={ __( 'Migration support resources' ) }
 					>
-						{ linkText }
+						{ __( 'Migration support resources' ) }
 					</Link>
 				</VStack>
 			</Flex>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/87990

## Proposed Changes

Removing the translation machinery

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?