### PR TITLE
Stats: Show reasons for commercial sites

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -405,9 +405,9 @@ Thanks\n\n`;
 							commercialReasons
 								?.map(
 									( reason: string ) =>
-										COMMERCIAL_REASONS[ reason as keyof typeof COMMERCIAL_REASONS ]
+										COMMERCIAL_REASONS[ reason as keyof typeof COMMERCIAL_REASONS ] ?? 'Unknown'
 								)
-								.join( ' and/or ' ) ?? '',
+								.join( ' and/or ' ) ?? 'Unknown',
 					},
 				}
 		  )

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -336,10 +336,10 @@ function StatsCommercialFlowOptOutForm( {
 	) as string[];
 	const COMMERCIAL_REASONS = {
 		ads: translate( 'Ads' ),
-		adsense: translate( 'Adsense' ),
-		taboola: translate( 'Taboola' ),
-		infolink: translate( 'InfoLink' ),
-		exoclick: translate( 'ExoClick' ),
+		adsense: 'Adsense',
+		taboola: 'Taboola',
+		infolink: 'InfoLink',
+		exoclick: 'ExoClick',
 		'live-chat': translate( 'Live Chat' ),
 		'commercial-dext': translate( 'Commercial Domain Extension' ),
 		'manual-override': translate( 'Manual Override' ),

--- a/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-purchase-single-item.tsx
@@ -7,7 +7,7 @@ import React, { useState, useCallback } from 'react';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import getIsSiteWPCOM from 'calypso/state/selectors/is-site-wpcom';
-import { isJetpackSite, getSiteAdminUrl } from 'calypso/state/sites/selectors';
+import { isJetpackSite, getSiteAdminUrl, getSiteOption } from 'calypso/state/sites/selectors';
 import useStatsPurchases from '../hooks/use-stats-purchases';
 import { StatsCommercialUpgradeSlider, getTierQuentity } from './stats-commercial-upgrade-slider';
 import gotoCheckoutPage from './stats-purchase-checkout-redirect';
@@ -331,6 +331,19 @@ function StatsCommercialFlowOptOutForm( {
 	const isJetpackSupport: boolean = useSelector( ( state ) =>
 		Boolean( isJetpackSite( state, siteId, { treatAtomicAsJetpackSite: false } ) )
 	);
+	const commercialReasons = useSelector( ( state ) =>
+		getSiteOption( state, siteId, 'is_commercial_reasons' )
+	) as string[];
+	const COMMERCIAL_REASONS = {
+		ads: translate( 'Ads' ),
+		adsense: translate( 'Adsense' ),
+		taboola: translate( 'Taboola' ),
+		infolink: translate( 'InfoLink' ),
+		exoclick: translate( 'ExoClick' ),
+		'live-chat': translate( 'Live Chat' ),
+		'commercial-dext': translate( 'Commercial Domain Extension' ),
+		'manual-override': translate( 'Manual Override' ),
+	};
 
 	// Checkbox state
 	const [ isAdsChecked, setAdsChecked ] = useState( false );
@@ -385,7 +398,18 @@ Thanks\n\n`;
 	// Message, button text, and handler differ based on isCommercial flag.
 	const formMessage = isCommercial
 		? translate(
-				'If you think we misidentified your site as commercial, confirm the information below and we’ll take a look.'
+				'Your site is identified as a commercial site, which is not eligible for a non-commercial license, reason(s) being ’%(reasons)s’. If you think this is an error, confirm the information below and let us know.',
+				{
+					args: {
+						reasons:
+							commercialReasons
+								?.map(
+									( reason: string ) =>
+										COMMERCIAL_REASONS[ reason as keyof typeof COMMERCIAL_REASONS ]
+								)
+								.join( ' and/or ' ) ?? '',
+					},
+				}
 		  )
 		: translate( 'To use a non-commercial license you must agree to the following:' );
 	const formButton = isCommercial ? translate( 'Request update' ) : translate( 'Continue' );

--- a/client/state/sites/constants.js
+++ b/client/state/sites/constants.js
@@ -84,6 +84,7 @@ export const SITE_REQUEST_OPTIONS = [
 	'wpcom_staging_blog_ids',
 	'can_blaze',
 	'is_commercial',
+	'is_commercial_reasons',
 	'wpcom_admin_interface',
 	'wpcom_classic_early_release',
 ].join();

--- a/packages/data-stores/src/site/types.ts
+++ b/packages/data-stores/src/site/types.ts
@@ -274,6 +274,7 @@ export interface SiteDetailsOptions {
 	wpcom_staging_blog_ids?: number[];
 	can_blaze?: boolean;
 	is_commercial?: boolean | null;
+	is_commercial_reasons?: string[];
 	wpcom_admin_interface?: string;
 }
 


### PR DESCRIPTION
## Proposed Changes

* Show reasons why the site is identified as commercial sites on the purchase page

## Testing Instructions

* Find a commercial site and switch to user
* Open `/stats/purchase/kangzj3.wpcomstaging.com`
* Ensure the reasons are shown in the copy

<img width="623" alt="image" src="https://github.com/Automattic/wp-calypso/assets/1425433/e8353299-2413-4bc0-a494-4cbf1b447a08">

<img width="657" alt="Screenshot 2024-03-07 at 2 35 57 PM" src="https://github.com/Automattic/wp-calypso/assets/1425433/9b0a9ffb-f61e-45ec-9637-aa7fc37bf5c8">



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?