### PR TITLE
Stats: some copy changes

### DIFF
--- a/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
+++ b/client/my-sites/stats/stats-purchase/stats-commercial-upgrade-slider/index.tsx
@@ -15,10 +15,10 @@ import './styles.scss';
 
 function useTranslatedStrings() {
 	const translate = useTranslate();
-	const limits = translate( 'Monthly site views limit', {
+	const limits = translate( 'Monthly views limit', {
 		comment: 'Heading for Stats Upgrade slider. The monthly views limit.',
 	} ) as string;
-	const price = translate( 'You will pay', {
+	const price = translate( 'You pay', {
 		comment: 'Heading for Stats Upgrade slider. The monthly price.',
 	} ) as string;
 	const strategy = translate( 'Price per month, billed yearly', {


### PR DESCRIPTION
Related to #88270

## Proposed Changes

- “Monthly site views limit” to “Monthly views limit”
- “You will pay” to “You pay”

“The most advanced stats Jetpack has to offer for you” to “The most advanced stats Jetpack has to offer” is already changed.

## Testing Instructions

Ensure the new copy looks okay.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?