### PR TITLE
Sharing: add support for Threads

### DIFF
--- a/client/components/social-logo/docs/example.jsx
+++ b/client/components/social-logo/docs/example.jsx
@@ -40,6 +40,7 @@ const logos = [
 	'squarespace',
 	'stumbleupon',
 	'telegram',
+	'threads',
 	'tumblr',
 	'tumblr-alt',
 	'twitch',

--- a/client/my-sites/marketing/style.scss
+++ b/client/my-sites/marketing/style.scss
@@ -39,6 +39,12 @@
 		}
 	}
 
+	&.threads {
+		.sharing-service__logo {
+			color: var(--color-threads);
+		}
+	}
+
 	&.tumblr {
 		.sharing-service__logo {
 			color: var(--color-tumblr);
@@ -317,6 +323,7 @@
 @include sharing-service( "facebook", var( --color-facebook ) );
 @include sharing-service( "twitter", var( --color-twitter ) );
 @include sharing-service( "google_plus", var( --color-google-plus ) );
+@include sharing-service( "threads", var( --color-threads ) );
 @include sharing-service( "tumblr", var( --color-tumblr ) );
 @include sharing-service( "linkedin", var( --color-linkedin ) );
 @include sharing-service( "instagram-basic-display", var( --color-instagram ) );
@@ -986,6 +993,7 @@
 @include sharing-button-service( "instagram-basic-display", var( --color-instagram ) );
 @include sharing-button-service( "linkedin", var( --color-linkedin ) );
 @include sharing-button-service( "stumbleupon", var( --color-stumbleupon ) );
+@include sharing-button-service( "threads", var( --color-threads ) );
 @include sharing-button-service( "tumblr", var( --color-tumblr ) );
 @include sharing-button-service( "reddit", var( --color-reddit ) );
 @include sharing-button-service( "pinterest", var( --color-pinterest ) );

--- a/packages/calypso-color-schemes/CHANGELOG.md
+++ b/packages/calypso-color-schemes/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 3.1.3
+
+- Add a new color for Threads.
+
 ## 3.1.2
 
 - Added a new color for X.

--- a/packages/calypso-color-schemes/package.json
+++ b/packages/calypso-color-schemes/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/calypso-color-schemes",
-	"version": "3.1.2",
+	"version": "3.1.3",
 	"description": "Calypso Shared Style Bits.",
 	"author": "Automattic Inc.",
 	"license": "GPL-2.0-or-later",

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_classic-dark.scss
@@ -317,6 +317,7 @@
 	--color-substack: #ff6719;
 	--color-squarespace: #222;
 	--color-telegram: #08c;
+	--color-threads: #000;
 	--color-tumblr: #35465c;
 	--color-twitter: #55acee;
 	--color-whatsapp: #43d854;

--- a/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
+++ b/packages/calypso-color-schemes/src/shared/color-schemes/_default.scss
@@ -317,6 +317,7 @@
 	--color-substack: #ff6719;
 	--color-squarespace: #222;
 	--color-telegram: #08c;
+	--color-threads: #000;
 	--color-tumblr: #35465c;
 	--color-twitter: #55acee;
 	--color-whatsapp: #43d854;


### PR DESCRIPTION
See https://github.com/Automattic/jetpack/pull/36220/

## Proposed Changes

This adds support for the Threads service to Calypso.

## Testing Instructions

* You'll need a local installation of Jetpack running the branch from https://github.com/Automattic/jetpack/pull/36220/
* Spin up Calypso locally with this branch and go to http://calypso.localhost:3000/marketing/sharing-buttons/
* Click to edit the sharing buttons
* You should see the black Threads logo

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
