### PR TITLE
Add last status badge

### DIFF
--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -5,6 +5,7 @@ import { usePreparePluginsTooltipInfo } from 'calypso/blocks/plugins-update-mana
 import { ellipsis } from 'calypso/blocks/plugins-update-manager/icons';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
+import { Badge } from './badge';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { usePrepareScheduleName } from './hooks/use-prepare-schedule-name';
 import { useSiteSlug } from './hooks/use-site-slug';
@@ -57,7 +58,13 @@ export const ScheduleListCards = ( props: Props ) => {
 
 					<div className="schedule-list--card-label">
 						<label htmlFor="last-update">Last Update</label>
-						<span id="last-update"></span>
+						<span id="last-update">
+							{ schedule.last_run_status !== null && (
+								<Badge type={ schedule.last_run_status === 'success' ? 'success' : 'failed' } />
+							) }
+							{ schedule.last_run_timestamp !== null &&
+								moment( schedule.last_run_timestamp * 1000 ).format( MOMENT_TIME_FORMAT ) }
+						</span>
 					</div>
 
 					<div className="schedule-list--card-label">

--- a/client/blocks/plugins-update-manager/schedule-list-cards.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-cards.tsx
@@ -59,10 +59,10 @@ export const ScheduleListCards = ( props: Props ) => {
 					<div className="schedule-list--card-label">
 						<label htmlFor="last-update">Last Update</label>
 						<span id="last-update">
-							{ schedule.last_run_status !== null && (
+							{ schedule.last_run_status && (
 								<Badge type={ schedule.last_run_status === 'success' ? 'success' : 'failed' } />
 							) }
-							{ schedule.last_run_timestamp !== null &&
+							{ schedule.last_run_timestamp &&
 								moment( schedule.last_run_timestamp * 1000 ).format( MOMENT_TIME_FORMAT ) }
 						</span>
 					</div>

--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -52,10 +52,10 @@ export const ScheduleListTable = ( props: Props ) => {
 							</Button>
 						</td>
 						<td>
-							{ schedule.last_run_status !== null && (
+							{ schedule.last_run_status && (
 								<Badge type={ schedule.last_run_status === 'success' ? 'success' : 'failed' } />
 							) }
-							{ schedule.last_run_timestamp !== null &&
+							{ schedule.last_run_timestamp &&
 								moment( schedule.last_run_timestamp * 1000 ).format( MOMENT_TIME_FORMAT ) }
 						</td>
 						<td>{ moment( schedule.timestamp * 1000 ).format( MOMENT_TIME_FORMAT ) }</td>

--- a/client/blocks/plugins-update-manager/schedule-list-table.tsx
+++ b/client/blocks/plugins-update-manager/schedule-list-table.tsx
@@ -2,6 +2,7 @@ import { Button, DropdownMenu, Tooltip } from '@wordpress/components';
 import { Icon, info } from '@wordpress/icons';
 import { useLocalizedMoment } from 'calypso/components/localized-moment';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
+import { Badge } from './badge';
 import { MOMENT_TIME_FORMAT } from './config';
 import { useIsEligibleForFeature } from './hooks/use-is-eligible-for-feature';
 import { usePreparePluginsTooltipInfo } from './hooks/use-prepare-plugins-tooltip-info';
@@ -50,7 +51,13 @@ export const ScheduleListTable = ( props: Props ) => {
 								{ prepareScheduleName( schedule ) }
 							</Button>
 						</td>
-						<td></td>
+						<td>
+							{ schedule.last_run_status !== null && (
+								<Badge type={ schedule.last_run_status === 'success' ? 'success' : 'failed' } />
+							) }
+							{ schedule.last_run_timestamp !== null &&
+								moment( schedule.last_run_timestamp * 1000 ).format( MOMENT_TIME_FORMAT ) }
+						</td>
 						<td>{ moment( schedule.timestamp * 1000 ).format( MOMENT_TIME_FORMAT ) }</td>
 						<td>
 							{

--- a/client/data/plugins/use-update-schedules-query.ts
+++ b/client/data/plugins/use-update-schedules-query.ts
@@ -9,6 +9,8 @@ export type ScheduleUpdates = {
 	timestamp: number;
 	schedule: 'weekly' | 'daily';
 	args: string[];
+	last_run_status: 'success' | 'failure-and-rollback' | 'failure-and-rollback-fail' | null;
+	last_run_timestamp: number | null;
 };
 
 export const useUpdateScheduleQuery = (


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-forge/issues/5963

## Proposed Changes

* Add last status badge and time

<img width="1089" alt="screenshot" src="https://github.com/Automattic/wp-calypso/assets/167611/0342a521-1bf7-44f9-9e87-58e76f7c7b3e">

## Testing Instructions

Follow the instructions found in D141242-code.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?