### PR TITLE
GitHub deployments: Fix connection wizard quirks

### DIFF
--- a/client/my-sites/github-deployments/components/github-connection-form/index.tsx
+++ b/client/my-sites/github-deployments/components/github-connection-form/index.tsx
@@ -50,13 +50,14 @@ export const GitHubConnectionForm = ( {
 	onSubmit,
 }: GitHubConnectionFormProps ) => {
 	const [ submitted, setSubmitted ] = useState( false );
+
 	const [ branch, setBranch ] = useState( initialValues.branch );
 	const [ destPath, setDestPath ] = useState( initialValues.destPath );
 	const [ isAutoDeploy, setIsAutoDeploy ] = useState( initialValues.isAutomated );
-
 	const [ workflowPath, setWorkflowPath ] = useState< string | undefined >(
 		initialValues.workflowPath
 	);
+
 	const { __ } = useI18n();
 
 	const { data: branches, isLoading: isFetchingBranches } = useGithubRepositoryBranchesQuery(
@@ -98,15 +99,11 @@ export const GitHubConnectionForm = ( {
 	);
 
 	useEffect( () => {
-		if ( repoChecks?.suggested_directory ) {
+		// Only apply path suggestions if creating a new deployment
+		if ( ! deploymentId && repoChecks?.suggested_directory ) {
 			setDestPath( repoChecks.suggested_directory );
-		} else {
-			setDestPath( initialValues.destPath );
 		}
-		setBranch( initialValues.branch );
-		setIsAutoDeploy( initialValues.isAutomated );
-		setWorkflowPath( initialValues.workflowPath );
-	}, [ initialValues, repoChecks ] );
+	}, [ deploymentId, repoChecks ] );
 
 	const displayMissingRepositoryError = submitted && ! repository;
 	const submitDisabled = !! workflowPath && workflowCheckResult?.conclusion !== 'success';

--- a/client/my-sites/github-deployments/components/github-connection-form/style.scss
+++ b/client/my-sites/github-deployments/components/github-connection-form/style.scss
@@ -22,10 +22,6 @@
 		.form-fieldset {
 			margin-bottom: 24px;
 		}
-
-		button[type="submit"] {
-			margin-top: 16px;
-		}
 	}
 
 	&__repository {
@@ -64,5 +60,10 @@
 		display: flex;
 		align-items: center;
 		gap: 8px;
+		margin-top: 40px;
+
+		.form-setting-explanation {
+			margin: 0;
+		}
 	}
 }

--- a/client/my-sites/github-deployments/components/target-dir-input.tsx
+++ b/client/my-sites/github-deployments/components/target-dir-input.tsx
@@ -18,7 +18,7 @@ export const TargetDirInput = ( { onChange, value }: TargetDirInputProps ) => {
 			<FormLabel htmlFor="targetDir">{ __( 'Destination directory' ) }</FormLabel>
 			<FormTextInput
 				id="targetDir"
-				placehlder="/"
+				placeholder="/"
 				value={ value }
 				onChange={ ( event: ChangeEvent< HTMLInputElement > ) => {
 					let targetDir = event.currentTarget.value.trim();

--- a/client/my-sites/github-deployments/deployment-creation/deployment-creation-form.tsx
+++ b/client/my-sites/github-deployments/deployment-creation/deployment-creation-form.tsx
@@ -114,6 +114,7 @@ export const GitHubDeploymentCreationForm = ( {
 		<>
 			<GitHubConnectionForm
 				installationId={ installation?.external_id }
+				key={ repository?.id ?? 'none' }
 				repository={ repository }
 				initialValues={ initialValues }
 				changeRepository={ () => dispatch( { type: 'open-repository-picker' } ) }


### PR DESCRIPTION
## Proposed Changes

I found the path suggestion was being applied when modifying a connection.

I also saw that we're applying the initial values whenever they changed, but in reality what we should do is to restart the connection wizard whenever the repository changes. So let's use the `key` prop to restart component state.