### PR TITLE
Plugins update manager: Remove name field

### DIFF
--- a/client/blocks/plugins-update-manager/hooks/use-prepare-schedule-name.ts
+++ b/client/blocks/plugins-update-manager/hooks/use-prepare-schedule-name.ts
@@ -1,0 +1,55 @@
+import { useTranslate } from 'i18n-calypso';
+import { useLocalizedMoment } from 'calypso/components/localized-moment';
+import type { ScheduleUpdates } from 'calypso/data/plugins/use-update-schedules-query';
+
+export function usePrepareScheduleName() {
+	const moment = useLocalizedMoment();
+	const translate = useTranslate();
+
+	function prepareScheduleName( schedule: ScheduleUpdates ) {
+		const tm = moment( schedule.timestamp * 1000 );
+		const translateArgs = { time: tm.format( 'LT' ) };
+
+		if ( schedule.schedule === 'daily' ) {
+			return translate( 'Daily at %(time)s', {
+				args: translateArgs,
+			} );
+		} else if ( schedule.schedule === 'weekly' ) {
+			switch ( tm.day() ) {
+				case 0:
+					return translate( 'Sundays at %(time)s', {
+						args: translateArgs,
+					} );
+				case 1:
+					return translate( 'Mondays at %(time)s', {
+						args: translateArgs,
+					} );
+				case 2:
+					return translate( 'Tuesdays at %(time)s', {
+						args: translateArgs,
+					} );
+				case 3:
+					return translate( 'Wednesdays at %(time)s', {
+						args: translateArgs,
+					} );
+				case 4:
+					return translate( 'Thursdays at %(time)s', {
+						args: translateArgs,
+					} );
+				case 5:
+					return translate( 'Fridays at %(time)s', {
+						args: translateArgs,
+					} );
+				case 6:
+					return translate( 'Saturdays at %(time)s', {
+						args: translateArgs,
+					} );
+			}
+		}
+
+		return schedule?.hook || '';
+	}
+	return {
+		prepareScheduleName,
+	};
+}

--- a/client/blocks/plugins-update-manager/hooks/use-prepare-schedule-name.ts
+++ b/client/blocks/plugins-update-manager/hooks/use-prepare-schedule-name.ts
@@ -11,36 +11,44 @@ export function usePrepareScheduleName() {
 		const translateArgs = { time: tm.format( 'LT' ) };
 
 		if ( schedule.schedule === 'daily' ) {
+			/* translators: Daily at 10 am. */
 			return translate( 'Daily at %(time)s', {
 				args: translateArgs,
 			} );
 		} else if ( schedule.schedule === 'weekly' ) {
 			switch ( tm.day() ) {
 				case 0:
+					/* translators: Sundays at 10 am. */
 					return translate( 'Sundays at %(time)s', {
 						args: translateArgs,
 					} );
 				case 1:
+					/* translators: Mondays at 10 am. */
 					return translate( 'Mondays at %(time)s', {
 						args: translateArgs,
 					} );
 				case 2:
+					/* translators: Tuesdays at 10 am. */
 					return translate( 'Tuesdays at %(time)s', {
 						args: translateArgs,
 					} );
 				case 3:
+					/* translators: Wednesdays at 10 am. */
 					return translate( 'Wednesdays at %(time)s', {
 						args: translateArgs,
 					} );
 				case 4:
+					/* translators: Thursdays at 10 am. */
 					return translate( 'Thursdays at %(time)s', {
 						args: translateArgs,
 					} );
 				case 5:
+					/* translators: Fridays at 10 am. */
 					return translate( 'Fridays at %(time)s', {
 						args: translateArgs,
 					} );
 				case 6:
+					/* translators: Saturdays at 10 am. */
 					return translate( 'Saturdays at %(time)s', {
 						args: translateArgs,
 					} );

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -1,5 +1,4 @@
 import {
-	TextControl,
 	RadioControl,
 	SearchControl,
 	SelectControl,
@@ -33,12 +32,7 @@ import {
 	PERIOD_OPTIONS,
 	WEEKLY_OPTION,
 } from './schedule-form.const';
-import {
-	prepareTimestamp,
-	validateName,
-	validatePlugins,
-	validateTimeSlot,
-} from './schedule-form.helper';
+import { prepareTimestamp, validatePlugins, validateTimeSlot } from './schedule-form.helper';
 
 import './schedule-form.scss';
 
@@ -67,7 +61,6 @@ export const ScheduleForm = ( props: Props ) => {
 		onSuccess: () => onSyncSuccess && onSyncSuccess(),
 	} );
 
-	const [ name, setName ] = useState( scheduleForEdit?.hook || '' );
 	const [ selectedPlugins, setSelectedPlugins ] = useState< string[] >(
 		scheduleForEdit?.args || []
 	);
@@ -85,7 +78,6 @@ export const ScheduleForm = ( props: Props ) => {
 	const scheduledPlugins = schedules.map( ( schedule ) => schedule.args );
 	const [ pluginSearchTerm, setPluginSearchTerm ] = useState( '' );
 	const [ validationErrors, setValidationErrors ] = useState< Record< string, string > >( {
-		name: validateName( name ),
 		plugins: validatePlugins( selectedPlugins, scheduledPlugins ),
 		timestamp: validateTimeSlot( { frequency, timestamp }, scheduledTimeSlots ),
 	} );
@@ -126,13 +118,11 @@ export const ScheduleForm = ( props: Props ) => {
 	const onFormSubmit = () => {
 		const formValid = ! Object.values( validationErrors ).filter( ( e ) => !! e ).length;
 		setFieldTouched( {
-			name: true,
 			plugins: true,
 			timestamp: true,
 		} );
 
 		const params = {
-			hook: name,
 			plugins: selectedPlugins,
 			schedule: {
 				timestamp,
@@ -146,12 +136,6 @@ export const ScheduleForm = ( props: Props ) => {
 				: createUpdateSchedule( params );
 		}
 	};
-
-	// Name validation
-	useEffect(
-		() => setValidationErrors( { ...validationErrors, name: validateName( name ) } ),
-		[ name ]
-	);
 
 	// Plugin selection validation
 	useEffect(
@@ -189,24 +173,6 @@ export const ScheduleForm = ( props: Props ) => {
 				gap={ 12 }
 			>
 				<FlexItem>
-					<div className="form-field">
-						<label htmlFor="name">Name</label>
-						<TextControl
-							id="name"
-							value={ name }
-							onBlur={ () => setFieldTouched( { ...fieldTouched, name: true } ) }
-							onChange={ setName }
-							__next40pxDefaultSize
-							placeholder="Example: Security plugins"
-							autoComplete="off"
-						/>
-						{ fieldTouched?.name && validationErrors?.name && (
-							<Text className="validation-msg">
-								<Icon className="icon-info" icon={ info } size={ 16 } />
-								{ validationErrors.name }
-							</Text>
-						) }
-					</div>
 					<div className="form-field">
 						<label htmlFor="frequency">Update every</label>
 						<div className={ classnames( 'radio-option', { selected: frequency === 'daily' } ) }>

--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -5,6 +5,7 @@ import { usePreparePluginsTooltipInfo } from 'calypso/blocks/plugins-update-mana
 import { ellipsis } from 'calypso/blocks/plugins-update-manager/icons';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
+import { usePrepareScheduleName } from './hooks/use-prepare-schedule-name';
 import { useSiteSlug } from './hooks/use-site-slug';
 
 interface Props {
@@ -17,6 +18,7 @@ export const ScheduleListCards = ( props: Props ) => {
 	const { onEditClick, onRemoveClick } = props;
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
+	const { prepareScheduleName } = usePrepareScheduleName();
 
 	return (
 		<div className="schedule-list--cards">
@@ -46,7 +48,7 @@ export const ScheduleListCards = ( props: Props ) => {
 								variant="link"
 								onClick={ () => onEditClick && onEditClick( schedule.id ) }
 							>
-								{ schedule.hook }
+								{ prepareScheduleName( schedule ) }
 							</Button>
 						</strong>
 					</div>

--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -4,6 +4,7 @@ import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { MOMENT_TIME_FORMAT } from './config';
 import { usePreparePluginsTooltipInfo } from './hooks/use-prepare-plugins-tooltip-info';
+import { usePrepareScheduleName } from './hooks/use-prepare-schedule-name';
 import { useSiteSlug } from './hooks/use-site-slug';
 import { ellipsis } from './icons';
 
@@ -17,6 +18,7 @@ export const ScheduleListTable = ( props: Props ) => {
 	const { onEditClick, onRemoveClick } = props;
 	const { data: schedules = [] } = useUpdateScheduleQuery( siteSlug );
 	const { preparePluginsTooltipInfo } = usePreparePluginsTooltipInfo( siteSlug );
+	const { prepareScheduleName } = usePrepareScheduleName();
 
 	/**
 	 * NOTE: If you update the table structure,
@@ -43,7 +45,7 @@ export const ScheduleListTable = ( props: Props ) => {
 								variant="link"
 								onClick={ () => onEditClick && onEditClick( schedule.id ) }
 							>
-								{ schedule.hook }
+								{ prepareScheduleName( schedule ) }
 							</Button>
 						</td>
 						<td></td>

--- a/client/data/plugins/use-update-schedules-mutation.ts
+++ b/client/data/plugins/use-update-schedules-mutation.ts
@@ -5,7 +5,6 @@ import type { ScheduleUpdates } from './use-update-schedules-query';
 import type { SiteSlug } from 'calypso/types';
 
 export type CreateRequestParams = {
-	hook: string;
 	plugins: string[];
 	schedule: {
 		interval: 'daily' | 'weekly';
@@ -34,7 +33,6 @@ export function useCreateUpdateScheduleMutation( siteSlug: SiteSlug, queryOption
 				...prevSchedules,
 				{
 					id: 'temp-id',
-					hook: params.hook,
 					args: params.plugins,
 					timestamp: params.schedule.timestamp,
 					schedule: params.schedule.interval,
@@ -91,7 +89,6 @@ export function useEditUpdateScheduleMutation( siteSlug: SiteSlug, queryOptions 
 				...prevSchedules.slice( 0, scheduleIndex ),
 				{
 					...prevSchedules[ scheduleIndex ],
-					hook: params.hook,
 					args: params.plugins,
 					timestamp: params.schedule.timestamp,
 					schedule: params.schedule.interval,

--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -4,6 +4,7 @@ import type { SiteSlug } from 'calypso/types';
 
 export type ScheduleUpdates = {
 	id: string;
+	hook?: string;
 	interval: number;
 	timestamp: number;
 	schedule: 'weekly' | 'daily';

--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -4,7 +4,6 @@ import type { SiteSlug } from 'calypso/types';
 
 export type ScheduleUpdates = {
 	id: string;
-	hook: string;
 	interval: number;
 	timestamp: number;
 	schedule: 'weekly' | 'daily';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes https://github.com/Automattic/wp-calypso/issues/88232

## Proposed Changes

* Removed Name field from the create/edit form
* Prepare Name based on schedule frequency and time

## Testing Instructions

* Go to `/plugins/scheduled-updates/{ATOMIC_SITE}`
* Check if the scheduled name is based on the picked frequency and time

<img width="1097" alt="Screenshot 2024-03-07 at 13 16 38" src="https://github.com/Automattic/wp-calypso/assets/1241413/01862ea7-220d-4508-a3de-213d0817154e">

<img width="1102" alt="Screenshot 2024-03-07 at 13 17 58" src="https://github.com/Automattic/wp-calypso/assets/1241413/da0ea4ab-b86f-4780-b57e-576ff2b512d4">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?