### PR TITLE
Fix rerenders caused by user suggestions selector.

### DIFF
--- a/client/state/user-suggestions/selectors.js
+++ b/client/state/user-suggestions/selectors.js
@@ -2,6 +2,8 @@ import { get } from 'lodash';
 
 import 'calypso/state/user-suggestions/init';
 
+const emptyArray = [];
+
 /**
  * Returns true if requesting user suggestions for the specified site ID, or
  * false otherwise.
@@ -13,10 +15,6 @@ export function isRequestingUserSuggestions( state, siteId ) {
 	return get( state.userSuggestions.requesting, [ siteId ], false );
 }
 
-// Use a consistent reference for the default user suggestions. If we don't and supply a new array
-// as the default, we cause unnecessary rerenders.
-const defaultSuggestions = [];
-
 /**
  * Returns the user suggestions for a site.
  * @param  {Object}  state   Global state tree
@@ -24,5 +22,6 @@ const defaultSuggestions = [];
  * @returns {Array}           Site user suggestions
  */
 export function getUserSuggestions( state, siteId ) {
-	return get( state.userSuggestions.items, [ siteId ], defaultSuggestions );
+	// Use a defined array as the default value to prevent unnecessary rerenders.
+	return get( state.userSuggestions.items, [ siteId ], emptyArray );
 }

--- a/client/state/user-suggestions/selectors.js
+++ b/client/state/user-suggestions/selectors.js
@@ -13,6 +13,10 @@ export function isRequestingUserSuggestions( state, siteId ) {
 	return get( state.userSuggestions.requesting, [ siteId ], false );
 }
 
+// Use a consistent reference for the default user suggestions. If we don't and supply a new array
+// as the default, we cause unnecessary rerenders.
+const defaultSuggestions = [];
+
 /**
  * Returns the user suggestions for a site.
  * @param  {Object}  state   Global state tree
@@ -20,5 +24,5 @@ export function isRequestingUserSuggestions( state, siteId ) {
  * @returns {Array}           Site user suggestions
  */
 export function getUserSuggestions( state, siteId ) {
-	return get( state.userSuggestions.items, [ siteId ], [] );
+	return get( state.userSuggestions.items, [ siteId ], defaultSuggestions );
 }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1709807270797209-slack-C06DN6QQVAQ

## Proposed Changes

* Uses a constant default value for the selector instead of defining a new array each time. In the previous implementation, the new array will not pass equality checks with the previous result and cause unnecessary rerenders - as was noted by the console warnings in the slack thread.
* This seems to have been triggered by a usage of `connectUserMentions` that is not getting a `siteId` value, causing the default value for our selector to be returned every time. This is a separate issue and will investigate outside the scope of this PR (edit - see https://github.com/Automattic/wp-calypso/pull/88316). But we should ensure that selector still returns a consistent reference of an empty array as the default for unexpected cases like this.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this calypso branch LOCALLY (warnings do not pop up outside of local calypso).
* Open the console.
* load */read
* there should be no warnings regarding "Selector unknown returned a different result..."


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?