### PR TITLE
Plan Type Selector: Add new tracks event for plan type updates

### DIFF
--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -516,6 +516,7 @@ const PlansFeaturesMain = ( {
 			coupon,
 			selectedSiteId: siteId,
 			withDiscount,
+			intent,
 		};
 
 		const handlePlanIntervalUpdate = ( interval: SupportedUrlFriendlyTermType ) => {
@@ -536,11 +537,6 @@ const PlansFeaturesMain = ( {
 				domain: isDomainUpsellFlow,
 				domainAndPlanPackage: isDomainAndPlanPackageFlow,
 				jetpackAppPlans: isJetpackAppFlow,
-			} );
-
-			recordTracksEvent( 'calypso_plans_plan_type_selector_option_change', {
-				interval_type: interval,
-				plans_intent: intent,
 			} );
 
 			if ( onPlanIntervalUpdate ) {
@@ -579,6 +575,7 @@ const PlansFeaturesMain = ( {
 		withDiscount,
 		getPlanTypeDestination,
 		onPlanIntervalUpdate,
+		intent,
 	] );
 
 	const isEligibleForTrial = useSelector( isUserEligibleForFreeHostingTrial );

--- a/client/my-sites/plans-features-main/index.tsx
+++ b/client/my-sites/plans-features-main/index.tsx
@@ -538,6 +538,11 @@ const PlansFeaturesMain = ( {
 				jetpackAppPlans: isJetpackAppFlow,
 			} );
 
+			recordTracksEvent( 'calypso_plans_plan_type_selector_option_change', {
+				interval_type: interval,
+				plans_intent: intent,
+			} );
+
 			if ( onPlanIntervalUpdate ) {
 				return onPlanIntervalUpdate( pathOrQueryParam );
 			}

--- a/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-dropdown.tsx
+++ b/packages/plans-grid-next/src/components/plan-type-selector/components/interval-type-dropdown.tsx
@@ -1,10 +1,11 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { CustomSelectControl } from '@wordpress/components';
 import DropdownOption from '../../dropdown-option';
 import useIntervalOptions from '../hooks/use-interval-options';
 import type { IntervalTypeProps, SupportedUrlFriendlyTermType } from '../../../types';
 
 export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > = ( props ) => {
-	const { hideDiscount, intervalType, displayedIntervals, onPlanIntervalUpdate } = props;
+	const { hideDiscount, intent, intervalType, displayedIntervals, onPlanIntervalUpdate } = props;
 	const supportedIntervalType = (
 		displayedIntervals.includes( intervalType ) ? intervalType : 'yearly'
 	) as SupportedUrlFriendlyTermType;
@@ -35,7 +36,13 @@ export const IntervalTypeDropdown: React.FunctionComponent< IntervalTypeProps > 
 					selectedItem: { key: intervalType },
 				}: {
 					selectedItem: { key: SupportedUrlFriendlyTermType };
-				} ) => onPlanIntervalUpdate && onPlanIntervalUpdate( intervalType ) }
+				} ) => {
+					recordTracksEvent( 'calypso_plans_plan_type_selector_option_change', {
+						interval_type: intervalType,
+						plans_intent: intent,
+					} );
+					onPlanIntervalUpdate && onPlanIntervalUpdate( intervalType );
+				} }
 			/>
 		</div>
 	);

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -205,6 +205,7 @@ export type PlanTypeSelectorProps = {
 	 */
 	coupon?: string;
 	displayedIntervals: UrlFriendlyTermType[];
+	intent: PlansIntent;
 };
 
 export type IntervalTypeProps = Pick<
@@ -225,6 +226,7 @@ export type IntervalTypeProps = Pick<
 	| 'title'
 	| 'coupon'
 	| 'onPlanIntervalUpdate'
+	| 'intent'
 >;
 
 export type SupportedUrlFriendlyTermType = Extract<

--- a/packages/plans-grid-next/src/types.ts
+++ b/packages/plans-grid-next/src/types.ts
@@ -205,7 +205,7 @@ export type PlanTypeSelectorProps = {
 	 */
 	coupon?: string;
 	displayedIntervals: UrlFriendlyTermType[];
-	intent: PlansIntent;
+	intent?: PlansIntent | null;
 };
 
 export type IntervalTypeProps = Pick<


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/martech/issues/2776
Tracks registration https://github.com/Automattic/martech/issues/2776

## Proposed Changes

* Adds a plan type selector on change tracks event

![2024-03-06 17 24 19](https://github.com/Automattic/wp-calypso/assets/5414230/d2a6134b-4e79-4c1b-83be-fa081edf4d9c)

### Notes

Something to consider before we create an entirely new tracks event. We've recently changed the plan type selector from a toggle to a dropdown. There may have been previous tracks events that were being recorded for user interactions with the plan term selector, but I'm not seeing anything obvious. Perhaps this warrants more digging 🤔 

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Check out branch
* Navigate to `/start/plans`
* Select a different option for the plan term selection dropdown
* Verify that the tracks event `calypso_plans_plan_type_selector_option_change` has been fired

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?