### PR TITLE
Sites dashboard: Properly set menu popover z-index

### DIFF
--- a/client/sites-dashboard/components/sites-ellipsis-menu.tsx
+++ b/client/sites-dashboard/components/sites-ellipsis-menu.tsx
@@ -165,7 +165,7 @@ const ModalContent = styled.div( {
 } );
 
 const modalOverlayClassName = css( {
-	// golbal-notices has z-index: 179
+	// global-notices has z-index: 179
 	zIndex: 178,
 } );
 
@@ -271,9 +271,11 @@ const SiteDropdownMenu = styled( DropdownMenu )( {
 		height: 'auto',
 		verticalAlign: 'middle',
 	},
-	'.components-popover': {
-		zIndex: 177,
-	},
+} );
+
+const siteDropdownMenuPopoverClassName = css( {
+	// modalOverlayClassName has z-index: 178
+	zIndex: 177,
 
 	'.submenu-popover > .components-popover__content': {
 		display: 'flex',
@@ -459,6 +461,7 @@ export const SitesEllipsisMenu = ( {
 		<SiteDropdownMenu
 			icon={ <Gridicon icon="ellipsis" /> }
 			className={ className }
+			popoverProps={ { className: siteDropdownMenuPopoverClassName } }
 			label={ __( 'Site Actions' ) }
 		>
 			{ () => (


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Fixes https://github.com/Automattic/dotcom-forge/issues/5981

## Proposed Changes

This PR explicitly adds a CSS class to the popover component since the popover is rendered as a direct child of body instead of inline.

| Before | After |
| --- | --- |
| ![Screenshot 2024-03-11 at 11 11 56 AM](https://github.com/Automattic/wp-calypso/assets/797888/8c3d25c6-fb3e-4245-9a0b-8a622f53d00d) | ![Screenshot 2024-03-11 at 11 11 41 AM](https://github.com/Automattic/wp-calypso/assets/797888/c01bbb9e-7673-443f-bce1-06a9b01f2043) |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Head to /sites.
* Click on the ellipsis menu for a site in Coming Soon mode.
* Ensure that the modal is not under the ellipsis menu.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?