### PR TITLE
Global Sidebar - update tooltip styles

### DIFF
--- a/client/layout/global-sidebar/style.scss
+++ b/client/layout/global-sidebar/style.scss
@@ -25,12 +25,13 @@ $brand-text: "SF Pro Text", $sans;
 			line-height: 20px;
 			background: var(--studio-white);
 			border-radius: 4px;
-			bottom: -30px;
+			bottom: -24px;
 			color: var(--studio-black);
 			content: attr(data-tooltip);
 			display: none;
-			font-size: $font-body-small;
-			padding: 6px 10px;
+			font-size: $font-body-extra-small;
+			opacity: 0.95;
+			padding: 3px 6px;
 			position: absolute;
 			right: 0;
 			white-space: nowrap;
@@ -54,7 +55,7 @@ $brand-text: "SF Pro Text", $sans;
 			right: unset;
 			bottom: unset;
 			left: 0;
-			top: -35px;
+			top: -29px;
 		}
 	}
 


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/dotcom-forge/issues/5931 

## Proposed Changes

* Updates the styles for tooltips in the global nav per the issue.

Before

<img width="288" alt="Screenshot 2024-03-06 at 11 57 11 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/d0bf30f2-77e2-4cbd-afcf-779616a05947">


After

<img width="300" alt="Screenshot 2024-03-06 at 11 56 43 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/d0ad5083-320b-4150-a2e3-f3e3c3f3923e">




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch and hover to see tooltips in the global nav header and footer.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
