### PR TITLE
Add Connections global site menu item

### DIFF
--- a/client/my-sites/marketing/main.jsx
+++ b/client/my-sites/marketing/main.jsx
@@ -12,11 +12,16 @@ import NavigationHeader from 'calypso/components/navigation-header';
 import SectionNav from 'calypso/components/section-nav';
 import NavItem from 'calypso/components/section-nav/item';
 import NavTabs from 'calypso/components/section-nav/tabs';
+import { useSelector } from 'calypso/state';
 import { canCurrentUser } from 'calypso/state/selectors/can-current-user';
 import isSiteP2Hub from 'calypso/state/selectors/is-site-p2-hub';
 import isSiteWpcomAtomic from 'calypso/state/selectors/is-site-wpcom-atomic';
 import isVipSite from 'calypso/state/selectors/is-vip-site';
-import { getSiteSlug, isJetpackSite } from 'calypso/state/sites/selectors';
+import {
+	getSiteSlug,
+	isGlobalSiteViewEnabled as getIsGlobalSiteViewEnabled,
+	isJetpackSite,
+} from 'calypso/state/sites/selectors';
 import { getSelectedSiteId } from 'calypso/state/ui/selectors';
 import './style.scss';
 
@@ -115,10 +120,19 @@ export const Sharing = ( {
 		} );
 	}
 
-	// For p2 hub sites show only connections tab
 	let titleHeader = translate( 'Marketing and Integrations' );
 
+	const isGlobalSiteViewEnabled = useSelector( ( state ) =>
+		getIsGlobalSiteViewEnabled( state, siteId )
+	);
+
+	if ( isGlobalSiteViewEnabled ) {
+		filters = [];
+		titleHeader = translate( 'Connections' );
+	}
+
 	if ( isP2Hub ) {
+		// For p2 hub sites show only connections tab.
 		filters = [ connectionsFilter ];
 		titleHeader = translate( 'Integrations' );
 	}

--- a/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
+++ b/client/my-sites/sidebar/static-data/global-site-sidebar-menu.ts
@@ -98,6 +98,12 @@ export default function globalSiteSidebarMenu( {
 			url: `/subscribers/${ siteDomain }`,
 		},
 		{
+			slug: 'connections',
+			title: translate( 'Connections' ),
+			type: 'menu-item',
+			url: `/marketing/connections/${ siteDomain }`,
+		},
+		{
 			slug: 'settings-site',
 			title: translate( 'Settings' ),
 			type: 'menu-item',


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5766

## Proposed Changes

* This PR adds a "Connections" menu item to the Global Site Nav menu.
* The "Connections" tab links to the existing `/marketing/connections/[site_slug]` page, but it re-titles it "Connections" and hides the page sub-tab navigation.

<img width="1720" alt="Screenshot 2024-03-08 at 3 56 26 PM" src="https://github.com/Automattic/wp-calypso/assets/140841/6562fd01-b572-4595-8395-6c3e6e448ccd">

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to `/marketing/connections/[site_slug]` and confirm all of the connections continue to work.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?