### PR TITLE
Github Deployments: Fix the destination directory not updating when selecting a new repo.

### DIFF
--- a/client/my-sites/github-deployments/components/github-connection-form/index.tsx
+++ b/client/my-sites/github-deployments/components/github-connection-form/index.tsx
@@ -2,7 +2,7 @@ import { Button, FormInputValidation, FormLabel, Spinner } from '@automattic/com
 import { ExternalLink } from '@wordpress/components';
 import { useI18n } from '@wordpress/react-i18n';
 import classNames from 'classnames';
-import { ChangeEvent, useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import { ChangeEvent, useEffect, useMemo, useState } from 'react';
 import FormFieldset from 'calypso/components/forms/form-fieldset';
 import FormSelect from 'calypso/components/forms/form-select';
 import FormSettingExplanation from 'calypso/components/forms/form-setting-explanation';
@@ -59,13 +59,6 @@ export const GitHubConnectionForm = ( {
 	);
 	const { __ } = useI18n();
 
-	useEffect( () => {
-		setBranch( initialValues.branch );
-		setDestPath( initialValues.destPath );
-		setIsAutoDeploy( initialValues.isAutomated );
-		setWorkflowPath( initialValues.workflowPath );
-	}, [ initialValues ] );
-
 	const { data: branches, isLoading: isFetchingBranches } = useGithubRepositoryBranchesQuery(
 		installationId,
 		repository?.owner,
@@ -104,11 +97,16 @@ export const GitHubConnectionForm = ( {
 		branch
 	);
 
-	useLayoutEffect( () => {
+	useEffect( () => {
 		if ( repoChecks?.suggested_directory ) {
 			setDestPath( repoChecks.suggested_directory );
+		} else {
+			setDestPath( initialValues.destPath );
 		}
-	}, [ repoChecks ] );
+		setBranch( initialValues.branch );
+		setIsAutoDeploy( initialValues.isAutomated );
+		setWorkflowPath( initialValues.workflowPath );
+	}, [ initialValues, repoChecks ] );
 
 	const displayMissingRepositoryError = submitted && ! repository;
 	const submitDisabled = !! workflowPath && workflowCheckResult?.conclusion !== 'success';


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes
The issue is that the suggested path was being set in `useLayoutEffect` while the `useEffect` was overriding it with the default value. This PR fixes that.

* set the destination directory to either the suggested directory or the default value.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to connect repository and select different repo to see the directory is updated with suggested path

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?