### PR TITLE
Allowing upload of plugins before going atomic

### DIFF
--- a/client/my-sites/hosting/hosting-activate-status.tsx
+++ b/client/my-sites/hosting/hosting-activate-status.tsx
@@ -5,7 +5,7 @@ import Notice from 'calypso/components/notice';
 import { useDispatch } from 'calypso/state';
 import { useAtomicTransferQuery } from 'calypso/state/atomic-transfer/use-atomic-transfer-query';
 import { fetchAutomatedTransferStatus } from 'calypso/state/automated-transfer/actions';
-import { transferStates } from 'calypso/state/automated-transfer/constants';
+import { transferInProgress, transferStates } from 'calypso/state/automated-transfer/constants';
 import { initiateThemeTransfer } from 'calypso/state/themes/actions';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { AppState } from 'calypso/types';
@@ -32,7 +32,9 @@ const HostingActivateStatus = ( {
 		refetchInterval: 5000,
 	} );
 	const dispatch = useDispatch();
-	const isTransferCompleted = transferStatus === transferStates.COMPLETED;
+	const isTransferCompleted = ! transferInProgress.includes(
+		transferStatus as ( typeof transferInProgress )[ number ]
+	);
 	const [ wasTransferring, setWasTransferring ] = useState( false );
 
 	useEffect( () => {

--- a/client/my-sites/plans/trials/trial-acknowledge/with-onclick-trial-request.tsx
+++ b/client/my-sites/plans/trials/trial-acknowledge/with-onclick-trial-request.tsx
@@ -6,7 +6,7 @@ import {
 	fetchAutomatedTransferStatus,
 	requestEligibility,
 } from 'calypso/state/automated-transfer/actions';
-import { transferStates } from 'calypso/state/automated-transfer/constants';
+import { transferInProgress, transferStates } from 'calypso/state/automated-transfer/constants';
 import {
 	getAutomatedTransferStatus,
 	isFetchingAutomatedTransferStatus,
@@ -34,7 +34,10 @@ export const WithOnclickTrialRequest = createHigherOrderComponent(
 			if ( siteId && isSiteAtomic ) {
 				return;
 			}
-			if ( ! isFetchingTransferStatus && transferStatus !== transferStates.COMPLETED ) {
+			if (
+				! isFetchingTransferStatus &&
+				transferInProgress.includes( transferStatus as ( typeof transferInProgress )[ number ] )
+			) {
 				waitFor( 2 ).then( () => dispatch( fetchAutomatedTransferStatus( siteId ) ) );
 			}
 			// Once the transferStatus is reported complete, query the sites endpoint

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -2,7 +2,7 @@ import page from '@automattic/calypso-router';
 import { Card } from '@automattic/components';
 import { localize } from 'i18n-calypso';
 import { isEmpty, flowRight } from 'lodash';
-import { Component, Fragment } from 'react';
+import { Component } from 'react';
 import { connect } from 'react-redux';
 import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import UploadDropZone from 'calypso/blocks/upload-drop-zone';
@@ -94,16 +94,8 @@ class PluginUpload extends Component {
 			? this.props.uploadPlugin
 			: this.props.initiateAutomatedTransferWithPluginZip;
 
-		const WrapperComponent = Fragment;
-
 		return (
-			<WrapperComponent>
-				<Card>
-					{ ! inProgress && ! complete && (
-						<UploadDropZone doUpload={ uploadAction } disabled={ false } />
-					) }
-				</Card>
-			</WrapperComponent>
+			<Card>{ ! inProgress && ! complete && <UploadDropZone doUpload={ uploadAction } /> }</Card>
 		);
 	}
 

--- a/client/my-sites/plugins/plugin-upload/index.jsx
+++ b/client/my-sites/plugins/plugin-upload/index.jsx
@@ -8,7 +8,6 @@ import EligibilityWarnings from 'calypso/blocks/eligibility-warnings';
 import UploadDropZone from 'calypso/blocks/upload-drop-zone';
 import QueryEligibility from 'calypso/components/data/query-atat-eligibility';
 import EmptyContent from 'calypso/components/empty-content';
-import FeatureExample from 'calypso/components/feature-example';
 import HeaderCake from 'calypso/components/header-cake';
 import Main from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
@@ -89,19 +88,19 @@ class PluginUpload extends Component {
 	};
 
 	renderUploadCard() {
-		const { inProgress, complete, isJetpack, isAtomic } = this.props;
+		const { inProgress, complete, isJetpack } = this.props;
 
 		const uploadAction = isJetpack
 			? this.props.uploadPlugin
 			: this.props.initiateAutomatedTransferWithPluginZip;
 
-		const WrapperComponent = ! isAtomic ? FeatureExample : Fragment;
+		const WrapperComponent = Fragment;
 
 		return (
 			<WrapperComponent>
 				<Card>
 					{ ! inProgress && ! complete && (
-						<UploadDropZone doUpload={ uploadAction } disabled={ ! isAtomic } />
+						<UploadDropZone doUpload={ uploadAction } disabled={ false } />
 					) }
 				</Card>
 			</WrapperComponent>


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound laabel to
the linked issue.
-->

Slack thread: p1709744214210699-slack-C02FMH4G8

## Proposed Changes

* Allow non-Atomic sites to upload a plugin, since that action will trigger the transfer and we can now show it to non-Atomic sites:

| Before | After |
|--------|--------|
|![image](https://github.com/Automattic/wp-calypso/assets/1044309/07be7c77-6cc6-481c-81f0-bbd4b1284f23) | ![image](https://github.com/Automattic/wp-calypso/assets/1044309/4922a4e7-9e22-4444-ab9c-145e9c5a737f) | 


https://github.com/Automattic/wp-calypso/assets/1044309/9b039c8d-8918-4565-9d78-683ea190867c




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Buy a creator plan from a free plan
* Try to upload a plugin on that Creator site which isn't Atomic yet

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?