### PR TITLE
New User Survey: Add survey goal for migration and other minor data fixes

### DIFF
--- a/client/signup/steps/new-user-survey/index.tsx
+++ b/client/signup/steps/new-user-survey/index.tsx
@@ -23,7 +23,12 @@ import Shuffle, { getCheckBoxKey } from './components/Shuffle';
 const defaultFormState = {
 	survey_goals_blogging: null,
 	survey_goals_website_building: null,
+	/**
+	 * This option is not in use currently
+	 */
 	survey_goals_wordpress_hosting: null,
+	survey_goals_website_hosting: null,
+	survey_goals_migration: null,
 	survey_goals_custom_check: null,
 	survey_goals_custom_text: '',
 	survey_describe_yourself_creator: null,
@@ -74,8 +79,9 @@ function SurveyForm( props: Props ) {
 	const [ isExperimentLoading, experimentAssignment ] = useExperiment(
 		'calypso_signup_onboarding_site_goals_survey'
 	);
+	const variantName = experimentAssignment?.variationName;
 	const isScrambled =
-		experimentAssignment?.variationName === 'treatment_scrambled' ||
+		variantName === 'treatment_scrambled' ||
 		config.isEnabled( 'onboarding/new-user-survey-scrambled' );
 
 	const [ formState, setFormState ] = useState< FormState >( defaultFormState );
@@ -139,6 +145,7 @@ function SurveyForm( props: Props ) {
 				...formState,
 				survey_field_order_goals: orderGoals?.join( ', ' ),
 				survey_field_order_describe_yourself: orderDescribeYourself?.join( ', ' ),
+				survey_experiment_variant_name: variantName,
 			}
 		);
 		goToNextStep();
@@ -193,6 +200,11 @@ function SurveyForm( props: Props ) {
 										onChange={ handleChange }
 									/>
 									<span>{ translate( 'WordPress hosting' ) }</span>
+								</StyledLabel>
+
+								<StyledLabel>
+									<FormInputCheckbox name="survey_goals_migration" onChange={ handleChange } />
+									<span>{ translate( 'Migrating an existing WordPress site' ) }</span>
 								</StyledLabel>
 							</Shuffle>
 							<StyledLabel>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

- Adds a migration option to the goals section `survey_goals_migration`
- Adds the default option for `survey_goals_website_hosting `
- Adds the variation name as a prop `survey_experiment_variant_name`
<img width="400" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/00784cdd-7148-4510-9599-338183ea19cf">
<img width="400" alt="image" src="https://github.com/Automattic/wp-calypso/assets/3422709/5c8a7d8b-a6eb-41be-adeb-80bef5c93234">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to the experiment variant `/start/new-user-survey?flags=onboarding%2Fnew-user-survey`
* `Migrating an existing WordPress site` option should be visible 
* When selected and submitting the option the prop should be funelled via tracks

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?