### PR TITLE
Sites Dashboard: Fix styles on smaller screen

### DIFF
--- a/client/components/split-button/style.scss
+++ b/client/components/split-button/style.scss
@@ -1,6 +1,7 @@
 .split-button {
 	// So both buttons drop together
 	display: inline-block;
+	white-space: nowrap;
 	--white-separator-color: rgba(255, 255, 255, 0.3);
 }
 .button.split-button__main {

--- a/client/sites-dashboard/components/sites-content-controls.tsx
+++ b/client/sites-dashboard/components/sites-content-controls.tsx
@@ -34,6 +34,10 @@ const FilterBar = styled.div( {
 
 	[ MEDIA_QUERIES.mediumOrSmaller ]: {
 		paddingBlock: '16px',
+
+		'.layout.focus-sidebar &': {
+			flexWrap: 'wrap',
+		},
 	},
 } );
 

--- a/client/sites-dashboard/components/sites-dashboard.tsx
+++ b/client/sites-dashboard/components/sites-dashboard.tsx
@@ -87,6 +87,7 @@ const DashboardHeading = styled.h1( {
 	lineHeight: '26px',
 	color: 'var( --studio-gray-100 )',
 	flex: 1,
+	marginInlineEnd: '1rem',
 } );
 
 const sitesMarginTable = css( {
@@ -154,6 +155,7 @@ const ScrollButton = styled( Button, { shouldForwardProp: ( prop ) => prop !== '
 
 const ManageAllDomainsButton = styled( Button )`
 	margin-inline-end: 1rem;
+	white-space: nowrap;
 `;
 
 const DownloadIcon = styled( Icon )`

--- a/client/sites-dashboard/components/sites-search.ts
+++ b/client/sites-dashboard/components/sites-search.ts
@@ -5,15 +5,12 @@ import { MEDIA_QUERIES } from '../utils';
 export const SitesSearch = styled( Search )( {
 	'--color-surface': 'var( --studio-white )',
 
-	height: '42px !important',
-
+	maxHeight: '42px',
 	overflow: 'hidden',
 	border: '1px solid #c3c4c7',
 
 	[ MEDIA_QUERIES.mediumOrLarger ]: {
 		flex: '0 1 390px !important',
-
-		height: 'auto !important',
 		alignSelf: 'stretch',
 	},
 } );

--- a/client/sites-dashboard/controller.tsx
+++ b/client/sites-dashboard/controller.tsx
@@ -139,6 +139,14 @@ function sitesDashboard( context: PageJSContext, next: () => void ) {
 					}
 				}
 			}
+
+			@media only screen and ( max-width: 781px ) {
+				div.layout.is-global-sidebar-visible {
+					.layout__primary {
+						overflow-x: auto;
+					}
+				}
+			}
 		`;
 	}
 	if ( isEnabled( 'layout/dotcom-nav-redesign' ) ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fix the styles on the smaller screen (660px ~ 781px)

| Before | After |
| - | - |
| ![image](https://github.com/Automattic/wp-calypso/assets/13596067/1fb58b23-489d-401d-bccf-0d244ddab037) | ![image](https://github.com/Automattic/wp-calypso/assets/13596067/cefbb897-c57e-4c7e-8cbe-83ef5931861a) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to /sites
* Open the sidebar and change the screen width from 660px to 781px
* Make sure the layout looks good

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?