### PR TITLE
Help Center: Fix links target _blank

### DIFF
--- a/client/components/embed-container/index.jsx
+++ b/client/components/embed-container/index.jsx
@@ -25,7 +25,7 @@ const embedsToLookFor = {
 	'.wp-embedded-content': embedWordPressPost,
 	'a[data-pin-do="embedPin"]': embedPinterest,
 	'div.embed-issuu': embedIssuu,
-	a: embedLink, // process plain links last
+	'a[href^="http://"], a[href^="https://"]': embedLink, // process plain links last
 };
 
 const cacheBustQuery = `?v=${ Math.floor( new Date().getTime() / ( 1000 * 60 * 60 * 24 * 10 ) ) }`; // A new query every 10 days

--- a/packages/help-center/src/components/help-center-article-content.tsx
+++ b/packages/help-center/src/components/help-center-article-content.tsx
@@ -3,7 +3,6 @@ import SupportArticleHeader from 'calypso/blocks/support-article-dialog/header';
 import EmbedContainer from 'calypso/components/embed-container';
 import Placeholders from './placeholder-lines';
 
-// import './style.scss';
 import './help-center-article-content.scss';
 
 interface ArticleContentProps {

--- a/packages/help-center/src/components/help-center-article-content.tsx
+++ b/packages/help-center/src/components/help-center-article-content.tsx
@@ -1,4 +1,3 @@
-import { useRef, useEffect } from '@wordpress/element';
 /* eslint-disable no-restricted-imports */
 import SupportArticleHeader from 'calypso/blocks/support-article-dialog/header';
 import EmbedContainer from 'calypso/components/embed-container';
@@ -14,23 +13,6 @@ interface ArticleContentProps {
 	isLoading?: boolean;
 }
 
-interface ContentWithExternalLinks {
-	content: string;
-	className?: string;
-}
-
-const ContentWithExternalLinks = ( { content, className }: ContentWithExternalLinks ) => {
-	const contentRef = useRef< HTMLDivElement >( null );
-
-	useEffect( () => {
-		if ( contentRef.current && content.length ) {
-			contentRef.current.innerHTML = content;
-		}
-	}, [ contentRef, content ] );
-
-	return <div ref={ contentRef } className={ className } />;
-};
-
 const ArticleContent = ( { content, title, link, isLoading = false }: ArticleContentProps ) => {
 	const post = { title: title, url: link };
 	return (
@@ -41,9 +23,10 @@ const ArticleContent = ( { content, title, link, isLoading = false }: ArticleCon
 				<>
 					<SupportArticleHeader post={ post } isLoading={ false } />
 					<EmbedContainer>
-						<ContentWithExternalLinks
+						<div
 							className="help-center-article-content__story-content"
-							content={ content }
+							// eslint-disable-next-line react/no-danger
+							dangerouslySetInnerHTML={ { __html: content } }
 						/>
 					</EmbedContainer>
 				</>

--- a/packages/help-center/src/components/help-center-article-content.tsx
+++ b/packages/help-center/src/components/help-center-article-content.tsx
@@ -25,8 +25,6 @@ const ContentWithExternalLinks = ( { content, className }: ContentWithExternalLi
 	useEffect( () => {
 		if ( contentRef.current && content.length ) {
 			contentRef.current.innerHTML = content;
-			const externalLinks = contentRef.current.querySelectorAll( 'a[href*="http"]' );
-			externalLinks.forEach( ( l ) => l.setAttribute( 'target', '_blank' ) );
 		}
 	}, [ contentRef, content ] );
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88127

## Proposed Changes

* Fixes `<a>` links inside Help Center, previously all the links were receiving a `target: _blank` aatribute because of https://github.com/Automattic/wp-calypso/pull/86269/files#diff-2114102cd5cd0a792345db2af178bfa0525cdef39981b31a1a9a71a8ea26a95dR28, some links are just anchors and this was making anchors to open in new tabs. This PR makes the `<a>` selector more specific to `<a>` with `http or https` as `href` and therefore, anchors don't get `taget _blank` and the Help Center can just scroll to the content.
c/c @roo2 


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Apply this branch and run calypso or use the live link
* Navigate to any site of yours and open the Help Center
* Find any content with ToC (anchor links) and make sure the ToC content is not opening in a new table
* Make sure links that are not anchors should open in a new tab

Example of ToC links - all links in this blue container
<img width="418" alt="image" src="https://github.com/Automattic/wp-calypso/assets/2653810/46dbef86-d05f-4a8c-bb5e-57f99fdcbdc6">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?