### PR TITLE
Stats: Wire up UTM summary page (take 2)

### DIFF
--- a/client/my-sites/stats/stats-module-utm/stats-module-utm-summary.jsx
+++ b/client/my-sites/stats/stats-module-utm/stats-module-utm-summary.jsx
@@ -1,0 +1,204 @@
+import { useQuery } from '@tanstack/react-query';
+import classNames from 'classnames';
+import { useTranslate } from 'i18n-calypso';
+import { useState } from 'react';
+import wpcom from 'calypso/lib/wp';
+import StatsModuleDataQuery from '../stats-module/stats-module-data-query';
+import statsStrings from '../stats-strings';
+import UTMDropdown from './stats-module-utm-dropdown';
+
+const OPTION_KEYS = {
+	SOURCE_MEDIUM: 'utm_source,utm_medium',
+	CAMPAIGN_SOURCE_MEDIUM: 'utm_campaign,utm_source,utm_medium',
+	SOURCE: 'utm_source',
+	MEDIUM: 'utm_medium',
+	CAMPAIGN: 'utm_campaign',
+};
+
+function StatsModuleUTMSummary( { siteId, period, postId, query, summary, className } ) {
+	// Note: The module is loaded multiple times on initial page render.
+	// Not sure why this is happening as the props are consistent across
+	// initial renders. Maybe worth investigating the routing.
+
+	const moduleStrings = statsStrings();
+	const translate = useTranslate();
+	const [ selectedOption, setSelectedOption ] = useState( OPTION_KEYS.SOURCE_MEDIUM );
+
+	// Tanstack query without Redux plumbing.
+	// That means this specific module does not follow the convention
+	// used for the other modules in the stats section.
+	const { data, isPending, isError } = useUTMQuery( siteId, selectedOption, query );
+	const dataLength = data?.length || 0;
+
+	// Handle network error.
+	// We should destinguish between network errors and api errors.
+	const isNetworkError = isError && ! isPending;
+
+	// Hide the module if the specific post is the Home page.
+	if ( postId === 0 ) {
+		return null;
+	}
+
+	const hideSummaryLink = postId !== undefined || summary === true;
+
+	const optionLabels = {
+		[ OPTION_KEYS.SOURCE_MEDIUM ]: {
+			selectLabel: translate( 'Source / Medium' ),
+			headerLabel: translate( 'Posts by Source / Medium' ),
+			isGrouped: true, // display in a group on top of the dropdown
+			// data query action
+		},
+		[ OPTION_KEYS.CAMPAIGN_SOURCE_MEDIUM ]: {
+			selectLabel: translate( 'Campaign / Source / Medium' ),
+			headerLabel: translate( 'Posts by Campaign / Source / Medium' ),
+			isGrouped: true,
+			// data query action
+		},
+		[ OPTION_KEYS.SOURCE ]: {
+			selectLabel: translate( 'Source' ),
+			headerLabel: translate( 'Posts by Source' ),
+		},
+		[ OPTION_KEYS.MEDIUM ]: {
+			selectLabel: translate( 'Medium' ),
+			headerLabel: translate( 'Posts by Medium' ),
+		},
+		[ OPTION_KEYS.CAMPAIGN ]: {
+			selectLabel: translate( 'Campaign' ),
+			headerLabel: translate( 'Posts by Campaign' ),
+		},
+	};
+
+	const queryString = Object.keys( query )
+		.map( ( key ) => `${ key }: ${ query[ key ] }` )
+		.join( ', ' );
+
+	return (
+		<>
+			<p>Query: { queryString } </p>
+			<p>Data length: { dataLength } </p>
+			{ isNetworkError && <p>Network error detected</p> }
+			<StatsModuleDataQuery
+				data={ data }
+				path="utm"
+				className={ classNames( className, 'stats-module-utm' ) }
+				moduleStrings={ moduleStrings.utm }
+				period={ period }
+				query={ query }
+				isLoading={ isPending ?? true }
+				hideSummaryLink={ hideSummaryLink }
+				selectedOption={ optionLabels[ selectedOption ] }
+				toggleControl={
+					<UTMDropdown
+						buttonLabel={ optionLabels[ selectedOption ].selectLabel }
+						onSelect={ setSelectedOption }
+						selectOptions={ optionLabels }
+						selected={ selectedOption }
+					/>
+				}
+			/>
+		</>
+	);
+}
+
+function useUTMQuery( siteId, selectedOption, query ) {
+	// Fetch UTM summary data. Does not include top posts as that might get
+	// out of hand on the summary page. For example, you easily get over
+	// 100 API requests when looking at 30 days or more as the period.
+	//
+	// Ideally we'd have the API updated to include the related posts
+	// data instead of requiring extra API requests.
+
+	const result = useQuery( {
+		queryKey: [ 'useUTMQuery', siteId, selectedOption, query ],
+		queryFn: () => fetchUTMMetrics( siteId, selectedOption, query ),
+		select: transformData,
+	} );
+
+	return result;
+}
+
+async function fetchUTMMetrics( siteId, selectedOption, query ) {
+	// API requests look like this:
+	//
+	// https://public-api.wordpress.com/rest/v1.1/sites/SITE_ID/
+	//	stats/utm/UTM_PARAMS?http_envelope=1 -- ie: "utm_source,utm_medium"
+	//	&period=day&date=2024-03-07&max=0&days=1 -- from query object
+	//	&kdl=kdl%20utm%20metrics -- for filtering in the network tab
+
+	const response = await wpcom.req.get(
+		{
+			path: `/sites/${ siteId }/stats/utm/${ selectedOption }`,
+		},
+		{
+			...query,
+			days: query?.num || 1,
+			kdl: 'kdl-utm-metrics',
+		}
+	);
+
+	return response;
+}
+
+// Utility functions for use with the returned API data.
+// Should live with the custom hook once it's moved to its own file.
+
+function isValidJSON( string ) {
+	try {
+		JSON.parse( string );
+		return true;
+	} catch ( e ) {
+		return false;
+	}
+}
+
+function parseKey( key ) {
+	if ( key.length === 0 ) {
+		return key;
+	}
+	if ( isValidJSON( key ) ) {
+		const parsedKey = JSON.parse( key );
+		if ( Array.isArray( parsedKey ) ) {
+			return parsedKey.join( ' / ' );
+		}
+		return parsedKey;
+	}
+	return key;
+}
+
+// Example data from API.
+// Either a string: number or
+// a JSON encoded array: number.
+//
+// "top_utm_values": {
+// 	"adwords": 89,
+// 	"bing": 27,
+// }
+//
+// "top_utm_values": {
+// 	"[\"adwords\",\"ppc\"]": 89,
+// 	"[\"bing\",\"cpc\"]": 27,
+// }
+
+function transformData( data ) {
+	const utmData = data?.top_utm_values;
+	if ( ! utmData ) {
+		return [];
+	}
+
+	const keys = Object.keys( utmData );
+	const values = Object.values( utmData );
+
+	const transformedData = keys.map( ( key, index ) => {
+		const parsedKey = parseKey( key );
+		return {
+			// children: [], -- include to enable disclosure toggle
+			label: parsedKey,
+			paramValues: key,
+			value: values[ index ],
+		};
+	} );
+
+	return transformedData;
+}
+
+export { StatsModuleUTMSummary as default, StatsModuleUTMSummary, OPTION_KEYS };

--- a/client/my-sites/stats/stats-module-utm/stats-module-utm-summary.jsx
+++ b/client/my-sites/stats/stats-module-utm/stats-module-utm-summary.jsx
@@ -48,7 +48,9 @@ function StatsModuleUTMSummary( { siteId, period, postId, query, summary, classN
 
 	const isSiteInternal = ! isFetchingUsage && usageData?.is_internal;
 	const isFetching = isFetchingUsage || isLoadingFeatureCheck || isPending;
-	const isAdvancedFeatureEnabled = isSiteInternal || supportCommercialUse;
+	let isAdvancedFeatureEnabled = isSiteInternal || supportCommercialUse;
+	isAdvancedFeatureEnabled = true;
+	// TODO: Remove above before merging.
 
 	// Hide the module if the specific post is the Home page.
 	if ( postId === 0 ) {

--- a/client/my-sites/stats/summary/index.jsx
+++ b/client/my-sites/stats/summary/index.jsx
@@ -18,7 +18,7 @@ import Countries from '../stats-countries';
 import DownloadCsv from '../stats-download-csv';
 import StatsModule from '../stats-module';
 import AllTimeNav from '../stats-module/all-time-nav';
-import StatsModuleUTM from '../stats-module-utm';
+import StatsModuleUTMSummary from '../stats-module-utm/stats-module-utm-summary';
 import PageViewTracker from '../stats-page-view-tracker';
 import statsStringsFactory from '../stats-strings';
 import StatsUpsellModal from '../stats-upsell-modal';
@@ -335,7 +335,7 @@ class StatsSummary extends Component {
 				summaryView = isEnabled( 'stats/utm-module' ) ? (
 					<>
 						{ this.renderSummaryHeader( path, statType, false, moduleQuery ) }
-						<StatsModuleUTM
+						<StatsModuleUTMSummary
 							siteId={ siteId }
 							period={ this.props.period }
 							query={ moduleQuery }


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #87687.

Not ready to merge. There is some debug UI visible on the page and some potential blockers. Just seeking feedback at this stage.

## Proposed Changes

Introduces a new version of the `StatsModuleUTM` for use on the summary page.

- Introduces `StatsModuleUTMSummary` component for summary page.
- Updates in response to period changes via header.
- Does not populate children in this version of the component.
- Uses Tanstack without Redux.

The main reason for implementing this as a new component is to work with a simplified hook and to allow for easier testing.

<img width="752" alt="SCR-20240308-ryeh" src="https://github.com/Automattic/wp-calypso/assets/40267301/31e8bdb9-b64c-4d50-ae62-7226e42ede88">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Launch Calypso Live site.
* Visit Stats → Traffic page.
* Enable the `stats/utm-module` flag.
* Navigate to the UTM box and click the "View all" link.
* Confirm the summary page loads correctly.
* Confirm the period controls properly update the view.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?