### PR TITLE
Pattern Library: Add search functionality

### DIFF
--- a/client/my-sites/patterns/components/header/index.tsx
+++ b/client/my-sites/patterns/components/header/index.tsx
@@ -12,7 +12,7 @@ type PatternsHeaderProps = {
 export const PatternsHeader = ( {
 	description,
 	initialSearchTerm = '',
-	onSearch,
+	onSearch = ( s ) => s,
 	title,
 }: PatternsHeaderProps ) => {
 	return (

--- a/client/my-sites/patterns/components/header/index.tsx
+++ b/client/my-sites/patterns/components/header/index.tsx
@@ -2,14 +2,19 @@ import Search from 'calypso/components/search';
 
 import './style.scss';
 
-type Props = {
+type PatternsHeaderProps = {
 	description: string;
 	onSearch?( searchTerm: string ): void;
 	searchTerm?: string;
 	title: string;
 };
 
-export const PatternsHeader = ( { description, onSearch, searchTerm = '', title }: Props ) => {
+export const PatternsHeader = ( {
+	description,
+	onSearch,
+	searchTerm = '',
+	title,
+}: PatternsHeaderProps ) => {
 	return (
 		<header className="patterns-header">
 			<div className="patterns-header__inner">

--- a/client/my-sites/patterns/components/header/index.tsx
+++ b/client/my-sites/patterns/components/header/index.tsx
@@ -12,7 +12,7 @@ type PatternsHeaderProps = {
 export const PatternsHeader = ( {
 	description,
 	initialSearchTerm = '',
-	onSearch = ( s ) => s,
+	onSearch = () => {},
 	title,
 }: PatternsHeaderProps ) => {
 	return (

--- a/client/my-sites/patterns/components/header/index.tsx
+++ b/client/my-sites/patterns/components/header/index.tsx
@@ -2,12 +2,13 @@ import Search from 'calypso/components/search';
 
 import './style.scss';
 
-type PatternsHeaderProps = {
-	title: string;
+type Props = {
 	description: string;
+	onSearch?( searchTerm: string ): void;
+	title: string;
 };
 
-export const PatternsHeader = ( { title, description }: PatternsHeaderProps ) => {
+export const PatternsHeader = ( { description, onSearch, title }: Props ) => {
 	return (
 		<header className="patterns-header">
 			<div className="patterns-header__inner">
@@ -15,8 +16,9 @@ export const PatternsHeader = ( { title, description }: PatternsHeaderProps ) =>
 				<div className="patterns-header__description">{ description }</div>
 				<Search
 					additionalClasses="patterns-header__search-input"
+					delaySearch
 					placeholder="Search patterns..."
-					onSearch={ () => {} }
+					onSearch={ onSearch }
 				/>
 			</div>
 		</header>

--- a/client/my-sites/patterns/components/header/index.tsx
+++ b/client/my-sites/patterns/components/header/index.tsx
@@ -5,10 +5,11 @@ import './style.scss';
 type Props = {
 	description: string;
 	onSearch?( searchTerm: string ): void;
+	searchTerm?: string;
 	title: string;
 };
 
-export const PatternsHeader = ( { description, onSearch, title }: Props ) => {
+export const PatternsHeader = ( { description, onSearch, searchTerm = '', title }: Props ) => {
 	return (
 		<header className="patterns-header">
 			<div className="patterns-header__inner">
@@ -19,6 +20,7 @@ export const PatternsHeader = ( { description, onSearch, title }: Props ) => {
 					delaySearch
 					placeholder="Search patterns..."
 					onSearch={ onSearch }
+					value={ searchTerm }
 				/>
 			</div>
 		</header>

--- a/client/my-sites/patterns/components/header/index.tsx
+++ b/client/my-sites/patterns/components/header/index.tsx
@@ -4,15 +4,15 @@ import './style.scss';
 
 type PatternsHeaderProps = {
 	description: string;
+	initialSearchTerm?: string;
 	onSearch?( searchTerm: string ): void;
-	searchTerm?: string;
 	title: string;
 };
 
 export const PatternsHeader = ( {
 	description,
+	initialSearchTerm = '',
 	onSearch,
-	searchTerm = '',
 	title,
 }: PatternsHeaderProps ) => {
 	return (
@@ -23,9 +23,9 @@ export const PatternsHeader = ( {
 				<Search
 					additionalClasses="patterns-header__search-input"
 					delaySearch
-					placeholder="Search patterns..."
+					initialValue={ initialSearchTerm }
 					onSearch={ onSearch }
-					value={ searchTerm }
+					placeholder="Search patterns..."
 				/>
 			</div>
 		</header>

--- a/client/my-sites/patterns/hooks/use-pattern-search-term.ts
+++ b/client/my-sites/patterns/hooks/use-pattern-search-term.ts
@@ -15,6 +15,9 @@ function getQueryParam( key: string ) {
 	return '';
 }
 
+/**
+ * Set up search form state and URL-related `useEffect` callbacks
+ */
 export function usePatternSearchTerm(): [ string, Dispatch< SetStateAction< string > > ] {
 	const [ searchTerm, setSearchTerm ] = useState( getQueryParam( 's' ) );
 
@@ -48,6 +51,9 @@ export function usePatternSearchTerm(): [ string, Dispatch< SetStateAction< stri
 	return [ searchTerm, setSearchTerm ];
 }
 
+/**
+ * Filter patterns by looking at their titles, description and category names
+ */
 export function filterPatternsByTerm( patterns: Pattern[], searchTerm: string ) {
 	return patterns.filter( ( pattern ) => {
 		const lowerCaseSearchTerm = searchTerm.toLowerCase();

--- a/client/my-sites/patterns/hooks/use-pattern-search-term.ts
+++ b/client/my-sites/patterns/hooks/use-pattern-search-term.ts
@@ -1,0 +1,63 @@
+import page from '@automattic/calypso-router';
+import { useEffect, useState } from 'react';
+import type { Pattern } from 'calypso/my-sites/patterns/types';
+import type { Dispatch, SetStateAction } from 'react';
+
+/**
+ * Retrieve a query parameter value from the URL
+ */
+function getQueryParam( key: string ) {
+	if ( typeof window !== 'undefined' ) {
+		const params = new URLSearchParams( window.location.search );
+		return params.get( key ) ?? '';
+	}
+
+	return '';
+}
+
+export function usePatternSearchTerm(): [ string, Dispatch< SetStateAction< string > > ] {
+	const [ searchTerm, setSearchTerm ] = useState( getQueryParam( 's' ) );
+
+	// Updates the URL of the page whenever the search term changes
+	useEffect( () => {
+		const params = new URLSearchParams( window.location.search );
+
+		if ( searchTerm ) {
+			params.set( 's', searchTerm );
+		} else {
+			params.delete( 's' );
+		}
+
+		const paramsString = params.toString().length ? `?${ params.toString() }` : '';
+		page.redirect( `${ window.location.pathname }${ paramsString }` );
+	}, [ searchTerm ] );
+
+	// Updates the search term whenever the URL of the page changes
+	useEffect( () => {
+		function onPopstate() {
+			setSearchTerm( getQueryParam( 's' ) );
+		}
+
+		window.addEventListener( 'popstate', onPopstate );
+
+		return () => {
+			window.removeEventListener( 'popstate', onPopstate );
+		};
+	}, [] );
+
+	return [ searchTerm, setSearchTerm ];
+}
+
+export function filterPatternsByTerm( patterns: Pattern[], searchTerm: string ) {
+	return patterns.filter( ( pattern ) => {
+		const lowerCaseSearchTerm = searchTerm.toLowerCase();
+		const patternCategories = Object.values( pattern.categories ).map(
+			( category ) => category?.title
+		);
+		const fields = [ pattern.title, pattern.description, ...patternCategories ].filter(
+			( x ): x is NonNullable< typeof x > => Boolean( x )
+		);
+
+		return fields.some( ( field ) => field.toLowerCase().includes( lowerCaseSearchTerm ) );
+	} );
+}

--- a/client/my-sites/patterns/hooks/use-pattern-search-term.ts
+++ b/client/my-sites/patterns/hooks/use-pattern-search-term.ts
@@ -3,6 +3,8 @@ import { useEffect, useState } from 'react';
 import type { Pattern } from 'calypso/my-sites/patterns/types';
 import type { Dispatch, SetStateAction } from 'react';
 
+export const QUERY_PARAM_SEARCH = 's';
+
 /**
  * Retrieve a query parameter value from the URL
  */
@@ -19,16 +21,16 @@ function getQueryParam( key: string ) {
  * Set up search form state and URL-related `useEffect` callbacks
  */
 export function usePatternSearchTerm(): [ string, Dispatch< SetStateAction< string > > ] {
-	const [ searchTerm, setSearchTerm ] = useState( getQueryParam( 's' ) );
+	const [ searchTerm, setSearchTerm ] = useState( getQueryParam( QUERY_PARAM_SEARCH ) );
 
 	// Updates the URL of the page whenever the search term changes
 	useEffect( () => {
 		const params = new URLSearchParams( window.location.search );
 
 		if ( searchTerm ) {
-			params.set( 's', searchTerm );
+			params.set( QUERY_PARAM_SEARCH, searchTerm );
 		} else {
-			params.delete( 's' );
+			params.delete( QUERY_PARAM_SEARCH );
 		}
 
 		const paramsString = params.toString().length ? `?${ params.toString() }` : '';
@@ -38,7 +40,7 @@ export function usePatternSearchTerm(): [ string, Dispatch< SetStateAction< stri
 	// Updates the search term whenever the URL of the page changes
 	useEffect( () => {
 		function onPopstate() {
-			setSearchTerm( getQueryParam( 's' ) );
+			setSearchTerm( getQueryParam( QUERY_PARAM_SEARCH ) );
 		}
 
 		window.addEventListener( 'popstate', onPopstate );
@@ -52,10 +54,10 @@ export function usePatternSearchTerm(): [ string, Dispatch< SetStateAction< stri
 }
 
 /**
- * Filter patterns by looking at their titles, description and category names
+ * Filter patterns by looking at their titles, descriptions and category names
  */
 export function filterPatternsByTerm( patterns: Pattern[], searchTerm: string ) {
-	const lowerCaseSearchTerm = searchTerm.toLowerCase();
+	const lowerCaseSearchTerm = searchTerm.toLowerCase().trim();
 
 	return patterns.filter( ( pattern ) => {
 		const patternCategories = Object.values( pattern.categories ).map(

--- a/client/my-sites/patterns/hooks/use-pattern-search-term.ts
+++ b/client/my-sites/patterns/hooks/use-pattern-search-term.ts
@@ -55,11 +55,13 @@ export function usePatternSearchTerm(): [ string, Dispatch< SetStateAction< stri
  * Filter patterns by looking at their titles, description and category names
  */
 export function filterPatternsByTerm( patterns: Pattern[], searchTerm: string ) {
+	const lowerCaseSearchTerm = searchTerm.toLowerCase();
+
 	return patterns.filter( ( pattern ) => {
-		const lowerCaseSearchTerm = searchTerm.toLowerCase();
 		const patternCategories = Object.values( pattern.categories ).map(
 			( category ) => category?.title
 		);
+		// Filters out falsy values in a way TS can understand
 		const fields = [ pattern.title, pattern.description, ...patternCategories ].filter(
 			( x ): x is NonNullable< typeof x > => Boolean( x )
 		);

--- a/client/my-sites/patterns/hooks/use-patterns.ts
+++ b/client/my-sites/patterns/hooks/use-patterns.ts
@@ -9,7 +9,7 @@ export function getPatternsQueryOptions(
 ) {
 	return {
 		queryKey: [ 'pattern-library', 'patterns', locale, category ],
-		queryFn: () => {
+		queryFn() {
 			return wpcom.req.get( `/ptk/patterns/${ locale }`, {
 				categories: category,
 				post_type: 'wp_block',

--- a/client/my-sites/patterns/pages/category/index.tsx
+++ b/client/my-sites/patterns/pages/category/index.tsx
@@ -8,6 +8,10 @@ import DocumentHead from 'calypso/components/data/document-head';
 import { PatternsGetStarted } from 'calypso/my-sites/patterns/components/get-started';
 import { PatternsHeader } from 'calypso/my-sites/patterns/components/header';
 import { usePatternCategories } from 'calypso/my-sites/patterns/hooks/use-pattern-categories';
+import {
+	usePatternSearchTerm,
+	filterPatternsByTerm,
+} from 'calypso/my-sites/patterns/hooks/use-pattern-search-term';
 import { usePatterns } from 'calypso/my-sites/patterns/hooks/use-patterns';
 import ImgGrid from './images/grid.svg';
 import ImgStar from './images/star.svg';
@@ -28,8 +32,11 @@ export const PatternsCategoryPage = ( {
 }: PatternsCategoryPageProps ) => {
 	const locale = useLocale();
 
+	const [ searchTerm, setSearchTerm ] = usePatternSearchTerm();
 	const { data: categories } = usePatternCategories( locale );
-	const { data: patterns } = usePatterns( locale, category );
+	const { data: patterns = [] } = usePatterns( locale, category, {
+		select: ( patterns ) => filterPatternsByTerm( patterns, searchTerm ),
+	} );
 
 	const categoryNavList = categories?.map( ( category ) => ( {
 		name: category.name || '',
@@ -42,8 +49,12 @@ export const PatternsCategoryPage = ( {
 			<DocumentHead title="WordPress Patterns- Category" />
 
 			<PatternsHeader
-				title={ category + ' patterns' }
 				description="Introduce yourself or your brand to visitors."
+				initialSearchTerm={ searchTerm }
+				onSearch={ ( query ) => {
+					setSearchTerm( query );
+				} }
+				title={ category + ' patterns' }
 			/>
 
 			{ categoryNavList && (

--- a/client/my-sites/patterns/pages/category/index.tsx
+++ b/client/my-sites/patterns/pages/category/index.tsx
@@ -3,6 +3,7 @@ import {
 	__experimentalToggleGroupControl as ToggleGroupControl,
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption,
 } from '@wordpress/components';
+import { useEffect, useRef, useState } from 'react';
 import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
 import DocumentHead from 'calypso/components/data/document-head';
 import { PatternsGetStarted } from 'calypso/my-sites/patterns/components/get-started';
@@ -31,12 +32,26 @@ export const PatternsCategoryPage = ( {
 	patternGallery: PatternGallery,
 }: PatternsCategoryPageProps ) => {
 	const locale = useLocale();
+	// Helps prevent resetting the search input if a search term was provided through the URL
+	const isInitialLoad = useRef( true );
+	// Helps reset the search input when navigating between categories
+	const [ searchFormKey, setSearchFormKey ] = useState( category );
 
 	const [ searchTerm, setSearchTerm ] = usePatternSearchTerm();
 	const { data: categories } = usePatternCategories( locale );
 	const { data: patterns = [] } = usePatterns( locale, category, {
 		select: ( patterns ) => filterPatternsByTerm( patterns, searchTerm ),
 	} );
+
+	// Resets the search term whenever the category changes
+	useEffect( () => {
+		if ( isInitialLoad.current ) {
+			isInitialLoad.current = false;
+		} else {
+			setSearchTerm( '' );
+			setSearchFormKey( category );
+		}
+	}, [ category ] );
 
 	const categoryNavList = categories?.map( ( category ) => ( {
 		name: category.name || '',
@@ -50,6 +65,7 @@ export const PatternsCategoryPage = ( {
 
 			<PatternsHeader
 				description="Introduce yourself or your brand to visitors."
+				key={ searchFormKey }
 				initialSearchTerm={ searchTerm }
 				onSearch={ ( query ) => {
 					setSearchTerm( query );

--- a/client/my-sites/patterns/pages/category/index.tsx
+++ b/client/my-sites/patterns/pages/category/index.tsx
@@ -33,7 +33,7 @@ export const PatternsCategoryPage = ( {
 }: PatternsCategoryPageProps ) => {
 	const locale = useLocale();
 	// Helps prevent resetting the search input if a search term was provided through the URL
-	const isInitialLoad = useRef( true );
+	const isInitialRender = useRef( true );
 	// Helps reset the search input when navigating between categories
 	const [ searchFormKey, setSearchFormKey ] = useState( category );
 
@@ -45,8 +45,8 @@ export const PatternsCategoryPage = ( {
 
 	// Resets the search term whenever the category changes
 	useEffect( () => {
-		if ( isInitialLoad.current ) {
-			isInitialLoad.current = false;
+		if ( isInitialRender.current ) {
+			isInitialRender.current = false;
 		} else {
 			setSearchTerm( '' );
 			setSearchFormKey( category );

--- a/client/my-sites/patterns/pages/home/index.tsx
+++ b/client/my-sites/patterns/pages/home/index.tsx
@@ -36,6 +36,18 @@ function filterPatternsByQuery( patterns: Pattern[], searchTerm: string ) {
 	} );
 }
 
+/**
+ * Retrieve a query parameter value from the URL
+ */
+function getQueryParam( key: string ) {
+	if ( typeof window !== 'undefined' ) {
+		const params = new URLSearchParams( window.location.search );
+		return params.get( key ) ?? '';
+	}
+
+	return '';
+}
+
 type PatternsHomePageProps = {
 	isGridView?: boolean;
 	patternGallery: PatternGalleryFC;
@@ -47,14 +59,7 @@ export const PatternsHomePage = ( {
 }: PatternsHomePageProps ) => {
 	const locale = useLocale();
 
-	const [ searchTerm, setSearchTerm ] = useState( () => {
-		if ( typeof window !== 'undefined' ) {
-			const params = new URLSearchParams( window.location.search );
-			return params.get( 's' ) ?? '';
-		}
-
-		return '';
-	} );
+	const [ searchTerm, setSearchTerm ] = useState( getQueryParam( 's' ) );
 
 	const { data: categories } = usePatternCategories( locale );
 	const { data: patterns = [] } = usePatterns( locale, '', {
@@ -63,6 +68,7 @@ export const PatternsHomePage = ( {
 
 	const patternSearchResults = filterPatternsByQuery( patterns, searchTerm );
 
+	// Updates the URL of the page whenever the search term changes
 	useEffect( () => {
 		const params = new URLSearchParams( window.location.search );
 
@@ -76,10 +82,10 @@ export const PatternsHomePage = ( {
 		page( `${ window.location.pathname }${ paramsString }` );
 	}, [ searchTerm ] );
 
+	// Updates the search term whenever the URL of the page changes
 	useEffect( () => {
 		function onPopstate() {
-			const params = new URLSearchParams( window.location.search );
-			setSearchTerm( params.get( 's' ) ?? '' );
+			setSearchTerm( getQueryParam( 's' ) );
 		}
 
 		window.addEventListener( 'popstate', onPopstate );
@@ -95,10 +101,10 @@ export const PatternsHomePage = ( {
 
 			<PatternsHeader
 				description="Hundreds of expertly designed, fully responsive patterns allow you to craft a beautiful site in minutes."
+				initialSearchTerm={ searchTerm }
 				onSearch={ ( query ) => {
 					setSearchTerm( query );
 				} }
-				searchTerm={ searchTerm }
 				title="Build your perfect site with patterns"
 			/>
 

--- a/client/my-sites/patterns/pages/home/index.tsx
+++ b/client/my-sites/patterns/pages/home/index.tsx
@@ -18,13 +18,13 @@ import type { Pattern, PatternGalleryFC } from 'calypso/my-sites/patterns/types'
 
 import './style.scss';
 
-function filterPatternsByQuery( patterns: Pattern[], searchTerm: string ) {
+function filterPatternsByTerm( patterns: Pattern[], searchTerm: string ) {
 	if ( ! searchTerm ) {
 		return [];
 	}
 
 	return patterns.filter( ( pattern ) => {
-		const lowercaseSearch = searchTerm.toLowerCase();
+		const lowerCaseSearchTerm = searchTerm.toLowerCase();
 		const patternCategories = Object.values( pattern.categories ).map(
 			( category ) => category?.title
 		);
@@ -32,7 +32,7 @@ function filterPatternsByQuery( patterns: Pattern[], searchTerm: string ) {
 			( x ): x is NonNullable< typeof x > => Boolean( x )
 		);
 
-		return fields.some( ( field ) => field.toLowerCase().includes( lowercaseSearch ) );
+		return fields.some( ( field ) => field.toLowerCase().includes( lowerCaseSearchTerm ) );
 	} );
 }
 
@@ -66,7 +66,7 @@ export const PatternsHomePage = ( {
 		enabled: Boolean( searchTerm ),
 	} );
 
-	const patternSearchResults = filterPatternsByQuery( patterns, searchTerm );
+	const patternSearchResults = filterPatternsByTerm( patterns, searchTerm );
 
 	// Updates the URL of the page whenever the search term changes
 	useEffect( () => {

--- a/client/my-sites/patterns/wrapper.tsx
+++ b/client/my-sites/patterns/wrapper.tsx
@@ -27,7 +27,7 @@ export const PatternsWrapper = ( {
 
 			<Main isLoggedOut fullWidthLayout>
 				{ ! category ? (
-					<PatternsHomePage />
+					<PatternsHomePage isGridView={ isGridView } patternGallery={ PatternGallery } />
 				) : (
 					<PatternsCategoryPage
 						category={ category }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5600

## Proposed Changes

This PR adds basic search functionality to the public pattern library. Searches are performed on the client by simple string matching of pattern titles, descriptions and category names.

On the `/patterns` home page, searches are performed against **all** patterns, and on category pages they are performed within that category.

Search queries are persisted to the URL in a query parameter. Back/forward history navigation is also supported.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. ~Apply D140727-code~
2. ~Sandbox `public-api.wordpress.com`~
3. Navigate to `/patterns`
4. Search for `contact`
5. Ensure that some pattern previews are rendered below the category links
6. Click on the `About` category
7. Search for `contact` again
8. Ensure that a single pattern preview is rendered below the category links

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?