### PR TITLE
A4A: Add payment method layout.

### DIFF
--- a/client/a8c-for-agencies/components/layout/style.scss
+++ b/client/a8c-for-agencies/components/layout/style.scss
@@ -153,7 +153,6 @@
 
 .a4a-layout__header-title {
 	font-size: 2.25rem;
-	margin-block-end: 0;
 	font-weight: 600;
 	line-height: 1.2;
 }
@@ -161,7 +160,7 @@
 .a4a-layout__header-subtitle {
 	font-size: 1rem;
 	color: var(--color-neutral-60);
-	margin: 0;
+	margin: 8px 0 0 0;
 	font-weight: 400;
 	line-height: 1.2;
 }

--- a/client/a8c-for-agencies/sections/purchases/lib/get-stripe-configuration.ts
+++ b/client/a8c-for-agencies/sections/purchases/lib/get-stripe-configuration.ts
@@ -1,0 +1,14 @@
+import wp from 'calypso/lib/wp';
+import type { GetStripeConfigurationArgs } from '@automattic/calypso-stripe';
+
+export async function getStripeConfiguration(
+	requestArgs: GetStripeConfigurationArgs & { needs_intent?: boolean }
+) {
+	return await wp.req.get(
+		{
+			apiNamespace: 'wpcom/v2',
+			path: '/jetpack/stripe/configuration',
+		},
+		requestArgs
+	);
+}

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/index.tsx
@@ -14,6 +14,7 @@ import { A4A_PAYMENT_METHODS_LINK } from 'calypso/a8c-for-agencies/components/si
 import PaymentMethodStripeInfo from 'calypso/jetpack-cloud/sections/partner-portal/payment-method-stripe-info';
 import { usePaymentMethodStepper } from 'calypso/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/hooks/use-payment-method-stepper';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+import PaymentMethodForm from './payment-method-form';
 
 import './style.scss';
 
@@ -62,7 +63,9 @@ export default function PaymentMethodAdd( { withAssignLicense }: Props ) {
 
 			<LayoutBody>
 				<div className="payment-method-add__content">
-					<Card className="payment-method-add__card payment-form">test</Card>
+					<Card className="payment-method-add__card payment-form">
+						<PaymentMethodForm />
+					</Card>
 
 					<Card className="payment-method-add__card aside">
 						<PaymentMethodStripeInfo />

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/index.tsx
@@ -1,3 +1,4 @@
+import { Card } from '@automattic/components';
 import { useTranslate } from 'i18n-calypso';
 import Layout from 'calypso/a8c-for-agencies/components/layout';
 import LayoutBody from 'calypso/a8c-for-agencies/components/layout/body';
@@ -10,8 +11,11 @@ import LayoutStepper from 'calypso/a8c-for-agencies/components/layout/stepper';
 import LayoutTop from 'calypso/a8c-for-agencies/components/layout/top';
 import MobileSidebarNavigation from 'calypso/a8c-for-agencies/components/sidebar/mobile-sidebar-navigation';
 import { A4A_PAYMENT_METHODS_LINK } from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import PaymentMethodStripeInfo from 'calypso/jetpack-cloud/sections/partner-portal/payment-method-stripe-info';
 import { usePaymentMethodStepper } from 'calypso/jetpack-cloud/sections/partner-portal/primary/payment-method-add-v2/hooks/use-payment-method-stepper';
 import PageViewTracker from 'calypso/lib/analytics/page-view-tracker';
+
+import './style.scss';
 
 type Props = {
 	withAssignLicense?: boolean;
@@ -56,7 +60,15 @@ export default function PaymentMethodAdd( { withAssignLicense }: Props ) {
 				</LayoutHeader>
 			</LayoutTop>
 
-			<LayoutBody>Payment Method Add</LayoutBody>
+			<LayoutBody>
+				<div className="payment-method-add__content">
+					<Card className="payment-method-add__card payment-form">test</Card>
+
+					<Card className="payment-method-add__card aside">
+						<PaymentMethodStripeInfo />
+					</Card>
+				</div>
+			</LayoutBody>
 		</Layout>
 	);
 }

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/index.tsx
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/index.tsx
@@ -1,0 +1,368 @@
+import page from '@automattic/calypso-router';
+import {
+	ReloadSetupIntentId,
+	StripeHookProvider,
+	StripeSetupIntentIdProvider,
+	useStripe,
+	useStripeSetupIntentId,
+} from '@automattic/calypso-stripe';
+import { Button } from '@automattic/components';
+import {
+	CheckoutProvider,
+	CheckoutFormSubmit,
+	useFormStatus,
+	FormStatus,
+	PaymentMethod,
+} from '@automattic/composite-checkout';
+import { isValueTruthy } from '@automattic/wpcom-checkout';
+import { CardElement, useElements } from '@stripe/react-stripe-js';
+import { useSelect } from '@wordpress/data';
+import { Icon, info } from '@wordpress/icons';
+import { getQueryArg } from '@wordpress/url';
+import { TranslateResult, useTranslate } from 'i18n-calypso';
+import { useCallback, useMemo, useEffect } from 'react';
+import {
+	A4A_MARKETPLACE_LINK,
+	A4A_PAYMENT_METHODS_ADD_LINK,
+	A4A_PAYMENT_METHODS_LINK,
+} from 'calypso/a8c-for-agencies/components/sidebar-menu/lib/constants';
+import CreditCardLoading from 'calypso/jetpack-cloud/sections/partner-portal/credit-card-fields/credit-card-loading';
+import {
+	useReturnUrl,
+	useIssueAndAssignLicenses,
+} from 'calypso/jetpack-cloud/sections/partner-portal/hooks';
+import { parseQueryStringProducts } from 'calypso/jetpack-cloud/sections/partner-portal/lib/querystring-products';
+import { assignNewCardProcessor } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods/assignment-processor-functions';
+import { useCreateStoredCreditCardMethod } from 'calypso/jetpack-cloud/sections/partner-portal/payment-methods/hooks/use-create-stored-credit-card';
+import { addQueryArgs } from 'calypso/lib/url';
+import { useSelector, useDispatch } from 'calypso/state';
+import { recordTracksEvent } from 'calypso/state/analytics/actions';
+import { getCurrentUserLocale } from 'calypso/state/current-user/selectors';
+import { errorNotice, removeNotice, successNotice } from 'calypso/state/notices/actions';
+import { creditCardStore } from 'calypso/state/partner-portal/credit-card-form';
+import { doesPartnerRequireAPaymentMethod } from 'calypso/state/partner-portal/partner/selectors';
+import { fetchStoredCards } from 'calypso/state/partner-portal/stored-cards/actions';
+import { APIError } from 'calypso/state/partner-portal/types';
+import getSites from 'calypso/state/selectors/get-sites';
+import { getStripeConfiguration } from '../../../lib/get-stripe-configuration';
+
+import './style.scss';
+
+function onPaymentSelectComplete( {
+	successCallback,
+	translate,
+	showSuccessMessage,
+	reloadSetupIntentId,
+}: {
+	successCallback: () => void;
+	translate: ReturnType< typeof useTranslate >;
+	showSuccessMessage: ( message: string | TranslateResult ) => void;
+	reloadSetupIntentId: ReloadSetupIntentId;
+} ) {
+	showSuccessMessage( translate( 'Your payment method has been added successfully.' ) );
+	// We need to regenerate the setup intent if the form was submitted.
+	reloadSetupIntentId();
+	successCallback();
+}
+
+function PaymentMethodForm() {
+	const translate = useTranslate();
+	const reduxDispatch = useDispatch();
+	const paymentMethodRequired = useSelector( doesPartnerRequireAPaymentMethod );
+	const { isStripeLoading, stripeLoadingError, stripeConfiguration, stripe } = useStripe();
+	const {
+		reload: reloadSetupIntentId,
+		setupIntentId: stripeSetupIntentId,
+		error: setupIntentError,
+	} = useStripeSetupIntentId();
+	const stripeMethod = useCreateStoredCreditCardMethod( {
+		isStripeLoading,
+		stripeLoadingError,
+		stripeConfiguration,
+		stripe,
+	} );
+	const paymentMethods = useMemo(
+		() => [ stripeMethod ].filter( isValueTruthy ),
+		[ stripeMethod ]
+	);
+	const useAsPrimaryPaymentMethod: boolean = useSelect(
+		( select ) => select( creditCardStore ).useAsPrimaryPaymentMethod(),
+		[]
+	);
+
+	const sites = useSelector( getSites );
+
+	const returnQueryArg = ( getQueryArg( window.location.href, 'return' ) ?? '' ).toString();
+	const products = ( getQueryArg( window.location.href, 'products' ) ?? '' ).toString();
+	const siteId = ( getQueryArg( window.location.href, 'site_id' ) ?? '' ).toString();
+
+	const source = useMemo(
+		() => ( getQueryArg( window.location.href, 'source' ) || '' ).toString(),
+		[]
+	);
+
+	const dispatch = useDispatch();
+	const { issueAndAssignLicenses, isReady: isIssueAndAssignLicensesReady } =
+		useIssueAndAssignLicenses(
+			siteId ? sites.find( ( site ) => site?.ID === parseInt( siteId ) ) : null,
+			{
+				onIssueError: ( error: APIError ) => {
+					if ( error.code === 'missing_valid_payment_method' ) {
+						dispatch(
+							errorNotice(
+								translate(
+									'A primary payment method is required.{{br/}} {{a}}Try adding a new payment method{{/a}} or contact support.',
+									{
+										components: {
+											a: (
+												<a
+													href={ `${ A4A_PAYMENT_METHODS_ADD_LINK }?return=${ A4A_MARKETPLACE_LINK }` }
+												/>
+											),
+											br: <br />,
+										},
+									}
+								)
+							)
+						);
+
+						return;
+					}
+
+					dispatch( errorNotice( error.message ) );
+				},
+				onAssignError: ( error: Error ) =>
+					dispatch( errorNotice( error.message, { isPersistent: true } ) ),
+			}
+		);
+
+	useReturnUrl( ! paymentMethodRequired );
+
+	const handleChangeError = useCallback(
+		( { transactionError }: { transactionError: string | null } ) => {
+			if (
+				transactionError &&
+				( transactionError.toLowerCase().includes( 'cvc' ) ||
+					transactionError.toLowerCase().includes( 'security code' ) )
+			) {
+				transactionError = translate(
+					'Your payment method cvc code or expiration date is invalid.'
+				);
+			}
+			reduxDispatch(
+				errorNotice(
+					transactionError ||
+						translate( 'There was a problem assigning that payment method. Please try again.' ),
+					{ id: 'payment-method-failure' }
+				)
+			);
+			// We need to regenerate the setup intent if the form was submitted.
+			reloadSetupIntentId();
+		},
+		[ reduxDispatch, translate, reloadSetupIntentId ]
+	);
+
+	const showSuccessMessage = useCallback(
+		( message: TranslateResult ) => {
+			reduxDispatch(
+				successNotice( message, { isPersistent: true, displayOnNextPage: true, duration: 5000 } )
+			);
+		},
+		[ reduxDispatch ]
+	);
+
+	const successCallback = useCallback( () => {
+		// returnQueryArg - will make sure the license issuing flow will be resumed
+		// when the user already has a license issued but not assigned, and will
+		// assign the license after adding a payment method.
+		//
+		// product - will make sure there will be a license issuing for that product
+		//
+		if ( returnQueryArg || products ) {
+			reduxDispatch(
+				fetchStoredCards( {
+					startingAfter: '',
+					endingBefore: '',
+				} )
+			);
+		} else {
+			page( A4A_PAYMENT_METHODS_LINK );
+		}
+	}, [ returnQueryArg, products, reduxDispatch ] );
+
+	useEffect( () => {
+		if ( paymentMethodRequired ) {
+			return;
+		}
+
+		if ( ! products ) {
+			return;
+		}
+
+		dispatch(
+			recordTracksEvent( 'calypso_a4a_issue_multiple_licenses_submit', {
+				products,
+			} )
+		);
+
+		const itemsToIssue = parseQueryStringProducts( products );
+		issueAndAssignLicenses( itemsToIssue );
+		// Do not update the dependency array with products since
+		// it gets changed on every product change, which triggers this `useEffect` to run infinitely.
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ dispatch, issueAndAssignLicenses, paymentMethodRequired ] );
+
+	useEffect( () => {
+		if ( stripeLoadingError ) {
+			reduxDispatch( errorNotice( stripeLoadingError.message ) );
+		}
+	}, [ stripeLoadingError, reduxDispatch ] );
+
+	useEffect( () => {
+		if ( setupIntentError ) {
+			reduxDispatch( errorNotice( setupIntentError.message ) );
+		}
+	}, [ setupIntentError, reduxDispatch ] );
+
+	const elements = useElements();
+
+	const getPreviousPageLink = () => {
+		if ( products ) {
+			return addQueryArgs(
+				{
+					products,
+					...( siteId && { site_id: siteId } ),
+					...( source && { source } ),
+				},
+				A4A_MARKETPLACE_LINK
+			);
+		}
+		return A4A_PAYMENT_METHODS_LINK;
+	};
+
+	return (
+		<CheckoutProvider
+			onPaymentComplete={ () => {
+				onPaymentSelectComplete( {
+					successCallback,
+					translate,
+					showSuccessMessage,
+					reloadSetupIntentId,
+				} );
+			} }
+			onPaymentError={ handleChangeError }
+			paymentMethods={ paymentMethods }
+			paymentProcessors={ {
+				card: ( data: unknown ) => {
+					reduxDispatch( removeNotice( 'payment-method-failure' ) );
+					return assignNewCardProcessor(
+						{
+							useAsPrimaryPaymentMethod,
+							translate,
+							stripe,
+							stripeConfiguration,
+							stripeSetupIntentId,
+							cardElement: elements?.getElement( CardElement ) ?? undefined,
+							reduxDispatch,
+						},
+						data
+					);
+				},
+			} }
+			initiallySelectedPaymentMethodId="card"
+			isLoading={ isStripeLoading }
+		>
+			<div className="payment-method-form">
+				<h1 className="payment-method-form__title">{ translate( 'Credit card details' ) } </h1>
+
+				<PaymentMethodFormMain
+					paymentMethods={ paymentMethods }
+					useAsPrimaryPaymentMethod={ useAsPrimaryPaymentMethod }
+				/>
+
+				<PaymentMethodFormFooter
+					disableBackButton={ isStripeLoading || ! isIssueAndAssignLicensesReady }
+					backButtonHref={ getPreviousPageLink() }
+				/>
+			</div>
+		</CheckoutProvider>
+	);
+}
+
+function PaymentMethodFormMain( {
+	paymentMethods,
+	useAsPrimaryPaymentMethod,
+}: {
+	paymentMethods: PaymentMethod[];
+	useAsPrimaryPaymentMethod: boolean;
+} ) {
+	const translate = useTranslate();
+
+	return (
+		<div className="payment-method-form__main">
+			{ 0 === paymentMethods.length && <CreditCardLoading /> }
+
+			{ paymentMethods && paymentMethods[ 0 ] && paymentMethods[ 0 ].activeContent }
+
+			{ 0 < paymentMethods.length && useAsPrimaryPaymentMethod && (
+				<p className="payment-method-form__notice">
+					<Icon className="payment-method-form__notice-icon" size={ 20 } icon={ info } />
+
+					{ translate(
+						'By adding your primary payment method, you authorize automatic monthly charges for your active licenses.'
+					) }
+				</p>
+			) }
+		</div>
+	);
+}
+
+function PaymentMethodFormFooter( {
+	disableBackButton,
+	backButtonHref,
+}: {
+	disableBackButton: boolean;
+	backButtonHref: string;
+} ) {
+	const translate = useTranslate();
+	const dispatch = useDispatch();
+
+	const onGoToPaymentMethods = () => {
+		dispatch( recordTracksEvent( 'calypso_a4a_payment_method_card_go_back_click' ) );
+	};
+
+	const { formStatus } = useFormStatus();
+
+	const shouldDisableBackButton = formStatus !== FormStatus.READY || disableBackButton;
+
+	return (
+		<div className="payment-method-form__footer">
+			<Button
+				className="payment-method-form__back-button"
+				href={ shouldDisableBackButton ? undefined : backButtonHref }
+				disabled={ shouldDisableBackButton }
+				onClick={ onGoToPaymentMethods }
+			>
+				{ translate( 'Go back' ) }
+			</Button>
+
+			<span className="payment-method-form__submit-button">
+				<CheckoutFormSubmit />
+			</span>
+		</div>
+	);
+}
+
+export default function PaymentMethodFormWrapper() {
+	const locale = useSelector( getCurrentUserLocale );
+
+	return (
+		<StripeHookProvider locale={ locale } fetchStripeConfiguration={ getStripeConfiguration }>
+			<StripeSetupIntentIdProvider
+				fetchStripeSetupIntentId={ () => getStripeConfiguration( { needs_intent: true } ) }
+			>
+				<PaymentMethodForm />
+			</StripeSetupIntentIdProvider>
+		</StripeHookProvider>
+	);
+}

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/style.scss
@@ -1,0 +1,48 @@
+.payment-method-form {
+	display: flex;
+	flex-direction: column;
+	gap: 24px;
+}
+
+.payment-method-form__title {
+	font-size: rem(20px);
+	line-height: 1.2;
+	font-weight: 500;
+}
+
+.payment-method-form__footer {
+	display: flex;
+	gap: 16px;
+}
+
+.payment-method-form__submit-button {
+	.checkout-steps__submit-button-wrapper {
+		padding: 0;
+	}
+}
+
+.payment-method-form__back-button {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+}
+
+.payment-method-form__notice,
+.payment-method-form .credit-card-fields__input-field :is(label, .credit-card-fields__label-text) {
+	font-size: rem(14px);
+	line-height: 1.4;
+	font-weight: 500;
+}
+
+.payment-method-form__notice {
+	color: var(--studio-gray-50);
+	font-weight: 400;
+	margin-block-start: 24px;
+	display: flex;
+	gap: 8px;
+}
+
+.payment-method-form__notice-icon {
+	fill: var(--studio-gray-30);
+	flex-shrink: 0;
+}

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/payment-method-form/style.scss
@@ -35,7 +35,7 @@
 }
 
 .payment-method-form__notice {
-	color: var(--studio-gray-50);
+	color: var(--color-neutral-50);
 	font-weight: 400;
 	margin-block-start: 24px;
 	display: flex;
@@ -43,6 +43,6 @@
 }
 
 .payment-method-form__notice-icon {
-	fill: var(--studio-gray-30);
+	fill: var(--color-neutral-30);
 	flex-shrink: 0;
 }

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/style.scss
@@ -2,7 +2,6 @@
 @import "@wordpress/base-styles/mixins";
 
 .card.payment-method-add__card {
-	background-color: var(--studio-white);
 	border: none;
 	outline: none;
 	box-shadow: none;

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/style.scss
@@ -1,0 +1,42 @@
+@import "@wordpress/base-styles/breakpoints";
+@import "@wordpress/base-styles/mixins";
+
+.card.payment-method-add__card {
+	background-color: var(--studio-white);
+	border: none;
+	outline: none;
+	box-shadow: none;
+	padding: 24px;
+	margin: 0;
+	width: 100%;
+}
+
+.payment-method-add__content {
+	padding-block: 47px;
+	display: flex;
+	flex-direction: column;
+	gap: 27px;
+
+	@include break-small {
+		padding-block: 32px;
+	}
+
+	@include break-xlarge {
+		flex-direction: row;
+	}
+}
+
+.payment-method-add__card.aside {
+	display: flex;
+	width: 100%;
+	align-items: center;
+	align-content: center;
+
+	.payment-method-stripe-info {
+		margin: auto;
+	}
+
+	@include break-xlarge {
+		max-width: 380px;
+	}
+}

--- a/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/style.scss
+++ b/client/a8c-for-agencies/sections/purchases/payment-methods/payment-method-add/style.scss
@@ -5,7 +5,7 @@
 	border: none;
 	outline: none;
 	box-shadow: none;
-	padding: 24px;
+	padding: 0;
 	margin: 0;
 	width: 100%;
 }


### PR DESCRIPTION
This PR ports the 'Add payment method' page layout from Jetpack Manage to A4A.

<img width="1701" alt="Screenshot 2024-03-13 at 2 40 39 PM" src="https://github.com/Automattic/wp-calypso/assets/56598660/abdf92d8-7899-4528-834a-b4d9f925b471">


Closes https://github.com/Automattic/jetpack-genesis/issues/277

## Proposed Changes

* For this PR, we ported the page layout from Jetpack Manage's add payment method page. Note that the payment form still refers to hooks from Jetpack Manage. We will handle this on a separate PR. A few pieces of logic for specific flows were also omitted as they were no longer applicable in the context of A4A (e.g., the site creation flow).

## Testing Instructions
* Switch branch: `git checkout add/a4a-add-payment-method-page-layout`.
* Start the server by running `yarn start-a8c-for-agencies`.
* Go to http://agencies.localhost:3000/purchases/payment-methods/add
* Confirm that the page matches the one from Jetpack Manage. https://cloud.jetpack.com/partner-portal/payment-methods/add
**Note that the form does not function at the moment as it is referencing hooks from Jetpack Manage. This will be updated on a separate PR.**

**Additionally, after 5 seconds, the 'Sorry, there was an error loading this page' error message will appear. This is expected since we are pulling a non-existing Stripe account. This will be sorted out once the Billing Infrastructure is implemented.**
 
## Pre-merge Checklist


- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?