### PR TITLE
Checkout: Improve display of price increases in cost overrides

### DIFF
--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -106,6 +106,7 @@ export function CostOverridesList( {
 							<span className="cost-overrides-list-item__discount">
 								{ formatCurrency( -costOverride.discountAmount, currency, {
 									isSmallestUnit: true,
+									signForPositive: true,
 								} ) }
 							</span>
 						</div>
@@ -123,6 +124,7 @@ export function CostOverridesList( {
 							<span className="cost-overrides-list-item__discount">
 								{ formatCurrency( -costOverride.discountAmount, currency, {
 									isSmallestUnit: true,
+									signForPositive: true,
 								} ) }
 							</span>
 						</div>
@@ -143,6 +145,7 @@ export function CostOverridesList( {
 							<span className="cost-overrides-list-item__discount">
 								{ formatCurrency( -costOverride.discountAmount, currency, {
 									isSmallestUnit: true,
+									signForPositive: true,
 								} ) }
 							</span>
 							<span className="cost-overrides-list-item__actions">
@@ -250,6 +253,7 @@ function LineItemCostOverride( {
 				{ costOverride.discountAmount &&
 					formatCurrency( -costOverride.discountAmount, product.currency, {
 						isSmallestUnit: true,
+						signForPositive: true,
 					} ) }
 			</span>
 			<LineItemCostOverrideIntroOfferDueDate product={ product } />

--- a/packages/format-currency/README.md
+++ b/packages/format-currency/README.md
@@ -112,13 +112,17 @@ Changes function to treat number as an integer in the currency's smallest unit.
 
 Since rounding errors are common in floating point math, sometimes a price is provided as an integer in the smallest unit of a currency (eg: cents in USD or yen in JPY). If this option is false, the function will format the amount `1025` in `USD` as `$1,025.00`, but when the option is true, it will return `$10.25` instead.
 
+### `signForPositive?: boolean`
+
+If the number is greater than 0, setting this to true will include its sign (eg: `+$35.00`). Has no effect on negative numbers or 0.
+
 ## CurrencyObject
 
 An object with the following properties:
 
-### `sign: '-'|''`
+### `sign: '-' | '+' | ''`
 
-The symbol to use for negative values.
+The negative sign for the price, if it is negative, or the positive sign if `signForPositive` is set.
 
 ### `symbol: string`
 

--- a/packages/format-currency/src/index.ts
+++ b/packages/format-currency/src/index.ts
@@ -114,7 +114,9 @@ export function createFormatter(): CurrencyFormatter {
 	}
 
 	/**
-	 * Returns a formatted price object.
+	 * Returns a formatted price object which can be used to manually render a
+	 * formatted currency (eg: if you wanted to render the currency symbol in a
+	 * different font size).
 	 *
 	 * The currency will define the properties to use for this formatting, but
 	 * those properties can be overridden using the options. Be careful when doing
@@ -433,22 +435,104 @@ export async function geolocateCurrencySymbol() {
 	return defaultFormatter.geolocateCurrencySymbol();
 }
 
+/**
+ * Formats money with a given currency code.
+ *
+ * The currency will define the properties to use for this formatting, but
+ * those properties can be overridden using the options. Be careful when doing
+ * this.
+ *
+ * For currencies that include decimals, this will always return the amount
+ * with decimals included, even if those decimals are zeros. To exclude the
+ * zeros, use the `stripZeros` option. For example, the function will normally
+ * format `10.00` in `USD` as `$10.00` but when this option is true, it will
+ * return `$10` instead.
+ *
+ * Since rounding errors are common in floating point math, sometimes a price
+ * is provided as an integer in the smallest unit of a currency (eg: cents in
+ * USD or yen in JPY). Set the `isSmallestUnit` to change the function to
+ * operate on integer numbers instead. If this option is not set or false, the
+ * function will format the amount `1025` in `USD` as `$1,025.00`, but when the
+ * option is true, it will return `$10.25` instead.
+ *
+ * If the number is NaN, it will be treated as 0.
+ *
+ * If the currency code is not known, this will assume a default currency
+ * similar to USD.
+ *
+ * If `isSmallestUnit` is set and the number is not an integer, it will be
+ * rounded to an integer.
+ */
 export function formatCurrency( ...args: Parameters< typeof defaultFormatter.formatCurrency > ) {
 	return defaultFormatter.formatCurrency( ...args );
 }
 
+/**
+ * Returns a formatted price object which can be used to manually render a
+ * formatted currency (eg: if you wanted to render the currency symbol in a
+ * different font size).
+ *
+ * The currency will define the properties to use for this formatting, but
+ * those properties can be overridden using the options. Be careful when doing
+ * this.
+ *
+ * For currencies that include decimals, this will always return the amount
+ * with decimals included, even if those decimals are zeros. To exclude the
+ * zeros, use the `stripZeros` option. For example, the function will normally
+ * format `10.00` in `USD` as `$10.00` but when this option is true, it will
+ * return `$10` instead.
+ *
+ * Since rounding errors are common in floating point math, sometimes a price
+ * is provided as an integer in the smallest unit of a currency (eg: cents in
+ * USD or yen in JPY). Set the `isSmallestUnit` to change the function to
+ * operate on integer numbers instead. If this option is not set or false, the
+ * function will format the amount `1025` in `USD` as `$1,025.00`, but when the
+ * option is true, it will return `$10.25` instead.
+ *
+ * Note that the `integer` return value of this function is not a number, but a
+ * locale-formatted string which may include symbols like spaces, commas, or
+ * periods as group separators. Similarly, the `fraction` property is a string
+ * that contains the decimal separator.
+ *
+ * If the number is NaN, it will be treated as 0.
+ *
+ * If the currency code is not known, this will assume a default currency
+ * similar to USD.
+ *
+ * If `isSmallestUnit` is set and the number is not an integer, it will be
+ * rounded to an integer.
+ */
 export function getCurrencyObject(
 	...args: Parameters< typeof defaultFormatter.getCurrencyObject >
 ) {
 	return defaultFormatter.getCurrencyObject( ...args );
 }
 
+/**
+ * Set a default locale for use by `formatCurrency` and `getCurrencyObject`.
+ *
+ * Note that this is global and will override any browser locale that is set!
+ * Use it with care.
+ */
 export function setDefaultLocale(
 	...args: Parameters< typeof defaultFormatter.setDefaultLocale >
 ) {
 	return defaultFormatter.setDefaultLocale( ...args );
 }
 
+/**
+ * Change the currency symbol override used by formatting.
+ *
+ * By default, `formatCurrency` and `getCurrencyObject` use a currency symbol
+ * from a list of hard-coded overrides in this package keyed by the currency
+ * code. For example, `CAD` is always rendered as `C$` even if the locale is
+ * `en-CA` which would normally render the symbol `$`.
+ *
+ * With this function, you can change the override used by any given currency.
+ *
+ * Note that this is global and will take effect no matter the locale! Use it
+ * with care.
+ */
 export function setCurrencySymbol(
 	...args: Parameters< typeof defaultFormatter.setCurrencySymbol >
 ) {

--- a/packages/format-currency/src/types.ts
+++ b/packages/format-currency/src/types.ts
@@ -1,12 +1,106 @@
 export interface CurrencyFormatter {
 	geolocateCurrencySymbol: () => Promise< void >;
+
+	/**
+	 * Set a default locale for use by `formatCurrency` and `getCurrencyObject`.
+	 *
+	 * Note that this is global and will override any browser locale that is set!
+	 * Use it with care.
+	 */
 	setDefaultLocale: ( locale: string | undefined ) => void;
+
+	/**
+	 * Change the currency symbol override used by formatting.
+	 *
+	 * By default, `formatCurrency` and `getCurrencyObject` use a currency symbol
+	 * from a list of hard-coded overrides in this package keyed by the currency
+	 * code. For example, `CAD` is always rendered as `C$` even if the locale is
+	 * `en-CA` which would normally render the symbol `$`.
+	 *
+	 * With this function, you can change the override used by any given currency.
+	 *
+	 * Note that this is global and will take effect no matter the locale! Use it
+	 * with care.
+	 */
 	setCurrencySymbol: ( currencyCode: string, currencySymbol: string | undefined ) => void;
+
+	/**
+	 * Formats money with a given currency code.
+	 *
+	 * The currency will define the properties to use for this formatting, but
+	 * those properties can be overridden using the options. Be careful when doing
+	 * this.
+	 *
+	 * For currencies that include decimals, this will always return the amount
+	 * with decimals included, even if those decimals are zeros. To exclude the
+	 * zeros, use the `stripZeros` option. For example, the function will normally
+	 * format `10.00` in `USD` as `$10.00` but when this option is true, it will
+	 * return `$10` instead.
+	 *
+	 * Since rounding errors are common in floating point math, sometimes a price
+	 * is provided as an integer in the smallest unit of a currency (eg: cents in
+	 * USD or yen in JPY). Set the `isSmallestUnit` to change the function to
+	 * operate on integer numbers instead. If this option is not set or false, the
+	 * function will format the amount `1025` in `USD` as `$1,025.00`, but when the
+	 * option is true, it will return `$10.25` instead.
+	 *
+	 * If the number is NaN, it will be treated as 0.
+	 *
+	 * If the currency code is not known, this will assume a default currency
+	 * similar to USD.
+	 *
+	 * If `isSmallestUnit` is set and the number is not an integer, it will be
+	 * rounded to an integer.
+	 * @param      {number}                   number     number to format; assumed to be a float unless isSmallestUnit is set.
+	 * @param      {string}                   code       currency code e.g. 'USD'
+	 * @param      {CurrencyObjectOptions}    options    options object
+	 * @returns    {string}                  A formatted string.
+	 */
 	formatCurrency: (
 		amount: number,
 		currencyCode: string,
 		options?: CurrencyObjectOptions
 	) => string;
+
+	/**
+	 * Returns a formatted price object which can be used to manually render a
+	 * formatted currency (eg: if you wanted to render the currency symbol in a
+	 * different font size).
+	 *
+	 * The currency will define the properties to use for this formatting, but
+	 * those properties can be overridden using the options. Be careful when doing
+	 * this.
+	 *
+	 * For currencies that include decimals, this will always return the amount
+	 * with decimals included, even if those decimals are zeros. To exclude the
+	 * zeros, use the `stripZeros` option. For example, the function will normally
+	 * format `10.00` in `USD` as `$10.00` but when this option is true, it will
+	 * return `$10` instead.
+	 *
+	 * Since rounding errors are common in floating point math, sometimes a price
+	 * is provided as an integer in the smallest unit of a currency (eg: cents in
+	 * USD or yen in JPY). Set the `isSmallestUnit` to change the function to
+	 * operate on integer numbers instead. If this option is not set or false, the
+	 * function will format the amount `1025` in `USD` as `$1,025.00`, but when the
+	 * option is true, it will return `$10.25` instead.
+	 *
+	 * Note that the `integer` return value of this function is not a number, but a
+	 * locale-formatted string which may include symbols like spaces, commas, or
+	 * periods as group separators. Similarly, the `fraction` property is a string
+	 * that contains the decimal separator.
+	 *
+	 * If the number is NaN, it will be treated as 0.
+	 *
+	 * If the currency code is not known, this will assume a default currency
+	 * similar to USD.
+	 *
+	 * If `isSmallestUnit` is set and the number is not an integer, it will be
+	 * rounded to an integer.
+	 * @param      {number}                   number     number to format; assumed to be a float unless isSmallestUnit is set.
+	 * @param      {string}                   code       currency code e.g. 'USD'
+	 * @param      {CurrencyObjectOptions}    options    options object
+	 * @returns    {CurrencyObject}          A formatted string e.g. { symbol:'$', integer: '$99', fraction: '.99', sign: '-' }
+	 */
 	getCurrencyObject: (
 		amount: number,
 		currencyCode: string,

--- a/packages/format-currency/src/types.ts
+++ b/packages/format-currency/src/types.ts
@@ -158,9 +158,10 @@ export interface CurrencyObjectOptions {
 
 export interface CurrencyObject {
 	/**
-	 * The negative sign for the price, if it is negative.
+	 * The negative sign for the price, if it is negative, or the positive sign
+	 * if `signForPositive` is set.
 	 */
-	sign: '-' | '';
+	sign: '-' | '+' | '';
 
 	/**
 	 * The currency symbol for the formatted price.

--- a/packages/format-currency/src/types.ts
+++ b/packages/format-currency/src/types.ts
@@ -148,6 +148,12 @@ export interface CurrencyObjectOptions {
 	 * set, this will be retrieved from the user's browser.
 	 */
 	locale?: string;
+
+	/**
+	 * If the number is greater than 0, setting this to true will include its
+	 * sign (eg: `+$35.00`). Has no effect on negative numbers or 0.
+	 */
+	signForPositive?: boolean;
 }
 
 export interface CurrencyObject {

--- a/packages/format-currency/test/index.ts
+++ b/packages/format-currency/test/index.ts
@@ -117,6 +117,37 @@ describe( 'formatCurrency', () => {
 		expect( money3 ).toBe( '9.800.900,32 €' );
 	} );
 
+	test( 'returns a plus sign for positive numbers if signForPositive is true (USD)', () => {
+		const money = formatter.formatCurrency( 9800900, 'USD', {} );
+		expect( money ).toBe( '$9,800,900.00' );
+
+		const money2 = formatter.formatCurrency( 9800900, 'USD', {
+			signForPositive: true,
+		} );
+		expect( money2 ).toBe( '+$9,800,900.00' );
+	} );
+
+	test( 'returns a negative sign for negative numbers if signForPositive is true (USD)', () => {
+		const money = formatter.formatCurrency( -9800900, 'USD', {} );
+		expect( money ).toBe( '-$9,800,900.00' );
+
+		const money2 = formatter.formatCurrency( -9800900, 'USD', {
+			signForPositive: true,
+		} );
+		expect( money2 ).toBe( '-$9,800,900.00' );
+	} );
+
+	test( 'returns a plus sign for positive numbers if signForPositive is true (EUR)', () => {
+		const money = formatter.formatCurrency( 9800900, 'EUR', { locale: 'de-DE' } );
+		expect( money ).toBe( '9.800.900,00 €' );
+
+		const money2 = formatter.formatCurrency( 9800900, 'EUR', {
+			locale: 'de-DE',
+			signForPositive: true,
+		} );
+		expect( money2 ).toBe( '+9.800.900,00 €' );
+	} );
+
 	test( 'returns a number in latin numbers even for locales which default to other character sets', () => {
 		const money = formatter.formatCurrency( 9800900, 'INR', { locale: 'mr-IN' } );
 		expect( money ).toBe( '₹9,800,900.00' );
@@ -387,6 +418,30 @@ describe( 'getCurrencyObject()', () => {
 				integer: '9,800,900',
 				fraction: '.32',
 				sign: '',
+				hasNonZeroFraction: true,
+			} );
+		} );
+
+		test( 'USD with signForPositive set', () => {
+			const money = formatter.getCurrencyObject( 9800900.32, 'USD', { signForPositive: true } );
+			expect( money ).toEqual( {
+				symbol: '$',
+				symbolPosition: 'before',
+				integer: '9,800,900',
+				fraction: '.32',
+				sign: '+',
+				hasNonZeroFraction: true,
+			} );
+		} );
+
+		test( 'USD with signForPositive set and negative number', () => {
+			const money = formatter.getCurrencyObject( -9800900.32, 'USD', { signForPositive: true } );
+			expect( money ).toEqual( {
+				symbol: '$',
+				symbolPosition: 'before',
+				integer: '9,800,900',
+				fraction: '.32',
+				sign: '-',
 				hasNonZeroFraction: true,
 			} );
 		} );

--- a/packages/wpcom-checkout/src/checkout-line-items.tsx
+++ b/packages/wpcom-checkout/src/checkout-line-items.tsx
@@ -1186,13 +1186,15 @@ function JetpackAkismetSaleCouponCallout( { product }: { product: ResponseCartPr
 
 	const interval = product.bill_period === '31' ? 'month' : 'year';
 	const interval_count = interval === 'month' ? 1 : parseInt( product.bill_period ) / 365;
-	const discountText = getIntroductoryOfferIntervalDisplay(
+	const discountText = getIntroductoryOfferIntervalDisplay( {
 		translate,
-		interval,
-		interval_count,
-		false,
-		''
-	);
+		intervalUnit: interval,
+		intervalCount: interval_count,
+		isFreeTrial: false,
+		isPriceIncrease: false,
+		context: '',
+		remainingRenewalsUsingOffer: 0,
+	} );
 
 	return <DiscountCallout>{ discountText }</DiscountCallout>;
 }

--- a/packages/wpcom-checkout/src/introductory-offer.ts
+++ b/packages/wpcom-checkout/src/introductory-offer.ts
@@ -54,11 +54,11 @@ export function getIntroductoryOfferIntervalDisplay( {
 		if ( intervalUnit === 'month' ) {
 			if ( intervalCount === 1 ) {
 				text = isPriceIncrease
-					? translate( 'First month', { textOnly: true } )
+					? translate( 'Price for first month', { textOnly: true } )
 					: String( translate( 'Discount for first month' ) );
 			} else {
 				text = isPriceIncrease
-					? translate( 'First %(numberOfMonths)d months', {
+					? translate( 'Price for first %(numberOfMonths)d months', {
 							textOnly: true,
 							args: {
 								numberOfMonths: intervalCount,
@@ -76,11 +76,11 @@ export function getIntroductoryOfferIntervalDisplay( {
 		if ( intervalUnit === 'year' ) {
 			if ( intervalCount === 1 ) {
 				text = isPriceIncrease
-					? translate( 'First year', { textOnly: true } )
+					? translate( 'Price for first year', { textOnly: true } )
 					: String( translate( 'Discount for first year' ) );
 			} else {
 				text = isPriceIncrease
-					? translate( 'First %(numberOfYears)d years', {
+					? translate( 'Price for first %(numberOfYears)d years', {
 							textOnly: true,
 							args: { numberOfYears: intervalCount },
 					  } )

--- a/packages/wpcom-checkout/src/introductory-offer.ts
+++ b/packages/wpcom-checkout/src/introductory-offer.ts
@@ -3,15 +3,26 @@ import { formatCurrency } from '@automattic/format-currency';
 import i18n from 'i18n-calypso';
 import type { ResponseCartProduct } from '@automattic/shopping-cart';
 
-export function getIntroductoryOfferIntervalDisplay(
-	translate: typeof i18n.translate,
-	intervalUnit: string,
-	intervalCount: number,
-	isFreeTrial: boolean,
-	context: string,
-	remainingRenewalsUsingOffer = 0
-): string {
-	let text = String( translate( 'Discount for first period' ) );
+export function getIntroductoryOfferIntervalDisplay( {
+	translate,
+	intervalUnit,
+	intervalCount,
+	isFreeTrial,
+	isPriceIncrease,
+	context,
+	remainingRenewalsUsingOffer = 0,
+}: {
+	translate: typeof i18n.translate;
+	intervalUnit: string;
+	intervalCount: number;
+	isFreeTrial: boolean;
+	isPriceIncrease: boolean;
+	context: string;
+	remainingRenewalsUsingOffer: number;
+} ): string {
+	let text = isPriceIncrease
+		? translate( 'First billing period', { textOnly: true } )
+		: String( translate( 'Discount for first period' ) );
 	if ( isFreeTrial ) {
 		if ( intervalUnit === 'month' ) {
 			if ( intervalCount === 1 ) {
@@ -42,28 +53,44 @@ export function getIntroductoryOfferIntervalDisplay(
 	} else {
 		if ( intervalUnit === 'month' ) {
 			if ( intervalCount === 1 ) {
-				text = String( translate( 'Discount for first month' ) );
+				text = isPriceIncrease
+					? translate( 'First month', { textOnly: true } )
+					: String( translate( 'Discount for first month' ) );
 			} else {
-				text = String(
-					translate( 'Discount for first %(numberOfMonths)d months', {
-						args: {
-							numberOfMonths: intervalCount,
-						},
-					} )
-				);
+				text = isPriceIncrease
+					? translate( 'First %(numberOfMonths)d months', {
+							textOnly: true,
+							args: {
+								numberOfMonths: intervalCount,
+							},
+					  } )
+					: String(
+							translate( 'Discount for first %(numberOfMonths)d months', {
+								args: {
+									numberOfMonths: intervalCount,
+								},
+							} )
+					  );
 			}
 		}
 		if ( intervalUnit === 'year' ) {
 			if ( intervalCount === 1 ) {
-				text = String( translate( 'Discount for first year' ) );
+				text = isPriceIncrease
+					? translate( 'First year', { textOnly: true } )
+					: String( translate( 'Discount for first year' ) );
 			} else {
-				text = String(
-					translate( 'Discount for first %(numberOfYears)d years', {
-						args: {
-							numberOfYears: intervalCount,
-						},
-					} )
-				);
+				text = isPriceIncrease
+					? translate( 'First %(numberOfYears)d years', {
+							textOnly: true,
+							args: { numberOfYears: intervalCount },
+					  } )
+					: String(
+							translate( 'Discount for first %(numberOfYears)d years', {
+								args: {
+									numberOfYears: intervalCount,
+								},
+							} )
+					  );
 			}
 		}
 	}
@@ -71,40 +98,55 @@ export function getIntroductoryOfferIntervalDisplay(
 		text += ' - ';
 		if ( context === 'checkout' ) {
 			if ( remainingRenewalsUsingOffer === 1 ) {
-				text += String(
-					translate( 'The first renewal is also discounted.', {
-						args: {
-							remainingRenewals: remainingRenewalsUsingOffer,
-						},
-					} )
-				);
+				text += isPriceIncrease
+					? translate( 'Applies for one renewal', { textOnly: true } )
+					: translate( 'The first renewal is also discounted.', { textOnly: true } );
 			} else {
-				text += String(
-					translate(
-						'The first %(remainingRenewals)d renewal is also discounted.',
-						'The first %(remainingRenewals)d renewals are also discounted.',
+				text += isPriceIncrease
+					? translate( 'Applies for %(remainingRenewals)d renewals', {
+							textOnly: true,
+							args: {
+								remainingRenewals: remainingRenewalsUsingOffer,
+							},
+					  } )
+					: String(
+							translate(
+								'The first %(remainingRenewals)d renewal is also discounted.',
+								'The first %(remainingRenewals)d renewals are also discounted.',
+								{
+									count: remainingRenewalsUsingOffer,
+									args: {
+										remainingRenewals: remainingRenewalsUsingOffer,
+									},
+								}
+							)
+					  );
+			}
+		} else {
+			text += isPriceIncrease
+				? translate(
+						'Applies for %(remainingRenewals)d renewal',
+						'Applies for %(remainingRenewals)d renewals',
 						{
+							textOnly: true,
 							count: remainingRenewalsUsingOffer,
 							args: {
 								remainingRenewals: remainingRenewalsUsingOffer,
 							},
 						}
-					)
-				);
-			}
-		} else {
-			text += String(
-				translate(
-					'%(remainingRenewals)d discounted renewal remaining.',
-					'%(remainingRenewals)d discounted renewals remaining.',
-					{
-						count: remainingRenewalsUsingOffer,
-						args: {
-							remainingRenewals: remainingRenewalsUsingOffer,
-						},
-					}
-				)
-			);
+				  )
+				: String(
+						translate(
+							'%(remainingRenewals)d discounted renewal remaining.',
+							'%(remainingRenewals)d discounted renewals remaining.',
+							{
+								count: remainingRenewalsUsingOffer,
+								args: {
+									remainingRenewals: remainingRenewalsUsingOffer,
+								},
+							}
+						)
+				  );
 		}
 	}
 	return text;
@@ -184,14 +226,15 @@ export function getItemIntroductoryOfferDisplay(
 	}
 
 	const isFreeTrial = product.item_subtotal_integer === 0;
-	const text = getIntroductoryOfferIntervalDisplay(
+	const text = getIntroductoryOfferIntervalDisplay( {
 		translate,
-		product.introductory_offer_terms.interval_unit,
-		product.introductory_offer_terms.interval_count,
+		intervalUnit: product.introductory_offer_terms.interval_unit,
+		intervalCount: product.introductory_offer_terms.interval_count,
 		isFreeTrial,
-		'checkout',
-		product.introductory_offer_terms.transition_after_renewal_count
-	);
+		isPriceIncrease: false,
+		context: 'checkout',
+		remainingRenewalsUsingOffer: product.introductory_offer_terms.transition_after_renewal_count,
+	} );
 
 	return { enabled: true, text };
 }

--- a/packages/wpcom-checkout/src/transformations.ts
+++ b/packages/wpcom-checkout/src/transformations.ts
@@ -218,6 +218,10 @@ function makeSaleCostOverrideUnique(
 	return costOverride;
 }
 
+/**
+ * Replace introductory offer cost override text with wording specific to that
+ * offer, like "Discount for first 3 months" instead of "Introductory offer".
+ */
 function makeIntroductoryOfferCostOverrideUnique(
 	costOverride: ResponseCartCostOverride,
 	product: ResponseCartProduct,
@@ -228,16 +232,25 @@ function makeIntroductoryOfferCostOverrideUnique(
 		return costOverride;
 	}
 
-	// Replace introductory offer cost override text with wording specific to
-	// that offer, but not for renewals because an introductory offer manual
-	// renewal can be hard to explain simply and saying "Discount for first 3
-	// months" may not be accurate.
+	// If the introductory offer actually increases the price, we want to be
+	// sure not to display it with wording that mentions "discount".
+	if ( costOverride.old_subtotal_integer < costOverride.new_subtotal_integer ) {
+		return {
+			...costOverride,
+			human_readable_reason: translate( 'Initial price' ),
+		};
+	}
+
+	// Renewals get generic text because an introductory offer manual renewal
+	// can be hard to explain simply and saying "Discount for first 3 months"
+	// may not be accurate.
 	if ( product.is_renewal ) {
 		return {
 			...costOverride,
 			human_readable_reason: translate( 'Prorated renewal discount' ),
 		};
 	}
+
 	return {
 		...costOverride,
 		human_readable_reason: getDiscountReasonForIntroductoryOffer(


### PR DESCRIPTION
In checkout, we display a list of cost overrides (changes to the base price of a product) in the sidebar. Typically these overrides are discounts, but there's no reason that they cannot increase the price as well, and that sometimes happens. However, the way that they are displayed currently makes it confusing to read because you might see something like "Discount for first year: $30", which makes it seem like there is a $30 discount rather than a $30 price increase! (A regular discount would read "Discount for first year: -$30"; note the minus sign.)

## Proposed Changes

There are several overlapping problems that contribute to this confusion. First, there is no number sign displayed for positive cost overrides, only for negative ones. This PR adds a `+` sign before any positive prices in the cost overrides list.

Second, all introductory offers have the same description, "Introductory offer", so we change each one to be more specific based on the length of that offer, like "Discount for first year". But for a price increase, words like "Discount" are incorrect. In this PR, we change introductory offers which increase the price to have slightly more generic text, changing the above example to "Price for first year". (This wording could be improved further for specific products.)

Third, cost overrides which are not introductory offers that increase the price might have confusing wording like "Prorated balance from previous number of items". We cannot easily correct those descriptions inside calypso because we'd need a different string for each situation. A better option is to modify the cost override itself on the server to use a different description for price increases. In D140636-code, we've changed the above example to "Prorated additional charge".

Before             |  After
:-------------------------:|:-------------------------:
<img width="320" alt="Screenshot 2024-03-07 at 2 05 51 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/4b0219e8-5a46-42f2-86a7-ac95ad478a0a"> | <img width="320" alt="Screenshot 2024-03-07 at 2 16 42 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/4cbb56a2-a1c1-4bd1-88c6-f7fdc87e32d9">

Before (v2 checkout)            |  After (v2 checkout)
:-------------------------:|:-------------------------:
<img width="421" alt="Screenshot 2024-03-07 at 2 11 51 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/d7d58bd2-d31c-43b7-82f7-06f11719368a"> | <img width="415" alt="Screenshot 2024-03-07 at 2 16 04 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/23dd025d-cc7a-4ccd-a47f-8b700b43ef56">

Fixes https://github.com/Automattic/payments-shilling/issues/2540

## Testing Instructions

To test this, you'll need to have a cost override that increases a product's price. A simple way to do that is to hack the shopping cart to change the price of a cost override to be very large.

To test an introductory offer, add a product which already has an introductory offer to your cart, and then hack the shopping cart to change the price of the introductory offer cost override to be very large.

Once you've made such a change, visit checkout and verify that the cost override is displayed in the sidebar with a `+` sign.