### PR TITLE
properly filter out Jetpack search free so it does not show on the Jetpack pricing page

### DIFF
--- a/client/my-sites/plans/jetpack-plans/product-grid/utils.ts
+++ b/client/my-sites/plans/jetpack-plans/product-grid/utils.ts
@@ -9,6 +9,8 @@ import {
 	PRODUCT_JETPACK_STATS_YEARLY,
 	findPlansKeys,
 	getPlan,
+	JETPACK_SEARCH_PRODUCTS,
+	PRODUCT_JETPACK_SEARCH,
 } from '@automattic/calypso-products';
 import { SELECTOR_PLANS } from '../constants';
 import slugToSelectorProduct from '../slug-to-selector-product';
@@ -105,6 +107,13 @@ export const getProductsToDisplay = ( {
 				( JETPACK_STATS_PRODUCTS as ReadonlyArray< string > ).includes( product?.productSlug )
 			) {
 				return product?.productSlug === PRODUCT_JETPACK_STATS_YEARLY;
+			}
+
+			// Removes Jetpack search free from products that can be displayed
+			if (
+				( JETPACK_SEARCH_PRODUCTS as ReadonlyArray< string > ).includes( product?.productSlug )
+			) {
+				return product?.productSlug === PRODUCT_JETPACK_SEARCH;
 			}
 
 			return true;


### PR DESCRIPTION
## Proposed Changes

* This diff properly filters out Jetpack search free from showing in display products so it does not show on the Jeptack pricing page

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to: https://cloud.jetpack.com/pricing#
* See that Jetpack Search shows twice in the pricing grid. This is incorrect.
![Screenshot 2024-03-06 at 5 57 07 PM](https://github.com/Automattic/wp-calypso/assets/18016357/77fa9db0-2276-44a2-9ac4-6266eefc41eb)
* Now, test this PR locally or on Calypso live 
* Visit the Jetpack pricing page - locally this is http://jetpack.cloud.localhost:3001/pricing
* Confirm that Search only shows once and that it is the yearly search product
![Screenshot 2024-03-06 at 5 58 21 PM](https://github.com/Automattic/wp-calypso/assets/18016357/25cbe004-d9f3-4347-8c54-9447dce86940)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?