### PR TITLE
Adjust logic for resending verification email

### DIFF
--- a/client/components/thank-you-v2/header/style.scss
+++ b/client/components/thank-you-v2/header/style.scss
@@ -36,6 +36,11 @@
 	text-align: left;
 	letter-spacing: -0.1px;
 
+	.button-plain {
+		color: var(--studio-blue-50);
+		cursor: pointer;
+	}
+
 	@include break-mobile {
 		text-align: center;
 	}

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -572,7 +572,6 @@ export class CheckoutThankYou extends Component<
 		}
 
 		/** REFACTORED REDESIGN */
-
 		if ( isRefactoredForThankYouV2( this.props ) ) {
 			let pageContent = null;
 			const domainPurchase = getDomainPurchase( purchases );
@@ -590,7 +589,12 @@ export class CheckoutThankYou extends Component<
 			} else if ( isDomainOnly( purchases ) ) {
 				pageContent = <DomainOnlyThankYou purchases={ purchases } receiptId={ receiptId } />;
 			} else if ( purchases.length === 1 && isPlan( purchases[ 0 ] ) ) {
-				pageContent = <PlanOnlyThankYou primaryPurchase={ purchases[ 0 ] } />;
+				pageContent = (
+					<PlanOnlyThankYou
+						primaryPurchase={ purchases[ 0 ] }
+						isEmailVerified={ this.props.isEmailVerified }
+					/>
+				);
 			} else if ( wasTitanEmailOnlyProduct ) {
 				const titanPurchase = purchases.find( ( purchase ) => isTitanMail( purchase ) );
 

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -59,7 +59,6 @@ import {
 	isCurrentUserEmailVerified,
 } from 'calypso/state/current-user/selectors';
 import { recordStartTransferClickInThankYou } from 'calypso/state/domains/actions';
-import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import {
 	getPlugins as getInstalledPlugins,
@@ -594,9 +593,6 @@ export class CheckoutThankYou extends Component<
 					<PlanOnlyThankYou
 						primaryPurchase={ purchases[ 0 ] }
 						isEmailVerified={ this.props.isEmailVerified }
-						errorNotice={ this.props.errorNotice }
-						removeNotice={ this.props.removeNotice }
-						successNotice={ this.props.successNotice }
 					/>
 				);
 			} else if ( wasTitanEmailOnlyProduct ) {
@@ -994,9 +990,6 @@ export default connect(
 		recordStartTransferClickInThankYou,
 		requestThenActivate,
 		requestSite,
-		errorNotice,
-		removeNotice,
-		successNotice,
 	}
 )( localize( CheckoutThankYou ) );
 

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -59,6 +59,7 @@ import {
 	isCurrentUserEmailVerified,
 } from 'calypso/state/current-user/selectors';
 import { recordStartTransferClickInThankYou } from 'calypso/state/domains/actions';
+import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { fetchSitePlugins } from 'calypso/state/plugins/installed/actions';
 import {
 	getPlugins as getInstalledPlugins,
@@ -593,6 +594,9 @@ export class CheckoutThankYou extends Component<
 					<PlanOnlyThankYou
 						primaryPurchase={ purchases[ 0 ] }
 						isEmailVerified={ this.props.isEmailVerified }
+						errorNotice={ this.props.errorNotice }
+						removeNotice={ this.props.removeNotice }
+						successNotice={ this.props.successNotice }
 					/>
 				);
 			} else if ( wasTitanEmailOnlyProduct ) {
@@ -990,6 +994,9 @@ export default connect(
 		recordStartTransferClickInThankYou,
 		requestThenActivate,
 		requestSite,
+		errorNotice,
+		removeNotice,
+		successNotice,
 	}
 )( localize( CheckoutThankYou ) );
 

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -117,13 +117,12 @@ export default function PlanOnlyThankYou( {
 			);
 
 			const isSendingEmail = resendStatus === RESEND_PENDING;
-			const isSent = resendStatus === RESEND_SUCCESS;
 
 			headerButtons = (
 				<Button
 					onClick={ resendEmail }
 					busy={ isSendingEmail }
-					disabled={ isSendingEmail || isSent }
+					disabled={ isSendingEmail || resendStatus === RESEND_SUCCESS }
 				>
 					{ resendButtonText() }
 				</Button>

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -3,12 +3,14 @@ import { Button } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
 import { useState } from 'react';
+import { connect } from 'react-redux';
 import ThankYouV2 from 'calypso/components/thank-you-v2';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { preventWidows } from 'calypso/lib/formatting';
 import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
+import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSiteOptions, getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import ThankYouPlanProduct from '../products/plan-product';
@@ -36,13 +38,13 @@ const isMonthsOld = ( months: number, rawDate?: string ) => {
 	return moment().diff( parsedDate, 'months' ) > months;
 };
 
-export default function PlanOnlyThankYou( {
+const PlanOnlyThankYou = ( {
 	primaryPurchase,
 	isEmailVerified,
 	errorNotice,
 	removeNotice,
 	successNotice,
-}: PlanOnlyThankYouProps ) {
+}: PlanOnlyThankYouProps ) => {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
 	const siteCreatedTimeStamp = useSelector(
@@ -200,4 +202,10 @@ export default function PlanOnlyThankYou( {
 			footerDetails={ footerDetails }
 		/>
 	);
-}
+};
+
+export default connect( null, {
+	errorNotice,
+	removeNotice,
+	successNotice,
+} )( PlanOnlyThankYou );

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -10,7 +10,7 @@ import wpcom from 'calypso/lib/wp';
 import { useSelector } from 'calypso/state';
 import { getCurrentUserEmail } from 'calypso/state/current-user/selectors';
 import { errorNotice, removeNotice } from 'calypso/state/notices/actions';
-import { getSiteOptions } from 'calypso/state/sites/selectors';
+import { getSiteOptions, getSiteWooCommerceUrl } from 'calypso/state/sites/selectors';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import ThankYouPlanProduct from '../products/plan-product';
 import type { ReceiptPurchase } from 'calypso/state/receipts/types';
@@ -84,15 +84,16 @@ export default function PlanOnlyThankYou( {
 	};
 
 	let subtitle;
+	// At this point in the flow, having purchased a plan for a specific site,
+	// we can be confident that `siteId` is a number and not `null`
+	const siteAdminUrl = useSelector( ( state ) => getSiteWooCommerceUrl( state, siteId as number ) );
+
 	let headerButtons;
 	if ( primaryPurchase.productSlug === 'ecommerce-bundle' ) {
 		if ( isEmailVerified ) {
 			subtitle = translate( "With the plan sorted, it's time to start setting up your store." );
-			headerButtons = (
-				<Button
-					variant="primary"
-					href={ `http://${ siteSlug }/wp-admin/admin.php?page=wc-admin&from-calypso` }
-				>
+			headerButtons = typeof siteAdminUrl === 'string' && (
+				<Button variant="primary" href={ siteAdminUrl }>
 					Create your store
 				</Button>
 			);

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -24,9 +24,9 @@ const RESEND_SUCCESS = 'RESEND_SUCCESS';
 interface PlanOnlyThankYouProps {
 	primaryPurchase: ReceiptPurchase;
 	isEmailVerified: boolean;
-	errorNotice: () => void;
-	removeNotice: () => void;
-	successNotice: () => void;
+	errorNotice: ( text: string, noticeOptions: object ) => void;
+	removeNotice: ( text: string, noticeOptions: object ) => void;
+	successNotice: ( text: string, noticeOptions: object ) => void;
 }
 
 const isMonthsOld = ( months: number, rawDate?: string ) => {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -40,7 +40,6 @@ export default function PlanOnlyThankYou( {
 }: PlanOnlyThankYouProps ) {
 	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
-	const emailAddress = useSelector( getCurrentUserEmail );
 	const siteCreatedTimeStamp = useSelector(
 		( state ) => getSiteOptions( state, siteId ?? 0 )?.created_at
 	);
@@ -83,10 +82,11 @@ export default function PlanOnlyThankYou( {
 		}
 	};
 
-	let subtitle;
 	// At this point in the flow, having purchased a plan for a specific site,
 	// we can be confident that `siteId` is a number and not `null`
 	const siteAdminUrl = useSelector( ( state ) => getSiteWooCommerceUrl( state, siteId as number ) );
+	const emailAddress = useSelector( getCurrentUserEmail );
+	let subtitle;
 
 	let headerButtons;
 	if ( primaryPurchase.productSlug === 'ecommerce-bundle' ) {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -1,5 +1,5 @@
 import { isP2Plus } from '@automattic/calypso-products';
-import { Button } from '@wordpress/components';
+import { Button } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import moment from 'moment';
 import { useState } from 'react';
@@ -93,7 +93,7 @@ export default function PlanOnlyThankYou( {
 		if ( isEmailVerified ) {
 			subtitle = translate( "With the plan sorted, it's time to start setting up your store." );
 			headerButtons = typeof siteAdminUrl === 'string' && (
-				<Button variant="primary" href={ siteAdminUrl }>
+				<Button href={ siteAdminUrl } primary>
 					Create your store
 				</Button>
 			);
@@ -113,7 +113,7 @@ export default function PlanOnlyThankYou( {
 			);
 			const isSendingEmail = resendStatus === RESEND_PENDING;
 			headerButtons = (
-				<Button variant="secondary" onClick={ resendEmail } busy={ isSendingEmail } disabled={ isSendingEmail }>
+				<Button onClick={ resendEmail } busy={ isSendingEmail } disabled={ isSendingEmail }>
 					{ resendButtonText() }
 				</Button>
 			);

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -24,9 +24,9 @@ const RESEND_SUCCESS = 'RESEND_SUCCESS';
 interface PlanOnlyThankYouProps {
 	primaryPurchase: ReceiptPurchase;
 	isEmailVerified: boolean;
-	errorNotice: ( text: string, noticeOptions: object ) => void;
-	removeNotice: ( text: string, noticeOptions: object ) => void;
-	successNotice: ( text: string, noticeOptions: object ) => void;
+	errorNotice: ( text: string, noticeOptions?: object ) => void;
+	removeNotice: ( noticeId: string ) => void;
+	successNotice: ( text: string, noticeOptions?: object ) => void;
 }
 
 const isMonthsOld = ( months: number, rawDate?: string ) => {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/plan-only.tsx
@@ -99,14 +99,21 @@ export default function PlanOnlyThankYou( {
 			);
 		} else {
 			subtitle = translate(
-				"{{paragraph}}With the plan sorted, verify your email address to create your store.{{br/}}Please click the link in the email we sent to %(emailAddress)s.{{/paragraph}}{{paragraph}}If you haven't received the verification email, please click here.{{/paragraph}}",
+				"{{paragraph}}With the plan sorted, verify your email address to create your store.{{br/}}Please click the link in the email we sent to {{strong}}%(emailAddress)s{{/strong}}.{{/paragraph}}{{paragraph}}If you haven't received the verification email, please {{a}}click here{{/a}}.{{/paragraph}}",
 				{
 					args: { emailAddress: emailAddress },
-					components: { paragraph: <p />, br: <br /> },
+					components: {
+						paragraph: <p />,
+						br: <br />,
+						strong: <strong />,
+						// eslint-disable-next-line jsx-a11y/anchor-is-valid
+						a: <a href="" onClick={ resendEmail } />,
+					},
 				}
 			);
+			const isSendingEmail = resendStatus === RESEND_PENDING;
 			headerButtons = (
-				<Button variant="secondary" onClick={ resendEmail }>
+				<Button variant="secondary" onClick={ resendEmail } busy={ isSendingEmail } disabled={ isSendingEmail }>
 					{ resendButtonText() }
 				</Button>
 			);

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/plan-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/plan-product.tsx
@@ -109,14 +109,16 @@ export default function ThankYouPlanProduct( {
 			details={ expirationDate }
 			actions={
 				<>
-					<Button
-						isBusy={ letsWorkButtonBusy }
-						variant="primary"
-						href={ letsWorkHref }
-						onClick={ letsWorkButtonOnClick }
-					>
-						{ translate( 'Let’s work on the site' ) }
-					</Button>
+					{ purchase.productSlug !== 'ecommerce-bundle' && (
+						<Button
+							isBusy={ letsWorkButtonBusy }
+							variant="primary"
+							href={ letsWorkHref }
+							onClick={ letsWorkButtonOnClick }
+						>
+							{ translate( 'Let’s work on the site' ) }
+						</Button>
+					) }
 					<Button variant="secondary" href={ `/plans/my-plan/${ siteSlug }` }>
 						{ translate( 'Manage plan' ) }
 					</Button>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/pull/88152

## Proposed Changes

* Use `<Button>` instead of an anchor tag to eliminate the linter warning mentioned in https://github.com/Automattic/wp-calypso/pull/88152#discussion_r1513568702.
* Fixed the issue where the error notice wasn't showing when email resend failed.
* Adjusted the UX such that we show a success notice when the email is sent, instead of rendering "Email sent" as a button label. Once an email is successfully sent, the button is disabled to prevent user from triggering any send request.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Adjust the endpoint per p1709747356887679/1709741415.384849-slack-C06ELHR6L9J 

2. Purchase an Entrepreneur Plan. Or if you already have one, you can navigate to the respective Congrats Page with the following path:
```
/checkout/thank-you/:site/:receipt_id
```
3. Assert that you see the description about resending the verificaton email.
 
<img width="967" alt="Screen Shot 2024-03-06 at 1 46 11 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/26b6f731-c096-4a5a-a3d6-5a970abb960f">

4. Click "Resend email". Assert that you see the error notice:

<img width="1067" alt="Screen Shot 2024-03-06 at 1 47 02 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/c3d8a31a-2811-4453-acc0-9715686204dc">

5. Apply this diff 33bf9-pb/#diff to your sandbox.

6. Click "Resend email". Assert that you see the success notice and that the "Resend email" button is disabled:

<img width="1068" alt="Screen Shot 2024-03-06 at 1 48 38 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/9d73c6db-4c6d-478d-af21-ab1cba46c09b">

