### PR TITLE
Whats New: Make it on the center of the screen

### DIFF
--- a/packages/whats-new/src/style.scss
+++ b/packages/whats-new/src/style.scss
@@ -21,9 +21,6 @@ $wpcom-modal-footer-height: 30px + ( $wpcom-modal-content-spacing * 2 );
 		overflow: auto;
 		max-height: 80vh;
 		pointer-events: auto;
-		position: fixed;
-		bottom: 20px;
-		right: 20px;
 
 		@media ( max-width: $wpcom-modal-breakpoint ) {
 			width: 90vw;


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Related to https://github.com/Automattic/wp-calypso/issues/88324

## Proposed Changes

* Move the What's New modal to the center of the screen

| Before | After |
| - | - |
| <img width="975" alt="image" src="https://github.com/Automattic/wp-calypso/assets/13596067/76aedaab-a0fd-41eb-afae-d0b2ed18fa51"> | <img width="973" alt="image" src="https://github.com/Automattic/wp-calypso/assets/13596067/22089378-10a7-4cd7-8968-5cc0b0264fa0"> |

## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

* Go to your site with the nav redesign
* Make sure the What's New modal is on the center of the screen. If the modal is not shown, you can open the Help Center and scroll down to click "What's new"

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?