### PR TITLE
Remove one-off theme purchases from customizer

### DIFF
--- a/client/my-sites/customize/main.jsx
+++ b/client/my-sites/customize/main.jsx
@@ -1,3 +1,4 @@
+import { getPlan } from '@automattic/calypso-products';
 import page from '@automattic/calypso-router';
 import { getUrlParts } from '@automattic/calypso-url';
 import debugFactory from 'debug';
@@ -8,6 +9,7 @@ import { stringify } from 'qs';
 import { Component } from 'react';
 import { connect } from 'react-redux';
 import EmptyContent from 'calypso/components/empty-content';
+import { THEME_TIERS } from 'calypso/components/theme-tier/constants';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
 import wpcom from 'calypso/lib/wp';
 import CustomizerLoadingPanel from 'calypso/my-sites/customize/loading-panel';
@@ -281,14 +283,19 @@ class Customize extends Component {
 					}
 					break;
 				case 'activated':
+					debug( 'iframe says it activated a theme', message );
 					trackClick( 'customizer', 'activate' );
 					page( '/themes/' + site.slug );
 					this.props.themeActivated( message.theme.stylesheet, site.ID, 'customizer' );
 					break;
 				case 'purchased': {
-					const themeSlug = message.theme.stylesheet.split( '/' )[ 1 ];
+					debug( 'iframe says it wants to purchase a theme', message );
+					const tier = message?.theme_tier_slug;
+					const tierMinimumUpsellPlan = THEME_TIERS[ tier ]?.minimumUpsellPlan;
+					const mappedPlan = getPlan( tierMinimumUpsellPlan );
+					const planPathSlug = mappedPlan?.getPathSlug();
 					trackClick( 'customizer', 'purchase' );
-					page( '/checkout/' + site.slug + '/theme:' + themeSlug );
+					page( '/checkout/' + site.slug + '/' + planPathSlug );
 					break;
 				}
 				case 'navigateTo': {
@@ -297,6 +304,7 @@ class Customize extends Component {
 						debug( 'missing destination' );
 						return;
 					}
+					debug( 'iframe says it wants to navigate', destination );
 					this.navigateTo( destination );
 					break;
 				}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5944 and dependant upon D141194-code

## Proposed Changes

One-off purchases of individual themes were removed last year so that themes were only available by buying the relevant plan or themes bundle. It is still possible though to make the customizer display a purchase link for individual themes.

This change (when deployed after a server side counterpart) prevents that, it sends the user to buy the lowest necessary WordPress.com plan for the theme they're looking at.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

 1. Apply D141194-code to your sandbox, assuming it has not yet been deployed
 2. Sandbox a free site
 3. Use the calypso.live link below to go to /customize/:siteSlug?theme=pub/cakely
 4. Press the "Upgrade plan" button near the top left of the screen

You should be taken to the checkout for the explorer plan.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?