### PR TITLE
Domains: Fix incorrect behavior when canceling bundled domains in AGP

### DIFF
--- a/client/me/purchases/cancel-purchase/button.jsx
+++ b/client/me/purchases/cancel-purchase/button.jsx
@@ -19,6 +19,7 @@ import {
 	getSubscriptionEndDate,
 	hasAmountAvailableToRefund,
 	isOneTimePurchase,
+	isRefundable,
 	isSubscription,
 } from 'calypso/lib/purchases';
 import {
@@ -298,6 +299,11 @@ class CancelPurchaseButton extends Component {
 
 			if ( isDomainRegistration( purchase ) ) {
 				text = translate( 'Cancel Domain' );
+
+				// Domain in AGP bought with domain credits should be canceled immediately
+				if ( isRefundable( purchase ) ) {
+					onClick = this.handleCancelPurchaseClick;
+				}
 			}
 
 			if ( isSubscription( purchase ) ) {

--- a/client/me/purchases/cancel-purchase/index.jsx
+++ b/client/me/purchases/cancel-purchase/index.jsx
@@ -163,6 +163,12 @@ class CancelPurchase extends Component {
 		const expirationDate = this.props.moment( expiryDate ).format( 'LL' );
 
 		if ( isDomainRegistration( purchase ) ) {
+			// Domain in AGP bought with domain credits
+			if ( isRefundable( purchase ) ) {
+				return this.props.translate(
+					'After you confirm this change, the domain will be removed immediately'
+				);
+			}
 			return this.props.translate(
 				'After you confirm this change, the domain will be removed on %(expirationDate)s',
 				{

--- a/client/me/purchases/cancel-purchase/refund-information.jsx
+++ b/client/me/purchases/cancel-purchase/refund-information.jsx
@@ -9,6 +9,7 @@ import FormCheckbox from 'calypso/components/forms/form-checkbox';
 import FormRadio from 'calypso/components/forms/form-radio';
 import {
 	getName,
+	hasAmountAvailableToRefund,
 	isRefundable,
 	isSubscription,
 	isOneTimePurchase,
@@ -45,13 +46,24 @@ const CancelPurchaseRefundInformation = ( {
 
 	if ( isRefundable( purchase ) ) {
 		if ( isDomainRegistration( purchase ) ) {
-			text = i18n.translate(
-				'When you cancel your domain within %(refundPeriodInDays)d days of purchasing, ' +
-					"you'll receive a refund and it will be removed from your site immediately.",
-				{
-					args: { refundPeriodInDays },
-				}
-			);
+			// Domain bought with domain credits, so there's no refund
+			if ( ! hasAmountAvailableToRefund( purchase ) ) {
+				text = i18n.translate(
+					'When you cancel your domain within %(refundPeriodInDays)d days of purchasing, ' +
+						'it will be removed from your site immediately.',
+					{
+						args: { refundPeriodInDays },
+					}
+				);
+			} else {
+				text = i18n.translate(
+					'When you cancel your domain within %(refundPeriodInDays)d days of purchasing, ' +
+						"you'll receive a refund and it will be removed from your site immediately.",
+					{
+						args: { refundPeriodInDays },
+					}
+				);
+			}
 		}
 
 		if ( isSubscription( purchase ) ) {


### PR DESCRIPTION
## Proposed Changes

This PR fixes incorrect behavior when canceling bundled domains in AGP. See p58i-g1X-p2#comment-60612 for a report of the incorrect behavior.

What was happening is when a user tried to cancel a bundled domain (i.e. bought with domain credits for $0) that's in AGP (Add Grace Period, usually 5 days after registration), they saw the following message:

![Markup on 2024-03-07 at 10:22:51](https://github.com/Automattic/wp-calypso/assets/5324818/92418513-cd6c-437c-8ede-d23817581b92)

Note that the main message says the domain will be removed immediately, but the footer says the domain will be removed in a date in the future, which is inconsistent. The main message also mentions a refund, which won't be made for a bundled domain. 

If the user clicked the "Cancel domain" button, what actually happened is that the domain's auto-renew will be turned off, but the domain would remain in the user's account until the date in the future. 

The underlying problem is that bundled domains in AGP are refundable, but their purchase has no value ($0), which caused these inconsistencies. This PR fixes this by updating the copy in both places to say the domain will be removed immediately, and actually removing the domain immediately if it's in AGP.

### Screenshots

- Before

![Markup on 2024-03-07 at 10:22:51](https://github.com/Automattic/wp-calypso/assets/5324818/79cb4a25-9a84-4df1-943a-ca1af1723ca8)

- After

<img width="1068" alt="Screenshot 2024-03-07 at 10 26 14" src="https://github.com/Automattic/wp-calypso/assets/5324818/78f5bc32-77da-4308-8624-24320dc1d27d">

## Testing Instructions

- Enable store sandbox in your backend to not really buy domains
- Open the live Calypso link or build this branch locally
- Go to `/start` and buy a domain with a paid plan
- Go to the purchase page and try to cancel the bundled domain
- Ensure the copy is correct like in the screenshot above
- Cancel the domain and ensure it was removed from the site

Ensure this page is shown after clicking on the "Cancel domain" button:

<img width="1063" alt="Screenshot 2024-03-07 at 11 40 07" src="https://github.com/Automattic/wp-calypso/assets/5324818/a5a174af-84f5-416a-9f03-03b4a9192815">

Also, please test these other cancelation scenarios to ensure there were no regressions: (the domain purchase's auto-renew must be turned on, otherwise the domain will be removed immediately)

- Bundled domain outside AGP

<img width="1070" alt="Screenshot 2024-03-07 at 11 34 57" src="https://github.com/Automattic/wp-calypso/assets/5324818/39448864-72e2-4605-8c65-bbe2fb35b66f">

- Not bundled domain in AGP

<img width="1090" alt="Screenshot 2024-03-06 at 20 55 33" src="https://github.com/Automattic/wp-calypso/assets/5324818/9fe6a671-8bcd-4a89-821c-c2a66e5c26d7">

- Not bundled domain outside AGP

<img width="1067" alt="Screenshot 2024-03-07 at 11 27 05" src="https://github.com/Automattic/wp-calypso/assets/5324818/23ecdc66-faa7-4a0f-99b4-309d7dbcd576">

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?