### PR TITLE
GitHub deployments: Consolidate repository search in connection screen

### DIFF
--- a/client/my-sites/github-deployments/components/deployment-style/index.tsx
+++ b/client/my-sites/github-deployments/components/deployment-style/index.tsx
@@ -14,7 +14,7 @@ import './style.scss';
 
 type DeploymentStyleProps = {
 	isDisabled: boolean;
-	repository: GitHubRepositoryData;
+	repository?: GitHubRepositoryData;
 	branchName: string;
 	workflowPath?: string;
 	onChooseWorkflow( workflowFilename: string | undefined ): void;
@@ -42,6 +42,7 @@ export const DeploymentStyle = ( {
 		refetch,
 	} = useDeploymentWorkflowsQuery( repository, branchName, {
 		refetchOnWindowFocus: false,
+		enabled: ! isDisabled,
 	} );
 
 	return (
@@ -76,7 +77,7 @@ export const DeploymentStyle = ( {
 				} }
 			/>
 
-			{ workflowPath && (
+			{ repository && workflowPath && (
 				<DeploymentStyleContext.Provider
 					value={ {
 						isCheckingWorkflow,

--- a/client/my-sites/github-deployments/components/deployment-style/use-check-workflow-query.ts
+++ b/client/my-sites/github-deployments/components/deployment-style/use-check-workflow-query.ts
@@ -19,7 +19,7 @@ export interface WorkflowsValidation {
 }
 
 interface CheckWorkflowQueryParams {
-	repository: GitHubRepositoryData;
+	repository: GitHubRepositoryData | undefined;
 	branchName: string;
 	workflowFilename?: string;
 }
@@ -32,15 +32,15 @@ export const useCheckWorkflowQuery = (
 		queryKey: [
 			GITHUB_DEPLOYMENTS_QUERY_KEY,
 			CODE_DEPLOYMENTS_QUERY_KEY,
-			repository.name,
-			repository.owner,
+			repository?.name,
+			repository?.owner,
 			branchName,
 			workflowFilename,
 		],
 		queryFn: (): WorkflowsValidation => {
 			const path = addQueryArgs( '/hosting/github/workflows/checks', {
-				repository_name: repository.name,
-				repository_owner: repository.owner,
+				repository_name: repository?.name,
+				repository_owner: repository?.owner,
 				branch_name: branchName,
 				workflow_filename: workflowFilename,
 			} );

--- a/client/my-sites/github-deployments/components/deployment-style/use-deployment-workflows-query.ts
+++ b/client/my-sites/github-deployments/components/deployment-style/use-deployment-workflows-query.ts
@@ -14,13 +14,13 @@ export interface Workflow {
 const childWorkflows = [ 'lint-css.yml', 'lint-js.yml', 'lint-php.yml' ];
 
 export const useDeploymentWorkflowsQuery = (
-	repository: GitHubRepositoryData,
+	repository: GitHubRepositoryData | undefined,
 	branchName: string,
 	options?: Partial< UseQueryOptions< Workflow[] > >
 ) => {
 	const path = addQueryArgs( '/hosting/github/workflows', {
-		repository_name: repository.name,
-		repository_owner: repository.owner,
+		repository_name: repository?.name,
+		repository_owner: repository?.owner,
 		branch_name: branchName,
 	} );
 
@@ -36,6 +36,7 @@ export const useDeploymentWorkflowsQuery = (
 		meta: {
 			persist: false,
 		},
+		enabled: !! repository,
 		...options,
 	} );
 };

--- a/client/my-sites/github-deployments/components/github-connection-form/index.tsx
+++ b/client/my-sites/github-deployments/components/github-connection-form/index.tsx
@@ -2,7 +2,7 @@ import { Button, FormInputValidation, FormLabel, Spinner } from '@automattic/com
 import { ExternalLink } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
-import { ChangeEvent, useLayoutEffect, useMemo, useState } from 'react';
+import { ChangeEvent, useEffect, useLayoutEffect, useMemo, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
@@ -64,6 +64,13 @@ export const GitHubConnectionForm = ( {
 		initialValues.workflowPath
 	);
 	const { __ } = useI18n();
+
+	useEffect( () => {
+		setBranch( initialValues.branch );
+		setDestPath( initialValues.destPath );
+		setIsAutoDeploy( initialValues.isAutomated );
+		setWorkflowPath( initialValues.workflowPath );
+	}, [ initialValues ] );
 
 	const { data: branches, isLoading: isFetchingBranches } = useGithubRepositoryBranchesQuery(
 		installationId,

--- a/client/my-sites/github-deployments/components/github-connection-form/style.scss
+++ b/client/my-sites/github-deployments/components/github-connection-form/style.scss
@@ -29,15 +29,25 @@
 	}
 
 	&__repository {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
-		padding: 7px 7px 7px 14px;
-		font-size: $font-body;
-		border: 1px solid var(--color-neutral-10);
-		border-radius: 2px;
-		background-color: #fff;
-		margin-bottom: 4px;
+		&-input {
+			display: flex;
+			align-items: center;
+			justify-content: space-between;
+			padding: 7px 7px 7px 14px;
+			font-size: $font-body;
+			border: 1px solid var(--color-neutral-10);
+			border-radius: 2px;
+			background-color: #fff;
+			margin-bottom: 4px;
+
+			&--has-error {
+				border-color: var(--color-error);
+			}
+		}
+
+		.form-input-validation {
+			padding-bottom: 0;
+		}
 	}
 
 	&__branch-select {

--- a/client/my-sites/github-deployments/components/repositories/browse-repositories.tsx
+++ b/client/my-sites/github-deployments/components/repositories/browse-repositories.tsx
@@ -18,10 +18,15 @@ export const GitHubBrowseRepositories = ( {
 	onSelectRepository,
 }: GitHubBrowseRepositoriesProps ) => {
 	const { __ } = useI18n();
-	const { installation, setInstallation, installations, onNewInstallationRequest } =
-		useLiveInstallations( {
-			initialInstallationId: initialInstallationId,
-		} );
+	const {
+		installation,
+		setInstallation,
+		installations,
+		onNewInstallationRequest,
+		isLoadingInstallations,
+	} = useLiveInstallations( {
+		initialInstallationId: initialInstallationId,
+	} );
 
 	const [ query, setQuery ] = useState( '' );
 
@@ -30,7 +35,17 @@ export const GitHubBrowseRepositories = ( {
 	}
 
 	const renderContent = () => {
-		if ( ! installations ) {
+		if ( installation ) {
+			return (
+				<GitHubBrowseRepositoriesList
+					onSelectRepository={ onSelectRepository }
+					installation={ installation }
+					query={ query }
+				/>
+			);
+		}
+
+		if ( isLoadingInstallations ) {
 			return <GitHubLoadingPlaceholder />;
 		}
 
@@ -41,14 +56,6 @@ export const GitHubBrowseRepositories = ( {
 				</Card>
 			);
 		}
-
-		return (
-			<GitHubBrowseRepositoriesList
-				onSelectRepository={ onSelectRepository }
-				installation={ installation }
-				query={ query }
-			/>
-		);
 	};
 
 	return (

--- a/client/my-sites/github-deployments/components/repositories/repository-list-item.tsx
+++ b/client/my-sites/github-deployments/components/repositories/repository-list-item.tsx
@@ -38,7 +38,7 @@ export const GitHubRepositoryListItem = ( {
 			<td>{ formatDate( locale, new Date( repository.updated_at ) ) }</td>
 			<td>
 				<Button compact onClick={ onSelect }>
-					{ __( 'Connect' ) }
+					{ __( 'Select' ) }
 				</Button>
 			</td>
 		</tr>

--- a/client/my-sites/github-deployments/components/repositories/repository-list.tsx
+++ b/client/my-sites/github-deployments/components/repositories/repository-list.tsx
@@ -16,7 +16,7 @@ import { GitHubRepositoryListTable } from './repository-list-table';
 
 import './style.scss';
 
-const pageSize = 10;
+const pageSize = 5;
 
 interface RepositoriesListProps {
 	installation: GitHubInstallationData;
@@ -72,18 +72,18 @@ export const GitHubBrowseRepositoriesList = ( {
 				sortDirection={ direction }
 				onSortChange={ handleSortChange }
 			/>
-			<p css={ { marginBottom: 0 } }>
-				{ __( 'Missing GitHub repositories?' ) }{ ' ' }
-				<ExternalLink href={ installation.management_url }>
-					{ __( 'Adjust permissions on GitHub' ) }
-				</ExternalLink>
-			</p>
 			<Pagination
 				page={ page }
 				perPage={ pageSize }
 				total={ filteredRepositories.length }
 				pageClick={ setPage }
 			/>
+			<p className="github-repositories-list-permissions-notice">
+				{ __( 'Missing GitHub repositories?' ) }{ ' ' }
+				<ExternalLink href={ installation.management_url }>
+					{ __( 'Adjust permissions on GitHub' ) }
+				</ExternalLink>
+			</p>
 		</div>
 	);
 };

--- a/client/my-sites/github-deployments/components/repositories/style.scss
+++ b/client/my-sites/github-deployments/components/repositories/style.scss
@@ -5,6 +5,7 @@
 .github-deployments-repositories {
 	display: flex;
 	flex-direction: column;
+	flex: 1;
 
 	&__search-bar {
 		display: flex;
@@ -19,7 +20,7 @@
 			top: 8px !important;
 		}
 		input {
-			max-width: 400px;
+			width: 100%;
 		}
 	}
 	.components-spinner {
@@ -48,9 +49,22 @@
 }
 
 .github-repositories-list {
-	.pagination {
-		margin-top: 32px;
+	&-permissions-notice {
+		margin-top: auto;
 	}
+
+	.pagination {
+		margin-top: auto;
+		margin-bottom: 16px;
+
+		+ .github-repositories-list-permissions-notice {
+			margin-top: initial;
+		}
+	}
+
+	display: flex;
+	flex-direction: column;
+	flex: 1;
 }
 
 .github-deployments-repository-list-table {

--- a/client/my-sites/github-deployments/controller.tsx
+++ b/client/my-sites/github-deployments/controller.tsx
@@ -33,10 +33,7 @@ export const deploymentCreation: Callback = ( context, next ) => {
 				title="Create GitHub Deployments"
 				delay={ 500 }
 			/>
-			<GitHubDeploymentCreation
-				installationId={ parseInt( context.query.installation_id, 10 ) || undefined }
-				repositoryId={ parseInt( context.query.repository_id, 10 ) || undefined }
-			/>
+			<GitHubDeploymentCreation />
 		</>
 	);
 	next();

--- a/client/my-sites/github-deployments/deployment-creation/deployment-creation-form.tsx
+++ b/client/my-sites/github-deployments/deployment-creation/deployment-creation-form.tsx
@@ -1,5 +1,5 @@
 import { __, sprintf } from '@wordpress/i18n';
-import { useReducer } from 'react';
+import { useMemo, useReducer } from 'react';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
@@ -73,6 +73,15 @@ export const GitHubDeploymentCreationForm = ( {
 		INITIAL_VALUES
 	);
 
+	const initialValues = useMemo( () => {
+		return {
+			branch: repository?.default_branch ?? 'main',
+			destPath: '/',
+			isAutomated: false,
+			workflowPath: undefined,
+		};
+	}, [ repository ] );
+
 	const siteId = useSelector( getSelectedSiteId );
 	const reduxDispatch = useDispatch();
 	const { createDeployment } = useCreateCodeDeployment( siteId, {
@@ -106,6 +115,7 @@ export const GitHubDeploymentCreationForm = ( {
 			<GitHubConnectionForm
 				installationId={ installation?.external_id }
 				repository={ repository }
+				initialValues={ initialValues }
 				changeRepository={ () => dispatch( { type: 'open-repository-picker' } ) }
 				onSubmit={ ( {
 					externalRepositoryId,

--- a/client/my-sites/github-deployments/deployment-creation/deployment-creation-form.tsx
+++ b/client/my-sites/github-deployments/deployment-creation/deployment-creation-form.tsx
@@ -1,14 +1,13 @@
-import page from '@automattic/calypso-router';
 import { __, sprintf } from '@wordpress/i18n';
+import { useReducer } from 'react';
 import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { errorNotice, successNotice } from 'calypso/state/notices/actions';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import { useDispatch, useSelector } from '../../../state';
 import { GitHubConnectionForm } from '../components/github-connection-form';
-import { GitHubLoadingPlaceholder } from '../components/loading-placeholder';
-import { createDeploymentPage } from '../routes';
-import { useGithubInstallationsQuery } from '../use-github-installations-query';
-import { useGithubRepositoriesQuery } from '../use-github-repositories-query';
+import { GitHubInstallationData } from '../use-github-installations-query';
+import { GitHubRepositoryData } from '../use-github-repositories-query';
+import { RepositorySelectionDialog } from './repository-selection-dialog';
 import { useCreateCodeDeployment } from './use-create-code-deployment';
 
 const noticeOptions = {
@@ -16,35 +15,73 @@ const noticeOptions = {
 };
 
 interface GitHubDeploymentCreationFormProps {
-	installationId: number;
-	repositoryId: number;
 	onConnected(): void;
 }
 
+interface ConnectionFormReducerData {
+	isRepositoryPickerOpen: boolean;
+	installation?: GitHubInstallationData;
+	repository?: GitHubRepositoryData;
+}
+
+const INITIAL_VALUES: ConnectionFormReducerData = {
+	isRepositoryPickerOpen: false,
+	installation: undefined,
+	repository: undefined,
+};
+
+type ConnectionFormReducerActions =
+	| { type: 'open-repository-picker' }
+	| {
+			type: 'select-repository';
+			installation: GitHubInstallationData;
+			repository: GitHubRepositoryData;
+	  }
+	| { type: 'close-repository-picker' };
+
+const connectionFormReducer = ( data = INITIAL_VALUES, action: ConnectionFormReducerActions ) => {
+	if ( action.type === 'open-repository-picker' ) {
+		return {
+			...data,
+			isRepositoryPickerOpen: true,
+		};
+	}
+
+	if ( action.type === 'select-repository' ) {
+		return {
+			isRepositoryPickerOpen: false,
+			installation: action.installation,
+			repository: action.repository,
+		};
+	}
+
+	if ( action.type === 'close-repository-picker' ) {
+		return {
+			...data,
+			isRepositoryPickerOpen: false,
+		};
+	}
+
+	return data;
+};
+
 export const GitHubDeploymentCreationForm = ( {
-	installationId,
-	repositoryId,
 	onConnected,
 }: GitHubDeploymentCreationFormProps ) => {
-	const installation = useGithubInstallationsQuery().data?.find(
-		( installation ) => installation.external_id === installationId
-	);
-	const dispatch = useDispatch();
-
-	const repository = useGithubRepositoriesQuery( installationId ).data?.find(
-		( repository ) => repository.id === repositoryId
+	const [ { isRepositoryPickerOpen, installation, repository }, dispatch ] = useReducer(
+		connectionFormReducer,
+		INITIAL_VALUES
 	);
 
 	const siteId = useSelector( getSelectedSiteId );
-	const siteSlug = useSelector( getSelectedSiteSlug );
-
+	const reduxDispatch = useDispatch();
 	const { createDeployment } = useCreateCodeDeployment( siteId, {
 		onSuccess: () => {
-			dispatch( successNotice( __( 'Deployment created.' ), noticeOptions ) );
+			reduxDispatch( successNotice( __( 'Deployment created.' ), noticeOptions ) );
 			onConnected();
 		},
 		onError: ( error ) => {
-			dispatch(
+			reduxDispatch(
 				errorNotice(
 					// translators: "reason" is why connecting the branch failed.
 					sprintf( __( 'Failed to create deployment: %(reason)s' ), { reason: error.message } ),
@@ -55,7 +92,7 @@ export const GitHubDeploymentCreationForm = ( {
 			);
 		},
 		onSettled: ( data, error ) => {
-			dispatch(
+			reduxDispatch(
 				recordTracksEvent( 'calypso_hosting_github_create_deployment_success', {
 					connected: ! error,
 					deployment_type: data ? getDeploymentTypeFromPath( data.target_dir ) : null,
@@ -64,35 +101,38 @@ export const GitHubDeploymentCreationForm = ( {
 		},
 	} );
 
-	if ( ! installation || ! repository ) {
-		return <GitHubLoadingPlaceholder />;
-	}
-
 	return (
-		<GitHubConnectionForm
-			installation={ installation }
-			repository={ repository }
-			changeRepository={ () => {
-				page( createDeploymentPage( siteSlug!, { installationId } ) );
-			} }
-			onSubmit={ ( {
-				externalRepositoryId,
-				branchName,
-				targetDir,
-				installationId,
-				isAutomated,
-				workflowPath,
-			} ) =>
-				createDeployment( {
+		<>
+			<GitHubConnectionForm
+				installationId={ installation?.external_id }
+				repository={ repository }
+				changeRepository={ () => dispatch( { type: 'open-repository-picker' } ) }
+				onSubmit={ ( {
 					externalRepositoryId,
 					branchName,
 					targetDir,
 					installationId,
 					isAutomated,
 					workflowPath,
-				} )
-			}
-		/>
+				} ) =>
+					createDeployment( {
+						externalRepositoryId,
+						branchName,
+						targetDir,
+						installationId,
+						isAutomated,
+						workflowPath,
+					} )
+				}
+			/>
+			<RepositorySelectionDialog
+				isVisible={ isRepositoryPickerOpen }
+				onChange={ ( installation, repository ) => {
+					dispatch( { type: 'select-repository', installation, repository } );
+				} }
+				onClose={ () => dispatch( { type: 'close-repository-picker' } ) }
+			/>
+		</>
 	);
 };
 

--- a/client/my-sites/github-deployments/deployment-creation/index.tsx
+++ b/client/my-sites/github-deployments/deployment-creation/index.tsx
@@ -3,19 +3,23 @@ import { __ } from '@wordpress/i18n';
 import ActionPanel from 'calypso/components/action-panel';
 import HeaderCake from 'calypso/components/header-cake';
 import { useSelector } from 'calypso/state';
-import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { PageShell } from '../components/page-shell';
+import { useCodeDeploymentsQuery } from '../deployments/use-code-deployments-query';
 import { indexPage } from '../routes';
 import { GitHubDeploymentCreationForm } from './deployment-creation-form';
 
 export const GitHubDeploymentCreation = () => {
+	const siteId = useSelector( getSelectedSiteId );
 	const siteSlug = useSelector( getSelectedSiteSlug );
+
+	const { data } = useCodeDeploymentsQuery( siteId! );
 
 	const goToDeployments = () => page( indexPage( siteSlug! ) );
 
 	return (
 		<PageShell pageTitle={ __( 'Connect GitHub repository' ) }>
-			<HeaderCake onClick={ goToDeployments } isCompact>
+			<HeaderCake onClick={ data?.length ? goToDeployments : undefined } isCompact>
 				<h1>{ __( 'Connect repository' ) }</h1>
 			</HeaderCake>
 			<ActionPanel>

--- a/client/my-sites/github-deployments/deployment-creation/index.tsx
+++ b/client/my-sites/github-deployments/deployment-creation/index.tsx
@@ -1,80 +1,26 @@
 import page from '@automattic/calypso-router';
 import { __ } from '@wordpress/i18n';
+import ActionPanel from 'calypso/components/action-panel';
+import HeaderCake from 'calypso/components/header-cake';
 import { useSelector } from 'calypso/state';
-import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import ActionPanel from '../../../components/action-panel';
-import HeaderCake from '../../../components/header-cake';
+import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 import { PageShell } from '../components/page-shell';
-import { GitHubBrowseRepositories } from '../components/repositories/browse-repositories';
-import { useCodeDeploymentsQuery } from '../deployments/use-code-deployments-query';
-import { createDeploymentPage, indexPage } from '../routes';
+import { indexPage } from '../routes';
 import { GitHubDeploymentCreationForm } from './deployment-creation-form';
 
-interface GitHubConnectedProps {
-	installationId?: number;
-	repositoryId?: number;
-}
-
-export const GitHubDeploymentCreation = ( {
-	installationId,
-	repositoryId,
-}: GitHubConnectedProps ) => {
-	const siteId = useSelector( getSelectedSiteId );
+export const GitHubDeploymentCreation = () => {
 	const siteSlug = useSelector( getSelectedSiteSlug );
-
-	const { data } = useCodeDeploymentsQuery( siteId! );
 
 	const goToDeployments = () => page( indexPage( siteSlug! ) );
 
-	const goToRepositorySelection = () =>
-		page(
-			createDeploymentPage( siteSlug!, {
-				installationId: installationId,
-			} )
-		);
-
-	const getBackButton = () => {
-		if ( installationId && repositoryId ) {
-			return goToRepositorySelection;
-		}
-
-		if ( data?.length ) {
-			return goToDeployments;
-		}
-	};
-
-	const renderContent = () => {
-		return (
-			<>
-				{ installationId && repositoryId ? (
-					<GitHubDeploymentCreationForm
-						installationId={ installationId }
-						repositoryId={ repositoryId }
-						onConnected={ goToDeployments }
-					/>
-				) : (
-					<GitHubBrowseRepositories
-						initialInstallationId={ installationId }
-						onSelectRepository={ ( installation, repository ) => {
-							page(
-								createDeploymentPage( siteSlug!, {
-									installationId: installation.external_id,
-									repositoryId: repository.id,
-								} )
-							);
-						} }
-					/>
-				) }
-			</>
-		);
-	};
-
 	return (
 		<PageShell pageTitle={ __( 'Connect GitHub repository' ) }>
-			<HeaderCake onClick={ getBackButton() } isCompact>
+			<HeaderCake onClick={ goToDeployments } isCompact>
 				<h1>{ __( 'Connect repository' ) }</h1>
 			</HeaderCake>
-			<ActionPanel>{ renderContent() }</ActionPanel>
+			<ActionPanel>
+				<GitHubDeploymentCreationForm onConnected={ goToDeployments } />
+			</ActionPanel>
 		</PageShell>
 	);
 };

--- a/client/my-sites/github-deployments/deployment-creation/repository-selection-dialog.tsx
+++ b/client/my-sites/github-deployments/deployment-creation/repository-selection-dialog.tsx
@@ -1,0 +1,33 @@
+import { Dialog } from '@automattic/components';
+import { useI18n } from '@wordpress/react-i18n';
+import { ComponentProps } from 'react';
+import { GitHubBrowseRepositories } from '../components/repositories/browse-repositories';
+
+interface DeleteDeploymentDialogProps {
+	isVisible: boolean;
+	onChange: ComponentProps< typeof GitHubBrowseRepositories >[ 'onSelectRepository' ];
+	onClose(): void;
+}
+
+export const RepositorySelectionDialog = ( {
+	isVisible,
+	onChange,
+	onClose,
+}: DeleteDeploymentDialogProps ) => {
+	const { __ } = useI18n();
+
+	return (
+		<Dialog
+			showCloseIcon
+			isVisible={ isVisible }
+			shouldCloseOnOverlayClick
+			shouldCloseOnEsc
+			onClose={ onClose }
+		>
+			<div css={ { width: '622px', height: '470px', display: 'flex', flexDirection: 'column' } }>
+				<h1 css={ { marginBottom: '24px !important' } }>{ __( 'Select repository' ) }</h1>
+				<GitHubBrowseRepositories onSelectRepository={ onChange } />
+			</div>
+		</Dialog>
+	);
+};

--- a/client/my-sites/github-deployments/deployment-management/deployment-management-form.tsx
+++ b/client/my-sites/github-deployments/deployment-management/deployment-management-form.tsx
@@ -75,7 +75,7 @@ export const GitHubDeploymentManagementForm = ( {
 
 	return (
 		<GitHubConnectionForm
-			installation={ installation }
+			installationId={ installation.external_id }
 			deploymentId={ codeDeployment.id }
 			repository={ repository }
 			initialValues={ initialValues }

--- a/client/my-sites/github-deployments/deployments/index.tsx
+++ b/client/my-sites/github-deployments/deployments/index.tsx
@@ -1,12 +1,12 @@
 import page from '@automattic/calypso-router';
 import { useI18n } from '@wordpress/react-i18n';
+import ActionPanel from 'calypso/components/action-panel';
+import HeaderCake from 'calypso/components/header-cake';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId, getSelectedSiteSlug } from 'calypso/state/ui/selectors';
-import ActionPanel from '../../../components/action-panel';
-import HeaderCake from '../../../components/header-cake';
 import { GitHubLoadingPlaceholder } from '../components/loading-placeholder';
 import { PageShell } from '../components/page-shell';
-import { GitHubBrowseRepositories } from '../components/repositories/browse-repositories';
+import { GitHubDeploymentCreationForm } from '../deployment-creation/deployment-creation-form';
 import { createDeploymentPage } from '../routes';
 import { useGithubInstallationsQuery } from '../use-github-installations-query';
 import { GitHubAuthorizeButton } from './authorize-button';
@@ -23,7 +23,7 @@ export function GitHubDeployments() {
 	const { __ } = useI18n();
 
 	const { data: installations, isLoading: isLoadingInstallations } = useGithubInstallationsQuery();
-	const { data: deployments } = useCodeDeploymentsQuery( siteId );
+	const { data: deployments, refetch } = useCodeDeploymentsQuery( siteId );
 
 	const hasConnectedAnInstallation = installations && installations.length > 0;
 	const hasDeployments = deployments && deployments.length > 0;
@@ -58,16 +58,7 @@ export function GitHubDeployments() {
 						<h1>{ __( 'Connect repository' ) }</h1>
 					</HeaderCake>
 					<ActionPanel>
-						<GitHubBrowseRepositories
-							onSelectRepository={ ( installation, repository ) => {
-								page(
-									createDeploymentPage( siteSlug!, {
-										installationId: installation.external_id,
-										repositoryId: repository.id,
-									} )
-								);
-							} }
-						/>
+						<GitHubDeploymentCreationForm onConnected={ refetch } />
 					</ActionPanel>
 				</>
 			);

--- a/client/my-sites/github-deployments/use-github-repository-branches-query.ts
+++ b/client/my-sites/github-deployments/use-github-repository-branches-query.ts
@@ -6,9 +6,9 @@ import { GITHUB_DEPLOYMENTS_QUERY_KEY } from './constants';
 const GITHUB_BRANCHES_QUERY_KEY = 'github-repository-branches';
 
 export const useGithubRepositoryBranchesQuery = (
-	installationId: number,
-	repositoryOwner: string,
-	repositoryName: string
+	installationId?: number,
+	repositoryOwner?: string,
+	repositoryName?: string
 ) => {
 	return useQuery< string[] >( {
 		queryKey: [
@@ -30,5 +30,6 @@ export const useGithubRepositoryBranchesQuery = (
 		meta: {
 			persist: false,
 		},
+		enabled: !! installationId,
 	} );
 };

--- a/client/my-sites/github-deployments/use-github-repository-checks-query.ts
+++ b/client/my-sites/github-deployments/use-github-repository-checks-query.ts
@@ -14,10 +14,10 @@ export type RepositoryChecks = {
 };
 
 export const useGithubRepositoryChecksQuery = (
-	installationId: number,
-	repositoryOwner: string,
-	repositoryName: string,
-	repositoryBranch: string
+	installationId?: number,
+	repositoryOwner?: string,
+	repositoryName?: string,
+	repositoryBranch?: string
 ) => {
 	return useQuery< RepositoryChecks >( {
 		queryKey: [


### PR DESCRIPTION
Closes https://github.com/Automattic/dotcom-forge/issues/5932.

## Proposed Changes

Instead of having a separate page that lists the repositories the user might connect (which might be confused with a list of repositories that are already connected to a site), let's add the repository search inside the connection wizard so that it's clearer to the user that an existing, available repository isn't connected by default.

The repository picker is now included in the connection wizard and opens in a modal, in the same context of the connection wizard.

![image](https://github.com/Automattic/wp-calypso/assets/26530524/9d57a134-c6a4-4eb5-b603-df5fadff0d01)

![image](https://github.com/Automattic/wp-calypso/assets/26530524/2e224657-23ea-4496-8cd3-7bf235c84a30)


## Testing Instructions

Check that you can connect any repository by clicking at the top-right corner or visiting the `/create` page directory, and modify any connection (you should not be able to change the repository).

Check that when there are no existing connections, the connection wizard shows up instead of the repositories list.