### PR TITLE
Apply redesign to Jetpack Search Congrats page

### DIFF
--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -60,32 +60,12 @@ export class CheckoutThankYouHeader extends PureComponent {
 		currency: PropTypes.string,
 	};
 
-	isSearch() {
-		const { purchases } = this.props;
-		return purchases?.length > 0 && purchases[ 0 ].productType === 'search';
-	}
-
 	getText() {
 		const { translate, isDataLoaded, hasFailedPurchases, primaryPurchase, displayMode } =
 			this.props;
 
 		if ( hasFailedPurchases ) {
 			return translate( 'Some of the items in your cart could not be added.' );
-		}
-
-		if ( this.isSearch() ) {
-			return (
-				<div>
-					<p>{ translate( 'We are currently indexing your site.' ) }</p>
-					<p>
-						{ translate(
-							'In the meantime, we have configured Jetpack Search on your site' +
-								' ' +
-								'— try customizing it!'
-						) }
-					</p>
-				</div>
-			);
 		}
 
 		if ( ! isDataLoaded || ! primaryPurchase ) {
@@ -488,10 +468,6 @@ export class CheckoutThankYouHeader extends PureComponent {
 
 		if ( hasFailedPurchases ) {
 			return translate( 'Some items failed.' );
-		}
-
-		if ( this.isSearch() ) {
-			return translate( 'Welcome to Jetpack Search!' );
 		}
 
 		if (

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -294,14 +294,6 @@ export class CheckoutThankYouHeader extends PureComponent {
 		page( domainManagementTransferInPrecheck( selectedSite.slug, primaryPurchase.meta ) );
 	};
 
-	recordThankYouClick = () => {
-		this.props.recordTracksEvent( 'calypso_jetpack_product_thankyou', {
-			product_name: 'search',
-			value: 'Customizer',
-			site: 'wpcom',
-		} );
-	};
-
 	getButtonText = () => {
 		const {
 			displayMode,

--- a/client/my-sites/checkout/checkout-thank-you/header.jsx
+++ b/client/my-sites/checkout/checkout-thank-you/header.jsx
@@ -413,18 +413,6 @@ export class CheckoutThankYouHeader extends PureComponent {
 		);
 	}
 
-	getSearchButtonProps() {
-		const { translate, selectedSite, jetpackSearchCustomizeUrl, jetpackSearchDashboardUrl } =
-			this.props;
-
-		const buttonTitle = selectedSite.jetpack
-			? translate( 'Go to Search Dashboard' )
-			: translate( 'Customize Search' );
-		const targetUrl = selectedSite.jetpack ? jetpackSearchDashboardUrl : jetpackSearchCustomizeUrl;
-
-		return { title: buttonTitle, url: targetUrl };
-	}
-
 	getButtons() {
 		const {
 			hasFailedPurchases,
@@ -437,22 +425,6 @@ export class CheckoutThankYouHeader extends PureComponent {
 		} = this.props;
 		const headerButtonClassName = 'button is-primary';
 		const isConciergePurchase = 'concierge' === displayMode;
-
-		if ( this.isSearch() ) {
-			const buttonProps = this.getSearchButtonProps();
-			return (
-				<div className="checkout-thank-you__header-button">
-					<Button
-						className={ headerButtonClassName }
-						primary
-						href={ buttonProps.url }
-						onClick={ this.recordThankYouClick }
-					>
-						{ buttonProps.title }
-					</Button>
-				</div>
-			);
-		}
 
 		if (
 			isDataLoaded &&

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -10,6 +10,7 @@ import {
 	isDomainRegistration,
 	isDomainTransfer,
 	isEcommerce,
+	isJetpackSearchSlug,
 	isGSuiteOrExtraLicenseOrGoogleWorkspace,
 	isGSuiteOrGoogleWorkspace,
 	isJetpackPlan,
@@ -96,6 +97,7 @@ import ProPlanDetails from './pro-plan-details';
 import MasterbarStyled from './redesign-v2/masterbar-styled';
 import DomainBulkTransferThankYou from './redesign-v2/pages/domain-bulk-transfer';
 import DomainOnlyThankYou from './redesign-v2/pages/domain-only';
+import JetpackSearchThankYou from './redesign-v2/pages/jetpack-search';
 import PlanOnlyThankYou from './redesign-v2/pages/plan-only';
 import { isRefactoredForThankYouV2 } from './redesign-v2/utils';
 import SiteRedirectDetails from './site-redirect-details';
@@ -619,6 +621,8 @@ export class CheckoutThankYou extends Component<
 				pageContent = (
 					<GoogleWorkspaceSetUpThankYou purchase={ gSuiteOrExtraLicenseOrGoogleWorkspace } />
 				);
+			} else if ( isJetpackSearchSlug( purchases[ 0 ]?.productSlug ) ) {
+				pageContent = <JetpackSearchThankYou />;
 			}
 
 			if ( pageContent ) {

--- a/client/my-sites/checkout/checkout-thank-you/index.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/index.tsx
@@ -10,7 +10,6 @@ import {
 	isDomainRegistration,
 	isDomainTransfer,
 	isEcommerce,
-	isJetpackSearchSlug,
 	isGSuiteOrExtraLicenseOrGoogleWorkspace,
 	isGSuiteOrGoogleWorkspace,
 	isJetpackPlan,
@@ -109,6 +108,7 @@ import {
 	getDomainPurchaseTypeAndPredicate,
 	isBulkDomainTransfer,
 	isDomainOnly,
+	isSearch,
 	isTitanWithoutMailboxes,
 } from './utils';
 import type { FindPredicate } from './utils';
@@ -597,6 +597,8 @@ export class CheckoutThankYou extends Component<
 						isEmailVerified={ this.props.isEmailVerified }
 					/>
 				);
+			} else if ( purchases.length === 1 && isSearch( purchases[ 0 ] ) ) {
+				pageContent = <JetpackSearchThankYou purchase={ purchases[ 0 ] } />;
 			} else if ( wasTitanEmailOnlyProduct ) {
 				const titanPurchase = purchases.find( ( purchase ) => isTitanMail( purchase ) );
 
@@ -621,8 +623,6 @@ export class CheckoutThankYou extends Component<
 				pageContent = (
 					<GoogleWorkspaceSetUpThankYou purchase={ gSuiteOrExtraLicenseOrGoogleWorkspace } />
 				);
-			} else if ( isJetpackSearchSlug( purchases[ 0 ]?.productSlug ) ) {
-				pageContent = <JetpackSearchThankYou />;
 			}
 
 			if ( pageContent ) {

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/jetpack-search.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/jetpack-search.tsx
@@ -37,8 +37,8 @@ export default function JetpackSearchThankYou( { purchase }: JetpackSearchThankY
 			buttonHref: localizeUrl( 'https://wordpress.com/support/category/plugins-and-integrations/' ),
 			buttonOnClick: () => {
 				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
-					context: 'plugins-support',
-					type: 'generic-support',
+					context: 'jetpack-search',
+					type: 'plugin-support',
 				} );
 			},
 		},

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/jetpack-search.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/jetpack-search.tsx
@@ -1,0 +1,73 @@
+import { Button } from '@automattic/components';
+import { translate } from 'i18n-calypso';
+import ThankYouV2 from 'calypso/components/thank-you-v2';
+import ThankYouProduct from 'calypso/components/thank-you-v2/product';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
+import { useSelector } from 'calypso/state';
+import {
+	getJetpackSearchCustomizeUrl,
+	getJetpackSearchDashboardUrl,
+} from 'calypso/state/sites/selectors';
+import { getSelectedSiteId, getSelectedSite } from 'calypso/state/ui/selectors';
+
+export default function JetpackSearchThankYou() {
+	const siteId = useSelector( getSelectedSiteId );
+	const jetpackSearchCustomizeUrl = useSelector( ( state ) =>
+		getJetpackSearchCustomizeUrl( state, siteId )
+	);
+	const jetpackSearchDashboardUrl = useSelector( ( state ) =>
+		getJetpackSearchDashboardUrl( state, siteId )
+	);
+	const selectedSite = useSelector( getSelectedSite );
+
+	const productButtonLabel = selectedSite.jetpack
+		? translate( 'Go to Search Dashboard' )
+		: translate( 'Customize Search' );
+	const productButtonHref = selectedSite.jetpack
+		? jetpackSearchDashboardUrl
+		: jetpackSearchCustomizeUrl;
+	const product = (
+		<ThankYouProduct
+			name="Jetpack Search"
+			actions={
+				<Button primary href={ productButtonHref }>
+					{ productButtonLabel }
+				</Button>
+			}
+		/>
+	);
+
+	const footerDetails = [
+		{
+			key: 'footer-generic-support',
+			title: translate( 'Everything you need to know' ),
+			description: translate( 'Explore our support guides and find an answer to every question.' ),
+			buttonText: translate( 'Explore support resources' ),
+			buttonHref: '/support',
+			buttonOnClick: () => {
+				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
+					context: context,
+					type: 'generic-support',
+				} );
+			},
+		},
+	];
+
+	return (
+		<ThankYouV2
+			title={ translate( 'Welcome to Jetpack Search!' ) }
+			subtitle={
+				<>
+					<>{ translate( 'We are currently indexing your site.' ) }</>
+					<>
+						{ translate(
+							'In the meantime, we have configured Jetpack Search on your site — you should try customizing it in your traditional WordPress dashboard.'
+						) }
+					</>
+				</>
+			}
+			products={ product }
+			footerDetails={ footerDetails }
+		/>
+	);
+}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/jetpack-search.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/jetpack-search.tsx
@@ -5,16 +5,13 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ThankYouJetpackSearchProduct from '../products/jetpack-search-product';
-import type { ThankYouJetpackSearchProductProps } from '../products/jetpack-search-product';
 import type { ReceiptPurchase } from 'calypso/state/receipts/types';
 
 export type JetpackSearchThankYouProps = {
 	purchase: ReceiptPurchase;
 };
 
-export default function JetpackSearchThankYou( {
-	purchase,
-}: Omit< ThankYouJetpackSearchProductProps, 'siteId' > ) {
+export default function JetpackSearchThankYou( { purchase }: JetpackSearchThankYouProps ) {
 	const siteId = useSelector( getSelectedSiteId );
 	const footerDetails = [
 		{

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/jetpack-search.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/jetpack-search.tsx
@@ -1,3 +1,4 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { translate } from 'i18n-calypso';
 import ThankYouV2 from 'calypso/components/thank-you-v2';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
@@ -5,7 +6,11 @@ import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ThankYouJetpackSearchProduct from '../products/jetpack-search-product';
 
-export default function JetpackSearchThankYou() {
+export type JetpackSearchThankYouProps = {
+	purchase: ReceiptPurchase;
+};
+
+export default function JetpackSearchThankYou( { purchase }: ThankYouJetpackSearchProductProps ) {
 	const siteId = useSelector( getSelectedSiteId );
 	const footerDetails = [
 		{
@@ -13,10 +18,25 @@ export default function JetpackSearchThankYou() {
 			title: translate( 'Everything you need to know' ),
 			description: translate( 'Explore our support guides and find an answer to every question.' ),
 			buttonText: translate( 'Explore support resources' ),
-			buttonHref: '/support',
+			buttonHref: localizeUrl( 'https://wordpress.com/support/' ),
 			buttonOnClick: () => {
 				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
 					context: 'jetpack-search',
+					type: 'generic-support',
+				} );
+			},
+		},
+		{
+			key: 'footer-plugins-support',
+			title: translate( 'All-in-one plugin documentation' ),
+			description: translate(
+				"Unlock your plugin's potential with our comprehensive support documentation."
+			),
+			buttonText: translate( 'Plugin documentation' ),
+			buttonHref: localizeUrl( 'https://wordpress.com/support/category/plugins-and-integrations/' ),
+			buttonOnClick: () => {
+				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
+					context: 'plugins-support',
 					type: 'generic-support',
 				} );
 			},
@@ -36,7 +56,7 @@ export default function JetpackSearchThankYou() {
 					</>
 				</>
 			}
-			products={ <ThankYouJetpackSearchProduct siteId={ siteId } /> }
+			products={ <ThankYouJetpackSearchProduct siteId={ siteId } purchase={ purchase } /> }
 			footerDetails={ footerDetails }
 		/>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/jetpack-search.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/jetpack-search.tsx
@@ -1,42 +1,12 @@
-import { Button } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import ThankYouV2 from 'calypso/components/thank-you-v2';
-import ThankYouProduct from 'calypso/components/thank-you-v2/product';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
-import {
-	getJetpackSearchCustomizeUrl,
-	getJetpackSearchDashboardUrl,
-} from 'calypso/state/sites/selectors';
-import { getSelectedSiteId, getSelectedSite } from 'calypso/state/ui/selectors';
+import { getSelectedSiteId } from 'calypso/state/ui/selectors';
+import ThankYouJetpackSearchProduct from '../products/jetpack-search-product';
 
 export default function JetpackSearchThankYou() {
 	const siteId = useSelector( getSelectedSiteId );
-	const jetpackSearchCustomizeUrl = useSelector( ( state ) =>
-		getJetpackSearchCustomizeUrl( state, siteId )
-	);
-	const jetpackSearchDashboardUrl = useSelector( ( state ) =>
-		getJetpackSearchDashboardUrl( state, siteId )
-	);
-	const selectedSite = useSelector( getSelectedSite );
-
-	const productButtonLabel = selectedSite.jetpack
-		? translate( 'Go to Search Dashboard' )
-		: translate( 'Customize Search' );
-	const productButtonHref = selectedSite.jetpack
-		? jetpackSearchDashboardUrl
-		: jetpackSearchCustomizeUrl;
-	const product = (
-		<ThankYouProduct
-			name="Jetpack Search"
-			actions={
-				<Button primary href={ productButtonHref }>
-					{ productButtonLabel }
-				</Button>
-			}
-		/>
-	);
-
 	const footerDetails = [
 		{
 			key: 'footer-generic-support',
@@ -66,7 +36,7 @@ export default function JetpackSearchThankYou() {
 					</>
 				</>
 			}
-			products={ product }
+			products={ <ThankYouJetpackSearchProduct siteId={ siteId } /> }
 			footerDetails={ footerDetails }
 		/>
 	);

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/jetpack-search.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/jetpack-search.tsx
@@ -5,12 +5,16 @@ import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import ThankYouJetpackSearchProduct from '../products/jetpack-search-product';
+import type { ThankYouJetpackSearchProductProps } from '../products/jetpack-search-product';
+import type { ReceiptPurchase } from 'calypso/state/receipts/types';
 
 export type JetpackSearchThankYouProps = {
 	purchase: ReceiptPurchase;
 };
 
-export default function JetpackSearchThankYou( { purchase }: ThankYouJetpackSearchProductProps ) {
+export default function JetpackSearchThankYou( {
+	purchase,
+}: Omit< ThankYouJetpackSearchProductProps, 'siteId' > ) {
 	const siteId = useSelector( getSelectedSiteId );
 	const footerDetails = [
 		{

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/jetpack-search.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/pages/jetpack-search.tsx
@@ -16,7 +16,7 @@ export default function JetpackSearchThankYou() {
 			buttonHref: '/support',
 			buttonOnClick: () => {
 				recordTracksEvent( 'calypso_thank_you_footer_link_click', {
-					context: context,
+					context: 'jetpack-search',
 					type: 'generic-support',
 				} );
 			},

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/jetpack-search-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/jetpack-search-product.tsx
@@ -1,0 +1,43 @@
+import { Button } from '@automattic/components';
+import { translate } from 'i18n-calypso';
+import ThankYouProduct from 'calypso/components/thank-you-v2/product';
+import { useSelector } from 'calypso/state';
+import {
+	getJetpackSearchCustomizeUrl,
+	getJetpackSearchDashboardUrl,
+} from 'calypso/state/sites/selectors';
+import { getSelectedSite } from 'calypso/state/ui/selectors';
+
+export type ThankYouJetpackSearchProductProps = {
+	siteId: number | null;
+};
+
+export default function ThankYouJetpackSearchProduct( {
+	siteId,
+}: ThankYouJetpackSearchProductProps ) {
+	const selectedSite = useSelector( getSelectedSite );
+	const jetpackSearchCustomizeUrl = useSelector( ( state ) =>
+		getJetpackSearchCustomizeUrl( state, siteId )
+	);
+	const jetpackSearchDashboardUrl = useSelector( ( state ) =>
+		getJetpackSearchDashboardUrl( state, siteId )
+	);
+
+	const productButtonLabel = selectedSite.jetpack
+		? translate( 'Go to Search Dashboard' )
+		: translate( 'Customize Search' );
+	const productButtonHref = selectedSite.jetpack
+		? jetpackSearchDashboardUrl
+		: jetpackSearchCustomizeUrl;
+
+	return (
+		<ThankYouProduct
+			name="Jetpack Search"
+			actions={
+				<Button primary href={ productButtonHref }>
+					{ productButtonLabel }
+				</Button>
+			}
+		/>
+	);
+}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/jetpack-search-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/jetpack-search-product.tsx
@@ -35,12 +35,13 @@ export default function ThankYouJetpackSearchProduct( {
 	const productButtonHref = selectedSite?.jetpack
 		? jetpackSearchDashboardUrl
 		: jetpackSearchCustomizeUrl;
-	const thankYouEventProps = selectedSite?.jetpack
-		? { product_name: 'search', value: 'Search Dashboard', site: 'jetpack' }
-		: { product_name: 'search', value: 'Customizer', site: 'wpcom' };
 
 	const recordThankYouClick = () => {
-		recordTracksEvent( 'calypso_jetpack_product_thankyou', thankYouEventProps );
+		recordTracksEvent( 'calypso_jetpack_product_thankyou', {
+			product_name: 'search',
+			value: selectedSite?.jetpack ? 'Search Dashboard' : 'Customizer',
+			site: selectedSite?.jetpack ? 'jetpack' : 'wpcom',
+		} );
 	};
 
 	return (

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/jetpack-search-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/jetpack-search-product.tsx
@@ -8,6 +8,7 @@ import {
 	getJetpackSearchDashboardUrl,
 } from 'calypso/state/sites/selectors';
 import { getSelectedSite } from 'calypso/state/ui/selectors';
+import type { ReceiptPurchase } from 'calypso/state/receipts/types';
 
 export type ThankYouJetpackSearchProductProps = {
 	purchase: ReceiptPurchase;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/jetpack-search-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/jetpack-search-product.tsx
@@ -21,13 +21,15 @@ export default function ThankYouJetpackSearchProduct( {
 		getJetpackSearchCustomizeUrl( state, siteId )
 	);
 	const jetpackSearchDashboardUrl = useSelector( ( state ) =>
-		getJetpackSearchDashboardUrl( state, siteId )
+		// At this point in the flow, having purchased a product for a specific
+		// site, we can assume that `siteId` is a umber and not `null`.
+		getJetpackSearchDashboardUrl( state, siteId as number )
 	);
 
-	const productButtonLabel = selectedSite.jetpack
+	const productButtonLabel = selectedSite?.jetpack
 		? translate( 'Go to Search Dashboard' )
 		: translate( 'Customize Search' );
-	const productButtonHref = selectedSite.jetpack
+	const productButtonHref = selectedSite?.jetpack
 		? jetpackSearchDashboardUrl
 		: jetpackSearchCustomizeUrl;
 
@@ -43,7 +45,7 @@ export default function ThankYouJetpackSearchProduct( {
 		<ThankYouProduct
 			name="Jetpack Search"
 			actions={
-				<Button primary href={ productButtonHref } onClick={ recordThankYouClick }>
+				<Button primary href={ productButtonHref as string } onClick={ recordThankYouClick }>
 					{ productButtonLabel }
 				</Button>
 			}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/jetpack-search-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/jetpack-search-product.tsx
@@ -28,10 +28,10 @@ export default function ThankYouJetpackSearchProduct( {
 		getJetpackSearchDashboardUrl( state, siteId as number )
 	);
 
-	const productButtonLabel = selectedSite?.jetpack
+	const productButtonLabel = selectedSite.jetpack
 		? translate( 'Go to Search Dashboard' )
 		: translate( 'Customize Search' );
-	const productButtonHref = selectedSite?.jetpack
+	const productButtonHref = selectedSite.jetpack
 		? jetpackSearchDashboardUrl
 		: jetpackSearchCustomizeUrl;
 

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/jetpack-search-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/jetpack-search-product.tsx
@@ -10,10 +10,12 @@ import {
 import { getSelectedSite } from 'calypso/state/ui/selectors';
 
 export type ThankYouJetpackSearchProductProps = {
+	purchase: ReceiptPurchase;
 	siteId: number | null;
 };
 
 export default function ThankYouJetpackSearchProduct( {
+	purchase,
 	siteId,
 }: ThankYouJetpackSearchProductProps ) {
 	const selectedSite = useSelector( getSelectedSite );
@@ -43,7 +45,7 @@ export default function ThankYouJetpackSearchProduct( {
 
 	return (
 		<ThankYouProduct
-			name="Jetpack Search"
+			name={ purchase.productName }
 			actions={
 				<Button primary href={ productButtonHref as string } onClick={ recordThankYouClick }>
 					{ productButtonLabel }

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/jetpack-search-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/jetpack-search-product.tsx
@@ -24,7 +24,7 @@ export default function ThankYouJetpackSearchProduct( {
 	);
 	const jetpackSearchDashboardUrl = useSelector( ( state ) =>
 		// At this point in the flow, having purchased a product for a specific
-		// site, we can assume that `siteId` is a umber and not `null`.
+		// site, we can assume that `siteId` is a number and not `null`.
 		getJetpackSearchDashboardUrl( state, siteId as number )
 	);
 

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/jetpack-search-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/jetpack-search-product.tsx
@@ -35,13 +35,12 @@ export default function ThankYouJetpackSearchProduct( {
 	const productButtonHref = selectedSite?.jetpack
 		? jetpackSearchDashboardUrl
 		: jetpackSearchCustomizeUrl;
+	const thankYouEventProps = selectedSite?.jetpack
+		? { product_name: 'search', value: 'Search Dashboard', site: 'jetpack' }
+		: { product_name: 'search', value: 'Customizer', site: 'wpcom' };
 
 	const recordThankYouClick = () => {
-		recordTracksEvent( 'calypso_jetpack_product_thankyou', {
-			product_name: 'search',
-			value: 'Customizer',
-			site: 'wpcom',
-		} );
+		recordTracksEvent( 'calypso_jetpack_product_thankyou', thankYouEventProps );
 	};
 
 	return (

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/jetpack-search-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/jetpack-search-product.tsx
@@ -29,10 +29,10 @@ export default function ThankYouJetpackSearchProduct( {
 		getJetpackSearchDashboardUrl( state, siteId as number )
 	);
 
-	const productButtonLabel = selectedSite.jetpack
+	const productButtonLabel = selectedSite?.jetpack
 		? translate( 'Go to Search Dashboard' )
 		: translate( 'Customize Search' );
-	const productButtonHref = selectedSite.jetpack
+	const productButtonHref = selectedSite?.jetpack
 		? jetpackSearchDashboardUrl
 		: jetpackSearchCustomizeUrl;
 

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/jetpack-search-product.tsx
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/products/jetpack-search-product.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@automattic/components';
 import { translate } from 'i18n-calypso';
 import ThankYouProduct from 'calypso/components/thank-you-v2/product';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import {
 	getJetpackSearchCustomizeUrl,
@@ -30,11 +31,19 @@ export default function ThankYouJetpackSearchProduct( {
 		? jetpackSearchDashboardUrl
 		: jetpackSearchCustomizeUrl;
 
+	const recordThankYouClick = () => {
+		recordTracksEvent( 'calypso_jetpack_product_thankyou', {
+			product_name: 'search',
+			value: 'Customizer',
+			site: 'wpcom',
+		} );
+	};
+
 	return (
 		<ThankYouProduct
 			name="Jetpack Search"
 			actions={
-				<Button primary href={ productButtonHref }>
+				<Button primary href={ productButtonHref } onClick={ recordThankYouClick }>
 					{ productButtonLabel }
 				</Button>
 			}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/test/is-refactored-for-thank-you-v2.js
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/test/is-refactored-for-thank-you-v2.js
@@ -93,7 +93,7 @@ describe( 'isRefactoredForThankYouV2', () => {
 		const props = {
 			receipt: {
 				data: {
-					purchases: [ { productSlug: 'jetpack_search' } ],
+					purchases: [ { productType: 'search' } ],
 					failedPurchases: [],
 				},
 			},

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/test/is-refactored-for-thank-you-v2.js
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/test/is-refactored-for-thank-you-v2.js
@@ -88,4 +88,16 @@ describe( 'isRefactoredForThankYouV2', () => {
 			expect( isRefactoredForThankYouV2( props ) ).toBe( true );
 		}
 	} );
+
+	it( 'should return true for Jetpack Search', () => {
+		const props = {
+			receipt: {
+				data: {
+					purchases: [ { productSlug: 'jetpack_search' } ],
+					failedPurchases: [],
+				},
+			},
+		};
+		expect( isRefactoredForThankYouV2( props ) ).toBe( true );
+	} );
 } );

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
@@ -59,7 +59,6 @@ export const isRefactoredForThankYouV2 = ( props: CheckoutThankYouCombinedProps 
 		if ( isTitanMail( purchase ) ) {
 			return true;
 		}
-
 		if ( isJetpackSearchSlug( purchase.productSlug ) ) {
 			return true;
 		}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
@@ -59,6 +59,7 @@ export const isRefactoredForThankYouV2 = ( props: CheckoutThankYouCombinedProps 
 		if ( isTitanMail( purchase ) ) {
 			return true;
 		}
+
 		if ( isJetpackSearchSlug( purchase.productSlug ) ) {
 			return true;
 		}

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
@@ -1,4 +1,5 @@
 import {
+	isJetpackSearchSlug,
 	isGSuiteOrExtraLicenseOrGoogleWorkspace,
 	isP2Plus,
 	isTitanMail,
@@ -47,7 +48,21 @@ export const isRefactoredForThankYouV2 = ( props: CheckoutThankYouCombinedProps 
 	if ( purchases.length === 1 ) {
 		const purchase = purchases[ 0 ];
 
-		return isWpComPlan( purchase.productSlug ) || isP2Plus( purchase ) || isTitanMail( purchase );
+		if ( isWpComPlan( purchase.productSlug ) ) {
+			return true;
+		}
+
+		if ( isP2Plus( purchase ) ) {
+			return true;
+		}
+
+		if ( isTitanMail( purchase ) ) {
+			return true;
+		}
+
+		if ( isJetpackSearchSlug( purchase.productSlug ) ) {
+			return true;
+		}
 	}
 
 	return false;

--- a/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
+++ b/client/my-sites/checkout/checkout-thank-you/redesign-v2/utils.ts
@@ -1,5 +1,4 @@
 import {
-	isJetpackSearchSlug,
 	isGSuiteOrExtraLicenseOrGoogleWorkspace,
 	isP2Plus,
 	isTitanMail,
@@ -10,6 +9,7 @@ import {
 	getDomainPurchase,
 	isBulkDomainTransfer,
 	isDomainOnly,
+	isSearch,
 	isTitanWithoutMailboxes,
 } from '../utils';
 
@@ -60,7 +60,7 @@ export const isRefactoredForThankYouV2 = ( props: CheckoutThankYouCombinedProps 
 			return true;
 		}
 
-		if ( isJetpackSearchSlug( purchase.productSlug ) ) {
+		if ( isSearch( purchase ) ) {
 			return true;
 		}
 	}

--- a/client/my-sites/checkout/checkout-thank-you/utils.ts
+++ b/client/my-sites/checkout/checkout-thank-you/utils.ts
@@ -144,5 +144,9 @@ export const getDomainPurchase = ( purchases: ReceiptPurchase[] ) =>
 
 export const getWPORGPluginSlugMap = () => WPORG_PLUGIN_SLUG_MAP;
 
+export const isSearch = ( purchase: ReceiptPurchase ) => {
+	return purchase.productType === 'search';
+};
+
 export const isTitanWithoutMailboxes = ( selectedFeature: string ) =>
 	selectedFeature === 'email-license';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 5892-gh-Automattic/dotcom-forge

## Proposed Changes

Apply redesign to the Jetpack Search Congrats Page.

|Before|After|
|------|------|
|<img width="1052" alt="Screen Shot 2024-03-06 at 3 29 42 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/f1979ff5-9ffe-4ff3-b7d0-4acf475fa79a">|<img width="1048" alt="Screen Shot 2024-03-07 at 8 06 36 PM" src="https://github.com/Automattic/wp-calypso/assets/104910361/b7197033-624c-448e-8056-5e5fc28c1566">|

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

- Purchase Jetpack Search on a Jetpack connected site, like a site with an Entrepreneur plan. If you already have it on a site, you can navigate to the respective Congrats Page with the following path:
```
/checkout/thank-you/:site/:receipt_id
```
- On that Congrats page, confirm you see the new design with the copy shown in the image above
- Test the main **Go to Search Dashboard** CTA, and confirm that it fires a `calypso_jetpack_product_thankyou` event with the following event props:
   - product_name: search
   - value: Customizer
   - site: wpcom
- Confirm that the CTA loaded `wp-admin/admin.php?page=jetpack-search`, which is in the Jetpack dashboard with some stats and settings, including a button to customize search results
- Purchase Jetpack on a non-Jetpack connected site, like a normal free site with now plan added to it yet.
- Confirm that the main CTA in this flow is a **Customize Search** button, instead of **Go to Search Dashboard**, and that it fires the same event as described above.
- Confirm that in this flow, the CTA loads `wp-admin/admin.php?page=jetpack-search`, which goes directly to the UI for customizing search results (skipping the Jetpack dashboard screen from the previous flow)
- Test the **Explore support resources** footer link, and confirm that it fires a `calypso_thank_you_footer_link_click` event with the following event props:
   - context: jetpack-search
   - type: generic-support
- Test the **All-in-one plugin documentation** footer link, and confirm that it fires a `calypso_thank_you_footer_link_click` event with the following event props:
   - context: jetpack-support
   - type: plugins-support

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?