### PR TITLE
Stats: Update overlay logic and show UTM for internal sites

### DIFF
--- a/client/my-sites/stats/hooks/use-plan-usage-query.ts
+++ b/client/my-sites/stats/hooks/use-plan-usage-query.ts
@@ -16,6 +16,7 @@ export interface PlanUsage {
 	views_limit: number;
 	over_limit_months: number;
 	current_tier: PriceTierListItemProps;
+	is_internal: boolean;
 }
 
 function selectPlanUsage( payload: PlanUsage ): PlanUsage {

--- a/client/my-sites/stats/stats-module-utm/index.jsx
+++ b/client/my-sites/stats/stats-module-utm/index.jsx
@@ -1,8 +1,15 @@
+import { StatsCard } from '@automattic/components';
 import classNames from 'classnames';
 import { useTranslate } from 'i18n-calypso';
 import { useState } from 'react';
+import { useSelector } from 'calypso/state';
+import { getSiteSlug } from 'calypso/state/sites/selectors';
+import { default as usePlanUsageQuery } from '../hooks/use-plan-usage-query';
+import useStatsPurchases from '../hooks/use-stats-purchases';
 import useUTMMetricTopPostsQuery from '../hooks/use-utm-metric-top-posts-query';
 import useUTMMetricsQuery from '../hooks/use-utm-metrics-query';
+import StatsCardUpsellJetpack from '../stats-card-upsell/stats-card-upsell-jetpack';
+import StatsModulePlaceholder from '../stats-module/placeholder';
 import StatsModuleDataQuery from '../stats-module/stats-module-data-query';
 import statsStrings from '../stats-strings';
 import UTMDropdown from './stats-module-utm-dropdown';
@@ -19,11 +26,25 @@ const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } )
 	const moduleStrings = statsStrings();
 	const translate = useTranslate();
 	const [ selectedOption, setSelectedOption ] = useState( OPTION_KEYS.SOURCE_MEDIUM );
+	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 
+	// Check if blog is internal.
+	const { isFetching: isFetchingUsage, data: usageData } = usePlanUsageQuery( siteId );
+	const { isLoading: isLoadingFeatureCheck, supportCommercialUse } = useStatsPurchases( siteId );
 	// Fetch UTM metrics with switched UTM parameters.
-	const { isFetching: isFetching, metrics } = useUTMMetricsQuery( siteId, selectedOption, postId );
+	const { isFetching: isFetchingUTM, metrics } = useUTMMetricsQuery(
+		siteId,
+		selectedOption,
+		postId
+	);
 	// Fetch top posts for all UTM metric items.
 	const { topPosts } = useUTMMetricTopPostsQuery( siteId, selectedOption, metrics );
+
+	const isSiteInternal = ! isFetchingUsage && usageData?.is_internal;
+	const isFetching = isFetchingUsage || isLoadingFeatureCheck || isFetchingUTM;
+	const isAdvancedFeatureEnabled = isSiteInternal || supportCommercialUse;
+
+	// TODO: trigger useUTMMetricsQuery manually once isAdvancedFeatureEnabled === true
 
 	// Combine metrics with top posts.
 	const data = metrics.map( ( metric ) => {
@@ -52,13 +73,11 @@ const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } )
 			selectLabel: translate( 'Source / Medium' ),
 			headerLabel: translate( 'Posts by Source / Medium' ),
 			isGrouped: true, // display in a group on top of the dropdown
-			// data query action
 		},
 		[ OPTION_KEYS.CAMPAIGN_SOURCE_MEDIUM ]: {
 			selectLabel: translate( 'Campaign / Source / Medium' ),
 			headerLabel: translate( 'Posts by Campaign / Source / Medium' ),
 			isGrouped: true,
-			// data query action
 		},
 		[ OPTION_KEYS.SOURCE ]: {
 			selectLabel: translate( 'Source' ),
@@ -75,25 +94,46 @@ const StatsModuleUTM = ( { siteId, period, postId, query, summary, className } )
 	};
 
 	return (
-		<StatsModuleDataQuery
-			data={ data }
-			path="utm"
-			className={ classNames( className, 'stats-module-utm' ) }
-			moduleStrings={ moduleStrings.utm }
-			period={ period }
-			query={ query }
-			isLoading={ isFetching ?? true }
-			hideSummaryLink={ hideSummaryLink }
-			selectedOption={ optionLabels[ selectedOption ] }
-			toggleControl={
-				<UTMDropdown
-					buttonLabel={ optionLabels[ selectedOption ].selectLabel }
-					onSelect={ setSelectedOption }
-					selectOptions={ optionLabels }
-					selected={ selectedOption }
+		<>
+			{ isFetching && (
+				<StatsCard
+					title="UTM"
+					className={ classNames( className, 'stats-module-utm', 'stats-module__card', 'utm' ) }
+				>
+					<StatsModulePlaceholder isLoading />
+				</StatsCard>
+			) }
+			{ ! isFetching && ! isAdvancedFeatureEnabled && (
+				// TODO: update the ghost card to only show the module name
+				<StatsCard
+					title="UTM"
+					className={ classNames( className, 'stats-module-utm', 'stats-module__card', 'utm' ) }
+				>
+					<StatsCardUpsellJetpack className="stats-module__upsell" siteSlug={ siteSlug } />
+				</StatsCard>
+			) }
+			{ ! isFetching && isAdvancedFeatureEnabled && (
+				<StatsModuleDataQuery
+					data={ data }
+					path="utm"
+					className={ classNames( className, 'stats-module-utm' ) }
+					moduleStrings={ moduleStrings.utm }
+					period={ period }
+					query={ query }
+					isLoading={ isFetching ?? true }
+					hideSummaryLink={ hideSummaryLink }
+					selectedOption={ optionLabels[ selectedOption ] }
+					toggleControl={
+						<UTMDropdown
+							buttonLabel={ optionLabels[ selectedOption ].selectLabel }
+							onSelect={ setSelectedOption }
+							selectOptions={ optionLabels }
+							selected={ selectedOption }
+						/>
+					}
 				/>
-			}
-		/>
+			) }
+		</>
 	);
 };
 

--- a/client/my-sites/stats/stats-module/placeholder.jsx
+++ b/client/my-sites/stats/stats-module/placeholder.jsx
@@ -1,29 +1,20 @@
 import { Spinner } from '@automattic/components';
 import classNames from 'classnames';
-import PropTypes from 'prop-types';
-import { PureComponent } from 'react';
 
 import './placeholder.scss';
 
-export default class StatsModulePlaceholder extends PureComponent {
-	static propTypes = {
-		className: PropTypes.string,
-		isLoading: PropTypes.bool,
-	};
-
-	render() {
-		const { className, isLoading } = this.props;
-
-		if ( ! isLoading ) {
-			return null;
-		}
-
-		const classes = classNames( 'stats-module__placeholder', 'is-void', className );
-
-		return (
-			<div className={ classes }>
-				<Spinner />
-			</div>
-		);
+const StatsModulePlaceholder = ( { className, isLoading } ) => {
+	if ( ! isLoading ) {
+		return null;
 	}
-}
+
+	const classes = classNames( 'stats-module__placeholder', 'is-void', className );
+
+	return (
+		<div className={ classes }>
+			<Spinner />
+		</div>
+	);
+};
+
+export default StatsModulePlaceholder;

--- a/client/my-sites/stats/stats-module/placeholder.tsx
+++ b/client/my-sites/stats/stats-module/placeholder.tsx
@@ -3,7 +3,15 @@ import classNames from 'classnames';
 
 import './placeholder.scss';
 
-const StatsModulePlaceholder = ( { className, isLoading } ) => {
+interface StatsModulePlaceholderProps {
+	className?: string;
+	isLoading: boolean;
+}
+
+const StatsModulePlaceholder: React.FC< StatsModulePlaceholderProps > = ( {
+	className,
+	isLoading,
+} ) => {
 	if ( ! isLoading ) {
 		return null;
 	}

--- a/client/my-sites/stats/stats-module/stats-module-data-query.jsx
+++ b/client/my-sites/stats/stats-module/stats-module-data-query.jsx
@@ -4,8 +4,6 @@ import { useEffect, useState } from 'react';
 import { useSelector } from 'calypso/state';
 import { getSiteSlug } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
-import useStatsPurchases from '../hooks/use-stats-purchases';
-import StatsCardUpsellJetpack from '../stats-card-upsell/stats-card-upsell-jetpack';
 import ErrorPanel from '../stats-error';
 import StatsListCard from '../stats-list/stats-list-card';
 import StatsModulePlaceholder from './placeholder';
@@ -30,9 +28,7 @@ const StatsModuleDataQuery = ( {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( ( state ) => getSiteSlug( state, siteId ) );
 	const translate = useTranslate();
-	const { isLoading: isLoadingFeatureCheck, supportCommercialUse: isAdvancedFeatureEnabled } =
-		useStatsPurchases( siteId );
-	const [ showLoader, setShowLoader ] = useState( isLoading || isLoadingFeatureCheck );
+	const [ showLoader, setShowLoader ] = useState( isLoading );
 
 	// Show error and loading based on the query
 	const hasError = false;
@@ -40,8 +36,8 @@ const StatsModuleDataQuery = ( {
 	const displaySummaryLink = data && ! hideSummaryLink;
 
 	useEffect( () => {
-		setShowLoader( isLoading || isLoadingFeatureCheck );
-	}, [ isLoadingFeatureCheck, isLoading ] );
+		setShowLoader( isLoading );
+	}, [ isLoading ] );
 
 	const getHref = () => {
 		// Some modules do not have view all abilities
@@ -81,12 +77,6 @@ const StatsModuleDataQuery = ( {
 			splitHeader
 			mainItemLabel={ selectedOption?.headerLabel }
 			toggleControl={ toggleControl }
-			overlay={
-				siteSlug &&
-				! isAdvancedFeatureEnabled && (
-					<StatsCardUpsellJetpack className="stats-module__upsell" siteSlug={ siteSlug } />
-				)
-			}
 		/>
 	);
 };


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87569

## Proposed Changes

* use `is_internal` flag to display the UTM module for all internal pages
* refactor UTM module to lift the overlay to a higher component allowing to query the data only when needed

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* apply diff D140888 to your sandbox
* open the live branch and apply `stats/utm-module` feature flag
* verify that the module loads for internal sites
* verify that the overlay loads for external sites without a proper subscription

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?