### PR TITLE
GitHub Deployments:  Update repository modal empty state copy to provide clear instructions

### DIFF
--- a/client/my-sites/github-deployments/components/installations-dropdown/index.tsx
+++ b/client/my-sites/github-deployments/components/installations-dropdown/index.tsx
@@ -1,4 +1,4 @@
-import { Button, SelectDropdown } from '@automattic/components';
+import { SelectDropdown } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
 import {
 	GitHubInstallationData,
@@ -24,43 +24,30 @@ export const GitHubInstallationsDropdown = ( {
 
 	const { isFetching } = useGithubInstallationsQuery();
 
-	if ( installations.length > 0 ) {
-		return (
-			<SelectDropdown
-				className="github-deployments-installations-select"
-				selectedText={ value?.account_name }
-				isLoading={ isFetching }
-			>
-				{ installations.map( ( installation ) => (
-					<SelectDropdown.Item
-						key={ installation.account_name }
-						selected={ value?.account_name === installation.account_name }
-						onClick={ () => onChange( installation ) }
-					>
-						{ installation.account_name }
-					</SelectDropdown.Item>
-				) ) }
-				<SelectDropdown.Separator />
-				<SelectDropdown.Item
-					onClick={ onAddInstallation }
-					key="add"
-					className="github-deployments-installations-select__add-installation"
-				>
-					{ __( 'Add GitHub account' ) }
-				</SelectDropdown.Item>
-			</SelectDropdown>
-		);
-	}
-
 	return (
-		<Button
-			busy={ isFetching }
-			disabled={ isFetching }
-			primary
-			onClick={ onAddInstallation }
-			key="add"
+		<SelectDropdown
+			className="github-deployments-installations-select"
+			selectedText={ value?.account_name || __( 'Select account' ) }
+			isLoading={ isFetching }
+			disabled={ ! installations.length }
 		>
-			{ __( 'Add GitHub account' ) }
-		</Button>
+			{ installations.map( ( installation ) => (
+				<SelectDropdown.Item
+					key={ installation.account_name }
+					selected={ value?.account_name === installation.account_name }
+					onClick={ () => onChange( installation ) }
+				>
+					{ installation.account_name }
+				</SelectDropdown.Item>
+			) ) }
+			<SelectDropdown.Separator />
+			<SelectDropdown.Item
+				onClick={ onAddInstallation }
+				key="add"
+				className="github-deployments-installations-select__add-installation"
+			>
+				{ __( 'Add GitHub account' ) }
+			</SelectDropdown.Item>
+		</SelectDropdown>
 	);
 };

--- a/client/my-sites/github-deployments/components/installations-dropdown/style.scss
+++ b/client/my-sites/github-deployments/components/installations-dropdown/style.scss
@@ -1,6 +1,18 @@
 .github-deployments-installations-select {
 	.select-dropdown__header {
 		height: 40px !important;
+
+	}
+
+
+	&.is-disabled .select-dropdown__header {
+		color: var(--studio-gray-10);
+		background: var(--color-surface);
+		border-color: var(--studio-gray-10);
+
+		.gridicons-chevron-down {
+			fill: var(--studio-gray-10);
+		}
 	}
 
 	.select-dropdown__header-text {

--- a/client/my-sites/github-deployments/components/page-shell/index.tsx
+++ b/client/my-sites/github-deployments/components/page-shell/index.tsx
@@ -69,7 +69,7 @@ export function PageShell( { topRightButton, pageTitle, children }: GitHubDeploy
 				css={ { paddingBottom: '40px !important' } }
 				title={ translate( 'GitHub Deployments' ) }
 				subtitle={ translate(
-					'Changes pushed to the selected repository’s branches will be automatically deployed. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
+					'Effortlessly connect and deploy code from your GitHub repository with automatic or manual triggers. {{learnMoreLink}}Learn more{{/learnMoreLink}}.',
 					{
 						components: {
 							learnMoreLink: (

--- a/client/my-sites/github-deployments/components/repositories/browse-repositories.tsx
+++ b/client/my-sites/github-deployments/components/repositories/browse-repositories.tsx
@@ -1,4 +1,4 @@
-import { Card } from '@automattic/components';
+import { Button, Card, Gridicon } from '@automattic/components';
 import { useI18n } from '@wordpress/react-i18n';
 import { ComponentProps, useState } from 'react';
 import { GitHubInstallationsDropdown } from '../installations-dropdown';
@@ -51,8 +51,26 @@ export const GitHubBrowseRepositories = ( {
 
 		if ( ! installation ) {
 			return (
-				<Card css={ { display: 'flex', flexDirection: 'column', alignItems: 'center', margin: 0 } }>
-					<span>{ __( 'Get started by adding a GitHub account.' ) }</span>
+				<Card
+					css={ {
+						display: 'flex',
+						flexDirection: 'column',
+						boxShadow: 'none',
+						alignItems: 'center',
+						margin: 0,
+						textAlign: 'center',
+						gap: '16px',
+					} }
+				>
+					<span css={ { paddingInline: '24px' } }>
+						{ __(
+							'To access your repositories, install the WordPress.com app on your GitHub account and grant it the necessary permissions.'
+						) }
+					</span>
+					<Button primary onClick={ onNewInstallationRequest }>
+						{ __( 'Install WordPress.com app' ) }
+						<Gridicon css={ { marginLeft: '4px' } } icon="external" size={ 18 } />
+					</Button>
 				</Card>
 			);
 		}
@@ -67,7 +85,11 @@ export const GitHubBrowseRepositories = ( {
 					value={ installation }
 					onChange={ setInstallation }
 				/>
-				<SearchRepos value={ query } onChange={ handleQueryChange } />
+				<SearchRepos
+					disabled={ ! installations.length }
+					value={ query }
+					onChange={ handleQueryChange }
+				/>
 			</div>
 			{ renderContent() }
 		</div>

--- a/client/my-sites/github-deployments/components/repositories/search-repos.tsx
+++ b/client/my-sites/github-deployments/components/repositories/search-repos.tsx
@@ -3,10 +3,11 @@ import { Search } from '../search/search';
 
 interface SearchReposProps {
 	value: string;
+	disabled?: boolean;
 	onChange?( query: string ): void;
 }
 
-export const SearchRepos = ( { value, onChange }: SearchReposProps ) => {
+export const SearchRepos = ( { value, onChange, disabled }: SearchReposProps ) => {
 	const { __ } = useI18n();
 
 	return (
@@ -16,6 +17,7 @@ export const SearchRepos = ( { value, onChange }: SearchReposProps ) => {
 			className="github-deployments-repositories__search"
 			placeholder={ __( 'Search repositories' ) }
 			options={ [] }
+			disabled={ disabled }
 			isSearching={ false }
 			onChange={ ( query ) => {
 				onChange?.( query.trim() );

--- a/client/my-sites/github-deployments/deployments/authorize-button.tsx
+++ b/client/my-sites/github-deployments/deployments/authorize-button.tsx
@@ -73,7 +73,7 @@ export const GitHubAuthorizeButton = () => {
 			onClick={ startAuthorization }
 		>
 			<SocialLogo icon="github" size={ 18 } css={ { marginRight: '4px' } } />
-			{ __( 'Authorize GitHub' ) }
+			{ __( 'Continue with GitHub' ) }
 		</Button>
 	);
 };

--- a/client/my-sites/github-deployments/deployments/authorize-card/index.tsx
+++ b/client/my-sites/github-deployments/deployments/authorize-card/index.tsx
@@ -7,9 +7,7 @@ import './style.scss';
 export const GitHubAuthorizeCard = () => {
 	return (
 		<Card css={ { display: 'flex', flexDirection: 'column', alignItems: 'center', padding: 32 } }>
-			<p css={ { marginBottom: 28 } }>
-				{ __( 'Authorize GitHub to connect an existing repository or create a new one.' ) }
-			</p>
+			<p css={ { marginBottom: 28 } }>{ __( 'Continue with GitHub to get started' ) }</p>
 			<GitHubAuthorizeButton />
 		</Card>
 	);


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to 
https://github.com/Automattic/dotcom-forge/issues/5979
https://github.com/Automattic/dotcom-forge/issues/5975
## Proposed Changes

* Update repository modal copy
* Update feature description 
* Update Authorise Button copy

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* go to `/github-deployments/site`
* Verify the copies are displayed and feature function as it should

<img width="1206" alt="image" src="https://github.com/Automattic/wp-calypso/assets/47489215/0c5df9db-e5f5-49ee-add7-9ccead89f02d">

<img width="1073" alt="image" src="https://github.com/Automattic/wp-calypso/assets/47489215/1ce521bf-29bb-4e56-ae7f-51722ab38c21">


## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?