### PR TITLE
Backup: Replace `Backup now` with `Back up now`

### DIFF
--- a/client/components/jetpack/backup-actions-toolbar/index.tsx
+++ b/client/components/jetpack/backup-actions-toolbar/index.tsx
@@ -39,7 +39,7 @@ const BackupActionsToolbar: FunctionComponent< Props > = ( { siteId, siteSlug } 
 			variant="primary"
 			trackEventName="calypso_jetpack_backup_now"
 		>
-			{ translate( 'Backup now' ) }
+			{ translate( 'Back up now' ) }
 		</BackupNowButton>
 	);
 

--- a/client/components/jetpack/backup-now-button/README.md
+++ b/client/components/jetpack/backup-now-button/README.md
@@ -16,7 +16,7 @@ function render() {
 				tooltipText="Click here to backup your site now."
 				trackEventName="calypso_jetpack_backup_now"
 			>
-				Backup now
+				Back up now
 			</BackupNowButton>
 		</div>
 	);

--- a/client/my-sites/backup/main.jsx
+++ b/client/my-sites/backup/main.jsx
@@ -103,7 +103,7 @@ const BackupPage = ( { queryDate } ) => {
 							variant="primary"
 							trackEventName="calypso_jetpack_backup_now"
 						>
-							{ translate( 'Backup now' ) }
+							{ translate( 'Back up now' ) }
 						</BackupNowButton>
 					</NavigationHeader>
 				) }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->
Related to peaFOp-2mq-p2#comment-2162

## Proposed Changes

* Replace `Backup now` with `Back up now` on the backup page

## Screenshots

| Before | After |
|---|---|
| ![CleanShot 2024-03-06 at 15 27 50@2x](https://github.com/Automattic/wp-calypso/assets/1488641/232cccfb-560c-4da6-be74-7a997bba4414) | ![CleanShot 2024-03-06 at 15 27 37@2x](https://github.com/Automattic/wp-calypso/assets/1488641/67450ee8-3968-4175-9cb3-b55bac815198) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a Calypso or Jetpack Cloud live branch
* Pick a site with a Jetpack VaultPress Backup plan
* Navigate to the Backup page in the left menu
* You should see the `Back up now` button at the top right of the page

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?