### PR TITLE
Add hotjar to Stepper

### DIFF
--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -4,6 +4,7 @@ import { initializeAnalytics } from '@automattic/calypso-analytics';
 import { CurrentUser } from '@automattic/calypso-analytics/dist/types/utils/current-user';
 import config from '@automattic/calypso-config';
 import { User as UserStore } from '@automattic/data-stores';
+import { IMPORT_HOSTED_SITE_FLOW } from '@automattic/onboarding';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useDispatch } from '@wordpress/data';
 import defaultCalypsoI18n from 'i18n-calypso';
@@ -15,6 +16,7 @@ import { setupErrorLogger } from 'calypso/boot/common';
 import { setupLocale } from 'calypso/boot/locale';
 import AsyncLoad from 'calypso/components/async-load';
 import CalypsoI18nProvider from 'calypso/components/calypso-i18n-provider';
+import { addHotJarScript } from 'calypso/lib/analytics/hotjar';
 import getSuperProps from 'calypso/lib/analytics/super-props';
 import { initializeCurrentUser } from 'calypso/lib/user/shared-utils';
 import { createReduxStore } from 'calypso/state';
@@ -74,7 +76,9 @@ window.AppBoot = async () => {
 	requestAllBlogsAccess();
 
 	setupWpDataDebug();
-	// addHotJarScript(); // Disabled temporarily.
+
+	const flowNameFromPathName = window.location.pathname.split( '/' )[ 2 ];
+	flowNameFromPathName === IMPORT_HOSTED_SITE_FLOW && addHotJarScript(); // Disabled temporarily.
 
 	// Add accessible-focus listener.
 	accessibleFocus();

--- a/client/landing/stepper/index.tsx
+++ b/client/landing/stepper/index.tsx
@@ -78,7 +78,7 @@ window.AppBoot = async () => {
 	setupWpDataDebug();
 
 	const flowNameFromPathName = window.location.pathname.split( '/' )[ 2 ];
-	flowNameFromPathName === IMPORT_HOSTED_SITE_FLOW && addHotJarScript(); // Disabled temporarily.
+	flowNameFromPathName === IMPORT_HOSTED_SITE_FLOW && addHotJarScript();
 
 	// Add accessible-focus listener.
 	accessibleFocus();


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->



## Proposed Changes

* Refer pdDR7T-1oU-p2#comment-1689. This PR enables Hotjar in the Stepper flow.
* We currently restrict Hotjar to the import flow, so that we can maximise the sessions in the Free plan of Hotjar.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Since the 'ad-tracking' config is only enabled in production, manually change the value to true and then re-run the Calypso build process.

https://github.com/Automattic/wp-calypso/blob/8abbe89d443c737d8ac47b9b5d243a5cfff096e8/config/development.json#L32

* Go to `http://calypso.localhost:3000/setup/import-hosted-site/import` and verify in the network log that the Hotjar script if fired. You should be proxied through a non-GDPR country since Hotjar is disabled by default unless you change cookie settings in the banner. Verify the country_code cookie in your browser is set to something that is not "unknown" or to a GDPR / CCPA geo.
* Configure on the Hotjar admin panel to fire a survey for this URL path, and verify that you can see the survey. 

