### PR TITLE
Migration Flow: Trigger Hotjar

### DIFF
--- a/client/blocks/import/capture/index.tsx
+++ b/client/blocks/import/capture/index.tsx
@@ -1,11 +1,12 @@
 import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Title } from '@automattic/onboarding';
+import { useEffect } from '@wordpress/element';
 import { useTranslate } from 'i18n-calypso';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useAnalyzeUrlQuery } from 'calypso/data/site-profiler/use-analyze-url-query';
 import { triggerMigrationStartingEvent } from 'calypso/my-sites/migrate/helpers';
 import { useSelector } from 'calypso/state';
-import { getCurrentUser } from 'calypso/state/current-user/selectors';
+import { getCurrentUser, getCurrentUserCountryCode } from 'calypso/state/current-user/selectors';
 import ScanningStep from '../scanning';
 import { GoToStep } from '../types';
 import CaptureInput from './capture-input';
@@ -63,6 +64,7 @@ export const CaptureStep: React.FunctionComponent< StepProps > = ( {
 	onImportListClick,
 } ) => {
 	const currentUser = useSelector( getCurrentUser );
+	const detectedCountryCode = useSelector( getCurrentUserCountryCode );
 	const isStartingPointEventTriggeredRef = useRef( false );
 	const [ url, setUrl ] = useState( initialUrl );
 	const {
@@ -72,6 +74,16 @@ export const CaptureStep: React.FunctionComponent< StepProps > = ( {
 		isFetchedAfterMount,
 	} = useAnalyzeUrlQuery( url );
 	const showCapture = ! isAnalyzing || ( initialUrl && isFetchedAfterMount );
+
+	useEffect( () => {
+		if ( ! [ 'US', 'GB', 'AU', 'JP' ].includes( detectedCountryCode ) ) {
+			return;
+		}
+
+		if ( window && window.hj ) {
+			window.hj( 'trigger', 'importer_capture_step' );
+		}
+	}, [ detectedCountryCode ] );
 
 	const decideStepRedirect = () => {
 		if ( ! urlData ) {


### PR DESCRIPTION


This PR adds a survey to the migration flow, in the URL step.

Context: pdDR7T-1oU-p2#comment-1667

## Testing steps

1. Reach `/setup/import-hosted-site/import?source=sites-dashboard&ref=hosting-flow`
2. You should see the survey

Make sure your browser cookie is set to be in one of these:  'US', 'GB', 'AU', 'JP'