### PR TITLE
Update migration import user list styling and added pagination

### DIFF
--- a/client/blocks/importer/wordpress/import-everything/import-users/style.scss
+++ b/client/blocks/importer/wordpress/import-everything/import-users/style.scss
@@ -22,6 +22,118 @@
 		font-size: 0.875rem;
 	}
 
+	.import__user-migration-user-list {
+		margin: 0 auto;
+		max-width: 536px;
+		border-radius: 4px;
+		border: 1px solid #bbb;
+		display: flex;
+		flex-direction: column;
+
+		@include break-small {
+			max-height: 548px;
+		}
+
+		.import__user-migration-users {
+			& > :first-child {
+				border-top-left-radius: 4px;
+				border-top-right-radius: 4px;
+			}
+
+			.imported-user-item {
+				border-bottom: 1px solid var(--studio-gray-5, #dcdcde);
+			}
+		}
+
+		.import__user-migration-user-list-pagination-container {
+			display: flex;
+			margin: 12px 24px;
+		}
+
+		.import__user-migration-user-list-pagination-info {
+			display: none;
+			align-items: center;
+			font-size: 0.75rem;
+			color: #757575;
+			width: 50%;
+
+			@include break-small {
+				display: flex;
+			}
+		}
+
+		.import__user-migration-user-list-pagination-list {
+			display: flex;
+			justify-content: center;
+			width: 100%;
+
+			@include break-small {
+				width: 50%;
+				justify-content: flex-end;
+			}
+
+			.pagination__list {
+				flex-wrap: wrap;
+
+				@include break-small {
+					flex-wrap: nowrap;
+				}
+
+				.pagination__list-item .pagination__list-button.button.is-borderless,
+				.pagination__list-item.pagination__ellipsis span {
+					border: none;
+				}
+
+				.pagination__arrow {
+					&.is-left {
+						padding-left: 0;
+						.pagination__list-button {
+							padding-left: 0;
+						}
+					}
+
+					&.is-right {
+						.pagination__list-button {
+							padding-right: 0;
+						}
+						padding-right: 0;
+					}
+				}
+
+				.pagination__list-item {
+					&:not(.pagination__arrow) {
+						.button {
+							font-size: 0.75rem;
+						}
+					}
+
+					&.pagination__page-number {
+						&.is-selected {
+							.pagination__list-button {
+								padding: 8px 12px;
+								border-radius: 4px;
+								line-height: 16px;
+							}
+						}
+
+						&:not(.is-selected) {
+							.pagination__list-button {
+								color: var(--studio-blue-50);
+							}
+						}
+					}
+
+					&.pagination__ellipsis {
+						span {
+							padding: 0;
+						}
+					}
+				}
+
+			}
+		}
+	}
+
 	.import__user-migration-list {
 		margin: 0 auto;
 
@@ -72,11 +184,10 @@
 	display: flex;
 	align-items: center;
 	box-shadow: none;
-	padding: 1rem 0 1rem 0;
+	padding: 0.75rem 1.5rem;
 	flex-wrap: wrap;
 
 	@include break-mobile {
-		padding: 1.25rem 0 1.25rem 0;
 		flex-wrap: nowrap;
 	}
 
@@ -163,8 +274,4 @@
 			flex-basis: 200px;
 		}
 	}
-}
-
-.imported-user-item + .imported-user-item {
-	border-top: 1px solid var(--studio-gray-5, #dcdcde);
 }

--- a/client/components/pagination/constants.ts
+++ b/client/components/pagination/constants.ts
@@ -2,3 +2,6 @@ export enum PaginationVariant {
 	outlined = 'outlined',
 	minimal = 'minimal',
 }
+
+export const PaginationLeftDefaultIcon = 'arrow-left';
+export const PaginationRightDefaultIcon = 'arrow-right';

--- a/client/components/pagination/index.jsx
+++ b/client/components/pagination/index.jsx
@@ -1,7 +1,11 @@
 import classnames from 'classnames';
 import PropTypes from 'prop-types';
 import { Component } from 'react';
-import { PaginationVariant } from './constants';
+import {
+	PaginationVariant,
+	PaginationLeftDefaultIcon,
+	PaginationRightDefaultIcon,
+} from './constants';
 import PaginationPage from './pagination-page';
 
 import './style.scss';
@@ -16,10 +20,15 @@ class Pagination extends Component {
 		prevLabel: PropTypes.string,
 		total: PropTypes.number,
 		variant: PropTypes.oneOf( Object.values( PaginationVariant ) ),
+		getPageList: PropTypes.func,
+		paginationLeftIcon: PropTypes.string,
+		paginationRightIcon: PropTypes.string,
 	};
 
 	static defaultProps = {
 		variant: PaginationVariant.outlined,
+		paginationLeftIcon: PaginationLeftDefaultIcon,
+		paginationRightIcon: PaginationRightDefaultIcon,
 	};
 
 	getPageList = ( page, pageCount ) => {
@@ -53,15 +62,29 @@ class Pagination extends Component {
 	};
 
 	render() {
-		const { className, compact, nextLabel, page, pageClick, perPage, prevLabel, total, variant } =
-			this.props;
+		const {
+			className,
+			compact,
+			nextLabel,
+			page,
+			pageClick,
+			perPage,
+			prevLabel,
+			total,
+			variant,
+			getPageList,
+			paginationLeftIcon,
+			paginationRightIcon,
+		} = this.props;
 		const pageCount = Math.ceil( total / perPage );
 
 		if ( pageCount <= 1 ) {
 			return null;
 		}
 
-		const pageList = this.getPageList( page, pageCount );
+		const pageList = getPageList
+			? getPageList( page, pageCount )
+			: this.getPageList( page, pageCount );
 		const pageListRendered = pageList.map( ( pageNumber, index ) => {
 			return (
 				<PaginationPage
@@ -73,6 +96,8 @@ class Pagination extends Component {
 					pageNumber={ pageNumber }
 					prevLabel={ prevLabel }
 					totalPages={ pageCount }
+					paginationLeftIcon={ paginationLeftIcon }
+					paginationRightIcon={ paginationRightIcon }
 				/>
 			);
 		} );

--- a/client/components/pagination/pagination-page.jsx
+++ b/client/components/pagination/pagination-page.jsx
@@ -13,6 +13,8 @@ class PaginationPage extends Component {
 		pageNumber: PropTypes.node.isRequired,
 		prevLabel: PropTypes.string,
 		totalPages: PropTypes.number.isRequired,
+		paginationLeftIcon: PropTypes.string,
+		paginationRightIcon: PropTypes.string,
 	};
 
 	clickHandler = ( event ) => {
@@ -51,6 +53,8 @@ class PaginationPage extends Component {
 			prevLabel,
 			totalPages,
 			compact,
+			paginationLeftIcon,
+			paginationRightIcon,
 		} = this.props;
 
 		switch ( pageNumber ) {
@@ -72,7 +76,7 @@ class PaginationPage extends Component {
 							onClick={ this.clickHandler }
 							disabled={ currentPage <= 1 }
 						>
-							<Gridicon icon="arrow-left" size={ 18 } />
+							<Gridicon icon={ paginationLeftIcon } size={ 18 } />
 							{ ! compact && ( prevLabel || translate( 'Previous' ) ) }
 						</Button>
 					</li>
@@ -91,7 +95,7 @@ class PaginationPage extends Component {
 							disabled={ currentPage >= totalPages }
 						>
 							{ ! compact && ( nextLabel || translate( 'Next' ) ) }
-							<Gridicon icon="arrow-right" size={ 18 } />
+							<Gridicon icon={ paginationRightIcon } size={ 18 } />
 						</Button>
 					</li>
 				);

--- a/packages/data-stores/src/users/types.ts
+++ b/packages/data-stores/src/users/types.ts
@@ -34,6 +34,7 @@ export type UseQuery = {
 type UsersQueryData = {
 	users: Member[];
 	total: number;
+	pages: { page: number; users: Member[] }[];
 };
 
 export type UsersQuery = {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/wp-calypso/issues/88341

## Proposed Changes

* Updates Site migration import users list.
Adds user list pagination and updates styling

Some of the styling was updated such the font size (from 13px to 12px) and border radius (from 6px to 4px) to match the Calypso styling standards.

Before: 

<img width="500" alt="CleanShot 2024-03-08 at 08 48 16@2x" src="https://github.com/Automattic/wp-calypso/assets/10482592/6de732f7-e9cb-4413-aa68-1e5282ddf4ef">


After:

<img width="500" alt="CleanShot 2024-03-08 at 08 48 56@2x" src="https://github.com/Automattic/wp-calypso/assets/10482592/0638776e-460f-4a6b-b0a8-14054f5b80f8">


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Checkout this branch or use live link.
* Create a Jurassic ninja site and add users to it.
* Navigate to `sites?hosting-flow=true` and click the `Migrate a site` button.
* Use the Jurassic ninja site URL as the source site.
* Compare the design (DASWajWXHUUjF4pu1yo4fI-fi-580%3A541) , verify pagination is working, and verify inviting users still works.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?