### PR TITLE
Update JP Monitor on Schedule Creation

### DIFF
--- a/client/blocks/plugins-update-manager/hooks/use-create-monitor.tsx
+++ b/client/blocks/plugins-update-manager/hooks/use-create-monitor.tsx
@@ -1,39 +1,21 @@
-import { wpcomRequest } from '@automattic/data-stores/src/wpcom-request-controls';
+import {
+	UpdateMonitorSettings,
+	useCreateMonitorSettingsMutation,
+} from 'calypso/data/plugins/use-monitor-settings-mutation';
 import { useSelector } from 'calypso/state';
 import { JETPACK_MODULE_ACTIVATE_SUCCESS } from 'calypso/state/action-types';
 import { activateModule } from 'calypso/state/jetpack/modules/actions';
 import getSiteUrl from 'calypso/state/selectors/get-site-url';
 import { getSiteId } from 'calypso/state/sites/selectors';
+import { SiteSlug } from 'calypso/types';
 import { CRON_CHECK_INTERVAL } from '../schedule-form.const';
 
-export type UpdateMonitorURLOptions = {
-	status_down_webhook_url: string;
-};
-
-export type UpdateMonitorURL = {
-	monitor_url: string;
-	check_interval: number;
-	options: UpdateMonitorURLOptions;
-};
-
-export type UpdateMonitorSettings = {
-	wp_note_notifications?: boolean;
-	email_notifications?: boolean;
-	sms_notifications?: boolean;
-	jetmon_defer_status_down_minutes?: number;
-	urls?: UpdateMonitorURL[];
-};
-
-export type UpdateMonitorSettingsCreate = {
-	success: boolean;
-	settings: UpdateMonitorSettings;
-};
-
-export function useCreateMonitor( siteSlug: string ) {
+export function useCreateMonitor( siteSlug: SiteSlug ) {
 	const siteId = useSelector( ( state ) => getSiteId( state, siteSlug ) );
 	const siteUrl = useSelector( ( state ) =>
 		getSiteUrl( state, getSiteId( state, siteSlug ) as number )
 	);
+	const { createMonitorSettings } = useCreateMonitorSettingsMutation( siteSlug );
 
 	const createMonitor = () => {
 		activateModule(
@@ -41,26 +23,21 @@ export function useCreateMonitor( siteSlug: string ) {
 			'monitor',
 			true
 		)( ( args: { type: string } ) => {
-			// The home URL needs to be one of the URLs monitored.
-			// Monitoring the wp-cron.php file to ensure that the cron jobs are running.
 			if ( args.type === JETPACK_MODULE_ACTIVATE_SUCCESS ) {
-				wpcomRequest( {
-					path: `/sites/${ siteSlug }/jetpack-monitor-settings`,
-					apiNamespace: 'wpcom/v2',
-					method: 'POST',
-					body: {
-						urls: [
-							{
-								check_interval: CRON_CHECK_INTERVAL,
-								monitor_url: siteUrl,
-							},
-							{
-								check_interval: CRON_CHECK_INTERVAL,
-								monitor_url: siteUrl + '/wp-cron.php',
-							},
-						],
-					},
-				} );
+				createMonitorSettings( {
+					urls: [
+						{
+							// The home URL needs to be one of the URLs monitored.
+							check_interval: CRON_CHECK_INTERVAL,
+							monitor_url: siteUrl,
+						},
+						{
+							// Monitoring the wp-cron.php file to ensure that the cron jobs are running.
+							check_interval: CRON_CHECK_INTERVAL,
+							monitor_url: siteUrl + '/wp-cron.php',
+						},
+					],
+				} as UpdateMonitorSettings );
 			}
 		} );
 	};

--- a/client/blocks/plugins-update-manager/hooks/use-create-monitor.tsx
+++ b/client/blocks/plugins-update-manager/hooks/use-create-monitor.tsx
@@ -1,0 +1,71 @@
+import { wpcomRequest } from '@automattic/data-stores/src/wpcom-request-controls';
+import { useSelector } from 'calypso/state';
+import { JETPACK_MODULE_ACTIVATE_SUCCESS } from 'calypso/state/action-types';
+import { activateModule } from 'calypso/state/jetpack/modules/actions';
+import getSiteUrl from 'calypso/state/selectors/get-site-url';
+import { getSiteId } from 'calypso/state/sites/selectors';
+import { CRON_CHECK_INTERVAL } from '../schedule-form.const';
+
+export type UpdateMonitorURLOptions = {
+	status_down_webhook_url: string;
+};
+
+export type UpdateMonitorURL = {
+	monitor_url: string;
+	check_interval: number;
+	options: UpdateMonitorURLOptions;
+};
+
+export type UpdateMonitorSettings = {
+	wp_note_notifications?: boolean;
+	email_notifications?: boolean;
+	sms_notifications?: boolean;
+	jetmon_defer_status_down_minutes?: number;
+	urls?: UpdateMonitorURL[];
+};
+
+export type UpdateMonitorSettingsCreate = {
+	success: boolean;
+	settings: UpdateMonitorSettings;
+};
+
+export function useCreateMonitor( siteSlug: string ) {
+	const siteId = useSelector( ( state ) => getSiteId( state, siteSlug ) );
+	const siteUrl = useSelector( ( state ) =>
+		getSiteUrl( state, getSiteId( state, siteSlug ) as number )
+	);
+
+	const createMonitor = () => {
+		activateModule(
+			siteId,
+			'monitor',
+			true
+		)( ( args: { type: string } ) => {
+			// The home URL needs to be one of the URLs monitored.
+			// Monitoring the wp-cron.php file to ensure that the cron jobs are running.
+			if ( args.type === JETPACK_MODULE_ACTIVATE_SUCCESS ) {
+				wpcomRequest( {
+					path: `/sites/${ siteSlug }/jetpack-monitor-settings`,
+					apiNamespace: 'wpcom/v2',
+					method: 'POST',
+					body: {
+						urls: [
+							{
+								check_interval: CRON_CHECK_INTERVAL,
+								monitor_url: siteUrl,
+							},
+							{
+								check_interval: CRON_CHECK_INTERVAL,
+								monitor_url: siteUrl + '/wp-cron.php',
+							},
+						],
+					},
+				} );
+			}
+		} );
+	};
+
+	return {
+		createMonitor,
+	};
+}

--- a/client/blocks/plugins-update-manager/schedule-create.tsx
+++ b/client/blocks/plugins-update-manager/schedule-create.tsx
@@ -14,6 +14,7 @@ import { useEffect } from 'react';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { MAX_SCHEDULES } from './config';
 import { useCanCreateSchedules } from './hooks/use-can-create-schedules';
+import { useCreateMonitor } from './hooks/use-create-monitor';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSiteSlug } from './hooks/use-site-slug';
 import { ScheduleForm } from './schedule-form';
@@ -23,6 +24,7 @@ interface Props {
 }
 export const ScheduleCreate = ( props: Props ) => {
 	const siteSlug = useSiteSlug();
+	const { createMonitor } = useCreateMonitor( siteSlug );
 	const isEligibleForFeature = useIsEligibleForFeature();
 	const { onNavBack } = props;
 	const { data: schedules = [], isFetched } = useUpdateScheduleQuery(
@@ -47,6 +49,8 @@ export const ScheduleCreate = ( props: Props ) => {
 		recordTracksEvent( 'calypso_scheduled_updates_create_schedule', {
 			site_slug: siteSlug,
 		} );
+
+		createMonitor();
 
 		return onNavBack && onNavBack();
 	};

--- a/client/blocks/plugins-update-manager/schedule-form.const.ts
+++ b/client/blocks/plugins-update-manager/schedule-form.const.ts
@@ -102,3 +102,5 @@ export const PERIOD_OPTIONS = [
 		value: 'pm',
 	},
 ];
+
+export const CRON_CHECK_INTERVAL = 5;

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -23,7 +23,6 @@ import {
 	ScheduleUpdates,
 } from 'calypso/data/plugins/use-update-schedules-query';
 import { MAX_SELECTABLE_PLUGINS } from './config';
-import { useCreateMonitor } from './hooks/use-create-monitor';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSiteSlug } from './hooks/use-site-slug';
 import {
@@ -45,7 +44,6 @@ interface Props {
 export const ScheduleForm = ( props: Props ) => {
 	const moment = useLocalizedMoment();
 	const siteSlug = useSiteSlug();
-	const { createMonitor } = useCreateMonitor( siteSlug );
 	const isEligibleForFeature = useIsEligibleForFeature();
 	const { scheduleForEdit, onSyncSuccess } = props;
 	const initDate = scheduleForEdit
@@ -135,12 +133,9 @@ export const ScheduleForm = ( props: Props ) => {
 		};
 
 		if ( formValid ) {
-			if ( scheduleForEdit ) {
-				editUpdateSchedule( scheduleForEdit.id, params );
-			} else {
-				createUpdateSchedule( params );
-				createMonitor( siteSlug );
-			}
+			scheduleForEdit
+				? editUpdateSchedule( scheduleForEdit.id, params )
+				: createUpdateSchedule( params );
 		}
 	};
 

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -26,7 +26,6 @@ import { MAX_SELECTABLE_PLUGINS } from './config';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSiteSlug } from './hooks/use-site-slug';
 import {
-	CRON_CHECK_INTERVAL,
 	DAILY_OPTION,
 	DAY_OPTIONS,
 	DEFAULT_HOUR,

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -23,6 +23,7 @@ import {
 	ScheduleUpdates,
 } from 'calypso/data/plugins/use-update-schedules-query';
 import { MAX_SELECTABLE_PLUGINS } from './config';
+import { useCreateMonitor } from './hooks/use-create-monitor';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSiteSlug } from './hooks/use-site-slug';
 import {
@@ -44,6 +45,7 @@ interface Props {
 export const ScheduleForm = ( props: Props ) => {
 	const moment = useLocalizedMoment();
 	const siteSlug = useSiteSlug();
+	const { createMonitor } = useCreateMonitor( siteSlug );
 	const isEligibleForFeature = useIsEligibleForFeature();
 	const { scheduleForEdit, onSyncSuccess } = props;
 	const initDate = scheduleForEdit
@@ -133,9 +135,12 @@ export const ScheduleForm = ( props: Props ) => {
 		};
 
 		if ( formValid ) {
-			scheduleForEdit
-				? editUpdateSchedule( scheduleForEdit.id, params )
-				: createUpdateSchedule( params );
+			if ( scheduleForEdit ) {
+				editUpdateSchedule( scheduleForEdit.id, params );
+			} else {
+				createUpdateSchedule( params );
+				createMonitor( siteSlug );
+			}
 		}
 	};
 

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -26,6 +26,7 @@ import { MAX_SELECTABLE_PLUGINS } from './config';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { useSiteSlug } from './hooks/use-site-slug';
 import {
+	CRON_CHECK_INTERVAL,
 	DAILY_OPTION,
 	DAY_OPTIONS,
 	DEFAULT_HOUR,

--- a/client/data/plugins/use-monitor-settings-mutation.ts
+++ b/client/data/plugins/use-monitor-settings-mutation.ts
@@ -1,0 +1,65 @@
+import { UseQueryResult, useMutation, useQuery } from '@tanstack/react-query';
+import { useCallback } from 'react';
+import wpcomRequest from 'wpcom-proxy-request';
+import type { SiteSlug } from 'calypso/types';
+
+export type UpdateMonitorURLOptions = {
+	status_down_webhook_url: string;
+};
+
+export type UpdateMonitorURL = {
+	monitor_url: string;
+	check_interval: number;
+	options: UpdateMonitorURLOptions;
+};
+
+export type UpdateMonitorSettings = {
+	wp_note_notifications?: boolean;
+	email_notifications?: boolean;
+	sms_notifications?: boolean;
+	jetmon_defer_status_down_minutes?: number;
+	urls?: UpdateMonitorURL[];
+};
+
+export type UpdateMonitorSettingsCreate = {
+	success: boolean;
+	settings: UpdateMonitorSettings;
+};
+
+export const useMonitorSettingsQuery = (
+	siteSlug: SiteSlug
+): UseQueryResult< UpdateMonitorSettings > => {
+	return useQuery( {
+		queryKey: [ 'monitor-settings', siteSlug ],
+		queryFn: () =>
+			wpcomRequest< { [ key: string ]: Partial< UpdateMonitorSettings > } >( {
+				path: `/sites/${ siteSlug }/jetpack-monitor-settings`,
+				apiNamespace: 'wpcom/v2',
+				method: 'GET',
+			} ),
+		meta: {
+			persist: false,
+		},
+		enabled: !! siteSlug,
+		retry: false,
+		refetchOnWindowFocus: false,
+	} );
+};
+
+export function useCreateMonitorSettingsMutation( siteSlug: SiteSlug, queryOptions = {} ) {
+	const mutation = useMutation( {
+		mutationFn: ( params: object ) =>
+			wpcomRequest( {
+				path: `/sites/${ siteSlug }/jetpack-monitor-settings`,
+				apiNamespace: 'wpcom/v2',
+				method: 'POST',
+				body: params,
+			} ),
+		...queryOptions,
+	} );
+
+	const { mutate } = mutation;
+	const createMonitorSettings = useCallback( ( params: object ) => mutate( params ), [ mutate ] );
+
+	return { createMonitorSettings, ...mutation };
+}


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5702

## Proposed Changes

* Enable the `monitor` module.
* Create/update the JP monitor on schedule creation.

## Testing Instructions
* `http://calypso.localhost:3000/plugins/scheduled-updates/create/__BLOG__`
* Create a new schedule
* On https://developer.wordpress.com/docs/api/console/ check `GET wpcom/v2/sites/__BLOG__/jetpack-monitor-settings`

It should output:
```json
{
  "success": true,
  "settings": {
    "monitor_active": true,
    "email_notifications": true,
    "sms_notifications": false,
    "wp_note_notifications": true,
    "urls": [
      {
        "monitor_url": "https://__BLOG__",
        "options": [],
        "check_interval": 5
      },
      {
        "monitor_url": "https://__BLOG__/wp-cron.php",
        "options": [],
        "check_interval": 5
      }
    ],
    "contacts": {
      "emails": [],
      "sms_numbers": []
    }
  }
}
```
A `monitor_url` of the homepage is required. Otherwise the endpoint outputs `monitor_url is a required property of urls` error.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?