### PR TITLE
Avoid reader shortcuts conflicting with cmd palette

### DIFF
--- a/client/blocks/reader-full-post/index.jsx
+++ b/client/blocks/reader-full-post/index.jsx
@@ -182,6 +182,11 @@ export class FullPostView extends Component {
 			return;
 		}
 
+		if ( event?.metaKey || event?.ctrlKey ) {
+			// avoid conflicting with the command palette shortcut cmd+k
+			return;
+		}
+
 		switch ( event.keyCode ) {
 			// Close full post - Esc
 			case 27: {

--- a/client/reader/stream/index.jsx
+++ b/client/reader/stream/index.jsx
@@ -214,6 +214,11 @@ class ReaderStream extends Component {
 			return;
 		}
 
+		if ( event?.metaKey || event?.ctrlKey ) {
+			// avoid conflicting with the command palette shortcut cmd+k
+			return;
+		}
+
 		switch ( event.keyCode ) {
 			// Move selection down - j
 			case 74: {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/88226

## Proposed Changes

[cmd+k is used to launch the wpcom command palette](https://github.com/Automattic/wp-calypso//blob/2ae4a692a614cf2f3b4b0ec549f6b45ed793684c/packages/command-palette/src/index.tsx#L320). `k` is also used to move between posts in the reader. This meant that toggling the command palette also changed the post being viewed in the background.

This change avoids that by disabling the reader keyboard shortcuts when the ctrl or cmd keys are being held.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

1. Use calypso live link
2. Open a post in the stream, not the first one
3. Press ⌘+k 
4. Notice the palette appears
5. Notice that the post behind the palette does not change
6. Press ⌘+k again
7. Notice the palette disappears
5. Notice that the post behind the palette does not change
6. Press k
7. Notice that the post changes


https://github.com/Automattic/wp-calypso/assets/93301/32d9ed80-4228-46b8-aeff-4128e5b36eb8


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?