### PR TITLE
Site Monitoring: Localize Response Types Legend

### DIFF
--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -598,11 +598,11 @@ export const MetricsTab = () => {
 					className="site-monitoring-php-static-pie-chart"
 					data={ getFormattedDataForPieChart( phpVsStaticFormattedData, {
 						php: {
-							name: 'Dynamic',
+							name: __( 'Dynamic' ),
 							className: 'dynamic',
 						},
 						static: {
-							name: 'Static',
+							name: __( 'Static' ),
 							className: 'static',
 						},
 					} ) }

--- a/client/my-sites/site-monitoring/metrics-tab.tsx
+++ b/client/my-sites/site-monitoring/metrics-tab.tsx
@@ -488,7 +488,7 @@ const useErrorHttpCodeSeries = () => {
 };
 
 export const MetricsTab = () => {
-	const { __ } = useI18n();
+	const { __, _x } = useI18n();
 	const moment = useLocalizedMoment();
 	const timeRange = useTimeRange();
 	const { handleTimeRangeChange } = timeRange;
@@ -598,11 +598,15 @@ export const MetricsTab = () => {
 					className="site-monitoring-php-static-pie-chart"
 					data={ getFormattedDataForPieChart( phpVsStaticFormattedData, {
 						php: {
-							name: __( 'Dynamic' ),
+							name:
+								/* translators: Page response type */
+								_x( 'Dynamic', 'response type' ),
 							className: 'dynamic',
 						},
 						static: {
-							name: __( 'Static' ),
+							name:
+								/* translators: Page response type */
+								_x( 'Static', 'response type' ),
 							className: 'static',
 						},
 					} ) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 755-gh-Automattic/i18n-issues

## Proposed Changes

* Localize legend items for Response types chart.

![5wYtlfECVcIWX8FO](https://github.com/Automattic/wp-calypso/assets/2722412/d8d428d0-d6d8-4a14-a5fa-b46f7c54535c)

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Code review.
* ~~Change UI to a Mag-16 language.~~
* ~~Navigate to `/site-monitoring`.~~
* ~~Confirm "Response types" chart legend is translated.~~ Translations are not available at the moment of creating the PR.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
