### PR TITLE
Global Sidebar: WP admin link - remove icon

### DIFF
--- a/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
+++ b/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
@@ -19,12 +19,6 @@ export default function globalSiteSidebarMenu( {
 } ) {
 	return [
 		{
-			slug: 'wp-admin',
-			title: translate( 'Open WP Admin' ),
-			url: `https://${ selectedSiteSlug }/wp-admin`,
-			className: 'sidebar__menu-item-wp-admin',
-		},
-		{
 			type: 'current-site',
 			url: `/home/${ siteDomain }`,
 			shouldHide: ! isDesktop,
@@ -35,6 +29,12 @@ export default function globalSiteSidebarMenu( {
 			type: 'menu-item',
 			url: `/home/${ siteDomain }`,
 			shouldHide: isDesktop,
+		},
+		{
+			slug: 'wp-admin',
+			title: translate( 'Open WP Admin' ),
+			url: `https://${ selectedSiteSlug }/wp-admin`,
+			className: 'sidebar__menu-item-wp-admin',
 		},
 		{
 			slug: 'upgrades',

--- a/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
+++ b/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
@@ -19,9 +19,8 @@ export default function globalSiteSidebarMenu( {
 } ) {
 	return [
 		{
-			icon: 'dashicons-arrow-left-alt2',
 			slug: 'wp-admin',
-			title: translate( 'WP Admin' ),
+			title: translate( 'Open WP Admin' ),
 			url: `https://${ selectedSiteSlug }/wp-admin`,
 			className: 'sidebar__menu-item-wp-admin',
 		},


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5821

This PR removes the chevron icon on the sites home page on Calypso and changes `WP Admin` to `Open WP Admin`;

### Before

![Image](https://github.com/Automattic/dotcom-forge/assets/1525580/207df4c5-20db-4ac7-a084-43244a6e291d)

### After

<img width="693" alt="Screenshot 2024-03-04 at 18 49 53" src="https://github.com/Automattic/wp-calypso/assets/5560595/cf7b4b51-8cf1-4f21-a41f-e921ae4de76f">

This is inline with how we present the option on my-sites site menu item

<img width="1067" alt="Screenshot 2024-03-04 at 18 41 30" src="https://github.com/Automattic/wp-calypso/assets/5560595/3b50e92e-b418-413b-bcb7-b6cc0b963fb5">


### Test

* You need to activate the global classic view – Once you have an Atomic site, navigate to Settings -> Hosting Configuration. Scroll down the page until you see “Admin interface style”. Click “Classic style”.
* Go to `https://container-pedantic-kare.calypso.live/home/eoinstestatomicsite.wpcomstaging.com` - replace `eoinstestatomicsite.wpcomstaging.com` with your atomic URL
* Confirm `Open WP Admin` is shown in sidebar

