### PR TITLE
Continue with GitHub: Handle case where user declines GitHub authorization

### DIFF
--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -7,6 +7,7 @@ import {
 	MouseEvent,
 	ReactElement,
 	ReactNode,
+	useCallback,
 	useEffect,
 	useRef,
 	useState,
@@ -69,13 +70,13 @@ const GitHubLoginButton = ( {
 
 	const errorRef = useRef< EventTarget | null >( null );
 
-	const handleGitHubError = () => {
+	const handleGitHubError = useCallback( () => {
 		dispatch(
 			errorNotice(
 				translate( 'Something went wrong when trying to connect with GitHub. Please try again.' )
 			)
 		);
-	};
+	}, [ dispatch, errorNotice, translate ] );
 
 	const exchangeCodeForToken = async ( auth_code: string ) => {
 		let response;

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -46,6 +46,20 @@ const GitHubLoginButton = ( {
 	const translate = useTranslate();
 
 	const { code, service } = useSelector( ( state: AppState ) => state.route?.query?.initial );
+	const authError = useSelector( ( state: AppState ) => {
+		const path = state?.route?.path?.current;
+		const { initial, current } = state?.route?.query ?? {};
+		const initialError = initial?.error;
+		const currentError = current?.error;
+
+		// Sign-up flow is losing the error query param when redirecting to `/start/user-social`
+		// because of that, we are returning the initial query param error.
+		if ( path?.includes( '/start/user-social' ) ) {
+			return initialError;
+		}
+		return currentError;
+	} );
+
 	const isFormDisabled = useSelector( isFormDisabledSelector );
 	const dispatch = useDispatch();
 
@@ -113,6 +127,16 @@ const GitHubLoginButton = ( {
 			exchangeCodeForToken( code );
 		}
 	}, [ code, service, userHasDisconnected ] );
+
+	useEffect( () => {
+		if ( authError ) {
+			dispatch(
+				errorNotice(
+					translate( 'Something went wrong when trying to connect with GitHub. Please try again.' )
+				)
+			);
+		}
+	}, [ authError, translate ] );
 
 	const isDisabled = isFormDisabled || disabledState;
 

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -156,8 +156,6 @@ const GitHubLoginButton = ( {
 
 	const eventHandlers = {
 		onClick: handleClick,
-		onMouseEnter: () => setShowError( true ),
-		onMouseLeave: () => setShowError( false ),
 	};
 
 	let customButton = null;

--- a/client/components/social-buttons/github.tsx
+++ b/client/components/social-buttons/github.tsx
@@ -69,6 +69,14 @@ const GitHubLoginButton = ( {
 
 	const errorRef = useRef< EventTarget | null >( null );
 
+	const handleGitHubError = () => {
+		dispatch(
+			errorNotice(
+				translate( 'Something went wrong when trying to connect with GitHub. Please try again.' )
+			)
+		);
+	};
+
 	const exchangeCodeForToken = async ( auth_code: string ) => {
 		let response;
 		try {
@@ -92,11 +100,7 @@ const GitHubLoginButton = ( {
 				);
 			}
 
-			dispatch(
-				errorNotice(
-					translate( 'Something went wrong when trying to connect with GitHub. Please try again.' )
-				)
-			);
+			handleGitHubError();
 			return;
 		}
 
@@ -130,13 +134,9 @@ const GitHubLoginButton = ( {
 
 	useEffect( () => {
 		if ( authError ) {
-			dispatch(
-				errorNotice(
-					translate( 'Something went wrong when trying to connect with GitHub. Please try again.' )
-				)
-			);
+			handleGitHubError();
 		}
-	}, [ authError, translate ] );
+	}, [ authError, handleGitHubError ] );
 
 	const isDisabled = isFormDisabled || disabledState;
 

--- a/client/me/social-login/action-button.jsx
+++ b/client/me/social-login/action-button.jsx
@@ -11,6 +11,7 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import { connectSocialUser, disconnectSocialUser } from 'calypso/state/login/actions';
 import { isRequesting } from 'calypso/state/login/selectors';
+import { errorNotice } from 'calypso/state/notices/actions';
 
 class SocialLoginActionButton extends Component {
 	static propTypes = {
@@ -28,6 +29,17 @@ class SocialLoginActionButton extends Component {
 		fetchingUser: false,
 		userHasDisconnected: false,
 	};
+
+	componentDidMount() {
+		const { errorParam, service } = this.props;
+		if ( errorParam && service === 'github' ) {
+			this.props.showErrorNotice(
+				this.props.translate(
+					'Something went wrong when trying to connect with GitHub. Please try again.'
+				)
+			);
+		}
+	}
 
 	refreshUser = async () => {
 		this.setState( { fetchingUser: true } );
@@ -196,11 +208,13 @@ class SocialLoginActionButton extends Component {
 export default connect(
 	( state ) => ( {
 		isUpdatingSocialConnection: isRequesting( state ),
+		errorParam: state.route?.query?.current?.error,
 	} ),
 	{
 		connectSocialUser,
 		disconnectSocialUser,
 		fetchCurrentUser,
 		recordTracksEvent,
+		showErrorNotice: errorNotice,
 	}
 )( localize( SocialLoginActionButton ) );

--- a/client/me/social-login/action-button.jsx
+++ b/client/me/social-login/action-button.jsx
@@ -11,7 +11,6 @@ import { recordTracksEvent } from 'calypso/state/analytics/actions';
 import { fetchCurrentUser } from 'calypso/state/current-user/actions';
 import { connectSocialUser, disconnectSocialUser } from 'calypso/state/login/actions';
 import { isRequesting } from 'calypso/state/login/selectors';
-import { errorNotice } from 'calypso/state/notices/actions';
 
 class SocialLoginActionButton extends Component {
 	static propTypes = {
@@ -29,17 +28,6 @@ class SocialLoginActionButton extends Component {
 		fetchingUser: false,
 		userHasDisconnected: false,
 	};
-
-	componentDidMount() {
-		const { errorParam, service } = this.props;
-		if ( errorParam && service === 'github' ) {
-			this.props.showErrorNotice(
-				this.props.translate(
-					'Something went wrong when trying to connect with GitHub. Please try again.'
-				)
-			);
-		}
-	}
 
 	refreshUser = async () => {
 		this.setState( { fetchingUser: true } );
@@ -208,13 +196,11 @@ class SocialLoginActionButton extends Component {
 export default connect(
 	( state ) => ( {
 		isUpdatingSocialConnection: isRequesting( state ),
-		errorParam: state.route?.query?.current?.error,
 	} ),
 	{
 		connectSocialUser,
 		disconnectSocialUser,
 		fetchCurrentUser,
 		recordTracksEvent,
-		showErrorNotice: errorNotice,
 	}
 )( localize( SocialLoginActionButton ) );


### PR DESCRIPTION
Related to https://github.com/Automattic/wp-calypso/issues/87701.

## Proposed Changes

* if authorization with GitHub fails for any reason, display an error message


| Social Logins page | Log-in flow | Sign-up flow |
|--------------------|--------|-------------|
| ![Social Logins Page](https://github.com/Automattic/wp-calypso/assets/25105483/593dea0b-6b39-4a91-9812-dfd987404525) | ![Log in Page](https://github.com/Automattic/wp-calypso/assets/25105483/cbab45d1-f94c-4327-8e9d-52b1e1362f08) | ![Markup on 2024-03-11 at 16:17:14](https://github.com/Automattic/wp-calypso/assets/25105483/eda21683-2b1b-4d5e-ac8b-b8f8c5862415) |

## Testing Instructions

0. Make sure the WordPress.com app is not yet authorized in your GitHub account. You can check / deauthorized it in https://github.com/settings/apps/authorizations.
1. Check out the proposed changes and build them.
2. Navigate to one of the following pages:
  - (as already logged-in user) http://calypso.localhost:3000/me/security/social-login
  - (as logged-out user) http://calypso.localhost:3000/start/user-social
  - (as logged-out user) http://calypso.localhost:3000/log-in
3. Click the GitHub "Connect" button.
4. When directed to the GitHub's authorization page, instead of clicking the "Authorize" button, click the "Cancel" button.
5. You should be automatically redirected back to Calypso, the red error message should display (as can be seen in the screenshots above).

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?