### PR TITLE
Fixes the Blaze config we got from Jetpack for an atomic site

### DIFF
--- a/apps/blaze-dashboard/src/load-config.js
+++ b/apps/blaze-dashboard/src/load-config.js
@@ -4,6 +4,11 @@ if ( window.configData?.intial_state ) {
 	delete window.configData.intial_state;
 }
 
+// Forces the blog_id to be a number (the component BlazePageViewTracker breaks on atomic if its gets a string).
+if ( window.configData?.blog_id ) {
+	window.configData.blog_id = +window.configData.blog_id;
+}
+
 const isWooStore = window.configData?.is_woo_store || false;
 const needSetup = window.configData?.need_setup || false;
 


### PR DESCRIPTION
We are getting an error when the Blaze Dashboard app loads for an atomic site using a sandbox. This only happens locally, not in production.

![Screenshot 2024-03-04 at 14 52 46](https://github.com/Automattic/wp-calypso/assets/1258162/de311857-0761-4a27-b44f-c8bf33e3560c)

There was a problem with the blog_id we are getting in the configuration that was making the BlazePageViewTracker to crash.  

## Proposed Changes

Converted the blog_id we are getting in the Jetpack config response to be a number.

## Testing Instructions

You will need to have a sandbox configured to test this change.

* Checkout this branch
* In a console, go to `wp-calypso/apps/blaze-dashboard`
* Execute `yarn dev --sync` 
* Move the traffic from `widgets.wp.com` to your sandbox
* Go to an atomic site and navigate to Tools->Advertising
* Check that the dashboard loads correctly

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?