### PR TITLE
wp-admin Command Palette: Optimize bundle

### DIFF
--- a/apps/command-palette-wp-admin/README.md
+++ b/apps/command-palette-wp-admin/README.md
@@ -1,3 +1,7 @@
 # Command Palette (WP Admin)
 
 This app provides a regular global JS function that renders the command palette from `@automattic/command-palette` in a given node. This way, we can load the command palette on a WP Admin context.
+
+## External dependencies
+
+Dependencies that are globally available on all WP sites (e.g. `@wordpress/components`, `@wordpress/url`, etc.) are not included in the bundled build to optimize its size. We need to declare these dependencies though when enqueueing the build in the `jetpack-mu-wpcom` package, so remember to keep [this list](https://github.com/Automattic/jetpack/blob/97b0d2e4091028e19d162cbdf1221a518dc4fa9d/projects/packages/jetpack-mu-wpcom/src/features/wpcom-command-palette/wpcom-command-palette.php#L45-L54) updated if you ever need to change the dependencies.

--- a/apps/command-palette-wp-admin/webpack.config.js
+++ b/apps/command-palette-wp-admin/webpack.config.js
@@ -8,7 +8,7 @@ const webpack = require( 'webpack' );
 const GenerateChunksMapPlugin = require( '../../build-tools/webpack/generate-chunks-map-plugin' );
 
 function getWebpackConfig( env, argv ) {
-	const webpackConfig = getBaseWebpackConfig( env, argv );
+	const webpackConfig = getBaseWebpackConfig( { ...env, WP: true }, argv );
 
 	return {
 		...webpackConfig,

--- a/packages/command-palette/src/commands/use-single-site-commands.tsx
+++ b/packages/command-palette/src/commands/use-single-site-commands.tsx
@@ -1,5 +1,6 @@
 import { JetpackLogo, WooCommerceWooLogo } from '@automattic/components';
 import { SiteCapabilities } from '@automattic/data-stores';
+import { __, _x } from '@wordpress/i18n';
 import {
 	alignJustify as acitvityLogIcon,
 	backup as backupIcon,
@@ -28,7 +29,6 @@ import {
 	wordpress as wordpressIcon,
 	comment as feedbackIcon,
 } from '@wordpress/icons';
-import { useI18n } from '@wordpress/react-i18n';
 import { Command, CommandCallBackParams } from '../use-command-palette';
 import { isCustomDomain } from '../utils';
 import { useCommandsParams } from './types';
@@ -79,7 +79,6 @@ const waitForElementAndClick = ( selector: string, attempt = 1 ) => {
 };
 
 const useSingleSiteCommands = ( { navigate, currentRoute }: useCommandsParams ): Command[] => {
-	const { __, _x } = useI18n();
 	const commandNavigation = useCommandNavigation( { navigate, currentRoute } );
 	const customWindow = window as CustomWindow | undefined;
 	const {


### PR DESCRIPTION
Fixes https://github.com/Automattic/wp-calypso/issues/87326

## Proposed Changes

This PR optimizes the build of the `command-palette-wp-admin` app by externalizing the dependencies that are [available globally on WP sites](https://core.trac.wordpress.org/browser/tags/6.4/src/wp-includes/assets/script-loader-packages.min.php) (these are loaded by default by [the `wp_default_packages` function](https://core.trac.wordpress.org/browser/tags/6.4/src/wp-includes/default-filters.php#L565)).

This decreases the bundle from 432 KB to 180 KB (gzipped from 141 KB to 58 KB).

Before | After
--- | ---
<img width="705" alt="Screenshot 2024-03-05 at 13 54 12" src="https://github.com/Automattic/wp-calypso/assets/1233880/ee6172ec-0761-4d1d-bff4-54a9539f227d"> | <img width="707" alt="Screenshot 2024-03-05 at 15 07 37" src="https://github.com/Automattic/wp-calypso/assets/1233880/4eff1968-9a5c-4f99-865c-4288ddec3cdb">
<img width="799" alt="Screenshot 2024-03-05 at 13 59 59" src="https://github.com/Automattic/wp-calypso/assets/1233880/f4fdeaf8-bc77-41e1-a3e2-157142fd2f6c"> | <img width="812" alt="Screenshot 2024-03-05 at 15 06 42" src="https://github.com/Automattic/wp-calypso/assets/1233880/472a4eaa-6011-4662-8608-b3d5852a1deb">

Turns out that `wp-react-i18n` is a non-default package, so I had to replace the imports from `@wordpress/react-i18n` with `@wordpress/i18n`. In my tests, this doesn't result in any regression.

## Testing Instructions

- Open the Calypso live below
- Open the command palette in Calypso
- Make sure there are no regressions because of the `@wordpress/react-i18n` -> `@wordpress/i18n` replacement (confirm that translations continue to work as before)
- Apply the changes to your sandbox: `install-plugin.sh command-palette update/command-palette-optimize-bundle`
- Sandbox `widgets.wp.com`
- Make sure the build size has decreased significantly
- Open the command palette in WP Admin
- Make sure you can still select a command as always
- Make sure there are no regressions because of the `@wordpress/react-i18n` -> `@wordpress/i18n` replacement (confirm that translations continue to work as before)