### PR TITLE
Plugins update manager: Handled generic server errors and unified style of eligibility check error

### DIFF
--- a/client/blocks/plugins-update-manager/schedule-create.tsx
+++ b/client/blocks/plugins-update-manager/schedule-create.tsx
@@ -9,7 +9,7 @@ import {
 	CardFooter,
 	Icon,
 } from '@wordpress/components';
-import { arrowLeft, warning } from '@wordpress/icons';
+import { arrowLeft, info } from '@wordpress/icons';
 import { useEffect } from 'react';
 import { useUpdateScheduleQuery } from 'calypso/data/plugins/use-update-schedules-query';
 import { MAX_SCHEDULES } from './config';
@@ -32,7 +32,7 @@ export const ScheduleCreate = ( props: Props ) => {
 		isEligibleForFeature
 	);
 
-	const { canCreateSchedules } = useCanCreateSchedules( siteSlug, isEligibleForFeature );
+	const { canCreateSchedules, errors } = useCanCreateSchedules( siteSlug, isEligibleForFeature );
 
 	const mutationState = useMutationState( {
 		filters: { mutationKey: [ 'create-update-schedule', siteSlug ] },
@@ -81,10 +81,10 @@ export const ScheduleCreate = ( props: Props ) => {
 				>
 					Create
 				</Button>
-				{ ! canCreateSchedules && (
+				{ ! canCreateSchedules && errors?.length && (
 					<Text as="p">
-						<Icon className="icon-info" icon={ warning } size={ 16 } />
-						This site is unable to schedule auto-updates for plugins.
+						<Icon className="icon-info" icon={ info } size={ 16 } />
+						{ errors[ 0 ].message }
 					</Text>
 				) }
 			</CardFooter>

--- a/client/blocks/plugins-update-manager/schedule-form.scss
+++ b/client/blocks/plugins-update-manager/schedule-form.scss
@@ -127,21 +127,4 @@
 			}
 		}
 	}
-
-	.components-text.validation-msg,
-	.components-text.info-msg {
-		display: block;
-		min-height: 1rem;
-		font-size: 0.75rem;
-		margin-bottom: 0.5rem;
-	}
-
-	.components-text.validation-msg {
-		color: var(--studio-red-50);
-
-		svg {
-			fill: var(--studio-red-50);
-			margin-left: 0;
-		}
-	}
 }

--- a/client/blocks/plugins-update-manager/schedule-form.tsx
+++ b/client/blocks/plugins-update-manager/schedule-form.tsx
@@ -40,12 +40,13 @@ import './schedule-form.scss';
 interface Props {
 	scheduleForEdit?: ScheduleUpdates;
 	onSyncSuccess?: () => void;
+	onSyncError?: ( error: string ) => void;
 }
 export const ScheduleForm = ( props: Props ) => {
 	const moment = useLocalizedMoment();
 	const siteSlug = useSiteSlug();
 	const isEligibleForFeature = useIsEligibleForFeature();
-	const { scheduleForEdit, onSyncSuccess } = props;
+	const { scheduleForEdit, onSyncSuccess, onSyncError } = props;
 	const initDate = scheduleForEdit
 		? moment( scheduleForEdit?.timestamp * 1000 )
 		: moment( new Date() ).hour( DEFAULT_HOUR );
@@ -58,9 +59,11 @@ export const ScheduleForm = ( props: Props ) => {
 	const schedules = schedulesData.filter( ( s ) => s.id !== scheduleForEdit?.id ) ?? [];
 	const { createUpdateSchedule } = useCreateUpdateScheduleMutation( siteSlug, {
 		onSuccess: () => onSyncSuccess && onSyncSuccess(),
+		onError: ( e: Error ) => onSyncError && onSyncError( e.message ),
 	} );
 	const { editUpdateSchedule } = useEditUpdateScheduleMutation( siteSlug, {
 		onSuccess: () => onSyncSuccess && onSyncSuccess(),
+		onError: ( e: Error ) => onSyncError && onSyncError( e.message ),
 	} );
 
 	const [ selectedPlugins, setSelectedPlugins ] = useState< string[] >(

--- a/client/blocks/plugins-update-manager/styles.scss
+++ b/client/blocks/plugins-update-manager/styles.scss
@@ -17,6 +17,23 @@
 	.components-text {
 		color: var(--studio-gray-60);
 		font-size: 0.875rem;
+
+		&.validation-msg,
+		&.info-msg {
+			display: block;
+			min-height: 1rem;
+			font-size: 0.75rem;
+			margin-bottom: 0.5rem;
+		}
+
+		&.validation-msg {
+			color: var(--studio-red-50);
+
+			svg {
+				fill: var(--studio-red-50);
+				margin-left: 0;
+			}
+		}
 	}
 
 	p.components-text {
@@ -107,6 +124,15 @@
 
 		.badge-component {
 			margin-inline-start: 0.5rem;
+		}
+	}
+
+	.components-card__footer {
+		display: flex;
+		align-items: baseline;
+
+		.validation-msg {
+			width: 100%;
 		}
 	}
 }


### PR DESCRIPTION
Closes https://github.com/Automattic/wp-calypso/issues/88334

## Proposed Changes

* Handled generic server (create/update) errors
* Unified style of eligibility check error

| Eligibility check | Generic server error |
|--------|--------|
| <img width="1105" alt="Screenshot 2024-03-08 at 17 11 30" src="https://github.com/Automattic/wp-calypso/assets/1241413/bb49e370-37cb-4b87-bac3-b4bae8fea26f"> | <img width="1077" alt="Screenshot 2024-03-08 at 18 48 25" src="https://github.com/Automattic/wp-calypso/assets/1241413/7fd53ee5-c30f-4797-a98b-8967ff5f9686"> | 


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/plugins/scheduled-updates/{ATOMIC_SITE}`
* To force the server error, comment out required params
* Check if everything works properly as before the change.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?