### PR TITLE
Sharing: open up sharing block recommendations

### DIFF
--- a/client/my-sites/marketing/buttons/buttons.jsx
+++ b/client/my-sites/marketing/buttons/buttons.jsx
@@ -183,7 +183,7 @@ class SharingButtons extends Component {
 						</NoticeAction>
 					</Notice>
 				) }
-				{ ! isFetchingModules && ! isSharingModuleInactive && (
+				{ ! isFetchingModules && ! isSharingModuleInactive && isBlockTheme && (
 					<Notice
 						status="is-info"
 						showDismiss={ false }

--- a/client/my-sites/marketing/buttons/buttons.jsx
+++ b/client/my-sites/marketing/buttons/buttons.jsx
@@ -123,11 +123,6 @@ class SharingButtons extends Component {
 		return Object.assign( {}, settings, disabledSettings, this.state.values );
 	}
 
-	disableLegacySharing = ( siteId ) => {
-		this.props.recordTracksEvent( 'calypso_sharing_buttons_disable_legacy_click', {} );
-		this.props.deactivateModule( siteId, 'sharedaddy' );
-	};
-
 	render() {
 		const {
 			buttons,
@@ -197,7 +192,7 @@ class SharingButtons extends Component {
 						) }
 					>
 						{ isJetpack && (
-							<NoticeAction onClick={ this.disableLegacySharing }>
+							<NoticeAction onClick={ () => this.props.deactivateModule( siteId, 'sharedaddy' ) }>
 								{ translate( 'Disable' ) }
 							</NoticeAction>
 						) }

--- a/client/my-sites/marketing/buttons/components/buttons-block-appearance.jsx
+++ b/client/my-sites/marketing/buttons/components/buttons-block-appearance.jsx
@@ -1,4 +1,6 @@
+import { localizeUrl } from '@automattic/i18n-utils';
 import { localize } from 'i18n-calypso';
+import ExternalLink from 'calypso/components/external-link';
 import { useSelector } from 'calypso/state';
 import { getSiteAdminUrl } from 'calypso/state/sites/selectors';
 import SharingButtonsPreviewButtons from '../preview-buttons';
@@ -11,15 +13,20 @@ const buttons = [
 	{ ID: 'pinterest', name: 'Pinterest', shortname: 'pinterest' },
 ];
 
-const ButtonsBlockAppearance = ( { translate, siteId } ) => {
+const ButtonsBlockAppearance = ( { isJetpack, translate, siteId } ) => {
 	const siteAdminUrl = useSelector( ( state ) => getSiteAdminUrl( state, siteId ) );
 	const siteEditorUrl = siteAdminUrl + 'site-editor.php?path=%2Fwp_template';
+	const supportDocLink = localizeUrl(
+		isJetpack
+			? 'https://jetpack.com/support/jetpack-blocks/sharing-buttons-block/'
+			: 'https://wordpress.com/support/wordpress-editor/blocks/sharing-buttons-block/'
+	);
 
 	return (
 		<div className="sharing-buttons__panel sharing-buttons-appearance">
 			<p className="sharing-buttons-appearance__description">
 				{ translate(
-					'Allow readers to easily share your posts with others by adding sharing buttons throughout your site.'
+					'Allow readers to easily share your posts with others by adding a sharing buttons block anywhere in one of your site’s templates.'
 				) }
 			</p>
 			<div className="sharing-buttons__buttons-wrapper">
@@ -27,7 +34,9 @@ const ButtonsBlockAppearance = ( { translate, siteId } ) => {
 					{ translate( 'Go to the Site Editor' ) }
 				</a>
 
-				<button className="button">{ translate( 'Learn how to add Sharing Buttons' ) }</button>
+				<ExternalLink className="button" href={ supportDocLink } icon={ true }>
+					{ translate( 'Learn how to add Sharing Buttons' ) }
+				</ExternalLink>
 			</div>
 			<p className="sharing-buttons__example-text">{ translate( 'Sharing Buttons example:' ) }</p>
 			<SharingButtonsPreviewButtons buttons={ buttons } style="icon-text" />


### PR DESCRIPTION
Follow-up to #85180

Related:

- https://github.com/Automattic/jetpack/issues/34327
- https://github.com/Automattic/jetpack/issues/34117

## Proposed Changes

Now that the sharing buttons block is widely available, both on WordPress.com Simple and on stable Jetpack releases, we can remove the previous flag and display the new screen to everyone, as long as they're on WordPress.com or using a recent version of Jetpack (the sharing buttons block was added to the plugin in version 13.1).

This PR also does a few other things:

- It updates the look of the sharing buttons block recommendation screen to link to the support docs, with an external link button, and with the right doc depending on your platform.
- It updates the wording on the sharing screen to try to make it clearer that the blocks is what you want to go with when using a block-based theme.
- It offers a quick option to deactivate the sharing module when you use a block-based theme.

## Testing Instructions

> [!NOTE]
> It's important to test this change on both WordPress.com and Jetpack sites, on sites that use a classic theme and sites that use a block-based theme.

* On a self-hosted site, go to Jetpack > Settings > Sharing and activate the sharing module. 
* Go to `http://calypso.localhost:3000/marketing/sharing-buttons/`
    * Ensure the display is relevant to the state of your site, following the screenshots below.`

**Jetpack, block-based theme, legacy sharing module active**

<img width="1127" alt="image" src="https://github.com/Automattic/wp-calypso/assets/426388/34aec754-cc51-4638-827c-c0559f1ea421">

**Jetpack, block-based theme, legacy sharing module inactive**

<img width="1124" alt="image" src="https://github.com/Automattic/wp-calypso/assets/426388/1ac3f9bb-4e94-41a4-98d4-6a4f3882f77c">

**Jetpack, classic theme, legacy sharing module active**

-> No changes to that scenario

<img width="1117" alt="image" src="https://github.com/Automattic/wp-calypso/assets/426388/077d0816-b834-4789-93b6-31132e54206e">

**Jetpack, classic theme, legacy sharing module inactive**

-> No changes to that scenario

<img width="1090" alt="image" src="https://github.com/Automattic/wp-calypso/assets/426388/e2109fb7-9c92-4259-b4f5-eb9cc1d45275">


**WordPress.com, block-based theme**

<img width="1118" alt="image" src="https://github.com/Automattic/wp-calypso/assets/426388/8a272539-6f10-45b7-ab90-d18e0cdb424f">

**WordPress.com, classic theme**

-> No changes to that scenario

<img width="1146" alt="image" src="https://github.com/Automattic/wp-calypso/assets/426388/c21708ec-b170-4bb9-baa5-0ed41b39d01f">

## Pre-merge Checklist

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
