### PR TITLE
Update JP Monitor on Schedule Creation

### DIFF
--- a/client/data/plugins/use-monitor-settings-mutation.ts
+++ b/client/data/plugins/use-monitor-settings-mutation.ts
@@ -1,0 +1,65 @@
+import { UseQueryResult, useMutation, useQuery } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import wpcomRequest from 'wpcom-proxy-request';
+import type { SiteSlug } from 'calypso/types';
+
+export type UpdateMonitorURLOptions = {
+	status_down_webhook_url: string;
+};
+
+export type UpdateMonitorURL = {
+	monitor_url: string;
+	check_interval: number;
+	options: UpdateMonitorURLOptions;
+};
+
+export type UpdateMonitorSettings = {
+	wp_note_notifications?: boolean;
+	email_notifications?: boolean;
+	sms_notifications?: boolean;
+	jetmon_defer_status_down_minutes?: number;
+	urls?: UpdateMonitorURL[];
+};
+
+export type UpdateMonitorSettingsCreate = {
+	success: boolean;
+	settings: UpdateMonitorSettings;
+};
+
+export const useMonitorSettingsQuery = (
+	siteSlug: SiteSlug
+): UseQueryResult< UpdateMonitorSettings > => {
+	return useQuery( {
+		queryKey: [ 'monitor-settings', siteSlug ],
+		queryFn: () =>
+			wpcomRequest< { [ key: string ]: Partial< UpdateMonitorSettings > } >( {
+				path: `/sites/${ siteSlug }/jetpack-monitor-settings`,
+				apiNamespace: 'wpcom/v2',
+				method: 'GET',
+			} ),
+		meta: {
+			persist: false,
+		},
+		enabled: !! siteSlug,
+		retry: false,
+		refetchOnWindowFocus: false,
+	} );
+};
+
+export function useCreateMonitorSettingsMutation( siteSlug: SiteSlug, queryOptions = {} ) {
+	const mutation = useMutation( {
+		mutationFn: ( params: object ) =>
+			wpcomRequest( {
+				path: `/sites/${ siteSlug }/jetpack-monitor-settings`,
+				apiNamespace: 'wpcom/v2',
+				method: 'POST',
+				body: params,
+			} ),
+		...queryOptions,
+	} );
+
+	const { mutate } = mutation;
+	const createMonitorSettings = useCallback( ( params: object ) => mutate( params ), [ mutate ] );
+
+	return { createMonitorSettings, ...mutation };
+}


### PR DESCRIPTION
**THIS IS A PROOF OF CONCEPT**.

Fixes https://github.com/Automattic/dotcom-forge/issues/5702

## Proposed Changes

* Create/update the schedule update on schedule creation.

## Testing Instructions
* `http://calypso.localhost:3000/plugins/scheduled-updates/create/__BLOG__`
* Create a new schedule
* On https://developer.wordpress.com/docs/api/console/ check `GET wpcom/v2/sites/__BLOG__/jetpack-monitor-settings`

It should output:
```json
{
  "success": true,
  "settings": {
    "monitor_active": true,
    "email_notifications": true,
    "sms_notifications": false,
    "wp_note_notifications": true,
    "urls": [
      {
        "monitor_url": "https://__BLOG__",
        "options": [],
        "check_interval": 5
      },
      {
        "monitor_url": "https://__BLOG__/wp-cron.php",
        "options": [],
        "check_interval": 5
      }
    ],
    "contacts": {
      "emails": [],
      "sms_numbers": []
    }
  }
}
```
A `monitor_url` of the homepage is required. Otherwise the endpoint outputs `monitor_url is a required property of urls` error.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?