### PR TITLE
Plugins update manager: Edit schedule

### DIFF
--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -12,13 +12,14 @@ import './styles.scss';
 
 interface Props {
 	siteSlug: string;
-	context: 'list' | 'create';
+	context: 'list' | 'create' | 'edit';
+	scheduleId?: string;
 	onNavBack?: () => void;
 	onCreateNewSchedule?: () => void;
 	onEditSchedule?: ( id: string ) => void;
 }
 export const PluginsUpdateManager = ( props: Props ) => {
-	const { siteSlug, context, onNavBack, onCreateNewSchedule, onEditSchedule } = props;
+	const { siteSlug, context, scheduleId, onNavBack, onCreateNewSchedule, onEditSchedule } = props;
 	const { data: schedules = [] } = useScheduleUpdatesQuery( siteSlug );
 	const hideCreateButton = schedules.length === MAX_SCHEDULES || schedules.length === 0;
 
@@ -52,7 +53,9 @@ export const PluginsUpdateManager = ( props: Props ) => {
 						/>
 					),
 					create: <ScheduleCreate siteSlug={ siteSlug } onNavBack={ onNavBack } />,
-					edit: <ScheduleEdit siteSlug={ siteSlug } onNavBack={ onNavBack } />,
+					edit: (
+						<ScheduleEdit siteSlug={ siteSlug } scheduleId={ scheduleId } onNavBack={ onNavBack } />
+					),
 				}[ context ]
 			}
 		</MainComponent>

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -5,6 +5,7 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updates-query';
 import { MAX_SCHEDULES } from './config';
 import { ScheduleCreate } from './schedule-create';
+import { ScheduleEdit } from './schedule-edit';
 import { ScheduleList } from './schedule-list';
 
 import './styles.scss';
@@ -14,9 +15,10 @@ interface Props {
 	context: 'list' | 'create';
 	onNavBack?: () => void;
 	onCreateNewSchedule?: () => void;
+	onEditSchedule?: ( id: string ) => void;
 }
 export const PluginsUpdateManager = ( props: Props ) => {
-	const { siteSlug, context, onNavBack, onCreateNewSchedule } = props;
+	const { siteSlug, context, onNavBack, onCreateNewSchedule, onEditSchedule } = props;
 	const { data: schedules = [] } = useScheduleUpdatesQuery( siteSlug );
 	const hideCreateButton = schedules.length === MAX_SCHEDULES || schedules.length === 0;
 
@@ -39,14 +41,20 @@ export const PluginsUpdateManager = ( props: Props ) => {
 				) }
 			</NavigationHeader>
 
-			{ context === 'list' && (
-				<ScheduleList
-					siteSlug={ siteSlug }
-					onNavBack={ onNavBack }
-					onCreateNewSchedule={ onCreateNewSchedule }
-				/>
-			) }
-			{ context === 'create' && <ScheduleCreate siteSlug={ siteSlug } onNavBack={ onNavBack } /> }
+			{
+				{
+					list: (
+						<ScheduleList
+							siteSlug={ siteSlug }
+							onNavBack={ onNavBack }
+							onCreateNewSchedule={ onCreateNewSchedule }
+							onEditSchedule={ onEditSchedule }
+						/>
+					),
+					create: <ScheduleCreate siteSlug={ siteSlug } onNavBack={ onNavBack } />,
+					edit: <ScheduleEdit siteSlug={ siteSlug } onNavBack={ onNavBack } />,
+				}[ context ]
+			}
 		</MainComponent>
 	);
 };

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -16,7 +16,7 @@ interface Props {
 	scheduleId?: string;
 	onNavBack?: () => void;
 	onCreateNewSchedule?: () => void;
-	onEditSchedule?: ( id: string ) => void;
+	onEditSchedule: ( id: string ) => void;
 }
 export const PluginsUpdateManager = ( props: Props ) => {
 	const { siteSlug, context, scheduleId, onNavBack, onCreateNewSchedule, onEditSchedule } = props;

--- a/client/blocks/plugins-update-manager/schedule-create.tsx
+++ b/client/blocks/plugins-update-manager/schedule-create.tsx
@@ -31,7 +31,7 @@ export const ScheduleCreate = ( props: Props ) => {
 				<div className="ch-placeholder"></div>
 			</CardHeader>
 			<CardBody>
-				<ScheduleForm siteSlug={ siteSlug } onCreateSuccess={ () => onNavBack && onNavBack() } />
+				<ScheduleForm siteSlug={ siteSlug } onSyncSuccess={ () => onNavBack && onNavBack() } />
 			</CardBody>
 			<CardFooter>
 				<Button form="schedule" type="submit" variant="primary">

--- a/client/blocks/plugins-update-manager/schedule-edit.tsx
+++ b/client/blocks/plugins-update-manager/schedule-edit.tsx
@@ -45,7 +45,7 @@ export const ScheduleEdit = ( props: Props ) => {
 					<ScheduleForm
 						siteSlug={ siteSlug }
 						scheduleForEdit={ schedule }
-						onCreateSuccess={ () => onNavBack && onNavBack() }
+						onSyncSuccess={ () => onNavBack && onNavBack() }
 					/>
 				) }
 			</CardBody>

--- a/client/blocks/plugins-update-manager/schedule-edit.tsx
+++ b/client/blocks/plugins-update-manager/schedule-edit.tsx
@@ -1,0 +1,43 @@
+import {
+	__experimentalText as Text,
+	Button,
+	Card,
+	CardHeader,
+	CardBody,
+	CardFooter,
+} from '@wordpress/components';
+import { arrowLeft } from '@wordpress/icons';
+import { SiteSlug } from 'calypso/types';
+import { ScheduleForm } from './schedule-form';
+
+interface Props {
+	siteSlug: SiteSlug;
+	onNavBack?: () => void;
+}
+export const ScheduleEdit = ( props: Props ) => {
+	const { siteSlug, onNavBack } = props;
+
+	return (
+		<Card className="plugins-update-manager">
+			<CardHeader size="extraSmall">
+				<div className="ch-placeholder">
+					{ onNavBack && (
+						<Button icon={ arrowLeft } onClick={ onNavBack }>
+							Back
+						</Button>
+					) }
+				</div>
+				<Text>Edit Schedule</Text>
+				<div className="ch-placeholder"></div>
+			</CardHeader>
+			<CardBody>
+				<ScheduleForm siteSlug={ siteSlug } onCreateSuccess={ () => onNavBack && onNavBack() } />
+			</CardBody>
+			<CardFooter>
+				<Button form="schedule" type="submit" variant="primary">
+					Edit
+				</Button>
+			</CardFooter>
+		</Card>
+	);
+};

--- a/client/blocks/plugins-update-manager/schedule-edit.tsx
+++ b/client/blocks/plugins-update-manager/schedule-edit.tsx
@@ -7,15 +7,25 @@ import {
 	CardFooter,
 } from '@wordpress/components';
 import { arrowLeft } from '@wordpress/icons';
+import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updates-query';
 import { SiteSlug } from 'calypso/types';
 import { ScheduleForm } from './schedule-form';
 
 interface Props {
 	siteSlug: SiteSlug;
+	scheduleId: string;
 	onNavBack?: () => void;
 }
 export const ScheduleEdit = ( props: Props ) => {
-	const { siteSlug, onNavBack } = props;
+	const { siteSlug, scheduleId, onNavBack } = props;
+	const { data: schedules = [], isFetched } = useScheduleUpdatesQuery( siteSlug );
+	const schedule = schedules.find( ( s ) => s.id === scheduleId );
+
+	// If the schedule is not found, navigate back to the list
+	if ( isFetched && ! schedule ) {
+		onNavBack && onNavBack();
+		return null;
+	}
 
 	return (
 		<Card className="plugins-update-manager">

--- a/client/blocks/plugins-update-manager/schedule-edit.tsx
+++ b/client/blocks/plugins-update-manager/schedule-edit.tsx
@@ -51,7 +51,7 @@ export const ScheduleEdit = ( props: Props ) => {
 			</CardBody>
 			<CardFooter>
 				<Button form="schedule" type="submit" variant="primary">
-					Edit
+					Save
 				</Button>
 			</CardFooter>
 		</Card>

--- a/client/blocks/plugins-update-manager/schedule-edit.tsx
+++ b/client/blocks/plugins-update-manager/schedule-edit.tsx
@@ -13,7 +13,7 @@ import { ScheduleForm } from './schedule-form';
 
 interface Props {
 	siteSlug: SiteSlug;
-	scheduleId: string;
+	scheduleId?: string;
 	onNavBack?: () => void;
 }
 export const ScheduleEdit = ( props: Props ) => {
@@ -41,7 +41,13 @@ export const ScheduleEdit = ( props: Props ) => {
 				<div className="ch-placeholder"></div>
 			</CardHeader>
 			<CardBody>
-				<ScheduleForm siteSlug={ siteSlug } onCreateSuccess={ () => onNavBack && onNavBack() } />
+				{ schedule && (
+					<ScheduleForm
+						siteSlug={ siteSlug }
+						scheduleForEdit={ schedule }
+						onCreateSuccess={ () => onNavBack && onNavBack() }
+					/>
+				) }
 			</CardBody>
 			<CardFooter>
 				<Button form="schedule" type="submit" variant="primary">

--- a/client/blocks/plugins-update-manager/schedule-form.const.ts
+++ b/client/blocks/plugins-update-manager/schedule-form.const.ts
@@ -1,3 +1,5 @@
+export const DEFAULT_HOUR = 9;
+
 export const DAILY_OPTION = {
 	label: 'Daily',
 	value: 'daily',

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -47,11 +47,11 @@ import './schedule-form.scss';
 interface Props {
 	siteSlug: SiteSlug;
 	scheduleForEdit?: ScheduleUpdates;
-	onCreateSuccess?: () => void;
+	onSyncSuccess?: () => void;
 }
 export const ScheduleForm = ( props: Props ) => {
 	const moment = useLocalizedMoment();
-	const { siteSlug, scheduleForEdit, onCreateSuccess } = props;
+	const { siteSlug, scheduleForEdit, onSyncSuccess } = props;
 	const initDate = scheduleForEdit
 		? moment( scheduleForEdit?.timestamp * 1000 )
 		: moment( new Date() ).hour( DEFAULT_HOUR );
@@ -63,10 +63,10 @@ export const ScheduleForm = ( props: Props ) => {
 	const { data: schedulesData = [] } = useScheduleUpdatesQuery( siteSlug );
 	const schedules = schedulesData.filter( ( x ) => x.id !== scheduleForEdit?.id ) ?? [];
 	const { createScheduleUpdates } = useCreateScheduleUpdatesMutation( siteSlug, {
-		onSuccess: () => onCreateSuccess && onCreateSuccess(),
+		onSuccess: () => onSyncSuccess && onSyncSuccess(),
 	} );
 	const { editScheduleUpdates } = useEditScheduleUpdatesMutation( siteSlug, {
-		onSuccess: () => onCreateSuccess && onCreateSuccess(),
+		onSuccess: () => onSyncSuccess && onSyncSuccess(),
 	} );
 
 	const [ name, setName ] = useState( scheduleForEdit?.hook || '' );

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -13,17 +13,15 @@ import {
 import { Icon, info } from '@wordpress/icons';
 import classnames from 'classnames';
 import { Fragment, useState, useCallback, useEffect } from 'react';
-import { useCorePluginsQuery, type CorePlugin } from 'calypso/data/plugins/use-core-plugins-query';
-import { useCreateScheduleUpdatesMutation } from 'calypso/data/plugins/use-schedule-updates-mutation';
-import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updates-query';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import { useCorePluginsQuery, type CorePlugin } from 'calypso/data/plugins/use-core-plugins-query';
 import {
 	useCreateScheduleUpdatesMutation,
 	useEditScheduleUpdatesMutation,
 } from 'calypso/data/plugins/use-schedule-updates-mutation';
 import {
-	ScheduleUpdates,
 	useScheduleUpdatesQuery,
+	ScheduleUpdates,
 } from 'calypso/data/plugins/use-schedule-updates-query';
 import { SiteSlug } from 'calypso/types';
 import { MAX_SELECTABLE_PLUGINS } from './config';

--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -9,7 +9,7 @@ import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updat
 interface Props {
 	siteSlug: string;
 	onRemoveClick: ( id: string ) => void;
-	onScheduleClick: ( id: string ) => void;
+	onScheduleClick?: ( id: string ) => void;
 }
 export const ScheduleListCards = ( props: Props ) => {
 	const moment = useLocalizedMoment();
@@ -39,7 +39,7 @@ export const ScheduleListCards = ( props: Props ) => {
 							<Button
 								className="schedule-name"
 								variant="link"
-								onClick={ () => onScheduleClick( schedule.id ) }
+								onClick={ () => onScheduleClick && onScheduleClick( schedule.id ) }
 							>
 								{ schedule.hook }
 							</Button>

--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -8,12 +8,12 @@ import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updat
 
 interface Props {
 	siteSlug: string;
+	onEditClick: ( id: string ) => void;
 	onRemoveClick: ( id: string ) => void;
-	onScheduleClick?: ( id: string ) => void;
 }
 export const ScheduleListCards = ( props: Props ) => {
 	const moment = useLocalizedMoment();
-	const { siteSlug, onRemoveClick, onScheduleClick } = props;
+	const { siteSlug, onEditClick, onRemoveClick } = props;
 	const { data: schedules = [] } = useScheduleUpdatesQuery( siteSlug );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 
@@ -24,6 +24,10 @@ export const ScheduleListCards = ( props: Props ) => {
 					<DropdownMenu
 						className="schedule-list--card-actions"
 						controls={ [
+							{
+								title: 'Edit',
+								onClick: () => onEditClick( schedule.id ),
+							},
 							{
 								title: 'Remove',
 								onClick: () => onRemoveClick( schedule.id ),
@@ -39,7 +43,7 @@ export const ScheduleListCards = ( props: Props ) => {
 							<Button
 								className="schedule-name"
 								variant="link"
-								onClick={ () => onScheduleClick && onScheduleClick( schedule.id ) }
+								onClick={ () => onEditClick && onEditClick( schedule.id ) }
 							>
 								{ schedule.hook }
 							</Button>

--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -1,4 +1,4 @@
-import { DropdownMenu, Tooltip } from '@wordpress/components';
+import { Button, DropdownMenu, Tooltip } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import { MOMENT_TIME_FORMAT } from 'calypso/blocks/plugins-update-manager/config';
 import { usePreparePluginsTooltipInfo } from 'calypso/blocks/plugins-update-manager/hooks/use-prepare-plugins-tooltip-info';
@@ -9,10 +9,11 @@ import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updat
 interface Props {
 	siteSlug: string;
 	onRemoveClick: ( id: string ) => void;
+	onScheduleClick: ( id: string ) => void;
 }
 export const ScheduleListCards = ( props: Props ) => {
 	const moment = useLocalizedMoment();
-	const { siteSlug, onRemoveClick } = props;
+	const { siteSlug, onRemoveClick, onScheduleClick } = props;
 	const { data: schedules = [] } = useScheduleUpdatesQuery( siteSlug );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 
@@ -34,7 +35,15 @@ export const ScheduleListCards = ( props: Props ) => {
 
 					<div className="schedule-list--card-label">
 						<label htmlFor="name">Name</label>
-						<strong id="name">{ schedule.hook }</strong>
+						<strong id="name">
+							<Button
+								className="schedule-name"
+								variant="link"
+								onClick={ () => onScheduleClick( schedule.id ) }
+							>
+								{ schedule.hook }
+							</Button>
+						</strong>
 					</div>
 
 					<div className="schedule-list--card-label">

--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -9,7 +9,7 @@ import { ellipsis } from './icons';
 interface Props {
 	siteSlug: string;
 	onRemoveClick: ( id: string ) => void;
-	onScheduleClick: ( id: string ) => void;
+	onScheduleClick?: ( id: string ) => void;
 }
 export const ScheduleListTable = ( props: Props ) => {
 	const moment = useLocalizedMoment();
@@ -40,7 +40,7 @@ export const ScheduleListTable = ( props: Props ) => {
 							<Button
 								className="schedule-name"
 								variant="link"
-								onClick={ () => onScheduleClick( schedule.id ) }
+								onClick={ () => onScheduleClick && onScheduleClick( schedule.id ) }
 							>
 								{ schedule.hook }
 							</Button>

--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -8,12 +8,12 @@ import { ellipsis } from './icons';
 
 interface Props {
 	siteSlug: string;
+	onEditClick: ( id: string ) => void;
 	onRemoveClick: ( id: string ) => void;
-	onScheduleClick?: ( id: string ) => void;
 }
 export const ScheduleListTable = ( props: Props ) => {
 	const moment = useLocalizedMoment();
-	const { siteSlug, onRemoveClick, onScheduleClick } = props;
+	const { siteSlug, onEditClick, onRemoveClick } = props;
 	const { data: schedules = [] } = useScheduleUpdatesQuery( siteSlug );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 
@@ -40,7 +40,7 @@ export const ScheduleListTable = ( props: Props ) => {
 							<Button
 								className="schedule-name"
 								variant="link"
-								onClick={ () => onScheduleClick && onScheduleClick( schedule.id ) }
+								onClick={ () => onEditClick && onEditClick( schedule.id ) }
 							>
 								{ schedule.hook }
 							</Button>
@@ -72,6 +72,10 @@ export const ScheduleListTable = ( props: Props ) => {
 							<DropdownMenu
 								popoverProps={ { position: 'bottom left' } }
 								controls={ [
+									{
+										title: 'Edit',
+										onClick: () => onEditClick( schedule.id ),
+									},
 									{
 										title: 'Remove',
 										onClick: () => onRemoveClick( schedule.id ),

--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -1,4 +1,4 @@
-import { DropdownMenu, Tooltip } from '@wordpress/components';
+import { Button, DropdownMenu, Tooltip } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updates-query';
@@ -9,10 +9,11 @@ import { ellipsis } from './icons';
 interface Props {
 	siteSlug: string;
 	onRemoveClick: ( id: string ) => void;
+	onScheduleClick: ( id: string ) => void;
 }
 export const ScheduleListTable = ( props: Props ) => {
 	const moment = useLocalizedMoment();
-	const { siteSlug, onRemoveClick } = props;
+	const { siteSlug, onRemoveClick, onScheduleClick } = props;
 	const { data: schedules = [] } = useScheduleUpdatesQuery( siteSlug );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 
@@ -35,7 +36,15 @@ export const ScheduleListTable = ( props: Props ) => {
 			<tbody>
 				{ schedules.map( ( schedule ) => (
 					<tr key={ schedule.id }>
-						<td className="name">{ schedule.hook }</td>
+						<td className="name">
+							<Button
+								className="schedule-name"
+								variant="link"
+								onClick={ () => onScheduleClick( schedule.id ) }
+							>
+								{ schedule.hook }
+							</Button>
+						</td>
 						<td></td>
 						<td>{ moment( schedule.timestamp * 1000 ).format( MOMENT_TIME_FORMAT ) }</td>
 						<td>

--- a/client/blocks/plugins-update-manager/schedule-list.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list.tsx
@@ -12,6 +12,7 @@ import { Icon, arrowLeft, info } from '@wordpress/icons';
 import { useState } from 'react';
 import { useDeleteScheduleUpdatesMutation } from 'calypso/data/plugins/use-schedule-updates-mutation';
 import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updates-query';
+import { MAX_SCHEDULES } from './config';
 import { ScheduleListCards } from './schedule-list-cards';
 import { ScheduleListEmpty } from './schedule-list-empty';
 import { ScheduleListTable } from './schedule-list-table';
@@ -24,7 +25,6 @@ interface Props {
 	onEditSchedule?: ( id: string ) => void;
 }
 export const ScheduleList = ( props: Props ) => {
-	const MAX_SCHEDULES = 2;
 	const isMobile = useMobileBreakpoint();
 
 	const { siteSlug, onNavBack, onCreateNewSchedule, onEditSchedule } = props;

--- a/client/blocks/plugins-update-manager/schedule-list.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list.tsx
@@ -88,13 +88,13 @@ export const ScheduleList = ( props: Props ) => {
 								<ScheduleListCards
 									siteSlug={ siteSlug }
 									onRemoveClick={ openRemoveDialog }
-									onScheduleClick={ onEditSchedule }
+									onEditClick={ onEditSchedule }
 								/>
 							) : (
 								<ScheduleListTable
 									siteSlug={ siteSlug }
 									onRemoveClick={ openRemoveDialog }
-									onScheduleClick={ onEditSchedule }
+									onEditClick={ onEditSchedule }
 								/>
 							) }
 						</>

--- a/client/blocks/plugins-update-manager/schedule-list.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list.tsx
@@ -21,12 +21,13 @@ interface Props {
 	siteSlug: SiteSlug;
 	onNavBack?: () => void;
 	onCreateNewSchedule?: () => void;
+	onEditSchedule?: ( id: string ) => void;
 }
 export const ScheduleList = ( props: Props ) => {
 	const MAX_SCHEDULES = 2;
 	const isMobile = useMobileBreakpoint();
 
-	const { siteSlug, onNavBack, onCreateNewSchedule } = props;
+	const { siteSlug, onNavBack, onCreateNewSchedule, onEditSchedule } = props;
 	const [ removeDialogOpen, setRemoveDialogOpen ] = useState( false );
 	const [ selectedScheduleId, setSelectedScheduleId ] = useState< undefined | string >();
 
@@ -84,9 +85,17 @@ export const ScheduleList = ( props: Props ) => {
 					{ isFetched && schedules.length > 0 && (
 						<>
 							{ isMobile ? (
-								<ScheduleListCards siteSlug={ siteSlug } onRemoveClick={ openRemoveDialog } />
+								<ScheduleListCards
+									siteSlug={ siteSlug }
+									onRemoveClick={ openRemoveDialog }
+									onScheduleClick={ onEditSchedule }
+								/>
 							) : (
-								<ScheduleListTable siteSlug={ siteSlug } onRemoveClick={ openRemoveDialog } />
+								<ScheduleListTable
+									siteSlug={ siteSlug }
+									onRemoveClick={ openRemoveDialog }
+									onScheduleClick={ onEditSchedule }
+								/>
 							) }
 						</>
 					) }

--- a/client/blocks/plugins-update-manager/schedule-list.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list.tsx
@@ -22,7 +22,7 @@ interface Props {
 	siteSlug: SiteSlug;
 	onNavBack?: () => void;
 	onCreateNewSchedule?: () => void;
-	onEditSchedule?: ( id: string ) => void;
+	onEditSchedule: ( id: string ) => void;
 }
 export const ScheduleList = ( props: Props ) => {
 	const isMobile = useMobileBreakpoint();

--- a/client/blocks/plugins-update-manager/styles.scss
+++ b/client/blocks/plugins-update-manager/styles.scss
@@ -50,6 +50,13 @@
 		}
 	}
 
+	button.schedule-name {
+		font-size: 0.875rem;
+		font-weight: 500;
+		text-decoration: none;
+		color: var(--studio-gray-100);
+	}
+
 	table {
 		th,
 		td {
@@ -66,11 +73,6 @@
 		td {
 			padding: 0.5rem 0;
 			vertical-align: middle;
-
-			&.name {
-				font-weight: 500;
-				color: var(--studio-gray-100);
-			}
 		}
 	}
 

--- a/client/data/plugins/use-schedule-updates-mutation.ts
+++ b/client/data/plugins/use-schedule-updates-mutation.ts
@@ -21,6 +21,30 @@ export function useCreateScheduleUpdatesMutation( siteSlug: SiteSlug, queryOptio
 	return { createScheduleUpdates, ...mutation };
 }
 
+export function useEditScheduleUpdatesMutation( siteSlug: SiteSlug, queryOptions = {} ) {
+	const mutation = useMutation( {
+		mutationFn: ( obj: { id: string; params: object } ) => {
+			const { id, params } = obj;
+
+			return wpcomRequest( {
+				path: `/sites/${ siteSlug }/update-schedules/${ id }`,
+				apiNamespace: 'wpcom/v2',
+				method: 'PUT',
+				body: params,
+			} );
+		},
+		...queryOptions,
+	} );
+
+	const { mutate } = mutation;
+	const editScheduleUpdates = useCallback(
+		( id: string, params: object ) => mutate( { id, params } ),
+		[ mutate ]
+	);
+
+	return { editScheduleUpdates, ...mutation };
+}
+
 export function useDeleteScheduleUpdatesMutation( siteSlug: SiteSlug, queryOptions = {} ) {
 	const mutation = useMutation( {
 		mutationFn: ( id: string ) =>

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -114,6 +114,7 @@ export function plugins( context, next ) {
 
 export function updatesManager( context, next ) {
 	const siteSlug = context?.params?.site_slug;
+	const scheduleId = context?.params?.schedule_id;
 
 	if ( ! siteSlug ) {
 		sites( context, next );
@@ -132,6 +133,7 @@ export function updatesManager( context, next ) {
 		case 'edit':
 			context.primary = createElement( PluginsUpdateManager, {
 				siteSlug,
+				scheduleId,
 				context: 'edit',
 				onNavBack: () => page.redirect( `/plugins/scheduled-updates/${ siteSlug }` ),
 			} );

--- a/client/my-sites/plugins/controller.js
+++ b/client/my-sites/plugins/controller.js
@@ -129,6 +129,14 @@ export function updatesManager( context, next ) {
 			} );
 			break;
 
+		case 'edit':
+			context.primary = createElement( PluginsUpdateManager, {
+				siteSlug,
+				context: 'edit',
+				onNavBack: () => page.redirect( `/plugins/scheduled-updates/${ siteSlug }` ),
+			} );
+			break;
+
 		case 'list':
 		default:
 			context.primary = createElement( PluginsUpdateManager, {
@@ -136,6 +144,8 @@ export function updatesManager( context, next ) {
 				context: 'list',
 				onCreateNewSchedule: () =>
 					page.redirect( `/plugins/scheduled-updates/create/${ siteSlug }` ),
+				onEditSchedule: ( id ) =>
+					page.redirect( `/plugins/scheduled-updates/edit/${ siteSlug }/${ id }` ),
 			} );
 			break;
 	}

--- a/client/my-sites/plugins/index.web.js
+++ b/client/my-sites/plugins/index.web.js
@@ -144,6 +144,7 @@ export default function ( router ) {
 			`/${ langParam }/plugins/scheduled-updates`,
 			`/${ langParam }/plugins/scheduled-updates/:site_slug?`,
 			`/${ langParam }/plugins/scheduled-updates/:action/:site_slug?`,
+			`/${ langParam }/plugins/scheduled-updates/:action/:site_slug?/:schedule_id`,
 		],
 		redirectLoggedOut,
 		siteSelection,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Relates https://github.com/Automattic/dotcom-forge/issues/5544
Closes https://github.com/Automattic/dotcom-forge/issues/5645

## Proposed Changes

* Implemented schedule update logic
* Introduced a new `edit` route in format: `/plugins/scheduled-updates/:action/:site_slug?/:schedule_id`

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `plugins/scheduled-updates/{ATOMIC SITE}`
* Try create/update/delete of schedules and check if it works

**NOTE:** https://github.com/Automattic/wp-calypso/pull/88198 will cover the submit button busy state and UX improvements of the whole CRUD process, such as waiting for the server to delete an item from the list, etc.

![Screen Capture on 2024-03-05 at 13-46-45](https://github.com/Automattic/wp-calypso/assets/1241413/6b740994-919a-44a1-917c-af72f955f2ab)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?