### PR TITLE
Plugin update manager: move siteSlug to context

### DIFF
--- a/client/blocks/plugins-update-manager/context/index.tsx
+++ b/client/blocks/plugins-update-manager/context/index.tsx
@@ -1,0 +1,21 @@
+import React, { createContext, ReactNode } from 'react';
+import type { SiteSlug } from 'calypso/types';
+
+interface PluginUpdateManagerContextProps {
+	siteSlug: SiteSlug;
+}
+
+const PluginUpdateManagerContext = createContext< PluginUpdateManagerContextProps >( {
+	siteSlug: '',
+} );
+
+const PluginUpdateManagerContextProvider = ( {
+	siteSlug,
+	children,
+}: PluginUpdateManagerContextProps & { children: ReactNode } ) => (
+	<PluginUpdateManagerContext.Provider value={ { siteSlug } }>
+		{ children }
+	</PluginUpdateManagerContext.Provider>
+);
+
+export { PluginUpdateManagerContext, PluginUpdateManagerContextProvider };

--- a/client/blocks/plugins-update-manager/hooks/use-site-slug.ts
+++ b/client/blocks/plugins-update-manager/hooks/use-site-slug.ts
@@ -1,0 +1,7 @@
+import { useContext } from 'react';
+import { PluginUpdateManagerContext } from '../context';
+
+export function useSiteSlug() {
+	const { siteSlug } = useContext( PluginUpdateManagerContext );
+	return siteSlug;
+}

--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -5,6 +5,7 @@ import MainComponent from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updates-query';
 import { MAX_SCHEDULES } from './config';
+import { PluginUpdateManagerContextProvider } from './context';
 import { ScheduleCreate } from './schedule-create';
 import { ScheduleEdit } from './schedule-edit';
 import { ScheduleList } from './schedule-list';
@@ -28,7 +29,6 @@ export const PluginsUpdateManager = ( props: Props ) => {
 		list: {
 			component: (
 				<ScheduleList
-					siteSlug={ siteSlug }
 					onNavBack={ onNavBack }
 					onCreateNewSchedule={ onCreateNewSchedule }
 					onEditSchedule={ onEditSchedule }
@@ -37,39 +37,41 @@ export const PluginsUpdateManager = ( props: Props ) => {
 			title: 'List schedules',
 		},
 		create: {
-			component: <ScheduleCreate siteSlug={ siteSlug } onNavBack={ onNavBack } />,
+			component: <ScheduleCreate onNavBack={ onNavBack } />,
 			title: 'Create a new schedule',
 		},
 		edit: {
 			component: (
-				<ScheduleEdit siteSlug={ siteSlug } scheduleId={ scheduleId } onNavBack={ onNavBack } />
+				<ScheduleEdit scheduleId={ scheduleId } onNavBack={ onNavBack } />
 			),
 			title: 'Edit schedule',
 		},
 	}[ context ];
 
 	return (
-		<MainComponent wideLayout>
+		<PluginUpdateManagerContextProvider siteSlug={ siteSlug }>
 			<DocumentHead title={ title } />
 
-			<NavigationHeader
-				navigationItems={ [] }
-				title="Plugin updates manager"
-				subtitle="Effortlessly schedule plugin auto-updates with built-in rollback logic."
-			>
-				{ context === 'list' && ! hideCreateButton && onCreateNewSchedule && (
-					<Button
-						__next40pxDefaultSize
-						icon={ plus }
-						variant="primary"
-						onClick={ onCreateNewSchedule }
-					>
-						Create a new schedule
-					</Button>
-				) }
-			</NavigationHeader>
+			<MainComponent wideLayout>
+				<NavigationHeader
+					navigationItems={ [] }
+					title="Plugin updates manager"
+					subtitle="Effortlessly schedule plugin auto-updates with built-in rollback logic."
+				>
+					{ context === 'list' && ! hideCreateButton && onCreateNewSchedule && (
+						<Button
+							__next40pxDefaultSize
+							icon={ plus }
+							variant="primary"
+							onClick={ onCreateNewSchedule }
+						>
+							Create a new schedule
+						</Button>
+					) }
+				</NavigationHeader>
+				{ component }
 
-			{ component }
-		</MainComponent>
+			</MainComponent>
+		</PluginUpdateManagerContextProvider>
 	);
 };

--- a/client/blocks/plugins-update-manager/schedule-create.tsx
+++ b/client/blocks/plugins-update-manager/schedule-create.tsx
@@ -7,15 +7,13 @@ import {
 	CardFooter,
 } from '@wordpress/components';
 import { arrowLeft } from '@wordpress/icons';
-import { SiteSlug } from 'calypso/types';
 import { ScheduleForm } from './schedule-form';
 
 interface Props {
-	siteSlug: SiteSlug;
 	onNavBack?: () => void;
 }
 export const ScheduleCreate = ( props: Props ) => {
-	const { siteSlug, onNavBack } = props;
+	const { onNavBack } = props;
 
 	return (
 		<Card className="plugins-update-manager">
@@ -31,7 +29,7 @@ export const ScheduleCreate = ( props: Props ) => {
 				<div className="ch-placeholder"></div>
 			</CardHeader>
 			<CardBody>
-				<ScheduleForm siteSlug={ siteSlug } onSyncSuccess={ () => onNavBack && onNavBack() } />
+				<ScheduleForm onSyncSuccess={ () => onNavBack && onNavBack() } />
 			</CardBody>
 			<CardFooter>
 				<Button form="schedule" type="submit" variant="primary">

--- a/client/blocks/plugins-update-manager/schedule-edit.tsx
+++ b/client/blocks/plugins-update-manager/schedule-edit.tsx
@@ -8,16 +8,17 @@ import {
 } from '@wordpress/components';
 import { arrowLeft } from '@wordpress/icons';
 import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updates-query';
-import { SiteSlug } from 'calypso/types';
+import { useSiteSlug } from './hooks/use-site-slug';
 import { ScheduleForm } from './schedule-form';
 
 interface Props {
-	siteSlug: SiteSlug;
 	scheduleId?: string;
 	onNavBack?: () => void;
 }
 export const ScheduleEdit = ( props: Props ) => {
-	const { siteSlug, scheduleId, onNavBack } = props;
+	const siteSlug = useSiteSlug();
+
+	const { scheduleId, onNavBack } = props;
 	const { data: schedules = [], isFetched } = useScheduleUpdatesQuery( siteSlug );
 	const schedule = schedules.find( ( s ) => s.id === scheduleId );
 
@@ -43,7 +44,6 @@ export const ScheduleEdit = ( props: Props ) => {
 			<CardBody>
 				{ schedule && (
 					<ScheduleForm
-						siteSlug={ siteSlug }
 						scheduleForEdit={ schedule }
 						onSyncSuccess={ () => onNavBack && onNavBack() }
 					/>

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -23,8 +23,8 @@ import {
 	useScheduleUpdatesQuery,
 	ScheduleUpdates,
 } from 'calypso/data/plugins/use-schedule-updates-query';
-import { SiteSlug } from 'calypso/types';
 import { MAX_SELECTABLE_PLUGINS } from './config';
+import { useSiteSlug } from './hooks/use-site-slug';
 import {
 	DAILY_OPTION,
 	DAY_OPTIONS,
@@ -43,13 +43,13 @@ import {
 import './schedule-form.scss';
 
 interface Props {
-	siteSlug: SiteSlug;
 	scheduleForEdit?: ScheduleUpdates;
 	onSyncSuccess?: () => void;
 }
 export const ScheduleForm = ( props: Props ) => {
 	const moment = useLocalizedMoment();
-	const { siteSlug, scheduleForEdit, onSyncSuccess } = props;
+	const siteSlug = useSiteSlug();
+	const { scheduleForEdit, onSyncSuccess } = props;
 	const initDate = scheduleForEdit
 		? moment( scheduleForEdit?.timestamp * 1000 )
 		: moment( new Date() ).hour( DEFAULT_HOUR );

--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -5,15 +5,16 @@ import { usePreparePluginsTooltipInfo } from 'calypso/blocks/plugins-update-mana
 import { ellipsis } from 'calypso/blocks/plugins-update-manager/icons';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updates-query';
+import { useSiteSlug } from './hooks/use-site-slug';
 
 interface Props {
-	siteSlug: string;
 	onEditClick: ( id: string ) => void;
 	onRemoveClick: ( id: string ) => void;
 }
 export const ScheduleListCards = ( props: Props ) => {
+	const siteSlug = useSiteSlug();
 	const moment = useLocalizedMoment();
-	const { siteSlug, onEditClick, onRemoveClick } = props;
+	const { onEditClick, onRemoveClick } = props;
 	const { data: schedules = [] } = useScheduleUpdatesQuery( siteSlug );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 

--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -4,16 +4,17 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updates-query';
 import { MOMENT_TIME_FORMAT } from './config';
 import { usePreparePluginsTooltipInfo } from './hooks/use-prepare-plugins-tooltip-info';
+import { useSiteSlug } from './hooks/use-site-slug';
 import { ellipsis } from './icons';
 
 interface Props {
-	siteSlug: string;
 	onEditClick: ( id: string ) => void;
 	onRemoveClick: ( id: string ) => void;
 }
 export const ScheduleListTable = ( props: Props ) => {
+	const siteSlug = useSiteSlug();
 	const moment = useLocalizedMoment();
-	const { siteSlug, onEditClick, onRemoveClick } = props;
+	const { onEditClick, onRemoveClick } = props;
 	const { data: schedules = [] } = useScheduleUpdatesQuery( siteSlug );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
 

--- a/client/blocks/plugins-update-manager/schedule-list.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list.tsx
@@ -13,13 +13,12 @@ import { useState } from 'react';
 import { useDeleteScheduleUpdatesMutation } from 'calypso/data/plugins/use-schedule-updates-mutation';
 import { useScheduleUpdatesQuery } from 'calypso/data/plugins/use-schedule-updates-query';
 import { MAX_SCHEDULES } from './config';
+import { useSiteSlug } from './hooks/use-site-slug';
 import { ScheduleListCards } from './schedule-list-cards';
 import { ScheduleListEmpty } from './schedule-list-empty';
 import { ScheduleListTable } from './schedule-list-table';
-import type { SiteSlug } from 'calypso/types';
 
 interface Props {
-	siteSlug: SiteSlug;
 	onNavBack?: () => void;
 	onCreateNewSchedule?: () => void;
 	onEditSchedule: ( id: string ) => void;
@@ -27,7 +26,9 @@ interface Props {
 export const ScheduleList = ( props: Props ) => {
 	const isMobile = useMobileBreakpoint();
 
-	const { siteSlug, onNavBack, onCreateNewSchedule, onEditSchedule } = props;
+	const siteSlug = useSiteSlug();
+
+	const { onNavBack, onCreateNewSchedule, onEditSchedule } = props;
 	const [ removeDialogOpen, setRemoveDialogOpen ] = useState( false );
 	const [ selectedScheduleId, setSelectedScheduleId ] = useState< undefined | string >();
 
@@ -86,13 +87,11 @@ export const ScheduleList = ( props: Props ) => {
 						<>
 							{ isMobile ? (
 								<ScheduleListCards
-									siteSlug={ siteSlug }
 									onRemoveClick={ openRemoveDialog }
 									onEditClick={ onEditSchedule }
 								/>
 							) : (
 								<ScheduleListTable
-									siteSlug={ siteSlug }
 									onRemoveClick={ openRemoveDialog }
 									onEditClick={ onEditSchedule }
 								/>


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/88140

## Proposed Changes

* Introduces `PluginUpdateManagerContextProvider`, which provides an object containing `siteSlug`
* Introduces `useSiteSlug` hook to fetch the siteSlug from context in one function call

## Testing Instructions

1. Apply this PR
2. Visit `http://calypso.localhost:3000/plugins/scheduled-updates/<youratomic.blog>`
4. Do a regression test

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?