### PR TITLE
Help Center: Fix dev style

### DIFF
--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -217,6 +217,17 @@
 					}
 				}
 			}
+
+			.help-center-search-results-dev__resource {
+				margin-right: 15px;
+				display: block;
+				background: var(--studio-gray-0);
+				fill: var(--studio-blue-50);
+				padding: 8px;
+				text-transform: uppercase;
+				font-weight: 500;
+				font-size: 0.75rem;
+			}
 		}
 
 		.inline-help__resource-item {

--- a/packages/help-center/src/components/help-center-search.scss
+++ b/packages/help-center/src/components/help-center-search.scss
@@ -132,8 +132,7 @@
 					color: var(--studio-gray-100);
 					font-size: $font-body-small;
 
-					svg:first-child,
-					.help-center-search-results-dev__resource {
+					svg:first-child {
 						margin-right: 15px;
 						display: block;
 						background: var(--studio-gray-0);
@@ -141,11 +140,6 @@
 						padding: 8px;
 					}
 
-					.help-center-search-results-dev__resource {
-						text-transform: uppercase;
-						font-weight: 500;
-						font-size: 0.75rem;
-					}
 
 					svg:last-child {
 						fill: var(--studio-gray-20);


### PR DESCRIPTION
Context: pdDR7T-1nN-p2#comment-1718
Related to https://github.com/Automattic/wp-calypso/pull/88131

This PR fixes the style in Sybil in the HC

## Testing steps

1. Live link
2. Visit Help Center, go to Email and digit oAuth
3. You should see dev articles with the correct icon