### PR TITLE
Decode HTML entities returned from the plugin endpoints

### DIFF
--- a/client/data/plugins/helpers.ts
+++ b/client/data/plugins/helpers.ts
@@ -1,0 +1,32 @@
+import { decodeEntities } from 'calypso/lib/formatting';
+
+/**
+ * Takes an array of objects and a list of fields to decode HTML entities from.
+ * Iterates over each object, creates a new one with the same properties,
+ * and decodes any HTML entities in the specified fields using decodeEntities().
+ * Returns an array of the modified objects with the fields decoded.
+ *
+ * If no fields are provided, it defaults to decoding the 'name' field.
+ *
+ * @param plugins - The array of objects to decode
+ * @param fields - The fields to decode (defaults to ['name'])
+ * @returns An array of the modified objects with the specified fields decoded
+ */
+const decodeEntitiesFromPlugins = < T >(
+	plugins: T[],
+	fields: ( keyof T )[] = [ 'name' as keyof T ]
+): T[] => {
+	return plugins.map( ( plugin ) => {
+		const decodedPlugin: T = { ...plugin };
+
+		fields.forEach( ( field ) => {
+			if ( plugin?.hasOwnProperty( field ) ) {
+				decodedPlugin[ field ] = decodeEntities( plugin[ field ] as string );
+			}
+		} );
+
+		return decodedPlugin;
+	} );
+};
+
+export { decodeEntitiesFromPlugins };

--- a/client/data/plugins/use-core-plugins-query.ts
+++ b/client/data/plugins/use-core-plugins-query.ts
@@ -30,10 +30,12 @@ export const useCorePluginsQuery = (
 	siteIdOrSlug: SiteId | SiteSlug | undefined,
 	hideManagedPlugins: boolean = false
 ): UseQueryResult< CorePluginsResponse > => {
-	const select = hideManagedPlugins
-		? ( plugins: CorePluginsResponse ) =>
-				decodeEntitiesFromPlugins( plugins ).filter( ( plugin ) => ! plugin.is_managed )
-		: undefined;
+	const select = ( plugins: CorePluginsResponse ) => {
+		const decodedPlugins = decodeEntitiesFromPlugins( plugins );
+		return hideManagedPlugins
+			? decodedPlugins.filter( ( plugin ) => ! plugin.is_managed )
+			: decodedPlugins;
+	};
 
 	return useQuery< CorePluginsResponse >( {
 		queryKey: [ 'core-plugins', siteIdOrSlug ],

--- a/client/data/plugins/use-core-plugins-query.ts
+++ b/client/data/plugins/use-core-plugins-query.ts
@@ -1,5 +1,6 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
+import { decodeEntitiesFromPlugins } from './helpers';
 import type { SiteId, SiteSlug } from 'calypso/types';
 
 export type CorePlugin = {
@@ -30,7 +31,8 @@ export const useCorePluginsQuery = (
 	hideManagedPlugins: boolean = false
 ): UseQueryResult< CorePluginsResponse > => {
 	const select = hideManagedPlugins
-		? ( plugins: CorePluginsResponse ) => plugins.filter( ( plugin ) => ! plugin.is_managed )
+		? ( plugins: CorePluginsResponse ) =>
+				decodeEntitiesFromPlugins( plugins ).filter( ( plugin ) => ! plugin.is_managed )
 		: undefined;
 
 	return useQuery< CorePluginsResponse >( {

--- a/client/data/plugins/use-site-plugins-query.ts
+++ b/client/data/plugins/use-site-plugins-query.ts
@@ -1,5 +1,6 @@
 import { useQuery, UseQueryResult } from '@tanstack/react-query';
 import wpcomRequest from 'wpcom-proxy-request';
+import { decodeEntitiesFromPlugins } from './helpers';
 import type { SiteId, SiteSlug } from 'calypso/types';
 
 export type SitePlugin = {
@@ -32,7 +33,7 @@ export type SitePluginsResponse = {
 export const useSitePluginsQuery = (
 	siteIdOrSlug: SiteId | SiteSlug | undefined
 ): UseQueryResult< SitePluginsResponse > => {
-	return useQuery( {
+	return useQuery< SitePluginsResponse >( {
 		queryKey: [ 'site-plugins', siteIdOrSlug ],
 		queryFn: () => {
 			return wpcomRequest( {
@@ -46,5 +47,11 @@ export const useSitePluginsQuery = (
 		enabled: !! siteIdOrSlug,
 		retry: false,
 		refetchOnWindowFocus: false,
+		select: ( data ) => {
+			return {
+				...data,
+				plugins: decodeEntitiesFromPlugins( data.plugins, [ 'display_name' ] ),
+			};
+		},
 	} );
 };


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/88250

## Proposed Changes

* Adds a `decodeEntitiesFromPlugins` function which takes an array of plugins, and an array of fields to decode and runs `decodeEntities` on the selected fields. If no fields are passed it will run on `name`.
* Adds this function as a selector on the `useCorePluginsQuery` and `useSitePluginsQuery` queries.

Since both endpoints return the plugins in a different data shape, I opted to make the `decodeEntitiesFromPlugins` as flexible as possible regarding type checking. 

## Testing Instructions

1. Apply this PR
2. Visit `http://calypso.localhost:3000/plugins/scheduled-updates/<youratomicblog>` and add a schedule for a plugin containing HTML entities (for example `CrowdSignal Polls & Ratings`.
3. This should render fine in both the add/edit form, and in the popover on the list.

![CleanShot 2024-03-07 at 15 27 17@2x](https://github.com/Automattic/wp-calypso/assets/528287/88ebcf1a-f4de-4b3e-8064-19b7dcdd31da)
![CleanShot 2024-03-07 at 15 27 47@2x](https://github.com/Automattic/wp-calypso/assets/528287/55619ee5-765e-4319-b138-1de266f80a3c)



## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?