### PR TITLE
Global site sidebar - add "< All Sites` menu item when on mobile

### DIFF
--- a/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
+++ b/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
@@ -19,6 +19,15 @@ export default function globalSiteSidebarMenu( {
 } ) {
 	return [
 		{
+			icon: 'dashicons-arrow-left-alt2',
+			slug: 'all-sites',
+			title: translate( 'All sites' ),
+			type: 'menu-item',
+			url: `/sites`,
+			className: 'sidebar__menu-item-all-sites',
+			shouldHide: isDesktop,
+		},
+		{
 			type: 'current-site',
 			url: `/home/${ siteDomain }`,
 			shouldHide: ! isDesktop,


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1709747521526289-slack-C06DN6QQVAQ

## Proposed Changes

Im not sure if this is the design we want (cc @davemart-in ). But this proposes a quick solution to what was mentioned in the above slack thread.

Currently there is no way to get back to "All Sites" from mobile views of the global site sidebar.  On desktop, this is linked in the header of the sidebar, but the header of sidebar is removed on mobile due to the addition of the top admin bar.

This proposes adding a `< All Sites` link on the global site view when on mobile. Desktop views remain unchanged.


BEFORE
<img width="515" alt="Screenshot 2024-03-06 at 12 44 57 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/b5147e7d-9b8b-444f-9d18-6c0568f31dee">


AFTER
<img width="563" alt="Screenshot 2024-03-06 at 2 23 31 PM" src="https://github.com/Automattic/wp-calypso/assets/28742426/9fe9ab9f-1a4f-42b4-b6cf-8979522d4de8">




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch and visit global site view of nav redesign (like on /home) on a mobile viewport.
* Verify the all sites link is present.
* View this page on a desktop viewport. There should be no < all sites link.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?