### PR TITLE
Calypso links: Update redirect to support site

### DIFF
--- a/client/components/inline-support-link/context-links.js
+++ b/client/components/inline-support-link/context-links.js
@@ -110,9 +110,8 @@ const contextLinks = {
 		post_id: 164969,
 	},
 	'hosting-connect-to-ssh': {
-		link: 'https://developer.wordpress.com/docs/developer-tools/sftp-ssh/',
-		post_id: 99380,
-		blog_id: DEVELOPER_WORDPRESS_BLOG_ID,
+		link: 'https://wordpress.com/support/connect-to-ssh-on-wordpress-com/',
+		post_id: 213309,
 	},
 	'hosting-mysql': {
 		link: 'https://developer.wordpress.com/docs/developer-tools/database-access/',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5782#issuecomment-1977697660

## Proposed Changes

* Point SSH link to support site https://wordpress.com/support/connect-to-ssh-on-wordpress-com/

<img width="1995" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/7cdd7008-6f36-4e4c-a5cc-ec460b9d7801">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Pull and run this branch or use live link.
* Navigate to {LIVE_LINK}/hosting-config/{SITE_SLUG}
* Check if ssh link is pointing to `[wordpress.com/support/connect-to-ssh-on-wordpress-com](https://wordpress.com/support/connect-to-ssh-on-wordpress-com/)` like the image above

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?