### PR TITLE
change colors on whats-new panel

### DIFF
--- a/packages/whats-new/src/style.scss
+++ b/packages/whats-new/src/style.scss
@@ -100,7 +100,7 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-content-spacing * 2 );
 				font-size: $font-body-small;
 
 				&:focus {
-					border: none;
+					border-color: transparent;
 					box-shadow: 0 0 0 2px var(--color-accent-light);
 				}
 			}
@@ -173,7 +173,7 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-content-spacing * 2 );
 	height: 50%;
 	max-height: 230px;
 	padding: 32px 52px 0;
-	background: #afbcf7;
+	background: #a6b1ee;
 	text-align: center;
 	display: flex;
 	flex-direction: column;

--- a/packages/whats-new/src/style.scss
+++ b/packages/whats-new/src/style.scss
@@ -93,14 +93,15 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-content-spacing * 2 );
 			}
 
 			.guide__forward-button {
-				background-color: var(--wp-admin-theme-color);
-				border-color: var(--wp-admin-theme-color);
+				background-color: var(--color-accent);
+				border-color: var(--color-accent);
 
 				color: var(--color-text-inverted);
 				font-size: $font-body-small;
 
 				&:focus {
 					border: none;
+					box-shadow: 0 0 0 2px var(--color-accent-light);
 				}
 			}
 
@@ -172,7 +173,7 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-content-spacing * 2 );
 	height: 50%;
 	max-height: 230px;
 	padding: 32px 52px 0;
-	background: var(--studio-blue-50);
+	background: #afbcf7;
 	text-align: center;
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
Basically the videos for the whats-new guide for the global nav project are made with a pastel blue background.

This updates the background to match.

And also updates the button color to be pink.
<img width="753" alt="Screenshot 2024-03-04 at 8 53 07 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/722a1434-4fc0-452a-9789-3a5cee2ffc67">

before:
<img width="746" alt="Screenshot 2024-03-04 at 8 55 42 pm" src="https://github.com/Automattic/wp-calypso/assets/22446385/2eaf0834-421e-4231-b5c8-bb50f7fa6d20">




See discussion about potential future changes here pfsHM7-cD-p2#comment-501