### PR TITLE
GitHub Deployments: Fix Hosting Configuration card padding

### DIFF
--- a/client/my-sites/hosting/style.scss
+++ b/client/my-sites/hosting/style.scss
@@ -64,7 +64,7 @@
 
 	@include breakpoint-deprecated( ">1280px" ) {
 		&__main-layout-col {
-			.card {
+			.card:not(.github-deployments-card) {
 				padding-left: 72px;
 
 				> .card-icon,


### PR DESCRIPTION
## Proposed Changes

We love CSS specificity!

| Before | After |
| ------- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/26530524/47e30c87-7262-419c-8312-19246ba4dc64) | ![image](https://github.com/Automattic/wp-calypso/assets/26530524/cdb02c50-5d7f-4d31-afc4-805a2c691bd0) |

## Testing Instructions

On trunk, browse GitHub Deployments, do not reload the page, and browse hosting config. You should see the GHD card tilted to the right.

On this branch, this should not happen.