### PR TITLE
Site Migration: Add site migration key hook

### DIFF
--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -1,3 +1,4 @@
+import { useSiteMigrationKey } from '@automattic/data-stores';
 import { StepContainer } from '@automattic/onboarding';
 import { ClipboardButton } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
@@ -6,13 +7,16 @@ import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
+import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
 import './style.scss';
 
 const SiteMigrationInstructions: Step = function () {
 	const translate = useTranslate();
-	const siteMigrationKey = 'Yjx3xUYYTm89s9xBFe7jitNA94noUg6tzgjnpx9zPVwGdbewfL';
+	const site = useSite();
+	const siteId = site?.ID;
+	const siteMigrationKey = useSiteMigrationKey( siteId );
 	const fromUrl = useQuery().get( 'from' ) || '';
 	const sourceSiteUrl = fromUrl
 		? addQueryArgs( fromUrl + '/wp-admin/admin.php', { page: 'migrateguru' } )
@@ -52,9 +56,11 @@ const SiteMigrationInstructions: Step = function () {
 						}
 					) }
 					<div className="site-migration-instructions__migration-key">
-						<code className="site-migration-instructions__key">{ siteMigrationKey }</code>
+						<code className="site-migration-instructions__key">
+							{ siteMigrationKey.data?.migration_key ?? '' }
+						</code>
 						<ClipboardButton
-							text={ siteMigrationKey }
+							text={ siteMigrationKey.data?.migration_key ?? '' }
 							className="site-migration-instructions__copy-key-button is-primary"
 							onCopy={ onCopy }
 						>

--- a/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
+++ b/client/landing/stepper/declarative-flow/internals/steps-repository/site-migration-instructions/index.tsx
@@ -1,4 +1,3 @@
-import { useSiteMigrationKey } from '@automattic/data-stores';
 import { StepContainer } from '@automattic/onboarding';
 import { ClipboardButton } from '@wordpress/components';
 import { addQueryArgs } from '@wordpress/url';
@@ -7,16 +6,13 @@ import { useState } from 'react';
 import DocumentHead from 'calypso/components/data/document-head';
 import FormattedHeader from 'calypso/components/formatted-header';
 import { useQuery } from 'calypso/landing/stepper/hooks/use-query';
-import { useSite } from 'calypso/landing/stepper/hooks/use-site';
 import { recordTracksEvent } from 'calypso/lib/analytics/tracks';
 import type { Step } from '../../types';
 import './style.scss';
 
 const SiteMigrationInstructions: Step = function () {
 	const translate = useTranslate();
-	const site = useSite();
-	const siteId = site?.ID;
-	const siteMigrationKey = useSiteMigrationKey( siteId );
+	const siteMigrationKey = 'Yjx3xUYYTm89s9xBFe7jitNA94noUg6tzgjnpx9zPVwGdbewfL';
 	const fromUrl = useQuery().get( 'from' ) || '';
 	const sourceSiteUrl = fromUrl
 		? addQueryArgs( fromUrl + '/wp-admin/admin.php', { page: 'migrateguru' } )
@@ -56,11 +52,9 @@ const SiteMigrationInstructions: Step = function () {
 						}
 					) }
 					<div className="site-migration-instructions__migration-key">
-						<code className="site-migration-instructions__key">
-							{ siteMigrationKey.data?.migration_key ?? '' }
-						</code>
+						<code className="site-migration-instructions__key">{ siteMigrationKey }</code>
 						<ClipboardButton
-							text={ siteMigrationKey.data?.migration_key ?? '' }
+							text={ siteMigrationKey }
 							className="site-migration-instructions__copy-key-button is-primary"
 							onCopy={ onCopy }
 						>

--- a/packages/data-stores/src/index.ts
+++ b/packages/data-stores/src/index.ts
@@ -15,6 +15,7 @@ import * as User from './user';
 import * as WpcomPlansUI from './wpcom-plans-ui';
 export { useHappinessEngineersQuery } from './queries/use-happiness-engineers-query';
 export { useSiteIntent } from './queries/use-site-intent';
+export { useSiteMigrationKey } from './queries/use-site-migration-key';
 export { useSendInvites } from './users/use-send-invites';
 export * from './add-ons/types';
 export * from './starter-designs-queries';

--- a/packages/data-stores/src/queries/use-site-migration-key.ts
+++ b/packages/data-stores/src/queries/use-site-migration-key.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import wpcomRequest from 'wpcom-proxy-request';
+
+export function useSiteMigrationKey( siteId: string | number | undefined ) {
+	return useQuery< {
+		migration_key: '';
+	} >( {
+		queryKey: [ 'site-migration', siteId ],
+		queryFn: async () =>
+			await wpcomRequest( {
+				path: `/sites/${ siteId }/site-migration`,
+				apiNamespace: 'wpcom/v2',
+			} ),
+		refetchOnWindowFocus: false,
+		staleTime: Infinity,
+		enabled: !! siteId,
+	} );
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/87393

## Proposed Changes

* Add a `useSiteMigrationKey` hook that fetches the site migration key from the new API endpoint introduced in https://github.com/Automattic/jetpack/pull/36253 and D141148-code
* Use the new hook in Stepper to show the migration key on the instructions step.

<img width="1089" alt="Screenshot 2024-03-07 at 1 47 09 PM" src="https://github.com/Automattic/wp-calypso/assets/2124984/8955cd16-8d25-438f-a996-d9264448206c">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* First set up the new API endpoint following the test instructions in https://github.com/Automattic/jetpack/pull/36253
* When the endpoint is working, switch to this branch 
* Navigate to `/setup/site-migration/site-migration-instructions?flags=onboarding/new-migration-flow&siteSlug=[your-jurassic-ninja-test-site]`
* You should see the site migration key in the instructions

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?