### PR TITLE
Plugin scheduler: Remove managed plugins from list

### DIFF
--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -12,7 +12,7 @@ import {
 } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
-import { Fragment, useState, useCallback, useEffect, useMemo } from 'react';
+import { Fragment, useState, useCallback, useEffect } from 'react';
 import { useCorePluginsQuery, type CorePlugin } from 'calypso/data/plugins/use-core-plugins-query';
 import { useCreateScheduleUpdatesMutation } from 'calypso/data/plugins/use-schedule-updates-mutation';
 import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updates-query';
@@ -40,16 +40,12 @@ interface Props {
 }
 export const ScheduleForm = ( props: Props ) => {
 	const { siteSlug, onCreateSuccess } = props;
+
 	const {
-		data: dataPlugins,
+		data: plugins = [],
 		isLoading: isPluginsFetching,
 		isFetched: isPluginsFetched,
-	} = useCorePluginsQuery( siteSlug );
-	const plugins = useMemo( () => {
-		const plugins = dataPlugins ?? [];
-		// don't display managed plugins
-		return plugins.filter( ( plugin ) => ! plugin.is_managed );
-	}, [ dataPlugins ] );
+	} = useCorePluginsQuery( siteSlug, true );
 	const { data: schedules = [] } = useScheduleUpdatesQuery( siteSlug );
 	const { createScheduleUpdates } = useCreateScheduleUpdatesMutation( siteSlug, {
 		onSuccess: () => onCreateSuccess && onCreateSuccess(),

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -12,10 +12,10 @@ import {
 } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
-import { Fragment, useState, useCallback, useEffect } from 'react';
+import { Fragment, useState, useCallback, useEffect, useMemo } from 'react';
+import { useCorePluginsQuery, type CorePlugin } from 'calypso/data/plugins/use-core-plugins-query';
 import { useCreateScheduleUpdatesMutation } from 'calypso/data/plugins/use-schedule-updates-mutation';
 import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updates-query';
-import { useSitePluginsQuery, type SitePlugin } from 'calypso/data/plugins/use-site-plugins-query';
 import { SiteSlug } from 'calypso/types';
 import { MAX_SELECTABLE_PLUGINS } from './config';
 import {
@@ -44,12 +44,16 @@ export const ScheduleForm = ( props: Props ) => {
 		data: dataPlugins,
 		isLoading: isPluginsFetching,
 		isFetched: isPluginsFetched,
-	} = useSitePluginsQuery( siteSlug );
+	} = useCorePluginsQuery( siteSlug );
+	const plugins = useMemo( () => {
+		const plugins = dataPlugins ?? [];
+		// don't display managed plugins
+		return plugins.filter( ( plugin ) => ! plugin.is_managed );
+	}, [ dataPlugins ] );
 	const { data: schedules = [] } = useScheduleUpdatesQuery( siteSlug );
 	const { createScheduleUpdates } = useCreateScheduleUpdatesMutation( siteSlug, {
 		onSuccess: () => onCreateSuccess && onCreateSuccess(),
 	} );
-	const { plugins = [] } = dataPlugins ?? {};
 
 	const [ name, setName ] = useState( '' );
 	const [ selectedPlugins, setSelectedPlugins ] = useState< string[] >( [] );
@@ -72,13 +76,13 @@ export const ScheduleForm = ( props: Props ) => {
 	const [ fieldTouched, setFieldTouched ] = useState< Record< string, boolean > >( {} );
 
 	const onPluginSelectionChange = useCallback(
-		( plugin: SitePlugin, isChecked: boolean ) => {
+		( plugin: CorePlugin, isChecked: boolean ) => {
 			if ( isChecked ) {
 				const _plugins: string[] = [ ...selectedPlugins ];
-				_plugins.push( plugin.name );
+				_plugins.push( plugin.plugin );
 				setSelectedPlugins( _plugins );
 			} else {
-				setSelectedPlugins( selectedPlugins.filter( ( name ) => name !== plugin.name ) );
+				setSelectedPlugins( selectedPlugins.filter( ( name ) => name !== plugin.plugin ) );
 			}
 		},
 		[ selectedPlugins ]
@@ -87,20 +91,20 @@ export const ScheduleForm = ( props: Props ) => {
 	const onPluginSelectAllChange = useCallback(
 		( isChecked: boolean ) => {
 			isChecked
-				? setSelectedPlugins( plugins.map( ( plugin ) => plugin.name ) ?? [] )
+				? setSelectedPlugins( plugins.map( ( plugin ) => plugin.plugin ) ?? [] )
 				: setSelectedPlugins( [] );
 		},
 		[ plugins ]
 	);
 
 	const isPluginSelectionDisabled = useCallback(
-		( plugin: SitePlugin ) => {
+		( plugin: CorePlugin ) => {
 			return (
 				selectedPlugins.length >= MAX_SELECTABLE_PLUGINS &&
-				! selectedPlugins.includes( plugin.name )
+				! selectedPlugins.includes( plugin.plugin )
 			);
 		},
-		[ selectedPlugins, MAX_SELECTABLE_PLUGINS ]
+		[ selectedPlugins ]
 	);
 
 	const onFormSubmit = () => {
@@ -306,14 +310,12 @@ export const ScheduleForm = ( props: Props ) => {
 								) }
 								{ isPluginsFetched &&
 									plugins.map( ( plugin ) => (
-										<Fragment key={ plugin.name }>
-											{ plugin.display_name
-												.toLowerCase()
-												.includes( pluginSearchTerm.toLowerCase() ) && (
+										<Fragment key={ plugin.plugin }>
+											{ plugin.name.toLowerCase().includes( pluginSearchTerm.toLowerCase() ) && (
 												<CheckboxControl
-													key={ plugin.name }
-													label={ plugin.display_name }
-													checked={ selectedPlugins.includes( plugin.name ) }
+													key={ plugin.plugin }
+													label={ plugin.name }
+													checked={ selectedPlugins.includes( plugin.plugin ) }
 													disabled={ isPluginSelectionDisabled( plugin ) }
 													className={ classnames( {
 														disabled: isPluginSelectionDisabled( plugin ),

--- a/client/data/plugins/use-core-plugins-query.ts
+++ b/client/data/plugins/use-core-plugins-query.ts
@@ -1,0 +1,47 @@
+import { useQuery, UseQueryResult } from '@tanstack/react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+import type { SiteId, SiteSlug } from 'calypso/types';
+
+export type CorePlugin = {
+	plugin: string;
+	status: 'active' | 'inactive';
+	name: string;
+	plugin_uri: string;
+	author: string;
+	author_uri: string;
+	description: string;
+	version: string;
+	network_only: boolean;
+	requires_wp: string;
+	requires_php: string;
+	textdomain: string;
+	is_managed?: boolean;
+	_links: { self: { [ key: number ]: { href: string } } };
+};
+
+export type CorePluginsResponse = CorePlugin[];
+
+/**
+ * Fetches the plugins for a given site
+ * @param siteIdOrSlug The site ID or slug
+ */
+export const useCorePluginsQuery = (
+	siteIdOrSlug: SiteId | SiteSlug | undefined
+): UseQueryResult< CorePluginsResponse > => {
+	return useQuery( {
+		queryKey: [ 'core-plugins', siteIdOrSlug ],
+		queryFn: () => {
+			return wpcomRequest( {
+				path: `/sites/${ siteIdOrSlug }/plugins`,
+				apiVersion: '2',
+				apiNamespace: 'wp/v2',
+			} );
+		},
+		meta: {
+			persist: false,
+		},
+		enabled: !! siteIdOrSlug,
+		retry: false,
+		refetchOnWindowFocus: false,
+	} );
+};

--- a/client/data/plugins/use-core-plugins-query.ts
+++ b/client/data/plugins/use-core-plugins-query.ts
@@ -26,9 +26,14 @@ export type CorePluginsResponse = CorePlugin[];
  * @param siteIdOrSlug The site ID or slug
  */
 export const useCorePluginsQuery = (
-	siteIdOrSlug: SiteId | SiteSlug | undefined
+	siteIdOrSlug: SiteId | SiteSlug | undefined,
+	hideManagedPlugins: boolean = false
 ): UseQueryResult< CorePluginsResponse > => {
-	return useQuery( {
+	const select = hideManagedPlugins
+		? ( plugins: CorePluginsResponse ) => plugins.filter( ( plugin ) => ! plugin.is_managed )
+		: undefined;
+
+	return useQuery< CorePluginsResponse >( {
 		queryKey: [ 'core-plugins', siteIdOrSlug ],
 		queryFn: () => {
 			return wpcomRequest( {
@@ -43,5 +48,6 @@ export const useCorePluginsQuery = (
 		enabled: !! siteIdOrSlug,
 		retry: false,
 		refetchOnWindowFocus: false,
+		select,
 	} );
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5665

## Proposed Changes

* This implements a core plugin endpoint and filters away the managed plugins.

## Testing Instructions

* Make sure you have the latest version of WordPress.com Features selected via the Jetpack Beta plugin.
* Switch to your WoA site.
* Go to `/plugins/scheduled-updates/create/woa.wpcomstaging.com`.
* Make sure managed plugins are not updated (verify by querying GET wp/v2/sites/woa.wpcomstaging.com/plugins in the developer console)

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?