### PR TITLE
Checkout: Fix promotional period messaging for introductory offers that renew

### DIFF
--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -112,7 +112,7 @@ function getMessageForTermsOfServiceRecordUnknown(
 	}
 
 	return translate(
-		'At the end of the promotional period your %(productName)s will renew at the normal price of %(maybeProratedRegularPrice)s. Subsequent renewals will be %(regularPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',
+		'At the end of the promotional period your %(productName)s will renew for %(maybeProratedRegularPrice)s. Subsequent renewals will be %(regularPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',
 		{
 			args: {
 				productName,

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -152,32 +152,23 @@ function getMessageForTermsOfServiceRecordUnknown(
 		);
 	}
 
-	const defaultRenewalArgs = {
-		args: {
-			productName: args.product_name,
-			renewalPrice: args.renewal_price,
-		},
-		components: {
-			link: (
-				<a
-					href={ `/purchases/subscriptions/${ siteSlug }` }
-					target="_blank"
-					rel="noopener noreferrer"
-				/>
-			),
-		},
-	};
-
-	if ( args.product_meta && args.product_meta !== '' ) {
+	if ( args.product_meta ) {
 		return translate(
 			'At the end of the promotional period your %(productName)s subscription for %(domainName)s will renew at the normal price of %(renewalPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',
 			{
 				args: {
-					...defaultRenewalArgs.args,
+					productName: args.product_name,
+					renewalPrice: args.renewal_price,
 					domainName: args.product_meta,
 				},
 				components: {
-					...defaultRenewalArgs.components,
+					link: (
+						<a
+							href={ `/purchases/subscriptions/${ siteSlug }` }
+							target="_blank"
+							rel="noopener noreferrer"
+						/>
+					),
 				},
 			}
 		);
@@ -185,7 +176,21 @@ function getMessageForTermsOfServiceRecordUnknown(
 
 	return translate(
 		'At the end of the promotional period your %(productName)s subscription will renew at the normal price of %(renewalPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',
-		defaultRenewalArgs
+		{
+			args: {
+				productName: args.product_name,
+				renewalPrice: args.renewal_price,
+			},
+			components: {
+				link: (
+					<a
+						href={ `/purchases/subscriptions/${ siteSlug }` }
+						target="_blank"
+						rel="noopener noreferrer"
+					/>
+				),
+			},
+		}
 	);
 }
 

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -82,8 +82,8 @@ function getMessageForTermsOfServiceRecordUnknown(
 		const numberOfDays = args.subscription_pre_renew_reminder_days || 7;
 		const renewalDate = moment( args.subscription_auto_renew_date ).format( 'll' );
 
-		return translate(
-			'The promotional period for your %(productName)s lasts from %(startDate)s to %(endDate)s. You will next be charged %(renewalPrice)s on %(renewalDate)s. On %(endDate)s, we will attempt to renew your subscription for %(maybeProratedRegularPrice)s. Subsequent renewals will be %(regularPrice)s. You will receive email notices %(numberOfDays)d days before renewals, and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
+		const nextRenewalText = translate(
+			'The promotional period for your %(productName)s lasts from %(startDate)s to %(endDate)s. You will next be charged %(renewalPrice)s on %(renewalDate)s.',
 			{
 				args: {
 					productName,
@@ -91,8 +91,30 @@ function getMessageForTermsOfServiceRecordUnknown(
 					endDate,
 					renewalPrice,
 					renewalDate,
+				},
+			}
+		);
+
+		const proratedNoticeText = translate(
+			'On %(endDate)s, we will attempt to renew your subscription for %(maybeProratedRegularPrice)s.',
+			{
+				args: {
+					endDate,
 					maybeProratedRegularPrice,
-					regularPrice,
+				},
+			}
+		);
+
+		const regularPriceNoticeText = translate( 'Subsequent renewals will be %(regularPrice)s.', {
+			args: {
+				regularPrice,
+			},
+		} );
+
+		const emailNoticesText = translate(
+			'You will receive email notices %(numberOfDays)d days before renewals, and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
+			{
+				args: {
 					numberOfDays,
 				},
 				components: {
@@ -108,6 +130,13 @@ function getMessageForTermsOfServiceRecordUnknown(
 					),
 				},
 			}
+		);
+
+		return (
+			<>
+				{ nextRenewalText } { args.is_renewal_price_prorated && proratedNoticeText }{ ' ' }
+				{ regularPriceNoticeText } { emailNoticesText }{ ' ' }
+			</>
 		);
 	}
 

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -57,7 +57,7 @@ function getMessageForTermsOfServiceRecordUnknown(
 		return '';
 	}
 
-	const productName = args.product_name + args.product_meta ? `(${ args.product_meta })` : '';
+	const productName = args.product_name + ( args.product_meta ? ` (${ args.product_meta })` : '' );
 	const regularPrice = formatCurrency( args.regular_renewal_price_integer, currency, {
 		isSmallestUnit: true,
 		stripZeros: true,

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -83,7 +83,7 @@ function getMessageForTermsOfServiceRecordUnknown(
 		const renewalDate = moment( args.subscription_auto_renew_date ).format( 'll' );
 
 		return translate(
-			'The promotional period for your %(productName)s subscription lasts from %(startDate)s to %(endDate)s. You will next be charged %(renewalPrice)s on %(renewalDate)s. On %(endDate)s, we will attempt to renew your subscription for %(maybeProratedRegularPrice)s. Subsequent renewals will be %(regularPrice)s. You will receive email notices %(numberOfDays)d days before renewals, and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
+			'The promotional period for your %(productName)s lasts from %(startDate)s to %(endDate)s. You will next be charged %(renewalPrice)s on %(renewalDate)s. On %(endDate)s, we will attempt to renew your subscription for %(maybeProratedRegularPrice)s. Subsequent renewals will be %(regularPrice)s. You will receive email notices %(numberOfDays)d days before renewals, and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
 			{
 				args: {
 					productName,
@@ -112,7 +112,7 @@ function getMessageForTermsOfServiceRecordUnknown(
 	}
 
 	return translate(
-		'At the end of the promotional period your %(productName)s subscription will renew at the normal price of %(renewalPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',
+		'At the end of the promotional period your %(productName)s will renew at the normal price of %(renewalPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',
 		{
 			args: {
 				productName,

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -1,5 +1,9 @@
 import { localizeUrl } from '@automattic/i18n-utils';
-import { TermsOfServiceRecord, useShoppingCart } from '@automattic/shopping-cart';
+import {
+	TermsOfServiceRecord,
+	TermsOfServiceRecordArgsRenewal,
+	useShoppingCart,
+} from '@automattic/shopping-cart';
 import debugFactory from 'debug';
 import { useTranslate, TranslateResult } from 'i18n-calypso';
 import moment from 'moment';
@@ -10,8 +14,6 @@ import { useSelector } from 'calypso/state';
 import { getSelectedSiteSlug } from 'calypso/state/ui/selectors';
 
 const debug = debugFactory( 'calypso:composite-checkout:additional-terms-of-service' );
-
-/* eslint-disable wpcalypso/jsx-classname-namespace */
 
 export default function AdditionalTermsOfServiceInCart() {
 	const translate = useTranslate();
@@ -42,217 +44,6 @@ export default function AdditionalTermsOfServiceInCart() {
 	);
 }
 
-function getMessageForTermsOfServiceRecordPayPal(
-	termsOfServiceRecord: TermsOfServiceRecord,
-	translate: ReturnType< typeof useTranslate >,
-	siteSlug: string | null
-): TranslateResult {
-	const args = termsOfServiceRecord.args;
-	if ( ! args ) {
-		return '';
-	}
-	if ( ! args.email || ! args.product_name || ! args.renewal_price ) {
-		debug(
-			`Malformed terms of service args with code: ${ termsOfServiceRecord.code }`,
-			termsOfServiceRecord
-		);
-		return '';
-	}
-	if (
-		args.subscription_start_date &&
-		args.subscription_expiry_date &&
-		args.subscription_auto_renew_date
-	) {
-		if ( args.is_renewal_price_prorated ) {
-			return translate(
-				'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (PAYPAL %(email)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
-				{
-					args: {
-						startDate: moment( args.subscription_start_date ).format( 'll' ),
-						endDate: moment( args.subscription_expiry_date ).format( 'll' ),
-						renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
-						email: args.email,
-						renewalPrice: args.renewal_price,
-						regularPrice: args.regular_renewal_price,
-						numberOfDays: args.subscription_pre_renew_reminder_days || 7,
-					},
-					components: {
-						updatePaymentMethodLink: (
-							<a
-								href={ localizeUrl( EDIT_PAYMENT_DETAILS ) }
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
-						),
-						manageSubscriptionLink: (
-							<a
-								href={ `/purchases/subscriptions/${ siteSlug }` }
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
-						),
-					},
-				}
-			);
-		}
-		return translate(
-			'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (PAYPAL %(email)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
-			{
-				args: {
-					startDate: moment( args.subscription_start_date ).format( 'll' ),
-					endDate: moment( args.subscription_expiry_date ).format( 'll' ),
-					renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
-					email: args.email,
-					renewalPrice: args.renewal_price,
-					numberOfDays: args.subscription_pre_renew_reminder_days || 7,
-				},
-				components: {
-					updatePaymentMethodLink: (
-						<a
-							href={ localizeUrl( EDIT_PAYMENT_DETAILS ) }
-							target="_blank"
-							rel="noopener noreferrer"
-						/>
-					),
-					manageSubscriptionLink: (
-						<a
-							href={ `/purchases/subscriptions/${ siteSlug }` }
-							target="_blank"
-							rel="noopener noreferrer"
-						/>
-					),
-				},
-			}
-		);
-	}
-	return translate(
-		'At the end of the promotional period we will begin charging your PayPal account (%(email)s) the normal %(productName)s subscription price of %(renewalPrice)s. You can update the payment method at any time {{link}}here{{/link}}',
-		{
-			args: {
-				email: args.email,
-				productName: args.product_name,
-				renewalPrice: args.renewal_price,
-			},
-			components: {
-				link: (
-					<a
-						href={ `/purchases/subscriptions/${ siteSlug }` }
-						target="_blank"
-						rel="noopener noreferrer"
-					/>
-				),
-			},
-		}
-	);
-}
-
-function getMessageForTermsOfServiceRecordCard(
-	termsOfServiceRecord: TermsOfServiceRecord,
-	translate: ReturnType< typeof useTranslate >,
-	siteSlug: string | null
-): TranslateResult {
-	const args = termsOfServiceRecord.args;
-	if ( ! args ) {
-		return '';
-	}
-	if ( ! args.card_type || ! args.card_last_4 || ! args.product_name || ! args.renewal_price ) {
-		debug(
-			`Malformed terms of service args with code: ${ termsOfServiceRecord.code }`,
-			termsOfServiceRecord
-		);
-		return '';
-	}
-	if (
-		args.subscription_start_date &&
-		args.subscription_expiry_date &&
-		args.subscription_auto_renew_date
-	) {
-		if ( args.is_renewal_price_prorated ) {
-			return translate(
-				'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will charge your payment method (%(cardType)s ****%(cardLast4)s) for %(renewalPrice)s. All subsequent renewals will be charged for the regular subscription price of %(regularPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription{{/manageSubscriptionLink}} at any time.',
-				{
-					args: {
-						startDate: moment( args.subscription_start_date ).format( 'll' ),
-						endDate: moment( args.subscription_expiry_date ).format( 'll' ),
-						renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
-						cardType: args.card_type,
-						cardLast4: args.card_last_4,
-						renewalPrice: args.renewal_price,
-						regularPrice: args.regular_renewal_price,
-						numberOfDays: args.subscription_pre_renew_reminder_days || 7,
-					},
-					components: {
-						updatePaymentMethodLink: (
-							<a
-								href={ localizeUrl( EDIT_PAYMENT_DETAILS ) }
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
-						),
-						manageSubscriptionLink: (
-							<a
-								href={ `/purchases/subscriptions/${ siteSlug }` }
-								target="_blank"
-								rel="noopener noreferrer"
-							/>
-						),
-					},
-				}
-			);
-		}
-		return translate(
-			'The promotional period for your subscription lasts from %(startDate)s to %(endDate)s. On %(renewalDate)s we will begin charging your payment method (%(cardType)s ****%(cardLast4)s) the regular subscription price of %(renewalPrice)s. You will receive at least one email notice %(numberOfDays)d days before being billed and can {{updatePaymentMethodLink}}update your payment method{{/updatePaymentMethodLink}} or {{manageSubscriptionLink}}manage your subscription {{/manageSubscriptionLink}} at any time.',
-			{
-				args: {
-					startDate: moment( args.subscription_start_date ).format( 'll' ),
-					endDate: moment( args.subscription_expiry_date ).format( 'll' ),
-					renewalDate: moment( args.subscription_auto_renew_date ).format( 'll' ),
-					cardType: args.card_type,
-					cardLast4: args.card_last_4,
-					renewalPrice: args.renewal_price,
-					numberOfDays: args.subscription_pre_renew_reminder_days || 7,
-				},
-				components: {
-					updatePaymentMethodLink: (
-						<a
-							href={ localizeUrl( EDIT_PAYMENT_DETAILS ) }
-							target="_blank"
-							rel="noopener noreferrer"
-						/>
-					),
-					manageSubscriptionLink: (
-						<a
-							href={ `/purchases/subscriptions/${ siteSlug }` }
-							target="_blank"
-							rel="noopener noreferrer"
-						/>
-					),
-				},
-			}
-		);
-	}
-	return translate(
-		'At the end of the promotional period we will begin charging your %(cardType)s card ending in %(cardLast4)s the normal %(productName)s subscription price of %(renewalPrice)s. You can update the payment method at any time {{link}}here{{/link}}',
-		{
-			args: {
-				cardType: args.card_type,
-				cardLast4: args.card_last_4,
-				productName: args.product_name,
-				renewalPrice: args.renewal_price,
-			},
-			components: {
-				link: (
-					<a
-						href={ `/purchases/subscriptions/${ siteSlug }` }
-						target="_blank"
-						rel="noopener noreferrer"
-					/>
-				),
-			},
-		}
-	);
-}
-
 function getMessageForTermsOfServiceRecordUnknown(
 	termsOfServiceRecord: TermsOfServiceRecord,
 	translate: ReturnType< typeof useTranslate >,
@@ -262,11 +53,7 @@ function getMessageForTermsOfServiceRecordUnknown(
 	if ( ! args ) {
 		return '';
 	}
-	if (
-		args.subscription_start_date &&
-		args.subscription_expiry_date &&
-		args.subscription_auto_renew_date
-	) {
+	if ( doesTermsOfServiceRecordHaveDates( args ) ) {
 		if ( args.is_renewal_price_prorated ) {
 			const proratedRenewalArgs = {
 				args: {
@@ -408,10 +195,6 @@ function getMessageForTermsOfServiceRecord(
 	siteSlug: string | null
 ): TranslateResult {
 	switch ( termsOfServiceRecord.code ) {
-		case 'terms_for_bundled_trial_auto_renewal_paypal':
-			return getMessageForTermsOfServiceRecordPayPal( termsOfServiceRecord, translate, siteSlug );
-		case 'terms_for_bundled_trial_auto_renewal_credit_card':
-			return getMessageForTermsOfServiceRecordCard( termsOfServiceRecord, translate, siteSlug );
 		case 'terms_for_bundled_trial_unknown_payment_method':
 			return getMessageForTermsOfServiceRecordUnknown( termsOfServiceRecord, translate, siteSlug );
 		default:
@@ -421,4 +204,11 @@ function getMessageForTermsOfServiceRecord(
 			);
 			return '';
 	}
+}
+
+function doesTermsOfServiceRecordHaveDates(
+	args: TermsOfServiceRecord[ 'args' ]
+): args is TermsOfServiceRecordArgsRenewal {
+	const argsWithDates = args as TermsOfServiceRecordArgsRenewal;
+	return Boolean( argsWithDates.subscription_expiry_date );
 }

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -95,7 +95,8 @@ function getMessageForTermsOfServiceRecordUnknown(
 			}
 		);
 
-		const proratedNoticeText = translate(
+		// This is necessary to add if the next renewal is not the end of the offer.
+		const endOfPromotionChargeText = translate(
 			'On %(endDate)s, we will attempt to renew your subscription for %(maybeProratedRegularPrice)s.',
 			{
 				args: {
@@ -132,9 +133,13 @@ function getMessageForTermsOfServiceRecordUnknown(
 			}
 		);
 
+		const shouldShowEndOfPromotionText =
+			args.subscription_auto_renew_date !== args.subscription_end_of_promotion_date ||
+			args.maybe_prorated_regular_renewal_price_integer !== args.renewal_price_integer;
+
 		return (
 			<>
-				{ nextRenewalText } { args.is_renewal_price_prorated && proratedNoticeText }{ ' ' }
+				{ nextRenewalText } { shouldShowEndOfPromotionText && endOfPromotionChargeText }{ ' ' }
 				{ regularPriceNoticeText } { emailNoticesText }{ ' ' }
 			</>
 		);

--- a/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
+++ b/client/my-sites/checkout/src/components/additional-terms-of-service-in-cart.tsx
@@ -67,19 +67,19 @@ function getMessageForTermsOfServiceRecordUnknown(
 		stripZeros: true,
 	} );
 	const startDate = moment( args.subscription_start_date ).format( 'll' );
+	const maybeProratedRegularPrice = formatCurrency(
+		args.maybe_prorated_regular_renewal_price_integer,
+		currency,
+		{
+			isSmallestUnit: true,
+			stripZeros: true,
+		}
+	);
 	const manageSubscriptionLink = `/purchases/subscriptions/${ siteSlug }`;
 
 	if ( doesTermsOfServiceRecordHaveDates( args ) ) {
 		const endDate = moment( args.subscription_end_of_promotion_date ).format( 'll' );
 		const numberOfDays = args.subscription_pre_renew_reminder_days || 7;
-		const maybeProratedRegularPrice = formatCurrency(
-			args.maybe_prorated_regular_renewal_price_integer,
-			currency,
-			{
-				isSmallestUnit: true,
-				stripZeros: true,
-			}
-		);
 		const renewalDate = moment( args.subscription_auto_renew_date ).format( 'll' );
 
 		return translate(
@@ -112,11 +112,12 @@ function getMessageForTermsOfServiceRecordUnknown(
 	}
 
 	return translate(
-		'At the end of the promotional period your %(productName)s will renew at the normal price of %(renewalPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',
+		'At the end of the promotional period your %(productName)s will renew at the normal price of %(maybeProratedRegularPrice)s. Subsequent renewals will be %(regularPrice)s. You can add or update your payment method at any time {{link}}here{{/link}}.',
 		{
 			args: {
 				productName,
-				renewalPrice,
+				maybeProratedRegularPrice,
+				regularPrice,
 			},
 			components: {
 				link: <a href={ manageSubscriptionLink } target="_blank" rel="noopener noreferrer" />,

--- a/client/my-sites/checkout/src/components/cost-overrides-list.tsx
+++ b/client/my-sites/checkout/src/components/cost-overrides-list.tsx
@@ -191,7 +191,10 @@ function LineItemCostOverrideIntroOfferDueDate( { product }: { product: Response
 		}
 		return true;
 	} )?.args;
-	const dueDate = tosData?.subscription_auto_renew_date;
+	const dueDate =
+		tosData && 'subscription_auto_renew_date' in tosData
+			? tosData.subscription_auto_renew_date
+			: undefined;
 	const dueAmount = tosData?.renewal_price_integer;
 	const renewAmount = tosData?.regular_renewal_price_integer;
 	if ( ! dueDate || ! dueAmount || ! renewAmount ) {

--- a/packages/shopping-cart/src/types.ts
+++ b/packages/shopping-cart/src/types.ts
@@ -719,26 +719,157 @@ export interface TermsOfServiceRecord {
 }
 
 export interface TermsOfServiceRecordArgsBase {
+	/**
+	 * The date that the subscription will begin, formatted as a ISO 8601 date
+	 * (eg: `2004-02-12T15:19:21+00:00`).
+	 */
 	subscription_start_date: string;
-	subscription_expiry_date?: string;
-	subscription_auto_renew_date?: string;
-	subscription_pre_renew_reminder_days?: string;
-	subscription_pre_renew_reminders_count?: number;
+
+	/**
+	 * The `meta` value of the product (eg: its domain name). May be an empty
+	 * string if there is no meta.
+	 */
 	product_meta: string;
+
+	/**
+	 * The human readable name of the product.
+	 */
 	product_name: string;
+
+	/**
+	 * The store product ID.
+	 */
+	product_id: number;
+
+	/**
+	 * The price of the next renewal of this product. This may be based on the
+	 * product's billing term (eg: in two years for a biennial plan) or the
+	 * billing term of the introductory offer, if it differs (eg: in 3 months for
+	 * a 3 month free trial of an annual plan).
+	 *
+	 * If an introductory offer applies for more than one renewal, this will be
+	 * the price of the next renewal only, NOT the price of the renewal after the
+	 * offer ends!
+	 *
+	 * This price is locale-formatted with a currency symbol.
+	 * @deprecated use renewal_price_integer and format manually
+	 */
 	renewal_price: string;
+
+	/**
+	 * The price of the next renewal of this product. This may be based on the
+	 * product's billing term (eg: in two years for a biennial plan) or the
+	 * billing term of the introductory offer, if it differs (eg: in 3 months for
+	 * a 3 month free trial of an annual plan).
+	 *
+	 * If an introductory offer applies for more than one renewal, this will be
+	 * the price of the next renewal only, NOT the price of the renewal after the
+	 * offer ends!
+	 *
+	 * This price is an integer in the currency's smallest unit.
+	 */
 	renewal_price_integer: number;
+
+	/**
+	 * If the promotional price is due to an introductory offer, this is true
+	 * when `should_prorate_when_offer_ends` is set on the offer.
+	 */
 	is_renewal_price_prorated: boolean;
+
+	/**
+	 * The price of the product after the promotional pricing expires. If the
+	 * next auto-renewal after the price expires would prorate the renewal price,
+	 * this DOES NOT include that proration. See
+	 * `maybe_prorated_regular_renewal_price_integer` for the price with that proration
+	 * included.
+	 *
+	 * This price is locale-formatted with a currency symbol.
+	 * @deprecated use regular_renewal_price_integer and format manually
+	 */
 	regular_renewal_price: string;
+
+	/**
+	 * The price of the product after the promotional pricing expires. If the
+	 * next auto-renewal after the price expires would prorate the renewal price,
+	 * this DOES NOT include that proration. See
+	 * `maybe_prorated_regular_renewal_price_integer` for the price with that proration
+	 * included.
+	 *
+	 * This price is an integer in the currency's smallest unit.
+	 */
 	regular_renewal_price_integer: number;
-	email?: string;
-	card_type?: string;
-	card_last_4?: string;
+
+	/**
+	 * The price of the product for the renewal immediately after the promotional
+	 * pricing expires. If the next auto-renewal after the price expires would
+	 * prorate the renewal price, this DOES include that proration. See
+	 * `regular_renewal_price_integer` for the price without that proration
+	 * included.
+	 *
+	 * This is the price that we will attempt to charge on
+	 * `subscription_end_of_promotion_date`.
+	 *
+	 * This price is an integer in the currency's smallest unit.
+	 */
+	maybe_prorated_regular_renewal_price_integer: number;
 }
 
 export interface TermsOfServiceRecordArgsRenewal extends TermsOfServiceRecordArgsBase {
+	/**
+	 * The date that the promotional pricing will end, formatted as a ISO 8601
+	 * date (eg: `2004-02-12T15:19:21+00:00`). This will be the date that an
+	 * auto-renew will be attempted with the non-promotional price
+	 * (`maybe_prorated_regular_renewal_price_integer`).
+	 *
+	 * If the promotional price only lasts for the initial purchase, then this
+	 * will be the same as `subscription_auto_renew_date`.
+	 *
+	 * Only set if we can easily determine when the product will renew. Does not
+	 * apply to domain transfers or multi-year domains.
+	 */
+	subscription_end_of_promotion_date: string;
+
+	/**
+	 * The date when the product's subscription will expire if not renewed. This
+	 * might be its renewal date, but it might not be since we often renew
+	 * products earlier than their expiry date.
+	 *
+	 * This is ISO 8601 formatted (eg: `2004-02-12T15:19:21+00:00`).
+	 *
+	 * Only set if we can easily determine when the product will renew. Does not
+	 * apply to domain transfers or multi-year domains.
+	 */
 	subscription_expiry_date: string;
+
+	/**
+	 * The date when the product's subscription will next automatically attempt a
+	 * renewal. Note that this may not be the end of the promotional price, since
+	 * some promotions apply to renewals also.
+	 *
+	 * This is ISO 8601 formatted (eg: `2004-02-12T15:19:21+00:00`).
+	 *
+	 * Only set if we can easily determine when the product will renew. Does not
+	 * apply to domain transfers or multi-year domains.
+	 */
 	subscription_auto_renew_date: string;
-	subscription_pre_renew_reminder_days: string;
+
+	/**
+	 * The number of days before the renewal attempt when the user will receive a
+	 * pre-renewal reminder email.
+	 *
+	 * Only set if we can easily determine when the product will renew. Does not
+	 * apply to domain transfers or multi-year domains.
+	 */
+	subscription_pre_renew_reminder_days: number;
+
+	/**
+	 * The number of pre-renewal emails the user will receive.
+	 *
+	 * Typically this is 1 or 0. For example, monthly subscriptions don't usually
+	 * get a pre-renewal email.
+	 *
+	 * Only set if we can easily determine when the product will renew. Does not
+	 * apply to domain transfers or multi-year domains.
+	 */
 	subscription_pre_renew_reminders_count: number;
 }


### PR DESCRIPTION
When a product has an introductory offer, there are two prices which I'll call the "regular" price and the "initial" price (typically a discount, but sometimes larger than the regular price). The initial price is charged on the original purchase, but renewals after that point are not so straightforward. In the simplest case, the next automatic renewal and all subsequent renewals are the regular price. 

However, sometimes the next renewal is still at the initial price (for offers that last for one or more renewals). Also, sometimes the first renewal after the offer ends charges a prorated amount (eg: for an annual product that gets 3 months free, the next charge will be for 9 months of service). The "promotional period" text that we display in checkout for these offers does not cover all these special cases and can display misleading or outright incorrect dates and prices.

## Proposed Changes

In D140488-code we modified the shopping-cart endpoint to return more data about introductory offers. In this PR we use that data to clarify the "promotional period" text we display in the "terms of service" section of checkout. Since there's a lot of dates and prices and space is limited, this PR also attempts to simplify the messaging.

(As a side benefit, this also removes the word "discount" from the text so it will better support promotional periods where the initial price is higher than the regular price, like premium domains.)

Type | Before              | After
:---:|:-------------------------:|:-------------------------:
Simple offer | <img width="569" alt="Screenshot 2024-03-07 at 8 35 54 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/24c6b475-4f8d-47c4-b0e9-5e4c0e6e9b13"> | <img width="557" alt="Screenshot 2024-03-07 at 8 58 37 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/8cc4129a-7141-473c-a6a4-67d245c61846">
Prorated offer | <img width="558" alt="Screenshot 2024-03-07 at 9 03 19 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/8332a6bb-092d-42e7-b263-f1e9d2642eaa"> | <img width="549" alt="Screenshot 2024-03-07 at 9 10 24 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/bbf15eff-b7ed-4733-82eb-dd12f0ba5b44">
Renewing offer | <img width="568" alt="Screenshot 2024-03-07 at 9 15 01 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/7d051499-b71b-41ed-bdaf-e27059b1d1c3"> | <img width="560" alt="Screenshot 2024-03-07 at 9 15 21 PM" src="https://github.com/Automattic/wp-calypso/assets/2036909/5e16c25c-fdb0-4436-8334-8b0ca8d25f06">


## Testing Instructions

Add various types of products with promotional periods to your shopping cart; not just introductory offers but also bundled domains and products on sale. Verify that the "promotional period" messaging at the bottom of checkout makes sense for each one.