### PR TITLE
Github Deployments: Fix processing logs page to match design more closely 

### DIFF
--- a/client/my-sites/github-deployments/components/sort-button/sort-button.tsx
+++ b/client/my-sites/github-deployments/components/sort-button/sort-button.tsx
@@ -30,7 +30,11 @@ export const SortButton = ( {
 	return (
 		<Button plain onClick={ handleClick } className="github-deployments-sort-button">
 			{ children }
-			{ isActive && <Icon icon={ icon } size={ 16 } css={ { verticalAlign: 'middle' } } /> }
+			<Icon
+				icon={ icon }
+				size={ 16 }
+				css={ { verticalAlign: 'middle', visibility: isActive ? 'visible' : 'hidden' } }
+			/>
 		</Button>
 	);
 };

--- a/client/my-sites/github-deployments/components/sort-button/style.scss
+++ b/client/my-sites/github-deployments/components/sort-button/style.scss
@@ -2,6 +2,9 @@
 	text-align: left;
 	line-height: 20px;
 	letter-spacing: -0.15px;
+	display: flex;
+	align-items: center;
+	gap: 8px;
 
 	&:focus {
 		outline: thin dotted;

--- a/client/my-sites/github-deployments/deployment-run-logs/style.scss
+++ b/client/my-sites/github-deployments/deployment-run-logs/style.scss
@@ -12,9 +12,28 @@ table.github-deployments-logs {
 		font-weight: normal;
 	}
 
+	tr th {
+		padding: 8px 0 16px 0;
+		color: var(--studio-gray-60, #50575e);
+	}
+
+	thead tr,
 	tbody tr:not(:last-of-type) {
 		border-bottom: 1px solid var(--color-border-subtle);
 	}
+
+
+	tbody tr td {
+		padding-top: 20px;
+		padding-bottom: 20px;
+	}
+
+	tbody tr:last-of-type {
+		td {
+			padding-bottom: 0;
+		}
+	}
+
 
 	td {
 		vertical-align: middle !important;


### PR DESCRIPTION
- Fix sort column chevron position
- Adjust column padding to match figma design

<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5939

## Proposed Changes

* Fix the positioning of sort column chevron
* Adjust column paddings to match figma

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to github deployments logs screen and confirm everything renders as it should
![image](https://github.com/Automattic/wp-calypso/assets/47489215/c1a000e1-f8c5-43d0-bb82-846d24cecd12)


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?