### PR TITLE
Add specific impression & skip button click events to the signup survey form

### DIFF
--- a/client/signup/steps/new-user-survey/index.tsx
+++ b/client/signup/steps/new-user-survey/index.tsx
@@ -92,6 +92,13 @@ function SurveyForm( props: Props ) {
 	const isMobileViewport = useMobileBreakpoint();
 	const isDesktopViewport = useDesktopBreakpoint();
 
+	useEffect( () => {
+		if ( isExperimentLoading ) {
+			return;
+		}
+		recordTracksEvent( 'calypso_signup_new_user_survey_view' );
+	}, [ isExperimentLoading ] );
+
 	if ( isExperimentLoading ) {
 		return null;
 	}

--- a/client/signup/steps/new-user-survey/index.tsx
+++ b/client/signup/steps/new-user-survey/index.tsx
@@ -6,6 +6,7 @@ import { ChangeEvent, useEffect, useRef, useState } from 'react';
 import CardHeading from 'calypso/components/card-heading';
 import FormInputCheckbox from 'calypso/components/forms/form-checkbox';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useExperiment } from 'calypso/lib/explat';
 import StepWrapper from 'calypso/signup/step-wrapper';
 import {
@@ -313,6 +314,7 @@ export default function NewUserSurvey( props: Props ) {
 
 	const handleSkip = () => {
 		const { stepName, goToNextStep, submitSignupStep } = props;
+		recordTracksEvent( 'calypso_signup_new_user_survey_skip_button_click' );
 		submitSignupStep( { stepName, wasSkipped: true } );
 		goToNextStep();
 	};


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->


## Proposed Changes

This PR adds specific impression & skip button click events to the signup survey form.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Open the network inspector, and monitor for `new_user_survey`
* Force the survey form to appear by accessing `/start?flags=onboarding/new-user-survey`
* When the survey form shows, there should be a Tracks request with the event name `calypso_signup_new_user_survey_view`
* When clicking on the skip button, there should be a Tracks request with the event name `calypso_signup_new_user_survey_skip_button_click`.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
