### PR TITLE
Patterns: Fix master bar appearing behind navigation bar header

### DIFF
--- a/client/assets/stylesheets/shared/functions/_z-index.scss
+++ b/client/assets/stylesheets/shared/functions/_z-index.scss
@@ -23,7 +23,7 @@
 //
 // Usage:
 // .environment-badge {
-//     z-index: z-index( 'root', '.environment-badge' );
+//     z-index: z-index("root", ".environment-badge");
 // }
 //
 // For a refresher on stacking contexts see:

--- a/client/components/search/style.scss
+++ b/client/components/search/style.scss
@@ -169,7 +169,7 @@
 		&::before {
 			@include long-content-fade(
 				$size: 32px,
-				$z-index: z-index( ".search", ".search__input" ) + 2
+				$z-index: z-index(".search", ".search__input") + 2
 			);
 			border-radius: inherit;
 		}
@@ -180,7 +180,7 @@
 				@include long-content-fade(
 					$direction: right,
 					$size: 32px,
-					$z-index: z-index( ".search", ".search__input" ) + 2
+					$z-index: z-index(".search", ".search__input") + 2
 				);
 				border-radius: inherit;
 			}

--- a/client/my-sites/patterns/components/get-started/style.scss
+++ b/client/my-sites/patterns/components/get-started/style.scss
@@ -1,5 +1,5 @@
 @import "@automattic/components/src/styles/typography";
-@import "@wordpress/base-styles/breakpoints.scss";
+@import "@wordpress/base-styles/breakpoints";
 
 
 .patterns-get-started__buttons {

--- a/client/my-sites/patterns/components/grid-gallery/style.scss
+++ b/client/my-sites/patterns/components/grid-gallery/style.scss
@@ -1,5 +1,5 @@
 @import "@automattic/components/src/styles/typography";
-@import "@wordpress/base-styles/breakpoints.scss";
+@import "@wordpress/base-styles/breakpoints";
 
 .patterns-grid-gallery {
 	display: grid;

--- a/client/my-sites/patterns/components/header/style.scss
+++ b/client/my-sites/patterns/components/header/style.scss
@@ -1,6 +1,6 @@
 
 @import "@automattic/components/src/styles/typography";
-@import "@wordpress/base-styles/breakpoints.scss";
+@import "@wordpress/base-styles/breakpoints";
 
 .patterns-header {
 	background: #1d2327;

--- a/client/my-sites/patterns/components/section/style.scss
+++ b/client/my-sites/patterns/components/section/style.scss
@@ -1,6 +1,6 @@
 @import "@automattic/typography/styles/variables";
 @import "@automattic/components/src/styles/typography";
-@import "@wordpress/base-styles/breakpoints.scss";
+@import "@wordpress/base-styles/breakpoints";
 
 .patterns-section {
 	padding: 90px 0 96px;

--- a/client/my-sites/patterns/pages/category/style.scss
+++ b/client/my-sites/patterns/pages/category/style.scss
@@ -1,4 +1,4 @@
-@import "@wordpress/base-styles/breakpoints.scss";
+@import "@wordpress/base-styles/breakpoints";
 @import "@automattic/components/src/styles/typography";
 
 .is-section-patterns .category-pill-navigation {

--- a/client/my-sites/patterns/pages/home/style.scss
+++ b/client/my-sites/patterns/pages/home/style.scss
@@ -1,5 +1,5 @@
 @import "@automattic/components/src/styles/typography";
-@import "@wordpress/base-styles/breakpoints.scss";
+@import "@wordpress/base-styles/breakpoints";
 
 .section-patterns-info {
 	overflow: auto;

--- a/client/my-sites/patterns/style.scss
+++ b/client/my-sites/patterns/style.scss
@@ -1,3 +1,5 @@
+@import "@wordpress/base-styles/breakpoints";
+
 .is-section-patterns {
 	.layout__content {
 		padding: 0;
@@ -11,6 +13,10 @@
 	.is-logged-in {
 		.lpc-header-nav-wrapper {
 			padding-top: 32px;
+
+			@media ( max-width: $break-medium ) {
+				padding-top: 46px;
+			}
 		}
 	}
 

--- a/client/my-sites/patterns/style.scss
+++ b/client/my-sites/patterns/style.scss
@@ -1,6 +1,11 @@
 .is-section-patterns {
 	.layout__content {
 		padding: 0;
+
+		.masterbar {
+			// Makes sure the navigation bar header appears below the masterbar and notices
+			z-index: z-index("root", ".main") - 1;
+		}
 	}
 
 	.is-logged-in {

--- a/packages/onboarding/styles/z-index.scss
+++ b/packages/onboarding/styles/z-index.scss
@@ -23,7 +23,7 @@
 //
 // Usage:
 // .environment-badge {
-//     z-index: onboarding-z-index( '.environment-badge' );
+//     z-index: onboarding-z-index(".environment-badge");
 // }
 //
 // For a refresher on stacking contexts see:


### PR DESCRIPTION
This pull request fixes https://github.com/Automattic/dotcom-forge/issues/5951 by making sure that the universal navigation bar header appears below the master bar as well as notices - something especially visible when scrolling down:

Before | After
------ | -----
<img width="624" alt="before" src="https://github.com/Automattic/wp-calypso/assets/594356/07fdc0a5-b5c5-405b-bfd4-72a2d86f638b"> | <img width="624" alt="after" src="https://github.com/Automattic/wp-calypso/assets/594356/2d6f4c90-fcdb-4321-9792-e410d05fd1fd">

#### Testing instructions

1. Run `git checkout fix/patterns-z-index` and start your server, or access a [live branch](https://github.com/Automattic/wp-calypso/pull/88309#issuecomment-1983948225)
2. Open the [`Patterns` page](http://calypso.localhost:3000/patterns) while logged-in
3. Check that the master bar is always shown even when scrolling