### PR TITLE
Help Center - update help center icon size in wp-admin-bar

### DIFF
--- a/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.scss
+++ b/apps/editing-toolkit/editing-toolkit-plugin/help-center/src/help-center.scss
@@ -70,11 +70,13 @@ body.is-nav-unification {
 
 		svg {
 			position: absolute;
+			height: 20px;
+			width: 20px;
 			top: 0;
 			left: 0;
 			right: 0;
 			bottom: 0;
-			padding: 4px 6px;
+			padding: 6px 8px;
 		}
 
 		&.unseen-notification {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # https://github.com/Automattic/jetpack/issues/36191 

## Proposed Changes

* Updates the help center size to 20px by 20px in the wp-admin-bar (down from 24x24), adjusts the padding values corresponding to this decrease to keep the icon centered in its parent elements.


Before:

<img width="139" alt="Screenshot 2024-03-06 at 1 09 44 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/683b65d0-23c3-497e-9115-46eecab69637">


After:

<img width="187" alt="Screenshot 2024-03-06 at 1 09 35 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/afab01fd-7d1f-4c98-afb0-390663685884">



## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Patch this ETK build using instructions in comment below.
* For an atomic site you can go to the checks below and find "Build Calypso Apps" -> "details". From here, click the "artifacts" tab and down load the editing-toolkit.zip. Install this plugin via the zip file on your atomic site (and disable the other version that exists).
* Visit wp-admin for a site. Verify the icon is 20px instead of 24px, centered, and works as expected.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
