### PR TITLE
VerbumBlockEditor: fix possible style collisions

### DIFF
--- a/packages/verbum-block-editor/src/editor/editor-style.scss
+++ b/packages/verbum-block-editor/src/editor/editor-style.scss
@@ -169,6 +169,11 @@ div[id^="portal/tooltip"] {
 			color: var(--wp-components-color-accent, var(--wp-admin-theme-color, #3858e9));
 		}
 
+		&:focus {
+			// the default rule uses `--wp-admin-border-width-focus` which is not always available
+			box-shadow: inset 0 0 0 1.5px var(--wp-admin-theme-color, #3858e9) !important;
+		}
+
 		svg {
 			fill: currentColor;
 		}
@@ -410,5 +415,12 @@ div[id^="portal/tooltip"] {
 		margin: 0;
 		padding: 0;
 		list-style: none;
+	}
+
+	svg,
+	button {
+		min-width: initial;
+		max-width: initial;
+		display: initial;
 	}
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #
p1709753508392349-slack-C02T4NVL4JJ

## Proposed Changes

* Ensure that button and svg max width or heigh overrides don't happen
* Ensure button outline is set properly

## Testing Instructions
- Sandbox widgets.wp.com
- Sandbox automattic.design and a8cdesignsimple.wordpress.com
- In packages/verbum-block-editor run `yarn dev --sync`.
- Check the issues in the thread and ensure that this PR fixes them

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

*

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?