### PR TITLE
Plugins Update Manager: Add titles to create, list & update screens

### DIFF
--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -34,7 +34,7 @@ export const PluginsUpdateManager = ( props: Props ) => {
 					onEditSchedule={ onEditSchedule }
 				/>
 			),
-			title: 'Plugin updates manager',
+			title: 'List schedules',
 		},
 		create: {
 			component: <ScheduleCreate siteSlug={ siteSlug } onNavBack={ onNavBack } />,

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
+import DocumentHead from 'calypso/components/data/document-head';
 import MainComponent from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updates-query';
@@ -23,8 +24,34 @@ export const PluginsUpdateManager = ( props: Props ) => {
 	const { data: schedules = [] } = useScheduleUpdatesQuery( siteSlug );
 	const hideCreateButton = schedules.length === MAX_SCHEDULES || schedules.length === 0;
 
+	const { component, title } = {
+		list: {
+			component: (
+				<ScheduleList
+					siteSlug={ siteSlug }
+					onNavBack={ onNavBack }
+					onCreateNewSchedule={ onCreateNewSchedule }
+					onEditSchedule={ onEditSchedule }
+				/>
+			),
+			title: 'Plugin updates manager',
+		},
+		create: {
+			component: <ScheduleCreate siteSlug={ siteSlug } onNavBack={ onNavBack } />,
+			title: 'Create a new schedule',
+		},
+		edit: {
+			component: (
+				<ScheduleEdit siteSlug={ siteSlug } scheduleId={ scheduleId } onNavBack={ onNavBack } />
+			),
+			title: 'Edit schedule',
+		},
+	}[ context ];
+
 	return (
 		<MainComponent wideLayout>
+			<DocumentHead title={ title } />
+
 			<NavigationHeader
 				navigationItems={ [] }
 				title="Plugin updates manager"
@@ -42,22 +69,7 @@ export const PluginsUpdateManager = ( props: Props ) => {
 				) }
 			</NavigationHeader>
 
-			{
-				{
-					list: (
-						<ScheduleList
-							siteSlug={ siteSlug }
-							onNavBack={ onNavBack }
-							onCreateNewSchedule={ onCreateNewSchedule }
-							onEditSchedule={ onEditSchedule }
-						/>
-					),
-					create: <ScheduleCreate siteSlug={ siteSlug } onNavBack={ onNavBack } />,
-					edit: (
-						<ScheduleEdit siteSlug={ siteSlug } scheduleId={ scheduleId } onNavBack={ onNavBack } />
-					),
-				}[ context ]
-			}
+			{ component }
 		</MainComponent>
 	);
 };


### PR DESCRIPTION
Closes #88139

## Proposed Changes

* Adds the titles to the create, list & update screens
* Intentionally didn't wrap the strings in translate calls (as previously discussed here: p1708960298883919/1708959675.673329-slack-C01A60HCGUA)

![CleanShot 2024-03-06 at 14 05 40@2x](https://github.com/Automattic/wp-calypso/assets/528287/25693e04-f8f9-422f-be37-7362b96e606e)

## Testing Instructions

1. Apply this PR
2. Visit `http://calypso.localhost:3000/plugins/scheduled-updates/<youratomic.blog>`
3. Click around between list, create and edit. The page title should update.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [X] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?