### PR TITLE
Add the Site Icon section on the `/settings/general` page

### DIFF
--- a/client/components/section-header/style.scss
+++ b/client/components/section-header/style.scss
@@ -44,6 +44,7 @@
 }
 
 .section-header__actions {
+	display: flex;
 	align-self: center;
 	flex-grow: 0;
 	margin-left: 8px;

--- a/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
+++ b/client/layout/guided-tours/tours/checklist-site-title-tour/index.js
@@ -12,6 +12,10 @@ import {
 } from 'calypso/layout/guided-tours/config-elements';
 import meta from './meta';
 
+/**
+ * This tour might be deprecated, as we aim to let users set the Site Title and Tagline on the wp-admin interface.
+ * @see pfsHM7-cr-p2
+ */
 /* eslint-disable wpcalypso/jsx-classname-namespace */
 export const ChecklistSiteTitleTour = makeTour(
 	<Tour { ...meta }>

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -596,7 +596,10 @@ export class SiteSettingsFormGeneral extends Component {
 						</Card>
 					</>
 				) : (
-					// We need to allow users to set the Site Icon even if the Global Site View is enabled.
+					/**
+					 * We need to allow users to set the Site Icon even if the Global Site View is enabled.
+					 * @see https://github.com/Automattic/wp-calypso/pull/88168
+					 */
 					<>
 						<SettingsSectionHeader showButton={ false } title={ translate( 'Site icon' ) }>
 							<InfoPopover position="bottom right">

--- a/client/my-sites/site-settings/form-general.jsx
+++ b/client/my-sites/site-settings/form-general.jsx
@@ -49,7 +49,7 @@ import {
 } from 'calypso/state/sites/plans/selectors';
 import {
 	getSiteOption,
-	isGlobalSiteViewEnabled,
+	isGlobalSiteViewEnabled as getIsGlobalSiteViewEnabled,
 	isJetpackSite,
 	isCurrentPlanPaid,
 	getCustomizerUrl,
@@ -59,6 +59,7 @@ import {
 	getSelectedSiteId,
 	getSelectedSiteSlug,
 } from 'calypso/state/ui/selectors';
+import InfoPopover from '../../components/info-popover';
 import { BuiltByUpsell } from './built-by-upsell-banner';
 import Masterbar from './masterbar';
 import SiteIconSetting from './site-icon-setting';
@@ -564,7 +565,7 @@ export class SiteSettingsFormGeneral extends Component {
 			isAtomicAndEditingToolkitDeactivated,
 			isWpcomStagingSite,
 			isUnlaunchedSite: propsisUnlaunchedSite,
-			isClassicView,
+			isGlobalSiteViewEnabled,
 		} = this.props;
 		const classes = classNames( 'site-settings__general-settings', {
 			'is-loading': isRequestingSettings,
@@ -574,7 +575,7 @@ export class SiteSettingsFormGeneral extends Component {
 			<div className={ classNames( classes ) }>
 				{ site && <QuerySiteSettings siteId={ site.ID } /> }
 
-				{ ! ( isEnabled( 'layout/dotcom-nav-redesign' ) && isClassicView ) && (
+				{ ! isGlobalSiteViewEnabled ? (
 					<>
 						<SettingsSectionHeader
 							data-tip-target="settings-site-profile-save"
@@ -591,6 +592,26 @@ export class SiteSettingsFormGeneral extends Component {
 								{ this.languageOptions() }
 								{ this.Timezone() }
 								{ siteIsJetpack && this.WordPressVersion() }
+							</form>
+						</Card>
+					</>
+				) : (
+					// We need to allow users to set the Site Icon even if the Global Site View is enabled.
+					<>
+						<SettingsSectionHeader showButton={ false } title={ translate( 'Site icon' ) }>
+							<InfoPopover position="bottom right">
+								{ translate(
+									'The Site Icon is used as a browser and app icon for your site.' +
+										' Icons must be square, and at least %s pixels wide and tall.',
+									{ args: [ 512 ] }
+								) }
+							</InfoPopover>
+						</SettingsSectionHeader>
+						<Card>
+							<form>
+								<div className="site-settings__site-icon">
+									<SiteIconSetting showLabel={ false } />
+								</div>
 							</form>
 						</Card>
 					</>
@@ -665,7 +686,7 @@ const connectComponent = connect( ( state ) => {
 		isAtomicAndEditingToolkitDeactivated:
 			isAtomicSite( state, siteId ) &&
 			getSiteOption( state, siteId, 'editing_toolkit_is_active' ) === false,
-		isClassicView: isGlobalSiteViewEnabled( state, siteId ),
+		isGlobalSiteViewEnabled: getIsGlobalSiteViewEnabled( state, siteId ),
 		isComingSoon: isSiteComingSoon( state, siteId ),
 		isP2HubSite: isSiteP2Hub( state, siteId ),
 		isPaidPlan: isCurrentPlanPaid( state, siteId ),

--- a/client/my-sites/site-settings/site-icon-setting/index.jsx
+++ b/client/my-sites/site-settings/site-icon-setting/index.jsx
@@ -48,6 +48,7 @@ class SiteIconSetting extends Component {
 		setEditorMediaModalView: PropTypes.func,
 		resetAllImageEditorState: PropTypes.func,
 		crop: PropTypes.object,
+		showLabel: PropTypes.bool,
 	};
 
 	state = {
@@ -166,6 +167,7 @@ class SiteIconSetting extends Component {
 			customizerUrl,
 			generalOptionsUrl,
 			siteSupportsImageEditor,
+			showLabel = true,
 		} = this.props;
 		const { isModalVisible, hasToggledModal, isEditingSiteIcon } = this.state;
 
@@ -200,16 +202,18 @@ class SiteIconSetting extends Component {
 
 		return (
 			<FormFieldset className="site-icon-setting">
-				<FormLabel className="site-icon-setting__heading">
-					{ translate( 'Site icon' ) }
-					<InfoPopover position="bottom right">
-						{ translate(
-							'The Site Icon is used as a browser and app icon for your site.' +
-								' Icons must be square, and at least %s pixels wide and tall.',
-							{ args: [ 512 ] }
-						) }
-					</InfoPopover>
-				</FormLabel>
+				{ showLabel && (
+					<FormLabel className="site-icon-setting__heading">
+						{ translate( 'Site icon' ) }
+						<InfoPopover position="bottom right">
+							{ translate(
+								'The Site Icon is used as a browser and app icon for your site.' +
+									' Icons must be square, and at least %s pixels wide and tall.',
+								{ args: [ 512 ] }
+							) }
+						</InfoPopover>
+					</FormLabel>
+				) }
 				{ createElement(
 					buttonProps.href ? 'a' : 'button',
 					{

--- a/client/my-sites/site-settings/style.scss
+++ b/client/my-sites/site-settings/style.scss
@@ -313,6 +313,15 @@
 	}
 }
 
+.site-settings__site-icon {
+	@include breakpoint-deprecated( ">660px" ) {
+		display: flex;
+	}
+	fieldset.form-fieldset.site-icon-setting {
+		padding: 0;
+	}
+}
+
 .site-settings__fiverr-logo-maker-cta {
 	margin-top: 10px;
 	margin-bottom: 20px;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound lbel to
the linked issue.
-->

Close https://github.com/Automattic/dotcom-forge/issues/5876

## Proposed Changes

This PR adds the "Site icon" section on the `/settings/general` page even if the Global Site View is enabled.
Please refer to https://github.com/Automattic/dotcom-forge/issues/5876 for more context. 

<img width="1034" alt="Screenshot 2024-03-05 at 14 44 32" src="https://github.com/Automattic/wp-calypso/assets/5287479/f5de61c6-43ed-4e63-a345-8820350e450c">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open Calypso Live
* Prepare a site with the classic view
* Go to `/settings/general/<your-site>`
* Ensure the "Site icon" section works. 
	* Note that it [is](https://github.com/Automattic/wp-calypso/blob/869fc7334d22d3c7805cb50f55ac964abdc9a918/client/my-sites/site-settings/site-icon-setting/index.jsx#L189) just a link to the Customizer if the site is Atomic. 
* Removing the flag (`?flags=-layout/dotcom-nav-redesign-early-release` or `flags=-layout/dotcom-nav-redesign`) shows you the "Site profile" section.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?