### PR TITLE
Congrats: Update Entrepreneur/Ecommerce Plan Congrats Page Content

### DIFF
--- a/client/components/thank-you-v2/header/style.scss
+++ b/client/components/thank-you-v2/header/style.scss
@@ -36,6 +36,11 @@
 	text-align: left;
 	letter-spacing: -0.1px;
 
+	.button-plain {
+		color: var(--studio-blue-50);
+		cursor: pointer;
+	}
+
 	@include break-mobile {
 		text-align: center;
 	}

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -572,7 +572,6 @@ export class CheckoutThankYou extends Component<
 		}
 
 		/** REFACTORED REDESIGN */
-
 		if ( isRefactoredForThankYouV2( this.props ) ) {
 			let pageContent = null;
 			const domainPurchase = getDomainPurchase( purchases );
@@ -590,7 +589,12 @@ export class CheckoutThankYou extends Component<
 			} else if ( isDomainOnly( purchases ) ) {
 				pageContent = <DomainOnlyThankYou purchases={ purchases } receiptId={ receiptId } />;
 			} else if ( purchases.length === 1 && isPlan( purchases[ 0 ] ) ) {
-				pageContent = <PlanOnlyThankYou primaryPurchase={ purchases[ 0 ] } />;
+				pageContent = (
+					<PlanOnlyThankYou
+						primaryPurchase={ purchases[ 0 ] }
+						isEmailVerified={ this.props.isEmailVerified }
+					/>
+				);
 			} else if ( wasTitanEmailOnlyProduct ) {
 				const titanPurchase = purchases.find( ( purchase ) => isTitanMail( purchase ) );
 

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -59,7 +59,6 @@ import {
 	isCurrentUserEmailVerified,
 } from 'calypso/state/current-user/selectors';
 import { recordStartTransferClickInThankYou } from 'calypso/state/domains/actions';
-import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import {
 	getPlugins as getInstalledPlugins,
@@ -594,9 +593,6 @@ export class CheckoutThankYou extends Component<
 					<PlanOnlyThankYou
 						primaryPurchase={ purchases[ 0 ] }
 						isEmailVerified={ this.props.isEmailVerified }
-						errorNotice={ this.props.errorNotice }
-						removeNotice={ this.props.removeNotice }
-						successNotice={ this.props.successNotice }
 					/>
 				);
 			} else if ( wasTitanEmailOnlyProduct ) {
@@ -994,9 +990,6 @@ export default connect(
 		recordStartTransferClickInThankYou,
 		requestThenActivate,
 		requestSite,
-		errorNotice,
-		removeNotice,
-		successNotice,
 	}
 )( localize( CheckoutThankYou ) );
 

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -59,6 +59,7 @@ import {
 	isCurrentUserEmailVerified,
 } from 'calypso/state/current-user/selectors';
 import { recordStartTransferClickInThankYou } from 'calypso/state/domains/actions';
+import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import {
 	getPlugins as getInstalledPlugins,
@@ -593,6 +594,9 @@ export class CheckoutThankYou extends Component<
 					<PlanOnlyThankYou
 						primaryPurchase={ purchases[ 0 ] }
 						isEmailVerified={ this.props.isEmailVerified }
+						errorNotice={ this.props.errorNotice }
+						removeNotice={ this.props.removeNotice }
+						successNotice={ this.props.successNotice }
 					/>
 				);
 			} else if ( wasTitanEmailOnlyProduct ) {
@@ -990,6 +994,9 @@ export default connect(
 		recordStartTransferClickInThankYou,
 		requestThenActivate,
 		requestSite,
+		errorNotice,
+		removeNotice,
+		successNotice,
 	}
 )( localize( CheckoutThankYou ) );
 

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -117,13 +117,12 @@ export default function PlanOnlyThankYou( {
 			);
 
 			const isSendingEmail = resendStatus === RESEND_PENDING;
-			const isSent = resendStatus === RESEND_SUCCESS;
 
 			headerButtons = (
 				<Button
 					onClick={ resendEmail }
 					busy={ isSendingEmail }
-					disabled={ isSendingEmail || isSent }
+					disabled={ isSendingEmail || resendStatus === RESEND_SUCCESS }
 				>
 					{ resendButtonText() }
 				</Button>

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -3,12 +3,14 @@ import { Button } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
 import { useState } from 'react';
+import { connect } from 'react-redux';
 import ThankYouV2 from 'calypso/components/thank-you-v2';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { preventWidows } from 'calypso/lib/formatting';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
+import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSiteOptions, getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import ThankYouPlanProduct from '../products/plan-product';
@@ -36,13 +38,13 @@ const isMonthsOld = ( months: number, rawDate?: string ) => {
 	return moment().diff( parsedDate, 'months' ) > months;
 };
 
-export default function PlanOnlyThankYou( {
+const PlanOnlyThankYou = ( {
 	primaryPurchase,
 	isEmailVerified,
 	errorNotice,
 	removeNotice,
 	successNotice,
-}: PlanOnlyThankYouProps ) {
+}: PlanOnlyThankYouProps ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const siteCreatedTimeStamp = useSelector(
@@ -200,4 +202,10 @@ export default function PlanOnlyThankYou( {
 			footerDetails={ footerDetails }
 		/>
 	);
-}
+};
+
+export default connect( null, {
+	errorNotice,
+	removeNotice,
+	successNotice,
+} )( PlanOnlyThankYou );

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -10,7 +10,7 @@ import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
-import { getSiteOptions } from 'calypso/state/sites/selectors';
+import { getSiteOptions, getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import ThankYouPlanProduct from '../products/plan-product';
 import type { ReceiptPurchase } from 'calypso/state/receipts/types';
@@ -84,15 +84,16 @@ export default function PlanOnlyThankYou( {
 	};
 
 	let subtitle;
+	// At this point in the flow, having purchased a plan for a specific site,
+	// we can be confident that `siteId` is a number and not `null`
+	const siteAdminUrl = useSelector( ( state ) => getSiteWooCommerceUrl( state, siteId as number ) );
+
 	let headerButtons;
 	if ( primaryPurchase.productSlug === 'ecommerce-bundle' ) {
 		if ( isEmailVerified ) {
 			subtitle = translate( "With the plan sorted, it's time to start setting up your store." );
-			headerButtons = (
-				<Button
-					variant="primary"
-					href={ `http://${ siteSlug }/wp-admin/admin.php?page=wc-admin&from-calypso` }
-				>
+			headerButtons = typeof siteAdminUrl === 'string' && (
+				<Button variant="primary" href={ siteAdminUrl }>
 					Create your store
 				</Button>
 			);

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -24,9 +24,9 @@ const RESEND_SUCCESS = 'RESEND_SUCCESS';
 interface PlanOnlyThankYouProps {
 	primaryPurchase: ReceiptPurchase;
 	isEmailVerified: boolean;
-	errorNotice: () => void;
-	removeNotice: () => void;
-	successNotice: () => void;
+	errorNotice: ( text: string, noticeOptions: object ) => void;
+	removeNotice: ( text: string, noticeOptions: object ) => void;
+	successNotice: ( text: string, noticeOptions: object ) => void;
 }
 
 const isMonthsOld = ( months: number, rawDate?: string ) => {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -1,4 +1,4 @@
-import { isP2Plus } from '@automattic/calypso-products';
+import { isP2Plus, isWpComEcommercePlan } from '@automattic/calypso-products';
 import { Button } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -96,7 +96,7 @@ const PlanOnlyThankYou = ( {
 	let subtitle;
 	let headerButtons;
 
-	if ( primaryPurchase.productSlug === 'ecommerce-bundle' ) {
+	if ( isWpComEcommercePlan( primaryPurchase.productSlug ) ) {
 		if ( isEmailVerified ) {
 			subtitle = translate( "With the plan sorted, it's time to start setting up your store." );
 			headerButtons = typeof siteAdminUrl === 'string' && (

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -40,7 +40,6 @@ export default function PlanOnlyThankYou( {
 }: PlanOnlyThankYouProps ) {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
-	const emailAddress = useSelector( getCurrentUserEmail );
 	const siteCreatedTimeStamp = useSelector(
 		( state ) => getSiteOptions( state, siteId ?? 0 )?.created_at
 	);
@@ -83,10 +82,11 @@ export default function PlanOnlyThankYou( {
 		}
 	};
 
-	let subtitle;
 	// At this point in the flow, having purchased a plan for a specific site,
 	// we can be confident that `siteId` is a number and not `null`
 	const siteAdminUrl = useSelector( ( state ) => getSiteWooCommerceUrl( state, siteId as number ) );
+	const emailAddress = useSelector( getCurrentUserEmail );
+	let subtitle;
 
 	let headerButtons;
 	if ( primaryPurchase.productSlug === 'ecommerce-bundle' ) {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -1,5 +1,5 @@
 import { isP2Plus } from '@automattic/calypso-products';
-import { Button } from '@wordpress/components';
+import { Button } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
 import { useState } from 'react';
@@ -93,7 +93,7 @@ export default function PlanOnlyThankYou( {
 		if ( isEmailVerified ) {
 			subtitle = translate( "With the plan sorted, it's time to start setting up your store." );
 			headerButtons = typeof siteAdminUrl === 'string' && (
-				<Button variant="primary" href={ siteAdminUrl }>
+				<Button href={ siteAdminUrl } primary>
 					Create your store
 				</Button>
 			);
@@ -113,7 +113,7 @@ export default function PlanOnlyThankYou( {
 			);
 			const isSendingEmail = resendStatus === RESEND_PENDING;
 			headerButtons = (
-				<Button variant="secondary" onClick={ resendEmail } busy={ isSendingEmail } disabled={ isSendingEmail }>
+				<Button onClick={ resendEmail } busy={ isSendingEmail } disabled={ isSendingEmail }>
 					{ resendButtonText() }
 				</Button>
 			);

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -24,9 +24,9 @@ const RESEND_SUCCESS = 'RESEND_SUCCESS';
 interface PlanOnlyThankYouProps {
 	primaryPurchase: ReceiptPurchase;
 	isEmailVerified: boolean;
-	errorNotice: ( text: string, noticeOptions: object ) => void;
-	removeNotice: ( text: string, noticeOptions: object ) => void;
-	successNotice: ( text: string, noticeOptions: object ) => void;
+	errorNotice: ( text: string, noticeOptions?: object ) => void;
+	removeNotice: ( noticeId: string ) => void;
+	successNotice: ( text: string, noticeOptions?: object ) => void;
 }
 
 const isMonthsOld = ( months: number, rawDate?: string ) => {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -99,14 +99,21 @@ export default function PlanOnlyThankYou( {
 			);
 		} else {
 			subtitle = translate(
-				"{{paragraph}}With the plan sorted, verify your email address to create your store.{{br/}}Please click the link in the email we sent to %(emailAddress)s.{{/paragraph}}{{paragraph}}If you haven't received the verification email, please click here.{{/paragraph}}",
+				"{{paragraph}}With the plan sorted, verify your email address to create your store.{{br/}}Please click the link in the email we sent to {{strong}}%(emailAddress)s{{/strong}}.{{/paragraph}}{{paragraph}}If you haven't received the verification email, please {{a}}click here{{/a}}.{{/paragraph}}",
 				{
 					args: { emailAddress: emailAddress },
-					components: { paragraph: <p />, br: <br /> },
+					components: {
+						paragraph: <p />,
+						br: <br />,
+						strong: <strong />,
+						// eslint-disable-next-line jsx-a11y/anchor-is-valid
+						a: <a href="" onClick={ resendEmail } />,
+					},
 				}
 			);
+			const isSendingEmail = resendStatus === RESEND_PENDING;
 			headerButtons = (
-				<Button variant="secondary" onClick={ resendEmail }>
+				<Button variant="secondary" onClick={ resendEmail } busy={ isSendingEmail } disabled={ isSendingEmail }>
 					{ resendButtonText() }
 				</Button>
 			);

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/plan-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/plan-product.tsx
@@ -109,7 +109,7 @@ export default function ThankYouPlanProduct( {
 			details={ expirationDate }
 			actions={
 				<>
-					{ purchase.productSlug !== 'ecommerce-bundle' && (
+					{ ! isWpComEcommercePlan( purchase.productSlug ) && (
 						<Button
 							isBusy={ letsWorkButtonBusy }
 							variant="primary"

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/plan-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/plan-product.tsx
@@ -109,14 +109,16 @@ export default function ThankYouPlanProduct( {
 			details={ expirationDate }
 			actions={
 				<>
-					<Button
-						isBusy={ letsWorkButtonBusy }
-						variant="primary"
-						href={ letsWorkHref }
-						onClick={ letsWorkButtonOnClick }
-					>
-						{ translate( 'Let’s work on the site' ) }
-					</Button>
+					{ purchase.productSlug !== 'ecommerce-bundle' && (
+						<Button
+							isBusy={ letsWorkButtonBusy }
+							variant="primary"
+							href={ letsWorkHref }
+							onClick={ letsWorkButtonOnClick }
+						>
+							{ translate( 'Let’s work on the site' ) }
+						</Button>
+					) }
 					<Button variant="secondary" href={ `/plans/my-plan/${ siteSlug }` }>
 						{ translate( 'Manage plan' ) }
 					</Button>

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/plan-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/plan-product.tsx
@@ -1,3 +1,4 @@
+import { isWpComEcommercePlan } from '@automattic/calypso-products';
 import { useLaunchpad } from '@automattic/data-stores';
 import { Button } from '@wordpress/components';
 import { useDispatch as useWPDispatch } from '@wordpress/data';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 4188-gh-Automattic/dotcom-forge, https://github.com/Automattic/wp-calypso/pull/79525

## Proposed Changes

- Update the Plans-Only congrats page to show specific header text for the Entrepreneur Plan based on [provided mock up](https://github.com/Automattic/wp-calypso/pull/79525#issuecomment-1663995023)
- Within that text, include a separate flow for accounts with unverified email addresses (see note on this below)
- Remove the `Let's work on the site` CTA button for Entrepreneur Plan purchases

**Before:**
<img width="1655" alt="entrepreneur plan 'before' image" src="https://github.com/Automattic/wp-calypso/assets/13856531/0c427f12-12e1-438b-ae4f-430d7d7380a1">

"After" images are below in the testing instructions.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

**With email verified:**
- Use an account with a verified email address
- Purchase an Entrepreneur Plan
- On the Congrats page, confirm that the updated text appears:
<img width="1366" alt="entrepreneur plan 'before' image with a verified email address" src="https://github.com/Automattic/wp-calypso/assets/71137829/06fa3d6a-3893-4397-a118-84b4830d42ba">

- Clicking on the CTA button loads the site's WooCommerce setup page

**With email unverified (please see notes below on re: testing this more thoroughly):**

- Use an account with an unverified email address, or
<details>
<summary>Or apply this super-simple testing diff:</summary>

```diff
diff --git a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
index 09bf783938..dc6313f657 100644
--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -86,7 +86,7 @@ export default function PlanOnlyThankYou( {
 	let subtitle;
 	let headerButtons;
 	if ( primaryPurchase.productSlug === 'ecommerce-bundle' ) {
-		if ( isEmailVerified ) {
+		if ( ! isEmailVerified ) {
 			subtitle = translate( "With the plan sorted, it's time to start setting up your store." );
 			headerButtons = (
 				<Button

```

</details>

- Purchase an Entrepreneur plan
- On the Congrats page, confirm that the updated text appears:
<img width="1366" alt="entrepreneur plan 'before' image with an unverified email address" src="https://github.com/Automattic/wp-calypso/assets/71137829/5e7c3e0e-df44-42e2-a8f6-4a2128b50314">

- Confirm that the correct email address for the account being used is displayed
- Confirm that clicking on the CTA button should resends a verification email (again, see note below regarding this part)

**For both flows:**
- Confirm that there is no **Let's work on the site** button in the page content. There should only be one button, labeled **Manage Plan**. No changes were made to that button on this PR so don't worry about testing it. Unless you really want, to I suppose. You do you.

## Notes
- There's currently one inline note on something I'd love advice/input on
- It doesn't look like we previously had Tracks events set for these CTAs, (unless i'm just overlooking them) do we want to set some up?
- I had a hard time effectively testing the unverified email flow. I can (as shown in the testing diff above) force the flow to trigger by inverting the `isEmailVerified` check, but in actual testing any account shows in Calypso as verified... even brand new testing accounts that I hadn't even opened the verification email for. I'm not sure if the account is being auto-verified somehow (I feel like I remember that being a thing a few years back but can't find a trace of it on MGS) or if I'm just not detecting the unverified state properly. If anyone has tips on how to more accurately test the unverified email flow I'd be super grateful. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?