### PR TITLE
Site Migration: add new comparison component

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -1,6 +1,10 @@
 import { Button } from '@automattic/components';
 import { StepContainer } from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
+import {
+	StandAloneComparisonGrid,
+	Column,
+} from 'calypso/../packages/components/src/standalone-comparison-grid';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
@@ -22,25 +26,49 @@ const SiteMigrationImportOrMigrate: Step = function ( { navigation } ) {
 	};
 
 	const stepContent = (
-		<div className="migration-info">
-			<div className="migration-info-column">
-				<h2>{ translate( 'Import' ) }</h2>
-				<Button primary onClick={ () => handleSubmit( 'import' ) }>
-					{ translate( 'Import my website content' ) }
-				</Button>
-			</div>
-			<div className="migration-info-column">
-				<h2>{ translate( 'Migrate' ) }</h2>
-				<Button
-					primary
-					onClick={ () => {
-						handleSubmit( canInstallPlugins ? 'migrate' : 'upgrade' );
-					} }
-				>
-					{ canInstallPlugins ? translate( 'Migrate my site' ) : translate( 'Upgrade to migrate' ) }
-				</Button>
-			</div>
-		</div>
+		<StandAloneComparisonGrid>
+			<Column
+				title={ translate( 'Import' ) }
+				introCopy={ translate( 'Import posts, pages, and media from our supported platforms.' ) }
+				features={ [
+					translate( 'Import your content from a WordPress export file' ),
+					translate( 'Import your content from Blogger' ),
+					translate( 'Import your content from Medium' ),
+					translate( 'Import your content from Squarespace' ),
+					translate( 'Import your content from Substack' ),
+					translate( 'Import your content from Wix' ),
+					translate( 'Import your content from other platforms' ),
+				] }
+				controls={
+					<Button primary onClick={ () => handleSubmit( 'import' ) }>
+						{ translate( 'Import my website content' ) }
+					</Button>
+				}
+			/>
+			<Column
+				title={ translate( 'Migrate' ) }
+				introCopy={ translate(
+					'This will copy your existing WordPress site to your new WordPress.com site, including your content, media, plugins, and theme.'
+				) }
+				features={ [
+					translate( 'Import your content' ),
+					translate( 'Import your theme' ),
+					translate( 'Import your plugins' ),
+				] }
+				controls={
+					<Button
+						primary
+						onClick={ () => {
+							handleSubmit( canInstallPlugins ? 'migrate' : 'upgrade' );
+						} }
+					>
+						{ canInstallPlugins
+							? translate( 'Migrate my site' )
+							: translate( 'Upgrade to migrate' ) }
+					</Button>
+				}
+			/>
+		</StandAloneComparisonGrid>
 	);
 
 	return (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/87905

## Proposed Changes

Implements the new component to handle the layout of the import vs migrate step in the new Site Migration flow. This obviously needs copy updates, but I figured it was best to commit this change sooner rather than later.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this diff or go to the Calypso live link below
* Go through /start and select a free plan
* On the Goals screen add `&flags=onboarding/new-migration-flow` to the URL if you don't have the flag enabled via local storage
* Add a test URL that points to a WordPress site, JN works here
* Verify you see the two column layout
<img width="978" alt="image" src="https://github.com/Automattic/wp-calypso/assets/375980/1d040191-69c0-402e-9255-bf4c55f6e4bb">
* Check that both buttons behave correctly


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?