### PR TITLE
Fix happiness engineering tray re-rendering avatars

### DIFF
--- a/client/components/happiness-engineers-tray/index.tsx
+++ b/client/components/happiness-engineers-tray/index.tsx
@@ -1,25 +1,29 @@
 import { Gravatar } from '@automattic/components';
 import { useHappinessEngineersQuery } from '@automattic/data-stores';
 import { shuffle } from 'lodash';
+import { useMemo } from 'react';
 
 import './style.scss';
 
 export const HappinessEngineersTray = ( { count = 5, shuffled = true } ) => {
 	const { data } = useHappinessEngineersQuery();
 
-	return (
-		<div className="happiness-engineers-tray">
-			{ data &&
-				( shuffled ? shuffle( data ) : data )
-					.slice( 0, count )
-					.map( ( user ) => (
-						<Gravatar
-							key={ user.avatar_URL }
-							user={ user }
-							size={ 42 }
-							className="happiness-engineers-tray__gravatar"
-						/>
-					) ) }
-		</div>
-	);
+	const gravatars = useMemo( () => {
+		if ( ! data ) {
+			return null;
+		}
+
+		const filteredHappinessEngineers = ( shuffled ? shuffle( data ) : data ).slice( 0, count );
+
+		return filteredHappinessEngineers.map( ( user ) => (
+			<Gravatar
+				key={ user.avatar_URL }
+				user={ user }
+				size={ 42 }
+				className="happiness-engineers-tray__gravatar"
+			/>
+		) );
+	}, [ data, count, shuffled ] );
+
+	return <div className="happiness-engineers-tray">{ gravatars }</div>;
 };

--- a/client/components/happiness-engineers-tray/index.tsx
+++ b/client/components/happiness-engineers-tray/index.tsx
@@ -8,22 +8,22 @@ import './style.scss';
 export const HappinessEngineersTray = ( { count = 5, shuffled = true } ) => {
 	const { data } = useHappinessEngineersQuery();
 
-	const gravatars = useMemo( () => {
+	const filteredHappinessEngineers = useMemo( () => {
 		if ( ! data ) {
 			return null;
 		}
 
-		const filteredHappinessEngineers = ( shuffled ? shuffle( data ) : data ).slice( 0, count );
-
-		return filteredHappinessEngineers.map( ( user ) => (
-			<Gravatar
-				key={ user.avatar_URL }
-				user={ user }
-				size={ 42 }
-				className="happiness-engineers-tray__gravatar"
-			/>
-		) );
+		return ( shuffled ? shuffle( data ) : data ).slice( 0, count );
 	}, [ data, count, shuffled ] );
+
+	const gravatars = filteredHappinessEngineers?.map( ( user ) => (
+		<Gravatar
+			key={ user.avatar_URL }
+			user={ user }
+			size={ 42 }
+			className="happiness-engineers-tray__gravatar"
+		/>
+	) );
 
 	return <div className="happiness-engineers-tray">{ gravatars }</div>;
 };

--- a/client/components/happiness-engineers-tray/index.tsx
+++ b/client/components/happiness-engineers-tray/index.tsx
@@ -16,7 +16,10 @@ export const HappinessEngineersTray = ( { count = 5, shuffled = true } ) => {
 		return ( shuffled ? shuffle( data ) : data ).slice( 0, count );
 	}, [ data, count, shuffled ] );
 
-	const gravatars = filteredHappinessEngineers?.map( ( user ) => (
+	if ( ! filteredHappinessEngineers ) {
+		return null;
+	}
+	const gravatars = filteredHappinessEngineers.map( ( user ) => (
 		<Gravatar
 			key={ user.avatar_URL }
 			user={ user }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5884

## Proposed Changes
The happiness engineering tray component re-renders a new set of gravatars each time it's parent components re-renders. We want to keep the same gravatars unless the inputs to the component change.

* memoized the gravatar list in the `HappinessEngineersTray`  component to prevent it rotating 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
See the issue to see the gravatars rotating on renders.

* go to `/hosting-config` on a simple site.
* Click try for free CTA then close it, Notice the Support Card gravatar list changes each time.
* Apply this fix, perform same action and notice the list doesn't change.

![image](https://github.com/Automattic/wp-calypso/assets/47489215/208171dc-8e49-4a8c-8167-19cd570aad6c)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?