### PR TITLE
Assembler Pattern Metrics: Use title rather than name

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -225,17 +225,17 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 				.filter( Boolean )
 				.join( ',' ),
 			pattern_ids: patterns.map( ( { ID } ) => ID ).join( ',' ),
-			pattern_names: patterns.map( ( { name } ) => name ).join( ',' ),
+			pattern_names: patterns.map( ( { title } ) => title ).join( ',' ),
 			pattern_categories: categories.join( ',' ),
 			category_count: categories.length,
 			pattern_count: patterns.length,
 			page_slugs: ( pageSlugs || [] ).join( ',' ),
 		} );
 
-		patterns.forEach( ( { ID, name, category } ) => {
+		patterns.forEach( ( { ID, title, category } ) => {
 			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_FINAL_SELECT, {
 				pattern_id: ID,
-				pattern_name: name,
+				pattern_name: title,
 				pattern_category: category?.name,
 			} );
 		} );
@@ -244,7 +244,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 			const category_slug = Object.keys( pattern.categories )[ 0 ];
 			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PAGE_FINAL_SELECT, {
 				pattern_id: pattern.ID,
-				pattern_name: pattern.name,
+				pattern_name: pattern.title,
 				...( category_slug && { pattern_category: category_slug } ),
 			} );
 		} );
@@ -347,7 +347,7 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 			trackEventPatternSelect( {
 				patternType: type,
 				patternId: selectedPattern.ID,
-				patternName: selectedPattern.name,
+				patternName: selectedPattern.title,
 				patternCategory: selectedPattern.category?.name,
 			} );
 

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/index.tsx
@@ -201,17 +201,20 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 		patternType,
 		patternId,
 		patternName,
+		patternTitle,
 		patternCategory,
 	}: {
 		patternType: string;
 		patternId: number;
 		patternName: string;
+		patternTitle: string;
 		patternCategory: string | undefined;
 	} ) => {
 		recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_SELECT_CLICK, {
 			pattern_type: patternType,
 			pattern_id: patternId,
 			pattern_name: patternName,
+			pattern_title: patternTitle,
 			pattern_category: patternCategory,
 		} );
 	};
@@ -225,17 +228,18 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 				.filter( Boolean )
 				.join( ',' ),
 			pattern_ids: patterns.map( ( { ID } ) => ID ).join( ',' ),
-			pattern_names: patterns.map( ( { title } ) => title ).join( ',' ),
+			pattern_names: patterns.map( ( { name } ) => name ).join( ',' ),
 			pattern_categories: categories.join( ',' ),
 			category_count: categories.length,
 			pattern_count: patterns.length,
 			page_slugs: ( pageSlugs || [] ).join( ',' ),
 		} );
 
-		patterns.forEach( ( { ID, title, category } ) => {
+		patterns.forEach( ( { ID, name, title, category } ) => {
 			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PATTERN_FINAL_SELECT, {
 				pattern_id: ID,
-				pattern_name: title,
+				pattern_name: name,
+				pattern_title: title,
 				pattern_category: category?.name,
 			} );
 		} );
@@ -244,7 +248,8 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 			const category_slug = Object.keys( pattern.categories )[ 0 ];
 			recordTracksEvent( PATTERN_ASSEMBLER_EVENTS.PAGE_FINAL_SELECT, {
 				pattern_id: pattern.ID,
-				pattern_name: pattern.title,
+				pattern_name: pattern.name,
+				pattern_title: pattern.title,
 				...( category_slug && { pattern_category: category_slug } ),
 			} );
 		} );
@@ -347,7 +352,8 @@ const PatternAssembler = ( props: StepProps & NoticesProps ) => {
 			trackEventPatternSelect( {
 				patternType: type,
 				patternId: selectedPattern.ID,
-				patternName: selectedPattern.title,
+				patternName: selectedPattern.name,
+				patternTitle: selectedPattern.title,
 				patternCategory: selectedPattern.category?.name,
 			} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to p1709532833775019-slack-CRWCHQGUB

## Proposed Changes

* Add pattern `title` on Tracks events for pattern usage

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Access the assembler
* Insert patterns and verify the Tracks events include `pattern_title`

<img width="785" alt="Screenshot 2567-03-05 at 17 33 14" src="https://github.com/Automattic/wp-calypso/assets/1881481/90804687-565b-4d90-b69f-0a7337407e2a">

* Continue to complete the flow and verify the final Tracks event include `pattern_title` too.

<img width="783" alt="Screenshot 2567-03-05 at 17 34 05" src="https://github.com/Automattic/wp-calypso/assets/1881481/1d46e91d-e206-4afd-b5e6-3228b034f2a5">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [X] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [X] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [X] Have you checked for TypeScript, React or other console errors?
- [X] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [X] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [X] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?