### PR TITLE
Adds "until stopped" when campaigns are evergreen

### DIFF
--- a/client/data/promote-post/types.ts
+++ b/client/data/promote-post/types.ts
@@ -48,6 +48,7 @@ export type Campaign = {
 	creative_html: string;
 	campaign_stats_loading: boolean;
 	campaign_stats?: CampaignStats;
+	is_evergreen: number;
 };
 
 export type CampaignStats = {

--- a/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
+++ b/client/my-sites/promote-post-i2/components/campaign-item/index.tsx
@@ -26,13 +26,13 @@ import './style.scss';
 interface Props {
 	campaign: Campaign;
 }
-const getCampaignEndText = ( end_date: Moment, status: string ) => {
+const getCampaignEndText = ( end_date: Moment, status: string, is_evergreen = 0 ) => {
 	if (
 		[ campaignStatus.SCHEDULED, campaignStatus.CREATED, campaignStatus.REJECTED ].includes( status )
 	) {
 		return '-';
 	} else if ( [ campaignStatus.APPROVED, campaignStatus.ACTIVE ].includes( status ) ) {
-		return __( 'Ongoing' );
+		return is_evergreen ? __( 'Until stopped' ) : __( 'Ongoing' );
 	} else if ( [ campaignStatus.CANCELED, campaignStatus.FINISHED ].includes( status ) ) {
 		// return moment in format similar to 27 June
 		return end_date.format( 'D MMMM' );
@@ -178,7 +178,13 @@ export default function CampaignItem( props: Props ) {
 				<div>{ statusBadge }</div>
 			</td>
 			<td className="campaign-item__ends">
-				<div>{ getCampaignEndText( moment( campaign.end_date ), campaign.status ) }</div>
+				<div>
+					{ getCampaignEndText(
+						moment( campaign.end_date ),
+						campaign.status,
+						campaign?.is_evergreen
+					) }
+				</div>
 			</td>
 			<td className="campaign-item__budget">
 				<div>{ budgetString }</div>


### PR DESCRIPTION
Related to 964-gh-tumblr/a8c-dsp

## Proposed Changes

* Adds "Until stopped" to the advertising dashboard when campaign is evergreen

<img width="766" alt="Screenshot 2024-03-08 at 12 09 56" src="https://github.com/Automattic/wp-calypso/assets/6440498/673b5d38-bf06-4e0b-8a09-8482d652bb31">

## Testing Instructions

Backend work is not complete yet,  so we should just change this manually to test.

And ensure that there's no errors whilst the campaign doesn't have an "is_evergreen" key defined.


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] [Have you written new tests](https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md) for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?
