### PR TITLE
Site Migration: Plugin install step

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx
@@ -113,8 +113,14 @@ const BundleTransfer: Step = function BundleTransfer( { navigation } ) {
 			const maxFinishTime = startTime + totalTimeout;
 			const maxRetry = 3;
 
-			// Initiate transfer
-			await initiateAtomicTransfer( siteId, softwareSet );
+			await requestLatestAtomicTransfer( siteId );
+			const preTransferCheck = getSiteLatestAtomicTransfer( siteId );
+
+			// Ensure we don't have an existing transfer in progress before starting a new one.
+			if ( preTransferCheck?.status !== transferStates.ACTIVE ) {
+				// Initiate transfer
+				await initiateAtomicTransfer( siteId, softwareSet );
+			}
 
 			// Poll for transfer status
 			let stopPollingTransfer = false;

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/bundle-transfer/index.tsx
@@ -169,8 +169,8 @@ const BundleTransfer: Step = function BundleTransfer( { navigation } ) {
 				stopPollingTransfer = transferStatus === transferStates.COMPLETED;
 			}
 
-			// Poll for software status
-			let stopPollingSoftware = false;
+			// If we have a valid software-set, poll for software status
+			let stopPollingSoftware = ! softwareSet;
 			let pollingSoftwareRetry = 0;
 
 			while ( ! stopPollingSoftware ) {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/processing-step/index.tsx
@@ -2,6 +2,7 @@ import {
 	StepContainer,
 	isNewsletterOrLinkInBioFlow,
 	isFreeFlow,
+	isNewSiteMigrationFlow,
 	isUpdateDesignFlow,
 	ECOMMERCE_FLOW,
 	isWooExpressFlow,
@@ -34,7 +35,7 @@ interface ProcessingStepProps extends StepProps {
 
 const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 	const { submit } = props.navigation;
-	const { flow } = props;
+	const { flow, data } = props;
 
 	const { __ } = useI18n();
 	const loadingMessages = useProcessingLoadingMessages( flow );
@@ -108,6 +109,12 @@ const ProcessingStep: React.FC< ProcessingStepProps > = function ( props ) {
 				} );
 			}
 
+			if ( isNewSiteMigrationFlow( flow ) ) {
+				submit?.( { ...props.data }, ProcessingResult.SUCCESS );
+				return;
+			}
+
+			// Default processing handler.
 			submit?.( destinationState, ProcessingResult.SUCCESS );
 		}
 		// A change in submit() doesn't cause this effect to rerun.

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-plugin-install/index.tsx
@@ -1,0 +1,87 @@
+/* eslint-disable no-console */
+import { useDispatch } from '@wordpress/data';
+import { useEffect } from 'react';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import wpcom from 'calypso/lib/wp';
+import { ONBOARD_STORE } from '../../../../stores';
+import type { Step } from '../../types';
+
+const wait = ( ms: number ) => new Promise( ( res ) => setTimeout( res, ms ) );
+
+const SiteMigrationPluginInstall: Step = ( { navigation } ) => {
+	const { submit } = navigation;
+	const { setPendingAction, setProgress } = useDispatch( ONBOARD_STORE );
+	const site = useSite();
+
+	const siteId = site?.ID;
+
+	useEffect( () => {
+		if ( ! siteId ) {
+			return;
+		}
+
+		setPendingAction( async () => {
+			setProgress( 0 );
+
+			let stopPollingPlugins = false;
+			let pollingPluginsRetry = 0;
+			const maxRetry = 10;
+			let installedPlugins = null;
+
+			// Poll until plugins are installed. Once this is done, it's safe to install our plugin.
+			while ( ! stopPollingPlugins ) {
+				try {
+					const response = await wpcom.req.get( `/sites/${ siteId }/plugins?http_envelope=1`, {
+						apiNamespace: 'rest/v1.1',
+					} );
+
+					if ( response?.plugins ) {
+						installedPlugins = response?.plugins;
+						stopPollingPlugins = true;
+						break;
+					}
+
+					pollingPluginsRetry++;
+					if ( pollingPluginsRetry <= maxRetry ) {
+						await wait( 5000 );
+					} else {
+						stopPollingPlugins = true;
+					}
+				} catch ( error ) {
+					// Pause and retry after an error
+					await wait( 3000 );
+				}
+			}
+			const pluginAlreadyInstalled = installedPlugins.find(
+				( plugin: { slug: string } ) => plugin.slug === 'migrate-guru'
+			);
+
+			if ( ! pluginAlreadyInstalled ) {
+				// Install the plugin
+				await wpcom.req.post( {
+					path: `/sites/${ siteId }/plugins/migrate-guru/install`,
+					apiNamespace: 'rest/v1.2',
+				} );
+			}
+
+			// Activate the plugin
+			await wpcom.req.post( {
+				path: `/sites/${ siteId }/plugins/migrate-guru%2fmigrateguru`,
+				apiNamespace: 'rest/v1.2',
+				body: {
+					active: true,
+				},
+			} );
+
+			setProgress( 1 );
+		} );
+
+		submit?.();
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ siteId ] );
+
+	return null;
+};
+
+export default SiteMigrationPluginInstall;

--- a/client/landing/stepper/declarative-flow/internals/steps.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps.tsx
@@ -230,4 +230,9 @@ export const STEPS = {
 		slug: 'site-migration-upgrade-plan',
 		asyncComponent: () => import( './steps-repository/site-migration-upgrade-plan' ),
 	},
+
+	SITE_MIGRATION_PLUGIN_INSTALL: {
+		slug: 'site-migration-plugin-install',
+		asyncComponent: () => import( './steps-repository/site-migration-plugin-install' ),
+	},
 };

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -62,7 +62,9 @@ describe( 'Site Migration Flow', () => {
 
 			expect( getFlowLocation() ).toEqual( {
 				path: '/processing',
-				state: null,
+				state: {
+					bundleProcessing: true,
+				},
 			} );
 		} );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #87498

## Proposed Changes

This adds back the new `SiteMigrationPluginInstall` step which handles the plugin installation. We queue up pending actions and then the actual work is handled via the `Processing` step (which is the recommended method for Stepper).

The step has to account for some timing issues that can occur with Trial plans. If we attempt to install the plugin too quickly, we get `The user is not authorized for the 'install_plugins' action`. 

We've discovered that it's safe to install new plugins once `/sites/:siteId/plugins` returns the list of current plugins. To that end, the step now polls until we get plugin data back. Then we install the migration plugin and activate it.

We also had to make a minor tweak to the `Processing` step so it has the context it needs to determine if it's finishing the `BundleTransfer` step or the `SiteMigrationPluginInstall` step so it can navigate to the appropriate locations.

Lastly, we made two minor improvements to the `BundleTransfer` step:

1. Check for an existing Atomic transfer before starting a new one. This is necessary for Trial plans which start a transfer automatically behind the scenes. The `BundleTransfer` step will still poll for transfer completion, even if it didn't start a new transfer.
2. Ensure there's a valid software-set before attempting to install software. Previously, we would still make the software install calls even if software-set was undefined which would throw errors.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* You can either check out this branch and run it locally or use the calypso.live link.
* Go to `/start`.
* On the Plans step, purchase a Creator plan.
* On the Goals step, add `&flags=onboarding/new-migration-flow` to the url and refresh.
* Choose the "Import existing content or website" goal to be taken into the migration flow.
* When prompted for the existing site url, provide the url for any publicly accessible WordPress site. You can use Jurassic Ninja or https://fakeblog.biek.dev/.
* On the "Import vs Migration" step, click the "Migrate" button.
* You should be taken to the Processing step.
* Once processing is complete, go to the Plugins page in the wp-admin for the site and verify that MigrateGuru is installed and activated.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
