### PR TITLE
Router: respect redirect_to for logged in

### DIFF
--- a/client/login/redirect-logged-in/index.web.js
+++ b/client/login/redirect-logged-in/index.web.js
@@ -5,7 +5,8 @@ export default function redirectLoggedIn( context, next ) {
 
 	if ( userLoggedIn ) {
 		// force full page reload to avoid SSR hydration issues.
-		window.location = '/';
+		// Redirect parameters should have higher priority.
+		window.location = context?.query?.redirect_to ?? '/';
 		return;
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

In D139279-code we have identified that `redirect_to` parameter is not respected for logged in users and instead we are force redirected to `/`. This PR attempts to give priority to `redirect_to` if it's not null.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Perform the following while logged in

Regressions
* load `/log-in/qr/en`
* you should land to `/home/:default_site`

New Behaviour

* load `/log-in/qr/en?redirect_to=/plugins`
* you should land to `/plugins`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?