### PR TITLE
Scheduled Updates: Fix upsell banner margin in scheduled updates

### DIFF
--- a/client/components/scheduled-updates/scheduled-updates-gate/style.scss
+++ b/client/components/scheduled-updates/scheduled-updates-gate/style.scss
@@ -3,3 +3,12 @@
 	pointer-events: none;
 	opacity: 0.33;
 }
+
+.is-section-plugins .main {
+	.scheduled-updates-gate {
+		.scheduled-updates-upsell-nudge.is-jetpack {
+			margin-top: 16px;
+			margin-bottom: 16px;
+		}
+	}
+}


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #88315

## Proposed Changes

* Fix the upsell banner margin issue on the scheduled updates page.

**Before**
![Screen Shot 2024-03-08 at 9 31 58 PM](https://github.com/Automattic/wp-calypso/assets/4074459/e0162f40-9fea-4573-b224-37b398821c09)

**After**
![Screen Shot 2024-03-08 at 9 21 57 PM](https://github.com/Automattic/wp-calypso/assets/4074459/a65d8709-414a-4c77-927a-48dc528da46b)


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Spin up a JN site and connect to your WordPress.com account.
* Navigate to http://calypso.localhost:3000/plugins/scheduled-updates/
* You'll see the upsell nudge banner does not overlap with other components.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?