### PR TITLE
E2E: Disable the WhatsNewGuide to prevent the element from being unclickable

### DIFF
--- a/packages/calypso-e2e/src/jest-playwright-config/environment.ts
+++ b/packages/calypso-e2e/src/jest-playwright-config/environment.ts
@@ -429,6 +429,15 @@ function setupBrowserProxyTrap( browser: Browser ): Browser {
 						}
 					} );
 
+					// Disable the WhatsNewGuide to prevent the element we want to click from
+					// being covered by it so that the element isn't clickable.
+					await page.route( /wpcom\/v2\/whats-new\/list/, ( route ) =>
+						route.fulfill( {
+							status: 200,
+							body: undefined,
+						} )
+					);
+
 					// Add route abort for slow requests on AT sites.
 					await page.route( /store\/v1\/cart/, ( route ) => {
 						route.abort();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/88160

## Proposed Changes

* Mock the response of the whats-new endpoint to disable the WhatsNewGuide when running e2e tests to prevent the element we want to click from being unclickable. Here is the screenshot of the failing tests:

<img width="300" src="https://github.com/Automattic/wp-calypso/assets/13596067/96edc296-2f04-4984-91e6-c9399f4786fd" />

#### Before

![image](https://github.com/Automattic/wp-calypso/assets/13596067/2161da2d-0b2d-4da7-9dc1-76e3a9fff41e)

#### After

![image](https://github.com/Automattic/wp-calypso/assets/13596067/66295484-4271-4d1f-a16a-f365203a3176)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Make sure the pre-release e2e tests passed!

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?