### PR TITLE
A4A: Implement the payment method overview page.

### DIFF
--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/empty-state.tsx
@@ -1,0 +1,65 @@
+import { Button } from '@automattic/components';
+import { Icon, lock, currencyDollar, postDate } from '@wordpress/icons';
+import { useTranslate } from 'i18n-calypso';
+import { useCallback } from 'react';
+import { A4A_PAYMENT_METHODS_ADD_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import CreditCardImg from 'calypso/assets/images/jetpack/credit-cards.png';
+import { useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+
+export default function EmptyState() {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const navigateToCreateMethod = useCallback( () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_license_list_empty_issue_license_click' ) );
+	}, [ dispatch ] );
+
+	return (
+		<div className="payment-method-overview-empty-state">
+			<div className="payment-method-overview-empty-state__top-content">
+				<img src={ CreditCardImg } alt="Credit Cards" />
+				<Button primary href={ A4A_PAYMENT_METHODS_ADD_LINK } onClick={ navigateToCreateMethod }>
+					{ translate( 'Add a card' ) }
+				</Button>
+			</div>
+			<div className="payment-method-overview-empty-state__bottom-content">
+				<div className="payment-method-overview-empty-state__card">
+					<Icon icon={ lock } />
+					<div className="payment-method-overview-empty-state__card-title">
+						{ translate( 'World-class card security' ) }
+					</div>
+					<div className="payment-method-overview-empty-state__card-description">
+						{ translate(
+							'Stripe, our payment provider, holds PCI Service Provider Level 1 certification—the highest security standard in the industry. Rest easy knowing your card data is in good hands.'
+						) }
+					</div>
+				</div>
+
+				<div className="payment-method-overview-empty-state__card">
+					<Icon icon={ currencyDollar } />
+					<div className="payment-method-overview-empty-state__card-title">
+						{ translate( 'Only pay for active licenses' ) }
+					</div>
+					<div className="payment-method-overview-empty-state__card-description">
+						{ translate(
+							'The platform is free to use. Your running total is calculated daily based on how many licenses you have issued. Your card will be charged on the 1st of the following month.'
+						) }
+					</div>
+				</div>
+
+				<div className="payment-method-overview-empty-state__card">
+					<Icon icon={ postDate } />
+					<div className="payment-method-overview-empty-state__card-title">
+						{ translate( 'Flexible billing in your control' ) }
+					</div>
+					<div className="payment-method-overview-empty-state__card-description">
+						{ translate(
+							"Our billing matches your monthly client payments, so you're not stuck with yearly fees. Cancel licenses anytime to cease billing immediately."
+						) }
+					</div>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/empty-state.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/empty-state.tsx
@@ -18,7 +18,7 @@ export default function EmptyState() {
 	return (
 		<div className="payment-method-overview-empty-state">
 			<div className="payment-method-overview-empty-state__top-content">
-				<img src={ CreditCardImg } alt="Credit Cards" />
+				<img src={ CreditCardImg } alt={ translate( 'Credit Cards' ) } />
 				<Button primary href={ A4A_PAYMENT_METHODS_ADD_LINK } onClick={ navigateToCreateMethod }>
 					{ translate( 'Add a card' ) }
 				</Button>

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/hooks/use-stored-cards-pagination.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/hooks/use-stored-cards-pagination.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useCursorPagination } from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
+import { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
+import { useDispatch } from 'calypso/state';
+
+type Props = {
+	storedCards: PaymentMethod[];
+	enabled: boolean;
+	hasMoreStoredCards: boolean;
+};
+
+/**
+ * Prepares the paging cursor for use in pagination.
+ * @param direction - The direction of the page change.
+ * @param items - The items to paginate.
+ * @param isFirstPage - Whether the current page is the first page.
+ * @returns The paging cursor.
+ */
+const preparePagingCursor = (
+	direction: 'next' | 'prev',
+	items: PaymentMethod[],
+	isFirstPage: boolean
+) => {
+	if ( ! items.length || isFirstPage ) {
+		return {
+			startingAfter: '',
+			endingBefore: '',
+		};
+	}
+
+	return {
+		startingAfter: direction === 'next' ? items[ items.length - 1 ].id : '',
+		endingBefore: direction === 'prev' ? items[ 0 ].id : '',
+	};
+};
+
+export default function useStoredCardsPagination( {
+	storedCards,
+	enabled,
+	hasMoreStoredCards,
+}: Props ) {
+	const dispatch = useDispatch();
+
+	const [ paging, setPaging ] = useState( { startingAfter: '', endingBefore: '' } );
+
+	const onPageClickCallback = useCallback(
+		( page: number, direction: 'next' | 'prev' ) => {
+			// Set a cursor for use in pagination.
+			setPaging( preparePagingCursor( direction, storedCards, page === 1 ) );
+		},
+		[ storedCards, setPaging ]
+	);
+
+	const [ page, showPagination, onPageClick ] = useCursorPagination(
+		enabled,
+		hasMoreStoredCards,
+		onPageClickCallback
+	);
+
+	useEffect( () => {
+		// FIXME: Dispatch an action to fetch the next page of stored cards.
+	}, [ dispatch, paging ] );
+
+	return {
+		page,
+		showPagination,
+		onPageClick,
+	};
+}

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/hooks/use-stored-cards.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/hooks/use-stored-cards.ts
@@ -1,0 +1,11 @@
+export default function useStoredCards() {
+	return {
+		allStoredCards: [],
+		primaryStoredCard: null,
+		secondaryStoredCards: [],
+		isFetching: false,
+		pageSize: 0,
+		hasStoredCards: false,
+		hasMoreStoredCards: false,
+	};
+}

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/hooks/use-stored-cards.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/hooks/use-stored-cards.ts
@@ -2,13 +2,14 @@ import { isEnabled } from '@automattic/calypso-config';
 import { useEffect, useState } from 'react';
 import { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
 
+// FIXME: Need to hook this up to the real API.
 export default function useStoredCards() {
 	const showDummyData = isEnabled( 'a4a/mock-api-data' );
 
-	// FIXME: Remove this once we have actual data source.
 	const [ isFetching, setIsFetching ] = useState( showDummyData );
 
 	useEffect( () => {
+		// Simulate a fake loading delay.
 		setTimeout( () => {
 			setIsFetching( false );
 		}, 1000 );

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/hooks/use-stored-cards.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/hooks/use-stored-cards.ts
@@ -8,6 +8,7 @@ export default function useStoredCards() {
 
 	const [ isFetching, setIsFetching ] = useState( showDummyData );
 
+	// FIXME: Don't forget to remove this fake loading delay for dummy data
 	useEffect( () => {
 		// Simulate a fake loading delay.
 		setTimeout( () => {

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/hooks/use-stored-cards.ts
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/hooks/use-stored-cards.ts
@@ -1,9 +1,51 @@
+import { isEnabled } from '@automattic/calypso-config';
+import { useEffect, useState } from 'react';
+import { PaymentMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods';
+
 export default function useStoredCards() {
+	const showDummyData = isEnabled( 'a4a/mock-api-data' );
+
+	// FIXME: Remove this once we have actual data source.
+	const [ isFetching, setIsFetching ] = useState( showDummyData );
+
+	useEffect( () => {
+		setTimeout( () => {
+			setIsFetching( false );
+		}, 1000 );
+	}, [] );
+
+	if ( showDummyData ) {
+		const allStoredCards: PaymentMethod[] = [
+			{
+				id: '1',
+				card: {
+					brand: 'mastercard',
+					exp_month: 12,
+					exp_year: 2027,
+					last4: '1234',
+				},
+				is_default: true,
+				name: 'Primary Card',
+				created: new Date().toString(),
+			},
+		];
+
+		return {
+			allStoredCards,
+			primaryStoredCard: allStoredCards.find( ( card ) => card.is_default ),
+			secondaryStoredCards: allStoredCards.filter( ( card ) => ! card.is_default ),
+			isFetching,
+			pageSize: 1,
+			hasStoredCards: !! allStoredCards.length,
+			hasMoreStoredCards: false,
+		};
+	}
+
 	return {
 		allStoredCards: [],
 		primaryStoredCard: null,
 		secondaryStoredCards: [],
-		isFetching: false,
+		isFetching,
 		pageSize: 0,
 		hasStoredCards: false,
 		hasMoreStoredCards: false,

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/loading-state.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/loading-state.tsx
@@ -1,0 +1,9 @@
+import StoreCreditPlaceholderCard from 'calypso/jetpack-cloud/sections/partner-portal/stored-credit-placeholder-card';
+
+export default function LoadingState() {
+	return (
+		<div className="payment-method-overview__stored-cards">
+			<StoreCreditPlaceholderCard />
+		</div>
+	);
+}

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/style.scss
@@ -1,0 +1,110 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.payment-method-overview {
+	@include breakpoint-deprecated( "<660px" ) {
+		.jetpack-cloud-layout__header-main {
+			margin-block-end: 16px;
+		}
+
+		.jetpack-cloud-layout__header-actions .button {
+			width: 100%;
+		}
+	}
+}
+
+.payment-method-overview-empty-state {
+	margin-block-start: 60px;
+
+	img {
+		margin: auto;
+		display: block;
+		width: 270px;
+	}
+}
+
+.payment-method-overview-empty-state__top-content {
+	width: 315px;
+	margin: auto;
+
+	.button {
+		margin-block-start: 40px;
+		width: 100%;
+	}
+}
+
+.payment-method-overview-empty-state__bottom-content {
+	margin-block-start: 50px;
+	display: flex;
+	flex-wrap: wrap;
+	justify-content: space-between;
+
+	.payment-method-overview-empty-state__card {
+		flex: 1;
+		width: calc(33.33% - 64px); /* 64px is the total margin width */
+		margin: 16px;
+		padding: 24px;
+		box-sizing: border-box;
+		flex-basis: 100%;
+		text-align: center;
+
+		svg {
+			fill: var(--color-neutral-40);
+			margin-block-end: 24px;
+		}
+
+		.payment-method-overview-empty-state__card-title {
+			font-size: rem(18px);
+			font-weight: 600;
+			margin-block-end: 8px;
+		}
+
+		.payment-method-overview-empty-state__card-description {
+			color: var(--color-neutral-60);
+			font-size: rem(14px);
+		}
+
+		@include break-medium {
+			flex-basis: calc(50% - 10px);
+		}
+
+		@include break-large {
+			flex-basis: unset;
+		}
+	}
+}
+
+.payment-method-overview__stored-cards {
+	margin-block-start: 50px;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 24px;
+
+	@include breakpoint-deprecated( "<660px" ) {
+		margin-block-start: 32px;
+	}
+}
+
+.payment-method-overview__pagination {
+	margin: 64px 0;
+
+	.pagination__list-item.is-right,
+	.pagination__list-item.is-left {
+		opacity: 0.5;
+		pointer-events: none;
+	}
+
+	.payment-method-overview__pagination--has-prev {
+		.pagination__list-item.is-left {
+			opacity: 1;
+			pointer-events: initial;
+		}
+	}
+
+	.payment-method-overview__pagination--has-next {
+		.pagination__list-item.is-right {
+			opacity: 1;
+			pointer-events: initial;
+		}
+	}
+}

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-overview/style.scss
@@ -1,18 +1,6 @@
 @import "@wordpress/base-styles/breakpoints";
 @import "@wordpress/base-styles/mixins";
 
-.payment-method-overview {
-	@include breakpoint-deprecated( "<660px" ) {
-		.jetpack-cloud-layout__header-main {
-			margin-block-end: 16px;
-		}
-
-		.jetpack-cloud-layout__header-actions .button {
-			width: 100%;
-		}
-	}
-}
-
 .payment-method-overview-empty-state {
 	margin-block-start: 60px;
 
@@ -80,7 +68,7 @@
 	flex-wrap: wrap;
 	gap: 24px;
 
-	@include breakpoint-deprecated( "<660px" ) {
+	@include break-small {
 		margin-block-start: 32px;
 	}
 }


### PR DESCRIPTION
This ported the payment method list from Jetpack Manage to the A4A portal. Note that the data is temporarily mocked to demonstrate the UI while awaiting a working backend API.

**Empty State**
<img width="1414" alt="Screenshot 2024-03-05 at 4 15 54 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/777a6bb0-c6b2-4c79-bbea-8c49d4525a38">
**Populated State**
<img width="1413" alt="Screenshot 2024-03-05 at 4 16 08 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/44ae893c-af47-4799-9c9d-676c1a301dab">


Closes https://github.com/Automattic/jetpack-genesis/issues/275

## Proposed Changes

* Port the [Payment Method list implementation from Jetpack Manage](https://github.com/Automattic/wp-calypso/tree/trunk/client/jetpack-cloud/sections/partner-portal/primary/payment-methods-v2). I added a few improvements in the main container by moving all data and pagination logic within hooks to declutter some codes in the main component.
* Added temporary mock data within the `useStoredCards` hook to feed and test the component with a populated state.

## Testing Instructions
* Switch branch: `git checkout add/a4a-payment-method-list`.
* Start the server by running `yarn start-a8c-for-agencies`.
* Go to http://agencies.localhost:3000/purchases/payment-methods
* Confirm that the page functions similarly to https://cloud.jetpack.com/partner-portal/payment-methods. Note that the card data you will see is coming from mocked data.
* To test an empty state, Go to http://agencies.localhost:3000/purchases/payment-methods?flags=-a4a/mock-api-data which will have the  `a4a/mock-api-data` feature flag disabled.
* Confirm that the empty state matches the one from https://cloud.jetpack.com/partner-portal/payment-methods
## Pre-merge Checklist

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?