### PR TITLE
Jetpack Manage: Sites Dashboard V2 Follow-up Tasks

### DIFF
--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-feature-previews/jetpack-preview-pane.tsx
@@ -76,7 +76,7 @@ export function JetpackPreviewPane( {
 			),
 			createFeaturePreview(
 				'jetpack_plugins',
-				'Plugins',
+				translate( 'Plugins' ),
 				true,
 				selectedFeatureId,
 				setSelectedFeatureId,

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-tabs/style.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/site-preview-pane/site-preview-pane-tabs/style.scss
@@ -2,7 +2,7 @@
 	display: flex;
 	justify-content: flex-start;
 	align-items: center;
-	height: 48px;
+	min-height: 48px;
 	padding: 0 32px;
 	border-bottom: 1px solid var(--studio-gray-0);
 	overflow: auto;

--- a/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style-dashboard-v2.scss
+++ b/client/jetpack-cloud/sections/agency-dashboard/sites-overview/style-dashboard-v2.scss
@@ -128,11 +128,12 @@
 		.sites-overview__column-action-button,
 		.sites-overview__row-status,
 		.toggle-activate-monitoring__toggle-button,
-		.sites-dataviews__favorite-btn-wrapper {
+		.sites-dataviews__favorite-btn-wrapper,
+		.sites-overview__boost-score {
 			display: none;
 		}
 
-		td:nth-child(n+2):nth-child(-n+8) {
+		td:nth-child(n+3):nth-child(-n+9) {
 			display: none;
 		}
 
@@ -280,7 +281,8 @@
 				.sites-overview__column-action-button,
 				.sites-overview__row-status,
 				.toggle-activate-monitoring__toggle-button,
-				.sites-dataviews__favorite-btn-wrapper {
+				.sites-dataviews__favorite-btn-wrapper,
+				.sites-overview__boost-score {
 					display: none;
 				}
 

--- a/client/jetpack-cloud/sections/sidebar-navigation/sites.tsx
+++ b/client/jetpack-cloud/sections/sidebar-navigation/sites.tsx
@@ -11,6 +11,7 @@ import {
 	JETPACK_MANAGE_OVERVIEW_LINK,
 } from './lib/constants';
 import { MenuItemProps } from './types';
+import './style.scss';
 
 const SitesSidebar = ( { path }: { path: string } ) => {
 	const translate = useTranslate();
@@ -59,6 +60,7 @@ const SitesSidebar = ( { path }: { path: string } ) => {
 	return (
 		<NewSidebar
 			isJetpackManage
+			className="sites-dashboard__sidebar"
 			path={ JETPACK_MANAGE_SITES_LINK }
 			menuItems={ menuItems }
 			title={ translate( 'Sites' ) }

--- a/client/jetpack-cloud/sections/sidebar-navigation/style.scss
+++ b/client/jetpack-cloud/sections/sidebar-navigation/style.scss
@@ -1,0 +1,9 @@
+.sites-dashboard__sidebar {
+	.sidebar-v2__navigator-sub-menu-header {
+		color: var(--studio-black);
+	}
+
+	.sidebar-v2__navigator-group-description {
+		font-size: rem(13px);
+	}
+}


### PR DESCRIPTION
Related to https://github.com/Automattic/jetpack-manage/issues/356
Related to https://github.com/Automattic/jetpack-manage/issues/353
Related to https://github.com/Automattic/jetpack-manage/issues/354
Related to https://github.com/Automattic/jetpack-manage/issues/359

## Proposed Changes

* This PR fixes some small issues with the initial implementation of the Sites Dashboard V2 (Table Atelier).

## Testing Instructions

* Ensure that https://github.com/Automattic/jetpack-manage/issues/356 is fixed:
  * When opening the preview panel for any sites the Boost score should be hidden
* Ensure that https://github.com/Automattic/jetpack-manage/issues/353 is fixed:
  * The `Plugins` tab should be properly translated
* Ensure https://github.com/Automattic/jetpack-manage/issues/354 is fixed:
  * Nav header should be black, and the description below it should be 13px
* Ensure https://github.com/Automattic/jetpack-manage/issues/359 is fixed:
  * Selecting the Activity tab in the preview pane no longer makes the tabs disappear. 

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?