### PR TITLE
Help Center: Improve search result dev indicator

### DIFF
--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -18,6 +18,7 @@ import {
 	chevronRight,
 	external as externalIcon,
 } from '@wordpress/icons';
+import { useRtl } from 'i18n-calypso';
 import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import { Fragment, useEffect, useMemo } from 'react';
@@ -121,6 +122,8 @@ function HelpSearchResults( {
 		() => getContextResults( sectionName, siteIntent ),
 		[ sectionName, siteIntent ]
 	);
+
+	const isRtl = useRtl();
 	const locale = useLocale();
 	const contextualResults = rawContextualResults.filter(
 		// Unless searching with Inline Help or on the Purchases section, hide the
@@ -231,10 +234,7 @@ function HelpSearchResults( {
 
 		const DeveloperResourceIndicator = () => {
 			return (
-				<div className="help-center-search-results-dev__resource">
-					{ /* translators: Dev is an acronym of Developers */ }
-					{ __( 'Dev', __i18n_text_domain__ ) }
-				</div>
+				<div className="help-center-search-results-dev__resource">{ isRtl ? 'ved' : 'dev' }</div>
 			);
 		};
 

--- a/packages/help-center/src/components/help-center-search-results.tsx
+++ b/packages/help-center/src/components/help-center-search-results.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-imports */
 import page from '@automattic/calypso-router';
-import { Gridicon, Badge } from '@automattic/components';
+import { Gridicon } from '@automattic/components';
 import {
 	getContextResults,
 	LinksForSection,
@@ -229,16 +229,11 @@ function HelpSearchResults( {
 			return <Icon icon={ pageIcon } />;
 		};
 
-		const DeveloperBadge = () => {
+		const DeveloperResourceIndicator = () => {
 			return (
-				<div className="help-center-search-results__content">
-					{ isResultFromDeveloperWordpress( result.link ) && (
-						<Badge type="info" className="help-center-search-results__badge">
-							{ /* translators: Dev is an acronym of Developers */ }
-							{ __( 'Dev', __i18n_text_domain__ ) }
-						</Badge>
-					) }
-					<span>{ preventWidows( decodeEntities( title ) ) }</span>
+				<div className="help-center-search-results-dev__resource">
+					{ /* translators: Dev is an acronym of Developers */ }
+					{ __( 'Dev', __i18n_text_domain__ ) }
 				</div>
 			);
 		};
@@ -260,8 +255,12 @@ function HelpSearchResults( {
 								rel: 'noreferrer',
 							} ) }
 						>
-							<LinkIcon />
-							<DeveloperBadge />
+							{ isResultFromDeveloperWordpress( result.link ) ? (
+								<DeveloperResourceIndicator />
+							) : (
+								<LinkIcon />
+							) }
+							<span>{ preventWidows( decodeEntities( title ) ) }</span>
 							<Icon
 								width={ 20 }
 								height={ 20 }

--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -144,6 +144,7 @@
 					.help-center-search-results-dev__resource {
 						text-transform: uppercase;
 						font-weight: 500;
+						font-size: 0.75rem;
 					}
 
 					svg:last-child {

--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -132,12 +132,18 @@
 					color: var(--studio-gray-100);
 					font-size: $font-body-small;
 
-					svg:first-child {
+					svg:first-child,
+					.help-center-search-results-dev__resource {
 						margin-right: 15px;
 						display: block;
 						background: var(--studio-gray-0);
 						fill: var(--studio-blue-50);
 						padding: 8px;
+					}
+
+					.help-center-search-results-dev__resource {
+						text-transform: uppercase;
+						font-weight: 500;
 					}
 
 					svg:last-child {
@@ -148,15 +154,7 @@
 						display: block;
 						align-self: center;
 					}
-					.help-center-search-results__content {
-						width: 100%;
-						.help-center-search-results__badge {
-							height: auto;
-							font-size: $font-body-extra-small;
-							padding: 0 8px;
-							text-transform: uppercase;
-						}
-					}
+
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88126
Fixes https://github.com/Automattic/wp-calypso/issues/88126

## Proposed Changes

* This PR is an improved design version of this https://github.com/Automattic/wp-calypso/pull/87838
* Instead of showing the "Dev" badge, it renders "Dev" instead of the page icon, to makes the result item less poluted.


Before:
<img width="414" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/c2014f86-932d-498b-bca7-fda7e75a133a">

After:
<img width="401" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/3ed280f5-6ccf-4071-b8c8-d59c44aee5ee">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull this branch and run calypso or use live link
* Open the help center and check if results from developers have the “DEV” indicator instead of the page icon
* Search for “OAuth”, “PHP” play with it :)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?