### PR TITLE
Stats: Sort subscriber module by recency

### DIFF
--- a/client/my-sites/stats/stats-followers/index.jsx
+++ b/client/my-sites/stats/stats-followers/index.jsx
@@ -82,10 +82,14 @@ class StatModuleFollowers extends Component {
 			? summaryPageLink
 			: 'https://wordpress.com' + summaryPageLink;
 
-		const data = [ ...( wpcomData?.subscribers ?? [] ), ...( emailData?.subscribers ?? [] ) ].slice(
-			0,
-			MAX_FOLLOWERS_TO_SHOW
-		);
+		// Combine data sets, sort by recency, and limit to 10.
+		const data = [ ...( wpcomData?.subscribers ?? [] ), ...( emailData?.subscribers ?? [] ) ]
+			.sort( ( a, b ) => {
+				// If value is undefined, send zero to ensure they sort to the bottom.
+				// Otherwise they stick to the top of the list which is not helpful.
+				return new Date( b.value?.value || 0 ) - new Date( a.value?.value || 0 );
+			} )
+			.slice( 0, MAX_FOLLOWERS_TO_SHOW );
 
 		return (
 			<>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

## Proposed Changes

Sort by recency after combining the two data sets (dot com & email). Currently we just append the email subs which means they show up after dot com followers or not at all (if the site has 10 or more dot com followers).

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

You'll need a site with both dot com and email subs to properly test this.

* Spin up Calypso Live branch.
* Visit Stats → Subscribers and scroll down to the Subscribers module.
* Confirm that dot com and email followers are displayed by recency (newest first).

I also tested this with some test data where the `relative-date` value was not provided. Sending zero as the timestamp forces any such followers to sort to the bottom so they don't stick to the top of the list.

### Before with email follower below dot com follower
<img width="629" alt="SCR-20240305-oerv" src="https://github.com/Automattic/wp-calypso/assets/40267301/5c802d9f-3c71-47ba-9677-49efa4bc439a">

### After; email follower sorts to top based on recency
<img width="632" alt="SCR-20240305-oeya" src="https://github.com/Automattic/wp-calypso/assets/40267301/528240b5-4e68-4a4e-ab80-e40657638f9a">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?