### PR TITLE
GitHub Deployments: Use correct tense in uploaded artifact validation description

### DIFF
--- a/client/my-sites/github-deployments/components/deployment-style/use-workflow-validations.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/use-workflow-validations.tsx
@@ -1,8 +1,8 @@
 import { useI18n } from '@wordpress/react-i18n';
 import { useMemo } from 'react';
 import {
-	CodePushExample,
-	UploadArtifactExample,
+	codePushExample,
+	uploadArtifactExample,
 	newWorkflowExample,
 } from './workflow-yaml-examples';
 
@@ -31,12 +31,12 @@ export const useWorkflowValidations = ( { branchName }: UseWorkflowValidationsPa
 			triggered_on_push: {
 				label: __( 'The workflow is triggered on push' ),
 				description: __( 'Ensure that your workflow triggers on code push:' ),
-				content: CodePushExample( branchName ),
+				content: codePushExample( branchName ),
 			},
 			upload_artifact_with_required_name: {
 				label: __( 'The uploaded artifact has the required name' ),
 				description: __( "Ensure that your workflow uploads an artifact named 'wpcom'. Example:" ),
-				content: UploadArtifactExample(),
+				content: uploadArtifactExample(),
 			},
 		};
 	}, [ __, branchName ] );

--- a/client/my-sites/github-deployments/components/deployment-style/use-workflow-validations.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/use-workflow-validations.tsx
@@ -34,7 +34,7 @@ export const useWorkflowValidations = ( { branchName }: UseWorkflowValidationsPa
 				content: CodePushExample( branchName ),
 			},
 			upload_artifact_with_required_name: {
-				label: __( 'The upload artifact has the required name' ),
+				label: __( 'The uploaded artifact has the required name' ),
 				description: __( "Ensure that your workflow uploads an artifact named 'wpcom'. Example:" ),
 				content: UploadArtifactExample(),
 			},

--- a/client/my-sites/github-deployments/components/deployment-style/workflow-yaml-examples.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/workflow-yaml-examples.tsx
@@ -91,7 +91,7 @@ jobs:
 `.trim();
 };
 
-export const CodePushExample = ( branch: string ) => {
+export const codePushExample = ( branch: string ) => {
 	return `
 on:
   push:
@@ -101,7 +101,7 @@ on:
 `.trim();
 };
 
-export const UploadArtifactExample = () => {
+export const uploadArtifactExample = () => {
 	// It's important to keep the indentation the same way we expect to see it in the final file
 	return `
 - name: Upload the artifact


### PR DESCRIPTION
## Proposed Changes

Title. It was "upload artifact" before.

![image](https://github.com/Automattic/wp-calypso/assets/26530524/40fc87e2-2cfa-4b83-bdb1-bc11aa522da9)

## Testing Instructions

Check that the copy in the workflow validation section uses the correct tense, in this case, past tense.