### PR TITLE
Scheduled Updates: Attempt first run at next full hour

### DIFF
--- a/client/blocks/plugins-update-manager/test/schedule-form.helper.test.tsx
+++ b/client/blocks/plugins-update-manager/test/schedule-form.helper.test.tsx
@@ -17,22 +17,30 @@ describe( 'Schedule form validation', () => {
 	} );
 
 	test( 'timestamp / time slot', () => {
-		const ts_3am = 1709172000;
-		const ts_9pm = 1709236800;
-		const ts_mon_6am = 1709528400;
-		const ts_mon_6pm = 1709226000;
-		const ts_fri_6am = 1709269200;
-		const ts_fri_6pm = 1709312400;
+		const timestamp = getTwoDaysFutureUTCTime();
+		const ts_3am = timestamp + 3 * 60 * 60;
+		const ts_6pm = timestamp + 18 * 60 * 60;
+		const ts_9pm = timestamp + 21 * 60 * 60;
 
+		const nextMondayMidnight = getNextMondayMidnightUTCTime();
+		const ts_mon_6am = nextMondayMidnight + 6 * 60 * 60;
+		const ts_mon_6pm = nextMondayMidnight + 18 * 60 * 60;
+		const ts_fri_6am = nextMondayMidnight + 4 * 24 * 60 * 60 + 6 * 60 * 60;
+		const ts_fri_6pm = nextMondayMidnight + 4 * 24 * 60 * 60 + 18 * 60 * 60;
+
+		const now = new Date();
+		const past = now.getTime() - 1000;
+
+		//
 		const existingSchedules = [
-			{ frequency: 'daily', timestamp: 1709085600 }, // daily at 3:00 am
+			{ frequency: 'daily', timestamp: ts_3am }, // daily at 3:00 am
 		];
 		const existingSchedules2 = [
-			{ frequency: 'weekly', timestamp: 1709571600 }, // weekly on Monday at 6:00 pm
+			{ frequency: 'weekly', timestamp: ts_6pm }, // weekly on Monday at 6:00 pm
 		];
 		const existingSchedules3 = [
-			{ frequency: 'weekly', timestamp: 1709571600 }, // weekly on Monday at 6:00 pm
-			{ frequency: 'daily', timestamp: 1709085600 }, // daily at 3:00 am
+			{ frequency: 'weekly', timestamp: ts_mon_6pm }, // weekly on Monday at 6:00 pm
+			{ frequency: 'daily', timestamp: ts_3am }, // daily at 3:00 am
 		];
 
 		// Truthy value means there is an error message
@@ -77,5 +85,35 @@ describe( 'Schedule form validation', () => {
 		expect(
 			validateTimeSlot( { frequency: 'weekly', timestamp: ts_fri_6pm }, existingSchedules3 )
 		).toBeFalsy();
+
+		// One second in the past
+		expect(
+			validateTimeSlot( { frequency: 'daily', timestamp: past / 1000 }, existingSchedules )
+		).toBeTruthy();
 	} );
+
+	function getTwoDaysFutureUTCTime() {
+		const currentDate = new Date();
+		const twoDaysFuture = new Date( currentDate.getTime() + 2 * 24 * 60 * 60 * 1000 );
+
+		twoDaysFuture.setUTCHours( 0, 0, 0, 0 );
+
+		return Math.floor( twoDaysFuture.getTime() / 1000 ); // Returning Unix time in seconds
+	}
+
+	function getNextMondayMidnightUTCTime() {
+		const currentDate = new Date();
+		let daysUntilNextMonday = 1 - currentDate.getUTCDay();
+
+		if ( daysUntilNextMonday <= 0 ) {
+			daysUntilNextMonday += 7;
+		}
+
+		const nextMonday = new Date(
+			currentDate.getTime() + daysUntilNextMonday * 24 * 60 * 60 * 1000
+		); // Adding days to get to next Monday
+		nextMonday.setUTCHours( 0, 0, 0, 0 );
+
+		return Math.floor( nextMonday.getTime() / 1000 );
+	}
 } );


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to #

## Proposed Changes

* Fixes a bug with 12am/12pm times always resulting in 12pm schedules.
* Only adds a day on daily schedules when the hour value is in the past.
* Only adds a week on weekly schedules when the hour value is in the past.

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Navigate to `/plugins/scheduled-updates` and select a site.
* Create or edit a schedule.
* Select a time that's just ahead or just past the current time.
* Submit the form.
* Make sure the resulting timestamp is correct.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?