### PR TITLE
add: woo passwordless login

### DIFF
--- a/client/blocks/authentication/form-divider/style.scss
+++ b/client/blocks/authentication/form-divider/style.scss
@@ -74,7 +74,7 @@ $breakpoint-mobile: 660px;
 // In this case we want the separator to be vertical
 .signup-form,
 .is-white-login .is-social-first,
-.is-woo-passwordless .wp-login__container .login {
+.login form.is-woo-passwordless {
 	.auth-form__separator {
 		@include horizontal-separator;
 		width: calc(100% - 32px);

--- a/client/blocks/authentication/form-divider/style.scss
+++ b/client/blocks/authentication/form-divider/style.scss
@@ -73,7 +73,8 @@ $breakpoint-mobile: 660px;
 
 // In this case we want the separator to be vertical
 .signup-form,
-.is-white-login .is-social-first {
+.is-white-login .is-social-first,
+.is-woo-passwordless .wp-login__container .login {
 	.auth-form__separator {
 		@include horizontal-separator;
 		width: calc(100% - 32px);

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -27,7 +27,7 @@ import { login } from 'calypso/lib/paths';
 import { addQueryArgs } from 'calypso/lib/route';
 import { isWebAuthnSupported } from 'calypso/lib/webauthn';
 import { sendEmailLogin } from 'calypso/state/auth/actions';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getCurrentUser, isUserLoggedIn } from 'calypso/state/current-user/selectors';
 import { wasManualRenewalImmediateLoginAttempted } from 'calypso/state/immediate-login/selectors';
 import { rebootAfterLogin } from 'calypso/state/login/actions';
 import { hideMagicLoginRequestForm } from 'calypso/state/login/magic-login/actions';
@@ -44,6 +44,7 @@ import {
 	getSocialAccountLinkService,
 } from 'calypso/state/login/selectors';
 import { isPasswordlessAccount, isPartnerSignupQuery } from 'calypso/state/login/utils';
+import { logoutUser } from 'calypso/state/logout/actions';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
@@ -360,6 +361,17 @@ class Login extends Component {
 		let headerText = translate( 'Log in to your account' );
 		let preHeader = null;
 		let postHeader = null;
+		const signupLink = (
+			<a
+				href={ this.getSignupUrl() }
+				onClick={ () => {
+					// If the user is already logged in, log them out before sending them to the signup page. Otherwise, they will see the weird logged-in state on the signup page.
+					if ( this.props.isLoggedIn ) {
+						this.props.logoutUser();
+					}
+				} }
+			/>
+		);
 
 		if ( isSocialFirst ) {
 			headerText = translate( 'Log in to WordPress.com' );
@@ -389,7 +401,7 @@ class Login extends Component {
 							<br />
 							{ translate( 'Don’t have an account? {{signupLink}}Sign up{{/signupLink}}', {
 								components: {
-									signupLink: <a href={ this.getSignupUrl() } />,
+									signupLink,
 								},
 							} ) }
 						</span>
@@ -452,7 +464,7 @@ class Login extends Component {
 							{ poweredByWpCom }
 							{ translate( "Don't have an account? {{signupLink}}Sign up{{/signupLink}}", {
 								components: {
-									signupLink: <a href={ this.getSignupUrl() } />,
+									signupLink,
 									br: <br />,
 								},
 							} ) }
@@ -473,7 +485,7 @@ class Login extends Component {
 								"Please, log in to continue. Don't have an account? {{signupLink}}Sign up{{/signupLink}}",
 								{
 									components: {
-										signupLink: <a href={ this.getSignupUrl() } />,
+										signupLink,
 										br: <br />,
 									},
 								}
@@ -563,7 +575,7 @@ class Login extends Component {
 						"In order to take advantage of the benefits offered by Jetpack, please log in to your WordPress.com account below. Don't have an account? {{signupLink}}Sign up{{/signupLink}}",
 						{
 							components: {
-								signupLink: <a href={ this.getSignupUrl() } />,
+								signupLink,
 							},
 						}
 					);
@@ -735,6 +747,17 @@ class Login extends Component {
 			loginButtons,
 		} = this.props;
 
+		const signupLink = (
+			<a
+				href={ this.getSignupUrl() }
+				onClick={ () => {
+					if ( this.props.isLoggedIn ) {
+						this.props.logoutUser();
+					}
+				} }
+			/>
+		);
+
 		if ( socialConnect ) {
 			return (
 				<AsyncLoad
@@ -760,7 +783,7 @@ class Login extends Component {
 							<p className="login__lost-password-no-account">
 								{ translate( 'Don’t have an account? {{signupLink}}Sign up{{/signupLink}}', {
 									components: {
-										signupLink: <a href={ this.getSignupUrl() } />,
+										signupLink,
 									},
 								} ) }
 							</p>
@@ -790,7 +813,7 @@ class Login extends Component {
 							<p className="login__two-factor-no-account">
 								{ translate( 'Don’t have an account? {{signupLink}}Sign up{{/signupLink}}', {
 									components: {
-										signupLink: <a href={ this.getSignupUrl() } />,
+										signupLink,
 									},
 								} ) }
 							</p>
@@ -943,11 +966,13 @@ export default connect(
 		requestError: getRequestError( state ),
 		isSendingEmail: isFetchingMagicLoginEmail( state ),
 		emailRequested: isMagicLoginEmailRequested( state ),
+		isLoggedIn: isUserLoggedIn( state ),
 	} ),
 	{
 		rebootAfterLogin,
 		hideMagicLoginRequestForm,
 		sendEmailLogin,
+		logoutUser,
 	},
 	( stateProps, dispatchProps, ownProps ) => ( {
 		...ownProps,

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -24,6 +24,7 @@ import {
 	isWooOAuth2Client,
 } from 'calypso/lib/oauth2-clients';
 import { login } from 'calypso/lib/paths';
+import { addQueryArgs } from 'calypso/lib/route';
 import { isWebAuthnSupported } from 'calypso/lib/webauthn';
 import { sendEmailLogin } from 'calypso/state/auth/actions';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
@@ -302,6 +303,7 @@ class Login extends Component {
 			signupUrl,
 			isWoo,
 			isWooCoreProfilerFlow,
+			isWooPasswordless,
 		} = this.props;
 
 		if ( signupUrl ) {
@@ -315,6 +317,13 @@ class Login extends Component {
 
 		if ( isWooCoreProfilerFlow && isEmpty( currentQuery ) ) {
 			return getSignupUrl( initialQuery, currentRoute, oauth2Client, locale, pathname );
+		}
+
+		if ( isWooPasswordless ) {
+			return addQueryArgs(
+				{ 'woo-passwordless': 'yes' },
+				getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname )
+			);
 		}
 
 		return getSignupUrl( currentQuery, currentRoute, oauth2Client, locale, pathname );
@@ -866,12 +875,11 @@ class Login extends Component {
 	}
 
 	render() {
-		const { isJetpack, oauth2Client, locale, isWoo, isWooPasswordless } = this.props;
+		const { isJetpack, oauth2Client, locale, isWoo } = this.props;
 
 		return (
 			<div
 				className={ classNames( 'login', {
-					'is-woo-passwordless': isWooPasswordless,
 					'is-jetpack': isJetpack,
 					'is-jetpack-cloud': isJetpackCloudOAuth2Client( oauth2Client ),
 					'is-a4a': isA4AOAuth2Client( oauth2Client ),

--- a/client/blocks/login/index.jsx
+++ b/client/blocks/login/index.jsx
@@ -429,6 +429,26 @@ class Login extends Component {
 							{ translate( 'First, select the account you’d like to use.' ) }
 						</p>
 					);
+				} else if ( this.props.isWooPasswordless ) {
+					headerText = <h3>{ translate( 'Log in to your account' ) }</h3>;
+					const poweredByWpCom = (
+						<>
+							{ translate( 'Log in with your WordPress.com account.' ) }
+							<br />
+						</>
+					);
+
+					postHeader = (
+						<p className="login__header-subtitle">
+							{ poweredByWpCom }
+							{ translate( "Don't have an account? {{signupLink}}Sign up{{/signupLink}}", {
+								components: {
+									signupLink: <a href={ this.getSignupUrl() } />,
+									br: <br />,
+								},
+							} ) }
+						</p>
+					);
 				} else {
 					headerText = <h3>{ translate( "Let's get started" ) }</h3>;
 					const poweredByWpCom =
@@ -846,11 +866,12 @@ class Login extends Component {
 	}
 
 	render() {
-		const { isJetpack, oauth2Client, locale, isWoo } = this.props;
+		const { isJetpack, oauth2Client, locale, isWoo, isWooPasswordless } = this.props;
 
 		return (
 			<div
 				className={ classNames( 'login', {
+					'is-woo-passwordless': isWooPasswordless,
 					'is-jetpack': isJetpack,
 					'is-jetpack-cloud': isJetpackCloudOAuth2Client( oauth2Client ),
 					'is-a4a': isA4AOAuth2Client( oauth2Client ),

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -60,6 +60,7 @@ import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
 import getWccomFrom from 'calypso/state/selectors/get-wccom-from';
+import getWooPasswordless from 'calypso/state/selectors/get-woo-passwordless';
 import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 import ErrorNotice from './error-notice';
 import SocialLoginForm from './social';
@@ -185,7 +186,7 @@ export class LoginForm extends Component {
 		return (
 			socialAccountIsLinking ||
 			( hasAccountTypeLoaded && isRegularAccount( accountType ) ) ||
-			( this.props.isWoo && ! this.props.isPartnerSignup )
+			( this.props.isWoo && ! this.props.isPartnerSignup && ! this.props.isWooPasswordless )
 		);
 	}
 
@@ -196,7 +197,7 @@ export class LoginForm extends Component {
 			! socialAccountIsLinking &&
 			hasAccountTypeLoaded &&
 			isRegularAccount( accountType ) &&
-			! ( this.props.isWoo && ! this.props.isPartnerSignup )
+			! ( this.props.isWoo && ! this.props.isPartnerSignup && ! this.props.isWooPasswordless )
 		);
 	}
 
@@ -206,7 +207,7 @@ export class LoginForm extends Component {
 			isSendingEmail ||
 			( ! socialAccountIsLinking &&
 				! hasAccountTypeLoaded &&
-				! ( this.props.isWoo && ! this.props.isPartnerSignup ) )
+				! ( this.props.isWoo && ! this.props.isPartnerSignup && ! this.props.isWooPasswordless ) )
 		);
 	}
 
@@ -241,7 +242,8 @@ export class LoginForm extends Component {
 	onSubmitForm = ( event ) => {
 		event.preventDefault();
 
-		const isWooAndNotPartnerSignup = this.props.isWoo && ! this.props.isPartnerSignup;
+		const isWooAndNotPartnerSignup =
+			this.props.isWoo && ! this.props.isPartnerSignup && ! this.props.isWooPasswordless;
 
 		// Skip this step if we're in the Woo and not the partner signup flow, and hasAccountTypeLoaded.
 		if ( ! isWooAndNotPartnerSignup && ! this.props.hasAccountTypeLoaded ) {
@@ -578,7 +580,9 @@ export class LoginForm extends Component {
 						);
 					} }
 				>
-					{ this.props.translate( 'Forgot password?' ) }
+					{ this.props.isWooPasswordless
+						? this.props.translate( 'Lost your password?' )
+						: this.props.translate( 'Forgot password?' ) }
 				</a>
 			);
 		}
@@ -671,6 +675,7 @@ export class LoginForm extends Component {
 			currentQuery,
 			showSocialLoginFormOnly,
 			isWoo,
+			isWooPasswordless,
 			isPartnerSignup,
 			isWooCoreProfilerFlow,
 			hideSignupLink,
@@ -683,7 +688,8 @@ export class LoginForm extends Component {
 		const isFormDisabled = this.state.isFormDisabledWhileLoading || this.props.isFormDisabled;
 		const isFormFilled =
 			this.state.usernameOrEmail.trim().length === 0 || this.state.password.trim().length === 0;
-		const isSubmitButtonDisabled = isWoo && ! isPartnerSignup ? isFormFilled : isFormDisabled;
+		const isSubmitButtonDisabled =
+			isWoo && ! isPartnerSignup && ! isWooPasswordless ? isFormFilled : isFormDisabled;
 		const isOauthLogin = !! oauth2Client;
 		const isPasswordHidden = this.isUsernameOrEmailView();
 		const isCoreProfilerLostPasswordFlow = isWooCoreProfilerFlow && currentQuery.lostpassword_flow;
@@ -874,7 +880,7 @@ export class LoginForm extends Component {
 					</div>
 
 					<p className="login__form-terms">{ socialToS }</p>
-					{ isWoo && ! isPartnerSignup && this.renderLostPasswordLink() }
+					{ isWoo && ! isPartnerSignup && ! isWooPasswordless && this.renderLostPasswordLink() }
 					<div className="login__form-action">
 						<FormsButton
 							primary
@@ -917,6 +923,7 @@ export class LoginForm extends Component {
 						</SocialLoginForm>
 					</Fragment>
 				) }
+				{ isWoo && ! isPartnerSignup && isWooPasswordless && this.renderLostPasswordLink() }
 
 				{ this.showJetpackConnectSiteOnly() && (
 					<JetpackConnectSiteOnly
@@ -960,6 +967,7 @@ export default connect(
 				getCurrentQueryArguments( state )?.email_address,
 			wccomFrom: getWccomFrom( state ),
 			currentQuery: getCurrentQueryArguments( state ),
+			isWooPasswordless: getWooPasswordless( state ),
 		};
 	},
 	{

--- a/client/blocks/login/login-form.jsx
+++ b/client/blocks/login/login-form.jsx
@@ -197,7 +197,7 @@ export class LoginForm extends Component {
 			! socialAccountIsLinking &&
 			hasAccountTypeLoaded &&
 			isRegularAccount( accountType ) &&
-			! ( this.props.isWoo && ! this.props.isPartnerSignup && ! this.props.isWooPasswordless )
+			! ( this.props.isWoo && ! this.props.isPartnerSignup )
 		);
 	}
 
@@ -383,16 +383,17 @@ export class LoginForm extends Component {
 	};
 
 	getLoginButtonText = () => {
-		const { translate, isWoo, isWooCoreProfilerFlow } = this.props;
-		if ( this.isPasswordView() || this.isFullView() ) {
-			if ( isWoo && ! isWooCoreProfilerFlow ) {
-				return translate( 'Get started' );
-			}
+		const { translate, isWoo, isWooCoreProfilerFlow, isWooPasswordless } = this.props;
 
-			return translate( 'Log In' );
+		if ( this.isUsernameOrEmailView() || isWooPasswordless ) {
+			return translate( 'Continue' );
 		}
 
-		return translate( 'Continue' );
+		if ( isWoo && ! isWooCoreProfilerFlow ) {
+			return translate( 'Get started' );
+		}
+
+		return translate( 'Log In' );
 	};
 
 	showJetpackConnectSiteOnly = () => {
@@ -585,9 +586,7 @@ export class LoginForm extends Component {
 						);
 					} }
 				>
-					{ this.props.isWooPasswordless
-						? this.props.translate( 'Lost your password?' )
-						: this.props.translate( 'Forgot password?' ) }
+					{ this.props.translate( 'Forgot password?' ) }
 				</a>
 			);
 		}
@@ -862,7 +861,7 @@ export class LoginForm extends Component {
 							aria-hidden={ isPasswordHidden }
 						>
 							<FormLabel htmlFor="password">
-								{ this.props.isWoo && ! this.props.isPartnerSignup
+								{ this.props.isWoo && ! this.props.isPartnerSignup && ! this.props.isWooPasswordless
 									? this.props.translate( 'Your password' )
 									: this.props.translate( 'Password' ) }
 							</FormLabel>

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1,5 +1,9 @@
 @import "@wordpress/base-styles/colors";
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
 @import "@automattic/typography/styles/woo-commerce";
+
+$breakpoint-mobile: 660px;
 
 .woo {
 	$woo-purple-40: #966ccf;
@@ -12,13 +16,13 @@
 	$woo-font-size-small: $font-body-extra-small;
 	$woo-font-size-base: $font-body-small;
 	$woo-font-size-input: $font-body-small;
+	$woo-inter-font:  "Inter", -apple-system, system-ui, sans-serif;
 	$woo-radius-input: 4px;
 	$woo-form-whitespace: 60px;
 	$woo-form-whitespace-660: 20px;
 	$woo-form-divider-border: 1px solid #e6e6e6;
 	$gray-60: #50575e;
 	$gray-50: #646970;
-	$woo-inter-font:  "Inter", -apple-system, system-ui, sans-serif;
 
 	background: #fff;
 	min-height: 100%;
@@ -205,7 +209,7 @@
 				margin-top: -10px;
 				font-weight: 500;
 
-				@media screen and ( max-width: 660px ) {
+				@media ( max-width: $break-mobile ) {
 					display: none;
 				}
 			}
@@ -237,12 +241,12 @@
 		background-color: #fff;
 		z-index: 999;
 
-		@media screen and ( max-width: 660px ) {
+		@media ( max-width: $break-mobile ) {
 			display: flex;
 		}
 
 		.masterbar__login-back-link {
-			@media screen and ( max-width: 660px ) {
+			@media ( max-width: $break-mobile ) {
 				display: block;
 			}
 		}
@@ -252,7 +256,7 @@
 	.layout__content {
 		padding-top: 85px;
 
-		@media screen and ( max-width: 660px ) {
+		@media ( max-width: $break-mobile ) {
 			padding-top: 50px;
 			padding-bottom: 80px;
 		}
@@ -276,7 +280,7 @@
 		flex-direction: column;
 		padding: 54px 24px 32px;
 
-		@media screen and ( max-width: 660px ) {
+		@media ( max-width: $break-mobile ) {
 			padding: 32px 16px 28px;
 		}
 	}
@@ -285,7 +289,7 @@
 		margin-top: 0;
 		margin-bottom: 8px;
 
-		@media screen and ( max-width: 660px ) {
+		@media ( max-width: $break-mobile ) {
 			margin-bottom: 16px;
 		}
 	}
@@ -313,7 +317,7 @@
 			font-size: 2.75rem;
 			line-height: 52px;
 
-			@media screen and ( max-width: 660px ) {
+			@media ( max-width: $break-mobile ) {
 				text-align: left;
 			}
 		}
@@ -339,7 +343,7 @@
 			}
 		}
 
-		@media screen and ( max-width: 660px ) {
+		@media ( max-width: $break-mobile ) {
 			text-align: left;
 		}
 	}
@@ -352,7 +356,7 @@
 	.auth-form__social-buttons {
 		align-items: center;
 
-		@media screen and ( max-width: 660px ) {
+		@media ( max-width: $break-mobile ) {
 			align-items: flex-start;
 		}
 
@@ -417,7 +421,7 @@
 		padding: 60px 0 0;
 		width: 100%;
 
-		@media screen and ( max-width: 660px ) {
+		@media ( max-width: $break-mobile ) {
 			padding-top: 30px;
 		}
 	}
@@ -447,14 +451,14 @@
 	.login__two-factor-footer {
 		padding-left: $woo-form-whitespace;
 		padding-right: $woo-form-whitespace;
-		@media screen and ( max-width: 660px ) {
+		@media ( max-width: $break-mobile ) {
 			padding-left: $woo-form-whitespace-660;
 			padding-right: $woo-form-whitespace-660;
 		}
 	}
 
 	.login__form-header-wrapper {
-		@media screen and ( max-width: 660px ) {
+		@media ( max-width: $break-mobile ) {
 			padding-left: $woo-form-whitespace-660;
 			padding-right: $woo-form-whitespace-660;
 		}
@@ -606,7 +610,7 @@
 		padding-bottom: 40px;
 		text-align: center;
 
-		@media screen and ( max-width: 660px ) {
+		@media ( max-width: $break-mobile ) {
 			padding-top: 28px;
 		}
 	}
@@ -631,7 +635,7 @@
 			text-decoration: none;
 		}
 
-		@media screen and ( max-width: 660px ) {
+		@media ( max-width: $break-mobile ) {
 			align-items: flex-start;
 		}
 	}
@@ -748,18 +752,18 @@
 		margin: 0 0 8px;
 		padding: 0;
 
-		@media screen and ( max-width: 660px ) {
+		@media ( max-width: $break-mobile ) {
 			padding-left: $woo-form-whitespace-660;
 			padding-right: $woo-form-whitespace-660;
 		}
 	}
 
 	.formatted-header__subtitle {
-		@media screen and ( max-width: 660px ) {
+		@media ( max-width: $break-mobile ) {
 			width: 250px;
 		}
 
-		@media screen and ( max-width: 660px ) {
+		@media ( max-width: $break-mobile ) {
 			padding-left: $woo-form-whitespace-660;
 			padding-right: $woo-form-whitespace-660;
 		}
@@ -793,7 +797,7 @@
 		flex-direction: column;
 		align-items: center;
 
-		@media screen and ( max-width: 660px ) {
+		@media ( max-width: $break-mobile ) {
 			align-items: flex-start;
 		}
 
@@ -875,7 +879,7 @@
 		.wp-login__container,
 		.magic-login,
 		.step-wrapper {
-			@media screen and ( max-width: 660px ) {
+			@media ( max-width: $break-mobile ) {
 				padding-top: 40px;
 			}
 		}
@@ -910,7 +914,7 @@
 			line-height: 32px;
 			font-weight: 500;
 
-			@media screen and ( max-width: 660px ) {
+			@media ( max-width: $break-mobile ) {
 				font-size: rem(28px);
 			}
 		}
@@ -920,7 +924,7 @@
 		}
 
 		form.two-factor-authentication__verification-code-form-wrapper {
-			@media screen and ( max-width: 660px ) {
+			@media ( max-width: $break-mobile ) {
 				margin: 0;
 				max-width: 660px;
 			}
@@ -930,7 +934,7 @@
 		.formatted-header__subtitle {
 			color: $gray-700;
 
-			@media screen and ( max-width: 660px ) {
+			@media ( max-width: $break-mobile ) {
 				width: auto;
 			}
 		}
@@ -1024,7 +1028,7 @@
 			text-align: center;
 			line-height: 16px;
 
-			@media screen and ( max-width: 660px ) {
+			@media ( max-width: $break-mobile ) {
 				text-align: start;
 			}
 
@@ -1034,14 +1038,14 @@
 		}
 
 		.jetpack-connect__logged-in-content {
-			@media screen and ( max-width: 660px ) {
+			@media ( max-width: $break-mobile ) {
 				padding-left: $woo-form-whitespace-660;
 				padding-right: $woo-form-whitespace-660;
 			}
 		}
 
 		.jetpack-connect__features_wrapper {
-			@media screen and ( max-width: 660px ) {
+			@media ( max-width: $break-mobile ) {
 				display: none !important;
 			}
 		}
@@ -1081,7 +1085,7 @@
 			flex-direction: column;
 			padding: 48px 24px 32px;
 
-			@media screen and ( max-width: 660px ) {
+			@media ( max-width: $break-mobile ) {
 				padding: 32px 16px 28px;
 			}
 
@@ -1104,12 +1108,13 @@
 
 
 	&.is-woo-passwordless {
+		$max-width: 327px;
+		$woo-font-size-input: $font-body;
+		$woo-radius-input: 8px;
+
 		* {
 			font-family: $woo-inter-font;
 		}
-
-		$woo-font-size-input: $font-body;
-		$woo-radius-input: 8px;
 
 		h1,
 		h3 {
@@ -1122,7 +1127,7 @@
 			line-height: 39.6px;
 			letter-spacing: -0.72px;
 
-			@media screen and ( max-width: 660px ) {
+			@media ( max-width: $break-mobile ) {
 				text-align: left;
 			}
 		}
@@ -1219,9 +1224,9 @@
 		.formatted-header__title {
 			margin-bottom: 12px;
 
-			@media screen and ( max-width: 660px ) {
+			@media ( max-width: $break-mobile ) {
 				padding: 0;
-				max-width: 327px;
+				max-width: $max-width;
 				margin: 0 auto 16px;
 			}
 		}
@@ -1250,9 +1255,9 @@
 				}
 			}
 
-			@media screen and ( max-width: 660px ) {
+			@media ( max-width: $break-mobile ) {
 				padding: 0;
-				max-width: 327px;
+				max-width: $max-width;
 				margin: 0 auto;
 				width: 100%;
 				text-align: left;
@@ -1282,7 +1287,7 @@
 			justify-content: center;
 			max-width: 758px;
 
-			@media screen and ( max-width: 660px ) {
+			@media ( max-width: $break-medium ) {
 				flex-direction: column;
 			}
 
@@ -1292,12 +1297,12 @@
 				flex-direction: column;
 				justify-content: center;
 				width: 100%;
-				max-width: var(--login-form-column-max-width);
+				max-width: $max-width;
 				margin: 0;
 
 				~ .auth-form__social.card {
 					width: 100%;
-					max-width: var(--login-form-column-max-width);
+					max-width: $max-width;
 					margin: 0;
 				}
 
@@ -1312,7 +1317,7 @@
 			}
 
 			.auth-form__separator {
-				@media screen and ( min-width: 660px ) {
+				@media screen and ( min-width: $break-medium ) {
 					margin-block: 0;
 				}
 			}
@@ -1325,8 +1330,8 @@
 			flex-direction: column;
 			margin: 40px auto 0;
 
-			@media screen and ( max-width: 660px ) {
-				max-width: 327px;
+			@media ( max-width: $break-mobile ) {
+				max-width: $max-width;
 				margin-bottom: 40px;
 			}
 
@@ -1435,7 +1440,7 @@
 
 		div.auth-form__separator {
 			margin: 32px auto;
-			max-width: initial;
+			max-width: $max-width;
 
 			&::before,
 			&::after {
@@ -1547,9 +1552,9 @@
 				letter-spacing: -0.72px;
 				margin: 0;
 
-				@media screen and ( max-width: 660px ) {
+				@media ( max-width: $break-mobile ) {
 					text-align: center;
-					max-width: 327px;
+					max-width: $max-width;
 					margin: 0 auto;
 				}
 			}
@@ -1572,7 +1577,7 @@
 					box-shadow: none;
 
 					form {
-						max-width: 327px;
+						max-width: $max-width;
 					}
 				}
 
@@ -1603,7 +1608,7 @@
 			}
 
 			.magic-login__emails-list {
-				max-width: 327px;
+				max-width: $max-width;
 				margin-inline: auto;
 
 				li {
@@ -1623,7 +1628,7 @@
 
 			.magic-login__footer {
 				margin: 0;
-				max-width: 327px;
+				max-width: $max-width;
 				margin-inline: auto;
 
 				p {
@@ -1674,7 +1679,7 @@
 		}
 
 		.login__lost-password-footer {
-			@media screen and ( max-width: 660px ) {
+			@media ( max-width: $break-mobile ) {
 				margin-bottom: 32px;
 				align-items: center;
 			}
@@ -1686,7 +1691,7 @@
 			.button,
 			.form-fieldset,
 			.auth-form__separator {
-				max-width: 327px !important;
+				max-width: $max-width !important;
 			}
 
 			.two-factor-authentication__verification-code-form {
@@ -1723,18 +1728,18 @@
 					font-weight: 500;
 					color: var(--studio-gray-100);
 					margin: 0 auto;
-					max-width: 327px !important;
+					max-width: $max-width !important;
 				}
 			}
 		}
 
 		.login__two-factor-footer {
 			p {
-				max-width: 327px;
+				max-width: $max-width;
 				text-align: center;
 			}
 
-			@media screen and ( max-width: 660px ) {
+			@media ( max-width: $break-mobile ) {
 				align-items: center;
 			}
 		}

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1307,6 +1307,26 @@
 			}
 		}
 
+		.wp-login__main-footer {
+			display: flex;
+			align-items: center;
+			width: 100%;
+			flex-direction: column;
+			margin-block-start: 40px;
+			.auth-form__social-buttons-tos {
+				margin: 0;
+			}
+
+			.login__lost-password-link {
+				color: $woo-purple-50;
+				text-align: center;
+				font-weight: 500;
+				line-height: 20px;
+				margin-block-start: 24px;
+				text-decoration: none;
+			}
+		}
+
 		.signup-form {
 			input[type="email"].form-text-input {
 				margin-bottom: 0;
@@ -1316,15 +1336,6 @@
 				padding: 0;
 				margin-top: 24px;
 			}
-		}
-
-		.login__form-forgot-password {
-			color: $woo-purple-50;
-			text-align: center;
-			font-weight: 500;
-			line-height: 20px;
-			margin-block-start: 32px;
-			text-decoration: none;
 		}
 
 		.auth-form__social {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -710,15 +710,6 @@
 		margin-top: -14px;
 	}
 
-	.is-woo-passwordless.login .login__form-forgot-password {
-		color: $woo-purple-50;
-		text-align: center;
-		font-weight: 500;
-		line-height: 20px;
-		margin-block-start: 32px;
-		text-decoration: none;
-	}
-
 	.logged-out-form__footer {
 		background: none;
 		border: none;
@@ -1265,7 +1256,6 @@
 		}
 
 		.signup-form,
-		.login form,
 		.login__body--continue-as-user {
 			width: 100%;
 			margin: 48px auto 0;
@@ -1273,6 +1263,48 @@
 			max-width: 327px;
 			display: flex;
 			flex-direction: column;
+		}
+
+		.wp-login__main.main {
+			max-width: 758px;
+		}
+
+		.login form.is-woo-passwordless {
+			display: flex;
+			flex-direction: row;
+			margin-top: 48px;
+			padding: 0;
+			justify-content: center;
+			max-width: 758px;
+
+			@media screen and ( max-width: 660px ) {
+				flex-direction: column;
+			}
+
+			.card.login__form {
+				padding: 0;
+				display: flex;
+				flex-direction: column;
+				justify-content: center;
+				width: 100%;
+				max-width: var(--login-form-column-max-width);
+				margin: 0;
+
+				~ .auth-form__social.card {
+					width: 100%;
+					max-width: var(--login-form-column-max-width);
+					margin: 0;
+				}
+
+				.login__form-userdata .form-label {
+					color: var(--color-gray-100);
+					font-size: 1rem;
+					font-style: normal;
+					font-weight: 600;
+					line-height: 24px;
+					margin-bottom: 16px;
+				}
+			}
 		}
 
 		.signup-form {
@@ -1283,25 +1315,6 @@
 			.signup-form__passwordless-form-wrapper .logged-out-form__footer {
 				padding: 0;
 				margin-top: 24px;
-			}
-		}
-
-		.card.login__form {
-			padding: 0;
-			border-bottom-width: 0;
-			margin-inline: 0;
-
-			~ .auth-form__separator {
-				margin-block: 32px;
-			}
-
-			.login__form-userdata .form-label {
-				color: var(--color-gray-100);
-				font-size: 1rem;
-				font-style: normal;
-				font-weight: 600;
-				line-height: 24px;
-				margin-bottom: 16px;
 			}
 		}
 

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -710,6 +710,15 @@
 		margin-top: -14px;
 	}
 
+	.is-woo-passwordless.login .login__form-forgot-password {
+		color: $woo-purple-50;
+		text-align: center;
+		font-weight: 500;
+		line-height: 20px;
+		margin-block-start: 32px;
+		text-decoration: none;
+	}
+
 	.logged-out-form__footer {
 		background: none;
 		border: none;
@@ -1256,6 +1265,7 @@
 		}
 
 		.signup-form,
+		.login form,
 		.login__body--continue-as-user {
 			width: 100%;
 			margin: 48px auto 0;
@@ -1274,6 +1284,34 @@
 				padding: 0;
 				margin-top: 24px;
 			}
+		}
+
+		.card.login__form {
+			padding: 0;
+			border-bottom-width: 0;
+			margin-inline: 0;
+
+			~ .auth-form__separator {
+				margin-block: 32px;
+			}
+
+			.login__form-userdata .form-label {
+				color: var(--color-gray-100);
+				font-size: 1rem;
+				font-style: normal;
+				font-weight: 600;
+				line-height: 24px;
+				margin-bottom: 16px;
+			}
+		}
+
+		.login__form-forgot-password {
+			color: $woo-purple-50;
+			text-align: center;
+			font-weight: 500;
+			line-height: 20px;
+			margin-block-start: 32px;
+			text-decoration: none;
 		}
 
 		.auth-form__social {
@@ -1302,6 +1340,7 @@
 					border: 2px solid var(--studio-gray-10);
 					width: 100%;
 					margin: 0;
+					text-decoration: none;
 
 					&:hover {
 						background: var(--studio-gray-0, #f6f7f7);

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1187,6 +1187,10 @@
 			padding: 0;
 			margin-top: 8px;
 
+			a {
+				line-height: 21px;
+			}
+
 			svg {
 				display: none;
 			}
@@ -1256,7 +1260,8 @@
 		}
 
 		.signup-form,
-		.login__body--continue-as-user {
+		.login__body--continue-as-user,
+		.login__lostpassword-form {
 			width: 100%;
 			margin: 48px auto 0;
 			padding: 0;
@@ -1305,6 +1310,10 @@
 					margin-bottom: 16px;
 				}
 			}
+
+			.auth-form__separator {
+				margin-block: 0;
+			}
 		}
 
 		.wp-login__main-footer {
@@ -1312,7 +1321,13 @@
 			align-items: center;
 			width: 100%;
 			flex-direction: column;
-			margin-block-start: 40px;
+			margin: 40px auto 0;
+
+			@media screen and ( max-width: 660px ) {
+				max-width: 327px;
+				margin-bottom: 40px;
+			}
+
 			.auth-form__social-buttons-tos {
 				margin: 0;
 			}
@@ -1416,14 +1431,19 @@
 			}
 		}
 
-		.auth-form__separator .auth-form__separator-text {
-			padding: 0 27px !important;
-		}
-
-
-		.auth-form__separator {
+		div.auth-form__separator {
 			margin: 32px auto;
 			max-width: initial;
+
+			&::before,
+			&::after {
+				border-block-start-color: #e0e0e1;
+			}
+
+			+ .auth-form__social.card {
+				border: 0;
+				padding: 0;
+			}
 		}
 
 		.continue-as-user {
@@ -1482,33 +1502,33 @@
 				text-align: center;
 				margin: 0;
 			}
-		}
 
-		.continue-as-user__not-you {
-			margin-bottom: 0;
-			display: flex;
-			height: 32px;
-			padding: 4px 16px;
-			justify-content: center;
-			align-items: center;
-			gap: 4px;
-		}
-
-		.continue-as-user__change-user-link {
-			text-decoration: none;
-			color: $woo-purple-50;
-			font-size: 0.875rem;
-			font-style: normal;
-			font-weight: 500;
-			line-height: 21px;
-
-			&:hover {
-				color: $woo-purple-70;
+			.continue-as-user__not-you {
+				margin-bottom: 0;
+				display: flex;
+				height: 32px;
+				padding: 4px 16px;
+				justify-content: center;
+				align-items: center;
+				gap: 4px;
 			}
-		}
 
-		.continue-as-user__continue-button {
-			margin-top: 24px;
+			.continue-as-user__change-user-link {
+				text-decoration: none;
+				color: $woo-purple-50;
+				font-size: 0.875rem;
+				font-style: normal;
+				font-weight: 500;
+				line-height: 21px;
+
+				&:hover {
+					color: $woo-purple-70;
+				}
+			}
+
+			.continue-as-user__continue-button {
+				margin-top: 24px;
+			}
 		}
 
 		.magic-login {
@@ -1640,9 +1660,10 @@
 			}
 		}
 
-		.auth-form__separator + .auth-form__social.card {
-			border: 0;
-			padding: 0;
+		.login__lostpassword-form {
+			.login__form-action {
+				margin: 8px 0 32px;
+			}
 		}
 
 		.two-factor-authentication__verification-code-form-wrapper {

--- a/client/layout/masterbar/woo.scss
+++ b/client/layout/masterbar/woo.scss
@@ -1312,7 +1312,9 @@
 			}
 
 			.auth-form__separator {
-				margin-block: 0;
+				@media screen and ( min-width: 660px ) {
+					margin-block: 0;
+				}
 			}
 		}
 
@@ -1546,7 +1548,7 @@
 				margin: 0;
 
 				@media screen and ( max-width: 660px ) {
-					text-align: left;
+					text-align: center;
 					max-width: 327px;
 					margin: 0 auto;
 				}
@@ -1663,6 +1665,18 @@
 		.login__lostpassword-form {
 			.login__form-action {
 				margin: 8px 0 32px;
+				width: 100%;
+			}
+
+			.login__form-userdata {
+				width: 100%;
+			}
+		}
+
+		.login__lost-password-footer {
+			@media screen and ( max-width: 660px ) {
+				margin-bottom: 32px;
+				align-items: center;
 			}
 		}
 

--- a/client/lib/login/index.js
+++ b/client/lib/login/index.js
@@ -189,7 +189,13 @@ export const canDoMagicLogin = ( twoFactorAuthType, oauth2Client, isJetpackWooCo
 	return true;
 };
 
-export const getLoginLinkPageUrl = ( locale = 'en', currentRoute, signupUrl, oauth2ClientId ) => {
+export const getLoginLinkPageUrl = ( {
+	locale = 'en',
+	currentRoute,
+	signupUrl,
+	oauth2ClientId,
+	...additionalParams
+} ) => {
 	// The email address from the URL (if present) is added to the login
 	// parameters in this.handleMagicLoginLinkClick(). But it's left out
 	// here deliberately, to ensure that if someone copies this link to
@@ -199,6 +205,7 @@ export const getLoginLinkPageUrl = ( locale = 'en', currentRoute, signupUrl, oau
 		twoFactorAuthType: 'link',
 		signupUrl: signupUrl,
 		oauth2ClientId,
+		...additionalParams,
 	};
 
 	if ( currentRoute === '/log-in/jetpack' ) {

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -427,7 +427,6 @@ export class Login extends Component {
 			isWhiteLogin,
 			isP2Login,
 			isGravPoweredClient,
-			oauth2Client,
 			privateSite,
 			socialConnect,
 			twoFactorAuthType,
@@ -438,6 +437,7 @@ export class Login extends Component {
 			isWooCoreProfilerFlow,
 			isWooPasswordless,
 			isPartnerSignup,
+			isWoo,
 		} = this.props;
 
 		if ( isGravPoweredLoginPage ) {
@@ -469,8 +469,9 @@ export class Login extends Component {
 			! socialConnect &&
 			! isJetpackMagicLinkSignUpFlow &&
 			// We don't want to render the footer for woo oauth2 flows but render it if it's partner signup
-			! ( isWooOAuth2Client( oauth2Client ) && ! isPartnerSignup ) &&
+			! ( isWoo && ! isPartnerSignup ) &&
 			! isWooCoreProfilerFlow;
+
 		if ( shouldRenderFooter ) {
 			return (
 				<>
@@ -624,7 +625,11 @@ export default connect(
 			isLoginView:
 				! props.twoFactorAuthType &&
 				! props.socialConnect &&
-				currentRoute !== '/log-in/lostpassword',
+				// React lost password screen.
+				! currentRoute.includes( '/lostpassword' ) &&
+				// When user clicks on the signup link, it changes the route but it doesn't immediately render the signup page
+				// So we need to check if the current route is not the signup route to avoid flickering
+				! currentRoute.includes( '/start' ),
 			emailQueryParam:
 				currentQuery.email_address || getInitialQueryArguments( state ).email_address,
 			isPartnerSignup: isPartnerSignupQuery( currentQuery ),

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -36,6 +36,7 @@ import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slu
 import getCurrentQueryArguments from 'calypso/state/selectors/get-current-query-arguments';
 import getCurrentRoute from 'calypso/state/selectors/get-current-route';
 import getInitialQueryArguments from 'calypso/state/selectors/get-initial-query-arguments';
+import getWooPasswordless from 'calypso/state/selectors/get-woo-passwordless';
 import isWooCommerceCoreProfilerFlow from 'calypso/state/selectors/is-woocommerce-core-profiler-flow';
 import { withEnhancers } from 'calypso/state/utils';
 import LoginButtons from './login-buttons';
@@ -412,6 +413,7 @@ export class Login extends Component {
 			signupUrl,
 			action,
 			isWooCoreProfilerFlow,
+			isWooPasswordless,
 			isPartnerSignup,
 			currentRoute,
 		} = this.props;
@@ -457,7 +459,7 @@ export class Login extends Component {
 
 		const loginButtons = (
 			<>
-				{ isSocialFirst && isWhiteLogin && (
+				{ ( ( isSocialFirst && isWhiteLogin ) || isWooPasswordless ) && (
 					<LoginButtons
 						locale={ locale }
 						twoFactorAuthType={ twoFactorAuthType }
@@ -467,6 +469,7 @@ export class Login extends Component {
 						signupUrl={ signupUrl }
 						usernameOrEmail={ this.state.usernameOrEmail }
 						oauth2Client={ this.props.oauth2Client }
+						isWooPasswordless={ isWooPasswordless }
 					/>
 				) }
 			</>
@@ -559,6 +562,7 @@ export default connect(
 			isFromMigrationPlugin: startsWith( get( currentQuery, 'from' ), 'wpcom-migration' ),
 			isWooCoreProfilerFlow: isWooCommerceCoreProfilerFlow( state ),
 			isWoo: isWooOAuth2Client( oauth2Client ),
+			isWooPasswordless: getWooPasswordless( state ),
 			currentRoute: getCurrentRoute( state ),
 			currentQuery,
 		};

--- a/client/login/wp-login/index.jsx
+++ b/client/login/wp-login/index.jsx
@@ -434,8 +434,11 @@ export class Login extends Component {
 
 		const footer = (
 			<>
-				{ isSocialFirst ? (
-					<LoginFooter lostPasswordLink={ this.getLostPasswordLink() } />
+				{ isSocialFirst || isWooPasswordless ? (
+					<LoginFooter
+						lostPasswordLink={ this.getLostPasswordLink() }
+						shouldRenderTos={ isWooPasswordless }
+					/>
 				) : (
 					shouldRenderFooter && (
 						<LoginLinks

--- a/client/login/wp-login/login-buttons.tsx
+++ b/client/login/wp-login/login-buttons.tsx
@@ -20,6 +20,7 @@ interface LoginButtonsProps {
 	};
 	twoFactorAuthType: string;
 	usernameOrEmail: string;
+	isWooPasswordless: boolean;
 }
 
 const LoginButtons = ( {
@@ -27,6 +28,7 @@ const LoginButtons = ( {
 	oauth2Client,
 	twoFactorAuthType,
 	usernameOrEmail,
+	isWooPasswordless,
 }: LoginButtonsProps ) => {
 	const translate = useTranslate();
 	const query = useSelector( getCurrentQueryArguments );
@@ -87,7 +89,8 @@ const LoginButtons = ( {
 			return null;
 		}
 		// Is not supported for any oauth 2 client.
-		if ( oauth2Client ) {
+		// n.b this seems to work for woo.com so it's not clear why the above comment is here
+		if ( oauth2Client && ! isWooPasswordless ) {
 			return null;
 		}
 

--- a/client/login/wp-login/login-buttons.tsx
+++ b/client/login/wp-login/login-buttons.tsx
@@ -1,6 +1,5 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Button } from '@wordpress/components';
-import { addQueryArgs } from '@wordpress/url';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import JetpackLogo from 'calypso/components/jetpack-logo';
@@ -42,16 +41,16 @@ const LoginButtons = ( {
 			return null;
 		}
 
-		const loginLink = getLoginLinkPageUrl(
+		const loginLink = getLoginLinkPageUrl( {
 			locale,
 			currentRoute,
-			query?.signup_url,
-			oauth2Client?.id
-		);
+			signupUrl: query?.signup_url,
+			oauth2ClientId: oauth2Client?.id,
+			emailAddress: usernameOrEmail || query?.email_address,
+			redirectTo: query?.redirect_to,
+		} );
 
-		const emailAddress = usernameOrEmail || query?.email_address;
-
-		return addQueryArgs( loginLink, { email_address: emailAddress } );
+		return loginLink;
 	};
 
 	const handleMagicLoginClick = () => {

--- a/client/login/wp-login/login-footer.tsx
+++ b/client/login/wp-login/login-footer.tsx
@@ -1,13 +1,21 @@
+import SocialTos from 'calypso/blocks/authentication/social/social-tos';
+
 interface LoginFooterProps {
 	lostPasswordLink: JSX.Element;
+	shouldRenderTos: boolean;
 }
 
-const LoginFooter = ( { lostPasswordLink }: LoginFooterProps ) => {
-	if ( ! lostPasswordLink ) {
+const LoginFooter = ( { lostPasswordLink, shouldRenderTos }: LoginFooterProps ) => {
+	if ( ! lostPasswordLink && ! shouldRenderTos ) {
 		return null;
 	}
 
-	return <div className="wp-login__main-footer">{ lostPasswordLink }</div>;
+	return (
+		<div className="wp-login__main-footer">
+			{ shouldRenderTos && <SocialTos /> }
+			{ lostPasswordLink }
+		</div>
+	);
 };
 
 export default LoginFooter;

--- a/client/login/wp-login/login-links.jsx
+++ b/client/login/wp-login/login-links.jsx
@@ -221,12 +221,12 @@ export class LoginLinks extends Component {
 			return null;
 		}
 
-		const loginLink = getLoginLinkPageUrl(
-			this.props.locale,
-			this.props.currentRoute,
-			this.props.query?.signup_url,
-			this.props.oauth2Client?.id
-		);
+		const loginLink = getLoginLinkPageUrl( {
+			locale: this.props.locale,
+			currentRoute: this.props.currentRoute,
+			signupUrl: this.props.query?.signup_url,
+			oauth2ClientId: this.props.oauth2Client?.id,
+		} );
 
 		return (
 			<a

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -501,6 +501,7 @@ $image-height: 47px;
 	}
 
 	.wp-login__main-footer {
+
 		max-width: var(--login-form-column-max-width);
 		margin: 0 auto;
 

--- a/client/login/wp-login/style.scss
+++ b/client/login/wp-login/style.scss
@@ -501,7 +501,6 @@ $image-height: 47px;
 	}
 
 	.wp-login__main-footer {
-
 		max-width: var(--login-form-column-max-width);
 		margin: 0 auto;
 

--- a/client/state/selectors/get-param-from-url-or-oauth2-redirect.ts
+++ b/client/state/selectors/get-param-from-url-or-oauth2-redirect.ts
@@ -1,6 +1,7 @@
 import { get } from 'lodash';
 import 'calypso/state/route/init';
 import getCurrentQueryArguments from './get-current-query-arguments';
+import getInitialQueryArguments from './get-initial-query-arguments';
 import type { AppState } from 'calypso/types';
 
 /**
@@ -13,6 +14,7 @@ export const getParamFromUrlOrOauth2Redirect = (
 	state: AppState,
 	paramName: string
 ): string | null => {
+	const initialQuery = getInitialQueryArguments( state );
 	const currentQuery = getCurrentQueryArguments( state );
 	const paramValue = get( currentQuery, paramName ) as string | null;
 
@@ -21,8 +23,14 @@ export const getParamFromUrlOrOauth2Redirect = (
 	}
 
 	try {
-		const queryOauth2Redirect = currentQuery?.oauth2_redirect || currentQuery?.redirect_to;
+		const queryOauth2Redirect =
+			currentQuery?.oauth2_redirect ||
+			currentQuery?.redirect_to ||
+			initialQuery?.oauth2_redirect ||
+			initialQuery?.redirect_to;
+
 		const oauth2RedirectUrl = new URL( queryOauth2Redirect as string );
+
 		return oauth2RedirectUrl.searchParams.get( paramName );
 	} catch ( e ) {
 		// ignore


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #https://github.com/Automattic/wp-calypso/issues/87630

## Proposed Changes

* Added branches for the login screen to handle Woo Passwordless
* Most of it was just excluding woo passwordless flow from the customised woo flows, as the existing wpcom passwordless flow handles our requirements quite well
* The other bulk of work was css changes for the updated design
* Allowed the "Send email link" and "Login with App" buttons to render as they were excluded from Woo login flow before. There was a comment about "Login with App" not working with oauth logins but it seemed to work fine for me - not sure if we should put this to more scrutiny

Figma: 4ixWMlzrxllx93tSFsCW6k-fi-9751_4240

<img width="1480" alt="03  Social login - Horizontal layout" src="https://github.com/Automattic/wp-calypso/assets/4344253/6abdabd2-b1c9-4707-933f-fb734a226084">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->


Set up the `woocommerce-start-dev-env`

1. Log out of your WP.com and Woo.com or Use incognito mode to test log-in flow. You will need two accounts, one that was created passwordless-ly and one that was passworded
2. Go to woocommerce.test/start and go through the flow, doesn't really matter what you enter. Click on the login link after you reach wpcom
3. Follow below specifications

**Passwordless login**

```
Given the user has a passwordless account
	and is logged out
	and is on the Woo Express site creation flow
When user enter their email address
	and clicks on "Continue with email"
Then a magic link will be sent to their email address
When user clicks on the magic link
Then 
    if 2FA is not enabled, they will be logged in automatically
	if 2FA is enabled, they will be prompted to complete 2FA
	and they will be redirected back to the Woo Express site creation flow
```

**Password login**

```
Given the user has a non-passwordless account
	and is logged out
	and is on the Woo Express site creation flow
When user continues with email
Then a password field will be shown
When user enters the correct password
	and completes 2FA (if enabled)
Then they will be logged in
	and they will be redirected back to the Woo Express site creation flow
```

Also, test around the existing flows and the non-passwordless flows (You can disable the feature flag by using `document.cookie = 'flags=-woo/passwordless;max-age=1209600;path=/';`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?