### PR TITLE
Add tracks event to Update Manager

### DIFF
--- a/client/blocks/plugins-update-manager/index.tsx
+++ b/client/blocks/plugins-update-manager/index.tsx
@@ -1,12 +1,14 @@
 import { WPCOM_FEATURES_SCHEDULED_UPDATES } from '@automattic/calypso-products';
 import { Button, Spinner } from '@wordpress/components';
 import { plus } from '@wordpress/icons';
+import { useEffect } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import QuerySitePlans from 'calypso/components/data/query-site-plans';
 import MainComponent from 'calypso/components/main';
 import NavigationHeader from 'calypso/components/navigation-header';
 import ScheduledUpdatesGate from 'calypso/components/scheduled-updates/scheduled-updates-gate';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { useSelector } from 'calypso/state';
 import getHasLoadedSiteFeatures from 'calypso/state/selectors/has-loaded-site-features';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
@@ -51,6 +53,12 @@ export const PluginsUpdateManager = ( props: Props ) => {
 		! isEligibleForFeature || schedules.length === MAX_SCHEDULES || schedules.length === 0;
 
 	const { canCreateSchedules } = useCanCreateSchedules( siteSlug, isEligibleForFeature );
+	useEffect( () => {
+		recordTracksEvent( 'calypso_scheduled_updates_page_view', {
+			site_slug: siteSlug,
+			context: context,
+		} );
+	}, [ context, siteSlug ] );
 
 	const { component, title } = {
 		list: {

--- a/client/blocks/plugins-update-manager/schedule-create.tsx
+++ b/client/blocks/plugins-update-manager/schedule-create.tsx
@@ -42,6 +42,11 @@ export const ScheduleCreate = ( props: Props ) => {
 		}
 	}, [ isFetched ] );
 
+	const onSyncSuccess = () => {
+		onNavBack && onNavBack();
+		return null;
+	};
+
 	return (
 		<Card className="plugins-update-manager">
 			<CardHeader size="extraSmall">
@@ -56,7 +61,7 @@ export const ScheduleCreate = ( props: Props ) => {
 				<div className="ch-placeholder"></div>
 			</CardHeader>
 			<CardBody>
-				<ScheduleForm onSyncSuccess={ () => onNavBack && onNavBack() } />
+				<ScheduleForm onSyncSuccess={ onSyncSuccess } />
 			</CardBody>
 			<CardFooter>
 				<Button

--- a/client/blocks/plugins-update-manager/schedule-create.tsx
+++ b/client/blocks/plugins-update-manager/schedule-create.tsx
@@ -44,7 +44,7 @@ export const ScheduleCreate = ( props: Props ) => {
 	}, [ isFetched ] );
 
 	const onSyncSuccess = () => {
-		recordTracksEvent( 'calypso_update_manager_schedule_create', {
+		recordTracksEvent( 'calypso_scheduled_updates_create_schedule', {
 			site_slug: siteSlug,
 		} );
 

--- a/client/blocks/plugins-update-manager/schedule-create.tsx
+++ b/client/blocks/plugins-update-manager/schedule-create.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useMutationState } from '@tanstack/react-query';
 import {
 	__experimentalText as Text,
@@ -43,8 +44,11 @@ export const ScheduleCreate = ( props: Props ) => {
 	}, [ isFetched ] );
 
 	const onSyncSuccess = () => {
-		onNavBack && onNavBack();
-		return null;
+		recordTracksEvent( 'calypso_update_manager_schedule_create', {
+			site_slug: siteSlug,
+		} );
+
+		return onNavBack && onNavBack();
 	};
 
 	return (

--- a/client/blocks/plugins-update-manager/schedule-edit.tsx
+++ b/client/blocks/plugins-update-manager/schedule-edit.tsx
@@ -46,8 +46,6 @@ export const ScheduleEdit = ( props: Props ) => {
 	const onSyncSuccess = () => {
 		recordTracksEvent( 'calypso_update_manager_schedule_edit', {
 			site_slug: siteSlug,
-			schedule: schedule?.schedule,
-			interval: schedule?.interval,
 		} );
 
 		return onNavBack && onNavBack();

--- a/client/blocks/plugins-update-manager/schedule-edit.tsx
+++ b/client/blocks/plugins-update-manager/schedule-edit.tsx
@@ -47,7 +47,7 @@ export const ScheduleEdit = ( props: Props ) => {
 		recordTracksEvent( 'calypso_update_manager_schedule_edit', {
 			site_slug: siteSlug,
 			schedule: schedule?.schedule,
-			Interval: schedule?.interval,
+			interval: schedule?.interval,
 		} );
 
 		return onNavBack && onNavBack();

--- a/client/blocks/plugins-update-manager/schedule-edit.tsx
+++ b/client/blocks/plugins-update-manager/schedule-edit.tsx
@@ -42,6 +42,11 @@ export const ScheduleEdit = ( props: Props ) => {
 		return null;
 	}
 
+	const onSyncSuccess = () => {
+		onNavBack && onNavBack();
+		return null;
+	};
+
 	return (
 		<Card className="plugins-update-manager">
 			<CardHeader size="extraSmall">
@@ -57,10 +62,7 @@ export const ScheduleEdit = ( props: Props ) => {
 			</CardHeader>
 			<CardBody>
 				{ schedule && (
-					<ScheduleForm
-						scheduleForEdit={ schedule }
-						onSyncSuccess={ () => onNavBack && onNavBack() }
-					/>
+					<ScheduleForm scheduleForEdit={ schedule } onSyncSuccess={ onSyncSuccess } />
 				) }
 			</CardBody>
 			<CardFooter>

--- a/client/blocks/plugins-update-manager/schedule-edit.tsx
+++ b/client/blocks/plugins-update-manager/schedule-edit.tsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useMutationState } from '@tanstack/react-query';
 import {
 	__experimentalText as Text,
@@ -43,8 +44,13 @@ export const ScheduleEdit = ( props: Props ) => {
 	}
 
 	const onSyncSuccess = () => {
-		onNavBack && onNavBack();
-		return null;
+		recordTracksEvent( 'calypso_update_manager_schedule_edit', {
+			site_slug: siteSlug,
+			schedule: schedule?.schedule,
+			Interval: schedule?.interval,
+		} );
+
+		return onNavBack && onNavBack();
 	};
 
 	return (

--- a/client/blocks/plugins-update-manager/schedule-edit.tsx
+++ b/client/blocks/plugins-update-manager/schedule-edit.tsx
@@ -44,7 +44,7 @@ export const ScheduleEdit = ( props: Props ) => {
 	}
 
 	const onSyncSuccess = () => {
-		recordTracksEvent( 'calypso_update_manager_schedule_edit', {
+		recordTracksEvent( 'calypso_scheduled_updates_edit_schedule', {
 			site_slug: siteSlug,
 		} );
 

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -22,6 +22,7 @@ import {
 	useUpdateScheduleQuery,
 	ScheduleUpdates,
 } from 'calypso/data/plugins/use-update-schedules-query';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { MAX_SELECTABLE_PLUGINS } from './config';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSiteSlug } from './hooks/use-site-slug';
@@ -56,12 +57,6 @@ export const ScheduleForm = ( props: Props ) => {
 	} = useCorePluginsQuery( siteSlug, true );
 	const { data: schedulesData = [] } = useUpdateScheduleQuery( siteSlug, isEligibleForFeature );
 	const schedules = schedulesData.filter( ( s ) => s.id !== scheduleForEdit?.id ) ?? [];
-	const { createUpdateSchedule } = useCreateUpdateScheduleMutation( siteSlug, {
-		onSuccess: () => onSyncSuccess && onSyncSuccess(),
-	} );
-	const { editUpdateSchedule } = useEditUpdateScheduleMutation( siteSlug, {
-		onSuccess: () => onSyncSuccess && onSyncSuccess(),
-	} );
 
 	const [ selectedPlugins, setSelectedPlugins ] = useState< string[] >(
 		scheduleForEdit?.args || []
@@ -84,6 +79,27 @@ export const ScheduleForm = ( props: Props ) => {
 		timestamp: validateTimeSlot( { frequency, timestamp }, scheduledTimeSlots ),
 	} );
 	const [ fieldTouched, setFieldTouched ] = useState< Record< string, boolean > >( {} );
+	const trackEventProps = {
+		site_slug: siteSlug,
+		frequency,
+		hour,
+		period,
+		day,
+	};
+	const { createUpdateSchedule } = useCreateUpdateScheduleMutation( siteSlug, {
+		onSuccess: () => {
+			recordTracksEvent( 'calypso_update_manager_schedule_create', trackEventProps );
+
+			return onSyncSuccess && onSyncSuccess();
+		},
+	} );
+	const { editUpdateSchedule } = useEditUpdateScheduleMutation( siteSlug, {
+		onSuccess: () => {
+			recordTracksEvent( 'calypso_update_manager_schedule_edit', trackEventProps );
+
+			return onSyncSuccess && onSyncSuccess();
+		},
+	} );
 
 	const onPluginSelectionChange = useCallback(
 		( plugin: CorePlugin, isChecked: boolean ) => {

--- a/client/blocks/plugins-update-manager/schedule-list.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list.tsx
@@ -70,7 +70,7 @@ export const ScheduleList = ( props: Props ) => {
 	const onRemoveDialogConfirm = () => {
 		if ( selectedScheduleId ) {
 			deleteUpdateSchedule( selectedScheduleId );
-			recordTracksEvent( 'calypso_update_manager_schedule_delete', {
+			recordTracksEvent( 'calypso_scheduled_updates_delete_schedule', {
 				site_slug: siteSlug,
 			} );
 		}

--- a/client/blocks/plugins-update-manager/schedule-list.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list.tsx
@@ -12,6 +12,7 @@ import { Icon, arrowLeft, info } from '@wordpress/icons';
 import { useState } from 'react';
 import { useDeleteUpdateScheduleMutation } from 'calypso/data/plugins/use-update-schedules-mutation';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
+import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import { MAX_SCHEDULES } from './config';
 import { useCanCreateSchedules } from './hooks/use-can-create-schedules';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
@@ -67,7 +68,12 @@ export const ScheduleList = ( props: Props ) => {
 	};
 
 	const onRemoveDialogConfirm = () => {
-		selectedScheduleId && deleteUpdateSchedule( selectedScheduleId );
+		if ( selectedScheduleId ) {
+			deleteUpdateSchedule( selectedScheduleId );
+			recordTracksEvent( 'calypso_update_manager_schedule_delete', {
+				site_slug: siteSlug,
+			} );
+		}
 		closeRemoveConfirm();
 	};
 


### PR DESCRIPTION
Fixes #87606 

## Proposed Changes

* Add `calypso_update_manager_schedule_create`
* Add `calypso_update_manager_schedule_edit`
* Add `calypso_update_manager_schedule_delete`
* Add `calypso_update_manager_page_view`

## Testing Instructions
1. Open `http://calypso.localhost:3000/plugins/scheduled-updates/__BLOG__`.
2. Create, edit, or delete a schedule.
3. On Tracks Vigilante, check if the events are spawned.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?