### PR TITLE
Scheduled Updats: Add gating component for scheduled updates feature

### DIFF
--- a/client/blocks/plugins-update-manager/context/index.tsx
+++ b/client/blocks/plugins-update-manager/context/index.tsx
@@ -3,17 +3,20 @@ import type { SiteSlug } from 'calypso/types';
 
 interface PluginUpdateManagerContextProps {
 	siteSlug: SiteSlug;
+	isEligibleForFeature: boolean;
 }
 
 const PluginUpdateManagerContext = createContext< PluginUpdateManagerContextProps >( {
 	siteSlug: '',
+	isEligibleForFeature: false,
 } );
 
 const PluginUpdateManagerContextProvider = ( {
 	siteSlug,
 	children,
+	isEligibleForFeature,
 }: PluginUpdateManagerContextProps & { children: ReactNode } ) => (
-	<PluginUpdateManagerContext.Provider value={ { siteSlug } }>
+	<PluginUpdateManagerContext.Provider value={ { siteSlug, isEligibleForFeature } }>
 		{ children }
 	</PluginUpdateManagerContext.Provider>
 );

--- a/client/blocks/plugins-update-manager/hooks/use-can-create-schedules.tsx
+++ b/client/blocks/plugins-update-manager/hooks/use-can-create-schedules.tsx
@@ -12,8 +12,11 @@ interface UseCanCreateSchedulesReturn {
 	isLoading: boolean;
 }
 
-export function useCanCreateSchedules( siteSlug: string ): UseCanCreateSchedulesReturn {
-	const { data, isLoading } = useUpdateScheduleCapabilitiesQuery( siteSlug );
+export function useCanCreateSchedules(
+	siteSlug: string,
+	isEligibleForFeature: boolean
+): UseCanCreateSchedulesReturn {
+	const { data, isLoading } = useUpdateScheduleCapabilitiesQuery( siteSlug, isEligibleForFeature );
 	const {
 		modify_files: modifyFiles,
 		autoupdate_files: autoUpdateFiles,

--- a/client/blocks/plugins-update-manager/hooks/use-is-eligible-for-feature.ts
+++ b/client/blocks/plugins-update-manager/hooks/use-is-eligible-for-feature.ts
@@ -1,0 +1,7 @@
+import { useContext } from 'react';
+import { PluginUpdateManagerContext } from '../context';
+
+export function useIsEligibleForFeature() {
+	const { isEligibleForFeature } = useContext( PluginUpdateManagerContext );
+	return isEligibleForFeature;
+}

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -2,6 +2,7 @@ import { WPCOM_FEATURES_SCHEDULED_UPDATES } from '@automattic/calypso-products';
 import { Button, Spinner } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
 import DocumentHead from 'calypso/components/data/document-head';
+import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import MainComponent from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import ScheduledUpdatesGate from 'calypso/components/scheduled-updates/scheduled-updates-gate';
@@ -10,7 +11,7 @@ import { useSelector } from 'calypso/state';
 import getHasLoadedSiteFeatures from 'calypso/state/selectors/has-loaded-site-features';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
+import { hasLoadedSitePlansFromServer } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { MAX_SCHEDULES } from './config';
 import { PluginUpdateManagerContextProvider } from './context';
@@ -42,8 +43,8 @@ export const PluginsUpdateManager = ( props: Props ) => {
 		getHasLoadedSiteFeatures( state, siteId )
 	);
 
-	const currentPlan = useSelector( ( state ) =>
-		siteId ? getCurrentPlan( state, siteId ) : undefined
+	const isSitePlansLoaded: boolean = useSelector( ( state ) =>
+		hasLoadedSitePlansFromServer( state, siteId )
 	);
 
 	const hideCreateButton =
@@ -78,7 +79,7 @@ export const PluginsUpdateManager = ( props: Props ) => {
 			isEligibleForFeature={ isEligibleForFeature }
 		>
 			<DocumentHead title={ title } />
-
+			{ ! isSitePlansLoaded && <QuerySitePlans siteId={ siteId } /> }
 			<MainComponent wideLayout>
 				<NavigationHeader
 					navigationItems={ [] }
@@ -97,7 +98,7 @@ export const PluginsUpdateManager = ( props: Props ) => {
 						</Button>
 					) }
 				</NavigationHeader>
-				{ ! isFeaturesLoaded || ! currentPlan ? (
+				{ ! isFeaturesLoaded || ! isSitePlansLoaded ? (
 					<Spinner className="plugins-update-manager-spinner" />
 				) : (
 					<ScheduledUpdatesGate

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -31,11 +31,11 @@ export const PluginsUpdateManager = ( props: Props ) => {
 	const { siteSlug, context, scheduleId, onNavBack, onCreateNewSchedule, onEditSchedule } = props;
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug );
 	const siteId = useSelector( getSelectedSiteId );
-	const hasScheduledUpdate = useSelector( ( state ) =>
+	const hasScheduledUpdatesFeature = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_SCHEDULED_UPDATES )
 	);
 	const isAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId as number ) );
-	const isEligibleForFeature = hasScheduledUpdate && isAtomic;
+	const isEligibleForFeature = hasScheduledUpdatesFeature && isAtomic;
 	const hideCreateButton =
 		! isEligibleForFeature || schedules.length === MAX_SCHEDULES || schedules.length === 0;
 
@@ -84,7 +84,11 @@ export const PluginsUpdateManager = ( props: Props ) => {
 						</Button>
 					) }
 				</NavigationHeader>
-				<ScheduledUpdatesGate hasScheduledUpdate={ hasScheduledUpdate } isAtomic={ isAtomic }>
+				<ScheduledUpdatesGate
+					isEligibleForFeature={ isEligibleForFeature }
+					hasScheduledUpdatesFeature={ hasScheduledUpdatesFeature }
+					isAtomic={ isAtomic }
+				>
 					{ component }
 				</ScheduledUpdatesGate>
 			</MainComponent>

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -34,7 +34,7 @@ export const PluginsUpdateManager = ( props: Props ) => {
 	const hasScheduledUpdate = useSelector( ( state ) =>
 		siteHasFeature( state, siteId, WPCOM_FEATURES_SCHEDULED_UPDATES )
 	);
-	const isAtomic = useSelector( ( state ) => siteId && isSiteWpcomAtomic( state, siteId ) );
+	const isAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId as number ) );
 	const isEligibleForFeature = hasScheduledUpdate && isAtomic;
 	const hideCreateButton =
 		! isEligibleForFeature || schedules.length === MAX_SCHEDULES || schedules.length === 0;
@@ -84,7 +84,7 @@ export const PluginsUpdateManager = ( props: Props ) => {
 						</Button>
 					) }
 				</NavigationHeader>
-				<ScheduledUpdatesGate needsUpgrade={ ! isEligibleForFeature }>
+				<ScheduledUpdatesGate hasScheduledUpdate={ hasScheduledUpdate } isAtomic={ isAtomic }>
 					{ component }
 				</ScheduledUpdatesGate>
 			</MainComponent>

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -31,27 +31,23 @@ interface Props {
 
 export const PluginsUpdateManager = ( props: Props ) => {
 	const { siteSlug, context, scheduleId, onNavBack, onCreateNewSchedule, onEditSchedule } = props;
-	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug );
 	const siteId = useSelector( getSelectedSiteId );
+	const hasScheduledUpdatesFeature = useSelector( ( state ) =>
+		siteHasFeature( state, siteId, WPCOM_FEATURES_SCHEDULED_UPDATES )
+	);
+	const isAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId as number ) );
+	const isEligibleForFeature = hasScheduledUpdatesFeature && isAtomic;
+	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const isFeaturesLoaded: boolean = useSelector( ( state ) =>
 		getHasLoadedSiteFeatures( state, siteId )
 	);
 	const isSitePlansLoaded: boolean = useSelector( ( state ) =>
 		hasLoadedSitePlansFromServer( state, siteId )
 	);
-
-	const hasScheduledUpdatesFeature = useSelector( ( state ) =>
-		siteHasFeature( state, siteId, WPCOM_FEATURES_SCHEDULED_UPDATES )
-	);
-	const isAtomic = useSelector( ( state ) => isSiteWpcomAtomic( state, siteId as number ) );
-	const isEligibleForFeature = hasScheduledUpdatesFeature && isAtomic;
 	const hideCreateButton =
 		! isEligibleForFeature || schedules.length === MAX_SCHEDULES || schedules.length === 0;
-<<<<<<< HEAD
 
 	const { canCreateSchedules } = useCanCreateSchedules( siteSlug );
-=======
->>>>>>> 96794ec8990 (Rebase)
 
 	const { component, title } = {
 		list: {
@@ -75,7 +71,10 @@ export const PluginsUpdateManager = ( props: Props ) => {
 	}[ context ];
 
 	return (
-		<PluginUpdateManagerContextProvider siteSlug={ siteSlug }>
+		<PluginUpdateManagerContextProvider
+			siteSlug={ siteSlug }
+			isEligibleForFeature={ isEligibleForFeature }
+		>
 			<DocumentHead title={ title } />
 
 			<MainComponent wideLayout>
@@ -102,7 +101,6 @@ export const PluginsUpdateManager = ( props: Props ) => {
 					<ScheduledUpdatesGate
 						hasScheduledUpdatesFeature={ hasScheduledUpdatesFeature }
 						isAtomic={ isAtomic }
-						isEligibleForFeature={ isEligibleForFeature }
 						siteId={ siteId as number }
 					>
 						{ component }

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -47,7 +47,7 @@ export const PluginsUpdateManager = ( props: Props ) => {
 	const hideCreateButton =
 		! isEligibleForFeature || schedules.length === MAX_SCHEDULES || schedules.length === 0;
 
-	const { canCreateSchedules } = useCanCreateSchedules( siteSlug );
+	const { canCreateSchedules } = useCanCreateSchedules( siteSlug, isEligibleForFeature );
 
 	const { component, title } = {
 		list: {

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -1,16 +1,21 @@
+import { WPCOM_FEATURES_SCHEDULED_UPDATES } from '@automattic/calypso-products';
 import { Button } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
 import DocumentHead from 'calypso/components/data/document-head';
 import MainComponent from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
+import ScheduledUpdatesGate from 'calypso/components/scheduled-updates/scheduled-updates-gate';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
+import { useSelector } from 'calypso/state';
+import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
+import siteHasFeature from 'calypso/state/selectors/site-has-feature';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { MAX_SCHEDULES } from './config';
 import { PluginUpdateManagerContextProvider } from './context';
 import { useCanCreateSchedules } from './hooks/use-can-create-schedules';
 import { ScheduleCreate } from './schedule-create';
 import { ScheduleEdit } from './schedule-edit';
 import { ScheduleList } from './schedule-list';
-
 import './styles.scss';
 
 interface Props {
@@ -25,7 +30,14 @@ interface Props {
 export const PluginsUpdateManager = ( props: Props ) => {
 	const { siteSlug, context, scheduleId, onNavBack, onCreateNewSchedule, onEditSchedule } = props;
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug );
-	const hideCreateButton = schedules.length === MAX_SCHEDULES || schedules.length === 0;
+	const siteId = useSelector( getSelectedSiteId );
+	const hasScheduledUpdate = useSelector( ( state ) =>
+		siteHasFeature( state, siteId, WPCOM_FEATURES_SCHEDULED_UPDATES )
+	);
+	const isAtomic = useSelector( ( state ) => siteId && isSiteWpcomAtomic( state, siteId ) );
+	const isEligibleForFeature = hasScheduledUpdate && isAtomic;
+	const hideCreateButton =
+		! isEligibleForFeature || schedules.length === MAX_SCHEDULES || schedules.length === 0;
 
 	const { canCreateSchedules } = useCanCreateSchedules( siteSlug );
 
@@ -72,7 +84,9 @@ export const PluginsUpdateManager = ( props: Props ) => {
 						</Button>
 					) }
 				</NavigationHeader>
-				{ component }
+				<ScheduledUpdatesGate needsUpgrade={ ! isEligibleForFeature }>
+					{ component }
+				</ScheduledUpdatesGate>
 			</MainComponent>
 		</PluginUpdateManagerContextProvider>
 	);

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -85,9 +85,9 @@ export const PluginsUpdateManager = ( props: Props ) => {
 					) }
 				</NavigationHeader>
 				<ScheduledUpdatesGate
-					isEligibleForFeature={ isEligibleForFeature }
 					hasScheduledUpdatesFeature={ hasScheduledUpdatesFeature }
 					isAtomic={ isAtomic }
+					isEligibleForFeature={ isEligibleForFeature }
 					siteId={ siteId as number }
 				>
 					{ component }

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -10,7 +10,7 @@ import { useSelector } from 'calypso/state';
 import getHasLoadedSiteFeatures from 'calypso/state/selectors/has-loaded-site-features';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import siteHasFeature from 'calypso/state/selectors/site-has-feature';
-import { hasLoadedSitePlansFromServer } from 'calypso/state/sites/plans/selectors';
+import { getCurrentPlan } from 'calypso/state/sites/plans/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { MAX_SCHEDULES } from './config';
 import { PluginUpdateManagerContextProvider } from './context';
@@ -41,9 +41,11 @@ export const PluginsUpdateManager = ( props: Props ) => {
 	const isFeaturesLoaded: boolean = useSelector( ( state ) =>
 		getHasLoadedSiteFeatures( state, siteId )
 	);
-	const isSitePlansLoaded: boolean = useSelector( ( state ) =>
-		hasLoadedSitePlansFromServer( state, siteId )
+
+	const currentPlan = useSelector( ( state ) =>
+		siteId ? getCurrentPlan( state, siteId ) : undefined
 	);
+
 	const hideCreateButton =
 		! isEligibleForFeature || schedules.length === MAX_SCHEDULES || schedules.length === 0;
 
@@ -95,7 +97,7 @@ export const PluginsUpdateManager = ( props: Props ) => {
 						</Button>
 					) }
 				</NavigationHeader>
-				{ ! isFeaturesLoaded || ! isSitePlansLoaded ? (
+				{ ! isFeaturesLoaded || ! currentPlan ? (
 					<Spinner className="plugins-update-manager-spinner" />
 				) : (
 					<ScheduledUpdatesGate

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -88,6 +88,7 @@ export const PluginsUpdateManager = ( props: Props ) => {
 					isEligibleForFeature={ isEligibleForFeature }
 					hasScheduledUpdatesFeature={ hasScheduledUpdatesFeature }
 					isAtomic={ isAtomic }
+					siteId={ siteId as number }
 				>
 					{ component }
 				</ScheduledUpdatesGate>

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -38,8 +38,11 @@ export const PluginsUpdateManager = ( props: Props ) => {
 	const isEligibleForFeature = hasScheduledUpdatesFeature && isAtomic;
 	const hideCreateButton =
 		! isEligibleForFeature || schedules.length === MAX_SCHEDULES || schedules.length === 0;
+<<<<<<< HEAD
 
 	const { canCreateSchedules } = useCanCreateSchedules( siteSlug );
+=======
+>>>>>>> 96794ec8990 (Rebase)
 
 	const { component, title } = {
 		list: {

--- a/client/blocks/plugins-update-manager/schedule-create.tsx
+++ b/client/blocks/plugins-update-manager/schedule-create.tsx
@@ -13,6 +13,7 @@ import { useEffect } from 'react';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { MAX_SCHEDULES } from './config';
 import { useCanCreateSchedules } from './hooks/use-can-create-schedules';
+import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSiteSlug } from './hooks/use-site-slug';
 import { ScheduleForm } from './schedule-form';
 
@@ -21,9 +22,12 @@ interface Props {
 }
 export const ScheduleCreate = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
+	const isEligibleForFeature = useIsEligibleForFeature();
 	const { onNavBack } = props;
-
-	const { data: schedules = [], isFetched } = useUpdateScheduleQuery( siteSlug );
+	const { data: schedules = [], isFetched } = useUpdateScheduleQuery(
+		siteSlug,
+		isEligibleForFeature
+	);
 	const { canCreateSchedules } = useCanCreateSchedules( siteSlug );
 
 	const mutationState = useMutationState( {

--- a/client/blocks/plugins-update-manager/schedule-create.tsx
+++ b/client/blocks/plugins-update-manager/schedule-create.tsx
@@ -28,7 +28,8 @@ export const ScheduleCreate = ( props: Props ) => {
 		siteSlug,
 		isEligibleForFeature
 	);
-	const { canCreateSchedules } = useCanCreateSchedules( siteSlug );
+
+	const { canCreateSchedules } = useCanCreateSchedules( siteSlug, isEligibleForFeature );
 
 	const mutationState = useMutationState( {
 		filters: { mutationKey: [ 'create-update-schedule', siteSlug ] },

--- a/client/blocks/plugins-update-manager/schedule-edit.tsx
+++ b/client/blocks/plugins-update-manager/schedule-edit.tsx
@@ -11,6 +11,7 @@ import {
 import { arrowLeft, warning } from '@wordpress/icons';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { useCanCreateSchedules } from './hooks/use-can-create-schedules';
+import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSiteSlug } from './hooks/use-site-slug';
 import { ScheduleForm } from './schedule-form';
 
@@ -20,9 +21,12 @@ interface Props {
 }
 export const ScheduleEdit = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
-
+	const isEligibleForFeature = useIsEligibleForFeature();
 	const { scheduleId, onNavBack } = props;
-	const { data: schedules = [], isFetched } = useUpdateScheduleQuery( siteSlug );
+	const { data: schedules = [], isFetched } = useUpdateScheduleQuery(
+		siteSlug,
+		isEligibleForFeature
+	);
 	const schedule = schedules.find( ( s ) => s.id === scheduleId );
 
 	const mutationState = useMutationState( {

--- a/client/blocks/plugins-update-manager/schedule-edit.tsx
+++ b/client/blocks/plugins-update-manager/schedule-edit.tsx
@@ -34,7 +34,7 @@ export const ScheduleEdit = ( props: Props ) => {
 	} );
 	const isBusy = mutationState.filter( ( { status } ) => status === 'pending' ).length > 0;
 
-	const { canCreateSchedules } = useCanCreateSchedules( siteSlug );
+	const { canCreateSchedules } = useCanCreateSchedules( siteSlug, isEligibleForFeature );
 
 	// If the schedule is not found, navigate back to the list
 	if ( isFetched && ! schedule ) {

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -23,6 +23,7 @@ import {
 	ScheduleUpdates,
 } from 'calypso/data/plugins/use-update-schedules-query';
 import { MAX_SELECTABLE_PLUGINS } from './config';
+import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSiteSlug } from './hooks/use-site-slug';
 import {
 	DAILY_OPTION,
@@ -43,6 +44,7 @@ interface Props {
 export const ScheduleForm = ( props: Props ) => {
 	const moment = useLocalizedMoment();
 	const siteSlug = useSiteSlug();
+	const isEligibleForFeature = useIsEligibleForFeature();
 	const { scheduleForEdit, onSyncSuccess } = props;
 	const initDate = scheduleForEdit
 		? moment( scheduleForEdit?.timestamp * 1000 )
@@ -52,7 +54,7 @@ export const ScheduleForm = ( props: Props ) => {
 		isLoading: isPluginsFetching,
 		isFetched: isPluginsFetched,
 	} = useCorePluginsQuery( siteSlug, true );
-	const { data: schedulesData = [] } = useUpdateScheduleQuery( siteSlug );
+	const { data: schedulesData = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const schedules = schedulesData.filter( ( s ) => s.id !== scheduleForEdit?.id ) ?? [];
 	const { createUpdateSchedule } = useCreateUpdateScheduleMutation( siteSlug, {
 		onSuccess: () => onSyncSuccess && onSyncSuccess(),

--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -5,6 +5,7 @@ import { usePreparePluginsTooltipInfo } from 'calypso/blocks/plugins-update-mana
 import { ellipsis } from 'calypso/blocks/plugins-update-manager/icons';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
+import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { usePrepareScheduleName } from './hooks/use-prepare-schedule-name';
 import { useSiteSlug } from './hooks/use-site-slug';
 
@@ -14,9 +15,10 @@ interface Props {
 }
 export const ScheduleListCards = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
+	const isEligibleForFeature = useIsEligibleForFeature();
 	const moment = useLocalizedMoment();
 	const { onEditClick, onRemoveClick } = props;
-	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug );
+	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 	const { prepareScheduleName } = usePrepareScheduleName();
 

--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -3,6 +3,7 @@ import { Icon, info } from '@wordpress/icons';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { MOMENT_TIME_FORMAT } from './config';
+import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { usePreparePluginsTooltipInfo } from './hooks/use-prepare-plugins-tooltip-info';
 import { usePrepareScheduleName } from './hooks/use-prepare-schedule-name';
 import { useSiteSlug } from './hooks/use-site-slug';
@@ -14,9 +15,10 @@ interface Props {
 }
 export const ScheduleListTable = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
+	const isEligibleForFeature = useIsEligibleForFeature();
 	const moment = useLocalizedMoment();
 	const { onEditClick, onRemoveClick } = props;
-	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug );
+	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 	const { prepareScheduleName } = usePrepareScheduleName();
 

--- a/client/blocks/plugins-update-manager/schedule-list.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list.tsx
@@ -40,11 +40,21 @@ export const ScheduleList = ( props: Props ) => {
 		isFetched,
 		refetch,
 	} = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
+
 	const { deleteUpdateSchedule } = useDeleteUpdateScheduleMutation( siteSlug, {
 		onSuccess: () => refetch(),
 	} );
-	const { canCreateSchedules, isLoading: isLoadingCanCreateSchedules } =
-		useCanCreateSchedules( siteSlug );
+
+	const { canCreateSchedules, isLoading: isLoadingCanCreateSchedules } = useCanCreateSchedules(
+		siteSlug,
+		isEligibleForFeature
+	);
+
+	const showScheduleListEmpty =
+		! isEligibleForFeature ||
+		( isFetched &&
+			! isLoadingCanCreateSchedules &&
+			( schedules.length === 0 || ! canCreateSchedules ) );
 
 	const openRemoveDialog = ( id: string ) => {
 		setRemoveDialogOpen( true );
@@ -84,15 +94,12 @@ export const ScheduleList = ( props: Props ) => {
 				</CardHeader>
 				<CardBody>
 					{ ( isLoading || isLoadingCanCreateSchedules ) && <Spinner /> }
-					{ ! isEligibleForFeature ||
-						( isFetched &&
-							! isLoadingCanCreateSchedules &&
-							( schedules.length === 0 || ! canCreateSchedules ) && (
-								<ScheduleListEmpty
-									onCreateNewSchedule={ onCreateNewSchedule }
-									canCreateSchedules={ canCreateSchedules }
-								/>
-							) ) }
+					{ showScheduleListEmpty && (
+						<ScheduleListEmpty
+							onCreateNewSchedule={ onCreateNewSchedule }
+							canCreateSchedules={ canCreateSchedules }
+						/>
+					) }
 					{ isFetched &&
 						! isLoadingCanCreateSchedules &&
 						schedules.length > 0 &&

--- a/client/blocks/plugins-update-manager/schedule-list.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list.tsx
@@ -14,6 +14,7 @@ import { useDeleteUpdateScheduleMutation } from 'calypso/data/plugins/use-update
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { MAX_SCHEDULES } from './config';
 import { useCanCreateSchedules } from './hooks/use-can-create-schedules';
+import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSiteSlug } from './hooks/use-site-slug';
 import { ScheduleListCards } from './schedule-list-cards';
 import { ScheduleListEmpty } from './schedule-list-empty';
@@ -26,6 +27,7 @@ interface Props {
 }
 export const ScheduleList = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
+	const isEligibleForFeature = useIsEligibleForFeature();
 	const isMobile = useMobileBreakpoint();
 
 	const { onNavBack, onCreateNewSchedule, onEditSchedule } = props;
@@ -37,7 +39,7 @@ export const ScheduleList = ( props: Props ) => {
 		isLoading,
 		isFetched,
 		refetch,
-	} = useUpdateScheduleQuery( siteSlug );
+	} = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const { deleteUpdateSchedule } = useDeleteUpdateScheduleMutation( siteSlug, {
 		onSuccess: () => refetch(),
 	} );
@@ -82,14 +84,15 @@ export const ScheduleList = ( props: Props ) => {
 				</CardHeader>
 				<CardBody>
 					{ ( isLoading || isLoadingCanCreateSchedules ) && <Spinner /> }
-					{ isFetched &&
-						! isLoadingCanCreateSchedules &&
-						( schedules.length === 0 || ! canCreateSchedules ) && (
-							<ScheduleListEmpty
-								onCreateNewSchedule={ onCreateNewSchedule }
-								canCreateSchedules={ canCreateSchedules }
-							/>
-						) }
+					{ ! isEligibleForFeature ||
+						( isFetched &&
+							! isLoadingCanCreateSchedules &&
+							( schedules.length === 0 || ! canCreateSchedules ) && (
+								<ScheduleListEmpty
+									onCreateNewSchedule={ onCreateNewSchedule }
+									canCreateSchedules={ canCreateSchedules }
+								/>
+							) ) }
 					{ isFetched &&
 						! isLoadingCanCreateSchedules &&
 						schedules.length > 0 &&

--- a/client/blocks/plugins-update-manager/styles.scss
+++ b/client/blocks/plugins-update-manager/styles.scss
@@ -110,3 +110,9 @@
 		}
 	}
 }
+
+.plugins-update-manager-spinner {
+	position: absolute;
+	left: 50%;
+	transform: translateX(-50%);
+}

--- a/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
+++ b/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
@@ -7,26 +7,27 @@ import { useDispatch, useSelector } from 'calypso/state';
 import { transferInProgress } from 'calypso/state/automated-transfer/constants';
 import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
 import { initiateThemeTransfer } from 'calypso/state/themes/actions';
-import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import UpsellNudgeNotice from './upsell-nudge';
+import type { SiteId } from 'calypso/types';
 
 import './style.scss';
 
 interface ScheduledUpdatesGateProps {
+	children: ReactNode;
 	hasScheduledUpdatesFeature: boolean;
 	isAtomic: boolean;
 	isEligibleForFeature: boolean;
-	children: ReactNode;
+	siteId: SiteId;
 }
 
 const ScheduledUpdatesGate: FC< ScheduledUpdatesGateProps > = ( {
+	children,
 	hasScheduledUpdatesFeature,
 	isAtomic,
 	isEligibleForFeature,
-	children,
+	siteId,
 } ) => {
 	const translate = useTranslate();
-	const siteId = useSelector( getSelectedSiteId );
 	const dispatch = useDispatch();
 	const transferState = useSelector( ( state ) => getAutomatedTransferStatus( state, siteId ) );
 	const [ hasTransfer, setHasTransferring ] = useState(

--- a/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
+++ b/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
@@ -65,7 +65,7 @@ const ScheduledUpdatesGate: FC< ScheduledUpdatesGateProps > = ( {
 					className="scheduled-updates__activating-notice"
 					status="is-info"
 					showDismiss={ false }
-					text={ translate( 'Please activate hosting access to begin using this feature.' ) }
+					text={ translate( 'Please activate hosting access to schedule plugin updates.' ) }
 					icon="globe"
 				>
 					<NoticeAction onClick={ clickActivate }>{ translate( 'Activate' ) }</NoticeAction>

--- a/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
+++ b/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
@@ -34,7 +34,7 @@ const ScheduledUpdatesGate: FC< ScheduledUpdatesGateProps > = ( {
 		)
 	);
 
-	const isEligibleForFeature = ! hasScheduledUpdate && isAtomic;
+	const isEligibleForFeature = hasScheduledUpdate && isAtomic;
 	const showHostingActivationBanner = ! isAtomic && ! hasTransfer;
 
 	const handleFocus = ( e: FocusEvent< HTMLDivElement > ) => {

--- a/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
+++ b/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
@@ -13,14 +13,16 @@ import UpsellNudgeNotice from './upsell-nudge';
 import './style.scss';
 
 interface ScheduledUpdatesGateProps {
-	hasScheduledUpdate: boolean;
+	hasScheduledUpdatesFeature: boolean;
 	isAtomic: boolean;
+	isEligibleForFeature: boolean;
 	children: ReactNode;
 }
 
 const ScheduledUpdatesGate: FC< ScheduledUpdatesGateProps > = ( {
-	hasScheduledUpdate,
+	hasScheduledUpdatesFeature,
 	isAtomic,
+	isEligibleForFeature,
 	children,
 } ) => {
 	const translate = useTranslate();
@@ -34,7 +36,6 @@ const ScheduledUpdatesGate: FC< ScheduledUpdatesGateProps > = ( {
 		)
 	);
 
-	const isEligibleForFeature = hasScheduledUpdate && isAtomic;
 	const showHostingActivationBanner = ! isAtomic && ! hasTransfer;
 
 	const handleFocus = ( e: FocusEvent< HTMLDivElement > ) => {
@@ -53,7 +54,7 @@ const ScheduledUpdatesGate: FC< ScheduledUpdatesGateProps > = ( {
 	};
 
 	const getNoticeBanner = () => {
-		if ( ! hasScheduledUpdate ) {
+		if ( ! hasScheduledUpdatesFeature ) {
 			return <UpsellNudgeNotice />;
 		}
 

--- a/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
+++ b/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
@@ -53,7 +53,7 @@ const ScheduledUpdatesGate: FC< ScheduledUpdatesGateProps > = ( {
 	};
 
 	const getNoticeBanner = () => {
-		if ( hasScheduledUpdate ) {
+		if ( ! hasScheduledUpdate ) {
 			return <UpsellNudgeNotice />;
 		}
 

--- a/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
+++ b/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
@@ -1,0 +1,53 @@
+import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
+import { addQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import { FC, ReactNode, FocusEvent } from 'react';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import './style.scss';
+
+interface ScheduledUpdatesGateProps {
+	needsUpgrade: boolean;
+	children: ReactNode;
+}
+
+const ScheduledUpdatesGate: FC< ScheduledUpdatesGateProps > = ( { needsUpgrade, children } ) => {
+	const translate = useTranslate();
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	const handleFocus = ( e: FocusEvent< HTMLDivElement > ) => {
+		e.target.blur();
+	};
+
+	const titleText = translate(
+		'Upgrade to the %(businessPlanName)s plan to access scheduled updates feature',
+		{
+			args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+		}
+	);
+
+	const href = addQueryArgs( `/checkout/${ siteSlug }/business`, {
+		redirect_to: `/scheduled-updates/${ siteSlug }`,
+	} );
+
+	if ( needsUpgrade ) {
+		return (
+			<div tabIndex={ -1 } className="scheduled-updates-gate" onFocus={ handleFocus }>
+				<UpsellNudge
+					className="scheduled-updates-upsell-nudge"
+					title={ titleText }
+					event="calypso_scheduled_updates_upgrade_click"
+					href={ href }
+					callToAction={ translate( 'Upgrade' ) }
+					plan={ PLAN_BUSINESS }
+					showIcon={ true }
+				/>
+				<div className="scheduled-updates-gate__content">{ children }</div>
+			</div>
+		);
+	}
+	return <div>{ children }</div>;
+};
+
+export default ScheduledUpdatesGate;

--- a/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
+++ b/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
@@ -44,7 +44,7 @@ const ScheduledUpdatesGate: FC< ScheduledUpdatesGateProps > = ( {
 	};
 
 	const clickActivate = () => {
-		dispatch( initiateThemeTransfer( siteId ?? 0, null, '', '', 'scheduled_updates' ) );
+		dispatch( initiateThemeTransfer( siteId, null, '', '', 'scheduled_updates' ) );
 		setHasTransferring( true );
 	};
 

--- a/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
+++ b/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
@@ -28,7 +28,7 @@ const ScheduledUpdatesGate: FC< ScheduledUpdatesGateProps > = ( { needsUpgrade, 
 	);
 
 	const href = addQueryArgs( `/checkout/${ siteSlug }/business`, {
-		redirect_to: `/scheduled-updates/${ siteSlug }`,
+		redirect_to: `/plugins/scheduled-updates/${ siteSlug }`,
 	} );
 
 	if ( needsUpgrade ) {

--- a/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
+++ b/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
@@ -1,4 +1,13 @@
-import { FC, ReactNode, FocusEvent } from 'react';
+import { useTranslate } from 'i18n-calypso';
+import { FC, ReactNode, FocusEvent, useState } from 'react';
+import Notice from 'calypso/components/notice';
+import NoticeAction from 'calypso/components/notice/notice-action';
+import HostingActivateStatus from 'calypso/my-sites/hosting/hosting-activate-status';
+import { useDispatch, useSelector } from 'calypso/state';
+import { transferInProgress } from 'calypso/state/automated-transfer/constants';
+import { getAutomatedTransferStatus } from 'calypso/state/automated-transfer/selectors';
+import { initiateThemeTransfer } from 'calypso/state/themes/actions';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import UpsellNudgeNotice from './upsell-nudge';
 
 import './style.scss';
@@ -14,15 +23,52 @@ const ScheduledUpdatesGate: FC< ScheduledUpdatesGateProps > = ( {
 	isAtomic,
 	children,
 } ) => {
+	const translate = useTranslate();
+	const siteId = useSelector( getSelectedSiteId );
+	const dispatch = useDispatch();
+	const transferState = useSelector( ( state ) => getAutomatedTransferStatus( state, siteId ) );
+	const [ hasTransfer, setHasTransferring ] = useState(
+		!! (
+			transferState &&
+			transferInProgress.includes( transferState as ( typeof transferInProgress )[ number ] )
+		)
+	);
+
 	const isEligibleForFeature = ! hasScheduledUpdate && isAtomic;
+	const showHostingActivationBanner = ! isAtomic && ! hasTransfer;
 
 	const handleFocus = ( e: FocusEvent< HTMLDivElement > ) => {
 		e.target.blur();
 	};
 
+	const clickActivate = () => {
+		dispatch( initiateThemeTransfer( siteId ?? 0, null, '', '', 'scheduled_updates' ) );
+		setHasTransferring( true );
+	};
+
+	const onTick = ( isTransferring?: boolean ) => {
+		if ( isTransferring && ! hasTransfer ) {
+			setHasTransferring( true );
+		}
+	};
+
 	const getNoticeBanner = () => {
 		if ( hasScheduledUpdate ) {
 			return <UpsellNudgeNotice />;
+		}
+
+		if ( showHostingActivationBanner ) {
+			return (
+				<Notice
+					className="scheduled-updates__activating-notice"
+					status="is-info"
+					showDismiss={ false }
+					text={ translate( 'Please activate hosting access to begin using this feature.' ) }
+					icon="globe"
+				>
+					<NoticeAction onClick={ clickActivate }>{ translate( 'Activate' ) }</NoticeAction>
+				</Notice>
+			);
 		}
 		return null;
 	};
@@ -31,6 +77,13 @@ const ScheduledUpdatesGate: FC< ScheduledUpdatesGateProps > = ( {
 		return (
 			<div tabIndex={ -1 } className="scheduled-updates-gate" onFocus={ handleFocus }>
 				{ getNoticeBanner() }
+				{ ! showHostingActivationBanner && (
+					<HostingActivateStatus
+						context="hosting"
+						onTick={ onTick }
+						keepAlive={ ! isAtomic && hasTransfer }
+					/>
+				) }
 				<div className="scheduled-updates-gate__content">{ children }</div>
 			</div>
 		);

--- a/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
+++ b/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
@@ -1,5 +1,6 @@
 import { useTranslate } from 'i18n-calypso';
 import { FC, ReactNode, FocusEvent, useState } from 'react';
+import { useIsEligibleForFeature } from 'calypso/blocks/plugins-update-manager/hooks/use-is-eligible-for-feature';
 import Notice from 'calypso/components/notice';
 import NoticeAction from 'calypso/components/notice/notice-action';
 import HostingActivateStatus from 'calypso/my-sites/hosting/hosting-activate-status';
@@ -16,7 +17,6 @@ interface ScheduledUpdatesGateProps {
 	children: ReactNode;
 	hasScheduledUpdatesFeature: boolean;
 	isAtomic: boolean;
-	isEligibleForFeature: boolean;
 	siteId: SiteId;
 }
 
@@ -24,12 +24,12 @@ const ScheduledUpdatesGate: FC< ScheduledUpdatesGateProps > = ( {
 	children,
 	hasScheduledUpdatesFeature,
 	isAtomic,
-	isEligibleForFeature,
 	siteId,
 } ) => {
 	const translate = useTranslate();
 	const dispatch = useDispatch();
 	const transferState = useSelector( ( state ) => getAutomatedTransferStatus( state, siteId ) );
+	const isEligibleForFeature = useIsEligibleForFeature();
 	const [ hasTransfer, setHasTransferring ] = useState(
 		!! (
 			transferState &&

--- a/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
+++ b/client/components/scheduled-updates/scheduled-updates-gate/index.tsx
@@ -1,48 +1,36 @@
-import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
-import { addQueryArgs } from '@wordpress/url';
-import { useTranslate } from 'i18n-calypso';
 import { FC, ReactNode, FocusEvent } from 'react';
-import UpsellNudge from 'calypso/blocks/upsell-nudge';
-import { useSelector } from 'calypso/state';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import UpsellNudgeNotice from './upsell-nudge';
+
 import './style.scss';
 
 interface ScheduledUpdatesGateProps {
-	needsUpgrade: boolean;
+	hasScheduledUpdate: boolean;
+	isAtomic: boolean;
 	children: ReactNode;
 }
 
-const ScheduledUpdatesGate: FC< ScheduledUpdatesGateProps > = ( { needsUpgrade, children } ) => {
-	const translate = useTranslate();
-	const siteSlug = useSelector( getSelectedSiteSlug );
+const ScheduledUpdatesGate: FC< ScheduledUpdatesGateProps > = ( {
+	hasScheduledUpdate,
+	isAtomic,
+	children,
+} ) => {
+	const isEligibleForFeature = ! hasScheduledUpdate && isAtomic;
 
 	const handleFocus = ( e: FocusEvent< HTMLDivElement > ) => {
 		e.target.blur();
 	};
 
-	const titleText = translate(
-		'Upgrade to the %(businessPlanName)s plan to access scheduled updates feature',
-		{
-			args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+	const getNoticeBanner = () => {
+		if ( hasScheduledUpdate ) {
+			return <UpsellNudgeNotice />;
 		}
-	);
+		return null;
+	};
 
-	const href = addQueryArgs( `/checkout/${ siteSlug }/business`, {
-		redirect_to: `/plugins/scheduled-updates/${ siteSlug }`,
-	} );
-
-	if ( needsUpgrade ) {
+	if ( ! isEligibleForFeature ) {
 		return (
 			<div tabIndex={ -1 } className="scheduled-updates-gate" onFocus={ handleFocus }>
-				<UpsellNudge
-					className="scheduled-updates-upsell-nudge"
-					title={ titleText }
-					event="calypso_scheduled_updates_upgrade_click"
-					href={ href }
-					callToAction={ translate( 'Upgrade' ) }
-					plan={ PLAN_BUSINESS }
-					showIcon={ true }
-				/>
+				{ getNoticeBanner() }
 				<div className="scheduled-updates-gate__content">{ children }</div>
 			</div>
 		);

--- a/client/components/scheduled-updates/scheduled-updates-gate/style.scss
+++ b/client/components/scheduled-updates/scheduled-updates-gate/style.scss
@@ -1,0 +1,5 @@
+.scheduled-updates-gate__content {
+	position: relative;
+	pointer-events: none;
+	opacity: 0.33;
+}

--- a/client/components/scheduled-updates/scheduled-updates-gate/upsell-nudge.tsx
+++ b/client/components/scheduled-updates/scheduled-updates-gate/upsell-nudge.tsx
@@ -10,7 +10,7 @@ const UpsellNudgeNotice = () => {
 	const siteSlug = useSelector( getSelectedSiteSlug );
 
 	const titleText = translate(
-		'Upgrade to the %(businessPlanName)s plan to access scheduled updates feature',
+		'Upgrade to the %(businessPlanName)s plan to install plugins and manage scheduled updates.',
 		{
 			args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
 		}

--- a/client/components/scheduled-updates/scheduled-updates-gate/upsell-nudge.tsx
+++ b/client/components/scheduled-updates/scheduled-updates-gate/upsell-nudge.tsx
@@ -1,4 +1,8 @@
-import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
+import {
+	PLAN_BUSINESS,
+	getPlan,
+	WPCOM_FEATURES_SCHEDULED_UPDATES,
+} from '@automattic/calypso-products';
 import { addQueryArgs } from '@wordpress/url';
 import { useTranslate } from 'i18n-calypso';
 import UpsellNudge from 'calypso/blocks/upsell-nudge';
@@ -29,6 +33,7 @@ const UpsellNudgeNotice = () => {
 			callToAction={ translate( 'Upgrade' ) }
 			plan={ PLAN_BUSINESS }
 			showIcon={ true }
+			feature={ WPCOM_FEATURES_SCHEDULED_UPDATES }
 		/>
 	);
 };

--- a/client/components/scheduled-updates/scheduled-updates-gate/upsell-nudge.tsx
+++ b/client/components/scheduled-updates/scheduled-updates-gate/upsell-nudge.tsx
@@ -1,0 +1,36 @@
+import { PLAN_BUSINESS, getPlan } from '@automattic/calypso-products';
+import { addQueryArgs } from '@wordpress/url';
+import { useTranslate } from 'i18n-calypso';
+import UpsellNudge from 'calypso/blocks/upsell-nudge';
+import { useSelector } from 'calypso/state';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+
+const UpsellNudgeNotice = () => {
+	const translate = useTranslate();
+	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	const titleText = translate(
+		'Upgrade to the %(businessPlanName)s plan to access scheduled updates feature',
+		{
+			args: { businessPlanName: getPlan( PLAN_BUSINESS )?.getTitle() ?? '' },
+		}
+	);
+
+	const href = addQueryArgs( `/checkout/${ siteSlug }/business`, {
+		redirect_to: `/plugins/scheduled-updates/${ siteSlug }`,
+	} );
+
+	return (
+		<UpsellNudge
+			className="scheduled-updates-upsell-nudge"
+			title={ titleText }
+			event="calypso_scheduled_updates_upgrade_click"
+			href={ href }
+			callToAction={ translate( 'Upgrade' ) }
+			plan={ PLAN_BUSINESS }
+			showIcon={ true }
+		/>
+	);
+};
+
+export default UpsellNudgeNotice;

--- a/client/data/plugins/use-update-schedules-capabilities-query.ts
+++ b/client/data/plugins/use-update-schedules-capabilities-query.ts
@@ -9,7 +9,8 @@ export type ScheduleUpdatesCapabilities = {
 };
 
 export const useUpdateScheduleCapabilitiesQuery = (
-	siteSlug: SiteSlug
+	siteSlug: SiteSlug,
+	isEligibleForFeature: boolean
 ): UseQueryResult< ScheduleUpdatesCapabilities > => {
 	return useQuery( {
 		queryKey: [ 'schedule-updates-capabilities', siteSlug ],
@@ -22,7 +23,7 @@ export const useUpdateScheduleCapabilitiesQuery = (
 		meta: {
 			persist: false,
 		},
-		enabled: !! siteSlug,
+		enabled: !! siteSlug && isEligibleForFeature,
 		retry: false,
 		refetchOnWindowFocus: false,
 	} );

--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -12,7 +12,8 @@ export type ScheduleUpdates = {
 };
 
 export const useUpdateScheduleQuery = (
-	siteSlug: SiteSlug
+	siteSlug: SiteSlug,
+	isEligibleForFeature: boolean
 ): UseQueryResult< ScheduleUpdates[] > => {
 	return useQuery( {
 		queryKey: [ 'schedule-updates', siteSlug ],
@@ -30,7 +31,7 @@ export const useUpdateScheduleQuery = (
 		meta: {
 			persist: false,
 		},
-		enabled: !! siteSlug,
+		enabled: !! siteSlug && isEligibleForFeature,
 		retry: false,
 		refetchOnWindowFocus: false,
 	} );

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -287,6 +287,7 @@ export const WPCOM_FEATURES_LIVE_SUPPORT = 'live_support';
 export const WPCOM_FEATURES_MANAGE_PLUGINS = 'manage-plugins';
 export const WPCOM_FEATURES_NO_ADVERTS = 'no-adverts/no-adverts.php';
 export const WPCOM_FEATURES_NO_WPCOM_BRANDING = 'no-wpcom-branding';
+export const WPCOM_FEATURES_SCHEDULED_UPDATES = 'scheduled-updates';
 /*
  * TODO: This constant value should be renamed (here and in `class-wpcom-features.php` in
  * WPCOM) to `premium-themes-unlimited` so it's not confused with `FEATURE_PREMIUM_THEMES`.

--- a/packages/calypso-products/src/constants/features.ts
+++ b/packages/calypso-products/src/constants/features.ts
@@ -287,7 +287,6 @@ export const WPCOM_FEATURES_LIVE_SUPPORT = 'live_support';
 export const WPCOM_FEATURES_MANAGE_PLUGINS = 'manage-plugins';
 export const WPCOM_FEATURES_NO_ADVERTS = 'no-adverts/no-adverts.php';
 export const WPCOM_FEATURES_NO_WPCOM_BRANDING = 'no-wpcom-branding';
-export const WPCOM_FEATURES_SCHEDULED_UPDATES = 'scheduled-updates';
 /*
  * TODO: This constant value should be renamed (here and in `class-wpcom-features.php` in
  * WPCOM) to `premium-themes-unlimited` so it's not confused with `FEATURE_PREMIUM_THEMES`.
@@ -301,6 +300,7 @@ export const WPCOM_FEATURES_PREMIUM_THEMES_LIMITED = 'personal-themes';
 export const WPCOM_FEATURES_PRIORITY_SUPPORT = 'priority_support';
 export const WPCOM_FEATURES_REAL_TIME_BACKUPS = 'real-time-backups';
 export const WPCOM_FEATURES_SCAN = 'scan';
+export const WPCOM_FEATURES_SCHEDULED_UPDATES = 'scheduled-updates';
 export const WPCOM_FEATURES_SEO_PREVIEW_TOOLS = 'seo-preview-tools';
 export const WPCOM_FEATURES_SUBSCRIPTION_GIFTING = 'subscription-gifting';
 export const WPCOM_FEATURES_LOCKED_MODE = 'locked-mode';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to Automattic/dotcom-forge#5894

## Proposed Changes

* Add a new WPCOM_Features in Calypso feature list.
* Add a new gating component for the scheduled update feature. This will block the UI if a user's site is not an Atomic site or doesn't have the scheduled update feature.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Use a simple site, navigate to `http://calypso.localhost:3000/plugins/scheduled-updates/<your-site-slug>`
* You should see the page is gated and showing the upsell banner like below:
![Screen Shot 2024-03-07 at 12 15 06 AM](https://github.com/Automattic/wp-calypso/assets/4074459/a0c11322-a034-425f-ab3c-12e8ff6ba5fc)

* Try to navigate to `http://calypso.localhost:3000/plugins/scheduled-updates/create/<your-site-slug>` and you'll see the same.
* Click the `Upgarde` button from the banner and make sure it brings you to the checkout page, it should redirect you back to the scheduled update page after you upgrade the plan.
* Once you're back, you'll see a banner asking you to activate the hosting access.

![Screen Shot 2024-03-07 at 12 16 39 AM](https://github.com/Automattic/wp-calypso/assets/4074459/d3c91786-87b6-4c00-9f0d-5004c59073d6)


* Click `Activate` and you'll see it change to a loading state while waiting for the transfer to finish.
![Screen Shot 2024-03-06 at 1 32 14 AM](https://github.com/Automattic/wp-calypso/assets/4074459/449aa95d-2c2a-4bd5-a1e3-ca667f0b6246)

* Once the transfer is finished the UI should be unblocked.
* Try to navigate to `http://calypso.localhost:3000/plugins/scheduled-updates/<your-site-slug>` directly, and you shouldn't get blocked now.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?