### PR TITLE
Tracks: Fix `signupDomainOrigin` property for `calypso_signup_complete` event

### DIFF
--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -249,7 +249,6 @@ export function generateSteps( {
 			stepName: 'new-user-survey',
 			fulfilledStepCallback: excludeSurveyStepIfInactive,
 		},
-		// TODO: Do we need to add the signupDomainOrigin dependency to other steps that share the plans component?
 		plans: {
 			stepName: 'plans',
 			apiRequestFunction: addPlanToCart,

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -254,8 +254,8 @@ export function generateSteps( {
 			stepName: 'plans',
 			apiRequestFunction: addPlanToCart,
 			dependencies: [ 'siteSlug' ],
-			optionalDependencies: [ 'emailItem', 'themeSlugWithRepo', 'signupDomainOrigin' ],
-			providesDependencies: [ 'cartItems', 'themeSlugWithRepo', 'signupDomainOrigin' ],
+			optionalDependencies: [ 'emailItem', 'themeSlugWithRepo' ],
+			providesDependencies: [ 'cartItems', 'themeSlugWithRepo' ],
 			fulfilledStepCallback: isPlanFulfilled,
 		},
 

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -249,12 +249,13 @@ export function generateSteps( {
 			stepName: 'new-user-survey',
 			fulfilledStepCallback: excludeSurveyStepIfInactive,
 		},
+		// TODO: Do we need to add the signupDomainOrigin dependency to other steps that share the plans component?
 		plans: {
 			stepName: 'plans',
 			apiRequestFunction: addPlanToCart,
 			dependencies: [ 'siteSlug' ],
-			optionalDependencies: [ 'emailItem', 'themeSlugWithRepo' ],
-			providesDependencies: [ 'cartItems', 'themeSlugWithRepo' ],
+			optionalDependencies: [ 'emailItem', 'themeSlugWithRepo', 'signupDomainOrigin' ],
+			providesDependencies: [ 'cartItems', 'themeSlugWithRepo', 'signupDomainOrigin' ],
 			fulfilledStepCallback: isPlanFulfilled,
 		},
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -68,7 +68,6 @@ export class PlansStep extends Component {
 				isPurchasingItem: false,
 				stepSectionName: undefined,
 			},
-			// TODO: Check to see if specs need to be updated
 			{ domainItem, signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.FREE }
 		);
 	};

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -11,6 +11,7 @@ import { connect } from 'react-redux';
 import { LoadingEllipsis } from 'calypso/components/loading-ellipsis';
 import MarketingMessage from 'calypso/components/marketing-message';
 import Notice from 'calypso/components/notice';
+import { SIGNUP_DOMAIN_ORIGIN } from 'calypso/lib/analytics/signup';
 import { getTld, isSubdomain } from 'calypso/lib/domains';
 import { triggerGuidesForStep } from 'calypso/lib/guides/trigger-guides-for-step';
 import { buildUpgradeFunction } from 'calypso/lib/signup/step-actions';
@@ -67,7 +68,7 @@ export class PlansStep extends Component {
 				isPurchasingItem: false,
 				stepSectionName: undefined,
 			},
-			{ domainItem }
+			{ domainItem, signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.FREE }
 		);
 	};
 

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -68,9 +68,8 @@ export class PlansStep extends Component {
 				isPurchasingItem: false,
 				stepSectionName: undefined,
 			},
-			// Since we're removing the paid domain, it means that the user
-			// will be using a free domain. Because of this, we set signupDomainOrigin
-			// to "free".
+			// Since we're removing the paid domain, it means that the user will be using
+			// a free domain. Because of this, we set signupDomainOrigin to "free".
 			{ domainItem, signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.FREE }
 		);
 	};

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -68,6 +68,7 @@ export class PlansStep extends Component {
 				isPurchasingItem: false,
 				stepSectionName: undefined,
 			},
+			// TODO: Check to see if specs need to be updated
 			{ domainItem, signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.FREE }
 		);
 	};

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -68,6 +68,9 @@ export class PlansStep extends Component {
 				isPurchasingItem: false,
 				stepSectionName: undefined,
 			},
+			// Since we're removing the paid domain, it means that the user
+			// will be using a free domain. Because of this, we set signupDomainOrigin
+			// to "free".
 			{ domainItem, signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.FREE }
 		);
 	};

--- a/client/signup/steps/plans/index.jsx
+++ b/client/signup/steps/plans/index.jsx
@@ -68,8 +68,10 @@ export class PlansStep extends Component {
 				isPurchasingItem: false,
 				stepSectionName: undefined,
 			},
-			// Since we're removing the paid domain, it means that the user will be using
-			// a free domain. Because of this, we set signupDomainOrigin to "free".
+			// Since we're removing the paid domain, it means that the user chose to continue
+			// with a free domain. Because signupDomainOrigin should reflect the last domain
+			// selection status before they land on the checkout page, we switch the value
+			// to "free".
 			{ domainItem, signupDomainOrigin: SIGNUP_DOMAIN_ORIGIN.FREE }
 		);
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/2774

## Proposed Changes

- When a custom, paid domain has been selected in the domains signup step
- And the user selects a free plan
- And the user, after being shown the paid plan upsell modal, decides to continue with the free plan ( which removes the paid domain from the user's final purchase )

We'd expect the signupDomainOrigin tracking property to not indicate that a paid domain was purchased.

Before this patch, `signupDomainOrigin` returns the 'custom' value which represents that a paid domain was purchased given the scenario above. After this patch, we override the `signupDomainOrigin` property to 'free' when removing the paid domain, which fixes the incorrect value.

**Note:**
The `/start/onboarding-pm` flow also has a plan upsell modal that is displayed when a custom paid domain is selected and a free plan is chosen. We _don't_ make updates to this flow because the custom paid domain is retained as signup completes, while in the `/start` flow, the custom domain is automatically removed from the site.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Checkout this branch
- Run `yarn` and `yarn start`
- Go to `http://calypso.localhost:3000/start`
- Open [Tracks Vigilante](https://github.com/Automattic/tracks-chrome-extension) so you can monitor tracks events
- Confirm issue fixed
  - Select one of the custom suggested domains. 
  - On the plans page, select a free plan. 
  - In the presented upsell modal, click on "Continue with free plan". 
  - Continue through the flow until you see the `calypso_signup_complete` event fire in tracks vigilante. 
  - Confirm the event now has the following property: `signup_domain_origin: 'free'`
- Smoke test some other scenarios that trigger different values for `signupDomainOrigin` to ensure correct behavior
  - Click on **Choose my domain later** in the sidebar. Continue through the flow until you see the `calypso_signup_complete` event fire in tracks vigilante. Confirm the event has the following property:`signup_domain_origin: 'choose later'`
  - Click on **Use a domain I own** in the sidebar. Continue through the flow until you see the `calypso_signup_complete` event fire in tracks vigilante. Confirm the event has the following property: `signup_domain_origin: 'use your domain'`
  - Select the free .wordpress.com domain. Continue through the flow until you see the `calypso_signup_complete` event fire in tracks vigilante. Confirm the event has the following property: `signup_domain_origin: 'free'`
  - Select one of the custom suggested domains. Continue through the flow until you see the `calypso_signup_complete` event fire in tracks vigilante. Confirm the event has the following property: `signup_domain_origin: 'custom'`

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?