### PR TITLE
Global sidebar: Unset margin for expandable content links

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -141,7 +141,16 @@ $brand-text: "SF Pro Text", $sans;
 			.sidebar__expandable-content .sidebar__menu-link {
 				font-size: $default-font-size;
 				line-height: 15px;
-				margin: 0;
+			}
+
+			.sidebar__expandable-content {
+				.sidebar__menu-link {
+					margin: 0;
+				}
+
+				.reader-sidebar-tags__text-input {
+					padding-right: 0;
+				}
 			}
 		}
 

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -141,6 +141,7 @@ $brand-text: "SF Pro Text", $sans;
 			.sidebar__expandable-content .sidebar__menu-link {
 				font-size: $default-font-size;
 				line-height: 15px;
+				margin: 0;
 			}
 		}
 

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -309,6 +309,10 @@ $brand-text: "SF Pro Text", $sans;
 			}
 		}
 	}
+
+	.is-section-reader & .sidebar__menu-item-siteicon {
+		margin-inline-end: 12px;
+	}
 }
 
 .accessible-focus div.global-sidebar {

--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -149,7 +149,7 @@ $brand-text: "SF Pro Text", $sans;
 				}
 
 				.reader-sidebar-tags__text-input {
-					padding-right: 0;
+					padding-inline-end: 0;
 				}
 			}
 		}


### PR DESCRIPTION
## Proposed Changes

This PR removes the indentation of the expandable menu content in the global sidebar.

| Before | After |
| --- | --- |
| ![Screenshot 2024-03-06 at 5 15 30 PM](https://github.com/Automattic/wp-calypso/assets/797888/dcdfa59f-23c3-4ad9-a536-b8ab9211679c) | ![Screenshot 2024-03-06 at 5 15 45 PM](https://github.com/Automattic/wp-calypso/assets/797888/2018a965-5961-45cd-a16e-b042449590f2) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to `/read`.
* Ensure that the spacing is updated as described above.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?