### PR TITLE
Update All sites -> All Sites for calypso Sidebar

### DIFF
--- a/client/my-sites/current-site/index.jsx
+++ b/client/my-sites/current-site/index.jsx
@@ -54,7 +54,7 @@ class CurrentSite extends Component {
 							// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 							className={ `gridicon dashicons-before dashicons-arrow-${ arrowDirection }-alt2` }
 						></span>
-						<span className="current-site__switch-sites-label">{ translate( 'All sites' ) }</span>
+						<span className="current-site__switch-sites-label">{ translate( 'All Sites' ) }</span>
 					</Button>
 				</span>
 			);
@@ -67,7 +67,7 @@ class CurrentSite extends Component {
 							// eslint-disable-next-line wpcalypso/jsx-classname-namespace
 							className={ `gridicon dashicons-before dashicons-arrow-${ arrowDirection }-alt2` }
 						></span>
-						<span className="current-site__switch-sites-label">{ translate( 'Switch site' ) }</span>
+						<span className="current-site__switch-sites-label">{ translate( 'Switch Site' ) }</span>
 					</Button>
 				</span>
 			)


### PR DESCRIPTION
Context: p1709624867864579-slack-C06DN6QQVAQ

## Proposed Changes

* All sites -> All Sites to match My Home for consistency

| Before  | After |
| :-------------: | :-------------: |
| <img src="https://github.com/Automattic/wp-calypso/assets/6586048/b408c0d0-f997-4dc9-8e5f-cb99ecff8057">  | <img src="https://github.com/Automattic/wp-calypso/assets/6586048/d0589094-b323-4b05-8fe1-29d4a697de51">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to wordpress.com/home/:site
* Check that the text is now All Sites

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?