### PR TITLE
Patterns: add category-pill-navigation to design system

### DIFF
--- a/client/blocks/category-pill-navigation/README.md
+++ b/client/blocks/category-pill-navigation/README.md
@@ -1,6 +1,6 @@
 # Category Pill Navigation
 
-This navigation component, designed for consistent design integration, is primarily used on the `/patterns/:category`, `/themes`, and `/blog` pages. It offers a uniform design aesthetic across various sections of the website.
+This component can be used to display a set of categories or tags as pills in an horizontal way. Each pill accepts a link, and the whole navigation bar can be scrolled.
 
 ## How to use
 
@@ -13,7 +13,7 @@ function render() {
 		<CategoryPillNavigation
 			list={ Array.from( { length: 15 }, ( _, i ) => ( {
 				name: `category-${ i }`,
-				label: `Category ${ i }`,
+				label: `Category ${ i + 1 }`,
 				link: '#',
 			} ) ) }
 			selectedCategory="category-2"

--- a/client/blocks/category-pill-navigation/README.md
+++ b/client/blocks/category-pill-navigation/README.md
@@ -43,9 +43,9 @@ An array of objects, each representing a navigation link:
 
 ```
 {
-	name: string; // Acts as an `id` and is primarily used for highlighting the active item.
-	label?: string; // The text displayed on the link.
-	link: string; // The URL that the link points to.
+	name: string; // Acts as an `id` and is primarily used for highlighting the active item
+	label?: string; // The text displayed on the link
+	link: string; // The URL that the link points to
 }[]
 ```
 
@@ -60,9 +60,9 @@ This property should match the `name` of one of the items in the `list` array to
 An optional array of additional link objects to prepend to the main list of links:
 ```
 {
-	icon: string; // The icon displayed before the label.
-	label: string; // The text displayed on the link.
-	link: string; // The URL that the link points to.
+	icon: string; // The icon displayed before the label
+	label: string; // The text displayed on the link
+	link: string; // The URL that the link points to
 }[] | undefined
 ```
 

--- a/client/blocks/category-pill-navigation/README.md
+++ b/client/blocks/category-pill-navigation/README.md
@@ -1,0 +1,68 @@
+# Category Pill Navigation
+
+This navigation component, designed for consistent design integration, is primarily used on the `/patterns/:category`, `/themes`, and `/blog` pages. It offers a uniform design aesthetic across various sections of the website.
+
+## How to use
+
+```js
+import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
+import ImgStar from 'calypso/my-sites/patterns/pages/category/images/star.svg';
+
+function render() {
+	return (
+		<CategoryPillNavigation
+			list={ Array.from( { length: 15 }, ( _, i ) => ( {
+				name: `category-${ i }`,
+				label: `Category ${ i }`,
+				link: '#',
+			} ) ) }
+			selectedCategory="category-2"
+			buttons={ [
+				{
+					icon: ImgStar,
+					label: 'Discover',
+					link: '/',
+				},
+				{
+					icon: ImgStar,
+					label: 'All categories',
+					link: '/',
+				},
+			] }
+		/>
+	);
+}
+```
+
+## Props
+
+Below is a list of supported props.
+
+### `list`
+An array of objects, each representing a navigation link:
+
+```
+{
+	name: string; // Acts as an `id` and is primarily used for highlighting the active item.
+	label?: string; // The text displayed on the link.
+	link: string; // The URL that the link points to.
+}[]
+```
+
+
+### `selectedCategory`
+
+Type: `string`
+
+This property should match the `name` of one of the items in the `list` array to indicate the currently active category.
+
+### `buttons`
+An optional array of additional link objects to prepend to the main list of links:
+```
+{
+	icon: string; // The icon displayed before the label.
+	label: string; // The text displayed on the link.
+	link: string; // The URL that the link points to.
+}[] | undefined
+```
+

--- a/client/blocks/category-pill-navigation/README.md
+++ b/client/blocks/category-pill-navigation/README.md
@@ -6,25 +6,25 @@ This component can be used to display a set of categories or tags as pills in an
 
 ```js
 import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
-import ImgStar from 'calypso/my-sites/patterns/pages/category/images/star.svg';
+import { Icon, starEmpty as iconStar, category as iconCategory } from '@wordpress/icons';
 
 function render() {
 	return (
 		<CategoryPillNavigation
 			list={ Array.from( { length: 15 }, ( _, i ) => ( {
-				name: `category-${ i }`,
+				id: `category-${ i }`,
 				label: `Category ${ i + 1 }`,
 				link: '#',
 			} ) ) }
 			selectedCategory="category-2"
 			buttons={ [
 				{
-					icon: ImgStar,
+					icon: <Icon icon={ iconStar } size={ 30 } />,
 					label: 'Discover',
 					link: '/',
 				},
 				{
-					icon: ImgStar,
+					icon: <Icon icon={ iconCategory } size={ 26 } />,
 					label: 'All categories',
 					link: '/',
 				},
@@ -43,7 +43,7 @@ An array of objects, each representing a navigation link:
 
 ```
 {
-	name: string; // Acts as an `id` and is primarily used for highlighting the active item
+	id: string; // Is used for highlighting the active item
 	label?: string; // The text displayed on the link
 	link: string; // The URL that the link points to
 }[]

--- a/client/blocks/category-pill-navigation/docs/example.tsx
+++ b/client/blocks/category-pill-navigation/docs/example.tsx
@@ -1,10 +1,10 @@
 import { Card } from '@automattic/components';
+import { Icon, starEmpty as iconStar, category as iconCategory } from '@wordpress/icons';
 import { FunctionComponent } from 'react';
 import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
-import ImgStar from 'calypso/my-sites/patterns/pages/category/images/star.svg';
 
 const list = Array.from( { length: 15 }, ( _, i ) => ( {
-	name: `category-${ i }`,
+	id: `category-${ i }`,
 	label: `Category ${ i }`,
 	link: '#',
 } ) );
@@ -21,12 +21,12 @@ export const CategoryPillNavigationExample: FunctionComponent = () => {
 					selectedCategory="category-2"
 					buttons={ [
 						{
-							icon: ImgStar,
+							icon: <Icon icon={ iconStar } size={ 30 } />,
 							label: 'Discover',
 							link: '/',
 						},
 						{
-							icon: ImgStar,
+							icon: <Icon icon={ iconCategory } size={ 26 } />,
 							label: 'All categories',
 							link: '/',
 						},

--- a/client/blocks/category-pill-navigation/docs/example.tsx
+++ b/client/blocks/category-pill-navigation/docs/example.tsx
@@ -1,0 +1,39 @@
+import { Card } from '@automattic/components';
+import { FunctionComponent } from 'react';
+import { CategoryPillNavigation } from 'calypso/components/category-pill-navigation';
+import ImgStar from 'calypso/my-sites/patterns/pages/category/images/star.svg';
+
+const list = Array.from( { length: 15 }, ( _, i ) => ( {
+	name: `category-${ i }`,
+	label: `Category ${ i }`,
+	link: '#',
+} ) );
+
+export const CategoryPillNavigationExample: FunctionComponent = () => {
+	return (
+		<div>
+			<Card>
+				<CategoryPillNavigation selectedCategory="category-2" list={ list } />
+			</Card>
+
+			<Card>
+				<CategoryPillNavigation
+					selectedCategory="category-2"
+					buttons={ [
+						{
+							icon: ImgStar,
+							label: 'Discover',
+							link: '/',
+						},
+						{
+							icon: ImgStar,
+							label: 'All categories',
+							link: '/',
+						},
+					] }
+					list={ list }
+				/>
+			</Card>
+		</div>
+	);
+};

--- a/client/components/category-pill-navigation/index.tsx
+++ b/client/components/category-pill-navigation/index.tsx
@@ -13,7 +13,7 @@ type CategoryPillNavigationProps = {
 		link: string;
 	}[];
 	list: {
-		name: string;
+		id: string;
 		label?: string;
 		link: string;
 	}[];
@@ -95,10 +95,10 @@ export const CategoryPillNavigation = ( {
 					) }
 					{ list.map( ( category ) => (
 						<LocalizedLink
-							key={ category.name }
+							key={ category.id }
 							href={ category.link }
 							className={ classnames( 'category-pill-navigation__button', {
-								'is-active': category.name === selectedCategory,
+								'is-active': category.id === selectedCategory,
 							} ) }
 						>
 							{ category.label }

--- a/client/devdocs/design/blocks.jsx
+++ b/client/devdocs/design/blocks.jsx
@@ -11,6 +11,7 @@ import AuthorCompactProfile from 'calypso/blocks/author-compact-profile/docs/exa
 import AuthorSelector from 'calypso/blocks/author-selector/docs/example';
 import CalendarButton from 'calypso/blocks/calendar-button/docs/example';
 import CalendarPopover from 'calypso/blocks/calendar-popover/docs/example';
+import { CategoryPillNavigationExample } from 'calypso/blocks/category-pill-navigation/docs/example';
 import ColorSchemePicker from 'calypso/blocks/color-scheme-picker/docs/example';
 import CommentButtons from 'calypso/blocks/comment-button/docs/example';
 import PostComment from 'calypso/blocks/comments/docs/post-comment-example';
@@ -174,6 +175,7 @@ export default class AppComponents extends Component {
 					<UpsellNudge />
 					<JetpackReviewPrompt readmeFilePath="jetpack-review-prompt" />
 					<ReaderJoinConversationDialogExample readmeFilePath="reader-join-conversation" />
+					<CategoryPillNavigationExample readmeFilePath="category-pill-navigation" />
 				</Collection>
 			</Main>
 		);

--- a/client/my-sites/patterns/pages/category/index.tsx
+++ b/client/my-sites/patterns/pages/category/index.tsx
@@ -89,7 +89,7 @@ export const PatternsCategoryPage = ( {
 			category.pagePatternCount === 0 ? PatternTypeFilter.REGULAR : patternTypeFilter;
 
 		return {
-			name: category.name || '',
+			id: category.name || '',
 			label: category.label,
 			link: getCategoryUrlPath( category.name, patternTypeFilterFallback, false ),
 		};


### PR DESCRIPTION
Related to https://github.com/Automattic/dotcom-forge/issues/5973

## Proposed Changes
It's a follow-up PR to https://github.com/Automattic/wp-calypso/pull/88244, where we introduced a new component - `CategoryPillNavigation`, and with this PR we are adding it to our design system.

## Testing Instructions
1. Open `http://calypso.localhost:3000/devdocs/blocks`
2. Assert that you see the component at the end of the page <br /> ![Screenshot 2024-03-08 at 16 18 30](https://github.com/Automattic/wp-calypso/assets/5598437/10732390-d438-4ba7-b641-fd97b54a9001)
3. Click on the title
4. Assert that you are landed to the page with description of the component <br /> ![Screenshot 2024-03-08 at 16 17 42](https://github.com/Automattic/wp-calypso/assets/5598437/e54e5eb8-b68c-4d2d-bd55-bd34afe1d1cc)

