### PR TITLE
Tweak submenu design of reader tags and lists menu

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -130,6 +130,7 @@ $brand-text: "SF Pro Text", $sans;
 			display: flex;
 			min-height: unset;
 			flex-direction: column;
+			gap: 3px;
 		}
 
 		.sidebar {

--- a/client/my-sites/sidebar/style.scss
+++ b/client/my-sites/sidebar/style.scss
@@ -172,14 +172,14 @@ $font-size: rem(14px);
 
 				&:hover,
 				&:focus {
-					background-color: var(--color-sidebar-submenu-hover-background);
-					color: var(--color-sidebar-submenu-hover-text);
+					background-color: var(--color-sidebar-menu-hover-background);
+					color: var(--color-sidebar-menu-hover-text);
 				}
 			}
 
 			.selected .sidebar__menu-link {
-				background-color: var(--color-sidebar-submenu-selected-background);
-				color: var(--color-sidebar-submenu-selected-text);
+				background-color: var(--color-sidebar-menu-selected-background);
+				color: var(--color-sidebar-menu-selected-text);
 				font-weight: 600;
 			}
 
@@ -286,9 +286,6 @@ $font-size: rem(14px);
 			}
 			// Is toggled open and selected
 			&.sidebar__menu--selected .sidebar__heading {
-				background: var(--color-sidebar-menu-selected-background);
-				color: var(--color-sidebar-menu-selected-text);
-
 				.stats-sparkline {
 					--color-stats-sparkline: var(--color-sidebar-menu-selected-text);
 				}
@@ -364,8 +361,13 @@ $font-size: rem(14px);
 			padding: 12px 10px;
 			margin: 0 12px;
 			border-radius: 2px;
+			outline: none;
 		}
 
+		.sidebar__expandable-content .sidebar__menu-link {
+			margin: 0;
+			padding-left: 30px;
+		}
 		.sidebar__heading:not([tabindex="-1"]),
 		.sidebar__menu-link {
 			color: var(--color-sidebar-text);
@@ -418,15 +420,15 @@ $font-size: rem(14px);
 			}
 		}
 
-		.sidebar__menu {
-			// Is toggled open and selected
-			&.sidebar__menu--selected .sidebar__heading {
-				background: var(--color-sidebar-menu-selected-background);
-				color: var(--color-sidebar-menu-selected-text);
-
-				&:hover {
-					background-color: var(--color-sidebar-menu-selected-background);
-				}
+		.sidebar__menu.is-toggle-open {
+			.sidebar__heading {
+				background-color: var(--color-sidebar-submenu-background);
+				border-bottom-left-radius: 0;
+				border-bottom-right-radius: 0;
+			}
+			.sidebar__expandable-content {
+				border-top-left-radius: 0;
+				border-top-right-radius: 0;
 			}
 		}
 

--- a/client/reader/sidebar/reader-sidebar-tags/list.jsx
+++ b/client/reader/sidebar/reader-sidebar-tags/list.jsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames';
 import { localize } from 'i18n-calypso';
 import { map } from 'lodash';
 import PropTypes from 'prop-types';
@@ -34,7 +35,11 @@ export class ReaderSidebarTagsList extends Component {
 		return (
 			<li className="reader-sidebar-tags__list">
 				<ul>{ this.renderItems() }</ul>
-				<a className="sidebar__menu-link" href="/tags" onClick={ this.trackTagsPageClick }>
+				<a
+					className={ classnames( 'sidebar__menu-link', 'sidebar__menu-item--see-all-tags-link' ) }
+					href="/tags"
+					onClick={ this.trackTagsPageClick }
+				>
 					<span className="reader-sidebar-tags__all-tags-link">
 						{ this.props.translate( 'See all tags' ) }
 					</span>


### PR DESCRIPTION
Address feedback on the reader nested menus by changing highlight colors and indent. p1709681790560899-slack-C03NLNTPZ2T
This should make it visually clearer that the menu items are nested, and also deal with hover and focus in a more consistent way.

Before:

https://github.com/Automattic/wp-calypso/assets/22446385/d6cbe4ee-1c05-4d6b-9cd4-58b4e6b9e7fb

After:

https://github.com/Automattic/wp-calypso/assets/22446385/45901d4b-d407-4f28-b7ef-66b89a254534