### PR TITLE
i18n: Localize Viewer site role display name

### DIFF
--- a/client/data/site-roles/use-site-roles-query.js
+++ b/client/data/site-roles/use-site-roles-query.js
@@ -1,14 +1,17 @@
 import { useQuery } from '@tanstack/react-query';
+import { useTranslate } from 'i18n-calypso';
 import wp from 'calypso/lib/wp';
 
 function useSiteRolesQuery( siteId, queryOptions = {} ) {
+	const translate = useTranslate();
+
 	return useQuery( {
 		queryKey: [ 'site-roles', siteId ],
 		queryFn: () => wp.req.get( `/sites/${ siteId }/roles` ),
 		...queryOptions,
 		select: ( { roles } ) => {
 			return roles.map( ( role ) =>
-				role.name === 'subscriber' ? { ...role, display_name: 'Viewer' } : role
+				role.name === 'subscriber' ? { ...role, display_name: translate( 'Viewer' ) } : role
 			);
 		},
 		enabled: !! siteId,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 752-gh-Automattic/i18n-issues

## Proposed Changes

* Wrap `Viewer` display name for subscriber role in `translate()` call.

**Before:**
![AmZ4Ta8QFbt2fRwh](https://github.com/Automattic/wp-calypso/assets/2722412/ba42c0b5-e96e-490f-a838-8b8bf40030e1)

**After:**
![Muf88L8X6knKDdVX](https://github.com/Automattic/wp-calypso/assets/2722412/79893675-fd16-4348-8dc0-40f4d0cfcc7f)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Change UI to a Mag-16 langauge.
* Navigate to `/marketing/traffic/`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
