### PR TITLE
Site Migration: Add back button for site-migration-identify and site-migration-upgrade-plan

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-upgrade-plan/index.tsx
@@ -43,8 +43,8 @@ const SiteMigrationUpgradePlan: Step = function ( { navigation } ) {
 				stepName="site-migration-upgrade-plan"
 				shouldHideNavButtons={ false }
 				className="is-step-site-migration-upgrade-plan"
+				goBack={ navigation.goBack }
 				hideSkip={ true }
-				hideBack={ true }
 				formattedHeader={
 					<FormattedHeader
 						id="site-migration-instructions-header"

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -2,6 +2,7 @@ import { useLocale } from '@automattic/i18n-utils';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect } from 'react';
 import { getLocaleFromQueryParam, getLocaleFromPathname } from 'calypso/boot/locale';
+import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
 import { addQueryArgs } from 'calypso/lib/url';
 import { useSiteSlugParam } from '../hooks/use-site-slug-param';
 import { USER_STORE, ONBOARD_STORE, SITE_STORE } from '../stores';
@@ -125,6 +126,7 @@ const siteMigration: Flow = {
 			[]
 		);
 		const siteSlugParam = useSiteSlugParam();
+		const urlQueryParams = useQuery();
 
 		const { getSiteIdBySlug } = useSelect( ( select ) => select( SITE_STORE ) as SiteSelect, [] );
 		const exitFlow = ( to: string ) => {
@@ -235,8 +237,11 @@ const siteMigration: Flow = {
 		}
 
 		const goBack = () => {
-			navigate( STEPS.SITE_MIGRATION_IDENTIFY.slug );
-			// NA
+			switch ( currentStep ) {
+				case STEPS.SITE_MIGRATION_IDENTIFY.slug: {
+					return exitFlow( `/setup/site-setup/goals?${ urlQueryParams }` );
+				}
+			}
 		};
 
 		return { goBack, submit, exitFlow };

--- a/client/landing/stepper/declarative-flow/site-migration-flow.ts
+++ b/client/landing/stepper/declarative-flow/site-migration-flow.ts
@@ -241,6 +241,10 @@ const siteMigration: Flow = {
 				case STEPS.SITE_MIGRATION_IDENTIFY.slug: {
 					return exitFlow( `/setup/site-setup/goals?${ urlQueryParams }` );
 				}
+
+				case STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug: {
+					return navigate( `${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }?${ urlQueryParams }` );
+				}
 			}
 		};
 

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -98,5 +98,17 @@ describe( 'Site Migration Flow', () => {
 				state: null,
 			} );
 		} );
+
+		it( 'redirects the user to the goal step when going back from the identify step', async () => {
+			const { runUseStepNavigationGoBack } = renderFlow( siteMigrationFlow );
+
+			runUseStepNavigationGoBack( {
+				currentStep: STEPS.SITE_MIGRATION_IDENTIFY.slug,
+			} );
+
+			expect( window.location.assign ).toHaveBeenCalledWith(
+				'/setup/site-setup/goals?siteSlug=example.wordpress.com'
+			);
+		} );
 	} );
 } );

--- a/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
+++ b/client/landing/stepper/declarative-flow/test/site-migration-flow.tsx
@@ -90,11 +90,11 @@ describe( 'Site Migration Flow', () => {
 			const { runUseStepNavigationGoBack } = renderFlow( siteMigrationFlow );
 
 			runUseStepNavigationGoBack( {
-				currentStep: STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug,
+				currentStep: STEPS.SITE_MIGRATION_UPGRADE_PLAN.slug,
 			} );
 
 			expect( getFlowLocation() ).toEqual( {
-				path: '/site-migration-identify',
+				path: `/${ STEPS.SITE_MIGRATION_IMPORT_OR_MIGRATE.slug }?siteSlug=example.wordpress.com`,
 				state: null,
 			} );
 		} );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes #88205

## Proposed Changes

This adds back the top-nav "Back" button on the "Where will you import from?" and "Upgrade Plan" steps in the site migration flow.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch locally or use the calypso.live url.
* Go to http://calypso.localhost:3000/start
* Pick a Free plan.
* On the "Goals" step, add `&flags=onboarding/new-migration-flow` to the url and refresh.
* Pick the "Import existing website or content goal" and click "Continue".
* On the "Where will you import from?" step, click the "Back" button in the upper left and verify you return to the "Goals" step.
* Continue through the flow and click the "Upgrade or Migrate" button on the "Import vs Migrate" step.
* On the "Upgrade Plan" step, click the "Back" button in the upper left and verify that you return to the "Import vs Migrate" step.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
