### PR TITLE
Site migration: Use new UI on the import or migrate screen

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -1,6 +1,13 @@
-import { Button } from '@automattic/components';
-import { StepContainer } from '@automattic/onboarding';
+import {
+	NextButton,
+	StepContainer,
+	Title,
+	SelectCardRadio,
+	SelectCardRadioList,
+} from '@automattic/onboarding';
 import { useTranslate } from 'i18n-calypso';
+import { useState, useCallback } from 'react';
+import DocumentHead from 'calypso/components/data/document-head';
 import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
@@ -11,44 +18,68 @@ type SubmitDestination = 'import' | 'migrate' | 'upgrade';
 const SiteMigrationImportOrMigrate: Step = function ( { navigation } ) {
 	const translate = useTranslate();
 	const site = useSite();
+	const options = [
+		{
+			label: translate( 'Everything (requires a Creator Plan)' ),
+			description: translate(
+				"All your site's content, themes, plugins, users, and customizations."
+			),
+			value: 'migrate',
+			selected: true,
+		},
+		{
+			label: translate( 'Content only (free)' ),
+			description: translate( 'Import just posts, pages, comments, and media.' ),
+			value: 'import',
+		},
+	];
+
+	const [ destination, setDestination ] = useState< SubmitDestination >(
+		( options.find( ( o ) => o.selected )?.value ?? options[ 0 ].value ) as SubmitDestination
+	);
+
 	const canInstallPlugins = site?.plan?.features?.active.find(
 		( feature ) => feature === 'install-plugins'
 	)
 		? true
 		: false;
 
-	const handleSubmit = ( destination: SubmitDestination ) => {
-		navigation.submit?.( { destination } );
-	};
+	const handleSubmit = useCallback( () => {
+		if ( destination === 'migrate' && ! canInstallPlugins ) {
+			return navigation.submit?.( { destination: 'upgrade' } );
+		}
+		return navigation.submit?.( { destination } );
+	}, [ destination, navigation, canInstallPlugins ] );
 
 	const stepContent = (
-		<div className="migration-info">
-			<div className="migration-info-column">
-				<h2>{ translate( 'Import' ) }</h2>
-				<Button primary onClick={ () => handleSubmit( 'import' ) }>
-					{ translate( 'Import my website content' ) }
-				</Button>
-			</div>
-			<div className="migration-info-column">
-				<h2>{ translate( 'Migrate' ) }</h2>
-				<Button
-					primary
-					onClick={ () => {
-						handleSubmit( canInstallPlugins ? 'migrate' : 'upgrade' );
-					} }
-				>
-					{ canInstallPlugins ? translate( 'Migrate my site' ) : translate( 'Upgrade to migrate' ) }
-				</Button>
-			</div>
+		<div className="import-or-migrate__content">
+			<Title className="import-or-migrate__title">
+				{ translate( 'What do you want to migrate?' ) }
+			</Title>
+
+			<SelectCardRadioList className="import-or-migrate__list">
+				{ options.map( ( option, i ) => (
+					<SelectCardRadio
+						key={ i }
+						option={ option }
+						name="import-or-migrate"
+						onChange={ () => {
+							setDestination( option.value as SubmitDestination );
+						} }
+					/>
+				) ) }
+			</SelectCardRadioList>
+			<NextButton onClick={ handleSubmit }>{ translate( 'Continue' ) }</NextButton>
 		</div>
 	);
 
 	return (
 		<>
+			<DocumentHead title={ translate( 'Where will you import from?' ) } />
 			<StepContainer
-				stepName="site-migration-source"
+				stepName="site-migration-import-or-migrate"
+				className="import-or-migrate"
 				shouldHideNavButtons={ false }
-				className="is-step-site-migration-source"
 				hideSkip={ true }
 				hideBack={ true }
 				stepContent={ stepContent }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/index.tsx
@@ -75,7 +75,7 @@ const SiteMigrationImportOrMigrate: Step = function ( { navigation } ) {
 
 	return (
 		<>
-			<DocumentHead title={ translate( 'Where will you import from?' ) } />
+			<DocumentHead title={ translate( 'What do you want to migrate?' ) } />
 			<StepContainer
 				stepName="site-migration-import-or-migrate"
 				className="import-or-migrate"

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
@@ -1,8 +1,11 @@
 .import-or-migrate {
-	width: 602px;
+	max-width: 602px;
+	padding: 0 12px;
+
 
 	.import-or-migrate__title {
 		font-size: 2.75rem;
+		text-align: center;
 	}
 
 	.import-or-migrate__content {

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/style.scss
@@ -1,15 +1,18 @@
-/* stylelint-disable-next-line scss/at-import-no-partial-leading-underscore */
-@import "calypso/assets/stylesheets/shared/_loading";
-@import "@automattic/onboarding/styles/mixins";
+.import-or-migrate {
+	width: 602px;
 
-.site-migration-import-or-migrate {
-	.migration-info {
+	.import-or-migrate__title {
+		font-size: 2.75rem;
+	}
+
+	.import-or-migrate__content {
 		display: flex;
-		flex-direction: row;
+		flex-direction: column;
+		gap: 80px;
+		align-items: center;
+	}
 
-		.migration-info-column {
-			width: 45%;
-			margin-right: 1rem;
-		}
+	.import-or-migrate__list {
+		width: 100%;
 	}
 }

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/test/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-import-or-migrate/test/index.tsx
@@ -1,0 +1,70 @@
+/**
+ * @jest-environment jsdom
+ */
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
+import SiteMigrationImportOrMigrate from '..';
+import { StepProps } from '../../../types';
+import { renderStep, mockStepProps } from '../../test/helpers';
+
+const render = ( props?: Partial< StepProps > ) => {
+	const combinedProps = { ...mockStepProps( props ) };
+	return renderStep( <SiteMigrationImportOrMigrate { ...combinedProps } /> );
+};
+
+jest.mock( 'calypso/landing/stepper/hooks/use-site' );
+
+( useSite as jest.Mock ).mockReturnValue( {
+	plan: { features: { active: [ 'install-plugins' ] } },
+} );
+describe( 'Site Migration Import or Migrate Step', () => {
+	it( 'renders the migration options', () => {
+		render();
+
+		expect( screen.getByRole( 'radio', { name: /Content only/ } ) ).toBeVisible();
+		expect( screen.getByRole( 'radio', { name: /Everything/ } ) ).toBeVisible();
+	} );
+
+	it( 'starts the migration as default option', async () => {
+		const submit = jest.fn();
+		render( { navigation: { submit } } );
+
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+		expect( submit ).toHaveBeenCalledWith( { destination: 'migrate' } );
+	} );
+
+	it( 'starts the import flow when the user selects the "Content only" option', async () => {
+		const submit = jest.fn();
+		render( { navigation: { submit } } );
+
+		await userEvent.click( screen.getByRole( 'radio', { name: /Content only/ } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+
+		expect( submit ).toHaveBeenCalledWith( { destination: 'import' } );
+	} );
+
+	it( 'starts the migration only when the user selects the "Everything" option', async () => {
+		const submit = jest.fn();
+		render( { navigation: { submit } } );
+
+		await userEvent.click( screen.getByRole( 'radio', { name: /Everything/ } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+
+		expect( submit ).toHaveBeenCalledWith( { destination: 'migrate' } );
+	} );
+
+	it( 'starts the upgrade flow when the current site can NOT install plugins', async () => {
+		( useSite as jest.Mock ).mockReturnValue( {
+			plan: { features: { active: [] } },
+		} );
+		const submit = jest.fn();
+		render( { navigation: { submit } } );
+
+		await userEvent.click( screen.getByRole( 'radio', { name: /Everything/ } ) );
+		await userEvent.click( screen.getByRole( 'button', { name: /Continue/ } ) );
+
+		expect( submit ).toHaveBeenCalledWith( { destination: 'upgrade' } );
+	} );
+} );

--- a/packages/onboarding/src/index.ts
+++ b/packages/onboarding/src/index.ts
@@ -30,6 +30,7 @@ export * from './navigator';
 export { default as Notice } from './notice';
 export { default as SelectCardCheckbox } from './select-card-checkbox';
 export * from './utils';
+export * from './select-card-radio';
 export type { SelectItem } from './select-items';
 export type { SelectItemAlt } from './select-items-alt';
 export type { MShotsOptions } from './mshots-image';

--- a/packages/onboarding/src/select-card-radio/index.tsx
+++ b/packages/onboarding/src/select-card-radio/index.tsx
@@ -1,0 +1,64 @@
+import classNames from 'classnames';
+import { useId, type FC, type ReactNode, ReactElement, useCallback } from 'react';
+import './style.scss';
+
+interface Option {
+	label: ReactNode;
+	description?: ReactNode;
+	value: string;
+	selected?: boolean;
+}
+
+interface SelectCardRadioProps {
+	option: Option;
+	onChange: ( value: Option[ 'value' ] ) => void;
+	name: string;
+	className?: string;
+}
+
+export const SelectCardRadio: FC< SelectCardRadioProps > = ( {
+	option,
+	onChange,
+	name,
+	className,
+} ) => {
+	const id = useId();
+
+	const handleChange = useCallback(
+		( event: React.ChangeEvent< HTMLInputElement > ) => {
+			onChange?.( event.target.value );
+		},
+		[ onChange ]
+	);
+
+	return (
+		<label
+			htmlFor={ `${ id }-radio` }
+			aria-labelledby={ `${ id }-info` }
+			className={ classNames( 'select-card-radio', className ) }
+		>
+			<input
+				type="radio"
+				className="select-card-radio__input"
+				id={ `${ id }-radio` }
+				value={ option.value }
+				defaultChecked={ option.selected }
+				onChange={ handleChange }
+				name={ name }
+			/>
+			<div className="select-card-radio__info" id={ `${ id }-info` }>
+				<span>{ option.label }</span>
+				<span className="select-card-radio__description">{ option.description }</span>
+			</div>
+		</label>
+	);
+};
+
+interface SelectCardRadioListProps {
+	className?: string;
+	children: ReactElement< typeof SelectCardRadio > | ReactElement< typeof SelectCardRadio >[];
+}
+
+export const SelectCardRadioList: FC< SelectCardRadioListProps > = ( { children, className } ) => {
+	return <div className={ classNames( 'select-card-radio__list', className ) }>{ children }</div>;
+};

--- a/packages/onboarding/src/select-card-radio/style.scss
+++ b/packages/onboarding/src/select-card-radio/style.scss
@@ -27,6 +27,7 @@
 
 	.select-card-radio__description {
 		font-weight: normal;
+		text-wrap: pretty;
 	}
 
 	.select-card-radio__input {

--- a/packages/onboarding/src/select-card-radio/style.scss
+++ b/packages/onboarding/src/select-card-radio/style.scss
@@ -8,6 +8,7 @@
 	align-items: baseline;
 	font-weight: 500;
 	width: 100%;
+	cursor: pointer;
 
 	&:hover {
 		border-color: var(--color-primary);

--- a/packages/onboarding/src/select-card-radio/style.scss
+++ b/packages/onboarding/src/select-card-radio/style.scss
@@ -7,7 +7,6 @@
 	padding: 24px 16px;
 	align-items: baseline;
 	font-weight: 500;
-	width: 100%;
 	cursor: pointer;
 
 	&:hover {

--- a/packages/onboarding/src/select-card-radio/style.scss
+++ b/packages/onboarding/src/select-card-radio/style.scss
@@ -1,0 +1,43 @@
+
+.select-card-radio {
+	border-radius: 4px;
+	border: 1px solid #dcdcde;
+	display: flex;
+	transition: all 0.15s ease-in-out;
+	padding: 24px 16px;
+	align-items: baseline;
+	font-weight: 500;
+	width: 100%;
+
+	&:hover {
+		border-color: var(--color-primary);
+	}
+
+	&:has(input:checked) {
+		border-color: var(--color-primary);
+		box-shadow: 0 0 0 2px var(--color-primary-10);
+		background-color: #f9fbfd;
+	}
+
+	.select-card-radio__info {
+		display: flex;
+		gap: 8px;
+		flex-direction: column;
+	}
+
+	.select-card-radio__description {
+		font-weight: normal;
+	}
+
+	.select-card-radio__input {
+		margin-right: 16px;
+		appearance: auto;
+	}
+
+}
+
+.select-card-radio__list {
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+}

--- a/packages/onboarding/src/select-card-radio/test/index.tsx
+++ b/packages/onboarding/src/select-card-radio/test/index.tsx
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { SelectCardRadio } from '../';
+
+describe( 'SelectCardRadio', () => {
+	const option = {
+		label: 'Some label',
+		description: 'Some description',
+		value: 'some-value',
+	};
+
+	const defaultProps = {
+		option: option,
+		onChange: jest.fn(),
+		name: 'radio-name',
+	};
+
+	it( 'shows all available options', () => {
+		render( <SelectCardRadio { ...defaultProps } /> );
+
+		expect( screen.getByText( /Some label/ ) ).toBeVisible();
+		expect( screen.getByText( /Some description/ ) ).toBeVisible();
+	} );
+
+	it( 'starts with an option selected by default', () => {
+		const selectedOption = {
+			label: 'Selected',
+			description: 'Some description',
+			value: 'some-value',
+			selected: true,
+		};
+
+		render( <SelectCardRadio { ...defaultProps } option={ selectedOption } /> );
+
+		expect( screen.getByRole( 'radio', { name: /Selected/ } ) ).toBeChecked();
+	} );
+
+	it( 'trigges the onChange event when an option is selected', async () => {
+		const onChange = jest.fn();
+		render( <SelectCardRadio { ...defaultProps } onChange={ onChange } /> );
+
+		await userEvent.click( screen.getByRole( 'radio' ) );
+
+		expect( onChange ).toHaveBeenCalledWith( option.value );
+	} );
+} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Resolve #88189.

## Proposed Changes

* Update the import or migrate screen with the new layout.
<img width="1376" alt="image" src="https://github.com/Automattic/wp-calypso/assets/38718/f9f6e70f-7863-41a6-a634-4e6d946bdadd">


## Testing Instructions
**Scenario: Layout**
* Compare the implemented layout with the Figma file. 5yhaC6umexdQLlLpCrCyEe-fi-1935_961

**Scenario: Migration using free site** 
* Create or use any existent free site (/setup/free)
* Enable the feature flag
* Access the `/setup/site-migration/site-migration-import-or-migrate?&siteSlug=[YOUR_FREE_SITE]&flags=onboarding/new-migration-flow`
* Select `Everything (requires a Creator Plan)`
* Check if you were redirected to the upgrade screen.

**Scenario: Migration using a creator site:** 
* Enable the feature flag
* Access the `/setup/site-migration/site-migration-import-or-migrate?&siteSlug=[YOUR_CRETORS_SITE]&flags=onboarding/new-migration-flow`
* Select `Everything (requires a Creator Plan)`
* Check if you were redirected to the processing and the instructions steps.

**Scenario: Import content only:** 
* Enable the feature flag
* Access the `/setup/site-migration/site-migration-import-or-migrate?&siteSlug=[ANY_WORDPRESS_SITE ]` using any WordPress site as param
* Select `Content only site`
* Check if you were redirected to the "Import your content" selection step

NOTE: The back button and improvements on the import your content link will be implemented in other PRs.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?