### PR TITLE
[Explore] Add hosting intent and transfer intent

### DIFF
--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -58,7 +58,7 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 		if ( migrationTrialEligibility?.error_code === 'email-unverified' ) {
 			navigateToVerifyEmailStep();
 		} else {
-			addHostingTrial( site.ID, PLAN_MIGRATION_TRIAL_MONTHLY );
+			addHostingTrial( site.ID, PLAN_MIGRATION_TRIAL_MONTHLY, 'migrate' );
 		}
 	};
 

--- a/client/blocks/importer/wordpress/upgrade-plan/index.tsx
+++ b/client/blocks/importer/wordpress/upgrade-plan/index.tsx
@@ -5,7 +5,9 @@ import { SiteDetails } from '@automattic/data-stores';
 import { Title, SubTitle, NextButton } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
 import React, { useEffect } from 'react';
-import useAddHostingTrialMutation from 'calypso/data/hosting/use-add-hosting-trial-mutation';
+import useAddHostingTrialMutation, {
+	HOSTING_INTENT_MIGRATE,
+} from 'calypso/data/hosting/use-add-hosting-trial-mutation';
 import useCheckEligibilityMigrationTrialPlan from 'calypso/data/plans/use-check-eligibility-migration-trial-plan';
 import { useDispatch } from 'calypso/state';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
@@ -58,7 +60,7 @@ export const UpgradePlan: React.FunctionComponent< Props > = ( props: Props ) =>
 		if ( migrationTrialEligibility?.error_code === 'email-unverified' ) {
 			navigateToVerifyEmailStep();
 		} else {
-			addHostingTrial( site.ID, PLAN_MIGRATION_TRIAL_MONTHLY, 'migrate' );
+			addHostingTrial( site.ID, PLAN_MIGRATION_TRIAL_MONTHLY, HOSTING_INTENT_MIGRATE );
 		}
 	};
 

--- a/client/data/hosting/use-add-hosting-trial-mutation.ts
+++ b/client/data/hosting/use-add-hosting-trial-mutation.ts
@@ -2,7 +2,9 @@ import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import wp from 'calypso/lib/wp';
 
-type HostingIntent = 'migrate';
+export const HOSTING_INTENT_MIGRATE = 'migrate';
+
+type HostingIntent = typeof HOSTING_INTENT_MIGRATE;
 
 interface Variables {
 	siteId: number;

--- a/client/data/hosting/use-add-hosting-trial-mutation.ts
+++ b/client/data/hosting/use-add-hosting-trial-mutation.ts
@@ -2,27 +2,34 @@ import { useMutation, UseMutationOptions } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import wp from 'calypso/lib/wp';
 
+type HostingIntent = 'migrate';
+
 interface Variables {
 	siteId: number;
 	planSlug: string;
+	hostingIntent?: HostingIntent;
 }
 
 export default function useAddHostingTrialMutation(
 	options: UseMutationOptions< unknown, unknown, Variables > = {}
 ) {
 	const mutation = useMutation( {
-		mutationFn: async ( { siteId, planSlug }: Variables ) =>
-			wp.req.post( {
+		mutationFn: async ( { siteId, planSlug, hostingIntent }: Variables ) => {
+			const body = hostingIntent ? { hosting_intent: hostingIntent } : undefined;
+			return wp.req.post( {
 				path: `/sites/${ siteId }/hosting/trial/add/${ planSlug }`,
 				apiNamespace: 'wpcom/v2',
-			} ),
+				body,
+			} );
+		},
 		...options,
 	} );
 
 	const { mutate } = mutation;
 
 	const addHostingTrial = useCallback(
-		( siteId: number, planSlug: string ) => mutate( { siteId, planSlug } ),
+		( siteId: number, planSlug: string, hostingIntent?: HostingIntent ) =>
+			mutate( { siteId, planSlug, hostingIntent } ),
 		[ mutate ]
 	);
 

--- a/client/state/atomic/transfers/actions.ts
+++ b/client/state/atomic/transfers/actions.ts
@@ -31,6 +31,7 @@ export interface InitiateTransfer {
 	pluginFile?: File;
 	themeFile?: File;
 	context?: string;
+	transferIntent?: string;
 }
 
 /**

--- a/client/state/data-layer/wpcom/sites/atomic/transfers/index.js
+++ b/client/state/data-layer/wpcom/sites/atomic/transfers/index.js
@@ -35,6 +35,10 @@ export const mapToRequestBody = ( action ) => {
 		requestBody.context = action.context;
 	}
 
+	if ( action.transferIntent ) {
+		requestBody.transfer_intent = action.transferIntent;
+	}
+
 	return requestBody;
 };
 

--- a/packages/data-stores/src/site/actions.ts
+++ b/packages/data-stores/src/site/actions.ts
@@ -527,16 +527,26 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		siteId,
 	} );
 
-	const atomicTransferStart = ( siteId: number, softwareSet: string | undefined ) => ( {
+	const atomicTransferStart = (
+		siteId: number,
+		softwareSet: string | undefined,
+		transferIntent: string | undefined
+	) => ( {
 		type: 'ATOMIC_TRANSFER_START' as const,
 		siteId,
 		softwareSet,
+		transferIntent,
 	} );
 
-	const atomicTransferSuccess = ( siteId: number, softwareSet: string | undefined ) => ( {
+	const atomicTransferSuccess = (
+		siteId: number,
+		softwareSet: string | undefined,
+		transferIntent: string | undefined
+	) => ( {
 		type: 'ATOMIC_TRANSFER_SUCCESS' as const,
 		siteId,
 		softwareSet,
+		transferIntent,
 	} );
 
 	const atomicTransferFailure = (
@@ -550,27 +560,26 @@ export function createActions( clientCreds: WpcomClientCredentials ) {
 		error,
 	} );
 
-	function* initiateAtomicTransfer( siteId: number, softwareSet: string | undefined ) {
-		yield atomicTransferStart( siteId, softwareSet );
+	function* initiateAtomicTransfer(
+		siteId: number,
+		softwareSet: string | undefined,
+		transferIntent: string | undefined
+	) {
+		yield atomicTransferStart( siteId, softwareSet, transferIntent );
 		try {
+			const body = {
+				context: softwareSet || 'unknown',
+				software_set: softwareSet ? encodeURIComponent( softwareSet ) : undefined,
+				transfer_intent: transferIntent ? encodeURIComponent( transferIntent ) : undefined,
+			};
+
 			yield wpcomRequest( {
 				path: `/sites/${ encodeURIComponent( siteId ) }/atomic/transfers`,
 				apiNamespace: 'wpcom/v2',
 				method: 'POST',
-				...( softwareSet
-					? {
-							body: {
-								software_set: encodeURIComponent( softwareSet ),
-								context: softwareSet,
-							},
-					  }
-					: {
-							body: {
-								context: 'unknown',
-							},
-					  } ),
+				body,
 			} );
-			yield atomicTransferSuccess( siteId, softwareSet );
+			yield atomicTransferSuccess( siteId, softwareSet, transferIntent );
 		} catch ( _ ) {
 			yield atomicTransferFailure( siteId, softwareSet, AtomicTransferError.INTERNAL );
 		}

--- a/packages/data-stores/src/site/reducer.ts
+++ b/packages/data-stores/src/site/reducer.ts
@@ -258,6 +258,7 @@ export const atomicTransferStatus: Reducer< { [ key: number ]: AtomicTransferSta
 			[ action.siteId ]: {
 				status: AtomicTransferStatus.IN_PROGRESS,
 				softwareSet: action.softwareSet,
+				transferIntent: action.transferIntent,
 				errorCode: undefined,
 			},
 		};
@@ -268,6 +269,7 @@ export const atomicTransferStatus: Reducer< { [ key: number ]: AtomicTransferSta
 			[ action.siteId ]: {
 				status: AtomicTransferStatus.SUCCESS,
 				softwareSet: action.softwareSet,
+				transferIntent: action.transferIntent,
 				errorCode: undefined,
 			},
 		};

--- a/packages/data-stores/src/site/test/actions.ts
+++ b/packages/data-stores/src/site/test/actions.ts
@@ -160,27 +160,31 @@ describe( 'Site Actions', () => {
 		it( 'should return a ATOMIC_TRANSFER_START Action', () => {
 			const { atomicTransferStart } = createActions( mockedClientCredentials );
 			const softwareSet = 'woo-on-plans';
+			const transferIntent = 'migrate';
 
 			const expected = {
 				type: 'ATOMIC_TRANSFER_START',
 				siteId,
 				softwareSet,
+				transferIntent,
 			};
 
-			expect( atomicTransferStart( siteId, softwareSet ) ).toEqual( expected );
+			expect( atomicTransferStart( siteId, softwareSet, transferIntent ) ).toEqual( expected );
 		} );
 
 		it( 'should return a ATOMIC_TRANSFER_SUCCESS Action', () => {
 			const { atomicTransferSuccess } = createActions( mockedClientCredentials );
 			const softwareSet = 'woo-on-plans';
+			const transferIntent = 'migrate';
 
 			const expected = {
 				type: 'ATOMIC_TRANSFER_SUCCESS',
 				siteId,
 				softwareSet,
+				transferIntent,
 			};
 
-			expect( atomicTransferSuccess( siteId, softwareSet ) ).toEqual( expected );
+			expect( atomicTransferSuccess( siteId, softwareSet, transferIntent ) ).toEqual( expected );
 		} );
 
 		it( 'should return a ATOMIC_TRANSFER_FAILURE Action', () => {
@@ -202,14 +206,19 @@ describe( 'Site Actions', () => {
 		it( 'should start an Atomic transfer', () => {
 			const { initiateAtomicTransfer } = createActions( mockedClientCredentials );
 			const softwareSet = 'woo-on-plans';
-			const generator = initiateAtomicTransfer( siteId, softwareSet );
+			const transferIntent = 'migrate';
+			const generator = initiateAtomicTransfer( siteId, softwareSet, transferIntent );
 
 			const mockedApiResponse = {
 				request: {
 					apiNamespace: 'wpcom/v2',
 					method: 'POST',
 					path: `/sites/${ siteId }/atomic/transfers`,
-					body: { software_set: softwareSet, context: 'woo-on-plans' },
+					body: {
+						software_set: softwareSet,
+						context: 'woo-on-plans',
+						transfer_intent: transferIntent,
+					},
 				},
 				type: 'WPCOM_REQUEST',
 			};
@@ -219,6 +228,7 @@ describe( 'Site Actions', () => {
 				type: 'ATOMIC_TRANSFER_START',
 				siteId,
 				softwareSet,
+				transferIntent,
 			} );
 
 			// Second iteration: WP_COM_REQUEST is fired
@@ -229,12 +239,14 @@ describe( 'Site Actions', () => {
 				type: 'ATOMIC_TRANSFER_SUCCESS',
 				siteId,
 				softwareSet,
+				transferIntent,
 			} );
 		} );
 		it( 'should fail to transfer a site to Atomic', () => {
 			const { initiateAtomicTransfer } = createActions( mockedClientCredentials );
 			const softwareSet = 'woo-on-plans';
-			const generator = initiateAtomicTransfer( siteId, softwareSet );
+			const transferIntent = undefined;
+			const generator = initiateAtomicTransfer( siteId, softwareSet, transferIntent );
 
 			const mockedApiResponse = {
 				request: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to D140551-code

## Proposed Changes

* This PR adds the client-side code to support  a proposed `hosting_intent` parameter hosting trials and a `transfer_intent` parameter for Atomic transfers. For this is 100% exploratory as a way to work out what would be involved in supporting this from the client.
* The eventual goal is to clearly identify sites that are transferred to the Atomic platform in preparation for an inbound site migration.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Don't test yet! This is intended for discussion for now

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?