### PR TITLE
Stats: Adding links to post summary page

### DIFF
--- a/client/my-sites/stats/hooks/use-utm-metric-top-posts-query.ts
+++ b/client/my-sites/stats/hooks/use-utm-metric-top-posts-query.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useDispatch, useSelector } from 'calypso/state';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { requestTopPosts } from 'calypso/state/stats/utm-metrics/actions';
 import { getTopPosts } from 'calypso/state/stats/utm-metrics/selectors';
 import { UTMMetricItem } from 'calypso/state/stats/utm-metrics/types';
@@ -10,13 +11,14 @@ export default function useUTMMetricTopPostsQuery(
 	metrics: Array< UTMMetricItem >
 ) {
 	const dispatch = useDispatch();
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) ) as string;
 
 	const metricsKey = JSON.stringify( metrics );
 	useEffect( () => {
 		if ( JSON.parse( metricsKey ).length > 0 ) {
 			JSON.parse( metricsKey ).forEach( ( metric: UTMMetricItem ) => {
 				if ( metric.paramValues ) {
-					dispatch( requestTopPosts( siteId, UTMParam, metric.paramValues ) );
+					dispatch( requestTopPosts( siteId, UTMParam, metric.paramValues, siteSlug ) );
 				}
 			} );
 		}

--- a/client/my-sites/stats/stats-module/stats-module-data-query.jsx
+++ b/client/my-sites/stats/stats-module/stats-module-data-query.jsx
@@ -46,16 +46,9 @@ const StatsModuleDataQuery = ( {
 	const getHref = () => {
 		// Some modules do not have view all abilities
 		if ( ! summary && period && path && siteSlug ) {
-			return (
-				'/stats/' +
-				period.period +
-				'/' +
-				path +
-				'/' +
-				siteSlug +
-				'?startDate=' +
-				period.startOf.format( 'YYYY-MM-DD' )
-			);
+			return `/stats/${ period.period }/${ path }/${ siteSlug }?startDate=${ period.startOf.format(
+				'YYYY-MM-DD'
+			) }`;
 		}
 	};
 

--- a/client/state/data-layer/wpcom/sites/stats/utm-metrics/index.ts
+++ b/client/state/data-layer/wpcom/sites/stats/utm-metrics/index.ts
@@ -72,8 +72,8 @@ registerHandlers( 'state/data-layer/wpcom/sites/stats/utm-metrics/index.js', {
 	[ STATS_UTM_TOP_POSTS_REQUEST ]: [
 		dispatchRequest( {
 			fetch: fetchTopPosts,
-			onSuccess: ( { siteId, paramValues }: AnyAction, data: object ) =>
-				receiveTopPosts( siteId, paramValues, data ),
+			onSuccess: ( { siteId, paramValues, siteSlug }: AnyAction, data: object ) =>
+				receiveTopPosts( siteId, paramValues, data, siteSlug ),
 			onError: () => null,
 		} ),
 	],

--- a/client/state/stats/utm-metrics/actions.ts
+++ b/client/state/stats/utm-metrics/actions.ts
@@ -56,20 +56,32 @@ export function receiveMetricsByPost( siteId: number, postId: number, data: obje
 	};
 }
 
-export function requestTopPosts( siteId: number, utmParam: string, paramValues: string ) {
+export function requestTopPosts(
+	siteId: number,
+	utmParam: string,
+	paramValues: string,
+	siteSlug?: string
+) {
 	return {
 		type: STATS_UTM_TOP_POSTS_REQUEST,
 		siteId,
 		utmParam,
 		paramValues,
+		siteSlug,
 	};
 }
 
-export function receiveTopPosts( siteId: number, paramValues: string, data: object ) {
+export function receiveTopPosts(
+	siteId: number,
+	paramValues: string,
+	data: object,
+	siteSlug?: string
+) {
 	return {
 		type: STATS_UTM_TOP_POSTS_RECEIVE,
 		siteId,
 		paramValues,
 		data,
+		siteSlug,
 	};
 }

--- a/client/state/stats/utm-metrics/actions.ts
+++ b/client/state/stats/utm-metrics/actions.ts
@@ -60,7 +60,7 @@ export function requestTopPosts(
 	siteId: number,
 	utmParam: string,
 	paramValues: string,
-	siteSlug?: string
+	siteSlug: string
 ) {
 	return {
 		type: STATS_UTM_TOP_POSTS_REQUEST,
@@ -75,7 +75,7 @@ export function receiveTopPosts(
 	siteId: number,
 	paramValues: string,
 	data: object,
-	siteSlug?: string
+	siteSlug: string
 ) {
 	return {
 		type: STATS_UTM_TOP_POSTS_RECEIVE,

--- a/client/state/stats/utm-metrics/reducer.ts
+++ b/client/state/stats/utm-metrics/reducer.ts
@@ -111,7 +111,7 @@ const dataReducer = ( state = {}, action: AnyAction ) => {
 							label: topPost.title,
 							value: topPost.views,
 							href: topPost.href,
-							page: siteSlug ? `stats/post/${ topPost.id }/${ action.siteSlug }` : null,
+							page: siteSlug ? `/stats/post/${ topPost.id }/${ action.siteSlug }` : null,
 							actions: [
 								{
 									data: topPost.href,

--- a/client/state/stats/utm-metrics/reducer.ts
+++ b/client/state/stats/utm-metrics/reducer.ts
@@ -95,6 +95,7 @@ const dataReducer = ( state = {}, action: AnyAction ) => {
 
 		case STATS_UTM_TOP_POSTS_RECEIVE: {
 			const data = action.data.top_posts;
+			const siteSlug = action.siteSlug;
 
 			const { topPosts } = state as {
 				topPosts: { [ key: string ]: Array< UTMMetricItemTopPost > };
@@ -110,6 +111,13 @@ const dataReducer = ( state = {}, action: AnyAction ) => {
 							label: topPost.title,
 							value: topPost.views,
 							href: topPost.href,
+							page: siteSlug ? `stats/post/${ topPost.id }/${ action.siteSlug }` : null,
+							actions: [
+								{
+									data: topPost.href,
+									type: 'link',
+								},
+							],
 						};
 					} ),
 				},


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88126

## Proposed Changes

* adding links to the UTM post rows redirecting to the post summary page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* navigate to the live branch and add the utm feature flag `stats/utm-module`
* open a blog that has utm data
* extend a metric and click on the title
* verify that you are redirected to the summary page
* got back and click on the post redirect icon on the right side actions menu
* verify that you are redirected to the reader facing post page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?