### PR TITLE
Github Deployments: Redirect to deployment logs when status is clicked

### DIFF
--- a/client/my-sites/github-deployments/deployments/deployment-status.tsx
+++ b/client/my-sites/github-deployments/deployments/deployment-status.tsx
@@ -1,3 +1,4 @@
+import { Button } from '@automattic/components';
 import { __ } from '@wordpress/i18n';
 
 export const DeployStatus = {
@@ -15,6 +16,7 @@ export type DeploymentStatusValue = ValueOf< typeof DeployStatus >;
 
 interface DeploymentStatusProps {
 	status: DeploymentStatusValue;
+	onStatusClick?: () => void;
 }
 
 function getText( status: DeploymentStatusValue ) {
@@ -36,10 +38,15 @@ function getText( status: DeploymentStatusValue ) {
 	}
 }
 
-export const DeploymentStatus = ( { status }: DeploymentStatusProps ) => {
+export const DeploymentStatus = ( { status, onStatusClick }: DeploymentStatusProps ) => {
 	return (
-		<div className={ `github-deployments-status github-deployments-status__${ status }` }>
+		<Button
+			plain
+			compact
+			className={ `github-deployments-status github-deployments-status__${ status }` }
+			onClick={ onStatusClick }
+		>
 			<span>{ getText( status ) }</span>
-		</div>
+		</Button>
 	);
 };

--- a/client/my-sites/github-deployments/deployments/deployment-status.tsx
+++ b/client/my-sites/github-deployments/deployments/deployment-status.tsx
@@ -1,4 +1,3 @@
-import { Button } from '@automattic/components';
 import { __ } from '@wordpress/i18n';
 
 export const DeployStatus = {
@@ -16,7 +15,7 @@ export type DeploymentStatusValue = ValueOf< typeof DeployStatus >;
 
 interface DeploymentStatusProps {
 	status: DeploymentStatusValue;
-	onStatusClick?: () => void;
+	href?: string;
 }
 
 function getText( status: DeploymentStatusValue ) {
@@ -38,15 +37,13 @@ function getText( status: DeploymentStatusValue ) {
 	}
 }
 
-export const DeploymentStatus = ( { status, onStatusClick }: DeploymentStatusProps ) => {
+export const DeploymentStatus = ( { status, href }: DeploymentStatusProps ) => {
 	return (
-		<Button
-			plain
-			compact
+		<a
+			href={ href }
 			className={ `github-deployments-status github-deployments-status__${ status }` }
-			onClick={ onStatusClick }
 		>
 			<span>{ getText( status ) }</span>
-		</Button>
+		</a>
 	);
 };

--- a/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
+++ b/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
@@ -17,7 +17,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { useDispatch, useSelector } from '../../../state';
-import { manageDeploymentPage } from '../routes';
+import { manageDeploymentPage, viewDeploymentLogs } from '../routes';
 import { DeleteDeploymentDialog } from './delete-deployment-dialog';
 import { DeploymentStarterMessage } from './deployment-starter-message';
 import { DeploymentsListItemActions } from './deployments-list-item-actions';
@@ -76,7 +76,16 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 	const columns = run ? (
 		<>
 			<td>{ run && <DeploymentCommitDetails run={ run } deployment={ deployment } /> }</td>
-			<td>{ run && <DeploymentStatus status={ run.status as DeploymentStatusValue } /> }</td>
+			<td>
+				{ run && (
+					<DeploymentStatus
+						status={ run.status as DeploymentStatusValue }
+						onStatusClick={ () => {
+							page( viewDeploymentLogs( siteSlug!, deployment.id ) );
+						} }
+					/>
+				) }
+			</td>
 			<td>
 				<span>{ formatDate( locale, new Date( run.created_on ) ) }</span>
 			</td>

--- a/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
+++ b/client/my-sites/github-deployments/deployments/deployments-list-item.tsx
@@ -80,9 +80,7 @@ export const DeploymentsListItem = ( { deployment }: DeploymentsListItemProps ) 
 				{ run && (
 					<DeploymentStatus
 						status={ run.status as DeploymentStatusValue }
-						onStatusClick={ () => {
-							page( viewDeploymentLogs( siteSlug!, deployment.id ) );
-						} }
+						href={ viewDeploymentLogs( siteSlug!, deployment.id ) }
 					/>
 				) }
 			</td>

--- a/client/my-sites/github-deployments/deployments/styles.scss
+++ b/client/my-sites/github-deployments/deployments/styles.scss
@@ -136,6 +136,7 @@
 	gap: 4px;
 	/* stylelint-disable-next-line scales/radii */
 	border-radius: 12px;
+	cursor: pointer;
 
 	&__pending,
 	&__queued {

--- a/client/my-sites/github-deployments/deployments/styles.scss
+++ b/client/my-sites/github-deployments/deployments/styles.scss
@@ -174,6 +174,11 @@
 		line-height: 20px; /* 153.846% */
 		text-transform: capitalize;
 	}
+
+	&:visited,
+	&:hover {
+		color: inherit;
+	}
 }
 
 .github-deployments-delete-deployment-dialog {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5899

## Proposed Changes

* Add click action on the deployment status that redirects to deployment logs

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `/github-deployments/siteSlug` 
* make sure you have deployments listed
* click the status badge and verify it brings you to the deployments logs page

![image](https://github.com/Automattic/wp-calypso/assets/47489215/60dc5b9b-56a3-4056-821b-1731994b9732)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?