### PR TITLE
Stats: Update stats query utm metrics by selected params - Try 2

### DIFF
--- a/client/my-sites/stats/hooks/use-utm-metric-top-posts-query.ts
+++ b/client/my-sites/stats/hooks/use-utm-metric-top-posts-query.ts
@@ -20,7 +20,9 @@ export default function useUTMMetricTopPostsQuery(
 				}
 			} );
 		}
-	}, [ dispatch, siteId, UTMParam, metricsKey ] );
+		// No passed `UTMParam` to prevent triggering a new request before fetching the new metrics.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ dispatch, siteId, metricsKey ] );
 
 	const topPosts = useSelector( ( state ) => getTopPosts( state, siteId ) );
 

--- a/client/my-sites/stats/stats-module-utm/index.jsx
+++ b/client/my-sites/stats/stats-module-utm/index.jsx
@@ -8,26 +8,22 @@ import statsStrings from '../stats-strings';
 import UTMDropdown from './stats-module-utm-dropdown';
 
 const OPTION_KEYS = {
-	SOURCE_MEDIUM: 'source_medium',
-	CAMPAIGN_SOURCE_MEDIUM: 'campaign_source_medium',
-	SOURCE: 'source',
-	MEDIUM: 'medium',
-	CAMPAIGN: 'campaign',
+	SOURCE_MEDIUM: 'utm_source,utm_medium',
+	CAMPAIGN_SOURCE_MEDIUM: 'utm_campaign,utm_source,utm_medium',
+	SOURCE: 'utm_source',
+	MEDIUM: 'utm_medium',
+	CAMPAIGN: 'utm_campaign',
 };
 
 const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } ) => {
 	const moduleStrings = statsStrings();
 	const translate = useTranslate();
-	const [ displayOption, setDisplayOption ] = useState( OPTION_KEYS.SOURCE_MEDIUM );
+	const [ selectedOption, setSelectedOption ] = useState( OPTION_KEYS.SOURCE_MEDIUM );
 
 	// Fetch UTM metrics with switched UTM parameters.
-	const { isFetching: isFetching, metrics } = useUTMMetricsQuery(
-		siteId,
-		'utm_source,utm_medium',
-		postId
-	);
+	const { isFetching: isFetching, metrics } = useUTMMetricsQuery( siteId, selectedOption, postId );
 	// Fetch top posts for all UTM metric items.
-	const { topPosts } = useUTMMetricTopPostsQuery( siteId, 'utm_source,utm_medium', metrics );
+	const { topPosts } = useUTMMetricTopPostsQuery( siteId, selectedOption, metrics );
 
 	// Combine metrics with top posts.
 	const data = metrics.map( ( metric ) => {
@@ -78,10 +74,6 @@ const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } )
 		},
 	};
 
-	const onDisplaySelect = ( optionKey ) => {
-		setDisplayOption( optionKey );
-	};
-
 	return (
 		<StatsModuleDataQuery
 			data={ data }
@@ -92,13 +84,13 @@ const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } )
 			query={ query }
 			isLoading={ isFetching ?? true }
 			hideSummaryLink={ hideSummaryLink }
-			selectedOption={ optionLabels[ displayOption ] }
+			selectedOption={ optionLabels[ selectedOption ] }
 			toggleControl={
 				<UTMDropdown
-					buttonLabel={ optionLabels[ displayOption ].selectLabel }
-					onSelect={ onDisplaySelect }
+					buttonLabel={ optionLabels[ selectedOption ].selectLabel }
+					onSelect={ setSelectedOption }
 					selectOptions={ optionLabels }
-					selected={ displayOption }
+					selected={ selectedOption }
 				/>
 			}
 		/>

--- a/client/state/stats/utm-metrics/reducer.ts
+++ b/client/state/stats/utm-metrics/reducer.ts
@@ -16,19 +16,37 @@ import {
 import { schema } from './schema';
 import type { Reducer, AnyAction } from 'redux';
 
+const isValidJSON = ( string: string ) => {
+	try {
+		JSON.parse( string );
+
+		return true;
+	} catch ( e ) {
+		return false;
+	}
+};
+
 const metricsParser = ( UTMValues: { [ key: string ]: number }, stopFurtherRequest?: boolean ) => {
 	const combinedKeys = Object.keys( UTMValues );
 
 	return combinedKeys.map( ( combinedKey: string ) => {
-		const parsedKey = JSON.parse( combinedKey );
+		const parsedKeys = isValidJSON( combinedKey ) ? JSON.parse( combinedKey ) : [ combinedKey ];
 		const value = UTMValues[ combinedKey ];
 
 		const data = {
-			source: parsedKey[ 0 ],
-			medium: parsedKey[ 1 ],
-			label: `${ parsedKey[ 0 ] } / ${ parsedKey[ 1 ] }`,
+			label: parsedKeys[ 0 ],
 			value,
 		} as UTMMetricItem;
+
+		// Show the label for two UTM parameters: `utm_source,utm_medium`.
+		if ( parsedKeys[ 1 ] ) {
+			data.label += ` / ${ parsedKeys[ 1 ] }`;
+		}
+
+		// Show the label for three UTM parameters: `utm_campaign,utm_source,utm_medium`.
+		if ( parsedKeys[ 2 ] ) {
+			data.label += ` / ${ parsedKeys[ 2 ] }`;
+		}
 
 		// Set no `paramValues` to prevent top post requests.
 		if ( stopFurtherRequest ) {

--- a/client/state/stats/utm-metrics/types.ts
+++ b/client/state/stats/utm-metrics/types.ts
@@ -1,9 +1,7 @@
 export interface UTMMetricItem {
-	source?: string;
-	medium?: string;
-	paramValues?: string;
 	label: string;
 	value: number;
+	paramValues?: string;
 }
 
 export interface UTMMetricItemTopPost {


### PR DESCRIPTION
**I thought https://github.com/Automattic/wp-calypso/pull/88144 broke Calypso E2E tests, but it seems it was not related. So we are trying it again.**

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87567 

## Proposed Changes

* Query UTM metrics with selected options from the `UTMDropdown` component.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin this change up with the Calypso Live link.
* Navigate to Stats > Traffic page with the feature flag: `stats/utm-module` for a Jetpack site purchased a commercial license.
* Ensure the UTM module dropdown triggers fetching corresponding metrics.

https://github.com/Automattic/wp-calypso/assets/6869813/98726955-e3b0-4b66-b458-d6bc364f2e21

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?