### PR TITLE
Global sidebar: Add Tracks events

### DIFF
--- a/client/layout/global-sidebar/events.ts
+++ b/client/layout/global-sidebar/events.ts
@@ -7,7 +7,7 @@ export const GLOBAL_SIDEBAR_EVENTS = {
 	NOTIFICATION_CLICK: 'calypso_global_sidebar_notification_click',
 
 	/**
-	 * Body
+	 * Main
 	 */
 	MENU_BACK_CLICK: 'calypso_global_sidebar_menu_back_click',
 	MENU_ITEM_CLICK: 'calypso_global_sidebar_menu_item_click',

--- a/client/layout/global-sidebar/events.ts
+++ b/client/layout/global-sidebar/events.ts
@@ -1,3 +1,21 @@
 export const GLOBAL_SIDEBAR_EVENTS = {
+	/**
+	 * Header
+	 */
+	ALLSITES_CLICK: 'calypso_global_sidebar_allsites_click',
+	SEARCH_CLICK: 'calypso_global_sidebar_search_click',
+	NOTIFICATION_CLICK: 'calypso_global_sidebar_notification_click',
+
+	/**
+	 * Body
+	 */
+	MENU_BACK_CLICK: 'calypso_global_sidebar_menu_back_click',
 	MENU_ITEM_CLICK: 'calypso_global_sidebar_menu_item_click',
+
+	/**
+	 * Footer
+	 */
+	HELPCENTER_CLICK: 'calypso_global_sidebar_helpcenter_click',
+	PROFILE_CLICK: 'calypso_global_sidebar_profile_click',
+	READER_CLICK: 'calypso_global_sidebar_reader_click',
 };

--- a/client/layout/global-sidebar/footer.tsx
+++ b/client/layout/global-sidebar/footer.tsx
@@ -1,9 +1,11 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { LocalizeProps } from 'i18n-calypso';
 import { FC } from 'react';
 import AsyncLoad from 'calypso/components/async-load';
 import Gravatar from 'calypso/components/gravatar';
 import SidebarFooter from 'calypso/layout/sidebar/footer';
 import { UserData } from 'calypso/lib/user/user';
+import { GLOBAL_SIDEBAR_EVENTS } from './events';
 
 const CustomReaderIcon = () => (
 	<svg
@@ -36,6 +38,7 @@ export const GlobalSidebarFooter: FC< {
 				className="sidebar__footer-link sidebar__footer-reader tooltip tooltip-top"
 				title={ translate( 'Reader' ) }
 				data-tooltip={ translate( 'Reader' ) }
+				onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.READER_CLICK ) }
 			>
 				<CustomReaderIcon />
 			</a>
@@ -44,6 +47,7 @@ export const GlobalSidebarFooter: FC< {
 				className="sidebar__footer-link sidebar__footer-profile tooltip tooltip-top"
 				title={ translate( 'Profile' ) }
 				data-tooltip={ translate( 'Profile' ) }
+				onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.PROFILE_CLICK ) }
 			>
 				<Gravatar user={ user } size={ 20 } />
 			</a>
@@ -56,6 +60,7 @@ export const GlobalSidebarFooter: FC< {
 						<span className="help"></span>
 					</div>
 				}
+				onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.HELPCENTER_CLICK ) }
 			/>
 		</SidebarFooter>
 	);

--- a/client/layout/global-sidebar/header.tsx
+++ b/client/layout/global-sidebar/header.tsx
@@ -1,5 +1,7 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { useTranslate } from 'i18n-calypso';
 import SkipNavigation from '../sidebar/skip-navigation';
+import { GLOBAL_SIDEBAR_EVENTS } from './events';
 import SidebarNotifications from './menu-items/notifications';
 import { SidebarSearch } from './menu-items/search';
 
@@ -15,15 +17,20 @@ export const GlobalSidebarHeader = () => {
 				href="/sites"
 				className="link-logo tooltip tooltip-bottom-left"
 				data-tooltip={ translate( 'View all sites' ) }
+				onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.ALLSITES_CLICK ) }
 			>
 				<span className="dotcom"></span>
 			</a>
 			<span className="gap"></span>
-			<SidebarSearch tooltip={ translate( 'Jump to…' ) } />
+			<SidebarSearch
+				tooltip={ translate( 'Jump to…' ) }
+				onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.SEARCH_CLICK ) }
+			/>
 			<SidebarNotifications
 				isActive={ true }
 				className="sidebar__item-notifications"
 				tooltip={ translate( 'Notifications' ) }
+				onClick={ () => recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.NOTIFICATION_CLICK ) }
 			/>
 		</div>
 	);

--- a/client/layout/global-sidebar/main.jsx
+++ b/client/layout/global-sidebar/main.jsx
@@ -1,3 +1,4 @@
+import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { Spinner, Gridicon } from '@automattic/components';
 import { useBreakpoint } from '@automattic/viewport-react';
 import { useTranslate } from 'i18n-calypso';
@@ -8,10 +9,17 @@ import useSiteMenuItems from 'calypso/my-sites/sidebar/use-site-menu-items';
 import { getIsRequestingAdminMenu } from 'calypso/state/admin-menu/selectors';
 import { getCurrentUser } from 'calypso/state/current-user/selectors';
 import Sidebar from '../sidebar';
+import { GLOBAL_SIDEBAR_EVENTS } from './events';
 import { GlobalSidebarFooter } from './footer';
 import './style.scss';
 
-const GlobalSidebar = ( { children, onClick = undefined, className = '', ...props } ) => {
+const GlobalSidebar = ( {
+	children,
+	onClick = undefined,
+	className = '',
+	path = '',
+	...props
+} ) => {
 	const wrapperRef = useRef( null );
 	const bodyRef = useRef( null );
 	const menuItems = useSiteMenuItems();
@@ -27,6 +35,10 @@ const GlobalSidebar = ( { children, onClick = undefined, className = '', ...prop
 			bodyEl.scrollTop += event.deltaY;
 		}
 	}, [] );
+
+	const handleBackLinkClick = () => {
+		recordTracksEvent( GLOBAL_SIDEBAR_EVENTS.MENU_BACK_CLICK, { path } );
+	};
 
 	useEffect( () => {
 		wrapperRef.current?.addEventListener( 'wheel', handleWheel, { passive: false } );
@@ -55,7 +67,7 @@ const GlobalSidebar = ( { children, onClick = undefined, className = '', ...prop
 				<Sidebar className={ className } { ...sidebarProps } onClick={ onClick }>
 					{ requireBackLink && (
 						<div className="sidebar__back-link">
-							<a href="/sites">
+							<a href="/sites" onClick={ handleBackLinkClick }>
 								<Gridicon icon="chevron-left" size={ 24 } />
 								<span className="sidebar__back-link-text">{ sidebarBackLinkText }</span>
 							</a>

--- a/client/layout/global-sidebar/menu-items/help-center/help-center.jsx
+++ b/client/layout/global-sidebar/menu-items/help-center/help-center.jsx
@@ -1,4 +1,3 @@
-//import { recordTracksEvent } from '@automattic/calypso-analytics';
 import { HelpCenter } from '@automattic/data-stores';
 import {
 	useDispatch as useDataStoreDispatch,
@@ -6,17 +5,11 @@ import {
 } from '@wordpress/data';
 import { Icon, help } from '@wordpress/icons';
 import classnames from 'classnames';
-//import { useRef } from 'react';
-//import { useSelector } from 'react-redux';
-//import { getSectionName } from 'calypso/state/ui/selectors';
 import SidebarMenuItem from '../menu-item';
 
 const HELP_CENTER_STORE = HelpCenter.register();
 
-const SidebarHelpCenter = ( { tooltip, tooltipPlacement } ) => {
-	//const helpIconRef = useRef();
-	//const sectionName = useSelector( getSectionName );
-
+const SidebarHelpCenter = ( { tooltip, tooltipPlacement, onClick } ) => {
 	const helpCenterVisible = useDateStoreSelect(
 		( select ) => select( HELP_CENTER_STORE ).isHelpCenterShown(),
 		[]
@@ -24,14 +17,8 @@ const SidebarHelpCenter = ( { tooltip, tooltipPlacement } ) => {
 	const { setShowHelpCenter } = useDataStoreDispatch( HELP_CENTER_STORE );
 
 	const handleToggleHelpCenter = () => {
-		// TODO: track this event when sidebar dev is ready
-		// recordTracksEvent( `calypso_inlinehelp_${ helpCenterVisible ? 'close' : 'show' }`, {
-		// 	force_site_id: true,
-		// 	location: 'help-center',
-		// 	section: sectionName,
-		// } );
-
 		setShowHelpCenter( ! helpCenterVisible );
+		onClick();
 	};
 
 	return (

--- a/client/layout/global-sidebar/menu-items/notifications/index.jsx
+++ b/client/layout/global-sidebar/menu-items/notifications/index.jsx
@@ -19,6 +19,7 @@ class SidebarNotifications extends Component {
 		isActive: PropTypes.bool,
 		className: PropTypes.string,
 		title: TranslatableString,
+		onClick: PropTypes.func,
 		//connected
 		isNotificationsOpen: PropTypes.bool,
 		hasUnseenNotifications: PropTypes.bool,
@@ -108,6 +109,11 @@ class SidebarNotifications extends Component {
 		} );
 	};
 
+	handleClick = ( event ) => {
+		this.toggleNotesFrame( event );
+		this.props.onClick();
+	};
+
 	render() {
 		const classes = classNames( this.props.className, 'sidebar-notifications', {
 			'is-active':
@@ -121,7 +127,7 @@ class SidebarNotifications extends Component {
 				<SidebarMenuItem
 					url="/notifications"
 					icon={ <BellIcon newItems={ this.state.newNote } active={ this.props.isActive } /> }
-					onClick={ this.toggleNotesFrame }
+					onClick={ this.handleClick }
 					isActive={ this.props.isActive }
 					tooltip={ this.props.tooltip }
 					className={ classes }

--- a/client/layout/global-sidebar/menu-items/search/index.jsx
+++ b/client/layout/global-sidebar/menu-items/search/index.jsx
@@ -4,10 +4,11 @@ import { useDispatch } from 'calypso/state';
 import { openCommandPalette } from 'calypso/state/command-palette/actions';
 import SidebarMenuItem from '../menu-item';
 
-export const SidebarSearch = ( { tooltip } ) => {
+export const SidebarSearch = ( { tooltip, onClick } ) => {
 	const dispatch = useDispatch();
 	const showCommandPalette = () => {
 		dispatch( openCommandPalette() );
+		onClick();
 	};
 	return (
 		<>

--- a/client/me/sidebar/index.jsx
+++ b/client/me/sidebar/index.jsx
@@ -75,8 +75,9 @@ class MeSidebar extends Component {
 	};
 
 	renderGlobalSidebar() {
+		const { context } = this.props;
 		const props = {
-			path: this.props.path,
+			path: context.path,
 			requireBackLink: true,
 		};
 		return <GlobalSidebar { ...props }>{ this.renderMenu( { isGlobal: true } ) }</GlobalSidebar>;

--- a/client/my-sites/sidebar/body.jsx
+++ b/client/my-sites/sidebar/body.jsx
@@ -36,7 +36,13 @@ export const MySitesSidebarUnifiedBody = ( { path, children, onMenuItemClick } )
 
 					if ( 'current-site' === item?.type ) {
 						return (
-							<Site key={ item.type } site={ site } href={ item?.url } isSelected={ isSelected } />
+							<Site
+								key={ item.type }
+								site={ site }
+								href={ item?.url }
+								isSelected={ isSelected }
+								onSelect={ () => onMenuItemClick( item?.url ) }
+							/>
 						);
 					}
 					if ( 'separator' === item?.type ) {


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/dotcom-forge/issues/5856

## Proposed Changes

This PR adds the following Tracks events to the global sidebar

| Event name | Description |
| -- | -- |
| calypso_global_sidebar_allsites_click | All sites (/sites) click |
| calypso_global_sidebar_search_click | Search click |
| calypso_global_sidebar_notification_click | Notification click |
| calypso_global_sidebar_menu_back_click | Back button click |
| calypso_global_sidebar_helpcenter_click | Help Center click |
| calypso_global_sidebar_profile_click | Profile (/me) click |
| calypso_global_sidebar_reader_click | Reader (/read) click |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Ensure that all the Tracks events listed above trigger as intended.

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [x] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [x] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [x] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [x] Have you checked for TypeScript, React or other console errors?
- [x] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [x] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [x] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?