### PR TITLE
Untangle: Enable layout/dotcom-nav-redesign in all env

### DIFF
--- a/config/production.json
+++ b/config/production.json
@@ -98,7 +98,7 @@
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
-		"layout/dotcom-nav-redesign": false,
+		"layout/dotcom-nav-redesign": true,
 		"legal-updates-banner": false,
 		"livechat_solution": true,
 		"login/github": false,

--- a/config/stage.json
+++ b/config/stage.json
@@ -92,7 +92,7 @@
 		"layout/guided-tours": true,
 		"layout/query-selected-editor": true,
 		"layout/support-article-dialog": true,
-		"layout/dotcom-nav-redesign": false,
+		"layout/dotcom-nav-redesign": true,
 		"legal-updates-banner": false,
 		"livechat_solution": true,
 		"login/github": true,


### PR DESCRIPTION
Related to:

- https://github.com/Automattic/dotcom-forge/issues/5838

## Proposed Changes

This launches the nav redesign in production (and staging).

## Testing Instructions

N/A

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?