### PR TITLE
Untangle: Disable collapse for global sidebar

### DIFF
--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -529,8 +529,12 @@ $font-size: rem(14px);
 
 	&.is-sidebar-collapsed {
 		.layout:not(.focus-sites) {
-			--sidebar-width-max: 36px;
-			--sidebar-width-min: 36px;
+			&:not(.is-global-sidebar-visible) {
+				&:not(.is-global-site-sidebar-visible) {
+					--sidebar-width-max: 36px;
+					--sidebar-width-min: 36px;
+				}
+			}
 		}
 
 		.sidebar__actions {


### PR DESCRIPTION
Slack: p1709641753664079-slack-C06DN6QQVAQ

## Proposed Changes

When user has the sidebar collapsed on their site, the Global & Global site sidebar shows collapsed. This PR disables the collapse.

It fixes at `/sites`, `/domains`, and all the Global Site pages.
Reader was not affected by this bug.

| Before | After |
| --- | --- |
| ![image](https://github.com/Automattic/wp-calypso/assets/402286/ef283441-e1e6-4569-8a96-f771d37259b0) | ![image](https://github.com/Automattic/wp-calypso/assets/402286/7df5eb8c-27c4-40bc-8586-eb06dbfba6d2) |

## Testing Instructions

* Go to a site and collapse the sidebar.
* Go to `/sites`
* Check the sidebar, it should not be collapsed.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?