### PR TITLE
Adapt branching for the new user sign-up survey experiment.

### DIFF
--- a/client/lib/signup/step-actions/index.js
+++ b/client/lib/signup/step-actions/index.js
@@ -1213,13 +1213,6 @@ export function excludeStepIfEmailVerified( stepName, defaultDependencies, nextP
 	flows.excludeStep( stepName );
 }
 
-export function excludeSurveyStepIfInactive( stepName, defaultDependencies, nextProps ) {
-	if ( ! nextProps.initialContext?.isSignupSurveyActive ) {
-		nextProps.submitSignupStep( { stepName, wasSkipped: true } );
-		flows.excludeStep( stepName );
-	}
-}
-
 export function excludeStepIfProfileComplete( stepName, defaultDependencies, nextProps ) {
 	if ( includes( flows.excludedSteps, stepName ) ) {
 		return;

--- a/client/signup/config/flows-pure.js
+++ b/client/signup/config/flows-pure.js
@@ -141,11 +141,25 @@ export function generateFlows( {
 		{
 			name: 'onboarding',
 			steps: isEnabled( 'signup/professional-email-step' )
-				? [ userSocialStep, 'new-user-survey', 'domains', 'emails', 'plans' ]
-				: [ userSocialStep, 'new-user-survey', 'domains', 'plans' ],
+				? [ userSocialStep, 'domains', 'emails', 'plans' ]
+				: [ userSocialStep, 'domains', 'plans' ],
 			destination: getSignupDestination,
 			description: 'Abridged version of the onboarding flow. Read more in https://wp.me/pau2Xa-Vs.',
 			lastModified: '2023-10-11',
+			showRecaptcha: true,
+			providesDependenciesInQuery: [ 'coupon' ],
+			optionalDependenciesInQuery: [ 'coupon' ],
+			hideProgressIndicator: true,
+			onEnterFlow: onEnterOnboarding,
+		},
+		{
+			name: 'with-new-user-survey',
+			steps: isEnabled( 'signup/professional-email-step' )
+				? [ userSocialStep, 'new-user-survey', 'domains', 'emails', 'plans' ]
+				: [ userSocialStep, 'new-user-survey', 'domains', 'plans' ],
+			destination: getSignupDestination,
+			description: 'The main onboarding flow with addition of the new user survey step',
+			lastModified: '2024-03-05',
 			showRecaptcha: true,
 			providesDependenciesInQuery: [ 'coupon' ],
 			optionalDependenciesInQuery: [ 'coupon' ],

--- a/client/signup/config/steps-pure.js
+++ b/client/signup/config/steps-pure.js
@@ -43,7 +43,6 @@ export function generateSteps( {
 	excludeStepIfEmailVerified = noop,
 	excludeStepIfProfileComplete = noop,
 	submitWebsiteContent = noop,
-	excludeSurveyStepIfInactive = noop,
 } = {} ) {
 	return {
 		// `themes` does not update the theme for an existing site as we normally
@@ -247,7 +246,6 @@ export function generateSteps( {
 		},
 		'new-user-survey': {
 			stepName: 'new-user-survey',
-			fulfilledStepCallback: excludeSurveyStepIfInactive,
 		},
 		plans: {
 			stepName: 'plans',

--- a/client/signup/config/steps.js
+++ b/client/signup/config/steps.js
@@ -22,7 +22,6 @@ import {
 	excludeStepIfEmailVerified,
 	submitWebsiteContent,
 	excludeStepIfProfileComplete,
-	excludeSurveyStepIfInactive,
 } from 'calypso/lib/signup/step-actions';
 import { generateSteps } from './steps-pure';
 
@@ -50,5 +49,4 @@ export default generateSteps( {
 	excludeStepIfEmailVerified,
 	excludeStepIfProfileComplete,
 	submitWebsiteContent,
-	excludeSurveyStepIfInactive,
 } );

--- a/config/_shared.json
+++ b/config/_shared.json
@@ -216,6 +216,7 @@
 		"with-theme",
 		"with-plugin",
 		"with-theme-assembler",
+		"with-new-user-survey",
 		"free",
 		"personal",
 		"personal-monthly",


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

WIP

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
