### PR TITLE
Pattern Library: Use new API endpoint in `usePatternCategories`

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-assembler-patterns.ts
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/hooks/use-assembler-patterns.ts
@@ -9,7 +9,7 @@ const useAssemblerPatterns = (
 	queryOptions: Omit< UseQueryOptions< any, unknown, Pattern[] >, 'queryKey' > = {}
 ): Pattern[] => {
 	const { data } = useQuery< any, unknown, Pattern[] >( {
-		queryKey: [ 'patterns', 'assembler', lang ],
+		queryKey: [ 'pattern-assembler', lang ],
 		queryFn: () => {
 			return wpcomRequest( {
 				path: `/ptk/patterns/${ lang }`,

--- a/client/my-sites/patterns/components/grid-gallery/index.tsx
+++ b/client/my-sites/patterns/components/grid-gallery/index.tsx
@@ -8,7 +8,7 @@ type PatternsGridGalleryProps = {
 	columnCount?: number;
 	list?: {
 		name?: string;
-		title: string;
+		label: string;
 		number: number;
 		image: string;
 		link: string;
@@ -31,12 +31,12 @@ export const PatternsGridGallery = ( {
 				className="patterns-grid-gallery"
 				style={ { '--column-count': columnCount } as React.CSSProperties }
 			>
-				{ list.map( ( { name, title, number, image, link } ) => (
+				{ list.map( ( { name, label, number, image, link } ) => (
 					<a className="patterns-grid-gallery__item" href={ link } key={ name }>
 						<div className="patterns-grid-gallery__item-image">
-							<img src={ image } alt={ title } />
+							<img src={ image } alt={ label } />
 						</div>
-						<div className="patterns-grid-gallery__item-name">{ title }</div>
+						<div className="patterns-grid-gallery__item-name">{ label }</div>
 						<div className="patterns-grid-gallery__item-number">{ number } patterns</div>
 					</a>
 				) ) }

--- a/client/my-sites/patterns/components/grid-gallery/index.tsx
+++ b/client/my-sites/patterns/components/grid-gallery/index.tsx
@@ -8,7 +8,7 @@ type PatternsGridGalleryProps = {
 	columnCount?: number;
 	list?: {
 		name?: string;
-		label?: string;
+		title: string;
 		number: number;
 		image: string;
 		link: string;
@@ -31,12 +31,12 @@ export const PatternsGridGallery = ( {
 				className="patterns-grid-gallery"
 				style={ { '--column-count': columnCount } as React.CSSProperties }
 			>
-				{ list.map( ( { name, label, number, image, link } ) => (
+				{ list.map( ( { name, title, number, image, link } ) => (
 					<a className="patterns-grid-gallery__item" href={ link } key={ name }>
 						<div className="patterns-grid-gallery__item-image">
-							<img src={ image } alt={ label } />
+							<img src={ image } alt={ title } />
 						</div>
-						<div className="patterns-grid-gallery__item-name">{ label }</div>
+						<div className="patterns-grid-gallery__item-name">{ title }</div>
 						<div className="patterns-grid-gallery__item-number">{ number } patterns</div>
 					</a>
 				) ) }

--- a/client/my-sites/patterns/components/grid-gallery/index.tsx
+++ b/client/my-sites/patterns/components/grid-gallery/index.tsx
@@ -1,5 +1,4 @@
 import { PatternsSection } from 'calypso/my-sites/patterns/components/section';
-import type { CSSProperties } from 'react';
 
 import './style.scss';
 
@@ -30,14 +29,14 @@ export const PatternsGridGallery = ( {
 		<PatternsSection title={ title } description={ description }>
 			<div
 				className="patterns-grid-gallery"
-				style={ { '--column-count': columnCount } as CSSProperties }
+				style={ { '--column-count': columnCount } as React.CSSProperties }
 			>
 				{ list.map( ( { name, label, number, image, link } ) => (
 					<a className="patterns-grid-gallery__item" href={ link } key={ name }>
 						<div className="patterns-grid-gallery__item-image">
 							<img src={ image } alt={ label } />
 						</div>
-						<div className="patterns-grid-gallery__item-name">{ name }</div>
+						<div className="patterns-grid-gallery__item-name">{ label }</div>
 						<div className="patterns-grid-gallery__item-number">{ number } patterns</div>
 					</a>
 				) ) }

--- a/client/my-sites/patterns/components/grid-gallery/style.scss
+++ b/client/my-sites/patterns/components/grid-gallery/style.scss
@@ -9,6 +9,7 @@
 
 .patterns-grid-gallery__item {
 	.patterns-grid-gallery__item-image {
+		aspect-ratio: 9 / 5;
 		margin-bottom: 14px;
 		border-radius: 4px;
 		background: #f6f7f7;

--- a/client/my-sites/patterns/components/grid-gallery/style.scss
+++ b/client/my-sites/patterns/components/grid-gallery/style.scss
@@ -9,7 +9,6 @@
 
 .patterns-grid-gallery__item {
 	.patterns-grid-gallery__item-image {
-		aspect-ratio: 9 / 5;
 		margin-bottom: 14px;
 		border-radius: 4px;
 		background: #f6f7f7;

--- a/client/my-sites/patterns/controller.tsx
+++ b/client/my-sites/patterns/controller.tsx
@@ -1,7 +1,1 @@
-import { PATTERN_CATEGORIES } from 'calypso/my-sites/patterns/hooks/use-pattern-categories';
-
 export const RENDERER_SITE_ID = 226011606; // assemblerdemo
-
-export function getPatternCategorySlugs() {
-	return PATTERN_CATEGORIES.join( '|' );
-}

--- a/client/my-sites/patterns/home/index.tsx
+++ b/client/my-sites/patterns/home/index.tsx
@@ -55,11 +55,12 @@ export const PatternsHomePage = ( {
 					list={ categories?.map( ( category ) => ( {
 						name: category.name,
 						title: category.title,
-						number: category.pattern_count,
+						number: category.regularPatternCount,
 						image: ImgPattern,
 						link: `/patterns/${ category.name }`,
 					} ) ) }
 				/>
+
 				<PatternGallery patterns={ patterns } isGridView={ isGridView } />
 
 				<PatternsSection
@@ -116,11 +117,11 @@ export const PatternsHomePage = ( {
 					description="Entire pages built of patterns, ready to be added to your site."
 					columnCount={ 3 }
 					list={ categories
-						?.filter( ( { page_pattern_count } ) => page_pattern_count )
+						?.filter( ( { pagePatternCount } ) => pagePatternCount )
 						.map( ( category ) => ( {
 							name: category.name,
-							label: category.title,
-							number: category.page_pattern_count,
+							title: category.title,
+							number: category.pagePatternCount,
 							image: ImgLayout,
 							link: `/patterns/${ category.name }`,
 						} ) ) }

--- a/client/my-sites/patterns/home/index.tsx
+++ b/client/my-sites/patterns/home/index.tsx
@@ -54,7 +54,7 @@ export const PatternsHomePage = ( {
 					description="Choose from a huge library of patterns to build any page you need."
 					list={ categories?.map( ( category ) => ( {
 						name: category.name,
-						label: category.label,
+						title: category.title,
 						number: category.pattern_count,
 						image: ImgPattern,
 						link: `/patterns/${ category.name }`,
@@ -119,7 +119,7 @@ export const PatternsHomePage = ( {
 						?.filter( ( { page_pattern_count } ) => page_pattern_count )
 						.map( ( category ) => ( {
 							name: category.name,
-							label: category.label,
+							label: category.title,
 							number: category.page_pattern_count,
 							image: ImgLayout,
 							link: `/patterns/${ category.name }`,

--- a/client/my-sites/patterns/home/index.tsx
+++ b/client/my-sites/patterns/home/index.tsx
@@ -6,7 +6,6 @@ import { PatternsGetStarted } from 'calypso/my-sites/patterns/components/get-sta
 import { PatternsGridGallery } from 'calypso/my-sites/patterns/components/grid-gallery';
 import { PatternsHeader } from 'calypso/my-sites/patterns/components/header';
 import { PatternsSection } from 'calypso/my-sites/patterns/components/section';
-import { RENDERER_SITE_ID } from 'calypso/my-sites/patterns/controller';
 import { usePatternCategories } from 'calypso/my-sites/patterns/hooks/use-pattern-categories';
 import { usePatterns } from 'calypso/my-sites/patterns/hooks/use-patterns';
 import { useSelector } from 'calypso/state';
@@ -35,7 +34,7 @@ export const PatternsHomePage = ( {
 	const locale = useLocale();
 	const isLoggedIn = useSelector( isUserLoggedIn );
 
-	const { data: categories } = usePatternCategories( locale, RENDERER_SITE_ID );
+	const { data: categories } = usePatternCategories( locale );
 	const { data: patterns } = usePatterns( locale, category );
 
 	return (
@@ -56,7 +55,7 @@ export const PatternsHomePage = ( {
 					list={ categories?.map( ( category ) => ( {
 						name: category.name,
 						label: category.label,
-						number: 15,
+						number: category.pattern_count,
 						image: ImgPattern,
 						link: `/patterns/${ category.name }`,
 					} ) ) }
@@ -116,12 +115,15 @@ export const PatternsHomePage = ( {
 					title="Beautifully curated page layouts"
 					description="Entire pages built of patterns, ready to be added to your site."
 					columnCount={ 3 }
-					list={ Array.from( Array( 5 ) ).map( () => ( {
-						name: 'About',
-						number: 7,
-						image: ImgLayout,
-						link: '#',
-					} ) ) }
+					list={ categories
+						?.filter( ( { page_pattern_count } ) => page_pattern_count )
+						.map( ( category ) => ( {
+							name: category.name,
+							label: category.label,
+							number: category.page_pattern_count,
+							image: ImgLayout,
+							link: `/patterns/${ category.name }`,
+						} ) ) }
 				/>
 
 				<PatternsGetStarted />

--- a/client/my-sites/patterns/home/index.tsx
+++ b/client/my-sites/patterns/home/index.tsx
@@ -54,7 +54,7 @@ export const PatternsHomePage = ( {
 					description="Choose from a huge library of patterns to build any page you need."
 					list={ categories?.map( ( category ) => ( {
 						name: category.name,
-						title: category.label,
+						label: category.label,
 						number: category.regularPatternCount,
 						image: ImgPattern,
 						link: `/patterns/${ category.name }`,
@@ -120,7 +120,7 @@ export const PatternsHomePage = ( {
 						?.filter( ( { pagePatternCount } ) => pagePatternCount )
 						.map( ( category ) => ( {
 							name: category.name,
-							title: category.label,
+							label: category.label,
 							number: category.pagePatternCount,
 							image: ImgLayout,
 							link: `/patterns/${ category.name }`,

--- a/client/my-sites/patterns/home/index.tsx
+++ b/client/my-sites/patterns/home/index.tsx
@@ -54,7 +54,7 @@ export const PatternsHomePage = ( {
 					description="Choose from a huge library of patterns to build any page you need."
 					list={ categories?.map( ( category ) => ( {
 						name: category.name,
-						title: category.title,
+						title: category.label,
 						number: category.regularPatternCount,
 						image: ImgPattern,
 						link: `/patterns/${ category.name }`,
@@ -120,7 +120,7 @@ export const PatternsHomePage = ( {
 						?.filter( ( { pagePatternCount } ) => pagePatternCount )
 						.map( ( category ) => ( {
 							name: category.name,
-							title: category.title,
+							title: category.label,
 							number: category.pagePatternCount,
 							image: ImgLayout,
 							link: `/patterns/${ category.name }`,

--- a/client/my-sites/patterns/hooks/test/use-pattern-categories.tsx
+++ b/client/my-sites/patterns/hooks/test/use-pattern-categories.tsx
@@ -30,14 +30,11 @@ describe( 'usePatternCategories', () => {
 	test( 'calls the API endpoint with the right parameters', async () => {
 		( wpcom.req.get as jest.MockedFunction< typeof wpcom.req.get > ).mockResolvedValue( [] );
 
-		const { result } = renderHook( () => usePatternCategories( 'fr', 12345 ), { wrapper } );
+		const { result } = renderHook( () => usePatternCategories( 'fr' ), { wrapper } );
 
 		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
 
-		expect( wpcom.req.get ).toHaveBeenCalledWith( '/sites/12345/block-patterns/categories', {
-			apiNamespace: 'wp/v2',
-			_locale: 'fr',
-		} );
+		expect( wpcom.req.get ).toHaveBeenCalledWith( '/ptk/categories/fr' );
 		expect( result.current.data ).toEqual( [] );
 	} );
 
@@ -54,7 +51,7 @@ describe( 'usePatternCategories', () => {
 			categories
 		);
 
-		const { result } = renderHook( () => usePatternCategories( 'fr', 12345 ), { wrapper } );
+		const { result } = renderHook( () => usePatternCategories( 'fr' ), { wrapper } );
 
 		await waitFor( () => expect( result.current.isSuccess ).toBe( true ) );
 

--- a/client/my-sites/patterns/hooks/use-pattern-categories.ts
+++ b/client/my-sites/patterns/hooks/use-pattern-categories.ts
@@ -1,6 +1,6 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
-import type { Category } from 'calypso/my-sites/patterns/types';
+import type { Category, CategorySnakeCase } from 'calypso/my-sites/patterns/types';
 
 export function getPatternCategoriesQueryOptions(
 	locale: string,
@@ -9,7 +9,17 @@ export function getPatternCategoriesQueryOptions(
 	return {
 		queryKey: [ 'pattern-library', 'categories', locale ],
 		queryFn() {
-			return wpcom.req.get( `/ptk/categories/${ locale }` );
+			return wpcom.req
+				.get( `/ptk/categories/${ locale }` )
+				.then( ( categories: CategorySnakeCase[] ) => {
+					return categories.map(
+						( { regular_cattern_count, page_pattern_count, ...restCategory } ) => ( {
+							...restCategory,
+							pagePatternCount: page_pattern_count,
+							regularPatternCount: regular_cattern_count,
+						} )
+					);
+				} );
 		},
 		staleTime: Infinity,
 		...queryOptions,

--- a/client/my-sites/patterns/hooks/use-pattern-categories.ts
+++ b/client/my-sites/patterns/hooks/use-pattern-categories.ts
@@ -2,74 +2,23 @@ import { useQuery, UseQueryOptions } from '@tanstack/react-query';
 import wpcom from 'calypso/lib/wp';
 import type { Category } from 'calypso/my-sites/patterns/types';
 
-export const PATTERN_CATEGORIES = [
-	'featured',
-	'intro',
-	'about',
-	// 'buttons',
-	// 'banner',
-	// 'query',
-	'blog',
-	'posts',
-	// 'call-to-action',
-	// 'columns',
-	// 'coming-soon',
-	'contact',
-	'footer',
-	'forms',
-	'gallery',
-	'header',
-	// 'link-in-bio',
-	// 'media',
-	'newsletter',
-	// 'podcast',
-	'portfolio', // For page patterns only in v1
-	// 'quotes',
-	'services',
-	'store',
-	// 'team',
-	'testimonials', // Reused as "Quotes"
-	// 'text',
-];
-
 export function getPatternCategoriesQueryOptions(
 	locale: string,
-	siteId: undefined | number,
 	queryOptions: Omit< UseQueryOptions< Category[] >, 'queryKey' > = {}
 ): UseQueryOptions< Category[] > {
 	return {
-		queryKey: [ locale, siteId, 'pattern-library', 'categories' ],
+		queryKey: [ 'pattern-library', 'categories', locale ],
 		queryFn() {
-			return wpcom.req.get(
-				`/sites/${ encodeURIComponent( siteId ?? '' ) }/block-patterns/categories`,
-				{
-					apiNamespace: 'wp/v2',
-					_locale: locale,
-				}
-			);
-		},
-		select( categories ) {
-			const result = [];
-
-			for ( const name of PATTERN_CATEGORIES ) {
-				const category = categories.find( ( category ) => category.name === name );
-				if ( category ) {
-					result.push( category );
-				}
-			}
-
-			return result;
+			return wpcom.req.get( `/ptk/categories/${ locale }` );
 		},
 		staleTime: Infinity,
 		...queryOptions,
-		enabled: !! siteId,
 	};
 }
 
 export function usePatternCategories(
 	locale: string,
-	siteId: undefined | number,
 	queryOptions: Omit< UseQueryOptions< Category[] >, 'queryKey' > = {}
 ) {
-	return useQuery< Category[] >( getPatternCategoriesQueryOptions( locale, siteId, queryOptions ) );
+	return useQuery< Category[] >( getPatternCategoriesQueryOptions( locale, queryOptions ) );
 }

--- a/client/my-sites/patterns/hooks/use-patterns.ts
+++ b/client/my-sites/patterns/hooks/use-patterns.ts
@@ -8,7 +8,7 @@ export function getPatternsQueryOptions(
 	queryOptions: Omit< UseQueryOptions< Pattern[] >, 'queryKey' > = {}
 ) {
 	return {
-		queryKey: [ 'patterns', 'library', locale, category ],
+		queryKey: [ 'pattern-library', 'patterns', locale, category ],
 		queryFn: () => {
 			return wpcom.req.get( `/ptk/patterns/${ locale }`, {
 				categories: category,

--- a/client/my-sites/patterns/index.node.tsx
+++ b/client/my-sites/patterns/index.node.tsx
@@ -7,7 +7,7 @@ import { getPatternCategoriesQueryOptions } from 'calypso/my-sites/patterns/hook
 import { getPatternsQueryOptions } from 'calypso/my-sites/patterns/hooks/use-patterns';
 import { serverRouter } from 'calypso/server/isomorphic-routing';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
-import type { RouterContext, RouterNext, Category, Pattern } from 'calypso/my-sites/patterns/types';
+import type { RouterContext, RouterNext, Pattern } from 'calypso/my-sites/patterns/types';
 
 function renderPatterns( context: RouterContext, next: RouterNext ) {
 	context.primary = (
@@ -21,7 +21,7 @@ function renderPatterns( context: RouterContext, next: RouterNext ) {
 	next();
 }
 
-function fetchPatterns( context: RouterContext, next: RouterNext ) {
+function fetchCategoriesAndPatterns( context: RouterContext, next: RouterNext ) {
 	const { cachedMarkup, queryClient, lang, params, store } = context;
 
 	if ( cachedMarkup ) {
@@ -31,15 +31,14 @@ function fetchPatterns( context: RouterContext, next: RouterNext ) {
 
 	const locale = getCurrentUserLocale( store.getState() ) || lang || 'en';
 
-	// Always fetch list of categories
+	// Fetches the list of categories first, then fetches patterns if a specific category was requested
 	queryClient
-		.fetchQuery< Category[] >(
+		.fetchQuery(
 			getPatternCategoriesQueryOptions( locale, {
 				staleTime: 10 * 60 * 1000,
 			} )
 		)
 		.then( ( categories ) => {
-			// Fetch patterns only if the user is requesting a category page
 			if ( ! params.category ) {
 				return;
 			}
@@ -73,7 +72,7 @@ export default function ( router: ReturnType< typeof serverRouter > ) {
 		ssrSetupLocale,
 		setHrefLangLinks,
 		setLocalizedCanonicalUrl,
-		fetchPatterns,
+		fetchCategoriesAndPatterns,
 		renderPatterns,
 		makeLayout
 	);

--- a/client/my-sites/patterns/index.node.tsx
+++ b/client/my-sites/patterns/index.node.tsx
@@ -1,5 +1,5 @@
 import { getLanguageRouteParam } from '@automattic/i18n-utils';
-import { makeLayout, ssrSetupLocale, notFound } from 'calypso/controller';
+import { makeLayout, ssrSetupLocale } from 'calypso/controller';
 import { setHrefLangLinks, setLocalizedCanonicalUrl } from 'calypso/controller/localized-links';
 import { PatternGalleryServer } from 'calypso/my-sites/patterns/components/pattern-gallery/server';
 import { PatternsHomePage } from 'calypso/my-sites/patterns/home';
@@ -40,18 +40,22 @@ function fetchPatterns( context: RouterContext, next: RouterNext ) {
 		)
 		.then( ( categories ) => {
 			// Fetch patterns only if the user is requesting a category page
-			if ( params.category ) {
-				const categoryNames = categories.map( ( category ) => category.name );
-
-				if ( ! categoryNames.includes( params.category ) ) {
-					notFound( context, next );
-					return;
-				}
-
-				return queryClient.fetchQuery< Pattern[] >(
-					getPatternsQueryOptions( locale, params.category, { staleTime: 10 * 60 * 1000 } )
-				);
+			if ( ! params.category ) {
+				return;
 			}
+
+			const categoryNames = categories.map( ( category ) => category.name );
+
+			if ( ! categoryNames.includes( params.category ) ) {
+				throw {
+					status: 404,
+					message: 'Category Not Found',
+				};
+			}
+
+			return queryClient.fetchQuery< Pattern[] >(
+				getPatternsQueryOptions( locale, params.category, { staleTime: 10 * 60 * 1000 } )
+			);
 		} )
 		.then( () => {
 			next();

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -5,7 +5,7 @@ import {
 	redirectWithoutLocaleParamInFrontIfLoggedIn,
 	render as clientRender,
 	notFound,
-} from 'calypso/controller';
+} from 'calypso/controller/index.web';
 import { PatternGalleryClient } from 'calypso/my-sites/patterns/components/pattern-gallery/client';
 import { PatternsHomePage } from 'calypso/my-sites/patterns/home';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -6,7 +6,6 @@ import {
 	render as clientRender,
 } from 'calypso/controller/index.web';
 import { PatternGalleryClient } from 'calypso/my-sites/patterns/components/pattern-gallery/client';
-import { getPatternCategorySlugs } from 'calypso/my-sites/patterns/controller';
 import { PatternsHomePage } from 'calypso/my-sites/patterns/home';
 import type { RouterContext, RouterNext } from 'calypso/my-sites/patterns/types';
 
@@ -24,13 +23,12 @@ function renderPatterns( context: RouterContext, next: RouterNext ) {
 
 export default function ( router: typeof clientRouter ) {
 	const langParam = getLanguageRouteParam();
-	const categorySlugs = getPatternCategorySlugs();
 	const middleware = [ renderPatterns, makeLayout, clientRender ];
 
 	router(
-		`/${ langParam }/patterns/:category(${ categorySlugs })?`,
+		`/${ langParam }/patterns/:category?`,
 		redirectWithoutLocaleParamInFrontIfLoggedIn,
 		...middleware
 	);
-	router( `/patterns/:category(${ categorySlugs })?`, ...middleware );
+	router( `/patterns/:category?`, ...middleware );
 }

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -10,7 +10,7 @@ import { PatternGalleryClient } from 'calypso/my-sites/patterns/components/patte
 import { PatternsHomePage } from 'calypso/my-sites/patterns/home';
 import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
 import { getPatternCategoriesQueryOptions } from './hooks/use-pattern-categories';
-import type { RouterContext, RouterNext, Category } from 'calypso/my-sites/patterns/types';
+import type { RouterContext, RouterNext } from 'calypso/my-sites/patterns/types';
 
 function renderPatterns( context: RouterContext, next: RouterNext ) {
 	if ( ! context.primary ) {
@@ -30,16 +30,15 @@ function checkCategorySlug( context: RouterContext, next: RouterNext ) {
 	const { queryClient, lang, params, store } = context;
 	const locale = getCurrentUserLocale( store.getState() ) || lang || 'en';
 
-	// Always fetch list of categories
 	queryClient
-		.fetchQuery< Category[] >( getPatternCategoriesQueryOptions( locale ) )
+		.fetchQuery( getPatternCategoriesQueryOptions( locale ) )
 		.then( ( categories ) => {
-			// Fetch patterns only if the user is requesting a category page
 			if ( params.category ) {
 				const categoryNames = categories.map( ( category ) => category.name );
 
 				if ( ! categoryNames.includes( params.category ) ) {
-					return notFound( context, next );
+					notFound( context, next );
+					return;
 				}
 			}
 

--- a/client/my-sites/patterns/index.web.tsx
+++ b/client/my-sites/patterns/index.web.tsx
@@ -4,26 +4,55 @@ import {
 	makeLayout,
 	redirectWithoutLocaleParamInFrontIfLoggedIn,
 	render as clientRender,
-} from 'calypso/controller/index.web';
+	notFound,
+} from 'calypso/controller';
 import { PatternGalleryClient } from 'calypso/my-sites/patterns/components/pattern-gallery/client';
 import { PatternsHomePage } from 'calypso/my-sites/patterns/home';
-import type { RouterContext, RouterNext } from 'calypso/my-sites/patterns/types';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { getPatternCategoriesQueryOptions } from './hooks/use-pattern-categories';
+import type { RouterContext, RouterNext, Category } from 'calypso/my-sites/patterns/types';
 
 function renderPatterns( context: RouterContext, next: RouterNext ) {
-	context.primary = (
-		<PatternsHomePage
-			category={ context.params.category }
-			isGridView={ !! context.query.grid }
-			patternGallery={ PatternGalleryClient }
-		/>
-	);
+	if ( ! context.primary ) {
+		context.primary = (
+			<PatternsHomePage
+				category={ context.params.category }
+				isGridView={ !! context.query.grid }
+				patternGallery={ PatternGalleryClient }
+			/>
+		);
+	}
 
 	next();
 }
 
+function checkCategorySlug( context: RouterContext, next: RouterNext ) {
+	const { queryClient, lang, params, store } = context;
+	const locale = getCurrentUserLocale( store.getState() ) || lang || 'en';
+
+	// Always fetch list of categories
+	queryClient
+		.fetchQuery< Category[] >( getPatternCategoriesQueryOptions( locale ) )
+		.then( ( categories ) => {
+			// Fetch patterns only if the user is requesting a category page
+			if ( params.category ) {
+				const categoryNames = categories.map( ( category ) => category.name );
+
+				if ( ! categoryNames.includes( params.category ) ) {
+					return notFound( context, next );
+				}
+			}
+
+			next();
+		} )
+		.catch( ( error ) => {
+			next( error );
+		} );
+}
+
 export default function ( router: typeof clientRouter ) {
 	const langParam = getLanguageRouteParam();
-	const middleware = [ renderPatterns, makeLayout, clientRender ];
+	const middleware = [ checkCategorySlug, renderPatterns, makeLayout, clientRender ];
 
 	router(
 		`/${ langParam }/patterns/:category?`,

--- a/client/my-sites/patterns/types.ts
+++ b/client/my-sites/patterns/types.ts
@@ -13,7 +13,7 @@ export type { Pattern };
 
 type CategoryBase = {
 	name: string;
-	title: string;
+	label: string;
 	description: string;
 };
 

--- a/client/my-sites/patterns/types.ts
+++ b/client/my-sites/patterns/types.ts
@@ -13,7 +13,7 @@ export type { Pattern };
 
 export type Category = {
 	name: string;
-	label: string;
+	title: string;
 	description: string;
 	pattern_count: number;
 	page_pattern_count: number;

--- a/client/my-sites/patterns/types.ts
+++ b/client/my-sites/patterns/types.ts
@@ -1,9 +1,6 @@
 import type { Context } from '@automattic/calypso-router';
 import type { QueryClient } from '@tanstack/react-query';
-import type {
-	Category,
-	Pattern,
-} from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types';
+import type { Pattern } from 'calypso/landing/stepper/declarative-flow/internals/steps-repository/pattern-assembler/types';
 
 export type RouterNext = ( error?: Error ) => void;
 
@@ -12,7 +9,15 @@ export type RouterContext = Context & {
 	queryClient: QueryClient;
 };
 
-export type { Category, Pattern };
+export type { Pattern };
+
+export type Category = {
+	name: string;
+	label: string;
+	description: string;
+	pattern_count: number;
+	page_pattern_count: number;
+};
 
 export type PatternGalleryProps = {
 	isGridView?: boolean;

--- a/client/my-sites/patterns/types.ts
+++ b/client/my-sites/patterns/types.ts
@@ -11,12 +11,20 @@ export type RouterContext = Context & {
 
 export type { Pattern };
 
-export type Category = {
+type CategoryBase = {
 	name: string;
 	title: string;
 	description: string;
-	pattern_count: number;
+};
+
+export type CategorySnakeCase = CategoryBase & {
 	page_pattern_count: number;
+	regular_cattern_count: number;
+};
+
+export type Category = CategoryBase & {
+	pagePatternCount: number;
+	regularPatternCount: number;
 };
 
 export type PatternGalleryProps = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5850

## Proposed Changes

The `/sites/:site_id/block-patterns/categories` API endpoint we previously used in `usePatternCategories` doesn't work for logged-out users. This PR updates that hook to instead request categories from the new `/ptk/categories` endpoint.

This new endpoint gives us more control on the back-end over which categories are returned and in what order, which means I opted to remove the `PATTERN_CATEGORIES` from Calypso. Consequently, the routing logic for `/patterns/:category` can no longer work with a predefined set of category slugs. I've updated `index.node` and `index.web` to account for this, ensuring we return 404 error pages when appropriate.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Apply D140727-code
2. Sandbox `public-api.wordpress.com`
3. Navigate to `/patterns`
4. Ensure that the categories load as expected
5. Navigate to `/patterns/hello`
6. Ensure that a `Page Not Found` page is rendered
7. In an incognito window, navigate to `/fr/patterns`
8. Ensure that the categories load as expected and that the titles are translated in French

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?