### PR TITLE
Calypso Color Schemes: prepare package for 3.1.2 release

### DIFF
--- a/packages/calypso-color-schemes/CHANGELOG.md
+++ b/packages/calypso-color-schemes/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 3.1.2
+
 - Added a new color for X.
 - Added a new color for Bluesky.
 

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-color-schemes",
-	"version": "3.1.1",
+	"version": "3.1.2",
 	"description": "Calypso Shared Style Bits.",
 	"author": "Automattic Inc.",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
## Proposed Changes

Let's make the new colors available to third-parties (like Jetpack) by releasing a new version of the package.

## Testing Instructions

* Not much to test here since we'll have to release the update first.

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
