### PR TITLE
Remove Open from WP Admin link

### DIFF
--- a/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
+++ b/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
@@ -32,7 +32,7 @@ export default function globalSiteSidebarMenu( {
 		},
 		{
 			slug: 'wp-admin',
-			title: translate( 'Open WP Admin' ),
+			title: translate( 'WP Admin' ),
 			url: `https://${ selectedSiteSlug }/wp-admin`,
 			className: 'sidebar__menu-item-wp-admin',
 		},

--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -251,7 +251,7 @@ const WpAdminItem = ( { site, recordTracks }: SitesMenuItemProps ) => {
 			href={ site.options?.admin_url }
 			onClick={ () => recordTracks( 'calypso_sites_dashboard_site_action_wpadmin_click' ) }
 		>
-			{ __( 'Open WP Admin' ) } <MenuItemGridIcon icon="external" size={ 18 } />
+			{ __( 'WP Admin' ) } <MenuItemGridIcon icon="external" size={ 18 } />
 		</MenuItemLink>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Proposing we remove the verb "Open" from the "Open WP Admin" menu links.

Before | After
--|--
<img width="372" alt="Screenshot 2024-03-05 at 6 33 52 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/09c99594-948b-477e-b92d-144a9dc3802e"> | <img width="312" alt="Screenshot 2024-03-05 at 6 31 06 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/db616fb6-36b7-4034-bd22-9c2136d8b386">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check mobile menu and desktop menu of Global Site View

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?