### PR TITLE
Untangle: show Odyssey stats link in My Home

### DIFF
--- a/client/my-sites/customer-home/cards/features/stats/index.jsx
+++ b/client/my-sites/customer-home/cards/features/stats/index.jsx
@@ -13,7 +13,11 @@ import InlineSupportLink from 'calypso/components/inline-support-link';
 import { preventWidows } from 'calypso/lib/formatting';
 import { buildChartData } from 'calypso/my-sites/stats/stats-chart-tabs/utility';
 import isUnlaunchedSite from 'calypso/state/selectors/is-unlaunched-site';
-import { getSiteOption } from 'calypso/state/sites/selectors';
+import {
+	getSiteAdminUrl,
+	getSiteOption,
+	isGlobalSiteViewEnabled as getIsGlobalSiteViewEnabled,
+} from 'calypso/state/sites/selectors';
 import { requestChartCounts } from 'calypso/state/stats/chart-tabs/actions';
 import { getCountRecords, getLoadingTabs } from 'calypso/state/stats/chart-tabs/selectors';
 import {
@@ -35,11 +39,13 @@ export const StatsV2 = ( {
 	insightsQuery,
 	isLoading,
 	isSiteUnlaunched,
+	isGlobalSiteViewEnabled,
 	mostPopularDay,
 	mostPopularTime,
 	siteCreatedAt,
 	siteId,
 	siteSlug,
+	siteAdminUrl,
 	topPage,
 	topPost,
 	topPostsQuery,
@@ -163,7 +169,14 @@ export const StatsV2 = ( {
 							) }
 						</div>
 						<div className="stats__all">
-							<a href={ `/stats/day/${ siteSlug }` } className="stats__all-link">
+							<a
+								href={
+									isGlobalSiteViewEnabled
+										? `${ siteAdminUrl }admin.php?page=stats`
+										: `/stats/day/${ siteSlug }`
+								}
+								className="stats__all-link"
+							>
 								{ translate( 'See all stats' ) }
 							</a>
 						</div>
@@ -269,7 +282,9 @@ const isLoadingStats = ( state, siteId, chartQuery, insightsQuery, topPostsQuery
 const mapStateToProps = ( state ) => {
 	const siteId = getSelectedSiteId( state );
 	const siteSlug = getSelectedSiteSlug( state );
+	const siteAdminUrl = getSiteAdminUrl( state, siteId );
 	const isSiteUnlaunched = isUnlaunchedSite( state, siteId );
+	const isGlobalSiteViewEnabled = getIsGlobalSiteViewEnabled( state, siteId );
 	const siteCreatedAt = getSiteOption( state, siteId, 'created_at' );
 
 	const { chartQuery, insightsQuery, topPostsQuery, visitsQuery } = getStatsQueries(
@@ -297,9 +312,11 @@ const mapStateToProps = ( state ) => {
 		insightsQuery,
 		isLoading: canShowStatsData ? statsData.chartData.length !== chartQuery.quantity : isLoading,
 		isSiteUnlaunched,
+		isGlobalSiteViewEnabled,
 		siteCreatedAt,
 		siteId,
 		siteSlug,
+		siteAdminUrl,
 		topPostsQuery,
 		visitsQuery,
 		...statsData,


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/5723

## Proposed Changes

After:

- https://github.com/Automattic/jetpack/pull/35528

was merged, the wp-admin version of Stats is now on par with Calypso's, so we can start pointing stats links to it.

This PR modifies the Stats card in My Home so that the "See all stats" link points to the wp-admin page:

<img width="1026" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1525580/75fcc7a3-f4d0-4397-94bf-ccdd9698ebda">


## Testing Instructions

> [!NOTE]  
> This needs https://github.com/Automattic/jetpack/pull/35528 to be deployed to Atomic sites. Alternatively, use Bleeding version of Jetpack via the Beta Tester.

1. Prepare an Atomic site with admin interface style set to classic.
1. Go to My Home
2. Scroll down until you see the "Views" card
3. Verify that the "See all stats" link points to the wp-admin page as shown in the above screenshot.

> [!NOTE]  
> If for some reason, you don't have stats yet for you site, you could check out this branch locally and apply this patch:

```diff
diff --git a/client/my-sites/customer-home/cards/features/stats/index.jsx b/client/my-sites/customer-home/cards/features/stats/index.jsx
index 0853ba64edc..a27952973ed 100644
--- a/client/my-sites/customer-home/cards/features/stats/index.jsx
+++ b/client/my-sites/customer-home/cards/features/stats/index.jsx
@@ -76,7 +76,7 @@ export const StatsV2 = ( {
                                ),
                                4
                  );
-       const renderChart = ! isSiteUnlaunched && ! isLoading && views > 0;
+       const renderChart = ! isSiteUnlaunched && ! isLoading;

        return (
                <div className="stats">
```

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?