### PR TITLE
Comments form - add siteID as a prop on the text area

### DIFF
--- a/client/blocks/comments/form.jsx
+++ b/client/blocks/comments/form.jsx
@@ -168,6 +168,7 @@ class PostCommentForm extends Component {
 						onBlur={ this.handleBlur }
 						onChange={ this.handleTextChange }
 						enableAutoFocus={ isReply }
+						siteId={ post.site_ID }
 					/>
 					<Button
 						className={ buttonClasses }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to # p1709807270797209-slack-C06DN6QQVAQ

## Proposed Changes

Adds siteId as a prop on the AutoresizingTextForm component called in the comments form.

This absence of a siteId prop (in combination with an inconsistent default return in a selector, fixed elsewhere), was causing the warnings noted in slack thread above.

* the comments form [uses the `AutoresizingTextForm` component](https://github.com/Automattic/wp-calypso/blob/2d0ebd26e0d4742a416bb826919f4c5d79e53c99/client/blocks/comments/form.jsx#L162), 
* This form component is then [wrapped in a HOC for `withUserMentions`](https://github.com/Automattic/wp-calypso/blob/a9e7b7a34cf79cf220c84fcabbd4929174d90efb/client/blocks/comments/autoresizing-form-textarea.jsx#L54). 
* The `withUserMentions` HOC [expects a siteId param to use for getting suggestions.](https://github.com/Automattic/wp-calypso/blob/a9e7b7a34cf79cf220c84fcabbd4929174d90efb/client/blocks/user-mentions/connect.jsx#L16)
* Since we don't pass siteId into the chain, this HOC then runs a selector with `null` as the siteId.
* This in turn causes unnecessary rerenders with how that selector is setup, that selector is fixed separately here https://github.com/Automattic/wp-calypso/pull/88313 
* This PR adds the siteId to the form so that the user mentions HOC can pass the siteId to the selector that expects it.
* So far in my testing, there is no change in functionality past the rerenders/warnings. While the selector has the siteId and can now retrieve the suggestions from state instead of returning the default/fallback, the state values have all had no suggestions anyways.  I am unsure in which cases suggestions are actually returned, but this does fix the connection to state for user mentions in the comments form. (EDIT - suggestions are returned with P2s as shown below).

You can see the functionality change on the "A8C Conversations" tab:

BEFORE

<img width="511" alt="Screenshot 2024-03-08 at 8 56 04 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/cbd61a17-851b-4b06-9dc7-44d5f42403a5">


AFTER 

<img width="785" alt="Screenshot 2024-03-08 at 8 55 56 AM" src="https://github.com/Automattic/wp-calypso/assets/28742426/29b4bde1-4732-488c-9fb6-7da908d455cf">




## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Run this branch of calypso locally (need local to see the warnings).
* Open the console.
* Load /read, and warnings regarding "Selector unknown returned a different result..." should not happen anymore.
* Smoke test comments throughout the reader. Is there any change in functionality?

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?