### PR TITLE
Add woo passwordless feature flag

### DIFF
--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -371,14 +371,14 @@ export default withCurrentRoute(
 			if (
 				// Wait until the currentRoute is not changed.
 				getCurrentRoute( state ) === currentRoute &&
+				// window.location.pathname === currentRoute &&
 				isWCCOM &&
 				! wooPasswordless &&
 				config.isEnabled( 'woo/passwordless' )
 			) {
 				// Update the URL to include the woo-passwordless query parameter when woo passwordless feature flag is enabled for Woo.
-				const queryParams = { 'woo-passwordless': 'yes' };
-				const currentPath = window.location.pathname + window.location.search;
-				page.replace( addQueryArgs( queryParams, currentPath ) );
+				const queryParams = { ...currentQuery, 'woo-passwordless': 'yes' };
+				page.replace( addQueryArgs( queryParams, currentRoute ) );
 			}
 
 			return {

--- a/client/layout/logged-out.jsx
+++ b/client/layout/logged-out.jsx
@@ -360,13 +360,16 @@ export default withCurrentRoute(
 				noMasterbarForSection ||
 				noMasterbarForRoute;
 
-			const isWooPasswordless =
-				// Feature can be enabled via config or query param.
-				config.isEnabled( 'woo/passwordless' ) || !! getWooPasswordless( state );
-
-			const isWoo = isWooOAuth2Client( oauth2Client );
 			const wooPasswordless = getWooPasswordless( state );
-			if ( isWoo && ! wooPasswordless && config.isEnabled( 'woo/passwordless' ) ) {
+			const isWoo = isWooOAuth2Client( oauth2Client );
+
+			if (
+				// Wait until the currentRoute is not changed.
+				getCurrentRoute( state ) === currentRoute &&
+				isWoo &&
+				! wooPasswordless &&
+				config.isEnabled( 'woo/passwordless' )
+			) {
 				// Update the URL to include the woo-passwordless query parameter when woo passwordless feature flag is enabled for Woo.
 				const queryParams = { 'woo-passwordless': 'yes' };
 				const currentPath = window.location.pathname + window.location.search;
@@ -393,7 +396,9 @@ export default withCurrentRoute(
 				isPartnerSignup,
 				isPartnerSignupStart,
 				isWooCoreProfilerFlow,
-				isWooPasswordless,
+				isWooPasswordless:
+					( config.isEnabled( 'woo/passwordless' ) || !! wooPasswordless ) &&
+					! ( isWooCoreProfilerFlow || isJetpackWooCommerceFlow || isJetpackWooDnaFlow ),
 			};
 		},
 		{ clearLastActionRequiresLogin }

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -156,17 +156,6 @@ class Signup extends Component {
 
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
 	UNSAFE_componentWillMount() {
-		if (
-			this.props.isWoo &&
-			! this.props.wooPasswordless &&
-			config.isEnabled( 'woo/passwordless' )
-		) {
-			// Update the URL to include the woo-passwordless query parameter when woo passwordless feature flag is enabled for Woo.
-			const queryParams = { 'woo-passwordless': 'yes' };
-			const currentPath = window.location.pathname + window.location.search;
-			page.replace( addQueryArgs( queryParams, currentPath ) );
-		}
-
 		let providedDependencies = this.getDependenciesInQuery();
 
 		// Prevent duplicate sites, check pau2Xa-1Io-p2#comment-6759.
@@ -912,7 +901,7 @@ class Signup extends Component {
 			<>
 				<div
 					className={ `signup is-${ kebabCase( this.props.flowName ) } ${
-						this.props.wooPasswordless ? 'is-woo-passwordless' : ''
+						this.props.isWooPasswordless ? 'is-woo-passwordless' : ''
 					}` }
 				>
 					<DocumentHead title={ this.props.pageTitle } />
@@ -962,6 +951,14 @@ export default connect(
 		const siteDomains = getDomainsBySiteId( state, siteId );
 		const oauth2Client = getCurrentOAuth2Client( state );
 		const hostingFlow = startedInHostingFlow( state );
+		const isWoo = isWooOAuth2Client( oauth2Client );
+		const wooPasswordless = getWooPasswordless( state );
+		if ( isWoo && ! wooPasswordless && config.isEnabled( 'woo/passwordless' ) ) {
+			// Update the URL to include the woo-passwordless query parameter when woo passwordless feature flag is enabled for Woo.
+			const queryParams = { 'woo-passwordless': 'yes' };
+			const currentPath = window.location.pathname + window.location.search;
+			page.replace( addQueryArgs( queryParams, currentPath ) );
+		}
 
 		return {
 			domainsWithPlansOnly: getCurrentUser( state )
@@ -983,8 +980,7 @@ export default connect(
 			oauth2Client,
 			isGravatar: isGravatarOAuth2Client( oauth2Client ),
 			hostingFlow,
-			wooPasswordless: getWooPasswordless( state ),
-			isWoo: isWooOAuth2Client( oauth2Client ),
+			isWooPasswordless: config.isEnabled( 'woo/passwordless' ) || !! wooPasswordless,
 		};
 	},
 	{

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -41,6 +41,7 @@ import {
 } from 'calypso/lib/analytics/signup';
 import * as oauthToken from 'calypso/lib/oauth-token';
 import { isWooOAuth2Client, isGravatarOAuth2Client } from 'calypso/lib/oauth2-clients';
+import { addQueryArgs } from 'calypso/lib/route';
 import SignupFlowController from 'calypso/lib/signup/flow-controller';
 import FlowProgressIndicator from 'calypso/signup/flow-progress-indicator';
 import P2SignupProcessingScreen from 'calypso/signup/p2-processing-screen';
@@ -155,6 +156,17 @@ class Signup extends Component {
 
 	// @TODO: Please update https://github.com/Automattic/wp-calypso/issues/58453 if you are refactoring away from UNSAFE_* lifecycle methods!
 	UNSAFE_componentWillMount() {
+		if (
+			this.props.isWoo &&
+			! this.props.wooPasswordless &&
+			config.isEnabled( 'woo/passwordless' )
+		) {
+			// Update the URL to include the woo-passwordless query parameter when woo passwordless feature flag is enabled for Woo.
+			const queryParams = { 'woo-passwordless': 'yes' };
+			const currentPath = window.location.pathname + window.location.search;
+			page.replace( addQueryArgs( queryParams, currentPath ) );
+		}
+
 		let providedDependencies = this.getDependenciesInQuery();
 
 		// Prevent duplicate sites, check pau2Xa-1Io-p2#comment-6759.
@@ -972,6 +984,7 @@ export default connect(
 			isGravatar: isGravatarOAuth2Client( oauth2Client ),
 			hostingFlow,
 			wooPasswordless: getWooPasswordless( state ),
+			isWoo: isWooOAuth2Client( oauth2Client ),
 		};
 	},
 	{

--- a/client/signup/main.jsx
+++ b/client/signup/main.jsx
@@ -41,7 +41,6 @@ import {
 } from 'calypso/lib/analytics/signup';
 import * as oauthToken from 'calypso/lib/oauth-token';
 import { isWooOAuth2Client, isGravatarOAuth2Client } from 'calypso/lib/oauth2-clients';
-import { addQueryArgs } from 'calypso/lib/route';
 import SignupFlowController from 'calypso/lib/signup/flow-controller';
 import FlowProgressIndicator from 'calypso/signup/flow-progress-indicator';
 import P2SignupProcessingScreen from 'calypso/signup/p2-processing-screen';
@@ -59,7 +58,6 @@ import {
 } from 'calypso/state/current-user/selectors';
 import { getCurrentOAuth2Client } from 'calypso/state/oauth2-clients/ui/selectors';
 import getCurrentLocaleSlug from 'calypso/state/selectors/get-current-locale-slug';
-import getWooPasswordless from 'calypso/state/selectors/get-woo-passwordless';
 import isDomainOnlySite from 'calypso/state/selectors/is-domain-only-site';
 import isUserRegistrationDaysWithinRange from 'calypso/state/selectors/is-user-registration-days-within-range';
 import { getSignupDependencyStore } from 'calypso/state/signup/dependency-store/selectors';
@@ -899,11 +897,7 @@ class Signup extends Component {
 
 		return (
 			<>
-				<div
-					className={ `signup is-${ kebabCase( this.props.flowName ) } ${
-						this.props.isWooPasswordless ? 'is-woo-passwordless' : ''
-					}` }
-				>
+				<div className={ `signup is-${ kebabCase( this.props.flowName ) }` }>
 					<DocumentHead title={ this.props.pageTitle } />
 					{ showPageHeader && (
 						<SignupHeader
@@ -951,14 +945,6 @@ export default connect(
 		const siteDomains = getDomainsBySiteId( state, siteId );
 		const oauth2Client = getCurrentOAuth2Client( state );
 		const hostingFlow = startedInHostingFlow( state );
-		const isWoo = isWooOAuth2Client( oauth2Client );
-		const wooPasswordless = getWooPasswordless( state );
-		if ( isWoo && ! wooPasswordless && config.isEnabled( 'woo/passwordless' ) ) {
-			// Update the URL to include the woo-passwordless query parameter when woo passwordless feature flag is enabled for Woo.
-			const queryParams = { 'woo-passwordless': 'yes' };
-			const currentPath = window.location.pathname + window.location.search;
-			page.replace( addQueryArgs( queryParams, currentPath ) );
-		}
 
 		return {
 			domainsWithPlansOnly: getCurrentUser( state )
@@ -980,7 +966,6 @@ export default connect(
 			oauth2Client,
 			isGravatar: isGravatarOAuth2Client( oauth2Client ),
 			hostingFlow,
-			isWooPasswordless: config.isEnabled( 'woo/passwordless' ) || !! wooPasswordless,
 		};
 	},
 	{

--- a/client/signup/steps/user/index.jsx
+++ b/client/signup/steps/user/index.jsx
@@ -60,12 +60,20 @@ function getRedirectToAfterLoginUrl( {
 	signupDependencies,
 	stepName,
 	userLoggedIn,
+	wooPasswordless,
 } ) {
 	if (
 		oauth2Signup &&
 		initialContext?.query?.oauth2_redirect &&
 		isOauth2RedirectValid( initialContext.query.oauth2_redirect )
 	) {
+		if (
+			wooPasswordless &&
+			! initialContext.query.oauth2_redirect.includes( 'woo-passwordless' )
+		) {
+			return initialContext.query.oauth2_redirect + '&woo-passwordless=yes';
+		}
+
 		return initialContext.query.oauth2_redirect;
 	}
 	if (

--- a/client/state/selectors/get-param-from-url-or-oauth2-redirect.ts
+++ b/client/state/selectors/get-param-from-url-or-oauth2-redirect.ts
@@ -21,7 +21,7 @@ export const getParamFromUrlOrOauth2Redirect = (
 	}
 
 	try {
-		const queryOauth2Redirect = currentQuery?.oauth2_redirect;
+		const queryOauth2Redirect = currentQuery?.oauth2_redirect || currentQuery?.redirect_to;
 		const oauth2RedirectUrl = new URL( queryOauth2Redirect as string );
 		return oauth2RedirectUrl.searchParams.get( paramName );
 	} catch ( e ) {

--- a/config/development.json
+++ b/config/development.json
@@ -231,6 +231,7 @@
 		"videomaker-trial": true,
 		"videopress-tv": true,
 		"woop": false,
+		"woo/passwordless": true,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": false,
 		"yolo/command-palette": true

--- a/config/production.json
+++ b/config/production.json
@@ -201,6 +201,7 @@
 		"videomaker-trial": true,
 		"videopress-tv": false,
 		"woop": false,
+		"woo/passwordless": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
 		"yolo/command-palette": true

--- a/config/stage.json
+++ b/config/stage.json
@@ -194,6 +194,7 @@
 		"user-management-revamp": true,
 		"videomaker-trial": true,
 		"woop": false,
+		"woo/passwordless": false,
 		"wordpress-action-search": false,
 		"wpcom-user-bootstrap": true,
 		"yolo/command-palette": true


### PR DESCRIPTION
<!--
Link a related issue to this PR. If the PR does not immediately resolve the issue,
for example, it requires a separate deployment to production, avoid
using the "fixes" keyword and instead attach the [Status] Fix Inbound label to
the linked issue.
-->

Closes #87635 

## Proposed Changes

We decided to start an experiment in Calypso so we added the feature flag in Calypso instead and will remove the feature flag in wccom.

* Add `woo/passwordless` feature flag
* Update the URL to include the woo-passwordless query parameter when woo passwordless feature flag is enabled for Signup.

This PR still uses `woo-passwordless` query parameter to determine whether to show passwordless screen. This way, we can also toggle the feature in production via query parameters, and it reduces the need for other code changes.


## Testing Instructions

<!--
Add as many details as possible to help others reproduce the issue and test the fix.
"Before / After" screenshots can also be very helpful when the change is visual.
-->

Feature flag is enabled:

1. Set up woo start env
2 Go to https://woo.com/start/#/installation
3 Click on "Try Woo Express for free" button
4 Observe that it shows the sign up screen without a password field.

Feature flag is disabled:

1. Disabled the feature flag: update `development.json` or use `document.cookie = 'flags=-woo/passwordless;max-age=1209600;path=/';`
2. Go to https://woo.com/start/#/installation
3. Click on "Try Woo Express for free" button
4. Observe that it shows the sign up screen with a password field

## Pre-merge Checklist

<!--
Complete applicable items on this checklist **before** merging into trunk. Inapplicable items can be left unchecked.

Both the PR author and reviewer are responsible for ensuring the checklist is completed.
-->

- [ ] Has the general commit checklist been followed? (PCYsg-hS-p2)
- [ ] https://wpcalypso.wordpress.com/devdocs/docs/testing/index.md for your changes?
- [ ] Have you tested the feature in Simple (P9HQHe-k8-p2), Atomic (P9HQHe-jW-p2), and self-hosted Jetpack sites (PCYsg-g6b-p2)?
- [ ] Have you checked for TypeScript, React or other console errors?
- [ ] Have you used memoizing on expensive computations? More info in [Memoizing with create-selector](https://github.com/Automattic/wp-calypso/blob/trunk/packages/state-utils/src/create-selector/README.md) and [Using memoizing selectors](https://react-redux.js.org/api/hooks#using-memoizing-selectors) and [Our Approach to Data](https://github.com/Automattic/wp-calypso/blob/trunk/docs/our-approach-to-data.md)
- [ ] Have we added the "[Status] String Freeze" label as soon as any new strings were ready for translation (p4TIVU-5Jq-p2)?
- [ ] For changes affecting Jetpack: Have we added the "[Status] Needs Privacy Updates" label if this pull request changes what data or activity we track or use (p4TIVU-aUh-p2)?