### PR TITLE
ToS: Add rtl styles

### DIFF
--- a/client/my-sites/checkout/src/components/checkout-terms.tsx
+++ b/client/my-sites/checkout/src/components/checkout-terms.tsx
@@ -41,6 +41,17 @@ const TermsCollapsedContent = styled.div`
 		top: -3px;
 		width: 20px;
 	}
+
+	& .foldable-card__secondary {
+		display: none;
+	}
+
+	.rtl & .foldable-card__main {
+		right: 20px;
+	}
+	.rtl & .foldable-card__expand {
+		right: -24px;
+	}
 `;
 
 export default function CheckoutTerms( { cart }: { cart: ResponseCart } ) {

--- a/client/my-sites/checkout/src/components/payment-method-step.tsx
+++ b/client/my-sites/checkout/src/components/payment-method-step.tsx
@@ -30,14 +30,6 @@ const CheckoutTermsWrapper = styled.div`
 		padding-left: 0;
 	}
 
-	& > div:first-of-type {
-		padding-right: 0;
-		padding-left: 0;
-		margin-right: 0;
-		margin-left: 0;
-		margin-top: 0;
-	}
-
 	a {
 		text-decoration: underline;
 	}


### PR DESCRIPTION
The ToS foldable card doesn't account for RTL styling, this PR addresses that.

Related to https://github.com/Automattic/payments-shilling/issues/2530

## Proposed Changes

| LTR | RTL |
| ----- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/16580129/73e510ce-4dce-4dfd-bd11-c0b7db55e728) | ![image](https://github.com/Automattic/wp-calypso/assets/16580129/9193c84f-76cb-4c72-979a-f4bae77314dc) |

| LTR | RTL |
| ----- | ----- |
| ![image](https://github.com/Automattic/wp-calypso/assets/16580129/9e23f6ff-27a4-4875-9977-6738329eb437) | ![image](https://github.com/Automattic/wp-calypso/assets/16580129/ea40c7c2-246c-4d07-a81d-4533045bc239) |


## Testing Instructions

* Add a product to cart, go to Checkout
* Ensure that LTR styling is unaffected by this PR
* Change interface language settings to RTL (Hebrew for example)
* Check that RTL styling looks as depicted above
