### PR TITLE
Patterns: Show navigation bar footer when user is logged-in

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -18,7 +18,6 @@ import OauthClientMasterbar from 'calypso/layout/masterbar/oauth-client';
 import WooCoreProfilerMasterbar from 'calypso/layout/masterbar/woo-core-profiler';
 import isJetpackCloud from 'calypso/lib/jetpack/is-jetpack-cloud';
 import { isWpMobileApp } from 'calypso/lib/mobile-app';
-import { navigate } from 'calypso/lib/navigate';
 import {
 	isCrowdsignalOAuth2Client,
 	isWooOAuth2Client,
@@ -247,14 +246,8 @@ const LayoutLoggedOut = ( {
 
 			{ [ 'plugins' ].includes( sectionName ) && (
 				<>
-					<UniversalNavbarFooter
-						currentRoute={ currentRoute }
-						isLoggedIn={ isLoggedIn }
-						onLanguageChange={ ( e ) => {
-							navigate( `/${ e.target.value + pathNameWithoutLocale }` );
-							window.location.reload();
-						} }
-					/>
+					<UniversalNavbarFooter currentRoute={ currentRoute } isLoggedIn={ isLoggedIn } />
+
 					{ config.isEnabled( 'layout/support-article-dialog' ) && (
 						<AsyncLoad require="calypso/blocks/support-article-dialog" placeholder={ null } />
 					) }
@@ -263,14 +256,7 @@ const LayoutLoggedOut = ( {
 
 			{ [ 'patterns', 'reader', 'theme', 'themes' ].includes( sectionName ) &&
 				! isReaderTagEmbed && (
-					<UniversalNavbarFooter
-						onLanguageChange={ ( e ) => {
-							navigate( `/${ e.target.value + pathNameWithoutLocale }` );
-							window.location.reload();
-						} }
-						currentRoute={ currentRoute }
-						isLoggedIn={ isLoggedIn }
-					/>
+					<UniversalNavbarFooter currentRoute={ currentRoute } isLoggedIn={ isLoggedIn } />
 				) }
 
 			{ ! isLoggedIn && ! isReaderTagEmbed && (

--- a/client/my-sites/patterns/index.node.tsx
+++ b/client/my-sites/patterns/index.node.tsx
@@ -26,6 +26,7 @@ function fetchCategoriesAndPatterns( context: RouterContext, next: RouterNext ) 
 
 	if ( cachedMarkup ) {
 		next();
+
 		return;
 	}
 

--- a/client/my-sites/patterns/style.scss
+++ b/client/my-sites/patterns/style.scss
@@ -10,6 +10,12 @@
 		}
 	}
 
+	.layout__primary {
+		.main {
+			padding-bottom: 0;
+		}
+	}
+
 	.is-logged-in {
 		.lpc-header-nav-wrapper {
 			padding-top: 32px;

--- a/client/my-sites/patterns/wrapper.tsx
+++ b/client/my-sites/patterns/wrapper.tsx
@@ -1,13 +1,9 @@
-import page from '@automattic/calypso-router';
-import { removeLocaleFromPathLocaleInFront } from '@automattic/i18n-utils';
 import { UniversalNavbarFooter, UniversalNavbarHeader } from '@automattic/wpcom-template-parts';
-import { ChangeEvent } from 'react';
 import Main from 'calypso/components/main';
 import { PatternsCategoryPage } from 'calypso/my-sites/patterns/pages/category';
 import { PatternsHomePage } from 'calypso/my-sites/patterns/pages/home';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
-import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import type { PatternGalleryFC } from 'calypso/my-sites/patterns/types';
 
 import './style.scss';
@@ -24,15 +20,6 @@ export const PatternsWrapper = ( {
 	patternGallery: PatternGallery,
 }: PatternsWrapperProps ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
-	const currentRoute = useSelector( getCurrentRoute );
-
-	const pathNameWithoutLocale = currentRoute && removeLocaleFromPathLocaleInFront( currentRoute );
-
-	const onLanguageChange = ( event: ChangeEvent< HTMLSelectElement > ) => {
-		page( `/${ event.target.value + pathNameWithoutLocale }` );
-
-		window.location.reload();
-	};
 
 	return (
 		<>
@@ -50,7 +37,7 @@ export const PatternsWrapper = ( {
 				) }
 			</Main>
 
-			{ isLoggedIn && <UniversalNavbarFooter isLoggedIn onLanguageChange={ onLanguageChange } /> }
+			{ isLoggedIn && <UniversalNavbarFooter isLoggedIn /> }
 		</>
 	);
 };

--- a/client/my-sites/patterns/wrapper.tsx
+++ b/client/my-sites/patterns/wrapper.tsx
@@ -1,9 +1,13 @@
-import { UniversalNavbarHeader } from '@automattic/wpcom-template-parts';
+import page from '@automattic/calypso-router';
+import { removeLocaleFromPathLocaleInFront } from '@automattic/i18n-utils';
+import { UniversalNavbarFooter, UniversalNavbarHeader } from '@automattic/wpcom-template-parts';
+import { ChangeEvent } from 'react';
 import Main from 'calypso/components/main';
 import { PatternsCategoryPage } from 'calypso/my-sites/patterns/pages/category';
 import { PatternsHomePage } from 'calypso/my-sites/patterns/pages/home';
 import { useSelector } from 'calypso/state';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
+import { getCurrentRoute } from 'calypso/state/selectors/get-current-route';
 import type { PatternGalleryFC } from 'calypso/my-sites/patterns/types';
 
 import './style.scss';
@@ -20,6 +24,15 @@ export const PatternsWrapper = ( {
 	patternGallery: PatternGallery,
 }: PatternsWrapperProps ) => {
 	const isLoggedIn = useSelector( isUserLoggedIn );
+	const currentRoute = useSelector( getCurrentRoute );
+
+	const pathNameWithoutLocale = currentRoute && removeLocaleFromPathLocaleInFront( currentRoute );
+
+	const onLanguageChange = ( event: ChangeEvent< HTMLSelectElement > ) => {
+		page( `/${ event.target.value + pathNameWithoutLocale }` );
+
+		window.location.reload();
+	};
 
 	return (
 		<>
@@ -36,6 +49,8 @@ export const PatternsWrapper = ( {
 					/>
 				) }
 			</Main>
+
+			{ isLoggedIn && <UniversalNavbarFooter isLoggedIn onLanguageChange={ onLanguageChange } /> }
 		</>
 	);
 };

--- a/client/site-profiler/controller.tsx
+++ b/client/site-profiler/controller.tsx
@@ -1,7 +1,6 @@
 import config from '@automattic/calypso-config';
 import page, { type Callback } from '@automattic/calypso-router';
 import { UniversalNavbarFooter } from '@automattic/wpcom-template-parts';
-import { ChangeEvent } from 'react';
 import Main from 'calypso/components/main';
 import SiteProfiler from 'calypso/site-profiler/components/site-profiler';
 import { isUserLoggedIn } from 'calypso/state/current-user/selectors';
@@ -43,17 +42,13 @@ export const siteProfilerContext: Callback = ( context, next ) => {
 	const pathName = context.pathname || '';
 	const routerDomain = pathName.split( '/site-profiler/' )[ 1 ]?.trim() || '';
 
-	const onLanguageChange = ( e: ChangeEvent< HTMLSelectElement > ) => {
-		page( `/${ e.target.value + pathName }` );
-		window.location.reload();
-	};
-
 	context.primary = (
 		<>
 			<Main fullWidthLayout>
 				<SiteProfiler routerDomain={ routerDomain } />
 			</Main>
-			<UniversalNavbarFooter isLoggedIn={ isLoggedIn } onLanguageChange={ onLanguageChange } />
+
+			<UniversalNavbarFooter isLoggedIn={ isLoggedIn } />
 		</>
 	);
 

--- a/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
+++ b/packages/wpcom-template-parts/src/universal-footer-navigation/index.tsx
@@ -18,10 +18,9 @@ import './style.scss';
 const useIsomorphicEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 const defaultOnLanguageChange: React.ChangeEventHandler< HTMLSelectElement > = ( event ) => {
-	const newURL = `${ event.target.value }${ removeLocaleFromPathLocaleInFront(
-		window.location.pathname
-	) }`;
-	window.location.href = newURL;
+	const pathWithoutLocale = removeLocaleFromPathLocaleInFront( window.location.pathname );
+
+	window.location.href = `/${ event.target.value }${ pathWithoutLocale }`;
 };
 
 const allLanguageOptions: LanguageOptions = {


### PR DESCRIPTION
This pull request is a follow-up of https://github.com/Automattic/wp-calypso/pull/88200 which addresses https://github.com/Automattic/dotcom-forge/issues/5847 by adding the navigation bar footer to the bottom of the `Patterns` page when the user is logged in (previously we would only display it to logged-out users):

![image](https://github.com/Automattic/wp-calypso/assets/594356/f1116afd-29b0-479a-aaf0-15efd82038d3)

Finally it simplifies code relate to language switching.

#### Testing instructions

1. Run `git checkout update/patterns-footer` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/88245#issuecomment-1981174218)
2. Open the [`Patterns` page](http://calypso.localhost:3000/patterns) while logged in
3. Assert that a footer is now displayed 
4. Open the page while logged out now
5. Assert that the language switcher works
6. Open the [`Plugins` page](http://calypso.localhost:3000/es/plugins) and check the same
7. Open the [`Themes` page](http://calypso.localhost:3000/fr/themes) and check the same
8. Open the [`Site Profiler` page](http://calypso.localhost:3000/site-profiler) and check the same