### PR TITLE
New User Survey: Restart experiment with new name and some code fixes

### DIFF
--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -12,7 +12,7 @@ export default class FormTextInput extends PureComponent {
 		className: PropTypes.string,
 		name: PropTypes.string,
 		value: PropTypes.any,
-		placeholder: PropTypes.string,
+		placeholder: PropTypes.any,
 		onChange: PropTypes.func,
 	};
 

--- a/client/components/forms/form-text-input/index.jsx
+++ b/client/components/forms/form-text-input/index.jsx
@@ -10,6 +10,10 @@ export default class FormTextInput extends PureComponent {
 		isValid: PropTypes.bool,
 		selectOnFocus: PropTypes.bool,
 		className: PropTypes.string,
+		name: PropTypes.string,
+		value: PropTypes.any,
+		placeholder: PropTypes.string,
+		onChange: PropTypes.func,
 	};
 
 	state = {

--- a/client/signup/controller.js
+++ b/client/signup/controller.js
@@ -245,7 +245,7 @@ export default {
 		const isOnboardingFlow = flowName === 'onboarding';
 		if ( isOnboardingFlow && ( ! userLoggedIn || ( userLoggedIn && isNewUser ) ) ) {
 			const experiment = await loadExperimentAssignment(
-				'calypso_signup_onboarding_site_goals_survey'
+				'calypso_signup_onboarding_site_goals_survey_i2'
 			);
 			initialContext.isSignupSurveyActive =
 				experiment.variationName === 'treatment' ||

--- a/client/signup/steps/new-user-survey/components/Shuffle/index.tsx
+++ b/client/signup/steps/new-user-survey/components/Shuffle/index.tsx
@@ -83,7 +83,11 @@ const Shuffle = ( props: ShuffleProps ) => {
 	sortedChildrenClone =
 		sortedChildrenClone.map( ( child, i ) => {
 			if ( isValidElement( child ) ) {
-				return React.cloneElement< any >( child, { ...child.props, 'data-testid': i + 1 } );
+				return React.cloneElement< any >( child, {
+					...child.props,
+					'data-testid': i + 1,
+					key: i + 1,
+				} );
 			}
 			return child;
 		} ) ?? [];

--- a/client/signup/steps/new-user-survey/components/Shuffle/index.tsx
+++ b/client/signup/steps/new-user-survey/components/Shuffle/index.tsx
@@ -39,7 +39,7 @@ type ShuffleProps = {
 	getChildKey: ( child: ReactNode ) => string;
 
 	/**
-	 * A boolean indicating whether the Shuffling of elements is active is active.
+	 * A boolean indicating whether the Shuffling of elements is active.
 	 */
 	isShuffleActive?: boolean;
 };

--- a/client/signup/steps/new-user-survey/components/index.tsx
+++ b/client/signup/steps/new-user-survey/components/index.tsx
@@ -2,16 +2,23 @@ import { Card, FormLabel } from '@automattic/components';
 import styled from '@emotion/styled';
 import FormTextInput from 'calypso/components/forms/form-text-input';
 
+const propForwardFilter = ( prop: string ) => prop !== 'currentViewport';
 export type Viewport = 'desktop' | 'mobile' | 'tablet';
+
 type PropsWithViewport = { currentViewport: Viewport };
-export const SurveyFormContainer = styled.div`
+
+export const SurveyFormContainer = styled( 'div', {
+	shouldForwardProp: propForwardFilter,
+} )`
 	margin: 0
 		${ ( { currentViewport }: PropsWithViewport ) =>
 			currentViewport === 'desktop' ? 'auto' : '10px' };
 	margin-bottom: 15px;
 `;
 
-export const StyledCard = styled( Card )`
+export const StyledCard = styled( Card, {
+	shouldForwardProp: propForwardFilter,
+} )`
 	margin: 0 auto;
 	padding: 25px 30px;
 	display: flex;
@@ -30,7 +37,7 @@ export const StyledLabel = styled( FormLabel )`
 	}
 `;
 
-export const StyledFormTextInput = styled< any >( FormTextInput )`
+export const StyledFormTextInput = styled( FormTextInput )`
 	&.form-text-input.form-text-input {
 		margin-left: 24px;
 		max-width: 385px;

--- a/client/signup/steps/new-user-survey/components/index.tsx
+++ b/client/signup/steps/new-user-survey/components/index.tsx
@@ -37,7 +37,7 @@ export const StyledLabel = styled( FormLabel )`
 	}
 `;
 
-export const StyledFormTextInput = styled( FormTextInput )`
+export const StyledFormTextInput = styled< any >( FormTextInput )`
 	&.form-text-input.form-text-input {
 		margin-left: 24px;
 		max-width: 385px;

--- a/client/signup/steps/new-user-survey/components/index.tsx
+++ b/client/signup/steps/new-user-survey/components/index.tsx
@@ -37,7 +37,7 @@ export const StyledLabel = styled( FormLabel )`
 	}
 `;
 
-export const StyledFormTextInput = styled< any >( FormTextInput )`
+export const StyledFormTextInput = styled( FormTextInput )`
 	&.form-text-input.form-text-input {
 		margin-left: 24px;
 		max-width: 385px;

--- a/client/signup/steps/new-user-survey/components/index.tsx
+++ b/client/signup/steps/new-user-survey/components/index.tsx
@@ -8,6 +8,7 @@ export const SurveyFormContainer = styled.div`
 	margin: 0
 		${ ( { currentViewport }: PropsWithViewport ) =>
 			currentViewport === 'desktop' ? 'auto' : '10px' };
+	margin-bottom: 15px;
 `;
 
 export const StyledCard = styled( Card )`
@@ -19,9 +20,6 @@ export const StyledCard = styled( Card )`
 		props.currentViewport === 'mobile' ? '100%' : 'fit-content' };
 	min-width: ${ ( props: PropsWithViewport ) =>
 		props.currentViewport === 'mobile' ? 'unset' : '459px' };
-	&&&&& {
-		margin-bottom: 15px;
-	}
 `;
 
 export const StyledLabel = styled( FormLabel )`

--- a/client/signup/steps/new-user-survey/index.tsx
+++ b/client/signup/steps/new-user-survey/index.tsx
@@ -78,7 +78,7 @@ function ControlledCheckbox( props: {
 
 function SurveyForm( props: Props ) {
 	const [ isExperimentLoading, experimentAssignment ] = useExperiment(
-		'calypso_signup_onboarding_site_goals_survey'
+		'calypso_signup_onboarding_site_goals_survey_i2'
 	);
 	const variantName = experimentAssignment?.variationName;
 	const isScrambled =


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Restarts the concluded experiment with a new name, 
* Experiment design: pbxNRc-3xO-p2
* New Experiment: 21671-explat-experiment

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->
See
* https://github.com/Automattic/wp-calypso/pull/87560
* Assign yourself to variants and make sure you're seeing the new user survey on `/start`


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?